### PR TITLE
fix(agent): add Homebrew paths to PATH for cron-run wacli

### DIFF
--- a/scripts/apple_data_agent.sh
+++ b/scripts/apple_data_agent.sh
@@ -16,6 +16,10 @@
 
 set -euo pipefail
 
+# Cron on macOS runs with a minimal PATH that excludes Homebrew. Prepend the
+# standard brew locations so Python subprocesses (e.g. wacli) resolve.
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
 LIFEOS_DIR="${LIFEOS_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 PYTHON="${LIFEOS_DIR}/../.venvs/lifeos/bin/python"
 LINUX_SERVER="${LIFEOS_LINUX_HOST:?Set LIFEOS_LINUX_HOST to your Linux server IP}"


### PR DESCRIPTION
## Summary
- macOS cron uses a minimal PATH that excludes Homebrew dirs. When the Apple Data Agent's WhatsApp export calls `wacli` via `subprocess.run`, it fails with `FileNotFoundError` silently in cron.
- Prepend `/opt/homebrew/bin` (Apple Silicon) and `/usr/local/bin` (Intel) so the lookup resolves regardless of Mac architecture.
- Only `apple_data_agent.sh` is touched; it's already gated to `uname == Darwin`, so the added PATH entries don't leak into Linux.

## Why this wasn't caught earlier
Last night's 2026-04-12 cron run was the first after PR #79 added the WhatsApp export path. The Mac Mini was behind `origin/main` so it didn't actually execute the new code — meaning the regression is new-as-of-sync, not observed in a past failure.

## Test plan
- [x] `./scripts/test.sh` — 1155 passed in pre-push hook
- [ ] Pull on Mac Mini, trigger `apple_data_agent.sh` manually, confirm `wacli` invocation succeeds and `whatsapp.json` is written
- [ ] Confirm rsync delivers file to Linux and `/health/full` reports `sync_sources.whatsapp` as healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)