### PR TITLE
fix: Delegate server.sh to systemctl when systemd manages the service

### DIFF
--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -259,17 +259,46 @@ show_status() {
     echo ""
 }
 
+# Check if systemd is managing the service (avoid ghost processes)
+is_systemd_managed() {
+    systemctl is-active lifeos-api.service &>/dev/null ||
+    systemctl is-enabled lifeos-api.service &>/dev/null
+}
+
+# Run systemctl command with sudo (passwordless via sudoers rule from setup-systemd.sh)
+sctl() {
+    sudo systemctl "$@"
+}
+
 # Main
 case "${1:-status}" in
     start)
-        start_server
+        if is_systemd_managed; then
+            log_info "Delegating to systemd..."
+            kill_server  # Clear any ghost processes holding the port
+            sctl start lifeos-api
+            wait_for_healthy
+        else
+            start_server
+        fi
         ;;
     stop)
-        stop_server
+        if is_systemd_managed; then
+            log_info "Delegating to systemd..."
+            sctl stop lifeos-api
+        else
+            stop_server
+        fi
         ;;
     restart)
         log_info "Restarting server..."
-        start_server
+        if is_systemd_managed; then
+            log_info "Delegating to systemd..."
+            sctl restart lifeos-api
+            wait_for_healthy
+        else
+            start_server
+        fi
         ;;
     foreground)
         run_foreground

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -91,6 +91,22 @@ if [ -f "$LOGROTATE_SRC" ]; then
     echo "  Installed /etc/logrotate.d/lifeos"
 fi
 
+# Install sudoers rule so server.sh can restart via systemctl without a password
+# (required for nightly sync to restart the server after completion)
+echo ""
+echo "Installing sudoers rule for passwordless systemctl..."
+SUDOERS_FILE="/etc/sudoers.d/lifeos"
+TMP_SUDOERS=$(mktemp)
+echo "$REAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start lifeos-api, /usr/bin/systemctl stop lifeos-api, /usr/bin/systemctl restart lifeos-api, /usr/bin/systemctl start lifeos-api.service, /usr/bin/systemctl stop lifeos-api.service, /usr/bin/systemctl restart lifeos-api.service" > "$TMP_SUDOERS"
+if visudo -c -f "$TMP_SUDOERS" > /dev/null 2>&1; then
+    mv "$TMP_SUDOERS" "$SUDOERS_FILE"
+    chmod 440 "$SUDOERS_FILE"
+    echo "  Installed $SUDOERS_FILE"
+else
+    rm -f "$TMP_SUDOERS"
+    echo "  ERROR: Invalid sudoers syntax — skipping installation"
+fi
+
 # Show status
 echo ""
 echo "=== Service Status ==="


### PR DESCRIPTION
## Summary
- `server.sh start/stop/restart` now detect when `lifeos-api` is managed by systemd and delegate to `systemctl` instead of manually spawning processes via `nohup`. This prevents ghost server processes that escape systemd's cgroup tracking and cause port conflicts + crash-loops.
- Adds a `sudoers` rule to `setup-systemd.sh` so the nightly sync can restart the server without a password prompt.

## Test plan
- [x] `server.sh restart` — delegates to systemd, no ghost processes, systemd PID matches port owner
- [x] `server.sh stop` — delegates to systemd, port freed
- [x] `server.sh start` — delegates to systemd, waits for healthy
- [x] Full test suite: 1755 passed, 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)