### PR TITLE
fix(sync): offline HF cache + mtime-dated undated vault notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,19 @@
 # LIFEOS_LOCAL_LLM_AUTOSTART=false
 
 # =============================================================================
+# EMBEDDING MODEL — sentence-transformers (cached locally)
+# =============================================================================
+
+# Force the embedding loader to use the local HuggingFace cache only.
+# Without this, sentence-transformers pings huggingface.co on every model load
+# to check etag freshness — and a transient DNS failure during the 03:30 nightly
+# sync window has caused 60-minute retry storms (e.g. crm_vectorstore timeout
+# on 2026-05-23). The model files are pinned by `requirements.txt` so we never
+# need a live HF round-trip.
+HF_HUB_OFFLINE=1
+TRANSFORMERS_OFFLINE=1
+
+# =============================================================================
 # VAULT CONFIGURATION
 # =============================================================================
 

--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,22 @@ TRANSFORMERS_OFFLINE=1
 # VAULT CONFIGURATION
 # =============================================================================
 
+# Undated notes: use the file's mtime as the interaction date only when
+# mtime is strictly LATER than this cutoff. Otherwise the note's interactions
+# fall back to the 1970 "undated" sentinel.
+#
+# Why this exists: a bulk migration (clone + restore from backup, switching
+# vault directories, mass-rename, etc.) gives thousands of files the same
+# recent mtime even though the underlying notes are years old. Without this
+# gate, all those migration-era mtimes would show up on the timeline as
+# recent activity. Set the cutoff to a date AFTER your last bulk migration
+# so only post-migration mtimes are trusted.
+#
+# Leave unset to keep all undated notes on the 1970 sentinel (safe default,
+# matches pre-fix behavior).
+# LIFEOS_VAULT_MTIME_TRUSTED_AFTER=2026-02-01
+
+
 LIFEOS_VAULT_PATH=/path/to/your/obsidian/vault
 LIFEOS_CHROMA_PATH=./data/chromadb
 LIFEOS_PORT=8000

--- a/api/services/indexer.py
+++ b/api/services/indexer.py
@@ -41,6 +41,50 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _mtime_trust_cutoff() -> datetime | None:
+    """Parse `LIFEOS_VAULT_MTIME_TRUSTED_AFTER` (YYYY-MM-DD) into a UTC datetime.
+
+    Returns None if the env var is unset or unparseable. When None, undated
+    notes get UNDATED_SENTINEL — never the filesystem mtime — to avoid
+    polluting the timeline with bulk-migration / restore-from-backup mtimes
+    on installations that don't opt in.
+    """
+    raw = os.environ.get("LIFEOS_VAULT_MTIME_TRUSTED_AFTER", "").strip()
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError:
+        logger.warning(
+            "LIFEOS_VAULT_MTIME_TRUSTED_AFTER=%r is not a valid YYYY-MM-DD date; "
+            "ignoring (undated notes will get UNDATED_SENTINEL)",
+            raw,
+        )
+        return None
+
+
+_MTIME_TRUST_CUTOFF = _mtime_trust_cutoff()
+
+
+def _resolve_undated_note_date(path) -> datetime:
+    """Return the best-effort date for an undated note's interactions.
+
+    Uses the file's mtime when it is strictly later than
+    `LIFEOS_VAULT_MTIME_TRUSTED_AFTER`; otherwise falls back to
+    UNDATED_SENTINEL. See the env-var docstring on `_mtime_trust_cutoff`
+    for the rationale (bulk migrations cluster mtimes).
+    """
+    if _MTIME_TRUST_CUTOFF is None:
+        return UNDATED_SENTINEL
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except Exception:
+        return UNDATED_SENTINEL
+    if mtime > _MTIME_TRUST_CUTOFF:
+        return mtime
+    return UNDATED_SENTINEL
+
+
 class VaultEventHandler(FileSystemEventHandler):
     """Handle file system events in the vault with global batch debouncing.
 
@@ -345,10 +389,24 @@ class IndexerService:
                     # Dated note: use extracted date
                     note_date = datetime.strptime(note_date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
                 else:
-                    # Undated note: use sentinel date so it still appears in counts
-                    # and can be shown in an "Undated" section of timeline
-                    note_date = UNDATED_SENTINEL
-                    logger.debug(f"Undated note (using sentinel date): {path.name}")
+                    # Undated note: fall back to filesystem mtime so the
+                    # interaction lands on the timeline at a meaningful date
+                    # (when the user last touched the note) rather than
+                    # 1970-01-01.
+                    #
+                    # Caveat: a bulk migration / restore-from-backup can give
+                    # thousands of files the same recent mtime even though
+                    # the underlying notes are years old. Gate mtime use
+                    # behind `LIFEOS_VAULT_MTIME_TRUSTED_AFTER=YYYY-MM-DD`:
+                    # only mtimes strictly later than that cutoff are used,
+                    # everything else falls back to UNDATED_SENTINEL. If the
+                    # env var is unset, mtime is never trusted (legacy
+                    # behavior, safe default).
+                    note_date = _resolve_undated_note_date(path)
+                    if note_date == UNDATED_SENTINEL:
+                        logger.debug(f"Undated note (sentinel): {path.name}")
+                    else:
+                        logger.debug(f"Undated note (mtime {note_date.date()}): {path.name}")
 
                 affected_person_ids = self._sync_people_to_v2(path, all_people, note_date, is_granola)
 


### PR DESCRIPTION
## Summary

Two related reliability fixes flagged in today's investigation of the vault-staleness symptom:

### 1. `HF_HUB_OFFLINE=1` + `TRANSFORMERS_OFFLINE=1` (.env.example)
\`crm_vectorstore\` timed out at the 60-min limit during last night's 03:30 sync because sentence-transformers tried to check huggingface.co for cache freshness, hit a DNS resolution failure, and retried for the full hour. The model files are fully cached locally — the round-trip is unnecessary. Setting these forces both libraries to use cached files only.

**Live impact:** \`crm_vectorstore\` failed → \`entity_cleanup\` and \`consistency_verify\` dependency-skipped. The PR #83 cascade fix held so the rest of the pipeline ran. Manually retriggered the three affected sources with \`HF_HUB_OFFLINE=1\` set — all succeeded, health is now 24/25 enabled sources passing (only \`monarch_money\` stale, which is monthly).

### 2. Use file mtime for undated notes — gated by migration cutoff (`api/services/indexer.py`)
Undated vault notes used the 1970-01-01 sentinel, so any note that mentioned a person but didn't have a date in its filename / frontmatter / body landed on the timeline at epoch — effectively invisible to "what did I discuss with X recently" queries. Now they fall back to file mtime.

But: a bulk migration clusters thousands of mtimes at the same recent date even when the underlying notes are years old. Without a gate, all those mtimes would pretend to be recent. Added \`LIFEOS_VAULT_MTIME_TRUSTED_AFTER=YYYY-MM-DD\` — only mtimes strictly later than that cutoff are used.

- Safe default: env var unset → never trust mtime → sentinel (matches pre-fix behavior).
- For Nathan's vault: ~3800 files have mtime in 2026-01 (migration), so cutoff = \`2026-02-01\`.

After merge, a forced \`vault_reindex\` will backfill the new mtime-based dates for the existing ~1925 sentinel-timestamped vault interactions.

## Test plan

- [x] Syntax + unit tests pass (pre-push 1122 passed in 152s on the new parallel hook)
- [x] Manual: \`_resolve_undated_note_date\` returns mtime when cutoff set + file is post-cutoff; returns sentinel otherwise
- [x] Manual: crm_vectorstore retrigger succeeds with HF_HUB_OFFLINE=1 (162s, normal duration)
- [ ] Post-merge: forced vault reindex to apply new logic to existing files

## Review focus

- The mtime gate in `api/services/indexer.py:_resolve_undated_note_date` — should anything other than mtime > cutoff also qualify (e.g. files with `created` field in frontmatter)?
- Whether `HF_HUB_OFFLINE` ever needs to be turned off (model upgrade workflow). Today: only when the user manually swaps the embedding model version in requirements.txt — at which point they'd toggle the var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)