### PR TITLE
fix: call Python directly in apple export — LifeOS.app exec loses FDA

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -81,10 +81,10 @@ class Settings(BaseSettings):
                     "When false, llama-server must be started manually."
     )
 
-    # Local LLM Router (Ollama — used for query routing only)
+    # Local LLM Router (Ollama — used for query routing, summarization, fact validation)
     ollama_host: str = Field(default="http://localhost:11434", alias="OLLAMA_HOST")
     ollama_model: str = Field(default="qwen2.5:7b-instruct", alias="OLLAMA_MODEL")
-    ollama_timeout: int = Field(default=45, alias="OLLAMA_TIMEOUT")  # 7B model needs more time
+    ollama_timeout: int = Field(default=45, alias="OLLAMA_TIMEOUT")
     ollama_retry_timeout: int = Field(default=60, alias="OLLAMA_RETRY_TIMEOUT")  # Longer timeout for retries
 
     # Cross-encoder re-ranking (P9.2)

--- a/scripts/apple_data_agent.sh
+++ b/scripts/apple_data_agent.sh
@@ -53,13 +53,14 @@ log "Linux server: ${LINUX_USER}@${LINUX_SERVER}"
 
 # -------------------------------------------------------------------
 # Step 1: Export Apple data to data/apple-exports/
-# Route through LifeOS.app for Full Disk Access (required for
-# Messages.db and CallHistoryDB)
+# cron and /bin/bash both have Full Disk Access on the Mac Mini,
+# so we call Python directly. The LifeOS.app exec wrapper doesn't
+# work because exec replaces the process, losing FDA context.
 # -------------------------------------------------------------------
-log "Step 1: Exporting Apple data (via LifeOS.app for FDA)..."
+log "Step 1: Exporting Apple data..."
 
 cd "${LIFEOS_DIR}"
-if /Applications/LifeOS.app/Contents/MacOS/LifeOS exec "${PYTHON}" scripts/apple_data_export.py --execute >> "${LOG_FILE}" 2>&1; then
+if "${PYTHON}" scripts/apple_data_export.py --execute >> "${LOG_FILE}" 2>&1; then
     log "Export: OK"
 else
     log "Export: FAILED"


### PR DESCRIPTION
## Summary
- Remove LifeOS.app `exec` wrapper from `apple_data_agent.sh` — call Python directly instead
- macOS TCC checks the actual binary doing file access, not the parent process. `exec "$@"` replaced LifeOS.app with Python, losing the FDA context entirely.
- Since `cron` and `/bin/bash` both have Full Disk Access on the Mac Mini, no wrapper is needed.
- This fixes iMessage and phone exports silently returning "Full Disk Access required" every night since the wrapper was introduced.

## Root cause
The `exec` builtin in the LifeOS.app wrapper script replaces the current process with the child. So the process performing the actual file read (Python) has no FDA — only the now-dead LifeOS.app process did.

## Test evidence
- `./scripts/test.sh` — 1155 passed
- Ran `apple_data_export.py` on Mac Mini via SSH — all 3 sources exported successfully (contacts: 3670, iMessage: 62.2 MB, phone: 718 calls)
- Verified Mac Mini TCC database: `/usr/sbin/cron` and `/bin/bash` both have `auth_value=2` (FDA granted)

## Test plan
- [x] Manual export test on Mac Mini
- [ ] Verify tonight's 2:50 AM cron produces iMessage + phone data in manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)