### PR TITLE
fix: Prevent nightly sync from hanging indefinitely

### DIFF
--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -432,11 +432,15 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
         logger.info(f"[DRY RUN] Would run: python {script_path} {' '.join(args)}")
         return True, {"dry_run": True}
 
-    # Record sync start — track globally for SIGTERM cleanup
+    # Record sync start — track globally for SIGTERM cleanup.
+    # Mask SIGTERM briefly so a signal can't arrive between the DB insert
+    # and the global assignment, which would leave a stale RUNNING row.
     global _active_run_id, _active_source
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
     run_id = record_sync_start(source)
     _active_run_id = run_id
     _active_source = source
+    signal.signal(signal.SIGTERM, _handle_sigterm)
 
     try:
         logger.info(f"Starting sync for {source}...")
@@ -481,6 +485,7 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
                 interactions_created=stats.get("interactions_created", 0),
                 source_entities_created=stats.get("source_entities_created", 0),
             )
+            _active_run_id = None
 
             record_sync_error(
                 source,
@@ -508,6 +513,7 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             interactions_created=stats.get("interactions_created", 0),
             source_entities_created=stats.get("source_entities_created", 0),
         )
+        _active_run_id = None
 
         return True, stats
 
@@ -545,6 +551,7 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             interactions_created=stats.get("interactions_created", 0),
             source_entities_created=stats.get("source_entities_created", 0),
         )
+        _active_run_id = None
 
         # Include partial output in markdown log for visibility
         full_error_msg = error_msg
@@ -566,6 +573,7 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             errors=1,
             error_message=error_msg[:500],
         )
+        _active_run_id = None
 
         record_sync_error(
             source,

--- a/scripts/run_sync_wrapper.sh
+++ b/scripts/run_sync_wrapper.sh
@@ -36,18 +36,28 @@ for i in $(seq 1 $MAX_RETRIES); do
         # LIFEOS_HEADLESS prevents Google OAuth from blocking on browser flow
         export LIFEOS_HEADLESS=true
 
-        # Start a watchdog that kills the sync if it exceeds MAX_RUNTIME.
-        # After exec, $$ still refers to this process (now Python).
-        # SIGTERM first (Python handler cleans up), SIGKILL after 60s as backstop.
+        # Run Python in the background so we can start a watchdog alongside it.
+        # When Python exits normally, we kill the watchdog to prevent it from
+        # firing kill on a recycled PID hours later.
+        "$PYTHON" "$SYNC_SCRIPT" "$@" &
+        SYNC_PID=$!
+
+        # Watchdog: SIGTERM after MAX_RUNTIME, SIGKILL 60s later as backstop.
         (
             sleep "$MAX_RUNTIME"
-            echo "$(date '+%Y-%m-%d %H:%M:%S') [WRAPPER] Killing stuck sync after ${MAX_RUNTIME}s" >> "$LOG"
-            kill -TERM $$ 2>/dev/null
+            echo "$(date '+%Y-%m-%d %H:%M:%S') [WRAPPER] Killing stuck sync (PID $SYNC_PID) after ${MAX_RUNTIME}s" >> "$LOG"
+            kill -TERM "$SYNC_PID" 2>/dev/null
             sleep 60
-            kill -KILL $$ 2>/dev/null
+            kill -KILL "$SYNC_PID" 2>/dev/null
         ) &
+        WATCHDOG_PID=$!
 
-        exec "$PYTHON" "$SYNC_SCRIPT" "$@"
+        # Wait for sync to finish, then clean up watchdog
+        wait "$SYNC_PID"
+        EXIT_CODE=$?
+        kill "$WATCHDOG_PID" 2>/dev/null
+        wait "$WATCHDOG_PID" 2>/dev/null
+        exit "$EXIT_CODE"
     fi
 
     echo "$(date '+%Y-%m-%d %H:%M:%S') [WRAPPER] Python/NVMe not ready (attempt $i/$MAX_RETRIES)" >> "$LOG"


### PR DESCRIPTION
## Summary

- Set `vault_reindex` timeout to 2 hours (was `None`/unlimited) so `subprocess.run` raises `TimeoutExpired` instead of blocking forever
- Add a 6-hour watchdog in `run_sync_wrapper.sh` that SIGTERMs the process if it exceeds wall-clock time (SIGKILL after 60s as backstop) — catches hangs in the orchestrator itself
- Install a SIGTERM handler in `run_all_syncs.py` that marks the active sync run as FAILED in `sync_health.db` before exiting, preventing stale RUNNING rows

## Context

On March 2nd, `vault_reindex` hit an NVMe I/O deadlock (`OSError: [Errno 11] Resource deadlock avoided`). The error hit Python's logging layer in the orchestrator process (not the subprocess), causing `run_all_syncs.py` to hang indefinitely. launchd saw it as still running and skipped the March 3rd sync entirely.

## Test plan

- [x] Full test suite passes (1681 passed, 1 pre-existing failure unrelated to this PR)
- [x] Server restarted and health check passing
- [ ] Verify tonight's sync fires normally at 3 AM

🤖 Generated with [Claude Code](https://claude.com/claude-code)