### PR TITLE
fix: Telegram messages cut off — multi-line NOTIFY regex, restore skills

### DIFF
--- a/.claude/skills/draft-issue/SKILL.md
+++ b/.claude/skills/draft-issue/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: draft-issue
+description: >
+  Draft and create a GitHub issue from a description, investigation, or conversation context.
+  Use when a problem is too large for a quick fix, when you want to propose a change for later,
+  or when the user asks to "file an issue", "create an issue", "draft an issue", "open a ticket",
+  or "log this for later". Also useful when another skill (like tune) determines a
+  change is too large and needs to be tracked as an issue instead.
+argument-hint: <issue description or context>
+---
+
+# Draft Issue
+
+Create a GitHub issue for: **$ARGUMENTS**
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -5`
+- Open issues: !`gh issue list --state=open --json number,title --limit=10 --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null || echo "GH_ERROR"`
+
+## Instructions
+
+### Step 1: Understand the ask
+
+Parse `$ARGUMENTS` to determine what the issue should cover. The input could be:
+- A direct description ("add rate limiting to the search endpoint")
+- A problem statement ("the sync pipeline sometimes misses new contacts")
+- A reference to something discovered during other work ("tune found this needs a larger refactor")
+- A conversation context where the user said "file an issue for this"
+
+If the description is too vague to write a useful issue, ask one clarifying question.
+
+### Step 2: Research (if needed)
+
+If the issue relates to specific code or behavior, quickly investigate:
+- Read relevant files to understand the current state
+- Check if a similar issue already exists (use the open issues list above)
+- Identify which files/modules would be affected
+
+Skip this if the user already provided enough detail.
+
+### Step 3: Write and create the issue
+
+Create the issue with a clear structure:
+
+```bash
+gh issue create \
+  --title "<type>: <imperative summary>" \
+  --label "<label>" \
+  --body "$(cat <<'EOF'
+## Problem
+
+<What's wrong or what's missing — 2-3 sentences>
+
+## Context
+
+<How this was discovered, why it matters, any relevant background>
+
+## Suggested approach
+
+<High-level direction — not a full spec, just enough to orient whoever picks it up>
+
+## Files involved
+
+<List of files/modules likely affected>
+
+## Acceptance criteria
+
+- [ ] <Verifiable condition 1>
+- [ ] <Verifiable condition 2>
+EOF
+)"
+```
+
+**Title format:** Use the same `<type>: <summary>` convention as commits (feat, fix, refactor, docs, etc.). Keep it under 70 characters.
+
+**Labels:** Use existing labels. Common ones: `bug`, `enhancement`, `documentation`. Check what's available with `gh label list` if unsure.
+
+**Body guidelines:**
+- Problem section should be understandable by someone with no context
+- Suggested approach should be directional, not prescriptive
+- Acceptance criteria should be objectively verifiable
+- Don't include implementation details unless they're critical constraints
+- Use synthetic data in any examples
+
+### Step 4: Report
+
+Tell the user:
+- The issue number and URL
+- A one-line summary of what was filed
+
+Keep it brief — the user can read the full issue on GitHub.

--- a/.claude/skills/standup/SKILL.md
+++ b/.claude/skills/standup/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: standup
+description: Personal daily summary — what you shipped, what's in progress, what needs attention
+argument-hint: [hours]
+---
+
+# Standup: Personal Daily Summary
+
+Arguments: `$ARGUMENTS`
+
+Parameters (all optional):
+- **hours** — numeric, defaults to 24
+
+## My Data
+
+Merged PRs by me in the window:
+
+!`H=$(echo "${ARGUMENTS:-}" | grep -oE '[0-9]+' | head -1); H=${H:-24}; gh pr list --author=@me --state=merged --search="merged:>=$(date -u -d "${H} hours ago" +%Y-%m-%dT%H:%M:%S)Z" --json number,title,mergedAt,additions,deletions,changedFiles --limit 50 2>/dev/null || echo "GH_ERROR"`
+
+Open PRs by me with review status:
+
+!`gh pr list --author=@me --state=open --json number,title,createdAt,updatedAt,isDraft,reviewDecision,additions,deletions,changedFiles --limit 50 2>/dev/null || echo "GH_ERROR"`
+
+Issues assigned to me:
+
+!`gh issue list --assignee=@me --state=open --json number,title,createdAt,updatedAt,labels --limit 50 2>/dev/null || echo "GH_ERROR"`
+
+My commits on main in the window:
+
+!`H=$(echo "${ARGUMENTS:-}" | grep -oE '[0-9]+' | head -1); H=${H:-24}; EMAIL=$(git config user.email); git log --author="$EMAIL" --since="$(date -u -d "${H} hours ago" +%Y-%m-%dT%H:%M:%S)" --oneline origin/main 2>/dev/null || echo "No commits found"`
+
+My git stats for the window:
+
+!`H=$(echo "${ARGUMENTS:-}" | grep -oE '[0-9]+' | head -1); H=${H:-24}; EMAIL=$(git config user.email); SINCE=$(date -u -d "${H} hours ago" +%Y-%m-%dT%H:%M:%S); COMMITS=$(git log --author="$EMAIL" --since="$SINCE" --oneline origin/main 2>/dev/null | wc -l | tr -d ' '); STATS=$(git log --author="$EMAIL" --since="$SINCE" --shortstat origin/main 2>/dev/null | grep "insertion\|deletion" | awk '{for(i=1;i<=NF;i++){if($i~/insertion/)ins+=$(i-1);if($i~/deletion/)del+=$(i-1)}} END {printf "+%d / -%d lines", ins+0, del+0}'); echo "commits=$COMMITS $STATS"`
+
+## Instructions
+
+You are producing a **personal standup summary** — a quick status report of what *I* shipped, what's in progress, and what needs my attention.
+
+### Step 1: Triage
+
+If any data block shows `GH_ERROR`, report that `gh` failed (likely auth or network) and stop.
+
+Parse the hours parameter from the arguments (default 24). Note the time window in the output header.
+
+### Step 2: Write the standup
+
+Produce the following sections:
+
+---
+
+#### Stats
+
+A single compact line summarizing activity:
+
+> **3 commits, 1 PR merged, 2 PRs open, +713 / -28 lines (last 24h)**
+
+Derive values from the git stats and PR data above. Adjust the "(last Nh)" to match the actual window.
+
+#### Done
+
+List merged PRs and landed commits in the window. For each:
+- PR number and title
+- Brief description of what it accomplished (one line)
+
+If no merged PRs or commits, say "Nothing landed in this window."
+
+#### In Progress
+
+List open PRs by me. For each:
+- PR number and title
+- Status label derived from the data:
+  - `DRAFT` — if `isDraft` is true
+  - `CHANGES REQUESTED` — if `reviewDecision` is `CHANGES_REQUESTED`
+  - `APPROVED` — if `reviewDecision` is `APPROVED`
+  - `AWAITING REVIEW` — otherwise (not draft, no decision yet)
+- Lines changed (`+N / -M`)
+
+If no open PRs, say "No open PRs."
+
+#### Needs Attention
+
+Flag items that require action. Include only items that apply:
+- PRs with `CHANGES REQUESTED` status — need to address feedback
+- Stale open PRs (updated 7+ days ago) — need to push forward or close
+- Assigned issues — list with age and labels
+
+If nothing needs attention, omit this section entirely.
+
+---
+
+### Formatting rules
+
+- Use markdown headers and bullets
+- Reference PR numbers as `#N`
+- Reference issues as `#N`
+- Keep it scannable — this should take under 1 minute to read
+- Don't editorialize or add motivational commentary
+
+## Escalation
+
+Stop and tell the user when:
+- `gh` commands fail
+- Any PR list returns exactly 50 results — suggest a shorter time window

--- a/.claude/skills/tune/SKILL.md
+++ b/.claude/skills/tune/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: tune
+description: >
+  Tune LifeOS orchestrator behavior based on feedback about a bad response.
+  Use when the user describes a problem with how LifeOS answered a query — wrong sources,
+  too verbose, not persistent enough, poor tool selection, bad source integration,
+  missing detail, gave up too early, etc. Also covers Claude Code task execution issues
+  (scope, persistence, notification style). Makes a surgical prompt edit, branches, commits, and pushes.
+  Trigger on: "tune", "response-tuning", "fix the prompt", "tune the response",
+  "it didn't search enough", "too verbose", "improve the orchestrator", "the response was bad",
+  or any feedback about LifeOS chat/orchestrator quality.
+argument-hint: <feedback about what went wrong>
+---
+
+# Response Tuning
+
+Improve LifeOS orchestrator behavior based on this feedback: **$ARGUMENTS**
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -3`
+- Recent conversations: !`sqlite3 data/conversations.db "SELECT m.role, substr(m.content, 1, 200), m.created_at FROM messages m JOIN conversations c ON m.conversation_id = c.id ORDER BY m.created_at DESC LIMIT 10;" 2>/dev/null || echo "NO_CONVERSATION_DB"`
+- Recent perf traces: !`curl -s http://localhost:8000/api/perf/traces?limit=3 2>/dev/null | python3 -c "import sys,json; data=json.load(sys.stdin); [print(f'{t.get(\"question\",\"\")[:100]} | tools: {[s[\"name\"] for s in t.get(\"spans\",[]) if s[\"name\"].startswith(\"tool_\")]}') for t in data.get('traces',[])]" 2>/dev/null || echo "NO_PERF_DATA"`
+
+## How this works
+
+You are fixing the orchestrator's behavior — the instructions that tell LifeOS how to search,
+pick tools, integrate sources, and format responses. The user got a bad result and is telling
+you what went wrong so you can prevent it from happening again.
+
+The fix is almost always a targeted edit to an instruction in a system prompt. Think of it like
+tuning a knob — you're adjusting the model's tendencies, not rewriting the system.
+
+## Step 1: Diagnose
+
+Read the feedback and the recent conversation context above. Identify:
+
+1. **What went wrong** — Map the feedback to a specific failure mode:
+   - Didn't search enough sources → tool persistence / multi-tool patterns
+   - Too verbose / too terse → response format section
+   - Gave up without trying → give-up detection / self-correction
+   - Wrong tool chosen → tool descriptions / when-to-use guidance
+   - Poor source integration → synthesis instructions
+   - Didn't follow up on partial results → search persistence rules
+   - Bad Claude Code task execution → orchestrator scope/persistence/notification rules
+
+2. **Which file owns this behavior:**
+
+   | Behavior | File | Key section |
+   |----------|------|-------------|
+   | Chat tool selection & search strategy | `api/services/agent_system_prompt.py` | `_STATIC_PROMPT_TEMPLATE` |
+   | Chat response format & conciseness | `api/services/agent_system_prompt.py` | Response format section |
+   | Chat tool round limits | `api/services/agent_loop.py` | `max_tool_rounds` param |
+   | Give-up detection patterns | `api/services/agent_loop.py` | `_GIVE_UP_PATTERNS` |
+   | Self-correction nudge | `api/services/agent_loop.py` | `SELF_CORRECTION_NUDGE` |
+   | Claude Code task scope & persistence | `api/services/claude_orchestrator.py` | `_SYSTEM_PROMPT` |
+   | Claude Code notifications | `api/services/claude_orchestrator.py` | NOTIFICATIONS section |
+
+3. **Read the target file(s)** — Read the actual current content of the file you plan to edit.
+   Do not work from memory. The prompt may have changed since you last saw it.
+
+## Step 2: Assess scope
+
+This skill is for **small, surgical changes**. Before editing, ask yourself:
+
+- Am I changing fewer than ~20 lines of prompt text? → Proceed.
+- Am I adding/adjusting a single behavioral rule or instruction? → Proceed.
+- Am I tweaking a parameter (like max_tool_rounds)? → Proceed.
+- Would this require restructuring the prompt, adding new tools, or changing multiple
+  modules? → **Stop.** Use the `/draft-issue` skill to create a GitHub issue:
+
+  ```
+  Skill tool → skill: "draft-issue", args: "Orchestrator: <summary>. Feedback: <user feedback>. Root cause: <your diagnosis>. Files: <list>. Too large for a prompt tweak because <reason>."
+  ```
+
+  Then notify the user that an issue was created and stop.
+
+## Step 3: Edit
+
+Make the change. Guidelines:
+
+- **Match the existing style.** The prompts use a specific tone and structure — imperative,
+  concise, example-driven. Don't introduce a different voice.
+- **Be specific, not vague.** "Search at least 3 different sources" is better than
+  "Be more thorough." The model responds to concrete instructions.
+- **Explain why when it's not obvious.** A brief parenthetical like "(the user can't easily
+  follow up from their phone)" helps the model internalize the intent.
+- **Don't bloat the prompt.** If you're adding a new rule, check if an existing rule already
+  covers a similar case and can be strengthened instead. Every line in the prompt costs
+  attention — keep it lean.
+- **Don't weaken other behaviors.** Read the surrounding context to make sure your edit
+  doesn't contradict or undermine an existing instruction.
+- **Test your edit mentally.** Imagine the same query that produced the bad response going
+  through the updated prompt. Would the model now behave differently? If not, your edit
+  isn't targeted enough.
+
+## Step 4: Branch, commit, push
+
+```bash
+# Ensure we branch from main
+git checkout main
+git pull --ff-only
+
+# Create branch
+git checkout -b fix/response-tuning-<short-description>
+
+# Stage only the changed files
+git add <changed-files>
+
+# Commit
+git commit -m "fix: tune orchestrator — <what was adjusted>
+
+Feedback: <brief user feedback>
+Change: <one-line description of what was edited>"
+
+# Push
+git push -u origin fix/response-tuning-<short-description>
+```
+
+## Step 5: Notify
+
+Report back with:
+- What you diagnosed
+- What you changed (quote the before/after of the edited lines)
+- The branch name so the user can review
+
+Keep it to 3-5 sentences. The user is on their phone.
+
+## Related skills
+
+This skill delegates to other skills when needed:
+
+- **`/draft-issue`** — When Step 2 determines the change is too large for a prompt tweak,
+  use the Skill tool to invoke `draft-issue` with context about the problem and diagnosis.
+- **`/implement`** — If the user later asks to implement a filed issue, point them to
+  `/implement #<issue-number>`. Don't invoke it automatically from this skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@ Available as slash commands. See `.claude/skills/` for full details.
 | `/address-review <number>` | Address PR review feedback with independent verification |
 | `/pr-check [number]` | Validate PR against standards before requesting review |
 | `/merge-pr <number>` | Merge PR, update linked issues |
+| `/tune <feedback>` | Tune orchestrator prompts based on bad response feedback |
+| `/draft-issue <description>` | Create a GitHub issue from a description or investigation |
+| `/standup [hours]` | Personal daily summary — shipped, in progress, needs attention |
+| `/catchup [period]` | Cross-PR net-effects briefing for a time period |
+| `/stale` | Find stale PRs, orphan branches, stale issues |
+| `/mine-for-ideas <repo>` | Analyze an open-source repo for patterns LifeOS could adopt |
 
 ## Quick Reference
 

--- a/api/services/claude_orchestrator.py
+++ b/api/services/claude_orchestrator.py
@@ -176,8 +176,8 @@ The user will review and approve the plan before you proceed.
 
 """
 
-_NOTIFY_RE = re.compile(r"\[NOTIFY\]\s*(.+)")
-_CLARIFY_RE = re.compile(r"\[CLARIFY\]\s*(.+)")
+_NOTIFY_RE = re.compile(r"\[NOTIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY)\]|\Z)", re.DOTALL)
+_CLARIFY_RE = re.compile(r"\[CLARIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY)\]|\Z)", re.DOTALL)
 
 HEARTBEAT_INTERVAL = 300  # 5 minutes
 
@@ -567,9 +567,6 @@ class ClaudeOrchestrator:
                         fallback = _CLARIFY_RE.sub("", fallback)
                         fallback = fallback.strip()
                         if fallback:
-                            # Truncate for Telegram (4096 char limit)
-                            if len(fallback) > 3500:
-                                fallback = fallback[:3500] + "\n\n…(truncated)"
                             self._notification_callback(fallback)
                         else:
                             self._notification_callback("Claude Code session completed.")

--- a/tests/test_claude_orchestrator.py
+++ b/tests/test_claude_orchestrator.py
@@ -4,7 +4,6 @@ Tests for the Claude Code orchestrator.
 Tests event parsing, [NOTIFY] extraction, session lifecycle, and plan mode.
 Does NOT spawn real Claude processes — all subprocess calls are mocked.
 """
-import json
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -31,12 +30,22 @@ class TestNotifyExtraction:
         match = _NOTIFY_RE.search("Just a regular line of text.")
         assert match is None
 
-    def test_notify_in_multiline(self):
+    def test_notify_captures_multiline_content(self):
+        """NOTIFY captures all continuation lines until next tag or end."""
         from api.services.claude_orchestrator import _NOTIFY_RE
         text = "Some preamble\n[NOTIFY] Found the issue.\nMore text"
         matches = list(_NOTIFY_RE.finditer(text))
         assert len(matches) == 1
-        assert matches[0].group(1) == "Found the issue."
+        assert matches[0].group(1).strip() == "Found the issue.\nMore text"
+
+    def test_notify_stops_at_next_tag(self):
+        """Multi-line NOTIFY stops capturing at the next [NOTIFY] or [CLARIFY]."""
+        from api.services.claude_orchestrator import _NOTIFY_RE
+        text = "[NOTIFY] First message\nwith continuation\n[CLARIFY] Question?"
+        matches = list(_NOTIFY_RE.finditer(text))
+        assert len(matches) == 1
+        assert "continuation" in matches[0].group(1)
+        assert "Question" not in matches[0].group(1)
 
     def test_multiple_notifies(self):
         from api.services.claude_orchestrator import _NOTIFY_RE
@@ -62,7 +71,7 @@ class TestHandleEvent:
     """Test event handling logic in the orchestrator."""
 
     def _make_orchestrator(self):
-        from api.services.claude_orchestrator import ClaudeOrchestrator, ClaudeSession
+        from api.services.claude_orchestrator import ClaudeOrchestrator
         orch = ClaudeOrchestrator()
         return orch
 


### PR DESCRIPTION
## Summary
- Fix [NOTIFY] regex that only captured the first line of multi-line messages — everything after the first newline was silently dropped
- Remove redundant 3500-char hard truncation in orchestrator (telegram.py already splits at 4096)
- Restore three skills from the unmerged `skills` branch: `/tune`, `/draft-issue`, `/standup`
- Update CLAUDE.md skill table with all available skills

## Test plan
- [x] Unit tests pass (1084 passed)
- [x] Regex validated against 6 test cases: single-line, multi-line, multiple tags, tag boundaries, sub(), finditer
- [x] Existing orchestrator tests updated for new multi-line behavior (53 passed)
- [x] Pre-existing lint issues in test file fixed (unused `json` import, unused `ClaudeSession` import)


🤖 Generated with [Claude Code](https://claude.com/claude-code)