### PR TITLE
feat: Add Qwen3-32B as a documented local model option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,11 @@
 # LIFEOS_LOCAL_LLM_TIMEOUT=90
 
 # Local LLM model (HuggingFace GGUF ID for llama-server)
-# Default: ggml-org/gpt-oss-120b-GGUF (~59 GB VRAM, MXFP4)
 # Also used by setup-systemd.sh for the systemd service
+# Available models:
+#   ggml-org/gpt-oss-120b-GGUF  — ~59 GB VRAM (MXFP4), highest quality
+#   Qwen/Qwen3-32B-GGUF        — ~20 GB VRAM (Q4_K_M), good quality, leaves headroom for embeddings
+# To switch models: change this value, then run: sudo ./scripts/setup-systemd.sh
 # LIFEOS_LLM_MODEL=ggml-org/gpt-oss-120b-GGUF
 
 # Auto-start local LLM on boot and restart on crash (default: false)

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -186,6 +186,32 @@ All checks should pass. If any fail, see [Troubleshooting](../reference/TROUBLES
 
 ---
 
+## Local LLM Model Selection
+
+LifeOS supports any GGUF model via llama-server. Two models are pre-configured:
+
+| Model | VRAM | Quality | Embeddings coexist? |
+|-------|------|---------|---------------------|
+| `ggml-org/gpt-oss-120b-GGUF` (default) | ~59 GB | Highest | No — sync stops LLM automatically |
+| `Qwen/Qwen3-32B-GGUF` | ~20 GB | Good | Yes — both fit in 80 GB GPU |
+
+### Switching models
+
+```bash
+# 1. Set the model in .env
+LIFEOS_LLM_MODEL=Qwen/Qwen3-32B-GGUF
+
+# 2. Reinstall systemd service (substitutes model into the service file)
+sudo ./scripts/setup-systemd.sh
+
+# 3. Restart (downloads the model on first start)
+sudo systemctl restart lifeos-llm
+```
+
+The first start with a new model downloads the GGUF file (~20 GB for Qwen3-32B Q4_K_M). Subsequent starts use the cached file in `~/.cache/llama.cpp/`.
+
+---
+
 ## GPU Memory (AMD Unified Memory Systems)
 
 If running a local LLM on an AMD APU with unified memory (e.g., Ryzen AI MAX+), the BIOS allocates GPU vs CPU memory from a shared pool.


### PR DESCRIPTION
## Summary

- Documents `Qwen/Qwen3-32B-GGUF` (~20 GB Q4_K_M) as an alternative to gpt-oss-120b (~59 GB)
- Adds model comparison table and 3-step switching workflow to installation guide
- No code changes — model switching infrastructure already exists from #48

Closes #49

## Test evidence

Docs-only change. 1085 tests passed (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)