### PR TITLE
fix(person-stats): aggregate by canonical ID before applying counts

### DIFF
--- a/api/services/person_entity.py
+++ b/api/services/person_entity.py
@@ -805,6 +805,19 @@ class PersonEntityStore:
             person_id = self._merged_ids[person_id]
         return person_id
 
+    def get_legacy_ids(self, canonical_id: str) -> set[str]:
+        """
+        All known legacy (pre-merge) person_ids that resolve to this canonical.
+
+        Used by stats / sync code that needs to query interaction rows for the
+        canonical entity but might still find rows tagged with legacy IDs that
+        haven't been repointed yet. Does NOT include the canonical itself —
+        callers typically union it in.
+        """
+        canon = self.get_canonical_id(canonical_id)
+        return {legacy for legacy, primary in self._merged_ids.items()
+                if self.get_canonical_id(primary) == canon}
+
     def _load_merged_ids(self) -> None:
         """Load the merged IDs mapping for durability."""
         if self.MERGED_IDS_PATH.exists():

--- a/api/services/person_stats.py
+++ b/api/services/person_stats.py
@@ -43,35 +43,49 @@ def refresh_person_stats(person_ids: Optional[list[str]] = None, save: bool = Tr
     stats = {'updated': 0, 'total_interactions': 0}
 
     if person_ids is None:
-        # Full refresh - get counts for all people in one query
+        # Full refresh — read all per-(person_id, source) counts, then collapse
+        # legacy (pre-merge) person_ids onto their canonical entity.id BEFORE
+        # applying. Without this, the loop processes the same canonical entity
+        # multiple times: get_by_id() follows the merge map and returns the
+        # canonical, then _apply_counts_to_entity / _update_timestamps overwrite
+        # with the *legacy* ID's (much smaller, much older) data — silently
+        # corrupting both stats and last_seen on every canonical with merged
+        # IDs that still carry stale interactions in the table.
         cursor = conn.execute("""
             SELECT person_id, source_type, COUNT(*) as cnt
             FROM interactions
             GROUP BY person_id, source_type
         """)
 
-        # Build per-person counts
-        person_counts: dict[str, dict[str, int]] = {}
+        canonical_counts: dict[str, dict[str, int]] = {}
+        # Map canonical_id -> set of raw person_ids that resolve to it
+        # (used by _update_timestamps to query MAX across all variants).
+        canonical_ids: dict[str, set[str]] = {}
+
         for row in cursor:
             pid, source_type, count = row
-            if pid not in person_counts:
-                person_counts[pid] = {}
-            person_counts[pid][source_type] = count
+            entity = store.get_by_id(pid)
+            if not entity:
+                continue
+            canon = entity.id
+            bucket = canonical_counts.setdefault(canon, {})
+            bucket[source_type] = bucket.get(source_type, 0) + count
+            canonical_ids.setdefault(canon, set()).add(pid)
             stats['total_interactions'] += count
 
-        # Update people with interactions
-        for person_id, counts in person_counts.items():
-            entity = store.get_by_id(person_id)
+        # Update each canonical entity exactly once, with aggregated counts.
+        for canon, counts in canonical_counts.items():
+            entity = store.get_by_id(canon)
             if entity:
                 _apply_counts_to_entity(entity, counts)
-                _update_timestamps(entity, person_id, conn)
+                _update_timestamps(entity, list(canonical_ids[canon]), conn)
                 store.update(entity)
                 stats['updated'] += 1
 
-        # Zero out people with no interactions (they may have had interactions deleted)
-        # They may still have source_entity timestamps worth updating
+        # Zero out people with no interactions (they may have had interactions
+        # deleted). They may still have source_entity timestamps worth updating.
         for entity in store.get_all():
-            if entity.id not in person_counts:
+            if entity.id not in canonical_counts:
                 modified = False
                 if entity.email_count or entity.meeting_count or entity.message_count or entity.mention_count or entity.photo_count:
                     entity.email_count = 0
@@ -80,29 +94,41 @@ def refresh_person_stats(person_ids: Optional[list[str]] = None, save: bool = Tr
                     entity.mention_count = 0
                     entity.photo_count = 0
                     modified = True
-                if _update_timestamps(entity, entity.id, conn):
+                if _update_timestamps(entity, [entity.id], conn):
                     modified = True
                 if modified:
                     store.update(entity)
                     stats['updated'] += 1
 
     else:
-        # Targeted refresh - only specified people
-        for person_id in person_ids:
-            cursor = conn.execute("""
+        # Targeted refresh — for each input, resolve to canonical and expand
+        # to the canonical + every known legacy ID that merges into it. This
+        # makes the refresh correct regardless of whether callers pass the
+        # canonical or a legacy ID, and regardless of whether interactions
+        # have been repointed yet.
+        canon_to_variants: dict[str, set[str]] = {}
+        for pid in person_ids:
+            entity = store.get_by_id(pid)
+            if not entity:
+                continue
+            variants = {entity.id, pid} | store.get_legacy_ids(entity.id)
+            canon_to_variants.setdefault(entity.id, set()).update(variants)
+
+        for canon, variants in canon_to_variants.items():
+            placeholders = ','.join(['?'] * len(variants))
+            cursor = conn.execute(f"""
                 SELECT source_type, COUNT(*) as cnt
                 FROM interactions
-                WHERE person_id = ?
+                WHERE person_id IN ({placeholders})
                 GROUP BY source_type
-            """, (person_id,))
-
+            """, tuple(variants))
             counts = {row[0]: row[1] for row in cursor}
             stats['total_interactions'] += sum(counts.values())
 
-            entity = store.get_by_id(person_id)
+            entity = store.get_by_id(canon)
             if entity:
                 _apply_counts_to_entity(entity, counts)
-                _update_timestamps(entity, person_id, conn)
+                _update_timestamps(entity, list(variants), conn)
                 store.update(entity)
                 stats['updated'] += 1
 
@@ -117,18 +143,33 @@ def refresh_person_stats(person_ids: Optional[list[str]] = None, save: bool = Tr
     return stats
 
 
-def _update_timestamps(entity, person_id: str, int_conn) -> bool:
+def _update_timestamps(entity, person_ids, int_conn) -> bool:
     """
     Update first_seen/last_seen from interactions and source_entities.
 
+    Args:
+        entity: PersonEntity to update.
+        person_ids: Either a single person_id (str) or a list of person_ids
+            covering the canonical entity plus any legacy IDs that merge to it.
+            Querying across all of them keeps stats correct when stale
+            interactions still carry legacy IDs (repoint_stale_ids hasn't
+            caught up).
+        int_conn: Open connection to interactions.db.
+
     Returns True if entity was modified.
     """
-    # Get timestamp range from interactions
-    cursor = int_conn.execute("""
+    if isinstance(person_ids, str):
+        person_ids = [person_ids]
+    if not person_ids:
+        return False
+    placeholders = ','.join(['?'] * len(person_ids))
+
+    # Get timestamp range from interactions across ALL person_id variants
+    cursor = int_conn.execute(f"""
         SELECT MIN(timestamp), MAX(timestamp)
         FROM interactions
-        WHERE person_id = ?
-    """, (person_id,))
+        WHERE person_id IN ({placeholders})
+    """, tuple(person_ids))
     row = cursor.fetchone()
     interaction_first = None
     interaction_last = None
@@ -137,17 +178,19 @@ def _update_timestamps(entity, person_id: str, int_conn) -> bool:
     if row and row[1]:
         interaction_last = datetime.fromisoformat(row[1]).replace(tzinfo=timezone.utc)
 
-    # Get timestamp range from source_entities
+    # Get timestamp range from source_entities across the same variants
+    # (source_entities.canonical_person_id may also still carry legacy IDs
+    # if a merge happened without backfilling that column).
     crm_db = Path("data/crm.db")
     source_first = None
     source_last = None
     if crm_db.exists():
         crm_conn = sqlite3.connect(str(crm_db))
-        crm_cursor = crm_conn.execute("""
+        crm_cursor = crm_conn.execute(f"""
             SELECT MIN(observed_at), MAX(observed_at)
             FROM source_entities
-            WHERE canonical_person_id = ?
-        """, (person_id,))
+            WHERE canonical_person_id IN ({placeholders})
+        """, tuple(person_ids))
         se_row = crm_cursor.fetchone()
         crm_conn.close()
         if se_row and se_row[0]:
@@ -232,15 +275,32 @@ def verify_person_stats(fix: bool = False) -> dict:
     store = get_person_entity_store()
     conn = sqlite3.connect(get_interaction_db_path())
 
+    # Group raw interaction person_ids by their canonical entity, so the
+    # comparison mirrors what refresh_person_stats writes. Without this,
+    # canonicals with merged legacy IDs would appear as "discrepancies" and
+    # fix=True would overwrite correct aggregated counts with canonical-only
+    # under-counts.
+    raw_ids: set[str] = set()
+    cursor = conn.execute("SELECT DISTINCT person_id FROM interactions")
+    for (pid,) in cursor:
+        raw_ids.add(pid)
+    canonical_to_raws: dict[str, set[str]] = {}
+    for pid in raw_ids:
+        entity = store.get_by_id(pid)
+        if entity:
+            canonical_to_raws.setdefault(entity.id, set()).add(pid)
+
     discrepancies = {}
 
     for entity in store.get_all():
-        cursor = conn.execute("""
+        variant_ids = list(canonical_to_raws.get(entity.id, {entity.id}))
+        placeholders = ','.join(['?'] * len(variant_ids))
+        cursor = conn.execute(f"""
             SELECT source_type, COUNT(*) as cnt
             FROM interactions
-            WHERE person_id = ?
+            WHERE person_id IN ({placeholders})
             GROUP BY source_type
-        """, (entity.id,))
+        """, tuple(variant_ids))
 
         counts = {row[0]: row[1] for row in cursor}
 

--- a/tests/test_p91_data_integrity.py
+++ b/tests/test_p91_data_integrity.py
@@ -10,14 +10,12 @@ NOTE: These tests require direct database access and will be skipped if
 the server is running (database locked). Stop the server to run these tests.
 """
 import os
-import re
-import random
 import sqlite3
 import pytest
 from pathlib import Path
 
 from api.services.person_entity import get_person_entity_store
-from api.services.interaction_store import get_interaction_store, get_interaction_db_path
+from api.services.interaction_store import get_interaction_db_path
 
 
 # All classes in this file require database access
@@ -313,13 +311,18 @@ class TestR6InteractionCounts:
         mismatches = []
 
         for person in sorted_people:
-            # Get actual counts from database
-            cursor = conn.execute("""
+            # Stored counts aggregate canonical + every legacy ID that merges
+            # to this person, so the "actual" comparison must query across the
+            # same variant set. Otherwise canonicals with legacy interactions
+            # show as over-counted mismatches even when stats are correct.
+            variant_ids = list({person.id} | store.get_legacy_ids(person.id))
+            placeholders = ','.join(['?'] * len(variant_ids))
+            cursor = conn.execute(f"""
                 SELECT source_type, COUNT(*)
                 FROM interactions
-                WHERE person_id = ?
+                WHERE person_id IN ({placeholders})
                 GROUP BY source_type
-            """, (person.id,))
+            """, tuple(variant_ids))
 
             actual_counts = {row[0]: row[1] for row in cursor.fetchall()}
 

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -80,6 +80,7 @@ class TestRefreshUpdatesLastSeen:
 
         mock_store = MagicMock()
         mock_store.get_by_id.return_value = entity
+        mock_store.get_legacy_ids.return_value = set()
         mock_store.get_all.return_value = [entity]
 
         with patch("api.services.person_entity.get_person_entity_store", return_value=mock_store), \
@@ -117,6 +118,7 @@ class TestRefreshUpdatesLastSeen:
         entity = PersonEntity(id=person_id, canonical_name="Alex Test")
         mock_store = MagicMock()
         mock_store.get_by_id.return_value = entity
+        mock_store.get_legacy_ids.return_value = set()
 
         with patch("api.services.person_entity.get_person_entity_store", return_value=mock_store), \
              patch("api.services.interaction_store.get_interaction_db_path", return_value=int_db), \
@@ -143,6 +145,7 @@ class TestRefreshUpdatesLastSeen:
         entity = PersonEntity(id=person_id, canonical_name="Alex Test")
         mock_store = MagicMock()
         mock_store.get_by_id.return_value = entity
+        mock_store.get_legacy_ids.return_value = set()
 
         with patch("api.services.person_entity.get_person_entity_store", return_value=mock_store), \
              patch("api.services.interaction_store.get_interaction_db_path", return_value=int_db), \
@@ -169,6 +172,7 @@ class TestRefreshUpdatesLastSeen:
         entity = PersonEntity(id=person_id, canonical_name="Alex Test")
         mock_store = MagicMock()
         mock_store.get_by_id.return_value = entity
+        mock_store.get_legacy_ids.return_value = set()
 
         with patch("api.services.person_entity.get_person_entity_store", return_value=mock_store), \
              patch("api.services.interaction_store.get_interaction_db_path", return_value=int_db), \
@@ -178,6 +182,83 @@ class TestRefreshUpdatesLastSeen:
 
         # 2 phone + 1 imessage = 3 messages
         assert entity.message_count == 3
+
+
+class TestMergedLegacyIds:
+    """Regression: full refresh used to corrupt canonicals that had legacy
+    (pre-merge) person_ids still attached to interaction rows. The loop would
+    process the canonical first (correct counts), then process the legacy ID,
+    resolve it via get_by_id() to the *same canonical*, and overwrite with the
+    legacy ID's under-counts and older last_seen. Fix: aggregate by canonical
+    before applying."""
+
+    def test_full_refresh_aggregates_legacy_into_canonical(self, tmp_path):
+        canonical_id = "canonical-001"
+        legacy_id = "legacy-002"
+        now = datetime.now(timezone.utc)
+        legacy_time = now - timedelta(days=400)
+        canonical_time = now - timedelta(days=1)
+
+        int_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(int_db, [
+            # 5 emails on the canonical, recent
+            *[(f"c{i}", canonical_id, canonical_time.isoformat(), "gmail",
+               "e", "", None, f"src-c{i}", now.isoformat()) for i in range(5)],
+            # 2 emails on the legacy id, old
+            *[(f"l{i}", legacy_id, legacy_time.isoformat(), "gmail",
+               "e", "", None, f"src-l{i}", now.isoformat()) for i in range(2)],
+        ])
+
+        # Canonical entity. get_by_id follows the merge map: both
+        # canonical_id and legacy_id return the SAME entity.
+        entity = PersonEntity(id=canonical_id, canonical_name="Merged Person")
+
+        mock_store = MagicMock()
+        mock_store.get_by_id.return_value = entity
+        mock_store.get_legacy_ids.return_value = set()
+        mock_store.get_all.return_value = [entity]
+
+        with patch("api.services.person_entity.get_person_entity_store", return_value=mock_store), \
+             patch("api.services.interaction_store.get_interaction_db_path", return_value=int_db), \
+             patch("api.services.person_stats.Path") as mock_path:
+            mock_path.return_value.exists.return_value = False
+            refresh_person_stats(person_ids=None, save=False)
+
+        # Counts must be SUM (7), not REPLACED with the legacy under-count (2).
+        assert entity.email_count == 7
+        # last_seen must be the recent canonical timestamp, not the 400-day-old
+        # legacy timestamp.
+        assert abs((entity.last_seen - canonical_time).total_seconds()) < 2
+
+    def test_targeted_refresh_handles_legacy_id(self, tmp_path):
+        """Targeted refresh called with a legacy ID should update the canonical
+        with the union of counts, not just the legacy subset."""
+        canonical_id = "canonical-003"
+        legacy_id = "legacy-004"
+        now = datetime.now(timezone.utc)
+
+        int_db = str(tmp_path / "interactions.db")
+        _create_interaction_db(int_db, [
+            ("c1", canonical_id, now.isoformat(), "gmail", "e", "", None, "src-c1", now.isoformat()),
+            ("c2", canonical_id, now.isoformat(), "gmail", "e", "", None, "src-c2", now.isoformat()),
+            ("l1", legacy_id, now.isoformat(), "gmail", "e", "", None, "src-l1", now.isoformat()),
+        ])
+
+        entity = PersonEntity(id=canonical_id, canonical_name="Merged Person")
+        mock_store = MagicMock()
+        mock_store.get_by_id.return_value = entity
+        mock_store.get_legacy_ids.return_value = {legacy_id}
+
+        with patch("api.services.person_entity.get_person_entity_store", return_value=mock_store), \
+             patch("api.services.interaction_store.get_interaction_db_path", return_value=int_db), \
+             patch("api.services.person_stats.Path") as mock_path:
+            mock_path.return_value.exists.return_value = False
+            # Caller passes only the legacy id; the store's reverse merge
+            # lookup expands to the canonical + every sibling legacy ID,
+            # so counts should reflect ALL interactions for the canonical.
+            refresh_person_stats([legacy_id], save=False)
+
+        assert entity.email_count == 3
 
 
 class TestApplyCountsToEntity:


### PR DESCRIPTION
## Summary
- **Bug**: `refresh_person_stats()` silently corrupted any canonical person entity that still had legacy (pre-merge) person_ids attached to interaction rows. The loop iterated raw `person_id` rows, `get_by_id()` followed the merge map back to the canonical, and the second-pass legacy ID overwrote correct counts and `last_seen` with under-counts and older timestamps (last-write-wins).
- **Impact**: ~4,800 people (32% of CRM) showed stale `last_seen` and order-of-magnitude-undercount stats — e.g. Emily Durfee showed `email_count=22, last_seen=2025-01-29` despite 1,859 recent emails through 2026-05-24.
- **Fix**: Aggregate raw per-`(person_id, source)` counts onto the canonical *before* applying. Full refresh and targeted refresh both go through the canonical exactly once with the union of all variant IDs. Targeted path uses a new `PersonEntityStore.get_legacy_ids()` reverse lookup so callers can pass either canonical or legacy. `verify_person_stats` and the R6 integrity test query the same variant set; otherwise the post-fix state looks like a "discrepancy" and `verify(fix=True)` would silently revert.

## Test plan
- [x] New regression tests in `tests/test_person_stats.py::TestMergedLegacyIds` reproduce the corruption and assert the fix (full + targeted paths).
- [x] All 10 person-stats tests pass; all 66 merge/split/consistency tests pass.
- [x] Full unit suite (1,912 tests) green except one pre-existing data-integrity failure on main (orphan vault files — unrelated).
- [x] Real-data verification:
  - Pre-fix: Emily `email=22, last_seen=2025-01-29`; Taylor `email=40, msg=0, last_seen=2025-01-28`
  - Post-fix full refresh: Emily `email=1859, msg=809, last_seen=2026-05-24`; Taylor `email=880, msg=64807, last_seen=2026-05-24`
- [x] Targeted refresh with a *legacy* ID correctly resolves and updates the canonical (2,859 interactions aggregated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)