### PR TITLE
fix(interactions): upgrade UNDATED_SENTINEL timestamps on re-index

### DIFF
--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -369,12 +369,18 @@ class InteractionStore:
 
         conn = self._get_connection()
         try:
+            # If the existing row carries the 1970 UNDATED_SENTINEL timestamp
+            # but we now have a real date (from the indexer's mtime fallback or
+            # a newly-extractable filename date), upgrade the timestamp in place.
+            # All other columns stay frozen to avoid stomping legitimate edits.
             cursor = conn.execute(
                 """
                 INSERT INTO interactions
                 (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(source_type, source_id) DO NOTHING
+                ON CONFLICT(source_type, source_id) DO UPDATE SET
+                    timestamp = excluded.timestamp
+                WHERE interactions.timestamp = ? AND excluded.timestamp != ?
             """,
                 (
                     interaction.id,
@@ -386,6 +392,8 @@ class InteractionStore:
                     interaction.source_link,
                     interaction.source_id,
                     interaction.created_at.isoformat(),
+                    UNDATED_SENTINEL.isoformat(),
+                    UNDATED_SENTINEL.isoformat(),
                 ),
             )
             if cursor.rowcount == 0 and interaction.source_id is not None:


### PR DESCRIPTION
## Summary

Companion to PR #92's mtime-fallback for undated vault notes. The INSERT in `InteractionStore.add` was `ON CONFLICT … DO NOTHING`, so once an interaction was created with the 1970 sentinel it was frozen — even when a later indexer run produced a real date.

Concretely: yesterday's manual force-reindex ran with `LIFEOS_VAULT_MTIME_TRUSTED_AFTER=2026-02-01` set and successfully computed mtime-based dates for 568 sentinel-timestamped vault rows, but `DO NOTHING` discarded every one. I separately ran a backfill script that promoted 310 of them in place (the remaining 258 correctly stay sentinel — pre-cutoff migration files or files deleted from disk).

Permanent fix: the conflict path now conditionally upgrades only sentinel → real-date transitions:

\`\`\`sql
ON CONFLICT(source_type, source_id) DO UPDATE SET
    timestamp = excluded.timestamp
WHERE interactions.timestamp = UNDATED_SENTINEL
  AND excluded.timestamp != UNDATED_SENTINEL
\`\`\`

Never overwrites a real date with another real date (risk: stomping legitimate frontmatter edits). Never downgrades to sentinel (risk: erasing a previously-resolved date).

## Test plan

- [x] py_compile clean
- [x] `tests/test_interaction_store.py` — 46 passed (existing insert + conflict tests still cover the normal path)
- [ ] Tonight's 03:30 cron: should see the remaining sentinel rows get upgraded automatically as files get re-touched

## Live state

After the backfill + this PR, vault MAX timestamp is **2026-05-24 09:02** (today, ~14h ago) instead of 2026-04-17. Distribution: 11 in May, 139 in April, 76 in March, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)