### PR TITLE
fix: Apple Data Agent pipeline — FDA, photos, iMessage linking, stats

### DIFF
--- a/api/routes/monarch.py
+++ b/api/routes/monarch.py
@@ -35,6 +35,7 @@ async def list_transactions(
     category: Optional[str] = None,
     search: Optional[str] = None,
     limit: int = 100,
+    account_id: Optional[str] = None,
 ):
     """
     Search/filter recent transactions.
@@ -45,6 +46,7 @@ async def list_transactions(
     - category: Filter by category name
     - search: Search by merchant name
     - limit: Max results (default 100)
+    - account_id: Filter by Monarch account ID
     """
     if not start_date:
         start_date = (date.today() - timedelta(days=30)).isoformat()
@@ -59,6 +61,7 @@ async def list_transactions(
             search=search or "",
             category=category,
             limit=min(limit, 500),
+            account_ids=[account_id] if account_id else None,
         )
         return {
             "transactions": transactions,

--- a/api/services/monarch.py
+++ b/api/services/monarch.py
@@ -97,10 +97,13 @@ class MonarchClient:
         search: str = "",
         category: Optional[str] = None,
         limit: int = 500,
+        account_ids: Optional[list[str]] = None,
     ) -> list[dict]:
         """Get transactions, optionally filtered by date range and category."""
         mm = await self._get_client()
         kwargs = {"limit": limit, "offset": 0, "search": search}
+        if account_ids:
+            kwargs["account_ids"] = account_ids
         if start_date:
             kwargs["start_date"] = start_date
         if end_date:
@@ -136,6 +139,10 @@ class MonarchClient:
             if isinstance(txn.get("account"), dict):
                 account_name = txn["account"].get("displayName", "")
 
+            tags = []
+            if isinstance(txn.get("tags"), list):
+                tags = [t.get("name", "") for t in txn["tags"] if isinstance(t, dict)]
+
             result.append({
                 "id": txn.get("id"),
                 "date": txn.get("date", ""),
@@ -145,6 +152,9 @@ class MonarchClient:
                 "account": account_name,
                 "notes": txn.get("notes", ""),
                 "pending": txn.get("pending", False),
+                "is_recurring": txn.get("isRecurring", False),
+                "is_split": txn.get("isSplitTransaction", False),
+                "tags": tags,
             })
 
         return result

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -15,7 +15,7 @@ import json
 import sys
 import httpx
 import logging
-from typing import Any
+import os
 
 # Configure logging to stderr (stdout is for MCP protocol)
 logging.basicConfig(
@@ -25,7 +25,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-import os
 API_BASE = os.environ.get("LIFEOS_API_URL", "http://localhost:8000")
 OPENAPI_URL = f"{API_BASE}/openapi.json"
 
@@ -843,7 +842,8 @@ class LifeOSMCPServer:
                     "end_date": {"type": "string", "description": "End date (YYYY-MM-DD), defaults to today"},
                     "category": {"type": "string", "description": "Filter by category name"},
                     "search": {"type": "string", "description": "Search by merchant name"},
-                    "limit": {"type": "integer", "description": "Max results (default: 100)", "default": 100}
+                    "limit": {"type": "integer", "description": "Max results (default: 100)", "default": 100},
+                    "account_id": {"type": "string", "description": "Filter by Monarch account ID"}
                 }
             },
             "lifeos_monarch_cashflow": {
@@ -1199,7 +1199,7 @@ class LifeOSMCPServer:
                 if active:
                     text += f"  Active channels: {', '.join(active)}\n"
                 else:
-                    text += f"  Active channels: none recently\n"
+                    text += "  Active channels: none recently\n"
                 if entity_id:
                     text += f"  Entity ID: {entity_id}\n"
                 text += "\n"
@@ -1482,11 +1482,11 @@ class LifeOSMCPServer:
             if not accounts:
                 return "No accounts found."
             text = f"Found {len(accounts)} accounts:\n\n"
-            text += "| Account | Type | Balance | Institution |\n"
-            text += "|---------|------|---------|-------------|\n"
+            text += "| Account | Type | Balance | Institution | ID |\n"
+            text += "|---------|------|---------|-------------|-----|\n"
             for a in accounts:
                 bal = a.get("balance", 0)
-                text += f"| {a.get('name', '')} | {a.get('type', '')} | ${bal:,.2f} | {a.get('institution', '')} |\n"
+                text += f"| {a.get('name', '')} | {a.get('type', '')} | ${bal:,.2f} | {a.get('institution', '')} | {a.get('id', '')} |\n"
             return text
 
         elif tool_name == "lifeos_monarch_transactions":
@@ -1494,12 +1494,12 @@ class LifeOSMCPServer:
             if not txns:
                 return "No transactions found."
             text = f"Found {len(txns)} transactions ({data.get('start_date', '')} to {data.get('end_date', '')}):\n\n"
-            text += "| Date | Merchant | Category | Amount |\n"
-            text += "|------|----------|----------|--------|\n"
+            text += "| Date | Merchant | Category | Amount | Account |\n"
+            text += "|------|----------|----------|--------|---------|\n"
             for t in txns[:50]:
                 amount = t.get("amount", 0)
                 sign = "" if amount >= 0 else "-"
-                text += f"| {t.get('date', '')} | {t.get('merchant', '')} | {t.get('category', '')} | {sign}${abs(amount):,.2f} |\n"
+                text += f"| {t.get('date', '')} | {t.get('merchant', '')} | {t.get('category', '')} | {sign}${abs(amount):,.2f} | {t.get('account', '')} |\n"
             if len(txns) > 50:
                 text += f"\n_... and {len(txns) - 50} more transactions_\n"
             return text

--- a/scripts/apple_data_agent.sh
+++ b/scripts/apple_data_agent.sh
@@ -52,15 +52,27 @@ log "LifeOS dir: ${LIFEOS_DIR}"
 log "Linux server: ${LINUX_USER}@${LINUX_SERVER}"
 
 # -------------------------------------------------------------------
+# Step 0: Ensure Messages and Photos are running for iCloud sync
+# These apps must be open for iCloud to deliver new data to the local
+# SQLite databases. Open them early so they can sync while we work.
+# -------------------------------------------------------------------
+log "Step 0: Opening Messages and Photos for iCloud sync..."
+osascript -e 'tell application "Messages" to activate' >> "${LOG_FILE}" 2>&1 || true
+osascript -e 'tell application "Photos" to activate' >> "${LOG_FILE}" 2>&1 || true
+# Give iCloud a head start before we read the databases
+sleep 600
+
+# -------------------------------------------------------------------
 # Step 1: Export Apple data to data/apple-exports/
-# cron and /bin/bash both have Full Disk Access on the Mac Mini,
-# so we call Python directly. The LifeOS.app exec wrapper doesn't
-# work because exec replaces the process, losing FDA context.
+# Route through LifeOS.app's "run" subcommand so Python inherits
+# Full Disk Access (TCC checks the responsible process — LifeOS.app).
+# "run" keeps LifeOS.app as the parent; "exec" replaces it, losing FDA.
 # -------------------------------------------------------------------
 log "Step 1: Exporting Apple data..."
+LIFEOS_APP="/Applications/LifeOS.app/Contents/MacOS/LifeOS"
 
 cd "${LIFEOS_DIR}"
-if "${PYTHON}" scripts/apple_data_export.py --execute >> "${LOG_FILE}" 2>&1; then
+if "${LIFEOS_APP}" run "${PYTHON}" scripts/apple_data_export.py --execute >> "${LOG_FILE}" 2>&1; then
     log "Export: OK"
 else
     log "Export: FAILED"

--- a/scripts/apple_data_export.py
+++ b/scripts/apple_data_export.py
@@ -341,11 +341,135 @@ def export_phone_calls(dry_run: bool = False) -> dict:
     return {"status": "ok", "count": len(export), "path": str(out_path)}
 
 
+def export_photos_faces(dry_run: bool = False) -> dict:
+    """Export Photos face recognition data as JSON.
+
+    Reads directly from Apple's Photos.sqlite database (requires the Photos
+    library to be mounted). Exports named people and their face appearances
+    so the Linux server can create SourceEntity/Interaction records without
+    needing access to the Photos library.
+    """
+    # Seconds from Unix epoch to Apple epoch (2001-01-01)
+    APPLE_EPOCH_OFFSET = 978307200
+
+    # Try common Photos library locations
+    photos_db = None
+    candidates = [
+        Path.home() / "Pictures" / "Photos Library.photoslibrary" / "database" / "Photos.sqlite",
+        Path("/Volumes/NVMe External Storage/Photos Library.photoslibrary/database/Photos.sqlite"),
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            photos_db = candidate
+            break
+
+    if not photos_db:
+        logger.warning("Photos.sqlite not found at any known location")
+        return {"status": "skipped", "reason": "Photos.sqlite not found"}
+
+    logger.info(f"Reading Photos database: {photos_db}")
+
+    try:
+        conn = sqlite3.connect(f"file:{photos_db}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.OperationalError as e:
+        logger.warning(f"Cannot open Photos database: {e}")
+        return {"status": "skipped", "reason": str(e)}
+
+    # Get named people with contact links
+    people_rows = conn.execute("""
+        SELECT Z_PK, ZFULLNAME, ZDISPLAYNAME, ZFACECOUNT, ZPERSONURI
+        FROM ZPERSON
+        WHERE ZFULLNAME IS NOT NULL
+          AND ZFACECOUNT > 0
+          AND ZPERSONURI IS NOT NULL
+        ORDER BY ZFACECOUNT DESC
+    """).fetchall()
+
+    logger.info(f"Found {len(people_rows)} Photos people linked to contacts")
+
+    if dry_run:
+        conn.close()
+        return {"status": "dry_run", "people": len(people_rows)}
+
+    people_export = []
+    faces_export = []
+    errors = 0
+
+    for person in people_rows:
+        contact_uri = person["ZPERSONURI"]
+        contact_uuid = contact_uri.replace(":ABPerson", "") if ":ABPerson" in contact_uri else None
+
+        people_export.append({
+            "photos_pk": person["Z_PK"],
+            "full_name": person["ZFULLNAME"],
+            "display_name": person["ZDISPLAYNAME"],
+            "face_count": person["ZFACECOUNT"] or 0,
+            "contact_uuid": contact_uuid,
+            "contact_uri": contact_uri,
+        })
+
+        # Get face appearances for this person
+        try:
+            photos = conn.execute("""
+                SELECT
+                    a.ZUUID,
+                    a.ZDATECREATED,
+                    a.ZLATITUDE,
+                    a.ZLONGITUDE
+                FROM ZASSET a
+                JOIN ZDETECTEDFACE f ON f.ZASSETFORFACE = a.Z_PK
+                WHERE f.ZPERSONFORFACE = ?
+                ORDER BY a.ZDATECREATED DESC
+                LIMIT 5000
+            """, (person["Z_PK"],)).fetchall()
+
+            for photo in photos:
+                ts = None
+                if photo["ZDATECREATED"] is not None:
+                    unix_ts = photo["ZDATECREATED"] + APPLE_EPOCH_OFFSET
+                    ts = datetime.fromtimestamp(unix_ts, tz=timezone.utc).isoformat()
+
+                faces_export.append({
+                    "person_pk": person["Z_PK"],
+                    "asset_uuid": photo["ZUUID"],
+                    "timestamp": ts,
+                    "latitude": photo["ZLATITUDE"],
+                    "longitude": photo["ZLONGITUDE"],
+                })
+        except Exception as e:
+            errors += 1
+            if errors <= 5:
+                logger.warning(f"Error reading photos for {person['ZFULLNAME']}: {e}")
+
+    conn.close()
+
+    out_path = EXPORT_DIR / "photos_faces.json"
+    with open(out_path, "w") as f:
+        json.dump({
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "people_count": len(people_export),
+            "face_appearances_count": len(faces_export),
+            "people": people_export,
+            "face_appearances": faces_export,
+        }, f)  # No indent — this file can be large
+
+    logger.info(
+        f"Exported {len(people_export)} people, {len(faces_export)} face appearances to {out_path}"
+    )
+    return {
+        "status": "ok",
+        "people": len(people_export),
+        "faces": len(faces_export),
+        "path": str(out_path),
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Export Apple ecosystem data")
     parser.add_argument("--execute", action="store_true", help="Actually export (not dry-run)")
     parser.add_argument("--dry-run", action="store_true", help="Preview what would be exported")
-    parser.add_argument("--source", choices=["contacts", "imessage", "phone"], help="Export single source")
+    parser.add_argument("--source", choices=["contacts", "imessage", "phone", "photos"], help="Export single source")
     args = parser.parse_args()
 
     if not args.execute and not args.dry_run:
@@ -365,6 +489,7 @@ def main():
         "contacts": export_contacts,
         "imessage": export_imessage,
         "phone": export_phone_calls,
+        "photos": export_photos_faces,
     }
 
     if args.source:

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -301,11 +301,162 @@ def import_phone_calls(dry_run: bool = False) -> dict:
     return {"status": "ok", "imported": imported, "skipped": skipped, "unresolved": unresolved}
 
 
+def import_photos_faces(dry_run: bool = False) -> dict:
+    """Import Photos face recognition data from Mac Mini export.
+
+    Matches Photos people to PersonEntity records using contact UUIDs
+    (via previously imported contacts), then creates SourceEntity and
+    Interaction records — the same records that sync_photos.py would
+    create if the Photos library were available locally.
+    """
+    photos_path = IMPORT_DIR / "photos_faces.json"
+    if not photos_path.exists():
+        return {"status": "skipped", "reason": "photos_faces.json not found"}
+
+    with open(photos_path) as f:
+        data = json.load(f)
+
+    people = data.get("people", [])
+    faces = data.get("face_appearances", [])
+    logger.info(
+        f"Found {len(people)} people, {len(faces)} face appearances "
+        f"(exported {data.get('exported_at', '?')})"
+    )
+
+    if dry_run:
+        return {"status": "dry_run", "people": len(people), "faces": len(faces)}
+
+    from api.services.source_entity import get_source_entity_store, SourceEntity
+    from api.services.interaction_store import get_interaction_store, Interaction
+    from api.services.person_entity import get_person_entity_store
+
+    se_store = get_source_entity_store()
+    ia_store = get_interaction_store()
+    pe_store = get_person_entity_store()
+
+    # Build contact UUID → PersonEntity ID mapping
+    uuid_to_person: dict[str, str | None] = {}
+    for person_data in people:
+        contact_uuid = person_data.get("contact_uuid")
+        if not contact_uuid:
+            continue
+
+        # Look up the imported contact source entity by UUID
+        source_id = f"contacts:{contact_uuid}"
+        contact_se = se_store.get_by_source("contacts", source_id)
+        if contact_se and contact_se.canonical_person_id:
+            uuid_to_person[contact_uuid] = contact_se.canonical_person_id
+            continue
+
+        # Fallback: the contact may be stored with the raw UUID as source_id
+        # (different import batches may use different formats)
+        contact_se = se_store.get_by_source("contacts", contact_uuid)
+        if contact_se and contact_se.canonical_person_id:
+            uuid_to_person[contact_uuid] = contact_se.canonical_person_id
+            continue
+
+        # Final fallback: match by name
+        pe = pe_store.get_by_name(person_data.get("full_name", ""))
+        if pe:
+            uuid_to_person[contact_uuid] = pe.id
+        else:
+            uuid_to_person[contact_uuid] = None
+
+    matched = sum(1 for v in uuid_to_person.values() if v)
+    logger.info(f"Matched {matched}/{len(people)} Photos people to PersonEntity records")
+
+    # Build person_pk → person_id lookup for face appearances
+    pk_to_person: dict[int, str] = {}
+    for person_data in people:
+        contact_uuid = person_data.get("contact_uuid")
+        person_id = uuid_to_person.get(contact_uuid) if contact_uuid else None
+        if person_id:
+            pk_to_person[person_data["photos_pk"]] = person_id
+
+    # Import face appearances
+    sources_created = 0
+    interactions_created = 0
+    skipped = 0
+
+    for face in faces:
+        person_id = pk_to_person.get(face.get("person_pk"))
+        if not person_id:
+            skipped += 1
+            continue
+
+        asset_uuid = face.get("asset_uuid")
+        if not asset_uuid:
+            skipped += 1
+            continue
+
+        source_id = f"{asset_uuid}:{face['person_pk']}"
+
+        # Skip if already exists
+        existing = se_store.get_by_source("photos", source_id)
+        if existing:
+            skipped += 1
+            continue
+
+        timestamp = None
+        if face.get("timestamp"):
+            try:
+                timestamp = datetime.fromisoformat(face["timestamp"])
+            except (ValueError, TypeError):
+                timestamp = datetime.now(timezone.utc)
+
+        # Create SourceEntity
+        se = SourceEntity(
+            source_type="photos",
+            source_id=source_id,
+            observed_name=next(
+                (p["full_name"] for p in people if p["photos_pk"] == face["person_pk"]),
+                "",
+            ),
+            canonical_person_id=person_id,
+            link_confidence=0.95,
+            link_method="contact_uuid",
+            observed_at=timestamp or datetime.now(timezone.utc),
+            metadata={
+                "photos_person_pk": face["person_pk"],
+                "asset_uuid": asset_uuid,
+                "latitude": face.get("latitude"),
+                "longitude": face.get("longitude"),
+            },
+        )
+        se_store.add(se)
+        sources_created += 1
+
+        # Create Interaction
+        interaction = Interaction(
+            id=str(uuid.uuid4()),
+            person_id=person_id,
+            timestamp=timestamp or datetime.now(timezone.utc),
+            source_type="photos",
+            title="Photo",
+            source_link=f"photos://asset/{asset_uuid}",
+            source_id=source_id,
+        )
+        ia_store.add_if_not_exists(interaction)
+        interactions_created += 1
+
+    logger.info(
+        f"Photos: {sources_created} sources, {interactions_created} interactions created, "
+        f"{skipped} skipped"
+    )
+    return {
+        "status": "ok",
+        "people_matched": matched,
+        "sources_created": sources_created,
+        "interactions_created": interactions_created,
+        "skipped": skipped,
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Import Apple ecosystem data from Mac Mini exports")
     parser.add_argument("--execute", action="store_true", help="Actually import")
     parser.add_argument("--dry-run", action="store_true", help="Preview only")
-    parser.add_argument("--source", choices=["contacts", "imessage", "phone"], help="Import single source")
+    parser.add_argument("--source", choices=["contacts", "imessage", "phone", "photos"], help="Import single source")
     args = parser.parse_args()
 
     if not args.execute and not args.dry_run:
@@ -327,6 +478,7 @@ def main():
         "contacts": import_contacts,
         "imessage": import_imessage,
         "phone": import_phone_calls,
+        "photos": import_photos_faces,
     }
 
     if args.source:

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -626,8 +626,10 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             }
         )
 
-        # Parse output for stats
-        stats = _parse_sync_output(result.stdout)
+        # Parse output for stats (check both stdout and stderr — many scripts
+        # log stats via Python's logging module which defaults to stderr)
+        combined_output = (result.stdout or "") + "\n" + (result.stderr or "")
+        stats = _parse_sync_output(combined_output)
 
         if result.returncode != 0:
             error_msg = result.stderr or result.stdout or "Unknown error"

--- a/scripts/sync_imessage_interactions.py
+++ b/scripts/sync_imessage_interactions.py
@@ -57,13 +57,15 @@ def sync_imessage_interactions(dry_run: bool = True, limit: int = None) -> dict:
         # Continue anyway - we can still sync existing messages
 
     # STEP 2: Link exported messages to PersonEntity records
-    if export_stats.get('messages_exported', 0) > 0:
-        logger.info("Linking messages to people...")
-        try:
-            join_stats = join_imessages_to_entities()
-            logger.info(f"Linked {join_stats['messages_updated']} messages to people")
-        except Exception as e:
-            logger.error(f"Failed to link messages: {e}")
+    # Always run linking — on Linux, messages arrive via apple_data_import.py
+    # (not from step 1), so there may be unlinked messages even when step 1
+    # exports 0.
+    logger.info("Linking messages to people...")
+    try:
+        join_stats = join_imessages_to_entities()
+        logger.info(f"Linked {join_stats['messages_updated']} messages to people")
+    except Exception as e:
+        logger.error(f"Failed to link messages: {e}")
 
     # STEP 3: Sync linked messages to interactions database
     imessage_db = get_imessage_db_path()


### PR DESCRIPTION
## Summary

Several fixes to the nightly Apple data sync pipeline that had been silently producing 0 records for weeks:

- **FDA via LifeOS.app.** `apple_data_agent.sh` now routes Python through the `LifeOS.app run` subcommand so it inherits Full Disk Access. Calling Python directly from cron failed because FDA was granted to cron/bash but not to the Homebrew Python binary, and TCC checks the binary opening the protected file.
- **iCloud warmup.** The agent now opens Messages.app and Photos.app 10 minutes before exporting so iCloud has time to deliver new data to the local databases (critical since the Mac Mini isn't used interactively).
- **Photos pipeline.** Added `export_photos_faces()` in `apple_data_export.py` and `import_photos_faces()` in `apple_data_import.py`. The Mac reads Photos.sqlite directly and exports face data as JSON; Linux imports and matches people via contact UUIDs. Previously photos sync only worked when the Photos library was locally accessible.
- **iMessage linking gate.** `sync_imessage_interactions.py` used to skip the `join_imessages_to_entities()` linking step unless step 1 exported new messages — which never happens on Linux (no Apple Messages.db). Messages arriving via `apple_data_import.py` were never linked to people. Now the linking step always runs.
- **Stats parsing.** `run_all_syncs.py` now parses both stdout and stderr for stats. Scripts using Python's logging module write to stderr by default, so stats like `Inserted: 1278` were being missed and `sync_health` reported 0 for everything even when work was being done.

## Test plan

- [x] Unit tests pass (1155 passed)
- [x] Manually verified `LifeOS.app run python scripts/apple_data_export.py --dry-run` succeeds for all 4 sources (contacts, iMessage, phone, photos) without FDA errors
- [x] Manually verified `apple_data_import.py --execute --source photos` matches 50/54 people and creates SourceEntity/Interaction records
- [x] Manually verified `sync_imessage_interactions.py --execute` links previously-unlinked messages and creates 1,278 backfilled interactions
- [x] Nightly cron ran successfully on 2026-04-10 at 2:50 AM: all 4 sources exported "ok", 80 new iMessages, 751 phone calls, 13 new iMessage interactions created via the stats fix
- [ ] Watch next nightly run to confirm photos face-count grows when new faces are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)