### PR TITLE
fix: Consistency verifier — stale merged relationships, hidden-people cleanup, per-table thresholds

### DIFF
--- a/api/services/relationship_discovery.py
+++ b/api/services/relationship_discovery.py
@@ -1316,10 +1316,9 @@ def run_full_discovery(days_back: int = DISCOVERY_WINDOW_DAYS) -> dict:
     # Discovery functions read person_ids from interactions and don't know
     # which people are hidden, so we clean up after the fact.
     person_store = get_person_entity_store()
-    hidden_ids = {
-        p.id for p in person_store.get_all(include_hidden=True) if p.hidden
-    }
-    if hidden_ids:
+    all_people = person_store.get_all(include_hidden=True)
+    hidden_ids = {p.id for p in all_people if p.hidden}
+    if hidden_ids and len(hidden_ids) <= len(all_people) * 0.5:
         import sqlite3
         from api.services.source_entity import get_crm_db_path
         conn = sqlite3.connect(get_crm_db_path(), timeout=60.0)

--- a/scripts/sync_consistency_verify.py
+++ b/scripts/sync_consistency_verify.py
@@ -84,13 +84,17 @@ def _check_orphaned_interactions(valid_ids: set, dry_run: bool, fix_threshold: i
     return {"count": count, "fixed": fixed}
 
 
-def _check_hidden_interactions(hidden_ids: set, dry_run: bool) -> dict:
+def _check_hidden_interactions(hidden_ids: set, valid_ids: set, dry_run: bool) -> dict:
     """Check 2b: Delete interactions for hidden (soft-deleted) people.
 
     These interactions drive unnecessary relationship discovery work and serve
     no purpose since the person is hidden.  Always cleaned up (no threshold).
     """
     if not hidden_ids:
+        return {"count": 0, "fixed": 0}
+    if len(hidden_ids) > len(valid_ids) * 0.5:
+        logger.warning("hidden_ids > 50%% of valid_ids (%d/%d) — skipping hidden cleanup as safety guard",
+                        len(hidden_ids), len(valid_ids))
         return {"count": 0, "fixed": 0}
 
     from api.services.interaction_store import get_interaction_db_path
@@ -156,7 +160,7 @@ def _check_stale_merged_ids(valid_ids: set, store, dry_run: bool, fix_threshold:
     return {"count": count, "fixed": fixed}
 
 
-def _check_stale_merged_relationships(valid_ids: set, store, dry_run: bool, fix_threshold: int) -> dict:
+def _check_stale_merged_relationships(valid_ids: set, store, dry_run: bool) -> dict:
     """Check 3b: Find relationships pointing to merged (old) person IDs that can be re-pointed."""
     from config.settings import settings
     crm_path = Path(settings.chroma_path).parent / "crm.db"
@@ -201,17 +205,25 @@ def _check_stale_merged_relationships(valid_ids: set, store, dry_run: bool, fix_
     # Re-pointing merged IDs is always safe (follows known merge chains),
     # so it's not gated by fix_threshold (which guards against mass deletions).
     if not dry_run and count > 0:
-        # Re-point person_a_id
+        # Re-point person_a_id and person_b_id.  Use OR IGNORE so rows that
+        # would violate UNIQUE(person_a_id, person_b_id) are skipped.
         conn.execute(
-            "UPDATE relationships SET person_a_id = ("
+            "UPDATE OR IGNORE relationships SET person_a_id = ("
             "  SELECT s.new_id FROM stale_rel_ids s WHERE s.old_id = relationships.person_a_id"
             ") WHERE person_a_id IN (SELECT old_id FROM stale_rel_ids)"
         )
-        # Re-point person_b_id
         conn.execute(
-            "UPDATE relationships SET person_b_id = ("
+            "UPDATE OR IGNORE relationships SET person_b_id = ("
             "  SELECT s.new_id FROM stale_rel_ids s WHERE s.old_id = relationships.person_b_id"
             ") WHERE person_b_id IN (SELECT old_id FROM stale_rel_ids)"
+        )
+
+        # Delete rows that still reference stale IDs (skipped due to UNIQUE conflicts —
+        # the canonical equivalent already exists).
+        conn.execute(
+            "DELETE FROM relationships "
+            "WHERE person_a_id IN (SELECT old_id FROM stale_rel_ids) "
+            "   OR person_b_id IN (SELECT old_id FROM stale_rel_ids)"
         )
         repointed = count
 
@@ -228,7 +240,7 @@ def _check_stale_merged_relationships(valid_ids: set, store, dry_run: bool, fix_
         )
 
         # Delete duplicate pairs (keep the one with highest total shared counts)
-        conn.execute("""
+        cursor = conn.execute("""
             DELETE FROM relationships WHERE id NOT IN (
                 SELECT id FROM (
                     SELECT id, ROW_NUMBER() OVER (
@@ -247,14 +259,14 @@ def _check_stale_merged_relationships(valid_ids: set, store, dry_run: bool, fix_
                 ) WHERE rn = 1
             )
         """)
-        deleted_dupes = conn.total_changes - repointed  # approximate
+        deleted_dupes = cursor.rowcount
         conn.commit()
 
     conn.close()
     return {"count": count, "fixed": repointed, "repointed": repointed, "deleted_dupes": deleted_dupes}
 
 
-def _check_relationship_hygiene(hidden_ids: set, dry_run: bool) -> dict:
+def _check_relationship_hygiene(hidden_ids: set, valid_ids: set, dry_run: bool) -> dict:
     """Check 4: Delete self-loop and hidden-person relationships.
 
     Self-loops are data errors. Relationships involving hidden people are
@@ -273,13 +285,15 @@ def _check_relationship_hygiene(hidden_ids: set, dry_run: bool) -> dict:
     ).fetchone()[0]
 
     hidden_rels = 0
-    if hidden_ids:
+    skip_hidden = hidden_ids and len(hidden_ids) > len(valid_ids) * 0.5
+    if hidden_ids and not skip_hidden:
         conn.execute("CREATE TEMP TABLE hidden_ids (id TEXT PRIMARY KEY)")
         conn.executemany("INSERT INTO hidden_ids (id) VALUES (?)", [(id,) for id in hidden_ids])
         hidden_rels = conn.execute(
             "SELECT COUNT(*) FROM relationships r "
-            "WHERE EXISTS (SELECT 1 FROM hidden_ids h WHERE h.id = r.person_a_id) "
-            "   OR EXISTS (SELECT 1 FROM hidden_ids h WHERE h.id = r.person_b_id)"
+            "WHERE (EXISTS (SELECT 1 FROM hidden_ids h WHERE h.id = r.person_a_id) "
+            "    OR EXISTS (SELECT 1 FROM hidden_ids h WHERE h.id = r.person_b_id)) "
+            "  AND r.person_a_id != r.person_b_id"
         ).fetchone()[0]
 
     count = self_loops + hidden_rels
@@ -428,16 +442,17 @@ def verify_consistency(dry_run: bool = True, fix_threshold: int = AUTO_FIX_THRES
             "auto_fix_skipped": False,
         }
 
-    # Person stats always fixes (threshold doesn't apply — it updates cached counts, not deletes)
-    person_stats = _check_person_stats(dry_run)
+    # Interaction-modifying checks first (deletions change counts)
     orphaned_interactions = _check_orphaned_interactions(valid_ids, dry_run, fix_threshold)
-    hidden_interactions = _check_hidden_interactions(hidden_ids, dry_run)
+    hidden_interactions = _check_hidden_interactions(hidden_ids, valid_ids, dry_run)
     stale_merged_ids = _check_stale_merged_ids(valid_ids, store, dry_run, fix_threshold)
     # Re-point stale merged IDs in relationships BEFORE checking for orphans
-    stale_merged_rels = _check_stale_merged_relationships(valid_ids, store, dry_run, fix_threshold)
+    stale_merged_rels = _check_stale_merged_relationships(valid_ids, store, dry_run)
     # Clean up self-loops and hidden-person relationships BEFORE orphan check
-    rel_hygiene = _check_relationship_hygiene(hidden_ids, dry_run)
+    rel_hygiene = _check_relationship_hygiene(hidden_ids, valid_ids, dry_run)
     orphaned_crm_records = _check_orphaned_crm_records(valid_ids, dry_run, fix_threshold)
+    # Person stats AFTER interaction-modifying checks so counts reflect final state
+    person_stats = _check_person_stats(dry_run)
 
     checks = [
         person_stats, orphaned_interactions, hidden_interactions,

--- a/tests/test_consistency_verify.py
+++ b/tests/test_consistency_verify.py
@@ -42,7 +42,15 @@ def _create_crm_db(db_path: str, *, relationships=None, facts=None, overrides=No
             id TEXT PRIMARY KEY,
             person_a_id TEXT NOT NULL,
             person_b_id TEXT NOT NULL,
-            relationship_type TEXT
+            relationship_type TEXT,
+            shared_events_count INTEGER DEFAULT 0,
+            shared_threads_count INTEGER DEFAULT 0,
+            shared_messages_count INTEGER DEFAULT 0,
+            shared_whatsapp_count INTEGER DEFAULT 0,
+            shared_slack_count INTEGER DEFAULT 0,
+            shared_phone_calls_count INTEGER DEFAULT 0,
+            shared_photos_count INTEGER DEFAULT 0,
+            UNIQUE(person_a_id, person_b_id)
         )
     """)
     conn.execute("""
@@ -420,3 +428,284 @@ class TestAutoFixStaleMergedIds:
         row = conn.execute("SELECT person_id FROM interactions WHERE id = 'i2'").fetchone()
         conn.close()
         assert row[0] == "p1"  # re-pointed from p_old to p1
+
+
+class TestCheckHiddenInteractions:
+    """Tests for _check_hidden_interactions."""
+
+    def test_detects_hidden_interactions_dry_run(self, tmp_path):
+        hidden_ids = {"p_hidden"}
+        valid_ids = {"p1", "p_hidden"}
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Valid", "", "", "src1", "2024-01-01"),
+            ("i2", "p_hidden", "2024-01-01", "gmail", "Hidden", "", "", "src2", "2024-01-01"),
+            ("i3", "p_hidden", "2024-01-01", "calendar", "Hidden2", "", "", "src3", "2024-01-01"),
+        ])
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_hidden_interactions
+            result = _check_hidden_interactions(hidden_ids, valid_ids, dry_run=True)
+
+        assert result["count"] == 2
+        assert result["fixed"] == 0
+
+        # Verify nothing deleted
+        conn = sqlite3.connect(interaction_db)
+        assert conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0] == 3
+        conn.close()
+
+    def test_deletes_hidden_interactions(self, tmp_path):
+        hidden_ids = {"p_hidden"}
+        valid_ids = {"p1", "p_hidden"}
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Valid", "", "", "src1", "2024-01-01"),
+            ("i2", "p_hidden", "2024-01-01", "gmail", "Hidden", "", "", "src2", "2024-01-01"),
+        ])
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_hidden_interactions
+            result = _check_hidden_interactions(hidden_ids, valid_ids, dry_run=False)
+
+        assert result["count"] == 1
+        assert result["fixed"] == 1
+
+        conn = sqlite3.connect(interaction_db)
+        assert conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0] == 1
+        conn.close()
+
+    def test_empty_hidden_ids_noop(self, tmp_path):
+        from scripts.sync_consistency_verify import _check_hidden_interactions
+        result = _check_hidden_interactions(set(), {"p1"}, dry_run=False)
+        assert result == {"count": 0, "fixed": 0}
+
+    def test_safety_guard_skips_when_majority_hidden(self, tmp_path):
+        """If >50% of people are hidden, skip cleanup as a safety guard."""
+        hidden_ids = {"p1", "p2", "p3"}
+        valid_ids = {"p1", "p2", "p3", "p4"}  # 3/4 = 75% hidden
+        interaction_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(interaction_db, [
+            ("i1", "p1", "2024-01-01", "gmail", "Hidden", "", "", "src1", "2024-01-01"),
+        ])
+
+        with patch("api.services.interaction_store.get_interaction_db_path", return_value=interaction_db):
+            from scripts.sync_consistency_verify import _check_hidden_interactions
+            result = _check_hidden_interactions(hidden_ids, valid_ids, dry_run=False)
+
+        assert result["count"] == 0  # skipped entirely
+        assert result["fixed"] == 0
+
+
+class TestCheckStaleMergedRelationships:
+    """Tests for _check_stale_merged_relationships."""
+
+    def test_detects_stale_merged_relationships_dry_run(self, tmp_path):
+        valid_ids = {"p1", "p2", "p3"}
+        merged_ids = {"p_old": "p1"}
+        mock_store = _mock_store(
+            [_make_person("p1", "Alice"), _make_person("p2", "Bob"), _make_person("p3", "Carol")],
+            merged_ids=merged_ids,
+        )
+
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[
+            ("r1", "p_old", "p2", "colleague"),  # stale: p_old → p1
+            ("r2", "p2", "p3", "friend"),          # valid
+        ])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_stale_merged_relationships
+            result = _check_stale_merged_relationships(valid_ids, mock_store, dry_run=True)
+
+        assert result["count"] == 1
+        assert result["fixed"] == 0
+
+    def test_repoints_stale_merged_relationships(self, tmp_path):
+        valid_ids = {"p1", "p2", "p3"}
+        merged_ids = {"p_old": "p1"}
+        mock_store = _mock_store(
+            [_make_person("p1", "Alice"), _make_person("p2", "Bob"), _make_person("p3", "Carol")],
+            merged_ids=merged_ids,
+        )
+
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[
+            ("r1", "p_old", "p2", "colleague"),  # stale
+            ("r2", "p2", "p3", "friend"),          # valid
+        ])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_stale_merged_relationships
+            result = _check_stale_merged_relationships(valid_ids, mock_store, dry_run=False)
+
+        assert result["repointed"] == 1
+
+        # Verify re-pointed
+        conn = sqlite3.connect(crm_db)
+        row = conn.execute("SELECT person_a_id, person_b_id FROM relationships WHERE id = 'r1'").fetchone()
+        conn.close()
+        assert row[0] == "p1"
+        assert row[1] == "p2"
+
+    def test_unique_constraint_handled(self, tmp_path):
+        """When re-pointing would create a duplicate pair, the stale row is deleted."""
+        valid_ids = {"p1", "p2"}
+        merged_ids = {"p_old": "p1"}
+        mock_store = _mock_store(
+            [_make_person("p1", "Alice"), _make_person("p2", "Bob")],
+            merged_ids=merged_ids,
+        )
+
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[
+            ("r1", "p1", "p2", "colleague"),   # canonical pair already exists
+            ("r2", "p_old", "p2", "friend"),    # stale — re-pointing would duplicate (p1, p2)
+        ])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_stale_merged_relationships
+            # Should NOT crash with IntegrityError
+            result = _check_stale_merged_relationships(valid_ids, mock_store, dry_run=False)
+
+        assert result["count"] == 1
+
+        # Only the canonical row should survive
+        conn = sqlite3.connect(crm_db)
+        rows = conn.execute("SELECT id, person_a_id, person_b_id FROM relationships").fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0][0] == "r1"
+
+    def test_no_stale_ids_noop(self, tmp_path):
+        valid_ids = {"p1", "p2"}
+        mock_store = _mock_store([_make_person("p1", "Alice"), _make_person("p2", "Bob")])
+
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[("r1", "p1", "p2", "colleague")])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_stale_merged_relationships
+            result = _check_stale_merged_relationships(valid_ids, mock_store, dry_run=False)
+
+        assert result["count"] == 0
+
+
+class TestCheckRelationshipHygiene:
+    """Tests for _check_relationship_hygiene."""
+
+    def test_detects_self_loops_dry_run(self, tmp_path):
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[
+            ("r1", "p1", "p2", "colleague"),
+            ("r2", "p1", "p1", "self-loop"),
+        ])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_relationship_hygiene
+            result = _check_relationship_hygiene(set(), {"p1", "p2"}, dry_run=True)
+
+        assert result["self_loops"] == 1
+        assert result["hidden"] == 0
+        assert result["count"] == 1
+        assert result["fixed"] == 0
+
+    def test_deletes_self_loops(self, tmp_path):
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[
+            ("r1", "p1", "p2", "colleague"),
+            ("r2", "p1", "p1", "self-loop"),
+        ])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_relationship_hygiene
+            result = _check_relationship_hygiene(set(), {"p1", "p2"}, dry_run=False)
+
+        assert result["fixed"] == 1
+
+        conn = sqlite3.connect(crm_db)
+        assert conn.execute("SELECT COUNT(*) FROM relationships").fetchone()[0] == 1
+        conn.close()
+
+    def test_detects_hidden_person_relationships(self, tmp_path):
+        hidden_ids = {"p_hidden"}
+        valid_ids = {"p1", "p2", "p_hidden"}
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[
+            ("r1", "p1", "p2", "colleague"),
+            ("r2", "p1", "p_hidden", "friend"),
+            ("r3", "p_hidden", "p2", "coworker"),
+        ])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_relationship_hygiene
+            result = _check_relationship_hygiene(hidden_ids, valid_ids, dry_run=False)
+
+        assert result["hidden"] == 2
+        assert result["fixed"] == 2
+
+        conn = sqlite3.connect(crm_db)
+        assert conn.execute("SELECT COUNT(*) FROM relationships").fetchone()[0] == 1
+        conn.close()
+
+    def test_no_double_counting_self_loop_hidden(self, tmp_path):
+        """A self-loop where the person is also hidden should count once, not twice."""
+        hidden_ids = {"p_hidden"}
+        valid_ids = {"p1", "p_hidden"}
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[
+            ("r1", "p1", "p_hidden", "friend"),        # hidden only
+            ("r2", "p_hidden", "p_hidden", "self"),     # self-loop AND hidden
+        ])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_relationship_hygiene
+            result = _check_relationship_hygiene(hidden_ids, valid_ids, dry_run=True)
+
+        # r2 counted as self_loop only (excluded from hidden count)
+        assert result["self_loops"] == 1
+        assert result["hidden"] == 1  # r1 only
+        assert result["count"] == 2   # not 3
+
+    def test_safety_guard_skips_when_majority_hidden(self, tmp_path):
+        """If >50% of people are hidden, skip hidden cleanup (self-loops still cleaned)."""
+        hidden_ids = {"p1", "p2", "p3"}
+        valid_ids = {"p1", "p2", "p3", "p4"}  # 75% hidden
+        crm_db = str(tmp_path / "crm.db")
+        _create_crm_db(crm_db, relationships=[
+            ("r1", "p1", "p4", "friend"),
+        ])
+
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.chroma_path = str(tmp_path / "chroma")
+            Path(mock_settings.chroma_path).mkdir()
+
+            from scripts.sync_consistency_verify import _check_relationship_hygiene
+            result = _check_relationship_hygiene(hidden_ids, valid_ids, dry_run=False)
+
+        assert result["hidden"] == 0  # hidden cleanup skipped
+        assert result["fixed"] == 0


### PR DESCRIPTION
## Summary

- **Stale merged relationships**: Re-points relationships with stale merged person IDs to canonical IDs, normalizes pair order, removes resulting self-loops and duplicates
- **Hidden-people cleanup**: Deletes relationships and interactions involving hidden (soft-deleted) people — both in the consistency verifier (defense-in-depth) and as post-discovery cleanup in relationship discovery
- **Per-table threshold**: Changes `fix_threshold` from a combined total across all CRM tables to per-table, so one large table doesn't block auto-fixes for smaller tables

## Test plan

- [x] Unit tests updated — mock return values changed to match new 3-tuple from `_get_valid_person_ids`
- [x] Full test suite passes (1083 tests)
- [ ] Run nightly sync and verify consistency verifier reports clean results
- [ ] Verify `--dry-run` mode correctly previews without modifying data

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)