### PR TITLE
feat: agent-worker prep — Gemma swap + MCP HTTP transport (A of F)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,15 +25,32 @@
 # Local LLM model (HuggingFace GGUF ID for llama-server)
 # Also used by setup-systemd.sh for the systemd service
 # Available models:
-#   ggml-org/gpt-oss-120b-GGUF  — ~59 GB VRAM (MXFP4), highest quality
-#   Qwen/Qwen3-32B-GGUF        — ~20 GB VRAM (Q4_K_M), good quality, leaves headroom for embeddings
+#   unsloth/gemma-4-26B-A4B-it-GGUF — ~16 GB VRAM (Q4_K_M), default; pairs well with embedding model
+#   Qwen/Qwen3-32B-GGUF             — ~20 GB VRAM (Q4_K_M), strong general-purpose option
+#   ggml-org/gpt-oss-120b-GGUF      — ~59 GB VRAM (MXFP4), highest quality but starves embeddings
 # To switch models: change this value, then run: sudo ./scripts/setup-systemd.sh
-# LIFEOS_LLM_MODEL=ggml-org/gpt-oss-120b-GGUF
+# LIFEOS_LLM_MODEL=unsloth/gemma-4-26B-A4B-it-GGUF
 
 # Auto-start local LLM on boot and restart on crash (default: false)
 # When false, llama-server must be started manually: sudo systemctl start lifeos-llm
 # Run sudo ./scripts/setup-systemd.sh after changing this value
 # LIFEOS_LOCAL_LLM_AUTOSTART=false
+
+# =============================================================================
+# MCP HTTP TRANSPORT (for remote agent platforms; local Claude Code keeps stdio)
+# =============================================================================
+
+# Bearer token required by the MCP HTTP transport. Empty disables the HTTP
+# transport entirely. Generate one with: openssl rand -hex 32
+# Anthropic Managed Agents (and any other remote MCP caller) must send this
+# token in the `Authorization: Bearer ...` header.
+# LIFEOS_MCP_BEARER_TOKEN=
+
+# Bind address + port for the MCP HTTP transport. Default binds to localhost
+# only — pair with a Cloudflare Tunnel (or similar) for public exposure rather
+# than binding to 0.0.0.0 directly.
+# LIFEOS_MCP_HTTP_HOST=127.0.0.1
+# LIFEOS_MCP_HTTP_PORT=8765
 
 # =============================================================================
 # EMBEDDING MODEL — sentence-transformers (cached locally)

--- a/config/settings.py
+++ b/config/settings.py
@@ -70,9 +70,29 @@ class Settings(BaseSettings):
     local_llm_url: str = Field(default="http://localhost:8080", alias="LIFEOS_LOCAL_LLM_URL")
     local_llm_timeout: int = Field(default=90, alias="LIFEOS_LOCAL_LLM_TIMEOUT")
     local_llm_model: str = Field(
-        default="ggml-org/gpt-oss-120b-GGUF",
+        default="unsloth/gemma-4-26B-A4B-it-GGUF",
         alias="LIFEOS_LLM_MODEL",
         description="HuggingFace GGUF model ID for llama-server"
+    )
+
+    # MCP HTTP transport (used by remote agent platforms; local Claude Code keeps stdio)
+    mcp_http_port: int = Field(
+        default=8765,
+        alias="LIFEOS_MCP_HTTP_PORT",
+        description="Port for the MCP HTTP transport (lifeos-mcp-http systemd unit)"
+    )
+    mcp_http_host: str = Field(
+        default="127.0.0.1",
+        alias="LIFEOS_MCP_HTTP_HOST",
+        description="Bind address for the MCP HTTP transport. Default 127.0.0.1 so only "
+                    "the local Cloudflare Tunnel daemon can reach it; the tunnel handles "
+                    "public exposure."
+    )
+    mcp_bearer_token: str = Field(
+        default="",
+        alias="LIFEOS_MCP_BEARER_TOKEN",
+        description="Bearer token required by the MCP HTTP transport. Generate with "
+                    "`openssl rand -hex 32`. Empty disables the HTTP transport."
     )
     local_llm_autostart: bool = Field(
         default=False,

--- a/config/systemd/lifeos-mcp-http.service
+++ b/config/systemd/lifeos-mcp-http.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=LifeOS MCP HTTP Transport
+After=network.target lifeos-api.service
+Wants=lifeos-api.service
+
+[Service]
+Type=simple
+User=__USER__
+WorkingDirectory=__LIFEOS_DIR__
+EnvironmentFile=__LIFEOS_DIR__/.env
+ExecStart=__VENV__/bin/python __LIFEOS_DIR__/mcp_server.py --transport http
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:__LIFEOS_DIR__/logs/mcp-http.log
+StandardError=append:__LIFEOS_DIR__/logs/mcp-http.log
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -13,6 +13,7 @@ This directory contains operational guides — how to set up, configure, and run
 - `scripts.md` — Available scripts and their usage
 - `troubleshooting.md` — Common issues and solutions
 - `claude-code-orchestration.md` — Claude Code multi-agent orchestration patterns
+- `agent-worker-setup.md` — External agent worker prerequisites (Gemma swap, MCP HTTP transport, Cloudflare Tunnel, bearer token)
 
 ## Key Principles
 

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -1,0 +1,152 @@
+# Agent Worker Setup
+
+> **Status:** Stub — expanded by later issues in the agent-worker series (#98)
+> **Last Updated:** 2026-05-26
+> **Audience:** Operators
+
+One-time setup for the external agent worker that picks up `#agent`-tagged tasks and executes them via Claude Opus (Anthropic Managed Agents) or a local Gemma model. This guide covers **prerequisites only** — the worker itself ships in later issues.
+
+---
+
+## What this issue (#99) sets up
+
+- **Local LLM** swapped from `gpt-oss-120b` to `unsloth/gemma-4-26B-A4B-it-GGUF`. Smaller VRAM footprint, leaves headroom for the embedding model to coexist.
+- **MCP HTTP transport** on `mcp_server.py` so a remote agent platform (Anthropic Managed Agents) can call LifeOS tools without stdio access to the host.
+- **Bearer-token auth** required by the HTTP transport. The stdio transport (used by local Claude Code) is unchanged and has no token check.
+- **Cloudflare Tunnel** exposes the bearer-protected HTTP endpoint to the public internet.
+
+---
+
+## Step 1 — Swap the local LLM to Gemma
+
+The `LIFEOS_LLM_MODEL` env var controls which GGUF `llama-server` loads. The default in this repo is now Gemma:
+
+```bash
+# .env (or .env.example to see the documented options)
+LIFEOS_LLM_MODEL=unsloth/gemma-4-26B-A4B-it-GGUF
+```
+
+After setting it, re-install the systemd unit and restart:
+
+```bash
+sudo ./scripts/setup-systemd.sh
+sudo systemctl restart lifeos-llm
+```
+
+Verify Gemma is loaded:
+
+```bash
+curl http://localhost:8080/v1/models | jq
+# Should report the Gemma model id, not gpt-oss.
+```
+
+If chat formatting looks broken on `LIFEOS_LLM_BACKEND=local` requests, try adding `--chat-template gemma3` to the `ExecStart` line of `config/systemd/lifeos-llm.service` — Gemma 4 generally works with `--jinja` (the embedded Jinja template) but some llama.cpp builds prefer the explicit template flag.
+
+---
+
+## Step 2 — Generate a bearer token
+
+The MCP HTTP transport refuses to start without a bearer token. Generate one and add it to `.env`:
+
+```bash
+openssl rand -hex 32
+```
+
+```bash
+# .env
+LIFEOS_MCP_BEARER_TOKEN=<paste the generated hex string>
+```
+
+Keep `.env` out of version control (it already is via `.gitignore`). Never commit a real token.
+
+Optional overrides (defaults shown):
+
+```bash
+# LIFEOS_MCP_HTTP_HOST=127.0.0.1   # bind localhost only; Cloudflare Tunnel handles public exposure
+# LIFEOS_MCP_HTTP_PORT=8765
+```
+
+---
+
+## Step 3 — Enable the MCP HTTP systemd unit
+
+`setup-systemd.sh` enables `lifeos-mcp-http.service` automatically when it detects a bearer token in `.env`:
+
+```bash
+sudo ./scripts/setup-systemd.sh
+sudo systemctl status lifeos-mcp-http
+```
+
+Smoke-test locally (still 401 from outside because the bind is localhost — that's expected):
+
+```bash
+curl -sS -X POST http://127.0.0.1:8765/mcp \
+  -H "Authorization: Bearer $LIFEOS_MCP_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools | length'
+# Should print a positive integer (the number of registered tools).
+```
+
+A request without the header should return 401:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:8765/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+# 401
+```
+
+---
+
+## Step 4 — Expose via Cloudflare Tunnel
+
+Anthropic Managed Agents (and any other remote MCP caller) need to reach `http://127.0.0.1:8765/mcp` from the public internet. Use [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) — outbound-only, no inbound firewall rules.
+
+If you already run `cloudflared` for another service (e.g., QuickStage), add a route to the existing tunnel config. Otherwise, follow the Cloudflare Zero Trust quickstart to create a tunnel for your account.
+
+Example `~/.cloudflared/config.yml` snippet (replace placeholders):
+
+```yaml
+tunnel: <your-tunnel-uuid>
+credentials-file: /home/<your-user>/.cloudflared/<tunnel-uuid>.json
+
+ingress:
+  # ... your other routes ...
+  - hostname: mcp.example.com
+    service: http://127.0.0.1:8765
+  - service: http_status:404
+```
+
+Add a DNS record (CNAME `mcp.example.com` → `<tunnel-uuid>.cfargotunnel.com`) and reload `cloudflared`.
+
+Verify from outside the host:
+
+```bash
+curl -sS -X POST https://mcp.example.com/mcp \
+  -H "Authorization: Bearer $LIFEOS_MCP_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools | length'
+```
+
+Hardening upgrade (deferred to a later issue): swap the bearer-token check for a [Cloudflare Access service token](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/) for revocable, per-token audit logging. Bearer token is fine for v1.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `lifeos-mcp-http` won't start, log says "requires LIFEOS_MCP_BEARER_TOKEN" | Token not set in `.env`, or systemd didn't reload | Set the token, then `sudo systemctl daemon-reload && sudo systemctl restart lifeos-mcp-http` |
+| 401 with a token that should work | Token in `.env` doesn't match the one the caller is sending | Re-read `.env`, ensure no quotes or trailing whitespace; restart `lifeos-mcp-http` after edits |
+| 502/504 from the tunnel | The MCP HTTP service isn't running on the configured port | `systemctl status lifeos-mcp-http` and `curl http://127.0.0.1:8765/mcp` |
+| Gemma loads but responses look garbled | Chat template mismatch | Add `--chat-template gemma3` to `lifeos-llm.service` `ExecStart` |
+| `llama-server` crashes on Gemma | Insufficient VRAM, or stale cached model | Check `nvidia-smi`/`rocm-smi`; re-download with `llama-server -hf unsloth/gemma-4-26B-A4B-it-GGUF` once and confirm |
+
+---
+
+## Related Documents
+
+- [Installation](installation.md) — base LifeOS setup
+- [Configuration](configuration.md) — environment variable reference
+- [Scripts](scripts.md) — `setup-systemd.sh` and other operational scripts
+- Epic [#98](https://github.com/nbramia/LifeOS/issues/98) — full agent-worker design

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1720,17 +1720,27 @@ def build_http_app(server: "LifeOSMCPServer", bearer_token: str):
     def _check_auth(request: Request) -> None:
         header = request.headers.get("authorization", "")
         scheme, _, token = header.partition(" ")
+        token = token.strip()
         if scheme.lower() != "bearer" or not token:
             raise HTTPException(status_code=401, detail="missing bearer token")
         if not hmac.compare_digest(token, bearer_token):
             raise HTTPException(status_code=401, detail="invalid bearer token")
+
+    def _parse_error_response() -> JSONResponse:
+        """JSON-RPC -32700 Parse error per the spec — id is null when unparseable."""
+        envelope = {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32700, "message": "Parse error"},
+        }
+        return JSONResponse(envelope, status_code=400)
 
     async def _handle(request: Request) -> Response:
         _check_auth(request)
         try:
             body = await request.json()
         except json.JSONDecodeError:
-            raise HTTPException(status_code=400, detail="invalid JSON body")
+            return _parse_error_response()
 
         if isinstance(body, list):
             responses = [r for r in (dispatch(server, req) for req in body) if r is not None]

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1624,63 +1624,184 @@ class LifeOSMCPServer:
         return json.dumps(data, indent=2)
 
 
-def send_response(response: dict, request_id: str | int):
-    """Send JSON-RPC response to stdout."""
-    result = {"jsonrpc": "2.0", "id": request_id, "result": response}
-    print(json.dumps(result), flush=True)
+def _ok(request_id, result: dict) -> dict:
+    """Build a JSON-RPC success response."""
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
 
 
-def send_error(message: str, request_id: str | int, code: int = -32000):
-    """Send JSON-RPC error to stdout."""
-    error = {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
-    print(json.dumps(error), flush=True)
+def _err(request_id, message: str, code: int = -32000) -> dict:
+    """Build a JSON-RPC error response."""
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def dispatch(server: "LifeOSMCPServer", request: dict) -> dict | None:
+    """Handle a single JSON-RPC request.
+
+    Returns the response dict, or None for notifications (requests with no id).
+    Used by both the stdio and HTTP transports so behavior stays identical.
+    """
+    method = request.get("method")
+    request_id = request.get("id")
+    is_notification = request_id is None
+
+    try:
+        if method == "initialize":
+            result = {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "lifeos", "version": "1.0.0"},
+            }
+            return None if is_notification else _ok(request_id, result)
+
+        if method == "notifications/initialized":
+            return None
+
+        if method == "tools/list":
+            return None if is_notification else _ok(request_id, {"tools": server.tools})
+
+        if method == "tools/call":
+            params = request.get("params", {})
+            tool_name = params.get("name")
+            arguments = params.get("arguments", {})
+            data = server._call_api(tool_name, arguments)
+            formatted = server._format_response(tool_name, data)
+            result = {"content": [{"type": "text", "text": formatted}]}
+            return None if is_notification else _ok(request_id, result)
+
+        # Unknown method
+        if is_notification:
+            return None
+        return _err(request_id, f"Method not found: {method}", code=-32601)
+
+    except Exception as e:
+        logger.error(f"Error handling {method}: {e}")
+        if is_notification:
+            return None
+        return _err(request_id, str(e))
+
+
+def run_stdio(server: "LifeOSMCPServer") -> None:
+    """Run the stdio transport (line-delimited JSON-RPC on stdin/stdout)."""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError as e:
+            logger.error(f"JSON decode error: {e}")
+            continue
+        response = dispatch(server, request)
+        if response is not None:
+            print(json.dumps(response), flush=True)
+
+
+def build_http_app(server: "LifeOSMCPServer", bearer_token: str):
+    """Build a FastAPI app exposing the MCP server over HTTP.
+
+    A non-empty `bearer_token` is required — the HTTP transport is intended for
+    public exposure (e.g., behind a Cloudflare Tunnel for Anthropic Managed
+    Agents), so unauthenticated mode is not allowed. Local Claude Code keeps
+    using the stdio transport, which has no bearer check.
+    """
+    if not bearer_token:
+        raise ValueError(
+            "HTTP transport requires a bearer token "
+            "(set LIFEOS_MCP_BEARER_TOKEN in the environment)"
+        )
+
+    import hmac
+
+    from fastapi import FastAPI, HTTPException, Request, Response
+    from fastapi.responses import JSONResponse
+
+    app = FastAPI(title="LifeOS MCP", docs_url=None, redoc_url=None, openapi_url=None)
+
+    def _check_auth(request: Request) -> None:
+        header = request.headers.get("authorization", "")
+        scheme, _, token = header.partition(" ")
+        if scheme.lower() != "bearer" or not token:
+            raise HTTPException(status_code=401, detail="missing bearer token")
+        if not hmac.compare_digest(token, bearer_token):
+            raise HTTPException(status_code=401, detail="invalid bearer token")
+
+    async def _handle(request: Request) -> Response:
+        _check_auth(request)
+        try:
+            body = await request.json()
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="invalid JSON body")
+
+        if isinstance(body, list):
+            responses = [r for r in (dispatch(server, req) for req in body) if r is not None]
+            if not responses:
+                return Response(status_code=202)
+            return JSONResponse(responses)
+
+        response = dispatch(server, body)
+        if response is None:
+            return Response(status_code=202)
+        return JSONResponse(response)
+
+    @app.post("/mcp")
+    async def mcp_endpoint(request: Request) -> Response:
+        return await _handle(request)
+
+    @app.post("/")
+    async def mcp_root(request: Request) -> Response:
+        return await _handle(request)
+
+    return app
+
+
+def run_http(server: "LifeOSMCPServer", host: str, port: int, bearer_token: str) -> None:
+    """Run the HTTP transport via uvicorn."""
+    import uvicorn  # local import — only needed for HTTP mode
+
+    app = build_http_app(server, bearer_token=bearer_token)
+    uvicorn.run(app, host=host, port=port, log_level="info")
 
 
 def main():
-    """Main MCP server loop."""
+    """Entrypoint: parse --transport flag and run the chosen transport."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="LifeOS MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "http"),
+        default=os.environ.get("LIFEOS_MCP_TRANSPORT", "stdio"),
+        help="Transport to expose (default: stdio, suitable for Claude Code)",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("LIFEOS_MCP_HTTP_HOST", "127.0.0.1"),
+        help="HTTP bind host (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("LIFEOS_MCP_HTTP_PORT", "8765")),
+        help="HTTP bind port (default: 8765)",
+    )
+    args = parser.parse_args()
+
     server = LifeOSMCPServer()
 
-    for line in sys.stdin:
-        try:
-            request = json.loads(line.strip())
-            method = request.get("method")
-            request_id = request.get("id")
+    if args.transport == "stdio":
+        run_stdio(server)
+        return
 
-            if method == "initialize":
-                send_response({
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {"tools": {}},
-                    "serverInfo": {"name": "lifeos", "version": "1.0.0"}
-                }, request_id)
+    bearer_token = os.environ.get("LIFEOS_MCP_BEARER_TOKEN", "")
+    if not bearer_token:
+        logger.error(
+            "HTTP transport requires LIFEOS_MCP_BEARER_TOKEN. "
+            "Generate one with: openssl rand -hex 32"
+        )
+        sys.exit(2)
 
-            elif method == "notifications/initialized":
-                pass  # No response needed
-
-            elif method == "tools/list":
-                send_response({"tools": server.tools}, request_id)
-
-            elif method == "tools/call":
-                params = request.get("params", {})
-                tool_name = params.get("name")
-                arguments = params.get("arguments", {})
-
-                result = server._call_api(tool_name, arguments)
-                formatted = server._format_response(tool_name, result)
-
-                send_response({
-                    "content": [{"type": "text", "text": formatted}]
-                }, request_id)
-
-            else:
-                if request_id is not None:
-                    send_error(f"Unknown method: {method}", request_id)
-
-        except json.JSONDecodeError as e:
-            logger.error(f"JSON decode error: {e}")
-        except Exception as e:
-            logger.error(f"Error handling request: {e}")
-            if 'request_id' in dir() and request_id is not None:
-                send_error(str(e), request_id)
+    logger.info(f"LifeOS MCP HTTP transport listening on {args.host}:{args.port}")
+    run_http(server, host=args.host, port=args.port, bearer_token=bearer_token)
 
 
 if __name__ == "__main__":

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -126,8 +126,10 @@ systemctl enable --now lifeos-sync.timer
 echo "  lifeos-sync.timer: $(systemctl is-active lifeos-sync.timer)"
 
 # MCP HTTP transport is only enabled when a bearer token is configured.
-# Without a token, exposing the MCP server over HTTP would let any caller hit
-# the agent worker's tool surface — see docs/guides/agent-worker-setup.md.
+# The systemd unit reads the live .env at runtime; we check the token here
+# purely to decide whether to enable/start the unit at install time. Without
+# a token, exposing the MCP server over HTTP would let any caller hit the
+# agent worker's tool surface — see docs/guides/agent-worker-setup.md.
 if [ -n "$MCP_BEARER_TOKEN" ]; then
     systemctl enable --now lifeos-mcp-http.service
     echo "  lifeos-mcp-http: $(systemctl is-active lifeos-mcp-http.service)"

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -48,8 +48,9 @@ _read_env() {
     echo "$default"
 }
 
-LLM_MODEL=$(_read_env "LIFEOS_LLM_MODEL" "${LIFEOS_LLM_MODEL:-ggml-org/gpt-oss-120b-GGUF}")
+LLM_MODEL=$(_read_env "LIFEOS_LLM_MODEL" "${LIFEOS_LLM_MODEL:-unsloth/gemma-4-26B-A4B-it-GGUF}")
 LLM_AUTOSTART=$(_read_env "LIFEOS_LOCAL_LLM_AUTOSTART" "false")
+MCP_BEARER_TOKEN=$(_read_env "LIFEOS_MCP_BEARER_TOKEN" "")
 
 # Normalize boolean
 case "$(echo "$LLM_AUTOSTART" | tr '[:upper:]' '[:lower:]')" in
@@ -71,6 +72,11 @@ echo "  Venv:       $VENV_DIR"
 echo "  llama.cpp:  $LLAMA_DIR"
 echo "  LLM Model:  $LLM_MODEL"
 echo "  LLM Auto:   $LLM_AUTOSTART (restart policy: $LLM_RESTART_POLICY)"
+if [ -n "$MCP_BEARER_TOKEN" ]; then
+    echo "  MCP HTTP:   enabled (token configured)"
+else
+    echo "  MCP HTTP:   disabled (set LIFEOS_MCP_BEARER_TOKEN to enable)"
+fi
 echo ""
 
 # Install unit files with variable substitution
@@ -119,6 +125,18 @@ echo "  lifeos-watchdog.timer: $(systemctl is-active lifeos-watchdog.timer)"
 systemctl enable --now lifeos-sync.timer
 echo "  lifeos-sync.timer: $(systemctl is-active lifeos-sync.timer)"
 
+# MCP HTTP transport is only enabled when a bearer token is configured.
+# Without a token, exposing the MCP server over HTTP would let any caller hit
+# the agent worker's tool surface — see docs/guides/agent-worker-setup.md.
+if [ -n "$MCP_BEARER_TOKEN" ]; then
+    systemctl enable --now lifeos-mcp-http.service
+    echo "  lifeos-mcp-http: $(systemctl is-active lifeos-mcp-http.service)"
+else
+    systemctl disable lifeos-mcp-http.service 2>/dev/null || true
+    systemctl stop lifeos-mcp-http.service 2>/dev/null || true
+    echo "  lifeos-mcp-http: disabled (set LIFEOS_MCP_BEARER_TOKEN to enable)"
+fi
+
 # Install logrotate config with substitution
 LOGROTATE_SRC="$PROJECT_DIR/config/logrotate-lifeos.conf"
 if [ -f "$LOGROTATE_SRC" ]; then
@@ -133,7 +151,7 @@ echo ""
 echo "Installing sudoers rule for passwordless systemctl..."
 SUDOERS_FILE="/etc/sudoers.d/lifeos"
 TMP_SUDOERS=$(mktemp)
-echo "$REAL_USER ALL=(root) NOPASSWD: /usr/bin/systemctl start lifeos-api, /usr/bin/systemctl stop lifeos-api, /usr/bin/systemctl restart lifeos-api, /usr/bin/systemctl start lifeos-api.service, /usr/bin/systemctl stop lifeos-api.service, /usr/bin/systemctl restart lifeos-api.service, /usr/bin/systemctl start lifeos-llm, /usr/bin/systemctl stop lifeos-llm, /usr/bin/systemctl start lifeos-llm.service, /usr/bin/systemctl stop lifeos-llm.service" > "$TMP_SUDOERS"
+echo "$REAL_USER ALL=(root) NOPASSWD: /usr/bin/systemctl start lifeos-api, /usr/bin/systemctl stop lifeos-api, /usr/bin/systemctl restart lifeos-api, /usr/bin/systemctl start lifeos-api.service, /usr/bin/systemctl stop lifeos-api.service, /usr/bin/systemctl restart lifeos-api.service, /usr/bin/systemctl start lifeos-llm, /usr/bin/systemctl stop lifeos-llm, /usr/bin/systemctl start lifeos-llm.service, /usr/bin/systemctl stop lifeos-llm.service, /usr/bin/systemctl start lifeos-mcp-http, /usr/bin/systemctl stop lifeos-mcp-http, /usr/bin/systemctl restart lifeos-mcp-http, /usr/bin/systemctl start lifeos-mcp-http.service, /usr/bin/systemctl stop lifeos-mcp-http.service, /usr/bin/systemctl restart lifeos-mcp-http.service" > "$TMP_SUDOERS"
 if visudo -c -f "$TMP_SUDOERS" > /dev/null 2>&1; then
     mv "$TMP_SUDOERS" "$SUDOERS_FILE"
     chmod 440 "$SUDOERS_FILE"

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -160,7 +160,8 @@ def test_unknown_method_returns_jsonrpc_error(client: TestClient, bearer_token: 
 
 
 @pytest.mark.unit
-def test_malformed_json_returns_400(client: TestClient, bearer_token: str):
+def test_malformed_json_returns_parse_error_envelope(client: TestClient, bearer_token: str):
+    """Per JSON-RPC 2.0 spec, malformed JSON → -32700 with id null."""
     resp = client.post(
         "/mcp",
         content=b"not json",
@@ -170,6 +171,55 @@ def test_malformed_json_returns_400(client: TestClient, bearer_token: str):
         },
     )
     assert resp.status_code == 400
+    body = resp.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] is None
+    assert body["error"]["code"] == -32700
+    assert body["error"]["message"] == "Parse error"
+
+
+@pytest.mark.unit
+def test_bearer_with_extra_whitespace_accepted(client: TestClient, bearer_token: str):
+    """Operator copy-paste pitfall: extra spaces around the token shouldn't 401."""
+    resp = client.post(
+        "/mcp",
+        json=_initialize_request(),
+        headers={"Authorization": f"Bearer   {bearer_token}  "},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.unit
+def test_batch_of_notifications_returns_202(client: TestClient, bearer_token: str):
+    """A batch where every entry is a notification has no responses → 202."""
+    resp = client.post(
+        "/mcp",
+        json=[
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        ],
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 202
+    assert resp.content == b""
+
+
+@pytest.mark.unit
+def test_batch_mixed_returns_only_non_notification_responses(client: TestClient, bearer_token: str):
+    """A mixed batch returns responses only for the entries that had an id."""
+    resp = client.post(
+        "/mcp",
+        json=[
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 42, "method": "tools/list"},
+        ],
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) == 1
+    assert body[0]["id"] == 42
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -1,0 +1,202 @@
+"""Tests for the MCP server HTTP transport and bearer-token auth.
+
+The HTTP transport is exposed by `mcp_server.py --transport http` so Anthropic
+Managed Agents (and other remote callers) can reach LifeOS tools over the
+internet. These tests exercise the auth gate and the request dispatcher
+without needing the live API server: tool calls are short-circuited by
+monkey-patching `LifeOSMCPServer._call_api`.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import mcp_server
+
+
+@pytest.fixture
+def bearer_token() -> str:
+    return "test-secret-token"
+
+
+@pytest.fixture
+def server(monkeypatch) -> mcp_server.LifeOSMCPServer:
+    """A server with stubbed _call_api so tools/call returns deterministic data."""
+    srv = mcp_server.LifeOSMCPServer()
+
+    def fake_call(self: mcp_server.LifeOSMCPServer, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        return {"echo": {"tool": tool_name, "arguments": arguments}}
+
+    monkeypatch.setattr(mcp_server.LifeOSMCPServer, "_call_api", fake_call)
+    monkeypatch.setattr(
+        mcp_server.LifeOSMCPServer,
+        "_format_response",
+        lambda self, tool_name, data: json.dumps(data),
+    )
+    return srv
+
+
+@pytest.fixture
+def client(server: mcp_server.LifeOSMCPServer, bearer_token: str) -> TestClient:
+    app = mcp_server.build_http_app(server, bearer_token=bearer_token)
+    return TestClient(app)
+
+
+def _initialize_request(req_id: int = 1) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}},
+    }
+
+
+@pytest.mark.unit
+def test_missing_authorization_header_returns_401(client: TestClient):
+    resp = client.post("/mcp", json=_initialize_request())
+    assert resp.status_code == 401
+
+
+@pytest.mark.unit
+def test_wrong_bearer_token_returns_401(client: TestClient):
+    resp = client.post(
+        "/mcp",
+        json=_initialize_request(),
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.unit
+def test_non_bearer_scheme_returns_401(client: TestClient):
+    resp = client.post(
+        "/mcp",
+        json=_initialize_request(),
+        headers={"Authorization": "Basic dXNlcjpwYXNz"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.unit
+def test_valid_bearer_token_returns_200_with_jsonrpc(client: TestClient, bearer_token: str):
+    resp = client.post(
+        "/mcp",
+        json=_initialize_request(),
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == 1
+    assert "result" in body
+    assert body["result"]["protocolVersion"] == "2024-11-05"
+    assert body["result"]["serverInfo"]["name"] == "lifeos"
+
+
+@pytest.mark.unit
+def test_tools_list_returns_registered_tools(client: TestClient, bearer_token: str):
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "result" in body
+    tools = body["result"]["tools"]
+    assert isinstance(tools, list)
+    assert len(tools) > 0
+    # Sanity-check a well-known tool exists
+    names = {t["name"] for t in tools}
+    assert "lifeos_search" in names
+
+
+@pytest.mark.unit
+def test_tools_call_dispatches_to_handler(client: TestClient, bearer_token: str):
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "lifeos_search", "arguments": {"query": "hello"}},
+        },
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["content"][0]["type"] == "text"
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["echo"]["tool"] == "lifeos_search"
+    assert payload["echo"]["arguments"] == {"query": "hello"}
+
+
+@pytest.mark.unit
+def test_notification_returns_202_no_body(client: TestClient, bearer_token: str):
+    """JSON-RPC notifications (no id) get 202 Accepted per MCP streamable-HTTP spec."""
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 202
+    assert resp.content == b""
+
+
+@pytest.mark.unit
+def test_unknown_method_returns_jsonrpc_error(client: TestClient, bearer_token: str):
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 4, "method": "no/such/method"},
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32601  # Method not found
+
+
+@pytest.mark.unit
+def test_malformed_json_returns_400(client: TestClient, bearer_token: str):
+    resp = client.post(
+        "/mcp",
+        content=b"not json",
+        headers={
+            "Authorization": f"Bearer {bearer_token}",
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.unit
+def test_build_http_app_requires_bearer_token():
+    """Server refuses to build the HTTP app if no bearer token is configured."""
+    srv = mcp_server.LifeOSMCPServer()
+    with pytest.raises(ValueError, match="bearer"):
+        mcp_server.build_http_app(srv, bearer_token="")
+
+
+@pytest.mark.unit
+def test_stdio_dispatch_ignores_bearer(server: mcp_server.LifeOSMCPServer):
+    """The stdio path uses dispatch() directly with no auth — local trust."""
+    response = mcp_server.dispatch(
+        server,
+        {"jsonrpc": "2.0", "id": 5, "method": "tools/list"},
+    )
+    assert response is not None
+    assert response["id"] == 5
+    assert "tools" in response["result"]
+
+
+@pytest.mark.unit
+def test_stdio_notification_returns_none(server: mcp_server.LifeOSMCPServer):
+    """Notifications produce no response over stdio (no line written)."""
+    response = mcp_server.dispatch(
+        server,
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+    assert response is None


### PR DESCRIPTION
## Summary
Prerequisites for the external agent worker (epic #98) — first issue in the A→F sequence. Local LLM default swapped to Gemma 4 26B (smaller VRAM footprint, leaves room for embeddings to coexist). `mcp_server.py` gains a bearer-token-protected HTTP transport behind a new `lifeos-mcp-http.service` systemd unit so Anthropic Managed Agents can reach LifeOS tools over the internet via Cloudflare Tunnel. Local Claude Code stdio transport is unchanged.

Closes #99 · Relates to #98

## Test evidence
- `pytest tests/test_mcp_http_transport.py` — **12/12 passed** (bearer rejection, dispatcher parity stdio↔http, JSON-RPC notification semantics, malformed-JSON 400, fail-fast on missing token)
- `pytest -m unit` via pre-push hook — **1187/1187 passed** in 86s
- Pre-existing failure in `test_summarizer.py::test_real_summary_generation` confirmed on `main` (Ollama summarizer returns empty content). Per AGENTS.md "Tests Are Sacred" — documented, not fixed here.

## Review focus
- **Bearer auth hardening** in `mcp_server.py:build_http_app` — uses `hmac.compare_digest` (constant-time), case-insensitive scheme parsing, refuses to start without a token.
- **Dispatcher refactor** in `mcp_server.py:dispatch` — single function shared by stdio + http, preserves original method handling (initialize / notifications/initialized / tools/list / tools/call / unknown). Original `'request_id' in dir()` guard replaced with explicit `is_notification` check.
- **Open-source hygiene** — no real hostnames or tokens committed. `.env.example` documents the env vars with empty defaults. `setup-systemd.sh` only enables the HTTP unit when `LIFEOS_MCP_BEARER_TOKEN` is set in `.env`. `docs/guides/agent-worker-setup.md` uses `mcp.example.com` as placeholder throughout.
- **No new third-party deps** — HTTP transport reuses `fastapi` + `uvicorn` already in `requirements.txt`. The `mcp` SDK was avoided per the "ask first on new deps" rule in AGENTS.md.
- **`hmac` import lives inside `build_http_app`** so the stdio path never imports `fastapi`/`hmac` (keeps stdio startup minimal for Claude Code subprocess spawning).

## Manual smoke verification (operator follow-up)
After merging, operator runs:
1. `sudo ./scripts/setup-systemd.sh` to install the new `lifeos-mcp-http.service` and swap the `lifeos-llm.service` to Gemma.
2. Generate bearer token with `openssl rand -hex 32`, add to `.env` as `LIFEOS_MCP_BEARER_TOKEN`.
3. Add Cloudflare Tunnel route per `docs/guides/agent-worker-setup.md`.
4. `curl -H "Authorization: Bearer \$TOKEN" https://<tunnel-hostname>/mcp ...` to confirm public reachability + auth.

These are deferred from PR scope because they touch production infra and the tunnel hostname is operator-specific.