### PR TITLE
chore: Move code directory from ~/Documents/Code to ~/Code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ LIFEOS_VAULT_PATH=/path/to/your/obsidian/vault
 LIFEOS_CHROMA_PATH=./data/chromadb
 LIFEOS_PORT=8000
 
+# Parent directory containing LifeOS and other code projects (default: ~/Code)
+# Used by Claude Code orchestrator for project directory resolution
+# LIFEOS_CODE_DIR=~/Code
+
 # =============================================================================
 # USER IDENTITY
 # =============================================================================

--- a/api/services/claude_orchestrator.py
+++ b/api/services/claude_orchestrator.py
@@ -111,8 +111,8 @@ KEY LOCATIONS:
   You can read these files directly with Read/Glob/Grep. Use this when you know the filename
   or want full file content. Use the LifeOS MCP search tools when you need to search across
   many files or need structured data like entity_ids and relationship scores.
-- LifeOS project: ~/Documents/Code/LifeOS (has CLAUDE.md with project conventions)
-- Other projects: ~/Documents/Code/
+- LifeOS project: {code_dir}/LifeOS (has CLAUDE.md with project conventions)
+- Other projects: {code_dir}/
 
 LIFEOS DATA ACCESS:
 You have LifeOS MCP tools for searching {user_name}'s personal data. Always use these
@@ -385,6 +385,7 @@ class ClaudeOrchestrator:
             "--append-system-prompt", _SYSTEM_PROMPT.format(
                 vault_path=settings.vault_path,
                 user_name=settings.user_name,
+                code_dir=settings.code_dir,
                 platform_desc="Linux server running Ubuntu" if platform.system() == "Linux" else "Mac Mini running macOS",
             ),
         ]

--- a/api/services/directory_resolver.py
+++ b/api/services/directory_resolver.py
@@ -23,15 +23,15 @@ _CODE_WORDS = ["script", "code", "function", "cron"]
 
 _HOME = os.path.expanduser("~")
 _VAULT_DIR = str(settings.vault_path)
-_LIFEOS_DIR = os.path.join(_HOME, "Documents", "Code", "LifeOS")
-_CODE_DIR = os.path.join(_HOME, "Documents", "Code")
+_CODE_DIR = os.path.expanduser(settings.code_dir)
+_LIFEOS_DIR = os.path.join(_CODE_DIR, "LifeOS")
 
 # Cache for scanned project directories
 _project_dirs: list[tuple[str, str]] | None = None
 
 
 def _scan_projects() -> list[tuple[str, str]]:
-    """Scan ~/Documents/Code/ for project directories. Returns (name_lower, full_path) sorted longest-name-first."""
+    """Scan code directory for project directories. Returns (name_lower, full_path) sorted longest-name-first."""
     global _project_dirs
     if _project_dirs is not None:
         return _project_dirs

--- a/config/settings.py
+++ b/config/settings.py
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
         description="ChromaDB server URL"
     )
 
+    # Code directory (parent directory containing LifeOS and other projects)
+    code_dir: str = Field(default="~/Code", alias="LIFEOS_CODE_DIR")
+
     # Server (port 8000 is canonical - keep in sync with scripts/server.sh)
     port: int = Field(default=8000, alias="LIFEOS_PORT")
     host: str = Field(default="0.0.0.0", alias="LIFEOS_HOST")

--- a/docs/guides/claude-code-orchestration.md
+++ b/docs/guides/claude-code-orchestration.md
@@ -59,7 +59,7 @@ These rarely need changing. The binary path matches the standard Claude Code ins
 
 After changing these values, restart the server:
 ```bash
-ssh <your-user>@<your-tailscale-ip> "cd ~/Documents/Code/LifeOS && ./scripts/server.sh restart"
+ssh <your-user>@<your-tailscale-ip> "cd ~/Code/LifeOS && ./scripts/server.sh restart"
 ```
 
 ---
@@ -100,9 +100,9 @@ The orchestrator picks the working directory based on keywords in your task:
 | Say this... | Claude works in... |
 |-------------|-------------------|
 | "edit the backlog", "update my journal" | `~/Notes 2025` (vault) |
-| "fix the lifeos server", "update sync" | `~/Documents/Code/LifeOS` |
-| "update the MyProject readme" | `~/Documents/Code/MyProject` |
-| "write a script", "create a cron job" | `~/Documents/Code` |
+| "fix the lifeos server", "update sync" | `~/Code/LifeOS` |
+| "update the MyProject readme" | `~/Code/MyProject` |
+| "write a script", "create a cron job" | `~/Code` |
 | anything else | `~` (home) |
 
 ### Plan Mode

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -24,6 +24,7 @@ Environment variables and configuration files for LifeOS.
 | `LIFEOS_PORT` | Server port | `8000` |
 | `LIFEOS_CHROMA_URL` | ChromaDB server URL | `http://localhost:8001` |
 | `LIFEOS_CHROMA_PATH` | ChromaDB data directory | `./data/chromadb` |
+| `LIFEOS_CODE_DIR` | Parent directory containing LifeOS and other projects | `~/Code` |
 
 ### LLM Backend
 

--- a/docs/specs/standards/testing-standards.md
+++ b/docs/specs/standards/testing-standards.md
@@ -38,14 +38,14 @@ Tests run on the server, not locally on the development machine. The virtual env
 
 ```bash
 # Run unit tests
-ssh <user>@<server-ip> "cd ~/Documents/Code/LifeOS && ./scripts/test.sh"
+ssh <user>@<server-ip> "cd ~/Code/LifeOS && ./scripts/test.sh"
 
 # Run a specific test file
-ssh <user>@<server-ip> "cd ~/Documents/Code/LifeOS && \
+ssh <user>@<server-ip> "cd ~/Code/LifeOS && \
   ~/.venvs/lifeos/bin/python -m pytest tests/test_task_manager.py -v --tb=short"
 
 # Run smoke tests (unit + critical browser)
-ssh <user>@<server-ip> "cd ~/Documents/Code/LifeOS && ./scripts/test.sh smoke"
+ssh <user>@<server-ip> "cd ~/Code/LifeOS && ./scripts/test.sh smoke"
 ```
 
 ## Test Naming
@@ -159,7 +159,7 @@ Option (a) is the default. Options (b) and (c) require explicit justification in
 `test_perf_benchmark.py` runs queries against a **live server**, collects perf traces, and validates answer quality. It is not part of the unit test suite.
 
 ```bash
-ssh <user>@<server-ip> "cd ~/Documents/Code/LifeOS && \
+ssh <user>@<server-ip> "cd ~/Code/LifeOS && \
   ~/.venvs/lifeos/bin/python -m pytest tests/test_perf_benchmark.py -v -s"
 ```
 

--- a/docs/specs/technical/observability.md
+++ b/docs/specs/technical/observability.md
@@ -62,7 +62,7 @@ curl http://localhost:8000/api/perf/traces/{trace_id} | jq
 
 ```bash
 # Run benchmarks (requires running server)
-ssh <user>@<server-ip> "cd ~/Documents/Code/LifeOS && ~/.venvs/lifeos/bin/python -m pytest tests/test_perf_benchmark.py -v -s"
+ssh <user>@<server-ip> "cd ~/Code/LifeOS && ~/.venvs/lifeos/bin/python -m pytest tests/test_perf_benchmark.py -v -s"
 ```
 
 Test queries and expected results are defined in `BENCHMARK_QUERIES` within the test file. Personal names/topics can be overridden via `tests/fixtures/benchmark_config.json` (gitignored).

--- a/scripts/apple_data_agent.sh
+++ b/scripts/apple_data_agent.sh
@@ -25,7 +25,7 @@ LIFEOS_DIR="${LIFEOS_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 PYTHON="${LIFEOS_DIR}/../.venvs/lifeos/bin/python"
 LINUX_SERVER="${LIFEOS_LINUX_HOST:?Set LIFEOS_LINUX_HOST to your Linux server IP}"
 LINUX_USER="${LIFEOS_LINUX_USER:-$USER}"
-LINUX_LIFEOS="/home/${LINUX_USER}/Documents/Code/LifeOS"
+LINUX_LIFEOS="${LIFEOS_LINUX_DIR:-/home/${LINUX_USER}/Code/LifeOS}"
 LOG_DIR="${LIFEOS_DIR}/logs"
 LOG_FILE="${LOG_DIR}/apple_agent_$(date +%Y%m%d_%H%M%S).log"
 

--- a/tests/test_directory_resolver.py
+++ b/tests/test_directory_resolver.py
@@ -36,20 +36,20 @@ class TestResolveWorkingDirectory:
         assert result != os.path.join(HOME, "Notes 2025")
 
     def test_lifeos_keywords(self):
-        assert self._resolve("fix the lifeos server") == os.path.join(HOME, "Documents", "Code", "LifeOS")
-        assert self._resolve("update the sync logic") == os.path.join(HOME, "Documents", "Code", "LifeOS")
-        assert self._resolve("change the telegram bot") == os.path.join(HOME, "Documents", "Code", "LifeOS")
-        assert self._resolve("check chromadb status") == os.path.join(HOME, "Documents", "Code", "LifeOS")
-        assert self._resolve("add an api endpoint") == os.path.join(HOME, "Documents", "Code", "LifeOS")
+        assert self._resolve("fix the lifeos server") == os.path.join(HOME, "Code", "LifeOS")
+        assert self._resolve("update the sync logic") == os.path.join(HOME, "Code", "LifeOS")
+        assert self._resolve("change the telegram bot") == os.path.join(HOME, "Code", "LifeOS")
+        assert self._resolve("check chromadb status") == os.path.join(HOME, "Code", "LifeOS")
+        assert self._resolve("add an api endpoint") == os.path.join(HOME, "Code", "LifeOS")
 
     def test_code_keywords(self):
-        code_dir = os.path.join(HOME, "Documents", "Code")
+        code_dir = os.path.join(HOME, "Code")
         assert self._resolve("write a script to automate") == code_dir
         assert self._resolve("create a cron job") == code_dir
 
     def test_code_word_boundary(self):
         """'code' should match as a word, not inside 'encode'."""
-        code_dir = os.path.join(HOME, "Documents", "Code")
+        code_dir = os.path.join(HOME, "Code")
         assert self._resolve("write some code") == code_dir
         # 'encode' contains 'code' but shouldn't match code keyword
         # (it would still match via word boundary since 'code' appears at end)
@@ -81,14 +81,14 @@ class TestResolveWorkingDirectory:
         mock_path_cls.return_value = mock_code_path
 
         # Patch str() on entries to return full paths
-        mock_entry1.__str__ = lambda self: f"{HOME}/Documents/Code/MyProject"
-        mock_entry2.__str__ = lambda self: f"{HOME}/Documents/Code/AnotherApp"
+        mock_entry1.__str__ = lambda self: f"{HOME}/Code/MyProject"
+        mock_entry2.__str__ = lambda self: f"{HOME}/Code/AnotherApp"
 
         # Need to also patch the entry str representation via the append
         mod._project_dirs = [
-            ("myproject", f"{HOME}/Documents/Code/MyProject"),
-            ("anotherapp", f"{HOME}/Documents/Code/AnotherApp"),
+            ("myproject", f"{HOME}/Code/MyProject"),
+            ("anotherapp", f"{HOME}/Code/AnotherApp"),
         ]
 
         result = mod.resolve_working_directory("update the myproject docs")
-        assert result == f"{HOME}/Documents/Code/MyProject"
+        assert result == f"{HOME}/Code/MyProject"


### PR DESCRIPTION
## Summary

Add configurable `LIFEOS_CODE_DIR` setting (default: `~/Code`) and update all hardcoded `~/Documents/Code` references. Prepares for moving the code folder from `~/Documents/Code` to `~/Code`.

- Add `LIFEOS_CODE_DIR` to `config/settings.py`, `.env.example`, and `configuration.md`
- Update `directory_resolver.py` and `claude_orchestrator.py` to use the setting
- Update `apple_data_agent.sh` to use `LIFEOS_LINUX_DIR` env var
- Update docs and tests to use `~/Code` paths

## Test plan

- [x] All 52 affected tests pass (directory resolver, web search, llm client, ask API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)