### PR TITLE
fix: add repoint_stale_ids to SYNC_SOURCES

### DIFF
--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -135,6 +135,15 @@ SYNC_SOURCES = {
         "depends_on": ["contacts"],
     },
 
+    # === Phase 2b: Stale ID Cleanup ===
+    "repoint_stale_ids": {
+        "description": "Re-point interactions with stale merged person IDs to canonical IDs",
+        "script": "scripts/sync_repoint_stale_ids.py",
+        "frequency": "daily",
+        "phase": 2,
+        "depends_on": ["link_imessage", "link_source_entities"],
+    },
+
     # === Phase 3: Relationship Building ===
     "person_stats_full": {
         "description": "Full refresh of all PersonEntity counts and timestamps",


### PR DESCRIPTION
## Summary
- Add `repoint_stale_ids` to `SYNC_SOURCES` in `sync_health.py` so it's recognized by the sync runner

This was in `SYNC_ORDER` and `SYNC_SCRIPTS` but missing from `SYNC_SOURCES`, causing the nightly sync to skip it with `WARNING Unknown source: repoint_stale_ids, skipping`. This meant stale merged person IDs were never re-pointed, leading to 1,690 consistency issues each night.

## Test plan
- [x] `./scripts/test.sh` — 1155 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)