### PR TITLE
fix: Linux migration cleanup

### DIFF
--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -98,6 +98,12 @@ SYNC_SOURCES = {
         "frequency": "daily",
         "phase": 1,
     },
+    "apple_import": {
+        "description": "Import Apple ecosystem data (contacts, iMessage, phone) from Mac exports",
+        "script": "scripts/apple_data_import.py",
+        "frequency": "daily",
+        "phase": 1,
+    },
 
     # === Phase 2: Entity Processing ===
     "link_slack": {

--- a/tests/test_p91_data_integrity.py
+++ b/tests/test_p91_data_integrity.py
@@ -99,7 +99,7 @@ class TestR2EntityResolution:
         cursor = conn.execute("""
             SELECT person_id, source_id, title FROM interactions
             WHERE source_type IN ('vault', 'granola')
-            AND source_id LIKE '/Users/%'
+            AND source_id LIKE '/%'
             ORDER BY RANDOM()
             LIMIT 20
         """)
@@ -211,7 +211,7 @@ class TestR3VaultLinks:
         cursor = conn.execute("""
             SELECT source_id FROM interactions
             WHERE source_type IN ('vault', 'granola')
-            AND source_id LIKE '/Users/%'
+            AND source_id LIKE '/%'
             LIMIT 1
         """)
         row = cursor.fetchone()
@@ -517,7 +517,7 @@ class TestR8Top10Verification:
             cursor2 = conn.execute("""
                 SELECT source_id FROM interactions
                 WHERE person_id = ? AND source_type IN ('vault', 'granola')
-                AND source_id LIKE '/Users/%'
+                AND source_id LIKE '/%'
                 LIMIT 5
             """, (person_id,))
 


### PR DESCRIPTION
## Summary
- Register `apple_import` in `SYNC_SOURCES` so nightly sync no longer skips it with "Unknown source" warning
- Fix `test_p91_data_integrity.py`: replace hardcoded path filters with generic `/%` to work on both macOS and Linux
- DB fix (applied manually, not in code): updated 2,210 vault interaction paths and removed 5 orphaned records for deleted files

## Test plan
- [x] `test_p91_data_integrity::TestR1CleanDatabase::test_all_vault_files_exist` — was failing (2211 bad paths), now passes
- [x] `test_p91_data_integrity::TestR2EntityResolution::test_vault_interactions_mention_linked_person` — was failing (0 records found), now passes
- [x] `apple_import` verified in `SYNC_SOURCES` via Python import
- [x] Full test suite: 1754 passed, 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)