### PR TITLE
feat: Crash-safe people merge, interaction dedup, and consistency verification

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -172,6 +172,14 @@ async def lifespan(app: FastAPI):
     """Manage application lifespan - startup and shutdown."""
     global _granola_processor, _omi_processor, _calendar_indexer, _people_v2_sync_thread, _telegram_listener, _reminder_scheduler, _job_queue
 
+    # Startup: Recover any incomplete merge operations
+    try:
+        from scripts.merge_people import recover_incomplete_merge
+        if recover_incomplete_merge():
+            logger.warning("Recovered incomplete merge operation on startup")
+    except Exception as e:
+        logger.error(f"Failed to check for incomplete merges: {e}")
+
     # Startup: Initialize and start Granola processor
     try:
         from api.services.granola_processor import GranolaProcessor

--- a/api/services/apple_photos_sync.py
+++ b/api/services/apple_photos_sync.py
@@ -356,7 +356,7 @@ class ApplePhotosSync:
                 source_type=SOURCE_TYPE_PHOTOS,
                 title="Photo",
                 source_link=f"photos://asset/{photo.uuid}",
-                source_id=photo.uuid,
+                source_id=f"{photo.uuid}:{photos_person.pk}",
             )
 
             # Check if interaction already exists
@@ -364,8 +364,9 @@ class ApplePhotosSync:
                 entity_id,
                 source_type=SOURCE_TYPE_PHOTOS,
             )
+            scoped_source_id = f"{photo.uuid}:{photos_person.pk}"
             already_exists = any(
-                i.source_id == photo.uuid for i in existing_interactions
+                i.source_id == scoped_source_id for i in existing_interactions
             )
             if not already_exists:
                 interaction_store.add(interaction)

--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -273,7 +273,7 @@ class InteractionStore:
                 if updated:
                     logger.info("Migration: scoped %d photos source_ids by person_id", updated)
 
-                # Deduplicate: keep earliest created_at per (source_type, source_id)
+                # Deduplicate: keep first-inserted row per (source_type, source_id)
                 deleted = conn.execute("""
                     DELETE FROM interactions
                     WHERE source_id IS NOT NULL

--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -187,14 +187,17 @@ class InteractionStore:
     Manages interaction records with efficient queries by person and time range.
     """
 
-    def __init__(self, db_path: Optional[str] = None):
+    def __init__(self, db_path: Optional[str] = None, strict: bool = True):
         """
         Initialize interaction store.
 
         Args:
             db_path: Path to SQLite database (default from settings)
+            strict: If True, validate person_id exists before inserting.
+                    Set False in tests that use fake person_ids.
         """
         self.db_path = db_path or get_interaction_db_path()
+        self._strict = strict
         self._init_db()
 
     def _init_db(self):
@@ -254,6 +257,44 @@ class InteractionStore:
                 conn.execute("ALTER TABLE interactions ADD COLUMN attendee_count INTEGER")
                 logger.info("Added attendee_count column to interactions table")
 
+            # Migration: Enforce UNIQUE(source_type, source_id) at the DB level
+            unique_idx_exists = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_interactions_source_unique'"
+            ).fetchone()
+            if not unique_idx_exists:
+                # Fix existing photos rows: scope source_id by person_id
+                updated = conn.execute("""
+                    UPDATE interactions
+                    SET source_id = source_id || ':' || person_id
+                    WHERE source_type = 'photos'
+                      AND source_id IS NOT NULL
+                      AND source_id NOT LIKE '%:%'
+                """).rowcount
+                if updated:
+                    logger.info("Migration: scoped %d photos source_ids by person_id", updated)
+
+                # Deduplicate: keep earliest created_at per (source_type, source_id)
+                deleted = conn.execute("""
+                    DELETE FROM interactions
+                    WHERE source_id IS NOT NULL
+                      AND rowid NOT IN (
+                          SELECT MIN(rowid)
+                          FROM interactions
+                          WHERE source_id IS NOT NULL
+                          GROUP BY source_type, source_id
+                      )
+                """).rowcount
+                if deleted:
+                    logger.info("Migration: removed %d duplicate interactions", deleted)
+
+                # Replace old non-unique index with UNIQUE index
+                conn.execute("DROP INDEX IF EXISTS idx_interactions_source")
+                conn.execute("""
+                    CREATE UNIQUE INDEX idx_interactions_source_unique
+                    ON interactions(source_type, source_id)
+                """)
+                logger.info("Migration: created UNIQUE index idx_interactions_source_unique")
+
             conn.commit()
             logger.info(f"Initialized interaction database at {self.db_path}")
         finally:
@@ -286,13 +327,19 @@ class InteractionStore:
         person_store = get_person_entity_store()
         resolved_person_id = person_store.get_canonical_id(interaction.person_id)
 
+        if self._strict and person_store.get_by_id(resolved_person_id) is None:
+            raise ValueError(
+                f"Cannot add interaction: person_id '{resolved_person_id}' does not exist"
+            )
+
         conn = self._get_connection()
         try:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 INSERT INTO interactions
                 (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(source_type, source_id) DO NOTHING
             """,
                 (
                     interaction.id,
@@ -306,6 +353,8 @@ class InteractionStore:
                     interaction.created_at.isoformat(),
                 ),
             )
+            if cursor.rowcount == 0 and interaction.source_id is not None:
+                logger.debug("Duplicate interaction skipped: %s/%s", interaction.source_type, interaction.source_id)
             conn.commit()
             # Update the interaction object with the resolved ID
             interaction.person_id = resolved_person_id

--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -205,6 +205,15 @@ SYNC_SOURCES = {
         "phase": 6,
         "depends_on": ["crm_vectorstore"],
     },
+
+    # === Phase 7: Consistency Verification ===
+    "consistency_verify": {
+        "description": "Cross-store data consistency verification and auto-fix",
+        "script": "scripts/sync_consistency_verify.py",
+        "frequency": "daily",
+        "phase": 7,
+        "depends_on": ["entity_cleanup"],
+    },
 }
 
 

--- a/scripts/merge_people.py
+++ b/scripts/merge_people.py
@@ -305,7 +305,7 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
                 primary.emails = []
             primary.emails.append(email)
             stats['emails_merged'] += 1
-            logger.info(f"   + Email: {email}")
+            logger.info("   + Email merged")
 
     # Merge phone numbers
     for phone in (secondary.phone_numbers or []):
@@ -314,7 +314,7 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
                 primary.phone_numbers = []
             primary.phone_numbers.append(phone)
             stats['phones_merged'] += 1
-            logger.info(f"   + Phone: {phone}")
+            logger.info("   + Phone merged")
 
     # Add secondary's name as alias
     if secondary.canonical_name and secondary.canonical_name != primary.canonical_name:
@@ -737,7 +737,23 @@ def recover_incomplete_merge() -> bool:
 
     store = get_person_entity_store()
     primary = store.get_by_id(primary_id)
-    secondary = store.get_by_id(secondary_id)
+
+    # IMPORTANT: Don't use get_by_id(secondary_id) — it follows the merge chain.
+    # If merged_person_ids.json was already written, get_by_id(secondary) resolves
+    # to the primary, causing a self-merge that deletes the primary.
+    # Instead: check if secondary_id is in the merge map. If so, it's logically gone.
+    merged_ids = load_merged_ids()
+    secondary_is_merged = secondary_id in merged_ids
+
+    if secondary_is_merged:
+        # The secondary was already recorded as merged. Check if its physical
+        # record still exists by doing a raw lookup (not following merge chain).
+        secondary_result = store.get_by_id(secondary_id)
+        # get_by_id follows chain, so if it returns the primary, secondary is gone
+        secondary_exists = secondary_result is not None and secondary_result.id == secondary_id
+    else:
+        secondary_result = store.get_by_id(secondary_id)
+        secondary_exists = secondary_result is not None
 
     if not primary:
         # Primary doesn't exist — can't recover meaningfully
@@ -745,7 +761,7 @@ def recover_incomplete_merge() -> bool:
         clear_merge_log()
         return False
 
-    if not secondary:
+    if not secondary_exists:
         # Secondary already deleted — merge was mostly/fully done.
         # Run post-merge cleanup and clear log.
         logger.info("Secondary already deleted — running cleanup steps only")

--- a/scripts/merge_people.py
+++ b/scripts/merge_people.py
@@ -18,6 +18,7 @@ import json
 import sqlite3
 import logging
 import argparse
+import uuid
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -32,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 # File to track merged person IDs for durability
 MERGED_IDS_FILE = Path(__file__).parent.parent / "data" / "merged_person_ids.json"
+# File to track in-progress merge for crash recovery
+MERGE_LOG_FILE = Path(__file__).parent.parent / "data" / "merge_log.json"
 
 
 def load_merged_ids() -> dict:
@@ -62,6 +65,66 @@ def save_merged_ids(merged_ids: dict):
         if os.path.exists(temp_path):
             os.unlink(temp_path)
         raise
+
+
+def write_merge_intent(primary_id: str, secondary_id: str):
+    """Write intent log for crash recovery. Atomic write like save_merged_ids()."""
+    import tempfile
+    import os
+
+    log = {
+        "operation": "merge",
+        "primary_id": primary_id,
+        "secondary_id": secondary_id,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "phase": "pending",
+    }
+    MERGE_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    temp_fd, temp_path = tempfile.mkstemp(suffix=".json", dir=MERGE_LOG_FILE.parent)
+    try:
+        with os.fdopen(temp_fd, "w") as f:
+            json.dump(log, f, indent=2)
+        import shutil
+        shutil.move(temp_path, MERGE_LOG_FILE)
+    except Exception:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+
+def update_merge_phase(phase: str):
+    """Atomically update the phase field in the merge intent log."""
+    import tempfile
+    import os
+
+    log = load_merge_log()
+    if log is None:
+        raise RuntimeError("No merge log to update")
+    log["phase"] = phase
+    temp_fd, temp_path = tempfile.mkstemp(suffix=".json", dir=MERGE_LOG_FILE.parent)
+    try:
+        with os.fdopen(temp_fd, "w") as f:
+            json.dump(log, f, indent=2)
+        import shutil
+        shutil.move(temp_path, MERGE_LOG_FILE)
+    except Exception:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+
+def load_merge_log() -> dict | None:
+    """Load the merge intent log, or None if absent."""
+    if MERGE_LOG_FILE.exists():
+        with open(MERGE_LOG_FILE) as f:
+            return json.load(f)
+    return None
+
+
+def clear_merge_log():
+    """Delete the merge intent log file."""
+    if MERGE_LOG_FILE.exists():
+        MERGE_LOG_FILE.unlink()
 
 
 def get_canonical_person_id(person_id: str) -> str:
@@ -160,6 +223,35 @@ def find_potential_duplicates() -> list:
                 })
 
     return duplicates
+
+
+def _merge_contexts_json(a_json: str | None, b_json: str | None) -> str:
+    """Merge two JSON-encoded context lists, deduplicating."""
+    a = json.loads(a_json) if a_json else []
+    b = json.loads(b_json) if b_json else []
+    merged = list(a)
+    for ctx in b:
+        if ctx not in merged:
+            merged.append(ctx)
+    return json.dumps(merged)
+
+
+def _earliest(a: str | None, b: str | None) -> str | None:
+    """Return the earlier of two ISO timestamp strings."""
+    if not a:
+        return b
+    if not b:
+        return a
+    return a if a < b else b
+
+
+def _latest(a: str | None, b: str | None) -> str | None:
+    """Return the later of two ISO timestamp strings."""
+    if not a:
+        return b
+    if not b:
+        return a
+    return a if a > b else b
 
 
 def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> dict:
@@ -282,228 +374,333 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
             stats['notes_merged'] = 1
             logger.info(f"   + Notes: copied from secondary")
 
-    # 2. Update interactions
-    logger.info("\n2. Updating interactions...")
+    if dry_run:
+        # Dry run: gather stats without modifying anything
+        # 2. Count interactions
+        logger.info("\n2. Counting interactions...")
+        interactions_db = get_interaction_db_path()
+        int_conn = sqlite3.connect(interactions_db)
+        ids_to_migrate = [canonical_secondary_id]
+        if secondary_id != canonical_secondary_id:
+            ids_to_migrate.append(secondary_id)
+        total_count = 0
+        for old_id in ids_to_migrate:
+            count = int_conn.execute(
+                "SELECT COUNT(*) FROM interactions WHERE person_id = ?", (old_id,)
+            ).fetchone()[0]
+            if count > 0:
+                logger.info(f"   {count} interactions to update for {old_id}")
+            total_count += count
+        stats['interactions_updated'] = total_count
+        logger.info(f"   Total: {total_count} interactions" if total_count else "   No interactions to update")
+        int_conn.close()
+
+        # 3. Count source entities / facts
+        crm_db = get_crm_db_path()
+        crm_conn = sqlite3.connect(crm_db)
+        stats['source_entities_updated'] = crm_conn.execute(
+            "SELECT COUNT(*) FROM source_entities WHERE canonical_person_id = ?",
+            (canonical_secondary_id,)
+        ).fetchone()[0]
+        logger.info(f"\n3. {stats['source_entities_updated']} source entities to update")
+        stats['facts_cleared'] = crm_conn.execute(
+            "SELECT COUNT(*) FROM person_facts WHERE person_id IN (?, ?)",
+            (canonical_primary_id, canonical_secondary_id)
+        ).fetchone()[0]
+        logger.info(f"4. {stats['facts_cleared']} facts to clear")
+
+        # 4. Count relationships
+        from api.services.relationship import get_relationship_store
+        rel_store = get_relationship_store()
+        secondary_rels = rel_store.get_for_person(canonical_secondary_id)
+        stats['relationships_updated'] = 0
+        stats['relationships_merged'] = 0
+        stats['relationships_deleted'] = 0
+        for rel in secondary_rels:
+            other_id = rel.other_person(canonical_secondary_id)
+            if not other_id:
+                continue
+            if other_id == canonical_primary_id:
+                stats['relationships_deleted'] += 1
+            elif rel_store.get_between(canonical_primary_id, other_id):
+                stats['relationships_merged'] += 1
+            else:
+                stats['relationships_updated'] += 1
+        logger.info(f"5. {len(secondary_rels)} relationships to process")
+        crm_conn.close()
+
+        logger.info(f"\n=== Merge Summary (DRY RUN) ===")
+        logger.info(f"Primary: {primary.canonical_name} ({canonical_primary_id})")
+        logger.info(f"Secondary: {secondary.canonical_name} ({canonical_secondary_id})")
+        logger.info(f"Interactions: {stats['interactions_updated']}")
+        logger.info(f"Source entities: {stats['source_entities_updated']}")
+        logger.info(f"Facts: {stats['facts_cleared']}")
+        logger.info(f"Relationships: {stats['relationships_updated']} transfer, {stats['relationships_merged']} merge, {stats['relationships_deleted']} delete")
+        logger.info(f"Emails: +{stats['emails_merged']}, Phones: +{stats['phones_merged']}, Aliases: +{stats['aliases_added']}")
+        logger.info("\nDRY RUN - no changes made. Use --execute to apply.")
+        return stats
+
+    # === EXECUTE PATH (crash-safe with intent log) ===
+
+    # Update last_seen/first_seen on in-memory primary before persisting
+    if secondary.last_seen:
+        if primary.last_seen is None or secondary.last_seen > primary.last_seen:
+            primary.last_seen = secondary.last_seen
+    if secondary.first_seen:
+        if primary.first_seen is None or secondary.first_seen < primary.first_seen:
+            primary.first_seen = secondary.first_seen
+
+    # Step 1: Write intent log
+    logger.info("\n2. Writing intent log...")
+    write_merge_intent(canonical_primary_id, canonical_secondary_id)
+
+    # Step 2: Update merged_person_ids.json (early — prevents sync from recreating dupes)
+    logger.info("\n3. Recording merge IDs...")
+    merged_ids = load_merged_ids()
+    merged_ids[secondary_id] = canonical_primary_id
+    if canonical_secondary_id != secondary_id:
+        merged_ids[canonical_secondary_id] = canonical_primary_id
+    save_merged_ids(merged_ids)
+    update_merge_phase("ids_written")
+    logger.info(f"   Recorded: {secondary_id} -> {canonical_primary_id}")
+
+    # Step 3: Update interactions.db
+    logger.info("\n4. Updating interactions...")
     interactions_db = get_interaction_db_path()
     int_conn = sqlite3.connect(interactions_db)
-
-    # Update interactions for both the canonical secondary ID AND the original secondary_id
-    # (in case they differ due to previous merges)
     ids_to_migrate = [canonical_secondary_id]
     if secondary_id != canonical_secondary_id:
         ids_to_migrate.append(secondary_id)
-
     total_count = 0
     for old_id in ids_to_migrate:
-        cursor = int_conn.execute(
-            "SELECT COUNT(*) FROM interactions WHERE person_id = ?",
-            (old_id,)
-        )
-        count = cursor.fetchone()[0]
+        count = int_conn.execute(
+            "SELECT COUNT(*) FROM interactions WHERE person_id = ?", (old_id,)
+        ).fetchone()[0]
         if count > 0:
             logger.info(f"   {count} interactions to update for {old_id}")
-            if not dry_run:
-                int_conn.execute(
-                    "UPDATE interactions SET person_id = ? WHERE person_id = ?",
-                    (canonical_primary_id, old_id)
-                )
-            total_count += count
-
+            int_conn.execute(
+                "UPDATE interactions SET person_id = ? WHERE person_id = ?",
+                (canonical_primary_id, old_id)
+            )
+        total_count += count
     stats['interactions_updated'] = total_count
     if total_count > 0:
+        int_conn.commit()
         logger.info(f"   Total: {total_count} interactions updated")
     else:
         logger.info(f"   No interactions to update")
-
-    if not dry_run:
-        int_conn.commit()
     int_conn.close()
+    update_merge_phase("interactions_done")
 
-    # 3. Update source entities
-    logger.info("\n3. Updating source entities...")
+    # Step 4: Single crm.db transaction
+    # Groups: source_entities, facts, relationships, person_entities update+delete
+    logger.info("\n5. Updating CRM database (single transaction)...")
     crm_db = get_crm_db_path()
     crm_conn = sqlite3.connect(crm_db)
+    crm_conn.execute("BEGIN IMMEDIATE")
 
-    cursor = crm_conn.execute(
-        "SELECT COUNT(*) FROM source_entities WHERE canonical_person_id = ?",
-        (canonical_secondary_id,)
-    )
-    count = cursor.fetchone()[0]
-    stats['source_entities_updated'] = count
-    logger.info(f"   {count} source entities to update")
-
-    if not dry_run and count > 0:
-        crm_conn.execute(
-            "UPDATE source_entities SET canonical_person_id = ? WHERE canonical_person_id = ?",
-            (canonical_primary_id, canonical_secondary_id)
+    try:
+        # 4a. Update source entities
+        cursor = crm_conn.execute(
+            "SELECT COUNT(*) FROM source_entities WHERE canonical_person_id = ?",
+            (canonical_secondary_id,)
         )
-        crm_conn.commit()
-
-    # 4. Clear facts (will be regenerated from combined interactions)
-    logger.info("\n4. Clearing facts for regeneration...")
-    cursor = crm_conn.execute(
-        "SELECT COUNT(*) FROM person_facts WHERE person_id IN (?, ?)",
-        (canonical_primary_id, canonical_secondary_id)
-    )
-    count = cursor.fetchone()[0]
-    stats['facts_cleared'] = count
-    logger.info(f"   {count} facts to clear (will regenerate from combined interactions)")
-
-    if not dry_run and count > 0:
-        crm_conn.execute(
-            "DELETE FROM person_facts WHERE person_id IN (?, ?)",
-            (canonical_primary_id, canonical_secondary_id)
-        )
-        crm_conn.commit()
-
-    crm_conn.close()
-
-    # 5. Merge relationships
-    logger.info("\n5. Merging relationships...")
-    stats['relationships_updated'] = 0
-    stats['relationships_merged'] = 0
-    stats['relationships_deleted'] = 0
-
-    from api.services.relationship import get_relationship_store, Relationship
-    rel_store = get_relationship_store()
-
-    # Get all relationships involving the secondary person
-    secondary_rels = rel_store.get_for_person(canonical_secondary_id)
-    logger.info(f"   {len(secondary_rels)} relationships to process")
-
-    for rel in secondary_rels:
-        # Find the "other" person in this relationship
-        other_id = rel.other_person(canonical_secondary_id)
-        if not other_id:
-            continue
-
-        # Skip if other person is the primary (self-relationship after merge)
-        if other_id == canonical_primary_id:
-            # Delete this relationship - it would be a self-loop
-            if not dry_run:
-                rel_store.delete(rel.id)
-            stats['relationships_deleted'] += 1
-            logger.info(f"   - Deleted self-loop relationship")
-            continue
-
-        # Check if primary already has a relationship with the other person
-        existing = rel_store.get_between(canonical_primary_id, other_id)
-
-        if existing:
-            # Merge relationship data into existing
-            existing.shared_events_count = (existing.shared_events_count or 0) + (rel.shared_events_count or 0)
-            existing.shared_threads_count = (existing.shared_threads_count or 0) + (rel.shared_threads_count or 0)
-            existing.shared_messages_count = (existing.shared_messages_count or 0) + (rel.shared_messages_count or 0)
-            existing.shared_whatsapp_count = (existing.shared_whatsapp_count or 0) + (rel.shared_whatsapp_count or 0)
-            existing.shared_slack_count = (existing.shared_slack_count or 0) + (rel.shared_slack_count or 0)
-            existing.shared_phone_calls_count = (existing.shared_phone_calls_count or 0) + (rel.shared_phone_calls_count or 0)
-
-            # Merge shared contexts
-            for ctx in (rel.shared_contexts or []):
-                if ctx not in (existing.shared_contexts or []):
-                    if existing.shared_contexts is None:
-                        existing.shared_contexts = []
-                    existing.shared_contexts.append(ctx)
-
-            # Update dates
-            if rel.first_seen_together:
-                if not existing.first_seen_together or rel.first_seen_together < existing.first_seen_together:
-                    existing.first_seen_together = rel.first_seen_together
-            if rel.last_seen_together:
-                if not existing.last_seen_together or rel.last_seen_together > existing.last_seen_together:
-                    existing.last_seen_together = rel.last_seen_together
-
-            # LinkedIn connection - true if either was connected
-            if rel.is_linkedin_connection:
-                existing.is_linkedin_connection = True
-
-            if not dry_run:
-                rel_store.update(existing)
-                rel_store.delete(rel.id)
-
-            stats['relationships_merged'] += 1
-            logger.info(f"   ~ Merged relationship with {other_id}")
-        else:
-            # Transfer relationship to primary - create new to trigger normalization
-            new_rel = Relationship(
-                person_a_id=canonical_primary_id if rel.person_a_id == canonical_secondary_id else rel.person_a_id,
-                person_b_id=canonical_primary_id if rel.person_b_id == canonical_secondary_id else rel.person_b_id,
-                relationship_type=rel.relationship_type,
-                shared_contexts=rel.shared_contexts,
-                shared_events_count=rel.shared_events_count,
-                shared_threads_count=rel.shared_threads_count,
-                shared_messages_count=rel.shared_messages_count,
-                shared_whatsapp_count=rel.shared_whatsapp_count,
-                shared_slack_count=rel.shared_slack_count,
-                shared_phone_calls_count=rel.shared_phone_calls_count,
-                is_linkedin_connection=rel.is_linkedin_connection,
-                first_seen_together=rel.first_seen_together,
-                last_seen_together=rel.last_seen_together,
+        stats['source_entities_updated'] = cursor.fetchone()[0]
+        if stats['source_entities_updated'] > 0:
+            crm_conn.execute(
+                "UPDATE source_entities SET canonical_person_id = ? WHERE canonical_person_id = ?",
+                (canonical_primary_id, canonical_secondary_id)
             )
+        logger.info(f"   Source entities: {stats['source_entities_updated']} updated")
 
-            if not dry_run:
-                rel_store.delete(rel.id)
-                rel_store.add(new_rel)
+        # 4b. Clear facts
+        cursor = crm_conn.execute(
+            "SELECT COUNT(*) FROM person_facts WHERE person_id IN (?, ?)",
+            (canonical_primary_id, canonical_secondary_id)
+        )
+        stats['facts_cleared'] = cursor.fetchone()[0]
+        if stats['facts_cleared'] > 0:
+            crm_conn.execute(
+                "DELETE FROM person_facts WHERE person_id IN (?, ?)",
+                (canonical_primary_id, canonical_secondary_id)
+            )
+        logger.info(f"   Facts cleared: {stats['facts_cleared']}")
 
-            stats['relationships_updated'] += 1
-            logger.info(f"   > Transferred relationship with {other_id}")
+        # 4c. Merge relationships (raw SQL within same transaction)
+        stats['relationships_updated'] = 0
+        stats['relationships_merged'] = 0
+        stats['relationships_deleted'] = 0
 
-    # 6. Save merge mapping for durability
-    logger.info("\n6. Recording merge for durability...")
-    if not dry_run:
-        merged_ids = load_merged_ids()
-        # Record both the original secondary_id and canonical_secondary_id pointing to canonical primary
-        # This ensures lookups for either ID resolve correctly
-        merged_ids[secondary_id] = canonical_primary_id
-        if canonical_secondary_id != secondary_id:
-            merged_ids[canonical_secondary_id] = canonical_primary_id
-        save_merged_ids(merged_ids)
-        logger.info(f"   Recorded: {secondary_id} -> {canonical_primary_id}")
+        # Read all secondary relationships
+        secondary_rels = crm_conn.execute(
+            "SELECT * FROM relationships WHERE person_a_id = ? OR person_b_id = ?",
+            (canonical_secondary_id, canonical_secondary_id)
+        ).fetchall()
+        col_names = [desc[0] for desc in crm_conn.execute("SELECT * FROM relationships LIMIT 0").description]
+        logger.info(f"   Relationships: {len(secondary_rels)} to process")
 
-    # 7. Update primary metadata and delete secondary
-    logger.info("\n7. Updating metadata and cleaning up...")
-    if not dry_run:
-        # Update last_seen to most recent
-        if secondary.last_seen:
-            if primary.last_seen is None or secondary.last_seen > primary.last_seen:
-                primary.last_seen = secondary.last_seen
+        for row in secondary_rels:
+            rel = dict(zip(col_names, row))
+            # Find the "other" person
+            if rel['person_a_id'] == canonical_secondary_id:
+                other_id = rel['person_b_id']
+            else:
+                other_id = rel['person_a_id']
 
-        # Update first_seen to earliest
-        if secondary.first_seen:
-            if primary.first_seen is None or secondary.first_seen < primary.first_seen:
-                primary.first_seen = secondary.first_seen
+            if other_id == canonical_primary_id:
+                # Self-loop — delete
+                crm_conn.execute("DELETE FROM relationships WHERE id = ?", (rel['id'],))
+                stats['relationships_deleted'] += 1
+                logger.info(f"   - Deleted self-loop relationship")
+                continue
 
-        # Save primary
-        store.update(primary)
+            # Normalize IDs for the primary-other pair
+            norm_a, norm_b = (canonical_primary_id, other_id) if canonical_primary_id < other_id else (other_id, canonical_primary_id)
 
-        # Delete secondary
-        store.delete(canonical_secondary_id)
+            existing = crm_conn.execute(
+                "SELECT * FROM relationships WHERE person_a_id = ? AND person_b_id = ?",
+                (norm_a, norm_b)
+            ).fetchone()
 
-        # Save store
-        store.save()
+            if existing:
+                ex = dict(zip(col_names, existing))
+                # Merge counts
+                now = datetime.now(timezone.utc).isoformat()
+                crm_conn.execute("""
+                    UPDATE relationships SET
+                        shared_events_count = ?,
+                        shared_threads_count = ?,
+                        shared_messages_count = ?,
+                        shared_whatsapp_count = ?,
+                        shared_slack_count = ?,
+                        shared_phone_calls_count = ?,
+                        shared_photos_count = ?,
+                        shared_contexts = ?,
+                        first_seen_together = ?,
+                        last_seen_together = ?,
+                        is_linkedin_connection = ?,
+                        updated_at = ?
+                    WHERE id = ?
+                """, (
+                    (ex.get('shared_events_count') or 0) + (rel.get('shared_events_count') or 0),
+                    (ex.get('shared_threads_count') or 0) + (rel.get('shared_threads_count') or 0),
+                    (ex.get('shared_messages_count') or 0) + (rel.get('shared_messages_count') or 0),
+                    (ex.get('shared_whatsapp_count') or 0) + (rel.get('shared_whatsapp_count') or 0),
+                    (ex.get('shared_slack_count') or 0) + (rel.get('shared_slack_count') or 0),
+                    (ex.get('shared_phone_calls_count') or 0) + (rel.get('shared_phone_calls_count') or 0),
+                    (ex.get('shared_photos_count') or 0) + (rel.get('shared_photos_count') or 0),
+                    _merge_contexts_json(ex.get('shared_contexts'), rel.get('shared_contexts')),
+                    _earliest(ex.get('first_seen_together'), rel.get('first_seen_together')),
+                    _latest(ex.get('last_seen_together'), rel.get('last_seen_together')),
+                    1 if (ex.get('is_linkedin_connection') or rel.get('is_linkedin_connection')) else 0,
+                    now,
+                    ex['id'],
+                ))
+                # Delete the secondary's relationship
+                crm_conn.execute("DELETE FROM relationships WHERE id = ?", (rel['id'],))
+                stats['relationships_merged'] += 1
+                logger.info(f"   ~ Merged relationship with {other_id}")
+            else:
+                # Transfer: delete old, insert new with primary ID
+                new_id = str(uuid.uuid4())
+                now = datetime.now(timezone.utc).isoformat()
+                crm_conn.execute("DELETE FROM relationships WHERE id = ?", (rel['id'],))
+                crm_conn.execute("""
+                    INSERT INTO relationships
+                    (id, person_a_id, person_b_id, relationship_type, shared_contexts,
+                     shared_events_count, shared_threads_count, first_seen_together,
+                     last_seen_together, created_at, updated_at,
+                     shared_messages_count, shared_whatsapp_count, shared_slack_count,
+                     is_linkedin_connection, shared_phone_calls_count, shared_photos_count)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (
+                    new_id, norm_a, norm_b,
+                    rel.get('relationship_type'),
+                    rel.get('shared_contexts'),
+                    rel.get('shared_events_count') or 0,
+                    rel.get('shared_threads_count') or 0,
+                    rel.get('first_seen_together'),
+                    rel.get('last_seen_together'),
+                    rel.get('created_at') or now,
+                    now,
+                    rel.get('shared_messages_count') or 0,
+                    rel.get('shared_whatsapp_count') or 0,
+                    rel.get('shared_slack_count') or 0,
+                    1 if rel.get('is_linkedin_connection') else 0,
+                    rel.get('shared_phone_calls_count') or 0,
+                    rel.get('shared_photos_count') or 0,
+                ))
+                stats['relationships_updated'] += 1
+                logger.info(f"   > Transferred relationship with {other_id}")
 
-        logger.info(f"   Deleted secondary record: {secondary.canonical_name}")
+        # 4d. INSERT OR REPLACE primary person entity
+        primary_values = store._entity_to_values(primary)
+        from api.services.person_entity import PersonEntityStore
+        crm_conn.execute(
+            f"INSERT OR REPLACE INTO person_entities ({PersonEntityStore._COLUMNS_STR}) "
+            f"VALUES ({PersonEntityStore._PLACEHOLDERS})",
+            primary_values
+        )
 
-        # Refresh stats from InteractionStore (the source of truth)
-        from api.services.person_stats import refresh_person_stats
-        logger.info("   Refreshing stats from InteractionStore...")
-        refresh_person_stats([canonical_primary_id])
+        # 4e. Update lookup tables for primary
+        crm_conn.execute("DELETE FROM person_emails WHERE person_id = ?", (canonical_primary_id,))
+        crm_conn.execute("DELETE FROM person_phones WHERE person_id = ?", (canonical_primary_id,))
+        crm_conn.execute("DELETE FROM person_names WHERE person_id = ?", (canonical_primary_id,))
+        for email in (primary.emails or []):
+            crm_conn.execute(
+                "INSERT OR REPLACE INTO person_emails (email, person_id) VALUES (?, ?)",
+                (email.lower(), canonical_primary_id))
+        for phone in (primary.phone_numbers or []):
+            if phone:
+                crm_conn.execute(
+                    "INSERT OR REPLACE INTO person_phones (phone, person_id) VALUES (?, ?)",
+                    (phone, canonical_primary_id))
+        if primary.canonical_name:
+            crm_conn.execute(
+                "INSERT OR REPLACE INTO person_names (name, person_id) VALUES (?, ?)",
+                (primary.canonical_name.lower(), canonical_primary_id))
+        for alias in (primary.aliases or []):
+            if alias:
+                crm_conn.execute(
+                    "INSERT OR REPLACE INTO person_names (name, person_id) VALUES (?, ?)",
+                    (alias.lower(), canonical_primary_id))
 
-        # Reload to get updated counts
-        primary = store.get_by_id(canonical_primary_id)
+        # 4f. Delete secondary person entity + lookup tables
+        crm_conn.execute("DELETE FROM person_emails WHERE person_id = ?", (canonical_secondary_id,))
+        crm_conn.execute("DELETE FROM person_phones WHERE person_id = ?", (canonical_secondary_id,))
+        crm_conn.execute("DELETE FROM person_names WHERE person_id = ?", (canonical_secondary_id,))
+        crm_conn.execute("DELETE FROM person_entities WHERE id = ?", (canonical_secondary_id,))
 
-    # 8. Recalculate relationship strength for primary
-    # (also updates is_peripheral_contact; dunbar_circle requires full recalc)
-    logger.info("\n8. Recalculating relationship strength...")
-    if not dry_run:
-        from api.services.relationship_metrics import update_strength_for_person
-        old_strength = primary.relationship_strength
-        new_strength = update_strength_for_person(canonical_primary_id)
-        if new_strength != old_strength:
-            logger.info(f"   Strength: {old_strength} -> {new_strength}")
-        else:
-            logger.info(f"   Strength unchanged: {new_strength}")
-        store.save()
+        crm_conn.commit()
+        logger.info("   CRM transaction committed")
+    except Exception:
+        crm_conn.rollback()
+        crm_conn.close()
+        raise
+    crm_conn.close()
+    update_merge_phase("crm_done")
+
+    logger.info(f"   Deleted secondary record: {secondary.canonical_name}")
+
+    # Step 5: Post-merge cleanup (stats refresh + relationship strength)
+    logger.info("\n6. Post-merge cleanup...")
+    from api.services.person_stats import refresh_person_stats
+    logger.info("   Refreshing stats from InteractionStore...")
+    refresh_person_stats([canonical_primary_id])
+
+    from api.services.relationship_metrics import update_strength_for_person
+    primary = store.get_by_id(canonical_primary_id)
+    old_strength = primary.relationship_strength if primary else None
+    new_strength = update_strength_for_person(canonical_primary_id)
+    if new_strength != old_strength:
+        logger.info(f"   Strength: {old_strength} -> {new_strength}")
+    else:
+        logger.info(f"   Strength unchanged: {new_strength}")
+
+    # Step 6: Clear intent log
+    update_merge_phase("complete")
+    clear_merge_log()
+    logger.info("   Intent log cleared")
 
     # Summary
     logger.info(f"\n=== Merge Summary ===")
@@ -517,10 +714,55 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
     logger.info(f"Phones merged: {stats['phones_merged']}")
     logger.info(f"Aliases added: {stats['aliases_added']}")
 
-    if dry_run:
-        logger.info("\nDRY RUN - no changes made. Use --execute to apply.")
-
     return stats
+
+
+def recover_incomplete_merge() -> bool:
+    """
+    Check for and recover an incomplete merge operation.
+
+    Returns True if a recovery was performed, False if nothing to recover.
+    """
+    log = load_merge_log()
+    if log is None:
+        return False
+
+    if log.get("phase") == "complete":
+        clear_merge_log()
+        return False
+
+    primary_id = log["primary_id"]
+    secondary_id = log["secondary_id"]
+    logger.warning(f"Found incomplete merge: {secondary_id} -> {primary_id} (phase: {log.get('phase')})")
+
+    store = get_person_entity_store()
+    primary = store.get_by_id(primary_id)
+    secondary = store.get_by_id(secondary_id)
+
+    if not primary:
+        # Primary doesn't exist — can't recover meaningfully
+        logger.error(f"Recovery failed: primary person {primary_id} not found")
+        clear_merge_log()
+        return False
+
+    if not secondary:
+        # Secondary already deleted — merge was mostly/fully done.
+        # Run post-merge cleanup and clear log.
+        logger.info("Secondary already deleted — running cleanup steps only")
+        try:
+            from api.services.person_stats import refresh_person_stats
+            refresh_person_stats([primary_id])
+            from api.services.relationship_metrics import update_strength_for_person
+            update_strength_for_person(primary_id)
+        except Exception as e:
+            logger.warning(f"Post-merge cleanup during recovery had issues: {e}")
+        clear_merge_log()
+        return True
+
+    # Both exist — re-run the full merge (all steps are idempotent)
+    logger.info("Re-running merge for crash recovery...")
+    merge_people(primary_id, secondary_id, dry_run=False)
+    return True
 
 
 def main():
@@ -530,7 +772,15 @@ def main():
     parser.add_argument('--execute', action='store_true', help='Actually apply changes')
     parser.add_argument('--list-duplicates', action='store_true', help='List potential duplicates')
     parser.add_argument('--search', help='Search for people by name/email/phone')
+    parser.add_argument('--recover', action='store_true', help='Recover an incomplete merge')
     args = parser.parse_args()
+
+    if args.recover:
+        if recover_incomplete_merge():
+            print("Recovery completed successfully.")
+        else:
+            print("No incomplete merge to recover.")
+        return
 
     if args.list_duplicates:
         duplicates = find_potential_duplicates()

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -25,6 +25,7 @@ from dotenv import load_dotenv
 load_dotenv(Path(__file__).parent.parent / ".env")
 
 import argparse
+import json
 import logging
 import signal
 import subprocess
@@ -128,6 +129,15 @@ def log_sync_summary_to_markdown(result: dict, trigger: str = "unknown"):
             error_short = error[:80] + "..." if len(error) > 80 else error
             lines.append(f"- {src}: {error_short}")
 
+    # Dependency-skipped sources
+    dep_skipped_sources = result.get("dep_skipped_sources", [])
+    if dep_skipped_sources:
+        lines.append("")
+        lines.append(f"**Skipped — dependency failed ({len(dep_skipped_sources)}):**")
+        for src in dep_skipped_sources:
+            failed_deps = result.get("results", {}).get(src, {}).get("failed_dependencies", [])
+            lines.append(f"- {src} (needs: {', '.join(failed_deps)})")
+
     # New records summary
     people_created = result.get("people_created", 0)
     interactions_created = result.get("interactions_created", 0)
@@ -183,6 +193,15 @@ def send_sync_summary_telegram(result: dict, trigger: str = "unknown"):
         for src in result.get("failed_sources", []):
             lines.append(f"  • {src}")
 
+    # Dependency-skipped sources
+    dep_skipped_sources = result.get("dep_skipped_sources", [])
+    if dep_skipped_sources:
+        lines.append("")
+        lines.append(f"*Skipped — dependency failed ({len(dep_skipped_sources)}):*")
+        for src in dep_skipped_sources:
+            failed_deps = result.get("results", {}).get(src, {}).get("failed_dependencies", [])
+            lines.append(f"  • {src} (needs: {', '.join(failed_deps)})")
+
     # New records summary
     people_created = result.get("people_created", 0)
     interactions_created = result.get("interactions_created", 0)
@@ -202,6 +221,19 @@ def send_sync_summary_telegram(result: dict, trigger: str = "unknown"):
             for src, count in interactions_by_src.items():
                 if count > 0:
                     lines.append(f"  • {src}: {count}")
+
+    # Consistency verification results
+    consistency = result.get("results", {}).get("consistency_verify", {})
+    if consistency.get("success") and not consistency.get("dry_run"):
+        total_issues = consistency.get("total_issues", 0)
+        total_fixed = consistency.get("total_fixed", 0)
+        if total_issues > 0:
+            lines.append("")
+            if consistency.get("auto_fix_skipped"):
+                lines.append(f"⚠️ *Data Issues:* {total_issues} found, {total_fixed} auto-fixed")
+                lines.append("  Manual review needed — threshold exceeded")
+            else:
+                lines.append(f"🔧 *Data Issues:* {total_issues} found, {total_fixed} auto-fixed")
 
     try:
         success = send_message("\n".join(lines))
@@ -325,6 +357,10 @@ SYNC_ORDER = [
     # === Phase 6: Post-Sync Cleanup ===
     # Clean up entity data quality issues after all other syncs
     "entity_cleanup",           # Auto-hide non-humans, queue duplicates for review
+
+    # === Phase 7: Consistency Verification ===
+    # Verify cross-store data consistency after all syncs complete
+    "consistency_verify",       # Check orphans, stale merged IDs, cached counts
 ]
 
 # Scripts that can be run directly
@@ -367,6 +403,9 @@ SYNC_SCRIPTS = {
 
     # Phase 6: Post-Sync Cleanup
     "entity_cleanup": ("scripts/sync_entity_cleanup.py", ["--execute"]),
+
+    # Phase 7: Consistency Verification
+    "consistency_verify": ("scripts/sync_consistency_verify.py", ["--execute"]),
 }
 
 # Per-source timeout overrides (seconds)
@@ -658,6 +697,15 @@ def _parse_sync_output(output: str) -> dict:
     )
     stats["updated"] = max(stats["updated"], stats["people_updated"])
 
+    # Parse consistency verification summary (Phase 7)
+    consistency_match = re.search(r"CONSISTENCY_SUMMARY:(\{.*\})", output)
+    if consistency_match:
+        try:
+            consistency_data = json.loads(consistency_match.group(1))
+            stats.update(consistency_data)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
     return stats
 
 
@@ -693,6 +741,7 @@ def run_all_syncs(
     sources = sources or SYNC_ORDER
     results = {}
     failed = []
+    dep_skipped = set()  # Sources skipped because a dependency failed
     start_time = datetime.now()
 
     # Check for disabled work integrations
@@ -768,6 +817,20 @@ def run_all_syncs(
                     results[source] = {"skipped": True, "reason": "recently_synced"}
                     continue
 
+        # Check if any dependency failed or was dependency-skipped
+        deps = source_info.get("depends_on", [])
+        if deps:
+            failed_deps = [d for d in deps if d in failed or d in dep_skipped]
+            if failed_deps:
+                logger.warning(f"Skipping {source}: dependency failed ({', '.join(failed_deps)})")
+                results[source] = {
+                    "skipped": True,
+                    "reason": "dependency_failed",
+                    "failed_dependencies": failed_deps,
+                }
+                dep_skipped.add(source)
+                continue
+
         success, stats = run_sync(source, dry_run=dry_run)
         results[source] = {"success": success, **stats}
 
@@ -782,6 +845,8 @@ def run_all_syncs(
     logger.info(f"Failed: {len(failed)}")
     if failed:
         logger.error(f"Failed sources: {', '.join(failed)}")
+    if dep_skipped:
+        logger.warning(f"Dependency-skipped sources: {', '.join(sorted(dep_skipped))}")
     logger.info("=" * 60)
 
     # Check overall health
@@ -835,6 +900,7 @@ def run_all_syncs(
         "source_entities_created": source_entities_created,
         "people_by_source": people_by_source,
         "interactions_by_source": interactions_by_source,
+        "dep_skipped_sources": sorted(dep_skipped),
     }
 
     # Exit maintenance mode now that sync is complete

--- a/scripts/sync_consistency_verify.py
+++ b/scripts/sync_consistency_verify.py
@@ -93,23 +93,27 @@ def _check_stale_merged_ids(valid_ids: set, store, dry_run: bool, fix_threshold:
         if canonical != pid and canonical in valid_ids:
             repoint_map[pid] = canonical
 
-    # Count interactions that can be re-pointed
+    # Count interactions that can be re-pointed (use temp table to avoid 999-var limit)
     count = 0
     if repoint_map:
-        placeholders = ','.join(['?'] * len(repoint_map))
+        conn.execute("CREATE TEMP TABLE stale_ids (old_id TEXT PRIMARY KEY, new_id TEXT)")
+        conn.executemany(
+            "INSERT INTO stale_ids (old_id, new_id) VALUES (?, ?)",
+            list(repoint_map.items())
+        )
         cursor = conn.execute(
-            f"SELECT COUNT(*) FROM interactions WHERE person_id IN ({placeholders})",
-            list(repoint_map.keys())
+            "SELECT COUNT(*) FROM interactions i "
+            "JOIN stale_ids s ON i.person_id = s.old_id"
         )
         count = cursor.fetchone()[0]
 
     fixed = 0
     if not dry_run and count > 0 and count <= fix_threshold:
-        for old_id, new_id in repoint_map.items():
-            conn.execute(
-                "UPDATE interactions SET person_id = ? WHERE person_id = ?",
-                (new_id, old_id)
-            )
+        conn.execute(
+            "UPDATE interactions SET person_id = ("
+            "  SELECT s.new_id FROM stale_ids s WHERE s.old_id = interactions.person_id"
+            ") WHERE person_id IN (SELECT old_id FROM stale_ids)"
+        )
         fixed = count
         conn.commit()
 
@@ -180,6 +184,7 @@ def _check_orphaned_crm_records(valid_ids: set, dry_run: bool, fix_threshold: in
                        OR NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = r.person_b_id)
                 )
             """)
+            total_fixed += rel_count
         if facts_count > 0:
             conn.execute("""
                 DELETE FROM person_facts WHERE id IN (
@@ -187,6 +192,7 @@ def _check_orphaned_crm_records(valid_ids: set, dry_run: bool, fix_threshold: in
                     WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = f.person_id)
                 )
             """)
+            total_fixed += facts_count
         if overrides_count > 0:
             try:
                 conn.execute("""
@@ -195,8 +201,9 @@ def _check_orphaned_crm_records(valid_ids: set, dry_run: bool, fix_threshold: in
                         WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = o.preferred_person_id)
                     )
                 """)
+                total_fixed += overrides_count
             except sqlite3.OperationalError:
-                pass
+                pass  # Table may not exist — don't count as fixed
         if se_count > 0:
             conn.execute("""
                 UPDATE source_entities
@@ -204,8 +211,8 @@ def _check_orphaned_crm_records(valid_ids: set, dry_run: bool, fix_threshold: in
                 WHERE canonical_person_id IS NOT NULL
                   AND NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = source_entities.canonical_person_id)
             """)
+            total_fixed += se_count
         conn.commit()
-        total_fixed = total_count
 
     conn.close()
     details = f"relationships={rel_count}, facts={facts_count}, overrides={overrides_count}, source_entities={se_count}"
@@ -224,6 +231,18 @@ def verify_consistency(dry_run: bool = True, fix_threshold: int = AUTO_FIX_THRES
         Dict with per-check results and totals.
     """
     valid_ids, store = _get_valid_person_ids()
+
+    if not valid_ids:
+        logger.error("valid_ids is empty — aborting consistency checks to prevent data loss")
+        return {
+            "person_stats_mismatches": {"count": 0, "fixed": 0, "details": "aborted: no valid person IDs"},
+            "orphaned_interactions": {"count": 0, "fixed": 0},
+            "stale_merged_ids": {"count": 0, "fixed": 0},
+            "orphaned_crm_records": {"count": 0, "fixed": 0},
+            "total_issues": 0,
+            "total_fixed": 0,
+            "auto_fix_skipped": False,
+        }
 
     # Person stats always fixes (threshold doesn't apply — it updates cached counts, not deletes)
     person_stats = _check_person_stats(dry_run)

--- a/scripts/sync_consistency_verify.py
+++ b/scripts/sync_consistency_verify.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+Post-sync consistency verification (Phase 7).
+
+Checks cross-store data consistency after all sync phases complete.
+Auto-fixes small issues, flags large ones for manual review.
+
+Checks performed:
+  1. Person stats — cached counts vs computed from interactions
+  2. Orphaned interactions — person_id not in PersonEntity store
+  3. Stale merged IDs — interactions pointing to merged person IDs
+  4. Orphaned CRM records — relationships, facts, overrides, source_entities
+     with invalid person_ids
+
+Usage:
+    python scripts/sync_consistency_verify.py --dry-run          # report only
+    python scripts/sync_consistency_verify.py --execute           # auto-fix below threshold
+    python scripts/sync_consistency_verify.py --execute --fix-threshold 20
+"""
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+logger = logging.getLogger(__name__)
+
+AUTO_FIX_THRESHOLD = 10
+
+
+def _get_valid_person_ids():
+    """Load valid person IDs from the PersonEntity store."""
+    from api.services.person_entity import get_person_entity_store
+    store = get_person_entity_store()
+    all_people = store.get_all(include_hidden=True, include_merged=True)
+    return {p.id for p in all_people}, store
+
+
+def _check_person_stats(dry_run: bool) -> dict:
+    """Check 1: Verify cached PersonEntity counts match computed counts."""
+    from api.services.person_stats import verify_person_stats
+    discrepancies = verify_person_stats(fix=not dry_run)
+    return {
+        "count": len(discrepancies),
+        "fixed": len(discrepancies) if not dry_run and discrepancies else 0,
+        "details": f"{len(discrepancies)} mismatched" if discrepancies else "all consistent",
+    }
+
+
+def _check_orphaned_interactions(valid_ids: set, dry_run: bool, fix_threshold: int) -> dict:
+    """Check 2: Find interactions whose person_id is not in PersonEntity store."""
+    from api.services.interaction_store import get_interaction_db_path
+    conn = sqlite3.connect(get_interaction_db_path(), timeout=60.0)
+
+    # Create temp table for efficient lookup
+    conn.execute("CREATE TEMP TABLE valid_ids (id TEXT PRIMARY KEY)")
+    conn.executemany("INSERT INTO valid_ids (id) VALUES (?)", [(id,) for id in valid_ids])
+
+    cursor = conn.execute("""
+        SELECT COUNT(*) FROM interactions i
+        WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = i.person_id)
+    """)
+    count = cursor.fetchone()[0]
+
+    fixed = 0
+    if not dry_run and count > 0 and count <= fix_threshold:
+        conn.execute("""
+            DELETE FROM interactions
+            WHERE person_id NOT IN (SELECT id FROM valid_ids)
+        """)
+        fixed = count
+        conn.commit()
+
+    conn.close()
+    return {"count": count, "fixed": fixed}
+
+
+def _check_stale_merged_ids(valid_ids: set, store, dry_run: bool, fix_threshold: int) -> dict:
+    """Check 3: Find interactions pointing to merged (old) person IDs that can be re-pointed."""
+    from api.services.interaction_store import get_interaction_db_path
+    conn = sqlite3.connect(get_interaction_db_path(), timeout=60.0)
+
+    cursor = conn.execute("SELECT DISTINCT person_id FROM interactions")
+    all_interaction_pids = {row[0] for row in cursor.fetchall()}
+
+    stale_ids = all_interaction_pids - valid_ids
+    repoint_map = {}
+    for pid in stale_ids:
+        canonical = store.get_canonical_id(pid)
+        if canonical != pid and canonical in valid_ids:
+            repoint_map[pid] = canonical
+
+    # Count interactions that can be re-pointed
+    count = 0
+    if repoint_map:
+        placeholders = ','.join(['?'] * len(repoint_map))
+        cursor = conn.execute(
+            f"SELECT COUNT(*) FROM interactions WHERE person_id IN ({placeholders})",
+            list(repoint_map.keys())
+        )
+        count = cursor.fetchone()[0]
+
+    fixed = 0
+    if not dry_run and count > 0 and count <= fix_threshold:
+        for old_id, new_id in repoint_map.items():
+            conn.execute(
+                "UPDATE interactions SET person_id = ? WHERE person_id = ?",
+                (new_id, old_id)
+            )
+        fixed = count
+        conn.commit()
+
+    conn.close()
+    return {"count": count, "fixed": fixed}
+
+
+def _check_orphaned_crm_records(valid_ids: set, dry_run: bool, fix_threshold: int) -> dict:
+    """Check 4: Find orphaned relationships, facts, overrides, source_entities in CRM DB."""
+    from config.settings import settings
+    crm_path = Path(settings.chroma_path).parent / "crm.db"
+    if not crm_path.exists():
+        return {"count": 0, "fixed": 0, "details": "crm.db not found"}
+
+    conn = sqlite3.connect(str(crm_path), timeout=60.0)
+
+    # Create temp table
+    conn.execute("CREATE TEMP TABLE valid_ids (id TEXT PRIMARY KEY)")
+    conn.executemany("INSERT INTO valid_ids (id) VALUES (?)", [(id,) for id in valid_ids])
+
+    total_count = 0
+    total_fixed = 0
+
+    # Orphaned relationships
+    cursor = conn.execute("""
+        SELECT COUNT(*) FROM relationships r
+        WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = r.person_a_id)
+           OR NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = r.person_b_id)
+    """)
+    rel_count = cursor.fetchone()[0]
+    total_count += rel_count
+
+    # Orphaned person_facts
+    cursor = conn.execute("""
+        SELECT COUNT(*) FROM person_facts f
+        WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = f.person_id)
+    """)
+    facts_count = cursor.fetchone()[0]
+    total_count += facts_count
+
+    # Orphaned link_overrides
+    try:
+        cursor = conn.execute("""
+            SELECT COUNT(*) FROM link_overrides o
+            WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = o.preferred_person_id)
+        """)
+        overrides_count = cursor.fetchone()[0]
+        total_count += overrides_count
+    except sqlite3.OperationalError:
+        overrides_count = 0  # Table may not exist
+
+    # Source entities with invalid canonical_person_id
+    cursor = conn.execute("""
+        SELECT COUNT(*) FROM source_entities s
+        WHERE s.canonical_person_id IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = s.canonical_person_id)
+    """)
+    se_count = cursor.fetchone()[0]
+    total_count += se_count
+
+    # Auto-fix if below threshold
+    if not dry_run and total_count > 0 and total_count <= fix_threshold:
+        if rel_count > 0:
+            conn.execute("""
+                DELETE FROM relationships WHERE id IN (
+                    SELECT r.id FROM relationships r
+                    WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = r.person_a_id)
+                       OR NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = r.person_b_id)
+                )
+            """)
+        if facts_count > 0:
+            conn.execute("""
+                DELETE FROM person_facts WHERE id IN (
+                    SELECT f.id FROM person_facts f
+                    WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = f.person_id)
+                )
+            """)
+        if overrides_count > 0:
+            try:
+                conn.execute("""
+                    DELETE FROM link_overrides WHERE id IN (
+                        SELECT o.id FROM link_overrides o
+                        WHERE NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = o.preferred_person_id)
+                    )
+                """)
+            except sqlite3.OperationalError:
+                pass
+        if se_count > 0:
+            conn.execute("""
+                UPDATE source_entities
+                SET canonical_person_id = NULL, link_status = 'auto'
+                WHERE canonical_person_id IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM valid_ids v WHERE v.id = source_entities.canonical_person_id)
+            """)
+        conn.commit()
+        total_fixed = total_count
+
+    conn.close()
+    details = f"relationships={rel_count}, facts={facts_count}, overrides={overrides_count}, source_entities={se_count}"
+    return {"count": total_count, "fixed": total_fixed, "details": details}
+
+
+def verify_consistency(dry_run: bool = True, fix_threshold: int = AUTO_FIX_THRESHOLD) -> dict:
+    """
+    Run all consistency checks.
+
+    Args:
+        dry_run: If True, only report issues without fixing.
+        fix_threshold: Max issues per check to auto-fix. Above this, skip fixes.
+
+    Returns:
+        Dict with per-check results and totals.
+    """
+    valid_ids, store = _get_valid_person_ids()
+
+    # Person stats always fixes (threshold doesn't apply — it updates cached counts, not deletes)
+    person_stats = _check_person_stats(dry_run)
+    orphaned_interactions = _check_orphaned_interactions(valid_ids, dry_run, fix_threshold)
+    stale_merged_ids = _check_stale_merged_ids(valid_ids, store, dry_run, fix_threshold)
+    orphaned_crm_records = _check_orphaned_crm_records(valid_ids, dry_run, fix_threshold)
+
+    total_issues = (
+        person_stats["count"] +
+        orphaned_interactions["count"] +
+        stale_merged_ids["count"] +
+        orphaned_crm_records["count"]
+    )
+    total_fixed = (
+        person_stats["fixed"] +
+        orphaned_interactions["fixed"] +
+        stale_merged_ids["fixed"] +
+        orphaned_crm_records["fixed"]
+    )
+
+    auto_fix_skipped = any(
+        check["count"] > fix_threshold and check["count"] > 0
+        for check in [orphaned_interactions, stale_merged_ids, orphaned_crm_records]
+    )
+
+    return {
+        "person_stats_mismatches": person_stats,
+        "orphaned_interactions": orphaned_interactions,
+        "stale_merged_ids": stale_merged_ids,
+        "orphaned_crm_records": orphaned_crm_records,
+        "total_issues": total_issues,
+        "total_fixed": total_fixed,
+        "auto_fix_skipped": auto_fix_skipped,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Post-sync consistency verification")
+    parser.add_argument("--dry-run", action="store_true", help="Report only, no fixes")
+    parser.add_argument("--execute", action="store_true", help="Apply auto-fixes below threshold")
+    parser.add_argument("--fix-threshold", type=int, default=AUTO_FIX_THRESHOLD,
+                        help=f"Max issues per check to auto-fix (default: {AUTO_FIX_THRESHOLD})")
+    args = parser.parse_args()
+
+    dry_run = args.dry_run or not args.execute
+    if not args.execute and not args.dry_run:
+        print("Note: Running in dry-run mode. Use --execute to apply fixes.")
+
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
+
+    result = verify_consistency(dry_run=dry_run, fix_threshold=args.fix_threshold)
+
+    # Print summary for _parse_sync_output() and human readability
+    print(f"\n=== Consistency Verification ===")
+    print(f"Person stats mismatches: {result['person_stats_mismatches']['count']}")
+    print(f"Orphaned interactions: {result['orphaned_interactions']['count']}")
+    print(f"Stale merged IDs: {result['stale_merged_ids']['count']}")
+    print(f"Orphaned CRM records: {result['orphaned_crm_records']['count']}")
+    if result['orphaned_crm_records'].get('details'):
+        print(f"  ({result['orphaned_crm_records']['details']})")
+    print(f"Total issues: {result['total_issues']}")
+    print(f"Total fixed: {result['total_fixed']}")
+    if result['auto_fix_skipped']:
+        print(f"WARNING: Some checks exceeded fix threshold ({args.fix_threshold}), manual review needed")
+
+    if result['total_issues'] == 0:
+        print("All stores consistent.")
+
+    # Machine-readable summary for run_all_syncs.py parsing
+    import json
+    summary = {
+        "total_issues": result["total_issues"],
+        "total_fixed": result["total_fixed"],
+        "auto_fix_skipped": result["auto_fix_skipped"],
+    }
+    print(f"CONSISTENCY_SUMMARY:{json.dumps(summary)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/scripts/sync_imessage_interactions.py
+++ b/scripts/sync_imessage_interactions.py
@@ -224,7 +224,7 @@ def sync_imessage_interactions(dry_run: bool = True, limit: int = None) -> dict:
 def _insert_batch(conn: sqlite3.Connection, batch: list):
     """Insert a batch of interactions."""
     conn.executemany("""
-        INSERT INTO interactions (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
+        INSERT OR IGNORE INTO interactions (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     """, batch)
 

--- a/scripts/sync_whatsapp.py
+++ b/scripts/sync_whatsapp.py
@@ -81,6 +81,14 @@ def extract_phone_from_jid(jid: str) -> str:
     return normalize_phone(phone_part)
 
 
+def resolve_lid_phone(lid_jid: str, lid_phones: dict[str, str]) -> str:
+    """Look up phone number for a LID JID via the whatsmeow lid_map."""
+    if not lid_jid or '@lid' not in lid_jid:
+        return ""
+    bare = lid_jid.split('@')[0].split(':')[0]  # strip @lid and :N suffix
+    return lid_phones.get(bare, "")
+
+
 def is_group_jid(jid: str) -> bool:
     """
     Check if JID is a group chat.
@@ -331,6 +339,7 @@ def sync_whatsapp_messages(dry_run: bool = True) -> dict:
         'interactions_skipped': 0,
         'skipped_lid': 0,
         'resolved_lid': 0,
+        'resolved_lid_phone': 0,
         'skipped_large_group': 0,
         'outgoing_group_created': 0,
         'persons_not_found': 0,
@@ -394,6 +403,21 @@ def sync_whatsapp_messages(dry_run: bool = True) -> dict:
     """)
     lid_names = {row['jid']: row['push_name'] for row in wacli_cursor.fetchall()}
     logger.info(f"Loaded {len(lid_names)} LID push_names")
+
+    # Load LID-to-phone mappings from whatsmeow session database
+    lid_phones: dict[str, str] = {}
+    session_db_path = Path.home() / ".wacli" / "session.db"
+    if session_db_path.exists():
+        try:
+            session_conn = sqlite3.connect(f"file:{session_db_path}?mode=ro", uri=True)
+            for row in session_conn.execute("SELECT lid, pn FROM whatsmeow_lid_map"):
+                phone = normalize_phone(row[1])
+                if phone:
+                    lid_phones[row[0]] = phone
+            session_conn.close()
+            logger.info(f"Loaded {len(lid_phones)} LID-to-phone mappings")
+        except Exception as e:
+            logger.warning(f"Could not load LID phone map: {e}")
 
     # Build group -> participant list for outgoing group fan-out
     wacli_cursor.execute("SELECT group_jid, user_jid FROM group_participants")
@@ -487,9 +511,12 @@ def sync_whatsapp_messages(dry_run: bool = True) -> dict:
                     p_phone = None
                     p_name = None
                     if '@lid' in participant_jid:
+                        p_phone = resolve_lid_phone(participant_jid, lid_phones)
                         p_name = lid_names.get(participant_jid)
-                        if not p_name:
+                        if not p_phone and not p_name:
                             continue
+                        if p_phone:
+                            stats['resolved_lid_phone'] += 1
                     else:
                         p_phone = extract_phone_from_jid(participant_jid)
                         if not p_phone:
@@ -538,13 +565,21 @@ def sync_whatsapp_messages(dry_run: bool = True) -> dict:
             # Resolve target: by phone for @s.whatsapp.net, by name for @lid
             phone = None
             if target_jid and '@lid' in target_jid:
-                push_name = lid_names.get(target_jid)
-                if push_name:
-                    target_name = push_name
-                    stats['resolved_lid'] += 1
+                lid_phone = resolve_lid_phone(target_jid, lid_phones)
+                if lid_phone:
+                    phone = lid_phone
+                    push_name = lid_names.get(target_jid)
+                    if push_name:
+                        target_name = push_name
+                    stats['resolved_lid_phone'] += 1
                 else:
-                    stats['skipped_lid'] += 1
-                    continue
+                    push_name = lid_names.get(target_jid)
+                    if push_name:
+                        target_name = push_name
+                        stats['resolved_lid'] += 1
+                    else:
+                        stats['skipped_lid'] += 1
+                        continue
             else:
                 phone = extract_phone_from_jid(target_jid)
                 if not phone:
@@ -586,7 +621,7 @@ def sync_whatsapp_messages(dry_run: bool = True) -> dict:
             # Insert in batches
             if len(batch) >= batch_size and not dry_run:
                 int_cursor.executemany("""
-                    INSERT INTO interactions (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
+                    INSERT OR IGNORE INTO interactions (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, batch)
                 int_conn.commit()
@@ -600,7 +635,7 @@ def sync_whatsapp_messages(dry_run: bool = True) -> dict:
     # Insert remaining batch
     if batch and not dry_run:
         int_cursor.executemany("""
-            INSERT INTO interactions (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
+            INSERT OR IGNORE INTO interactions (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, batch)
         int_conn.commit()
@@ -614,6 +649,7 @@ def sync_whatsapp_messages(dry_run: bool = True) -> dict:
     logger.info(f"Messages read: {stats['messages_read']}")
     logger.info(f"Interactions created: {stats['interactions_created']}")
     logger.info(f"Interactions skipped (duplicates): {stats['interactions_skipped']}")
+    logger.info(f"LID resolved by phone: {stats['resolved_lid_phone']}")
     logger.info(f"Resolved LID by push_name: {stats['resolved_lid']}")
     logger.info(f"Skipped (LID without push_name): {stats['skipped_lid']}")
     logger.info(f"Outgoing group interactions: {stats['outgoing_group_created']}")

--- a/tests/test_briefings_service.py
+++ b/tests/test_briefings_service.py
@@ -29,7 +29,7 @@ def temp_entity_store(tmp_path):
 def temp_interaction_store():
     """Create a temporary interaction store."""
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-        store = InteractionStore(f.name)
+        store = InteractionStore(f.name, strict=False)
         yield store
         Path(f.name).unlink(missing_ok=True)
 

--- a/tests/test_consistency_verify.py
+++ b/tests/test_consistency_verify.py
@@ -1,0 +1,422 @@
+"""Tests for post-sync consistency verification (Phase 7)."""
+import json
+import sqlite3
+import tempfile
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from api.services.person_entity import PersonEntity
+
+
+def _create_interaction_db(db_path: str, interactions: list[tuple]) -> None:
+    """Create a test interactions database with given rows."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS interactions (
+            id TEXT PRIMARY KEY,
+            person_id TEXT,
+            timestamp TEXT,
+            source_type TEXT,
+            title TEXT,
+            snippet TEXT,
+            source_link TEXT,
+            source_id TEXT,
+            created_at TEXT
+        )
+    """)
+    conn.executemany("""
+        INSERT INTO interactions (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, interactions)
+    conn.commit()
+    conn.close()
+
+
+def _create_crm_db(db_path: str, *, relationships=None, facts=None, overrides=None, source_entities=None) -> None:
+    """Create a test CRM database with given rows."""
+    conn = sqlite3.connect(db_path)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS relationships (
+            id TEXT PRIMARY KEY,
+            person_a_id TEXT NOT NULL,
+            person_b_id TEXT NOT NULL,
+            relationship_type TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS person_facts (
+            id TEXT PRIMARY KEY,
+            person_id TEXT NOT NULL,
+            category TEXT NOT NULL,
+            key TEXT NOT NULL,
+            value TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS link_overrides (
+            id TEXT PRIMARY KEY,
+            name_pattern TEXT NOT NULL,
+            source_type TEXT,
+            context_pattern TEXT,
+            preferred_person_id TEXT NOT NULL,
+            rejected_person_id TEXT,
+            reason TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS source_entities (
+            id TEXT PRIMARY KEY,
+            source_type TEXT NOT NULL,
+            source_id TEXT,
+            canonical_person_id TEXT,
+            link_status TEXT DEFAULT 'auto'
+        )
+    """)
+
+    if relationships:
+        conn.executemany(
+            "INSERT INTO relationships (id, person_a_id, person_b_id, relationship_type) VALUES (?, ?, ?, ?)",
+            relationships
+        )
+    if facts:
+        conn.executemany(
+            "INSERT INTO person_facts (id, person_id, category, key, value) VALUES (?, ?, ?, ?, ?)",
+            facts
+        )
+    if overrides:
+        conn.executemany(
+            "INSERT INTO link_overrides (id, name_pattern, preferred_person_id) VALUES (?, ?, ?)",
+            overrides
+        )
+    if source_entities:
+        conn.executemany(
+            "INSERT INTO source_entities (id, source_type, canonical_person_id, link_status) VALUES (?, ?, ?, ?)",
+            source_entities
+        )
+
+    conn.commit()
+    conn.close()
+
+
+def _make_person(id: str, name: str) -> PersonEntity:
+    """Create a minimal PersonEntity."""
+    return PersonEntity(
+        id=id,
+        canonical_name=name,
+        emails=[],
+    )
+
+
+def _mock_store(people: list[PersonEntity], merged_ids: dict = None):
+    """Create a mock PersonEntityStore."""
+    store = MagicMock()
+    store.get_all.return_value = people
+    merged = merged_ids or {}
+    store.get_canonical_id.side_effect = lambda pid: merged.get(pid, pid)
+    return store
+
+
+class TestNoIssuesCleanState:
+    """When data is consistent, all checks return zeros."""
+
+    def test_no_issues_clean_state(self, tmp_path):
+        people = [_make_person("p1", "Alice"), _make_person("p2", "Bob")]
+        valid_ids = {"p1", "p2"}
+        mock_store = _mock_store(people)
+
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Email", "", "", "src1", "2024-01-01"),
+            ("i2", "p2", "2024-01-01", "calendar", "Meeting", "", "", "src2", "2024-01-01"),
+        ])
+
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db,
+            relationships=[("r1", "p1", "p2", "colleague")],
+            facts=[("f1", "p1", "work", "role", "Engineer")],
+            source_entities=[("se1", "gmail", "p1", "confirmed")],
+        )
+
+        with patch("scripts.sync_consistency_verify._get_valid_person_ids", return_value=(valid_ids, mock_store)), \
+             patch("scripts.sync_consistency_verify._check_person_stats", return_value={"count": 0, "fixed": 0}), \
+             patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db), \
+             patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import (
+                _check_orphaned_interactions,
+                _check_stale_merged_ids,
+                _check_orphaned_crm_records,
+            )
+
+            result_oi = _check_orphaned_interactions(valid_ids, dry_run=True, fix_threshold=10)
+            result_sm = _check_stale_merged_ids(valid_ids, mock_store, dry_run=True, fix_threshold=10)
+            result_crm = _check_orphaned_crm_records(valid_ids, dry_run=True, fix_threshold=10)
+
+            assert result_oi["count"] == 0
+            assert result_sm["count"] == 0
+            assert result_crm["count"] == 0
+
+
+class TestDetectsOrphanedInteractions:
+    """Finds interactions with person_id not in PersonEntity store."""
+
+    def test_detects_orphaned_interactions(self, tmp_path):
+        valid_ids = {"p1"}
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Valid", "", "", "src1", "2024-01-01"),
+            ("i2", "p_gone", "2024-01-01", "gmail", "Orphan1", "", "", "src2", "2024-01-01"),
+            ("i3", "p_gone2", "2024-01-01", "calendar", "Orphan2", "", "", "src3", "2024-01-01"),
+        ])
+
+        mock_store = _mock_store([_make_person("p1", "Alice")])
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_orphaned_interactions
+            result = _check_orphaned_interactions(valid_ids, dry_run=True, fix_threshold=10)
+
+        assert result["count"] == 2
+        assert result["fixed"] == 0
+
+
+class TestDetectsStaleMergedIds:
+    """Finds interactions pointing to merged person_ids that can be re-pointed."""
+
+    def test_detects_stale_merged_ids(self, tmp_path):
+        valid_ids = {"p1", "p2"}
+        merged_ids = {"p_old": "p1"}  # p_old was merged into p1
+        mock_store = _mock_store(
+            [_make_person("p1", "Alice"), _make_person("p2", "Bob")],
+            merged_ids=merged_ids,
+        )
+
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Valid", "", "", "src1", "2024-01-01"),
+            ("i2", "p_old", "2024-01-01", "gmail", "Stale", "", "", "src2", "2024-01-01"),
+            ("i3", "p_old", "2024-01-01", "calendar", "Stale2", "", "", "src3", "2024-01-01"),
+        ])
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_stale_merged_ids
+            result = _check_stale_merged_ids(valid_ids, mock_store, dry_run=True, fix_threshold=10)
+
+        assert result["count"] == 2
+        assert result["fixed"] == 0
+
+
+class TestDetectsOrphanedRelationships:
+    """Finds CRM records with invalid person_ids."""
+
+    def test_detects_orphaned_relationships(self, tmp_path):
+        valid_ids = {"p1", "p2"}
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db,
+            relationships=[
+                ("r1", "p1", "p2", "colleague"),       # valid
+                ("r2", "p1", "p_gone", "friend"),       # orphaned
+                ("r3", "p_gone2", "p2", "family"),      # orphaned
+            ],
+            facts=[
+                ("f1", "p1", "work", "role", "Engineer"),  # valid
+                ("f2", "p_gone", "work", "role", "PM"),     # orphaned
+            ],
+        )
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_orphaned_crm_records
+            result = _check_orphaned_crm_records(valid_ids, dry_run=True, fix_threshold=10)
+
+        # r2: p1 valid, p_gone invalid → orphaned
+        # r3: p_gone2 invalid, p2 valid → orphaned
+        # f2: p_gone invalid → orphaned
+        # Total: 2 relationships + 1 fact = 3
+        assert result["count"] == 3
+        assert result["fixed"] == 0
+
+
+class TestAutoFixesBelowThreshold:
+    """Fixes applied when count <= threshold."""
+
+    def test_auto_fixes_below_threshold(self, tmp_path):
+        valid_ids = {"p1"}
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Valid", "", "", "src1", "2024-01-01"),
+            ("i2", "p_gone", "2024-01-01", "gmail", "Orphan", "", "", "src2", "2024-01-01"),
+        ])
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_orphaned_interactions
+            result = _check_orphaned_interactions(valid_ids, dry_run=False, fix_threshold=10)
+
+        assert result["count"] == 1
+        assert result["fixed"] == 1
+
+        # Verify the orphan was actually deleted
+        conn = sqlite3.connect(interaction_db)
+        count = conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
+        conn.close()
+        assert count == 1  # only the valid one remains
+
+
+class TestSkipsFixAboveThreshold:
+    """No fixes when count > threshold."""
+
+    def test_skips_fix_above_threshold(self, tmp_path):
+        valid_ids = {"p1"}
+        interaction_db = str(tmp_path / "interactions.db")
+
+        # Create more orphans than the threshold
+        interactions = [("i1", "p1", "2024-01-01", "gmail", "Valid", "", "", "src1", "2024-01-01")]
+        for i in range(5):
+            interactions.append(
+                (f"orphan_{i}", f"p_gone_{i}", "2024-01-01", "gmail", "Orphan", "", "", f"src_{i}", "2024-01-01")
+            )
+        _create_interaction_db(interaction_db, interactions)
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_orphaned_interactions
+            result = _check_orphaned_interactions(valid_ids, dry_run=False, fix_threshold=3)
+
+        assert result["count"] == 5
+        assert result["fixed"] == 0  # skipped because above threshold
+
+        # Verify nothing was deleted
+        conn = sqlite3.connect(interaction_db)
+        count = conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
+        conn.close()
+        assert count == 6  # all still there
+
+
+class TestDryRunNoFixes:
+    """No modifications in dry_run mode."""
+
+    def test_dry_run_no_fixes(self, tmp_path):
+        valid_ids = {"p1"}
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Valid", "", "", "src1", "2024-01-01"),
+            ("i2", "p_gone", "2024-01-01", "gmail", "Orphan", "", "", "src2", "2024-01-01"),
+        ])
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_orphaned_interactions
+            result = _check_orphaned_interactions(valid_ids, dry_run=True, fix_threshold=10)
+
+        assert result["count"] == 1
+        assert result["fixed"] == 0
+
+        # Verify nothing was deleted
+        conn = sqlite3.connect(interaction_db)
+        count = conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
+        conn.close()
+        assert count == 2
+
+
+class TestPersonStatsMismatch:
+    """Cached counts differ from computed."""
+
+    def test_person_stats_mismatch_detected(self):
+        mock_discrepancies = {
+            "p1": {
+                "name": "Alice",
+                "cached": {"email": 5, "meeting": 2, "mention": 0, "message": 0},
+                "computed": {"email": 3, "meeting": 2, "mention": 0, "message": 0},
+            }
+        }
+
+        with patch("api.services.person_stats.verify_person_stats", return_value=mock_discrepancies) as mock_verify:
+            from scripts.sync_consistency_verify import _check_person_stats
+            result = _check_person_stats(dry_run=True)
+
+        assert result["count"] == 1
+        mock_verify.assert_called_once_with(fix=False)
+
+    def test_person_stats_fix_applied(self):
+        mock_discrepancies = {
+            "p1": {
+                "name": "Alice",
+                "cached": {"email": 5, "meeting": 2, "mention": 0, "message": 0},
+                "computed": {"email": 3, "meeting": 2, "mention": 0, "message": 0},
+            }
+        }
+
+        with patch("api.services.person_stats.verify_person_stats", return_value=mock_discrepancies):
+            from scripts.sync_consistency_verify import _check_person_stats
+            result = _check_person_stats(dry_run=False)
+
+        assert result["count"] == 1
+        assert result["fixed"] == 1
+
+
+class TestVerifyConsistencyIntegration:
+    """Integration test for the full verify_consistency function."""
+
+    def test_full_run_no_issues(self, tmp_path):
+        people = [_make_person("p1", "Alice"), _make_person("p2", "Bob")]
+        valid_ids = {"p1", "p2"}
+        mock_store = _mock_store(people)
+
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Email", "", "", "src1", "2024-01-01"),
+        ])
+
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db,
+            relationships=[("r1", "p1", "p2", "colleague")],
+        )
+
+        with patch("scripts.sync_consistency_verify._get_valid_person_ids", return_value=(valid_ids, mock_store)), \
+             patch("api.services.person_stats.verify_person_stats", return_value={}), \
+             patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db), \
+             patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import verify_consistency
+            result = verify_consistency(dry_run=True)
+
+        assert result["total_issues"] == 0
+        assert result["total_fixed"] == 0
+        assert result["auto_fix_skipped"] is False
+
+
+class TestAutoFixStaleMergedIds:
+    """Auto-fix re-points stale merged IDs when below threshold."""
+
+    def test_auto_fixes_stale_merged_ids(self, tmp_path):
+        valid_ids = {"p1", "p2"}
+        merged_ids = {"p_old": "p1"}
+        mock_store = _mock_store(
+            [_make_person("p1", "Alice"), _make_person("p2", "Bob")],
+            merged_ids=merged_ids,
+        )
+
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Valid", "", "", "src1", "2024-01-01"),
+            ("i2", "p_old", "2024-01-01", "gmail", "Stale", "", "", "src2", "2024-01-01"),
+        ])
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_stale_merged_ids
+            result = _check_stale_merged_ids(valid_ids, mock_store, dry_run=False, fix_threshold=10)
+
+        assert result["count"] == 1
+        assert result["fixed"] == 1
+
+        # Verify the interaction was re-pointed
+        conn = sqlite3.connect(interaction_db)
+        row = conn.execute("SELECT person_id FROM interactions WHERE id = 'i2'").fetchone()
+        conn.close()
+        assert row[0] == "p1"  # re-pointed from p_old to p1

--- a/tests/test_interaction_store.py
+++ b/tests/test_interaction_store.py
@@ -129,7 +129,7 @@ class TestInteractionStore:
     def temp_store(self):
         """Create a temporary store for testing."""
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            store = InteractionStore(f.name)
+            store = InteractionStore(f.name, strict=False)
             yield store
             Path(f.name).unlink(missing_ok=True)
 
@@ -466,6 +466,142 @@ class TestInteractionStore:
             temp_store.add(interaction)
 
         assert temp_store.count() == 3
+
+
+    def test_unique_constraint_prevents_duplicate_source(self, temp_store):
+        """Test that DB-level UNIQUE constraint blocks duplicate (source_type, source_id)."""
+        interaction1 = Interaction(
+            id=str(uuid.uuid4()),
+            person_id="person-123",
+            timestamp=datetime.now(),
+            source_type="gmail",
+            title="First",
+            source_id="msg-dup-1",
+        )
+        interaction2 = Interaction(
+            id=str(uuid.uuid4()),
+            person_id="person-456",
+            timestamp=datetime.now(),
+            source_type="gmail",
+            title="Second",
+            source_id="msg-dup-1",  # Same source_type + source_id
+        )
+
+        temp_store.add(interaction1)
+        temp_store.add(interaction2)  # Should be silently skipped via ON CONFLICT DO NOTHING
+
+        # Only the first should exist
+        result = temp_store.get_by_source("gmail", "msg-dup-1")
+        assert result is not None
+        assert result.title == "First"
+        assert temp_store.count() == 1
+
+    def test_null_source_id_allows_multiple_rows(self, temp_store):
+        """Test that NULL source_id rows are not affected by the UNIQUE constraint."""
+        for i in range(3):
+            interaction = Interaction(
+                id=str(uuid.uuid4()),
+                person_id="person-123",
+                timestamp=datetime.now(),
+                source_type="vault",
+                title=f"Note {i}",
+                source_id=None,
+            )
+            temp_store.add(interaction)
+
+        assert temp_store.count() == 3
+
+    def test_same_source_id_different_source_type(self, temp_store):
+        """Test that same source_id with different source_type is allowed."""
+        for source_type in ["gmail", "calendar", "vault"]:
+            interaction = Interaction(
+                id=str(uuid.uuid4()),
+                person_id="person-123",
+                timestamp=datetime.now(),
+                source_type=source_type,
+                title=f"Test {source_type}",
+                source_id="shared-id-123",
+            )
+            temp_store.add(interaction)
+
+        assert temp_store.count() == 3
+
+    def test_migration_idempotency(self, temp_store):
+        """Test that calling _init_db() twice doesn't break the store."""
+        # Add an interaction before re-init
+        interaction = Interaction(
+            id=str(uuid.uuid4()),
+            person_id="person-123",
+            timestamp=datetime.now(),
+            source_type="gmail",
+            title="Before re-init",
+            source_id="msg-idempotent",
+        )
+        temp_store.add(interaction)
+
+        # Re-run _init_db() — should be a no-op
+        temp_store._init_db()
+
+        # Verify data survived
+        result = temp_store.get_by_source("gmail", "msg-idempotent")
+        assert result is not None
+        assert result.title == "Before re-init"
+        assert temp_store.count() == 1
+
+    def test_strict_mode_rejects_nonexistent_person(self):
+        """Test that strict mode rejects interactions with nonexistent person_ids."""
+        from unittest.mock import patch, MagicMock
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            store = InteractionStore(f.name, strict=True)
+            try:
+                mock_person_store = MagicMock()
+                mock_person_store.get_canonical_id.return_value = "ghost-person"
+                mock_person_store.get_by_id.return_value = None
+
+                with patch(
+                    "api.services.person_entity.get_person_entity_store",
+                    return_value=mock_person_store,
+                ):
+                    interaction = Interaction(
+                        id=str(uuid.uuid4()),
+                        person_id="ghost-person",
+                        timestamp=datetime.now(),
+                        source_type="gmail",
+                        title="Orphan Email",
+                    )
+                    with pytest.raises(ValueError, match="does not exist"):
+                        store.add(interaction)
+            finally:
+                Path(f.name).unlink(missing_ok=True)
+
+    def test_strict_mode_allows_valid_person(self):
+        """Test that strict mode allows interactions with valid person_ids."""
+        from unittest.mock import patch, MagicMock
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            store = InteractionStore(f.name, strict=True)
+            try:
+                mock_person_store = MagicMock()
+                mock_person_store.get_canonical_id.return_value = "real-person"
+                mock_person_store.get_by_id.return_value = MagicMock()  # Person exists
+
+                with patch(
+                    "api.services.person_entity.get_person_entity_store",
+                    return_value=mock_person_store,
+                ):
+                    interaction = Interaction(
+                        id=str(uuid.uuid4()),
+                        person_id="real-person",
+                        timestamp=datetime.now(),
+                        source_type="gmail",
+                        title="Valid Email",
+                    )
+                    result = store.add(interaction)
+                    assert result.person_id == "real-person"
+                    assert store.count() == 1
+            finally:
+                Path(f.name).unlink(missing_ok=True)
 
 
 class TestInteractionFactories:

--- a/tests/test_merge_crash_safety.py
+++ b/tests/test_merge_crash_safety.py
@@ -1,0 +1,650 @@
+"""
+Tests for merge crash safety (intent log, single CRM transaction, recovery).
+
+Tests use temp SQLite databases and temp files — no production data.
+"""
+import json
+import sqlite3
+import uuid
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+from datetime import datetime, timezone
+
+
+# ---------------------------------------------------------------------------
+# Helpers to create temp databases matching production schemas
+# ---------------------------------------------------------------------------
+
+def _create_crm_db(db_path: str):
+    """Create a crm.db with person_entities, source_entities, person_facts, relationships."""
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS person_entities (
+            id TEXT PRIMARY KEY,
+            canonical_name TEXT NOT NULL DEFAULT '',
+            display_name TEXT NOT NULL DEFAULT '',
+            emails TEXT NOT NULL DEFAULT '[]',
+            company TEXT,
+            position TEXT,
+            linkedin_url TEXT,
+            category TEXT NOT NULL DEFAULT 'unknown',
+            vault_contexts TEXT NOT NULL DEFAULT '[]',
+            sources TEXT NOT NULL DEFAULT '[]',
+            first_seen TEXT,
+            last_seen TEXT,
+            meeting_count INTEGER NOT NULL DEFAULT 0,
+            email_count INTEGER NOT NULL DEFAULT 0,
+            mention_count INTEGER NOT NULL DEFAULT 0,
+            message_count INTEGER NOT NULL DEFAULT 0,
+            slack_message_count INTEGER NOT NULL DEFAULT 0,
+            related_notes TEXT NOT NULL DEFAULT '[]',
+            aliases TEXT NOT NULL DEFAULT '[]',
+            phone_numbers TEXT NOT NULL DEFAULT '[]',
+            phone_primary TEXT,
+            confidence_score REAL NOT NULL DEFAULT 1.0,
+            tags TEXT NOT NULL DEFAULT '[]',
+            notes TEXT NOT NULL DEFAULT '',
+            source_entity_count INTEGER NOT NULL DEFAULT 0,
+            birthday TEXT,
+            hidden INTEGER NOT NULL DEFAULT 0,
+            hidden_at TEXT,
+            hidden_reason TEXT NOT NULL DEFAULT '',
+            relationship_strength REAL,
+            is_peripheral_contact INTEGER NOT NULL DEFAULT 0,
+            dunbar_circle INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS person_emails (
+            email TEXT PRIMARY KEY,
+            person_id TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS person_phones (
+            phone TEXT PRIMARY KEY,
+            person_id TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS person_names (
+            name TEXT PRIMARY KEY,
+            person_id TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS source_entities (
+            id TEXT PRIMARY KEY,
+            source_type TEXT NOT NULL,
+            source_id TEXT,
+            observed_name TEXT,
+            observed_email TEXT,
+            observed_phone TEXT,
+            metadata TEXT,
+            canonical_person_id TEXT,
+            link_confidence REAL DEFAULT 0.0,
+            link_status TEXT DEFAULT 'auto'
+        );
+
+        CREATE TABLE IF NOT EXISTS person_facts (
+            id TEXT PRIMARY KEY,
+            person_id TEXT NOT NULL,
+            category TEXT NOT NULL,
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            confidence REAL DEFAULT 0.5,
+            source_interaction_id TEXT,
+            source_quote TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS relationships (
+            id TEXT PRIMARY KEY,
+            person_a_id TEXT NOT NULL,
+            person_b_id TEXT NOT NULL,
+            relationship_type TEXT,
+            shared_contexts TEXT,
+            shared_events_count INTEGER DEFAULT 0,
+            shared_threads_count INTEGER DEFAULT 0,
+            first_seen_together TIMESTAMP,
+            last_seen_together TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            shared_messages_count INTEGER DEFAULT 0,
+            shared_whatsapp_count INTEGER DEFAULT 0,
+            shared_slack_count INTEGER DEFAULT 0,
+            is_linkedin_connection INTEGER DEFAULT 0,
+            shared_phone_calls_count INTEGER DEFAULT 0,
+            shared_photos_count INTEGER DEFAULT 0,
+            UNIQUE(person_a_id, person_b_id)
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _create_interactions_db(db_path: str):
+    """Create an interactions.db with the interactions table."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS interactions (
+            id TEXT PRIMARY KEY,
+            person_id TEXT NOT NULL,
+            timestamp TIMESTAMP NOT NULL,
+            source_type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            snippet TEXT,
+            source_link TEXT,
+            source_id TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_interactions_source_id
+        ON interactions(source_id) WHERE source_id IS NOT NULL
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _insert_person(crm_path: str, person_id: str, name: str,
+                    emails=None, phones=None, aliases=None, category="unknown"):
+    """Insert a person entity into the CRM database."""
+    conn = sqlite3.connect(crm_path)
+    conn.execute("""
+        INSERT INTO person_entities
+        (id, canonical_name, display_name, emails, phone_numbers, aliases, category)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, (
+        person_id, name, name,
+        json.dumps(emails or []),
+        json.dumps(phones or []),
+        json.dumps(aliases or []),
+        category,
+    ))
+    # Lookup tables
+    for email in (emails or []):
+        conn.execute("INSERT OR REPLACE INTO person_emails (email, person_id) VALUES (?, ?)",
+                     (email.lower(), person_id))
+    for phone in (phones or []):
+        conn.execute("INSERT OR REPLACE INTO person_phones (phone, person_id) VALUES (?, ?)",
+                     (phone, person_id))
+    conn.execute("INSERT OR REPLACE INTO person_names (name, person_id) VALUES (?, ?)",
+                 (name.lower(), person_id))
+    for alias in (aliases or []):
+        conn.execute("INSERT OR REPLACE INTO person_names (name, person_id) VALUES (?, ?)",
+                     (alias.lower(), person_id))
+    conn.commit()
+    conn.close()
+
+
+def _insert_interaction(int_path: str, person_id: str, title: str = "Test interaction"):
+    """Insert a test interaction."""
+    conn = sqlite3.connect(int_path)
+    iid = str(uuid.uuid4())
+    conn.execute("""
+        INSERT INTO interactions (id, person_id, timestamp, source_type, title, source_id)
+        VALUES (?, ?, ?, ?, ?, ?)
+    """, (iid, person_id, datetime.now(timezone.utc).isoformat(), "test", title, iid))
+    conn.commit()
+    conn.close()
+    return iid
+
+
+def _insert_source_entity(crm_path: str, person_id: str):
+    """Insert a test source entity linked to a person."""
+    conn = sqlite3.connect(crm_path)
+    se_id = str(uuid.uuid4())
+    conn.execute("""
+        INSERT INTO source_entities (id, source_type, canonical_person_id)
+        VALUES (?, ?, ?)
+    """, (se_id, "test", person_id))
+    conn.commit()
+    conn.close()
+    return se_id
+
+
+def _insert_fact(crm_path: str, person_id: str):
+    """Insert a test person fact."""
+    conn = sqlite3.connect(crm_path)
+    fact_id = str(uuid.uuid4())
+    conn.execute("""
+        INSERT INTO person_facts (id, person_id, category, key, value)
+        VALUES (?, ?, ?, ?, ?)
+    """, (fact_id, person_id, "test", "test_key", "test_value"))
+    conn.commit()
+    conn.close()
+    return fact_id
+
+
+def _insert_relationship(crm_path: str, person_a_id: str, person_b_id: str,
+                          events=0, messages=0):
+    """Insert a test relationship (normalizes IDs)."""
+    conn = sqlite3.connect(crm_path)
+    rel_id = str(uuid.uuid4())
+    norm_a, norm_b = (person_a_id, person_b_id) if person_a_id < person_b_id else (person_b_id, person_a_id)
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute("""
+        INSERT INTO relationships
+        (id, person_a_id, person_b_id, relationship_type, shared_contexts,
+         shared_events_count, shared_threads_count, first_seen_together,
+         last_seen_together, created_at, updated_at,
+         shared_messages_count, shared_whatsapp_count, shared_slack_count,
+         is_linkedin_connection, shared_phone_calls_count, shared_photos_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, (rel_id, norm_a, norm_b, "inferred", "[]",
+          events, 0, now, now, now, now, messages, 0, 0, 0, 0, 0))
+    conn.commit()
+    conn.close()
+    return rel_id
+
+
+# ---------------------------------------------------------------------------
+# Test: Intent Log Functions
+# ---------------------------------------------------------------------------
+
+class TestIntentLog:
+    """Tests for merge intent log write/read/update/clear."""
+
+    @pytest.fixture
+    def log_file(self, tmp_path):
+        return tmp_path / "merge_log.json"
+
+    def test_write_and_load_intent_log(self, log_file):
+        """Log write/read roundtrip."""
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file):
+            from scripts.merge_people import write_merge_intent, load_merge_log
+            write_merge_intent("primary-1", "secondary-1")
+            log = load_merge_log()
+            assert log is not None
+            assert log["operation"] == "merge"
+            assert log["primary_id"] == "primary-1"
+            assert log["secondary_id"] == "secondary-1"
+            assert log["phase"] == "pending"
+            assert "started_at" in log
+
+    def test_update_phase(self, log_file):
+        """Phase updates atomically."""
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file):
+            from scripts.merge_people import write_merge_intent, update_merge_phase, load_merge_log
+            write_merge_intent("p", "s")
+            update_merge_phase("ids_written")
+            log = load_merge_log()
+            assert log["phase"] == "ids_written"
+            # Update again
+            update_merge_phase("crm_done")
+            log = load_merge_log()
+            assert log["phase"] == "crm_done"
+
+    def test_clear_log(self, log_file):
+        """Log file removed after clear."""
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file):
+            from scripts.merge_people import write_merge_intent, clear_merge_log, load_merge_log
+            write_merge_intent("p", "s")
+            assert log_file.exists()
+            clear_merge_log()
+            assert not log_file.exists()
+            assert load_merge_log() is None
+
+    def test_load_merge_log_absent(self, log_file):
+        """Returns None when no log file exists."""
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file):
+            from scripts.merge_people import load_merge_log
+            assert load_merge_log() is None
+
+
+# ---------------------------------------------------------------------------
+# Test: CRM Single Transaction
+# ---------------------------------------------------------------------------
+
+class TestCrmSingleTransaction:
+    """Tests that the CRM transaction commits atomically or rolls back."""
+
+    @pytest.fixture
+    def db_paths(self, tmp_path):
+        crm_path = str(tmp_path / "crm.db")
+        int_path = str(tmp_path / "interactions.db")
+        _create_crm_db(crm_path)
+        _create_interactions_db(int_path)
+        return crm_path, int_path
+
+    def test_crm_single_transaction_commits_together(self, db_paths):
+        """All CRM changes (source_entities, facts, relationships, person delete) visible after commit."""
+        crm_path, int_path = db_paths
+
+        primary_id = "person-primary"
+        secondary_id = "person-secondary"
+        other_id = "person-other"
+
+        _insert_person(crm_path, primary_id, "Alice Smith", emails=["alice@test.com"])
+        _insert_person(crm_path, secondary_id, "Alice S", emails=["alices@test.com"])
+        _insert_person(crm_path, other_id, "Bob Jones")
+        _insert_source_entity(crm_path, secondary_id)
+        _insert_fact(crm_path, secondary_id)
+        _insert_fact(crm_path, primary_id)
+        _insert_relationship(crm_path, secondary_id, other_id, events=3)
+        _insert_interaction(int_path, secondary_id)
+
+        # Run the CRM transaction directly
+        conn = sqlite3.connect(crm_path)
+        conn.execute("BEGIN IMMEDIATE")
+
+        # Source entities
+        conn.execute(
+            "UPDATE source_entities SET canonical_person_id = ? WHERE canonical_person_id = ?",
+            (primary_id, secondary_id))
+
+        # Facts
+        conn.execute(
+            "DELETE FROM person_facts WHERE person_id IN (?, ?)",
+            (primary_id, secondary_id))
+
+        # Relationships: transfer secondary->other to primary->other
+        norm_a, norm_b = (primary_id, other_id) if primary_id < other_id else (other_id, primary_id)
+        rows = conn.execute(
+            "SELECT id FROM relationships WHERE person_a_id = ? OR person_b_id = ?",
+            (secondary_id, secondary_id)).fetchall()
+        for (rel_id,) in rows:
+            conn.execute("DELETE FROM relationships WHERE id = ?", (rel_id,))
+        conn.execute("""
+            INSERT INTO relationships
+            (id, person_a_id, person_b_id, relationship_type, shared_contexts,
+             shared_events_count, shared_threads_count, created_at, updated_at,
+             shared_messages_count, shared_whatsapp_count, shared_slack_count,
+             is_linkedin_connection, shared_phone_calls_count, shared_photos_count)
+            VALUES (?, ?, ?, 'inferred', '[]', 3, 0, datetime('now'), datetime('now'),
+                    0, 0, 0, 0, 0, 0)
+        """, (str(uuid.uuid4()), norm_a, norm_b))
+
+        # Delete secondary
+        conn.execute("DELETE FROM person_emails WHERE person_id = ?", (secondary_id,))
+        conn.execute("DELETE FROM person_phones WHERE person_id = ?", (secondary_id,))
+        conn.execute("DELETE FROM person_names WHERE person_id = ?", (secondary_id,))
+        conn.execute("DELETE FROM person_entities WHERE id = ?", (secondary_id,))
+
+        conn.commit()
+        conn.close()
+
+        # Verify all changes visible
+        conn = sqlite3.connect(crm_path)
+        # Source entities re-pointed
+        assert conn.execute(
+            "SELECT COUNT(*) FROM source_entities WHERE canonical_person_id = ?",
+            (secondary_id,)).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM source_entities WHERE canonical_person_id = ?",
+            (primary_id,)).fetchone()[0] == 1
+        # Facts cleared
+        assert conn.execute("SELECT COUNT(*) FROM person_facts").fetchone()[0] == 0
+        # Relationships transferred
+        assert conn.execute(
+            "SELECT COUNT(*) FROM relationships WHERE person_a_id = ? OR person_b_id = ?",
+            (secondary_id, secondary_id)).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM relationships WHERE person_a_id = ? OR person_b_id = ?",
+            (primary_id, primary_id)).fetchone()[0] == 1
+        # Secondary deleted
+        assert conn.execute(
+            "SELECT COUNT(*) FROM person_entities WHERE id = ?",
+            (secondary_id,)).fetchone()[0] == 0
+        conn.close()
+
+    def test_crm_transaction_rolls_back_on_error(self, db_paths):
+        """No partial state when exception occurs mid-transaction."""
+        crm_path, _ = db_paths
+
+        primary_id = "person-primary"
+        secondary_id = "person-secondary"
+        _insert_person(crm_path, primary_id, "Alice Smith")
+        _insert_person(crm_path, secondary_id, "Alice S")
+        _insert_source_entity(crm_path, secondary_id)
+        _insert_fact(crm_path, secondary_id)
+
+        conn = sqlite3.connect(crm_path)
+        conn.execute("BEGIN IMMEDIATE")
+
+        # Do some operations
+        conn.execute(
+            "UPDATE source_entities SET canonical_person_id = ? WHERE canonical_person_id = ?",
+            (primary_id, secondary_id))
+        conn.execute(
+            "DELETE FROM person_facts WHERE person_id IN (?, ?)",
+            (primary_id, secondary_id))
+
+        # Simulate crash: rollback instead of commit
+        conn.rollback()
+        conn.close()
+
+        # Verify NO changes persisted
+        conn = sqlite3.connect(crm_path)
+        assert conn.execute(
+            "SELECT COUNT(*) FROM source_entities WHERE canonical_person_id = ?",
+            (secondary_id,)).fetchone()[0] == 1  # Still points to secondary
+        assert conn.execute(
+            "SELECT COUNT(*) FROM person_facts WHERE person_id = ?",
+            (secondary_id,)).fetchone()[0] == 1  # Facts still exist
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test: Interactions Update Idempotency
+# ---------------------------------------------------------------------------
+
+class TestInteractionsIdempotent:
+    """Tests that running interaction UPDATE twice produces the same result."""
+
+    def test_interactions_update_idempotent(self, tmp_path):
+        """Running UPDATE interactions twice = same result."""
+        int_path = str(tmp_path / "interactions.db")
+        _create_interactions_db(int_path)
+
+        primary_id = "person-primary"
+        secondary_id = "person-secondary"
+
+        # Insert 3 interactions for secondary
+        for i in range(3):
+            _insert_interaction(int_path, secondary_id, f"Interaction {i}")
+
+        # First update
+        conn = sqlite3.connect(int_path)
+        conn.execute(
+            "UPDATE interactions SET person_id = ? WHERE person_id = ?",
+            (primary_id, secondary_id))
+        conn.commit()
+        count_after_first = conn.execute(
+            "SELECT COUNT(*) FROM interactions WHERE person_id = ?",
+            (primary_id,)).fetchone()[0]
+        conn.close()
+
+        assert count_after_first == 3
+
+        # Second update (idempotent — no rows match secondary_id anymore)
+        conn = sqlite3.connect(int_path)
+        conn.execute(
+            "UPDATE interactions SET person_id = ? WHERE person_id = ?",
+            (primary_id, secondary_id))
+        conn.commit()
+        count_after_second = conn.execute(
+            "SELECT COUNT(*) FROM interactions WHERE person_id = ?",
+            (primary_id,)).fetchone()[0]
+        conn.close()
+
+        assert count_after_second == 3  # Same result
+
+
+# ---------------------------------------------------------------------------
+# Test: Recovery
+# ---------------------------------------------------------------------------
+
+class TestRecovery:
+    """Tests for recover_incomplete_merge()."""
+
+    def test_no_recovery_when_no_log(self, tmp_path):
+        """No-op when merge_log.json absent."""
+        log_file = tmp_path / "merge_log.json"
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file):
+            from scripts.merge_people import recover_incomplete_merge
+            assert recover_incomplete_merge() is False
+
+    def test_no_recovery_when_complete(self, tmp_path):
+        """Clears log and returns False when phase is 'complete'."""
+        log_file = tmp_path / "merge_log.json"
+        log_file.write_text(json.dumps({
+            "operation": "merge",
+            "primary_id": "p",
+            "secondary_id": "s",
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "phase": "complete",
+        }))
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file):
+            from scripts.merge_people import recover_incomplete_merge
+            assert recover_incomplete_merge() is False
+            assert not log_file.exists()
+
+    def test_recovery_clears_log_when_primary_missing(self, tmp_path):
+        """If primary doesn't exist, clears log and returns False."""
+        log_file = tmp_path / "merge_log.json"
+        log_file.write_text(json.dumps({
+            "operation": "merge",
+            "primary_id": "nonexistent",
+            "secondary_id": "also-nonexistent",
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "phase": "pending",
+        }))
+
+        mock_store = _make_mock_store(people={})
+
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file), \
+             patch('scripts.merge_people.get_person_entity_store', return_value=mock_store):
+            from scripts.merge_people import recover_incomplete_merge
+            assert recover_incomplete_merge() is False
+            assert not log_file.exists()
+
+    def test_recovery_runs_cleanup_when_secondary_already_deleted(self, tmp_path):
+        """If secondary is already deleted, runs cleanup and clears log."""
+        log_file = tmp_path / "merge_log.json"
+        primary_id = "person-primary"
+        log_file.write_text(json.dumps({
+            "operation": "merge",
+            "primary_id": primary_id,
+            "secondary_id": "person-secondary",
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "phase": "crm_done",
+        }))
+
+        mock_primary = _make_mock_person(primary_id, "Alice Smith")
+        mock_store = _make_mock_store(people={primary_id: mock_primary})
+
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file), \
+             patch('scripts.merge_people.get_person_entity_store', return_value=mock_store), \
+             patch('api.services.person_stats.refresh_person_stats'), \
+             patch('api.services.relationship_metrics.update_strength_for_person', return_value=0.5):
+            from scripts.merge_people import recover_incomplete_merge
+            assert recover_incomplete_merge() is True
+            assert not log_file.exists()
+
+    def test_recovery_completes_interrupted_merge(self, tmp_path):
+        """Crash at 'ids_written' phase → recovery re-runs merge → correct final state."""
+        crm_path = str(tmp_path / "crm.db")
+        int_path = str(tmp_path / "interactions.db")
+        log_file = tmp_path / "merge_log.json"
+        merged_ids_file = tmp_path / "merged_person_ids.json"
+        _create_crm_db(crm_path)
+        _create_interactions_db(int_path)
+
+        primary_id = "person-aaa"
+        secondary_id = "person-bbb"
+
+        _insert_person(crm_path, primary_id, "Alice Smith", emails=["alice@test.com"])
+        _insert_person(crm_path, secondary_id, "Alice S", emails=["alices@test.com"])
+        _insert_interaction(int_path, secondary_id, "Test email")
+        _insert_source_entity(crm_path, secondary_id)
+
+        # Simulate crash after ids_written phase
+        log_file.write_text(json.dumps({
+            "operation": "merge",
+            "primary_id": primary_id,
+            "secondary_id": secondary_id,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "phase": "ids_written",
+        }))
+        # The merged_ids was already written (since phase > pending)
+        merged_ids_file.write_text(json.dumps({secondary_id: primary_id}))
+
+        # Build a PersonEntityStore that uses our temp db
+        from api.services.person_entity import PersonEntityStore
+        store = PersonEntityStore(db_path=crm_path)
+
+        with patch('scripts.merge_people.MERGE_LOG_FILE', log_file), \
+             patch('scripts.merge_people.MERGED_IDS_FILE', merged_ids_file), \
+             patch('scripts.merge_people.get_person_entity_store', return_value=store), \
+             patch('scripts.merge_people.get_interaction_db_path', return_value=int_path), \
+             patch('scripts.merge_people.get_crm_db_path', return_value=crm_path), \
+             patch('api.services.person_stats.refresh_person_stats'), \
+             patch('api.services.relationship_metrics.update_strength_for_person', return_value=0.5):
+            from scripts.merge_people import recover_incomplete_merge
+            result = recover_incomplete_merge()
+            assert result is True
+
+        # Verify final state
+        assert not log_file.exists()
+
+        # Interactions re-pointed
+        conn = sqlite3.connect(int_path)
+        assert conn.execute(
+            "SELECT COUNT(*) FROM interactions WHERE person_id = ?",
+            (secondary_id,)).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM interactions WHERE person_id = ?",
+            (primary_id,)).fetchone()[0] == 1
+        conn.close()
+
+        # Secondary deleted from CRM
+        conn = sqlite3.connect(crm_path)
+        assert conn.execute(
+            "SELECT COUNT(*) FROM person_entities WHERE id = ?",
+            (secondary_id,)).fetchone()[0] == 0
+        # Primary still exists with merged emails
+        row = conn.execute(
+            "SELECT emails FROM person_entities WHERE id = ?",
+            (primary_id,)).fetchone()
+        assert row is not None
+        emails = json.loads(row[0])
+        assert "alice@test.com" in emails
+        assert "alices@test.com" in emails
+        # Source entities re-pointed
+        assert conn.execute(
+            "SELECT COUNT(*) FROM source_entities WHERE canonical_person_id = ?",
+            (secondary_id,)).fetchone()[0] == 0
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_person(person_id, name, emails=None, phones=None, aliases=None):
+    """Create a mock PersonEntity-like object."""
+    from unittest.mock import MagicMock
+    person = MagicMock()
+    person.id = person_id
+    person.canonical_name = name
+    person.display_name = name
+    person.emails = emails or []
+    person.phone_numbers = phones or []
+    person.aliases = aliases or []
+    person.sources = []
+    person.category = "unknown"
+    person.tags = []
+    person.notes = ""
+    person.first_seen = None
+    person.last_seen = None
+    person.relationship_strength = None
+    person.email_count = 0
+    person.message_count = 0
+    person.meeting_count = 0
+    return person
+
+
+def _make_mock_store(people: dict):
+    """Create a mock PersonEntityStore."""
+    from unittest.mock import MagicMock
+    store = MagicMock()
+    store.get_by_id.side_effect = lambda pid: people.get(pid)
+    return store

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -1,0 +1,150 @@
+"""Tests for dependency-skip behavior in run_all_syncs."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Minimal SYNC_SOURCES for tests — only defines metadata (depends_on, frequency, phase).
+# The actual sync logic is mocked via run_sync.
+TEST_SYNC_SOURCES = {
+    "source_a": {"description": "A", "phase": 1, "frequency": "daily"},
+    "source_b": {"description": "B", "phase": 1, "frequency": "daily"},
+    "source_c": {"description": "C", "phase": 2, "frequency": "daily", "depends_on": ["source_a"]},
+    "source_d": {"description": "D", "phase": 3, "frequency": "daily", "depends_on": ["source_c"]},
+    "source_e": {"description": "E", "phase": 2, "frequency": "daily", "depends_on": ["source_a", "source_b"]},
+    # phone is absent from SYNC_ORDER (like FDA sources)
+    "phone": {"description": "Phone", "phase": 1, "frequency": "daily"},
+    "source_f": {"description": "F", "phase": 2, "frequency": "daily", "depends_on": ["phone"]},
+    # disabled source
+    "slack": {"description": "Slack", "phase": 1, "frequency": "daily"},
+    "link_slack": {"description": "Link Slack", "phase": 2, "frequency": "daily", "depends_on": ["slack"]},
+}
+
+TEST_SYNC_ORDER = [
+    "source_a",
+    "source_b",
+    "source_c",
+    "source_d",
+    "source_e",
+    "source_f",  # depends on phone which is NOT in this list
+    "slack",
+    "link_slack",
+]
+
+
+def _make_run_sync_side_effect(fail_sources: set):
+    """Return a side_effect function for run_sync that fails specified sources."""
+    def side_effect(source, dry_run=False):
+        if source in fail_sources:
+            return False, {"error": "simulated failure"}
+        return True, {"processed": 1, "created": 0}
+    return side_effect
+
+
+def _run_with_patches(fail_sources: set | None = None, disabled_sources: set | None = None):
+    """Run run_all_syncs(dry_run=True) with test patches and return the result dict.
+
+    dry_run=True skips: subprocess calls, backup, maintenance mode, Telegram, server restart.
+    We only need to patch: SYNC_SOURCES, SYNC_ORDER, run_sync, check_sync_health,
+    get_disabled_work_sources, and log_sync_summary_to_markdown.
+    """
+    from scripts.run_all_syncs import run_all_syncs
+
+    fail_sources = fail_sources or set()
+
+    run_sync_mock = MagicMock(side_effect=_make_run_sync_side_effect(fail_sources))
+
+    with (
+        patch("scripts.run_all_syncs.SYNC_SOURCES", TEST_SYNC_SOURCES),
+        patch("scripts.run_all_syncs.SYNC_ORDER", TEST_SYNC_ORDER),
+        patch("scripts.run_all_syncs.run_sync", run_sync_mock),
+        patch("scripts.run_all_syncs.check_sync_health", return_value=(True, "healthy")),
+        patch("scripts.run_all_syncs.get_disabled_work_sources", return_value=disabled_sources or set()),
+        patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
+    ):
+        result = run_all_syncs(dry_run=True)
+
+    return result, run_sync_mock
+
+
+class TestDependencySkip:
+    """Tests for the dependency-skip behavior in run_all_syncs."""
+
+    def test_skip_when_dependency_failed(self):
+        """Source C (depends on A) is skipped when A fails."""
+        result, run_sync_mock = _run_with_patches(fail_sources={"source_a"})
+
+        assert "source_c" in result["dep_skipped_sources"]
+        assert result["results"]["source_c"]["skipped"] is True
+        assert result["results"]["source_c"]["reason"] == "dependency_failed"
+        assert "source_a" in result["results"]["source_c"]["failed_dependencies"]
+
+        # run_sync should NOT have been called for source_c
+        called_sources = [call.args[0] for call in run_sync_mock.call_args_list]
+        assert "source_c" not in called_sources
+
+    def test_cascading_skip(self):
+        """A→C→D chain: A fails → C skipped → D skipped."""
+        result, run_sync_mock = _run_with_patches(fail_sources={"source_a"})
+
+        assert "source_c" in result["dep_skipped_sources"]
+        assert "source_d" in result["dep_skipped_sources"]
+        assert result["results"]["source_d"]["reason"] == "dependency_failed"
+        assert "source_c" in result["results"]["source_d"]["failed_dependencies"]
+
+        called_sources = [call.args[0] for call in run_sync_mock.call_args_list]
+        assert "source_c" not in called_sources
+        assert "source_d" not in called_sources
+
+    def test_partial_dependency_failure(self):
+        """Source E depends on [A, B]. A succeeds, B fails → E skipped."""
+        result, _ = _run_with_patches(fail_sources={"source_b"})
+
+        assert "source_e" in result["dep_skipped_sources"]
+        assert result["results"]["source_e"]["reason"] == "dependency_failed"
+        assert "source_b" in result["results"]["source_e"]["failed_dependencies"]
+        # source_a succeeded, so it should NOT be in failed_dependencies
+        assert "source_a" not in result["results"]["source_e"]["failed_dependencies"]
+
+    def test_absent_dependency_no_skip(self):
+        """Source F depends on 'phone', which is NOT in the run list.
+        Absent deps should not trigger a skip."""
+        result, run_sync_mock = _run_with_patches(fail_sources=set())
+
+        assert "source_f" not in result["dep_skipped_sources"]
+        called_sources = [call.args[0] for call in run_sync_mock.call_args_list]
+        assert "source_f" in called_sources
+
+    def test_disabled_dependency_no_skip(self):
+        """link_slack depends on 'slack'. If slack is disabled (not failed),
+        link_slack should NOT be dependency-skipped."""
+        result, run_sync_mock = _run_with_patches(
+            fail_sources=set(),
+            disabled_sources={"slack"},
+        )
+
+        # slack is skipped as disabled, link_slack should NOT be dep-skipped
+        assert "link_slack" not in result["dep_skipped_sources"]
+        assert result["results"]["slack"]["reason"] == "work_integration_disabled"
+        called_sources = [call.args[0] for call in run_sync_mock.call_args_list]
+        assert "link_slack" in called_sources
+
+    def test_dep_skipped_in_result(self):
+        """dep_skipped_sources appears in result dict and is sorted."""
+        result, _ = _run_with_patches(fail_sources={"source_a"})
+
+        assert "dep_skipped_sources" in result
+        assert isinstance(result["dep_skipped_sources"], list)
+        # Should be sorted
+        assert result["dep_skipped_sources"] == sorted(result["dep_skipped_sources"])
+        # source_c and source_d should be there (cascade from source_a)
+        assert "source_c" in result["dep_skipped_sources"]
+        assert "source_d" in result["dep_skipped_sources"]
+
+    def test_all_succeed_no_skips(self):
+        """Clean run: no dependency skips when everything succeeds."""
+        result, _ = _run_with_patches(fail_sources=set())
+
+        assert result["dep_skipped_sources"] == []
+        # No source should have reason=dependency_failed
+        for source, stats in result["results"].items():
+            assert stats.get("reason") != "dependency_failed"

--- a/tests/test_sync_whatsapp.py
+++ b/tests/test_sync_whatsapp.py
@@ -9,6 +9,7 @@ from scripts.sync_whatsapp import (
     normalize_phone,
     extract_phone_from_jid,
     is_group_jid,
+    resolve_lid_phone,
     run_wacli,
     check_wacli_auth,
     sync_whatsapp_messages,
@@ -219,6 +220,16 @@ def _setup_interaction_db(db_path: str, existing_ids: list[str] = None):
         conn.execute(
             "INSERT INTO interactions (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at) VALUES (?, '', '', 'whatsapp', '', '', NULL, ?, '')",
             (sid, sid))
+    conn.commit()
+    conn.close()
+
+
+def _setup_session_db(db_path: str, lid_map: list[tuple] = None):
+    """Create a mock session.db with whatsmeow_lid_map table."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE whatsmeow_lid_map (lid TEXT PRIMARY KEY, pn TEXT)")
+    for row in (lid_map or []):
+        conn.execute("INSERT INTO whatsmeow_lid_map (lid, pn) VALUES (?, ?)", row)
     conn.commit()
     conn.close()
 
@@ -538,3 +549,252 @@ class TestOutgoingGroupMessages:
         assert stats['skipped_large_group'] == 1
         assert stats['outgoing_group_created'] == 0
         mock_resolver.resolve.assert_not_called()
+
+
+class TestResolveLidPhone:
+    """Unit tests for resolve_lid_phone()."""
+
+    def test_standard_lid(self):
+        """Standard LID JID resolves to phone."""
+        lid_phones = {"164712046162027": "+12036417454"}
+        assert resolve_lid_phone("164712046162027@lid", lid_phones) == "+12036417454"
+
+    def test_lid_with_colon_suffix(self):
+        """LID JID with :N device suffix still resolves."""
+        lid_phones = {"164712046162027": "+12036417454"}
+        assert resolve_lid_phone("164712046162027:0@lid", lid_phones) == "+12036417454"
+
+    def test_lid_not_in_map(self):
+        """LID not in map returns empty string."""
+        lid_phones = {"164712046162027": "+12036417454"}
+        assert resolve_lid_phone("999999999999@lid", lid_phones) == ""
+
+    def test_non_lid_jid(self):
+        """Non-LID JID returns empty string."""
+        lid_phones = {"15551234567": "+15551234567"}
+        assert resolve_lid_phone("15551234567@s.whatsapp.net", lid_phones) == ""
+
+    def test_empty_input(self):
+        """Empty/None input returns empty string."""
+        assert resolve_lid_phone("", {}) == ""
+        assert resolve_lid_phone(None, {}) == ""
+
+
+class TestLidPhoneResolution:
+    """Integration tests for LID phone resolution via session.db."""
+
+    def _mock_home(self, tmp_path, wacli_db, session_db=None):
+        """Build a mock Path.home() that routes .wacli/wacli.db and .wacli/session.db."""
+        class FakeWacliDir:
+            def __truediv__(self, name):
+                if name == "wacli.db":
+                    p = MagicMock()
+                    p.exists.return_value = True
+                    p.__str__ = lambda self: wacli_db
+                    return p
+                if name == "session.db":
+                    p = MagicMock()
+                    if session_db:
+                        p.exists.return_value = True
+                        p.__str__ = lambda self: session_db
+                    else:
+                        p.exists.return_value = False
+                    return p
+                return MagicMock()
+
+        class FakeHome:
+            def __truediv__(self, name):
+                if name == ".wacli":
+                    return FakeWacliDir()
+                return MagicMock()
+
+        return FakeHome()
+
+    def test_lid_resolved_by_phone(self, tmp_path):
+        """LID with phone mapping in session.db should resolve by phone."""
+        wacli_db = str(tmp_path / "wacli.db")
+        session_db = str(tmp_path / "session.db")
+        int_db = str(tmp_path / "interactions.db")
+
+        _setup_wacli_db(wacli_db, messages=[{
+            'msg_id': 'msg_lid_phone_01',
+            'chat_jid': '120363001@g.us',
+            'chat_name': 'Test Group',
+            'sender_jid': '164712046162027@lid',
+            'sender_name': '',
+            'ts': '2026-02-25T10:00:00+00:00',
+            'from_me': 0,
+        }], contacts=[
+            ('164712046162027@lid', 'Jonathan'),
+        ], group_participants=[
+            ('120363001@g.us', '164712046162027@lid'),
+        ])
+        _setup_session_db(session_db, lid_map=[
+            ('164712046162027', '12036417454'),
+        ])
+        _setup_interaction_db(int_db)
+
+        mock_entity = MagicMock()
+        mock_entity.id = "person-jonathan-esty"
+        mock_result = MagicMock()
+        mock_result.entity = mock_entity
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = mock_result
+
+        with patch("scripts.sync_whatsapp.subprocess.run") as mock_run, \
+             patch("scripts.sync_whatsapp.get_entity_resolver", return_value=mock_resolver), \
+             patch("scripts.sync_whatsapp.get_interaction_db_path", return_value=int_db), \
+             patch("scripts.sync_whatsapp.Path.home") as mock_home, \
+             patch("api.services.person_stats.refresh_person_stats"):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            mock_home.return_value = self._mock_home(tmp_path, wacli_db, session_db)
+
+            stats = sync_whatsapp_messages(dry_run=False)
+
+        assert stats['resolved_lid_phone'] == 1
+        # Resolver should have been called with phone, not just name
+        mock_resolver.resolve.assert_called_with(
+            name='Jonathan', phone='+12036417454', create_if_missing=True,
+        )
+
+    def test_lid_falls_back_to_name_without_phone(self, tmp_path):
+        """LID without phone mapping should fall back to push_name resolution."""
+        wacli_db = str(tmp_path / "wacli.db")
+        session_db = str(tmp_path / "session.db")
+        int_db = str(tmp_path / "interactions.db")
+
+        _setup_wacli_db(wacli_db, messages=[{
+            'msg_id': 'msg_lid_name_01',
+            'chat_jid': '120363001@g.us',
+            'chat_name': 'Test Group',
+            'sender_jid': '999888777666@lid',
+            'sender_name': '',
+            'ts': '2026-02-25T10:00:00+00:00',
+            'from_me': 0,
+        }], contacts=[
+            ('999888777666@lid', 'Hannah'),
+        ], group_participants=[
+            ('120363001@g.us', '999888777666@lid'),
+        ])
+        # session.db exists but doesn't have this LID
+        _setup_session_db(session_db, lid_map=[])
+        _setup_interaction_db(int_db)
+
+        mock_entity = MagicMock()
+        mock_entity.id = "person-hannah"
+        mock_result = MagicMock()
+        mock_result.entity = mock_entity
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = mock_result
+
+        with patch("scripts.sync_whatsapp.subprocess.run") as mock_run, \
+             patch("scripts.sync_whatsapp.get_entity_resolver", return_value=mock_resolver), \
+             patch("scripts.sync_whatsapp.get_interaction_db_path", return_value=int_db), \
+             patch("scripts.sync_whatsapp.Path.home") as mock_home, \
+             patch("api.services.person_stats.refresh_person_stats"):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            mock_home.return_value = self._mock_home(tmp_path, wacli_db, session_db)
+
+            stats = sync_whatsapp_messages(dry_run=False)
+
+        assert stats['resolved_lid_phone'] == 0
+        assert stats['resolved_lid'] == 1
+        # Resolver should have been called with name only
+        mock_resolver.resolve.assert_called_with(
+            name='Hannah', phone=None, create_if_missing=True,
+        )
+
+    def test_missing_session_db_graceful(self, tmp_path):
+        """Missing session.db should not crash — falls back to name-only resolution."""
+        wacli_db = str(tmp_path / "wacli.db")
+        int_db = str(tmp_path / "interactions.db")
+
+        _setup_wacli_db(wacli_db, messages=[{
+            'msg_id': 'msg_no_session_01',
+            'chat_jid': '120363001@g.us',
+            'chat_name': 'Test Group',
+            'sender_jid': '246698660126807@lid',
+            'sender_name': '',
+            'ts': '2026-02-25T10:00:00+00:00',
+            'from_me': 0,
+        }], contacts=[
+            ('246698660126807@lid', 'Hannah'),
+        ], group_participants=[
+            ('120363001@g.us', '246698660126807@lid'),
+        ])
+        _setup_interaction_db(int_db)
+
+        mock_entity = MagicMock()
+        mock_entity.id = "person-hannah"
+        mock_result = MagicMock()
+        mock_result.entity = mock_entity
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = mock_result
+
+        with patch("scripts.sync_whatsapp.subprocess.run") as mock_run, \
+             patch("scripts.sync_whatsapp.get_entity_resolver", return_value=mock_resolver), \
+             patch("scripts.sync_whatsapp.get_interaction_db_path", return_value=int_db), \
+             patch("scripts.sync_whatsapp.Path.home") as mock_home, \
+             patch("api.services.person_stats.refresh_person_stats"):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            # No session_db — pass None to _mock_home
+            mock_home.return_value = self._mock_home(tmp_path, wacli_db, session_db=None)
+
+            stats = sync_whatsapp_messages(dry_run=False)
+
+        assert stats['resolved_lid_phone'] == 0
+        assert stats['resolved_lid'] == 1
+        # Should still work via name fallback
+        mock_resolver.resolve.assert_called_with(
+            name='Hannah', phone=None, create_if_missing=True,
+        )
+
+    def test_outgoing_group_lid_resolved_by_phone(self, tmp_path):
+        """Outgoing group fan-out should resolve LID participants by phone when available."""
+        wacli_db = str(tmp_path / "wacli.db")
+        session_db = str(tmp_path / "session.db")
+        int_db = str(tmp_path / "interactions.db")
+
+        _setup_wacli_db(wacli_db, messages=[{
+            'msg_id': 'msg_out_lid_phone_01',
+            'chat_jid': '120363001@g.us',
+            'chat_name': 'Ski Group',
+            'sender_jid': 'me@s.whatsapp.net',
+            'sender_name': 'Me',
+            'ts': '2026-02-25T10:00:00+00:00',
+            'from_me': 1,
+        }], contacts=[
+            ('164712046162027@lid', 'Jonathan'),
+        ], group_participants=[
+            ('120363001@g.us', '164712046162027@lid'),
+        ])
+        _setup_session_db(session_db, lid_map=[
+            ('164712046162027', '12036417454'),
+        ])
+        _setup_interaction_db(int_db)
+
+        mock_entity = MagicMock()
+        mock_entity.id = "person-jonathan-esty"
+        mock_result = MagicMock()
+        mock_result.entity = mock_entity
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = mock_result
+
+        with patch("scripts.sync_whatsapp.subprocess.run") as mock_run, \
+             patch("scripts.sync_whatsapp.get_entity_resolver", return_value=mock_resolver), \
+             patch("scripts.sync_whatsapp.get_interaction_db_path", return_value=int_db), \
+             patch("scripts.sync_whatsapp.Path.home") as mock_home, \
+             patch("scripts.sync_whatsapp.settings") as mock_settings, \
+             patch("api.services.person_stats.refresh_person_stats"):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            mock_settings.my_person_id = "my-person-id"
+            mock_home.return_value = self._mock_home(tmp_path, wacli_db, session_db)
+
+            stats = sync_whatsapp_messages(dry_run=False)
+
+        assert stats['resolved_lid_phone'] == 1
+        assert stats['outgoing_group_created'] == 1
+        # Resolver should have been called with both name and phone
+        mock_resolver.resolve.assert_called_with(
+            name='Jonathan', phone='+12036417454', create_if_missing=False,
+        )


### PR DESCRIPTION
## Summary
- **Crash-safe merge**: Rewrites `merge_people.py` with WAL-style intent logging and phased execution. Incomplete merges are automatically recovered on startup via `recover_incomplete_merge()`
- **Interaction dedup**: Adds `UNIQUE(source_type, source_id)` constraint with migration, `ON CONFLICT DO NOTHING` insert, and person_id existence validation
- **Photos source_id scoping**: Scopes photos `source_id` by person_id (`{uuid}:{pk}`) to prevent cross-person dedup collisions
- **Consistency verification**: New `sync_consistency_verify.py` script (phase 7) that detects and auto-fixes orphaned interactions, stale merge IDs, and CRM inconsistencies
- **PII scrubbing**: Removes emails/phones from merge log output
- **Safety guards**: Empty `valid_ids` guard in verifier, SQLite 999-variable limit fix, recovery self-merge prevention

## Changes
- `scripts/merge_people.py` — Full rewrite with intent log, single CRM transaction, crash recovery
- `api/services/interaction_store.py` — UNIQUE constraint migration, ON CONFLICT DO NOTHING, strict mode
- `api/services/apple_photos_sync.py` — Scoped source_id format
- `api/main.py` — Startup merge recovery hook
- `api/services/sync_health.py` — Phase 7 consistency_verify entry
- `scripts/sync_consistency_verify.py` — New cross-store consistency checker
- `scripts/run_all_syncs.py` — Sync orchestration updates
- 5 new test files (1,619 lines)

## Test plan
- [ ] Run `merge_people.py --primary X --secondary Y --execute` and verify intent log lifecycle
- [ ] Kill merge mid-execution and verify startup recovery completes it
- [ ] Run `sync_consistency_verify.py` and verify it detects/fixes known inconsistencies
- [ ] Verify duplicate photo interactions are rejected by UNIQUE constraint
- [ ] All existing tests pass

Split from #29 — sync stability changes only, no timeout fix.