### PR TITLE
Add ID-based family categorization override

### DIFF
--- a/api/routes/crm_models/_utils.py
+++ b/api/routes/crm_models/_utils.py
@@ -57,13 +57,14 @@ def _load_family_config():
                 config = json.load(f)
             return (
                 set(name.lower() for name in config.get("family_last_names", [])),
-                set(name.lower() for name in config.get("family_exact_names", []))
+                set(name.lower() for name in config.get("family_exact_names", [])),
+                set(config.get("family_person_ids", []))
             )
         except Exception as e:
             logging.getLogger(__name__).warning(f"Failed to load family config: {e}")
-    return set(), set()
+    return set(), set(), set()
 
-FAMILY_LAST_NAMES, FAMILY_EXACT_NAMES = _load_family_config()
+FAMILY_LAST_NAMES, FAMILY_EXACT_NAMES, FAMILY_PERSON_IDS = _load_family_config()
 
 
 def get_strength_override(person_id: str) -> float | None:
@@ -107,7 +108,9 @@ def compute_person_category(person: PersonEntity, source_entities: list = None) 
     if person.id == settings.my_person_id:
         return "self"
 
-    # 2. Check family membership (by name)
+    # 2. Check family membership (by ID first, then by name)
+    if person.id in FAMILY_PERSON_IDS:
+        return "family"
     if is_family_member(person.canonical_name):
         return "family"
     # Also check display name and aliases

--- a/api/services/person_entity.py
+++ b/api/services/person_entity.py
@@ -1079,14 +1079,15 @@ def _load_family_config():
                 config = json.load(f)
             return (
                 set(name.lower() for name in config.get("family_last_names", [])),
-                set(name.lower() for name in config.get("family_exact_names", []))
+                set(name.lower() for name in config.get("family_exact_names", [])),
+                set(config.get("family_person_ids", []))
             )
         except Exception as e:
             logger.warning(f"Failed to load family config: {e}")
-    return set(), set()
+    return set(), set(), set()
 
 
-FAMILY_LAST_NAMES, FAMILY_EXACT_NAMES = _load_family_config()
+FAMILY_LAST_NAMES, FAMILY_EXACT_NAMES, FAMILY_PERSON_IDS = _load_family_config()
 
 
 def _is_family_member(name: str) -> bool:
@@ -1129,7 +1130,9 @@ def compute_person_category(person: PersonEntity, source_entities: list = None) 
     if person.id == settings.my_person_id:
         return "self"
 
-    # 2. Check family membership (by name)
+    # 2. Check family membership (by ID first, then by name)
+    if person.id in FAMILY_PERSON_IDS:
+        return "family"
     if _is_family_member(person.canonical_name):
         return "family"
     # Also check display name and aliases

--- a/config/family_members.example.json
+++ b/config/family_members.example.json
@@ -6,6 +6,10 @@
     "grammy",
     "grandpa"
   ],
+  "family_person_ids": [
+    "uuid-of-partner",
+    "uuid-of-sibling"
+  ],
   "tracked_relationships": [
     {
       "name": "Parent Relationship",


### PR DESCRIPTION
## Summary
- Family categorization was purely name-based (last names + exact names), so people whose DB names didn't match the config were never categorized as family
- Added `family_person_ids` field to `family_members.json` for reliable UUID-based family overrides, checked before the existing name-based fallback
- Updated both copies of `compute_person_category` (in `person_entity.py` and `_utils.py`)

## Test plan
- [ ] Restart server and verify family dashboard populates with people whose IDs are in `family_person_ids`
- [ ] Verify name-based family matching still works as fallback
- [ ] Verify "self" category still takes priority over family for the owner's ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)