### PR TITLE
chore: Optimize git hooks — lint on commit, tests on push, async restart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,9 @@ google-auth>=2.27.0
 google-auth-oauthlib>=1.2.0
 google-api-python-client>=2.116.0
 
+# Linting
+ruff>=0.15.0
+
 # Testing
 pytest>=7.4.0
 pytest-asyncio>=0.23.0

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -2,8 +2,9 @@
 #
 # LifeOS Post-commit Hook
 #
-# Automatically restarts the server after each commit using server.sh
-# for consistent behavior with manual restarts.
+# Normalizes commit timestamps to 12:00 UTC (privacy: hides work schedule).
+# Conditionally restarts the server in the background when api/ or config/
+# files are in the commit.
 #
 # Installation:
 #   cp scripts/post-commit .git/hooks/post-commit
@@ -35,23 +36,14 @@ if [ -z "$_LIFEOS_SKIP_DATE_NORMALIZE" ]; then
     fi
 fi
 
-echo ""
-echo "========================================"
-echo "  Restarting LifeOS server..."
-echo "========================================"
+# Only restart server if api/ or config/ files were changed
+CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD -- api/ config/)
 
-# Use server.sh for consistent restart behavior
-# This ensures ChromaDB check, proper binding, and correct timeouts
-if [ -x "./scripts/server.sh" ]; then
-    ./scripts/server.sh restart
-    if [ $? -eq 0 ]; then
-        echo "  Server restarted successfully"
-    else
-        echo "  Warning: Server restart may have issues"
+if [ -n "$CHANGED" ]; then
+    if [ -x "./scripts/server.sh" ]; then
+        nohup ./scripts/server.sh restart > /tmp/lifeos-server-restart.log 2>&1 &
+        echo "Server restart triggered (log: /tmp/lifeos-server-restart.log)"
     fi
 else
-    echo "  Error: scripts/server.sh not found"
-    exit 1
+    echo "No server restart needed"
 fi
-
-echo "========================================"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -2,61 +2,32 @@
 #
 # LifeOS Pre-commit Hook
 #
-# Runs fast unit tests before allowing commits.
-# Slow tests (ChromaDB, embeddings) are skipped for speed.
-#
-# Test markers:
-#   @pytest.mark.unit        - Fast unit tests (run on commit)
-#   @pytest.mark.slow        - Slow tests (ChromaDB, embeddings)
-#   @pytest.mark.integration - Integration tests (require running server)
+# Runs ruff lint check on staged Python files. Fast (<1s).
+# Tests are deferred to the pre-push hook.
 #
 # Installation:
 #   cp scripts/pre-commit .git/hooks/pre-commit
 #   chmod +x .git/hooks/pre-commit
 #
-# Run all tests manually:
-#   pytest tests/ -v             # All tests
-#   pytest -m unit               # Unit tests only
-#   pytest -m "not slow"         # Skip slow tests
-#   pytest -m "not integration"  # Skip integration tests
-#
 
 set -e
 
-echo "========================================"
-echo "  LifeOS Pre-commit Hook"
-echo "  Running unit tests (fast)..."
-echo "========================================"
-echo ""
+# Get staged Python files
+STAGED=$(git diff --cached --name-only --diff-filter=ACM -- '*.py')
 
-# Get the project root directory
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-cd "$PROJECT_ROOT"
+if [ -z "$STAGED" ]; then
+    exit 0
+fi
 
-# Activate virtual environment (located outside Documents for faster startup)
+# Activate virtual environment
 if [ -f "$HOME/.venvs/lifeos/bin/activate" ]; then
     source "$HOME/.venvs/lifeos/bin/activate"
 fi
 
-# Run only unit tests (fast) - skip slow tests that require ChromaDB or Ollama
-echo "Running: python -m pytest -m 'unit and not slow' tests/ -v --tb=short"
-echo ""
-
-if python -m pytest -m "unit and not slow" tests/ -v --tb=short; then
-    echo ""
-    echo "========================================"
-    echo "  Unit tests passed! Proceeding with commit."
-    echo ""
-    echo "  Run 'pytest' for full test suite."
-    echo "========================================"
+if ruff check $STAGED --quiet 2>/dev/null; then
+    echo "ruff: ok"
     exit 0
 else
-    echo ""
-    echo "========================================"
-    echo "  COMMIT BLOCKED: Unit tests failed!"
-    echo ""
-    echo "  Fix the failing tests before committing."
-    echo "  To bypass (not recommended): git commit --no-verify"
-    echo "========================================"
+    echo "ruff: lint errors found (run 'ruff check --fix' to auto-fix)"
     exit 1
 fi

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# LifeOS Pre-push Hook
+#
+# Runs unit tests before allowing pushes. Output is redirected to a log
+# file to avoid flooding the terminal — only a pass/fail summary is shown.
+#
+# Installation:
+#   cp scripts/pre-push .git/hooks/pre-push
+#   chmod +x .git/hooks/pre-push
+#
+
+set -e
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+cd "$PROJECT_ROOT"
+
+LOG="/tmp/lifeos-prepush-tests.log"
+
+# Activate virtual environment
+if [ -f "$HOME/.venvs/lifeos/bin/activate" ]; then
+    source "$HOME/.venvs/lifeos/bin/activate"
+fi
+
+echo -n "Running unit tests... "
+
+if python -m pytest -m "unit and not slow" tests/ -q --tb=line --no-header > "$LOG" 2>&1; then
+    SUMMARY=$(tail -1 "$LOG")
+    echo "passed ($SUMMARY)"
+    exit 0
+else
+    SUMMARY=$(tail -1 "$LOG")
+    echo "FAILED ($SUMMARY)"
+    echo "  Full output: $LOG"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- **Pre-commit**: replaced pytest (88 files, multi-GB import) with `ruff check` on staged files only (<1s)
- **Pre-push** (new): unit tests run before push with output to `/tmp/lifeos-prepush-tests.log`, single pass/fail line to terminal
- **Post-commit**: server restart is now conditional (only when `api/` or `config/` changed) and async (`nohup` background), timestamp normalization preserved
- Added `ruff` to `requirements.txt`

Closes #42

## Test plan

- [x] `git commit` on test-only changes completes instantly with "No server restart needed"
- [x] Pre-commit runs ruff (no pytest, no CPU spike)
- [x] `git push` runs 1083 unit tests, shows single summary line
- [x] Warp terminal does not crash during git operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)