### PR TITLE
docs: correct LLM routing, default backend, and tool count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ LifeOS is a self-hosted AI assistant that indexes personal data (notes, emails, 
 | Backend | FastAPI (port 8000) |
 | Vector DB | ChromaDB (port 8001) |
 | Keyword Search | SQLite FTS5 (BM25) |
-| Query Router | Ollama + Qwen 2.5 (local) |
-| LLM (orchestration + synthesis) | Local model via OpenAI-compatible API, or Claude API (`LIFEOS_LLM_BACKEND`) |
+| Intent classifier | Claude Haiku via Anthropic API (default); pattern-matching fallback when the API is unavailable |
+| LLM (orchestration + synthesis) | Claude via Anthropic API (default), or a local OpenAI-compatible llama-server (`LIFEOS_LLM_BACKEND=local`). Model set by `LIFEOS_ANTHROPIC_MODEL`, defaults to `claude-haiku-4-5` |
 | LLM Client | `api/services/llm_client.py` — unified wrapper with Anthropic↔OpenAI tool format translation |
 | Embeddings | sentence-transformers (GPU via ROCm/CUDA) |
 | Frontend | Vanilla HTML/JS (no build step) |
@@ -378,7 +378,7 @@ curl http://localhost:8000/api/perf/traces/{trace_id} | jq        # Single trace
 | Severity | When Sent | Examples |
 |----------|-----------|----------|
 | **CRITICAL** | Immediately (rate-limited) | ChromaDB down, embedding model failed, vault inaccessible |
-| **WARNING** | Batched nightly (7 AM ET) | Ollama unavailable, backup failed, >5 degradation events |
+| **WARNING** | Batched nightly (7 AM ET) | LLM API errors, backup failed, >5 degradation events |
 | **INFO** | Log only | Telegram retry, config defaults used |
 
 Set `LIFEOS_ALERT_EMAIL` in `.env` for alerts. Telegram backup via `telegram_bot_token` + `telegram_chat_id`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ LifeOS is a self-hosted AI assistant that connects to your Gmail, Google Calenda
 
 LifeOS is also able to take action in response to requests you send through Telegram: not just creating tasks and reminders, but reading/editing files on your computer and autonomously managing Claude Code to accomplish discrete tasks.
 
-Everything runs locally. Your data never leaves your machine — a local LLM handles orchestration and synthesis by default (Claude API is available as an optional backend). A nightly sync pulls from your data sources, indexes everything for hybrid search (semantic + keyword), and keeps your knowledge graph fresh.
+All of your data is indexed and stored locally — your vault, messages, photos, financial summaries, and the like never leave your machine. By default, orchestration and synthesis call the Claude API (`LIFEOS_LLM_BACKEND=anthropic`, the default), which sends the current query and its retrieved context to Anthropic; set `LIFEOS_LLM_BACKEND=local` to route everything through a local llama-server instead. A nightly sync pulls from your data sources, indexes everything for hybrid search (semantic + keyword), and keeps your knowledge graph fresh.
 
 ---
 
@@ -65,16 +65,16 @@ macOS is only required if you want native Apple integrations (iMessage, Contacts
 
 ### LLM Options
 
-LifeOS uses a local LLM by default for orchestration and synthesis — no API key needed. The model size is configurable based on your hardware:
+Orchestration and synthesis can run against the Claude API (default) or a local OpenAI-compatible llama-server. Pick what matches your hardware and privacy posture:
 
-| Hardware | Recommended Model | Config |
-|----------|------------------|--------|
-| 8 GB RAM | Small model (e.g., 7B params) | `LIFEOS_LLM_BACKEND=local` |
-| 16–32 GB RAM | Medium model (e.g., 14–32B params) | `LIFEOS_LLM_BACKEND=local` |
-| 64 GB+ VRAM | Large model (e.g., 70–120B params) | `LIFEOS_LLM_BACKEND=local` |
-| No GPU / prefer cloud | Claude API | `LIFEOS_LLM_BACKEND=anthropic` + API key |
+| Hardware / preference | Config | Notes |
+|----------------------|--------|-------|
+| No GPU / prefer cloud (default) | `LIFEOS_LLM_BACKEND=anthropic` + `ANTHROPIC_API_KEY` | Default model: `claude-haiku-4-5`. Override via `LIFEOS_ANTHROPIC_MODEL`. Query text + retrieved context is sent to Anthropic. |
+| 8 GB RAM | `LIFEOS_LLM_BACKEND=local` + small llama-server model (~7B params) | Set `LIFEOS_LOCAL_LLM_URL` if not on localhost:8080. |
+| 16–32 GB RAM | `LIFEOS_LLM_BACKEND=local` + medium model (~14–32B params) | |
+| 64 GB+ VRAM | `LIFEOS_LLM_BACKEND=local` + large model (70–120B params) | |
 
-Set `LIFEOS_LLM_BACKEND=anthropic` and provide an `ANTHROPIC_API_KEY` in `.env` to use the Claude API instead of a local model. See the [Configuration Guide](docs/guides/configuration.md) for details.
+To stay fully local, set `LIFEOS_LLM_BACKEND=local` and point `LIFEOS_LOCAL_LLM_URL` at a running llama-server. See the [Configuration Guide](docs/guides/configuration.md) for details.
 
 ---
 
@@ -88,23 +88,15 @@ python3 -m venv ~/.venvs/lifeos
 source ~/.venvs/lifeos/bin/activate
 pip install -r requirements.txt
 
-# 2. Install Ollama (for query routing)
-# Linux:
-curl -fsSL https://ollama.com/install.sh | sh
-# macOS:
-brew install ollama
-
-ollama serve &
-ollama pull qwen2.5:7b-instruct
-
-# 3. Configure
+# 2. Configure
 cp .env.example .env
-# Edit .env with your settings (LIFEOS_VAULT_PATH at minimum)
+# Edit .env. Required: LIFEOS_VAULT_PATH and ANTHROPIC_API_KEY
+# (or LIFEOS_LLM_BACKEND=local with a running llama-server on LIFEOS_LOCAL_LLM_URL).
 
-# 4. Start services
+# 3. Start services
 ./scripts/server.sh start
 
-# 5. Open http://localhost:8000
+# 4. Open http://localhost:8000
 ```
 
 For persistent services on Linux, run `sudo ./scripts/setup-systemd.sh` to install systemd units.
@@ -123,25 +115,26 @@ Different query types are handled by different pipelines:
 
 ```mermaid
 flowchart LR
-    Q["User Query"] --> Router["Router\n(local Ollama)"]
+    Q["User Query"] --> Intent["Intent Classifier\n(Claude Haiku)"]
 
-    Router -->|"General"| Direct["Direct Answer\n(local LLM)"]
-    Router -->|"Web"| Web["Web Search\n(local LLM)"]
-    Router -->|"Personal"| Hybrid["Hybrid Search\n(local)"]
-    Router -->|"Compound"| Both["Web + Personal"]
+    Intent -->|"code"| Code["Claude Code\n(subprocess)"]
+    Intent -->|"ambiguous"| Clarify["Ask user"]
+    Intent -->|"everything else"| Agent["Agent Loop\n(orchestrator LLM)"]
 
-    Hybrid --> Syn["Synthesis\n(local LLM)"]
-    Both --> Syn
-    Direct --> Response["Response"]
-    Web --> Response
-    Syn --> Response
+    Agent --> Tools["Up to 5 rounds of tool calls\n(search_vault, search_email,\nsearch_web, manage_tasks, …)"]
+    Tools --> Agent
+    Agent --> Response["Response"]
+    Code --> Response
+    Clarify --> Response
 ```
 
+The orchestrator LLM defaults to Claude Haiku via the Anthropic API (`LIFEOS_LLM_BACKEND=anthropic`, model from `LIFEOS_ANTHROPIC_MODEL`). Set `LIFEOS_LLM_BACKEND=local` to route through a local llama-server instead.
+
 **Query types:**
-- **General knowledge**: "What's the capital of France?" → LLM answers directly
-- **Web search**: "What's the weather in NYC?" → Uses web_search tool
-- **Personal data**: "What did I discuss with John last week?" → Searches your data
-- **Compound**: "Look up the trash schedule and remind me the night before" → Multiple actions
+- **General knowledge**: "What's the capital of France?" → orchestrator answers directly without calling tools
+- **Web search**: "What's the weather in NYC?" → orchestrator calls `search_web`
+- **Personal data**: "What did I discuss with John last week?" → orchestrator calls `search_vault` / `search_email` / `search_calendar`
+- **Compound**: "Look up the trash schedule and remind me the night before" → orchestrator chains `search_web` + `manage_reminders`
 
 ### CRM UI
 
@@ -255,9 +248,9 @@ flowchart LR
         Vault["Vault\nFilesystem"]
     end
 
-    subgraph Fallback["Local (With Fallback)"]
+    subgraph Fallback["With Fallback"]
         direction TB
-        Ollama["Ollama\n:11434"] -->|fallback| Haiku["Anthropic\nHaiku"]
+        Intent["Intent classifier\n(Claude Haiku)"] -->|fallback| Patterns["Regex\npatterns"]
         BM25["BM25"] -->|fallback| VecOnly["Vector-only"]
     end
 
@@ -265,7 +258,7 @@ flowchart LR
         direction TB
         GCal["Google\nCalendar"]
         Gmail["Google\nGmail"]
-        LLM["LLM Backend\n(local or Claude)"]
+        LLM["LLM Backend\n(Claude API or local llama-server)"]
     end
 
     style Local fill:#ffcccc
@@ -275,7 +268,7 @@ flowchart LR
 
 **Severity levels:**
 - **CRITICAL**: Sent immediately (ChromaDB down, embedding failed, vault inaccessible)
-- **WARNING**: Batched nightly (Ollama unavailable, backup failed)
+- **WARNING**: Batched nightly (LLM API errors, backup failed, repeated degradation events)
 - **INFO**: Log only (Telegram retry, config defaults used)
 
 </details>
@@ -287,11 +280,11 @@ flowchart LR
 | Component | Technology |
 |-----------|------------|
 | Backend | FastAPI (port 8000) |
-| LLM (orchestration + synthesis) | Local model via llama.cpp, or Claude API |
+| LLM (orchestration + synthesis) | Claude via Anthropic API (default; `LIFEOS_ANTHROPIC_MODEL`, defaults to `claude-haiku-4-5`), or local llama.cpp server (`LIFEOS_LLM_BACKEND=local`) |
 | Embeddings | sentence-transformers (gte-Qwen2-1.5B-instruct) |
 | Vector DB | ChromaDB (port 8001) |
 | Keyword Search | SQLite FTS5 (BM25) |
-| Query Router | Ollama + Qwen 2.5 |
+| Intent classifier | Claude Haiku (Anthropic API), with a regex-pattern fallback |
 | Frontend | Vanilla HTML/JS (no build step) |
 | Job Queue | SQLite (background reindex, sync) |
 | Reminders | SQLite + cron scheduler |

--- a/docs/guides/first-run.md
+++ b/docs/guides/first-run.md
@@ -158,7 +158,7 @@ Run this checklist to ensure everything is working:
 |-------|---------|----------|
 | Server health | `curl localhost:8000/health/full \| jq` | All services "healthy" |
 | ChromaDB | `curl localhost:8001/api/v1/heartbeat` | `{"nanosecond heartbeat":...}` |
-| Ollama | `curl localhost:11434/api/tags \| jq` | Lists models |
+| Local LLM (only if `LIFEOS_LLM_BACKEND=local`) | `curl $LIFEOS_LOCAL_LLM_URL/v1/models \| jq` | Lists the loaded model |
 | Search works | Search via UI | Returns results |
 | Index populated | `curl localhost:8000/api/search -d '{"query":"test"}'` | Non-empty results |
 | Tasks API | `curl localhost:8000/api/tasks` | `{"tasks":[],"total":0}` |
@@ -186,7 +186,7 @@ Run this checklist to ensure everything is working:
 | Issue | Solution |
 |-------|----------|
 | Search returns no results | Run reindex: `curl -X POST localhost:8000/api/admin/reindex/sync` |
-| Slow first query | Ollama loading model - wait 30s |
+| Slow first query | If using `LIFEOS_LLM_BACKEND=local`, llama-server loads the model on first request — wait ~30s. If using the Anthropic backend, first call is uncached — subsequent calls within ~5 min hit Anthropic's prompt cache. |
 | MCP tools not working | Check server is running and MCP added correctly |
 
 See [Troubleshooting](troubleshooting.md) for more.

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -70,9 +70,9 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 **Pipeline routing (in order of priority):**
 1. **Ambiguous task/reminder** — asks user for clarification (task vs reminder vs both).
 2. **Code intent** — terminal, filesystem, browser tasks. Yields `code_intent` event for Telegram to spawn Claude Code.
-3. **Agentic loop** — everything else (including compose, tasks, reminders). Claude gets 15 tools and up to 5 rounds to fetch data and synthesize an answer.
+3. **Agentic loop** — everything else (including compose, tasks, reminders). Claude gets 18 tools and up to 5 rounds to fetch data and synthesize an answer. See `api/services/agent_tools.py::TOOL_DEFINITIONS` for the canonical list.
 
-**Agentic loop tools (15):**
+**Agentic loop tools (18):**
 
 | Tool | Description |
 |------|-------------|
@@ -89,6 +89,9 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 | `manage_tasks` | Create, list, or complete tasks (action: create/list/complete) |
 | `manage_reminders` | Create or list reminders (action: create/list) |
 | `create_email_draft` | Gmail draft |
+| `create_calendar_event` | Create a Google Calendar event |
+| `update_calendar_event` | Update a Google Calendar event |
+| `delete_calendar_event` | Delete a Google Calendar event |
 | `save_memory` | Save a memory for future reference |
 | `search_memories` | Search previously saved memories |
 

--- a/docs/specs/product/chat-ui.md
+++ b/docs/specs/product/chat-ui.md
@@ -67,7 +67,7 @@ The primary chat interface for LifeOS, providing AI-powered search and synthesis
 
 ## Query Routing
 
-The local LLM (Qwen 2.5 via Ollama) routes queries to appropriate data sources.
+The orchestrator LLM (Claude Haiku via Anthropic API by default; configurable via `LIFEOS_LLM_BACKEND` / `LIFEOS_ANTHROPIC_MODEL`) chooses which tools to call. A lightweight intent classifier runs first to short-circuit two special cases — Claude Code tasks and ambiguous task/reminder phrasing — and everything else flows through the agentic loop where the model picks tools per query.
 
 | Source | Content | Example Queries |
 |--------|---------|-----------------|

--- a/docs/specs/product/crm-ui.md
+++ b/docs/specs/product/crm-ui.md
@@ -1430,7 +1430,7 @@ They CAN'T find "{person}'s dog is named Max" anywhere else.
 - Fall back gracefully if local LLM unavailable
 
 **Configuration:**
-Controlled by `LIFEOS_LLM_BACKEND` setting (`local` or `anthropic`). The local backend uses llama-server on port 8080 via `llm_client.py`. Ollama is still used separately for query routing.
+Controlled by `LIFEOS_LLM_BACKEND` setting (`local` or `anthropic`, default `anthropic`). The local backend uses llama-server on `LIFEOS_LOCAL_LLM_URL` (default `http://localhost:8080`) via `llm_client.py`. Intent classification on the live chat path uses Claude Haiku via the Anthropic API regardless of backend (see `api/services/chat_helpers.py::_classify_via_haiku`).
 
 **Acceptance Criteria:**
 ```

--- a/docs/specs/technical/observability.md
+++ b/docs/specs/technical/observability.md
@@ -25,7 +25,7 @@ Every chat request is automatically traced with per-stage timing. Traces are sto
 |------|----------|--------|
 | `intent_classify` | chat.py | — |
 | `query_expand` | chat.py | — |
-| `model_select` | chat.py | — |
+| `model_select` | chat.py | — (records a recommended tier in the trace; the agent loop currently uses the configured `LIFEOS_ANTHROPIC_MODEL` regardless) |
 | `memory_inject` | agent_loop.py | — |
 | `claude_api_round_{n}` | agent_loop.py | — |
 | `tool_{name}` | agent_loop.py | — |

--- a/docs/specs/technical/security-privacy.md
+++ b/docs/specs/technical/security-privacy.md
@@ -32,12 +32,15 @@ LifeOS is single-user, self-hosted on Linux (or macOS). The threat model is fund
 
 ### What Leaves the Machine
 
+Whether chat traffic leaves the machine depends on `LIFEOS_LLM_BACKEND`. The default is `anthropic`, which routes the live chat path (intent classification + agentic orchestration) through the Claude API. Setting it to `local` keeps everything on a local llama-server.
+
 | Data | Destination | Purpose | Frequency |
 |------|-------------|---------|-----------|
-| Query text + search result snippets | Local LLM (default) or Claude API | Chat synthesis | Per user query |
-| Query text | Ollama (local process) | Query routing/classification | Per user query |
+| Query text (≤64 tokens of classification output) | Anthropic API (default) — Claude Haiku | Intent classification (`code` vs. ambiguous vs. agentic) | Per user query, unless `LIFEOS_LLM_BACKEND=local` |
+| Query text + retrieved tool results | Anthropic API (default) or local llama-server | Agentic orchestration & synthesis | Per user query and per tool round |
+| Email/note snippets for specialist tasks (web-search synthesis, fact extraction, relationship insights) | Anthropic API — pinned to `claude-sonnet-4-20250514` via `get_anthropic_llm()` | Quality-sensitive sub-calls | Per tool invocation, regardless of backend setting |
 | OAuth authentication flows | Google, Slack | Token refresh | Periodic |
-| Reminder messages | Telegram Bot API | Notification delivery | Per reminder |
+| Reminder messages, sync summaries | Telegram Bot API | Notification delivery | Per reminder / nightly |
 
 ## Credential Storage
 

--- a/docs/vision/philosophy.md
+++ b/docs/vision/philosophy.md
@@ -40,7 +40,7 @@ LifeOS handles the most sensitive data a person has: emails, therapy notes, fina
 
 ### Local-First, Always
 
-All data processing, indexing, and storage happens locally. LLM calls (local model for synthesis, Ollama for routing) send minimal context and receive only generated text. When using the Anthropic backend, discrete query payloads are sent to Claude for synthesis. The system must function fully if the network is unavailable — only the Anthropic backend requires connectivity.
+All data ingestion, indexing, and storage happen locally and remain on the machine. The orchestrator LLM is configurable: the default (`LIFEOS_LLM_BACKEND=anthropic`) sends discrete query payloads — the user's query plus the snippets of context the agent decided to retrieve — to the Claude API; `LIFEOS_LLM_BACKEND=local` keeps every LLM call on a local llama-server. Either way, indexes, raw data, and historical content stay on disk and are never wholesale uploaded.
 
 ### Intelligence Over Organization
 


### PR DESCRIPTION
## Summary

Tracing the live Telegram chat path turned up several outdated claims in the docs — including the privacy-relevant assertion that query text only goes to a local Ollama instance.

What the code actually does today (verified in `chat_helpers.py`, `agent_loop.py`, `llm_client.py`, `settings.py`):

- The default `LIFEOS_LLM_BACKEND` is `anthropic`, not `local`.
- The default orchestrator model is `LIFEOS_ANTHROPIC_MODEL`, which defaults to `claude-haiku-4-5`.
- Intent classification on the live chat path calls Claude Haiku via `_classify_via_haiku` with a regex-pattern fallback. The Ollama-based classifier exists in code (`_classify_via_ollama`) but is never called outside tests.
- The agent loop registers **18** tools, not 15. The API reference table was also missing `create_calendar_event` / `update_calendar_event` / `delete_calendar_event`.
- `model_select` in the perf trace records a recommended tier, but the agent loop currently uses the configured `LIFEOS_ANTHROPIC_MODEL` regardless.

## Files changed

- `README.md` — corrected default-backend claim, refreshed LLM options table, removed Ollama install step from Quick Start, redrew the routing diagram with the actual intent-classifier path, fixed the tech-stack table.
- `AGENTS.md` — tech-stack table now lists "Intent classifier" separately; alert example doesn't mention Ollama specifically.
- `docs/specs/product/api-reference.md` — 18 tools instead of 15; table now includes the three calendar-mutation tools.
- `docs/specs/technical/security-privacy.md` — "What Leaves the Machine" now reflects that query text + retrieved context go to the Anthropic API by default, plus a note that specialist sub-calls always use Sonnet via `get_anthropic_llm()`.
- `docs/specs/product/chat-ui.md`, `crm-ui.md` — corrected "Query Routing" wording.
- `docs/specs/technical/observability.md` — clarified that `model_select` doesn't currently change the model.
- `docs/vision/philosophy.md` — "Local-First, Always" rephrased to be honest about the default backend while preserving the local-data invariant.
- `docs/guides/first-run.md` — Ollama health check replaced with a conditional local-LLM check.

ADRs deliberately untouched (immutable per docs standards). The dead Ollama code paths in `chat_helpers.py` and the stale comments in `model_selector.py` are flagged for a separate cleanup PR.

## Test plan

- [x] Pre-push test suite passes (1157 tests)
- [x] All changes are documentation-only — no runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)