### PR TITLE
fix: Resolve synthesis round timeout and improve error logging

### DIFF
--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -272,13 +272,16 @@ async def run_agent_loop(
         messages.append({"role": "user", "content": list(tool_results)})
 
     else:
-        # Exhausted all tool rounds — force a final synthesis round without tools
+        # Exhausted all tool rounds — force a final synthesis round without tools.
+        # Use a longer timeout: the accumulated context from multiple tool rounds
+        # can be very large, and prompt processing alone may exceed the default timeout.
         print("[agent] Exhausted tool rounds, running synthesis round")
         try:
             async for event in client.astream(
                 messages,
                 system=system_prompt,
                 max_tokens=4096,
+                timeout=180,
             ):
                 if event["type"] == "text":
                     result.full_text += event["content"]
@@ -286,8 +289,9 @@ async def run_agent_loop(
                 elif event["type"] == "done":
                     _track_usage(event["usage"])
         except Exception as e:
-            print(f"[agent] Synthesis round error: {e}")
-            yield {"type": "text", "content": f"\n\n(Error during synthesis: {e})"}
+            error_msg = str(e) or f"{type(e).__name__} (no message)"
+            print(f"[agent] Synthesis round error: {error_msg}")
+            yield {"type": "text", "content": f"\n\n(Error during synthesis: {error_msg})"}
 
     print(f"[agent] Loop complete: {len(result.tool_calls_log)} tool calls, {len(result.full_text)}ch text")
     # Yield the final result

--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -291,6 +291,7 @@ class LocalLLMClient:
         max_tokens: int = 4096,
         tools: list[dict] | None = None,
         temperature: float | None = None,
+        timeout: float | None = None,
     ) -> AsyncGenerator[dict, None]:
         """Async streaming chat completion.
 
@@ -311,8 +312,10 @@ class LocalLLMClient:
         if tools:
             payload["tools"] = _anthropic_tools_to_openai(tools)
 
+        request_timeout = httpx.Timeout(timeout or self.timeout, connect=10.0) if timeout else None
         async with self.async_client.stream(
-            "POST", "/v1/chat/completions", json=payload
+            "POST", "/v1/chat/completions", json=payload,
+            **({"timeout": request_timeout} if request_timeout else {}),
         ) as resp:
             resp.raise_for_status()
             tool_calls_acc: dict[int, dict] = {}  # index -> accumulated tool call


### PR DESCRIPTION
## Summary
- Increased timeout for synthesis round from 90s to 180s — after 5 rounds of tool calls, the accumulated context (~13k tokens) exceeds the default httpx read timeout during llama-server prompt processing
- Improved error logging — exceptions with empty `str(e)` (like `httpx.ReadTimeout`) now log the exception type so failures are diagnosable

## Root Cause
When the agent exhausts all 5 tool rounds, the synthesis round fires with the full message history. At ~107 tokens/sec prompt processing, a 13k-token prompt takes ~125s — well beyond the 90s timeout. The httpx client closes the connection, llama-server cancels the task, and the exception surfaces as `Synthesis round error: ` (empty).

## Changes
- `api/services/agent_loop.py` — Pass `timeout=180` to synthesis `astream()` call; use `repr`-style error message when `str(e)` is empty
- `api/services/llm_client.py` — Add optional `timeout` parameter to `LocalLLMClient.astream()` for per-request timeout override

## Test plan
- [ ] Trigger synthesis round with large context and verify it completes within 180s
- [ ] Verify error message includes exception type on timeout

Split from #29 — timeout fix only, no sync stability changes.