### PR TITLE
fix: align ollama_model default + bump vault_reindex timeout to 4h

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -81,9 +81,13 @@ class Settings(BaseSettings):
                     "When false, llama-server must be started manually."
     )
 
-    # Local LLM Router (Ollama — used for query routing, summarization, fact validation)
+    # Local LLM Router (Ollama — used for summarization and fact validation)
+    # Default model picked because it's the one actually pre-installed on
+    # Nathan's setup; users with different ollama models should override via
+    # OLLAMA_MODEL. The summarizer 404s silently if this model isn't available,
+    # so installation order matters more than the specific identifier.
     ollama_host: str = Field(default="http://localhost:11434", alias="OLLAMA_HOST")
-    ollama_model: str = Field(default="qwen2.5:7b-instruct", alias="OLLAMA_MODEL")
+    ollama_model: str = Field(default="gemma4:26b", alias="OLLAMA_MODEL")
     ollama_timeout: int = Field(default=45, alias="OLLAMA_TIMEOUT")
     ollama_retry_timeout: int = Field(default=60, alias="OLLAMA_RETRY_TIMEOUT")  # Longer timeout for retries
 

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -605,7 +605,9 @@ SYNC_SCRIPTS = {
 DEFAULT_SYNC_TIMEOUT = 3600  # 60 minutes
 
 SYNC_TIMEOUTS = {
-    "vault_reindex": 7200,           # 2 hours - typically 30-90min, bounded for safety
+    "vault_reindex": 14400,          # 4 hours - incremental is typically 10-30min, but a
+                                     #            `--force` full reindex of a ~6K-file vault
+                                     #            plus per-file summary calls fits in ~3-4h
     "slack": 7200,                   # 2 hours - ~100 linked DMs + group DMs, rate-limited
     "google_docs": 300,              # 5 minutes - normally takes ~9s, hangs on expired OAuth
     "google_sheets": 300,            # 5 minutes - normally takes ~1s, hangs on expired OAuth

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -4,25 +4,25 @@ Tests for Local LLM Query Router (P3.5).
 Tests the OllamaClient and QueryRouter services.
 """
 import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+import httpx
 
 # Most tests in this file are fast unit tests (mocked Ollama)
 pytestmark = pytest.mark.unit
-import json
-from unittest.mock import patch, MagicMock, AsyncMock
-import httpx
 
 
 class TestOllamaClient:
     """Test the Ollama client for local LLM inference."""
 
     def test_client_initialization(self):
-        """Client should initialize with correct settings."""
+        """Client should initialize with the configured defaults."""
         from api.services.ollama_client import OllamaClient
+        from config.settings import settings
 
         client = OllamaClient()
-        assert client.host == "http://localhost:11434"
-        assert client.model == "qwen2.5:7b-instruct"
-        assert client.timeout == 45
+        assert client.host == settings.ollama_host
+        assert client.model == settings.ollama_model
+        assert client.timeout == settings.ollama_timeout
 
     def test_client_custom_settings(self):
         """Client should accept custom settings."""


### PR DESCRIPTION
## Summary

Two reliability tweaks from last night's investigation:

1. **`settings.ollama_model` default**: was `qwen2.5:7b-instruct`, only `gemma4:26b` is actually installed locally. Every per-file summarizer call during `vault_reindex` 404'd against ollama, retried, and burned wall time without producing summaries. Changed default to `gemma4:26b`. Downstream users with different models override via `OLLAMA_MODEL=...`.

2. **`SYNC_TIMEOUTS["vault_reindex"]`**: bumped from 2h → 4h. 2h was fine for the nightly incremental run (10-30 min) but tight for `--force` full reindex on a ~6K-file vault — last night's manual force-reindex hit the wall at 28K/~28K expected chunks. 4h leaves headroom without risking long hangs.

Side change: `tests/test_query_router.py::test_client_initialization` was asserting the literal `"qwen2.5:7b-instruct"` string. Rewrote to read from `settings.ollama_model` so the test tracks config instead of breaking on every model swap.

Both apply at the next cron firing (tonight's 03:30 EDT) since the orchestrator reads `SYNC_TIMEOUTS` per run and the summarizer reads `settings.ollama_model` per request.

## Test plan

- [x] py_compile clean
- [x] Pre-push test suite passes (1122 passed) — included after fixing the brittle test assertion the new default caught
- [ ] Post-merge: tonight's 03:30 EDT cron should show vault_reindex producing successful summaries (not 404s) and complete cleanly within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)