### PR TITLE
fix: Prevent GPU OOM during nightly sync

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -186,6 +186,27 @@ All checks should pass. If any fail, see [Troubleshooting](../reference/TROUBLES
 
 ---
 
+## GPU Memory (AMD Unified Memory Systems)
+
+If running a local LLM on an AMD APU with unified memory (e.g., Ryzen AI MAX+), the BIOS allocates GPU vs CPU memory from a shared pool.
+
+**Recommended allocation: 80 GB GPU** (for systems with 96+ GB total). This gives:
+- ~59 GB for gpt-oss-120b (MXFP4) with 21 GB GPU headroom
+- ~20 GB for Qwen3-32B (Q4_K_M) with 60 GB GPU headroom
+- ~46 GB visible to the CPU (vs ~30 GB at 96 GB GPU allocation)
+
+The setup script creates an 8 GB swap file as an OOM safety net. The nightly sync pipeline automatically stops the LLM before embedding phases if GPU memory is insufficient, and restarts it afterward.
+
+### Optional: cgroups for dev processes
+
+To prevent test suites from triggering OOM kills:
+
+```bash
+# Create a memory-limited slice for dev work
+sudo systemd-run --scope -p MemoryMax=16G --user bash
+# Or add to ~/.config/systemd/user/dev.slice for persistence
+```
+
 ## Common Issues
 
 | Issue | Solution |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ markers = [
     "requires_server: Tests that require the API server to be running",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# These scripts intentionally call load_dotenv() before stdlib imports
+"scripts/*.py" = ["E402"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["api*", "config*"]

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -30,8 +30,9 @@ import logging
 import signal
 import subprocess
 import sys
+import time
 import traceback
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 # Add project root to path
@@ -48,6 +49,89 @@ from api.services.sync_health import (
     check_sync_health,
 )
 from config.settings import settings
+
+# =============================================================================
+# LLM Service Management (memory-gated stop/start for embedding phases)
+# =============================================================================
+
+# Embedding phases that need GPU memory — LLM may need to yield
+EMBEDDING_SOURCES = {"vault_reindex", "crm_vectorstore"}
+
+# Minimum free GPU memory (MB) required to run embeddings alongside the LLM.
+# gte-Qwen2-1.5B needs ~3 GB; add headroom for PyTorch allocator overhead.
+_EMBEDDING_MEMORY_THRESHOLD_MB = 6_000
+
+
+def _is_llm_running() -> bool:
+    """Check if lifeos-llm systemd service is active."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", "--quiet", "lifeos-llm.service"],
+            timeout=5,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _get_available_gpu_memory_mb() -> int | None:
+    """Get available GPU memory in MB from AMDGPU sysfs, or None if unavailable."""
+    try:
+        # AMDGPU exposes VRAM info via sysfs
+        for card_dir in Path("/sys/class/drm").iterdir():
+            vram_total = card_dir / "device" / "mem_info_vram_total"
+            vram_used = card_dir / "device" / "mem_info_vram_used"
+            if vram_total.exists() and vram_used.exists():
+                total = int(vram_total.read_text().strip())
+                used = int(vram_used.read_text().strip())
+                return (total - used) // (1024 * 1024)
+    except Exception:
+        pass
+    return None
+
+
+def _stop_llm_for_embeddings() -> bool:
+    """Stop LLM service to free GPU memory. Returns True if stopped."""
+    logger = logging.getLogger(__name__)
+    try:
+        result = subprocess.run(
+            ["sudo", "systemctl", "stop", "lifeos-llm.service"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            logger.info("Stopped lifeos-llm to free GPU memory for embeddings")
+            # Wait for VRAM to actually be freed
+            for _ in range(10):
+                time.sleep(2)
+                available = _get_available_gpu_memory_mb()
+                if available is not None and available >= _EMBEDDING_MEMORY_THRESHOLD_MB:
+                    logger.info(f"GPU memory freed: {available} MB available")
+                    return True
+            logger.warning("LLM stopped but GPU memory not fully freed within timeout")
+            return True
+        else:
+            logger.warning(f"Failed to stop lifeos-llm: {result.stderr[:200]}")
+            return False
+    except Exception as e:
+        logger.warning(f"Could not stop lifeos-llm: {e}")
+        return False
+
+
+def _start_llm() -> None:
+    """Start LLM service back up."""
+    logger = logging.getLogger(__name__)
+    try:
+        result = subprocess.run(
+            ["sudo", "systemctl", "start", "lifeos-llm.service"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            logger.info("Restarted lifeos-llm after embedding phases")
+        else:
+            logger.warning(f"Failed to start lifeos-llm: {result.stderr[:200]}")
+    except Exception as e:
+        logger.warning(f"Could not start lifeos-llm: {e}")
+
 
 # Track current sync run for SIGTERM cleanup
 _active_run_id: int | None = None
@@ -102,7 +186,6 @@ def log_sync_summary_to_markdown(result: dict, trigger: str = "unknown"):
     Always logs to provide visibility into sync history.
     """
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    status = "FAILED" if result["failed"] > 0 else "SUCCESS"
 
     # Format duration
     duration_secs = result.get("duration_seconds", 0)
@@ -565,7 +648,7 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
 
         # Capture partial output from the killed process
         partial_stdout = e.stdout or ""
-        partial_stderr = e.stderr or ""
+        _ = e.stderr or ""  # available if needed for debugging
 
         # Parse what was accomplished before timeout
         stats = _parse_sync_output(partial_stdout)
@@ -794,6 +877,22 @@ def run_all_syncs(
             logger.warning(f"Unknown source: {source}, skipping")
             continue
 
+        # Memory-gated LLM management for embedding phases
+        if source in EMBEDDING_SOURCES and not dry_run and "_llm_stopped" not in results:
+            llm_was_running = _is_llm_running()
+            results["_llm_was_running"] = llm_was_running
+            if llm_was_running:
+                available = _get_available_gpu_memory_mb()
+                if available is None or available < _EMBEDDING_MEMORY_THRESHOLD_MB:
+                    logger.info(f"Insufficient GPU memory ({available} MB) for embeddings — stopping LLM")
+                    if _stop_llm_for_embeddings():
+                        results["_llm_stopped"] = True
+                else:
+                    logger.info(f"Sufficient GPU memory ({available} MB) — LLM stays running")
+                    results["_llm_stopped"] = False
+            else:
+                results["_llm_stopped"] = False
+
         # Skip sources disabled by work integration settings
         if source in disabled_sources:
             logger.info(f"Skipping {source}: work integration disabled")
@@ -837,6 +936,18 @@ def run_all_syncs(
         if not success:
             failed.append(source)
 
+        # Restart LLM after embedding phases complete (if we stopped it)
+        if source in EMBEDDING_SOURCES and results.get("_llm_stopped"):
+            # Check if next source is still an embedding source
+            source_idx = sources.index(source) if source in sources else -1
+            next_is_embedding = (
+                source_idx + 1 < len(sources)
+                and sources[source_idx + 1] in EMBEDDING_SOURCES
+            )
+            if not next_is_embedding:
+                _start_llm()
+                results["_llm_stopped"] = False
+
     # Log summary
     logger.info("=" * 60)
     logger.info("SYNC RUN COMPLETE")
@@ -848,6 +959,15 @@ def run_all_syncs(
     if dep_skipped:
         logger.warning(f"Dependency-skipped sources: {', '.join(sorted(dep_skipped))}")
     logger.info("=" * 60)
+
+    # Safety net: restart LLM if we stopped it and it's still down
+    if results.get("_llm_stopped") and results.get("_llm_was_running"):
+        logger.warning("LLM was stopped for embeddings but not restarted — restarting now")
+        _start_llm()
+
+    # Clean up internal tracking keys
+    results.pop("_llm_stopped", None)
+    results.pop("_llm_was_running", None)
 
     # Check overall health
     is_healthy, health_msg = check_sync_health()
@@ -956,7 +1076,7 @@ def main():
 
     if args.status:
         summary = get_sync_summary()
-        print(f"\nSync Health Summary:")
+        print("\nSync Health Summary:")
         print(f"  Total sources: {summary['total_sources']}")
         print(f"  Healthy: {summary['healthy']}")
         print(f"  Stale: {summary['stale']} {summary['stale_sources']}")

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -128,13 +128,12 @@ if [ -f "$LOGROTATE_SRC" ]; then
     echo "  Installed /etc/logrotate.d/lifeos"
 fi
 
-# Install sudoers rule so server.sh can restart via systemctl without a password
-# (required for nightly sync to restart the server after completion)
+# Install sudoers rule so server.sh and sync scripts can manage services without a password
 echo ""
 echo "Installing sudoers rule for passwordless systemctl..."
 SUDOERS_FILE="/etc/sudoers.d/lifeos"
 TMP_SUDOERS=$(mktemp)
-echo "$REAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start lifeos-api, /usr/bin/systemctl stop lifeos-api, /usr/bin/systemctl restart lifeos-api, /usr/bin/systemctl start lifeos-api.service, /usr/bin/systemctl stop lifeos-api.service, /usr/bin/systemctl restart lifeos-api.service" > "$TMP_SUDOERS"
+echo "$REAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start lifeos-api, /usr/bin/systemctl stop lifeos-api, /usr/bin/systemctl restart lifeos-api, /usr/bin/systemctl start lifeos-api.service, /usr/bin/systemctl stop lifeos-api.service, /usr/bin/systemctl restart lifeos-api.service, /usr/bin/systemctl start lifeos-llm, /usr/bin/systemctl stop lifeos-llm, /usr/bin/systemctl start lifeos-llm.service, /usr/bin/systemctl stop lifeos-llm.service" > "$TMP_SUDOERS"
 if visudo -c -f "$TMP_SUDOERS" > /dev/null 2>&1; then
     mv "$TMP_SUDOERS" "$SUDOERS_FILE"
     chmod 440 "$SUDOERS_FILE"
@@ -142,6 +141,30 @@ if visudo -c -f "$TMP_SUDOERS" > /dev/null 2>&1; then
 else
     rm -f "$TMP_SUDOERS"
     echo "  ERROR: Invalid sudoers syntax — skipping installation"
+fi
+
+# Set up swap file as OOM safety net (idempotent)
+SWAP_FILE="/swapfile"
+SWAP_SIZE_GB=8
+if [ ! -f "$SWAP_FILE" ]; then
+    echo ""
+    echo "Creating ${SWAP_SIZE_GB}GB swap file as OOM safety net..."
+    dd if=/dev/zero of="$SWAP_FILE" bs=1G count="$SWAP_SIZE_GB" status=progress
+    chmod 600 "$SWAP_FILE"
+    mkswap "$SWAP_FILE"
+    swapon "$SWAP_FILE"
+    # Add to fstab if not already there
+    if ! grep -q "$SWAP_FILE" /etc/fstab; then
+        echo "$SWAP_FILE none swap sw 0 0" >> /etc/fstab
+    fi
+    echo "  Swap enabled: ${SWAP_SIZE_GB}GB at $SWAP_FILE"
+else
+    # Ensure it's active
+    if ! swapon --show | grep -q "$SWAP_FILE"; then
+        swapon "$SWAP_FILE" 2>/dev/null || true
+    fi
+    echo ""
+    echo "Swap file already exists: $(swapon --show | grep "$SWAP_FILE" || echo "$SWAP_FILE (inactive)")"
 fi
 
 # Show status


### PR DESCRIPTION
## Summary
Prevents GPU OOM crashes during nightly sync by (1) sub-chunking oversized Granola Transcript sections that were producing 10K+ token chunks, causing 30-60GB attention matrix allocations, and (2) stopping lifeos-llm (60GB model) before embedding-heavy sync phases and restarting after, freeing GPU VRAM for the embedding model.

Also adds the `/pr` skill for full PR lifecycle orchestration.

## Test evidence
`./scripts/test.sh` — 1083 passed, 0 failures (pre-commit hook ran twice, once per commit).
Verified chunker fix live: reindex of 54 files with 0 errors, max chunk size dropped from 10,874 → ~700 tokens.
Verified `sudo -n systemctl stop/start lifeos-llm` works without password prompt after sudoers update.

## Review focus
- `chunk_by_headers` sub-chunking logic in `api/services/chunker.py`
- LLM stop/start lifecycle in `scripts/run_all_syncs.py` (correct placement around Phase 4 sources, safety restart at end)
- Sudoers rule scope in `scripts/setup-systemd.sh`