### PR TITLE
feat: agent-worker scaffolding + atomic claim (B of F)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,34 @@
 # LIFEOS_MCP_HTTP_PORT=8765
 
 # =============================================================================
+# AGENT WORKER (external worker that picks up #agent-tagged tasks)
+# =============================================================================
+
+# Enable systemd auto-start for the agent worker. Off by default — the worker
+# polls the task list and claims #agent-tagged tasks. Run sudo ./scripts/setup-systemd.sh
+# after changing.
+# LIFEOS_AGENT_WORKER_AUTOSTART=false
+
+# How often the worker polls for new #agent tasks (seconds).
+# LIFEOS_AGENT_WORKER_POLL_SECONDS=60
+
+# Default per-task budget when the task title doesn't specify one. Haiku
+# preflight (Issue C) parses natural-language budget hints from titles like
+# "spend 5 min" or "max $0.50" and falls back to these defaults.
+# LIFEOS_AGENT_DEFAULT_BUDGET_DOLLARS=5.00
+# LIFEOS_AGENT_DEFAULT_WALL_SECONDS=14400
+# LIFEOS_AGENT_DEFAULT_MAX_TOKENS=500000
+
+# Global daily $-cap across ALL agent tasks. New tasks are not claimed once
+# today's cumulative spend would exceed this. In-flight tasks finish their
+# own budgets. Set to 0 to pause all new claims.
+# LIFEOS_AGENT_DAILY_CAP_DOLLARS=100.00
+
+# How long a clarification (#agent-blocked) task waits for a Telegram reply
+# before being abandoned permanently. Used by Issue F.
+# LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS=72
+
+# =============================================================================
 # EMBEDDING MODEL — sentence-transformers (cached locally)
 # =============================================================================
 

--- a/.gitignore
+++ b/.gitignore
@@ -135,5 +135,8 @@ scripts/clear-caches.sh
 !.claude/settings.json
 !.claude/skills/
 
-# Duplicate of CLAUDE.md
-AGENTS.md
+# Per-subdirectory AGENTS.md files (api/, docs/, etc.) are project docs and
+# are tracked. This rule only ignores ad-hoc AGENTS.md files that some Claude
+# Code tooling may write at the repo root — the tracked root-level AGENTS.md
+# overrides this since gitignore doesn't apply to files already in the index.
+/AGENTS.md

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -6,7 +6,7 @@ CRUD endpoints for tasks stored in Obsidian-compatible markdown.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from api.services.task_manager import get_task_manager, Task
@@ -140,6 +140,31 @@ async def list_tags():
     """List all distinct tags across all tasks (any status) with usage counts."""
     manager = get_task_manager()
     return TagListResponse(tags=[TagUsage(**t) for t in manager.list_tags()])
+
+
+class SwapTagResponse(BaseModel):
+    swapped: bool
+    reason: Optional[str] = None
+
+
+@router.post("/{task_id}/swap-tag", response_model=SwapTagResponse)
+async def swap_tag(
+    task_id: str,
+    from_tag: str = Query(..., alias="from", description="Tag to remove (with or without '#')"),
+    to_tag: str = Query(..., alias="to", description="Tag to add in its place"),
+):
+    """Atomically replace one tag with another on a task.
+
+    Used by the external agent worker to claim `#agent` tasks. Returns
+    `{swapped: false}` (with a `reason`) when the task does not exist or
+    `from` is not currently among the task's tags — both indicate the worker
+    should move on to the next candidate rather than retry.
+    """
+    manager = get_task_manager()
+    if manager.get(task_id) is None:
+        return SwapTagResponse(swapped=False, reason="task not found")
+    ok = manager.swap_tag(task_id, from_tag, to_tag)
+    return SwapTagResponse(swapped=ok, reason=None if ok else f"tag '{from_tag}' not present")
 
 
 @router.get("/{task_id}", response_model=TaskResponse)

--- a/api/services/agent_worker/AGENTS.md
+++ b/api/services/agent_worker/AGENTS.md
@@ -1,0 +1,51 @@
+# Agent Worker
+
+External long-running worker that picks up `#agent`-tagged tasks, executes them via Claude Opus (Managed Agents) or local Gemma (llama-server), and notifies via Telegram. Lives outside the FastAPI process — talks to LifeOS over HTTP via `/api/tasks`.
+
+> **Status:** Scaffolding only (Issue B / #100). No LLM execution yet.
+> **Owning epic:** [#98](https://github.com/nbramia/LifeOS/issues/98)
+
+## Files in this package
+
+| File | Responsibility |
+|------|---------------|
+| `worker.py` | Main poll loop, claim/dispatch, startup resume, signal-safe stop |
+| `session_store.py` | SQLite-backed `sessions` + `daily_spend` tables; `Session` dataclass |
+| `transcript_store.py` | Append-only JSONL per `session_id` at `data/agent_transcripts/` |
+| `spend_tracker.py` | Daily $-cap ledger (inclusive ceiling; cap ≤ 0 pauses claims) |
+
+## Lifecycle (current scope)
+
+```
+poll → can_start_task(default_budget)?
+     → list /api/tasks?status=todo&tag=agent
+     → atomic swap #agent → #agent-running
+     → session row + transcript "claim" event
+     → no-op dispatcher (replaced in Issues C/D)
+     → mark task complete
+     → transcript "noop_complete" + Telegram notify
+```
+
+On startup, `resume_pending()` scans non-terminal sessions and either marks them complete or rolls the tag back to `#agent` for retry. This makes the worker SIGKILL-safe.
+
+## Where future issues plug in
+
+| Issue | Adds |
+|-------|------|
+| C ([#101](https://github.com/nbramia/LifeOS/issues/101)) | Haiku preflight + local Gemma executor → replaces `_dispatch_noop` for `#local`-tagged tasks |
+| D ([#102](https://github.com/nbramia/LifeOS/issues/102)) | Managed Agents driver → replaces `_dispatch_noop` for Claude-routed tasks |
+| E ([#103](https://github.com/nbramia/LifeOS/issues/103)) | `lifeos_agent_*` MCP tools, lineage budgets, yield-and-resume |
+| F ([#104](https://github.com/nbramia/LifeOS/issues/104)) | Telegram clarification round-trip via reply-threading |
+
+## Open-source guardrails
+
+- Worker is **opt-in** via `LIFEOS_AGENT_WORKER_AUTOSTART=true` (default `false`). Fresh clones don't start polling.
+- All operational knobs are env vars (see `config/settings.py` `agent_*` fields and `.env.example`).
+- Public-internet exposure (the MCP HTTP transport) requires `LIFEOS_MCP_BEARER_TOKEN` — empty disables the HTTP unit entirely.
+- Cap of 0 (or negative) pauses all new claims as a kill-switch.
+
+## Related Documents
+
+- [`docs/guides/agent-worker-setup.md`](../../../docs/guides/agent-worker-setup.md) — operator setup
+- [`api/services/AGENTS.md`](../AGENTS.md) — sibling services
+- [Epic #98](https://github.com/nbramia/LifeOS/issues/98) — full design

--- a/api/services/agent_worker/__init__.py
+++ b/api/services/agent_worker/__init__.py
@@ -1,0 +1,8 @@
+"""External agent worker for `#agent`-tagged tasks.
+
+This package is the scaffolding for the agent worker described in epic #98.
+Issue B (this issue) lands the plumbing: a long-running poll loop, atomic
+task claiming, a session/transcript store, and a daily spend cap. Real LLM
+execution arrives in Issues C and D; inter-agent coordination in E; Telegram
+clarifications in F.
+"""

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -1,0 +1,224 @@
+"""SQLite-backed session store for the agent worker.
+
+One row per agent session (which maps 1:1 to a claimed task in this issue).
+Schema is deliberately permissive — later issues add columns and tables
+(`messages`, `pending_questions`, `sleeps`, lineage fields). The store
+intentionally exposes thin CRUD; orchestration lives in `worker.py`.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_DB_PATH = Path("data/agent_sessions.db")
+
+
+# Status vocabulary used across the agent worker. Kept here so other modules
+# can import the constants instead of stringly-typed values.
+STATUS_CLAIMED = "claimed"
+STATUS_RUNNING = "running"
+STATUS_YIELDED = "yielded"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+STATUS_BUDGET_EXCEEDED = "budget_exceeded"
+STATUS_BLOCKED = "blocked"
+
+TERMINAL_STATUSES = frozenset({
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_BUDGET_EXCEEDED,
+})
+
+
+@dataclass
+class Session:
+    """Mirrors one row in the `sessions` table.
+
+    Only fields needed by Issue B are populated; later issues fill in routing,
+    budget, token counts, etc. Stored timestamps are unix epoch seconds (int).
+    """
+
+    task_id: str
+    session_id: str
+    status: str
+    started_at: int
+    last_activity_at: int
+    routing: str | None = None
+    budget: dict | None = None
+    expected_output: str | None = None
+    parent_session_id: str | None = None
+    managed_agent_session_id: str | None = None
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_dollars: float = 0.0
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+    task_id                   TEXT PRIMARY KEY,
+    session_id                TEXT UNIQUE NOT NULL,
+    status                    TEXT NOT NULL,
+    routing                   TEXT,
+    budget_json               TEXT,
+    started_at                INTEGER NOT NULL,
+    last_activity_at          INTEGER NOT NULL,
+    total_input_tokens        INTEGER NOT NULL DEFAULT 0,
+    total_output_tokens       INTEGER NOT NULL DEFAULT 0,
+    total_dollars             REAL    NOT NULL DEFAULT 0.0,
+    expected_output           TEXT,
+    parent_session_id         TEXT,
+    managed_agent_session_id  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
+
+CREATE TABLE IF NOT EXISTS daily_spend (
+    date           TEXT PRIMARY KEY,
+    total_dollars  REAL NOT NULL DEFAULT 0.0
+);
+"""
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def new_session_id() -> str:
+    """Generate an internal session_id. Independent of any platform id."""
+    return f"sess_{uuid.uuid4().hex[:16]}"
+
+
+class SessionStore:
+    """Thin SQLite wrapper. Each method opens a short-lived connection so the
+    store is safe to use from multiple threads or processes — SQLite's own
+    locking serializes writers."""
+
+    def __init__(self, db_path: Path | str = DEFAULT_DB_PATH):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path), isolation_level=None, timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        # WAL improves concurrent reader/writer behavior; safe to re-set.
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA)
+
+    # ------------------------------------------------------------------
+    # Session CRUD
+    # ------------------------------------------------------------------
+
+    def create(
+        self,
+        task_id: str,
+        session_id: str | None = None,
+        status: str = STATUS_CLAIMED,
+        routing: str | None = None,
+        budget: dict | None = None,
+        expected_output: str | None = None,
+        parent_session_id: str | None = None,
+    ) -> Session:
+        """Insert a new session row. Raises sqlite3.IntegrityError if `task_id`
+        already has a row — the caller should treat that as a lost-race signal.
+        """
+        sid = session_id or new_session_id()
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO sessions (
+                    task_id, session_id, status, routing, budget_json,
+                    started_at, last_activity_at,
+                    expected_output, parent_session_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    task_id, sid, status, routing,
+                    json.dumps(budget) if budget else None,
+                    now, now,
+                    expected_output, parent_session_id,
+                ),
+            )
+        return Session(
+            task_id=task_id,
+            session_id=sid,
+            status=status,
+            started_at=now,
+            last_activity_at=now,
+            routing=routing,
+            budget=budget,
+            expected_output=expected_output,
+            parent_session_id=parent_session_id,
+        )
+
+    def get(self, task_id: str) -> Session | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE task_id = ?", (task_id,)
+            ).fetchone()
+        return self._row_to_session(row) if row else None
+
+    def get_by_session_id(self, session_id: str) -> Session | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE session_id = ?", (session_id,)
+            ).fetchone()
+        return self._row_to_session(row) if row else None
+
+    def update_status(self, task_id: str, status: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE sessions
+                SET status = ?, last_activity_at = ?
+                WHERE task_id = ?
+                """,
+                (status, _now(), task_id),
+            )
+
+    def list_by_status(self, status: str) -> list[Session]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM sessions WHERE status = ? ORDER BY started_at ASC",
+                (status,),
+            ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
+    def list_non_terminal(self) -> list[Session]:
+        """Return sessions that the worker may still need to act on after restart."""
+        placeholders = ",".join("?" for _ in TERMINAL_STATUSES)
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM sessions WHERE status NOT IN ({placeholders})",
+                tuple(TERMINAL_STATUSES),
+            ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
+    @staticmethod
+    def _row_to_session(row: sqlite3.Row) -> Session:
+        return Session(
+            task_id=row["task_id"],
+            session_id=row["session_id"],
+            status=row["status"],
+            routing=row["routing"],
+            budget=json.loads(row["budget_json"]) if row["budget_json"] else None,
+            started_at=row["started_at"],
+            last_activity_at=row["last_activity_at"],
+            total_input_tokens=row["total_input_tokens"],
+            total_output_tokens=row["total_output_tokens"],
+            total_dollars=row["total_dollars"],
+            expected_output=row["expected_output"],
+            parent_session_id=row["parent_session_id"],
+            managed_agent_session_id=row["managed_agent_session_id"],
+        )

--- a/api/services/agent_worker/spend_tracker.py
+++ b/api/services/agent_worker/spend_tracker.py
@@ -65,15 +65,25 @@ class SpendTracker:
         Reasoning: budgets are inclusive — the cap is a ceiling the worker is
         willing to *reach*, not exceed. A task with estimate exactly equal to
         the remaining budget is allowed.
+
+        Special case: `daily_cap_dollars <= 0` is the operator's "pause"
+        signal. We refuse all claims unconditionally in that case so a fresh
+        clone setting `LIFEOS_AGENT_DAILY_CAP_DOLLARS=0` actually pauses
+        instead of allowing zero-dollar tasks through.
         """
         if estimated_dollars < 0:
             raise ValueError("estimated_dollars must be non-negative")
+        if self.daily_cap_dollars <= 0:
+            return False
         return self.today_total(today) + estimated_dollars <= self.daily_cap_dollars
 
     def record(self, dollars: float, today: date_cls | None = None) -> float:
         """Add `dollars` to today's bucket. Returns the new total."""
         if dollars < 0:
             raise ValueError("dollars must be non-negative")
+        if dollars == 0:
+            # No-op: don't create a daily_spend row just to accumulate zero.
+            return self.today_total(today)
         key = self._today_key(today)
         with self._connect() as conn:
             # UPSERT: insert or accumulate atomically.

--- a/api/services/agent_worker/spend_tracker.py
+++ b/api/services/agent_worker/spend_tracker.py
@@ -1,0 +1,92 @@
+"""Daily $-cap enforcement for the agent worker.
+
+A cumulative dollar counter per local date prevents runaway spend across all
+agent tasks. The worker calls `can_start_task(estimated_dollars)` before
+claiming; on completion it calls `record(actual_dollars)`. Issue B never
+spends real money (no-op dispatcher) but the tracker is exercised by tests
+and ready for Issue C/D.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import date as date_cls
+from pathlib import Path
+
+from api.services.agent_worker.session_store import DEFAULT_DB_PATH
+
+
+class SpendTracker:
+    """Daily spend ledger backed by the same SQLite file as `session_store`.
+
+    Sharing the DB keeps deployment simple (one file) and lets a future
+    "global cap reached → pause new claims" check join across sessions if
+    needed.
+    """
+
+    def __init__(self, db_path: Path | str = DEFAULT_DB_PATH, daily_cap_dollars: float = 100.0):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.daily_cap_dollars = daily_cap_dollars
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path), isolation_level=None, timeout=10.0)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _init_schema(self) -> None:
+        # session_store also creates this table; be idempotent so import order
+        # doesn't matter.
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS daily_spend (
+                    date TEXT PRIMARY KEY,
+                    total_dollars REAL NOT NULL DEFAULT 0.0
+                );
+                """
+            )
+
+    @staticmethod
+    def _today_key(today: date_cls | None = None) -> str:
+        return (today or date_cls.today()).isoformat()
+
+    def today_total(self, today: date_cls | None = None) -> float:
+        key = self._today_key(today)
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT total_dollars FROM daily_spend WHERE date = ?", (key,)
+            ).fetchone()
+        return float(row[0]) if row else 0.0
+
+    def can_start_task(self, estimated_dollars: float, today: date_cls | None = None) -> bool:
+        """Return True iff `today_total + estimated_dollars <= daily_cap_dollars`.
+
+        Reasoning: budgets are inclusive — the cap is a ceiling the worker is
+        willing to *reach*, not exceed. A task with estimate exactly equal to
+        the remaining budget is allowed.
+        """
+        if estimated_dollars < 0:
+            raise ValueError("estimated_dollars must be non-negative")
+        return self.today_total(today) + estimated_dollars <= self.daily_cap_dollars
+
+    def record(self, dollars: float, today: date_cls | None = None) -> float:
+        """Add `dollars` to today's bucket. Returns the new total."""
+        if dollars < 0:
+            raise ValueError("dollars must be non-negative")
+        key = self._today_key(today)
+        with self._connect() as conn:
+            # UPSERT: insert or accumulate atomically.
+            conn.execute(
+                """
+                INSERT INTO daily_spend (date, total_dollars)
+                VALUES (?, ?)
+                ON CONFLICT(date) DO UPDATE SET
+                    total_dollars = total_dollars + excluded.total_dollars
+                """,
+                (key, dollars),
+            )
+            row = conn.execute(
+                "SELECT total_dollars FROM daily_spend WHERE date = ?", (key,)
+            ).fetchone()
+        return float(row[0])

--- a/api/services/agent_worker/transcript_store.py
+++ b/api/services/agent_worker/transcript_store.py
@@ -25,8 +25,9 @@ class TranscriptStore:
         self.dir.mkdir(parents=True, exist_ok=True)
 
     def _path(self, session_id: str) -> Path:
-        # Defense in depth: refuse path-traversal-ish session ids.
-        if "/" in session_id or ".." in session_id:
+        # Defense in depth: refuse path-traversal-ish session ids. Reject all
+        # separators (Unix `/`, Windows `\`), `..` segments, and absolute paths.
+        if not session_id or "/" in session_id or "\\" in session_id or ".." in session_id:
             raise ValueError(f"invalid session_id: {session_id!r}")
         return self.dir / f"{session_id}.jsonl"
 

--- a/api/services/agent_worker/transcript_store.py
+++ b/api/services/agent_worker/transcript_store.py
@@ -1,0 +1,75 @@
+"""Append-only JSONL transcript store for agent sessions.
+
+Each session has one file at `data/agent_transcripts/{session_id}.jsonl`.
+Events from both the local executor (Issue C) and Managed Agents (Issue D)
+land here in the same shape so inter-agent tools (Issue E) can read across
+transports without branching.
+
+Issue B writes only a minimal subset of events (`claim`, `noop_complete`).
+Later issues append `llm_turn`, `tool_call`, `tool_result`, `error`, etc.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+
+DEFAULT_TRANSCRIPTS_DIR = Path("data/agent_transcripts")
+
+
+class TranscriptStore:
+    def __init__(self, transcripts_dir: Path | str = DEFAULT_TRANSCRIPTS_DIR):
+        self.dir = Path(transcripts_dir)
+        self.dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, session_id: str) -> Path:
+        # Defense in depth: refuse path-traversal-ish session ids.
+        if "/" in session_id or ".." in session_id:
+            raise ValueError(f"invalid session_id: {session_id!r}")
+        return self.dir / f"{session_id}.jsonl"
+
+    def append(self, session_id: str, kind: str, payload: dict[str, Any] | None = None) -> None:
+        """Append one event. `kind` is a short label (e.g. "claim", "tool_call")."""
+        event = {
+            "ts": time.time(),
+            "kind": kind,
+            "payload": payload or {},
+        }
+        path = self._path(session_id)
+        # Open in append mode each call so multiple processes / restarts work.
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+    def read(self, session_id: str) -> list[dict[str, Any]]:
+        path = self._path(session_id)
+        if not path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    # Skip malformed lines rather than crash the reader.
+                    continue
+        return events
+
+    def iter_events(self, session_id: str) -> Iterable[dict[str, Any]]:
+        """Generator variant for transcripts too large to materialize."""
+        path = self._path(session_id)
+        if not path.exists():
+            return
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1,0 +1,251 @@
+"""Main poll loop for the LifeOS agent worker.
+
+Issue B scope (this file): claim `#agent` tasks atomically via the API,
+record a session row + transcript event, run a no-op dispatcher, mark the
+session complete, and notify via Telegram. Later issues replace the no-op
+dispatcher with real LLM execution (C/D), inter-agent coordination (E), and
+the clarification round-trip (F).
+
+The worker is a stand-alone process (`python -m api.services.agent_worker.worker`)
+managed by the `lifeos-agent-worker.service` systemd unit. It does not import
+the FastAPI app — all task ops go through `/api/tasks`. This keeps the worker
+trivially restartable and lets the API enforce its own locking.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+from typing import Any
+
+import httpx
+
+from api.services.agent_worker.session_store import (
+    STATUS_CLAIMED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from config.settings import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+AGENT_TAG = "agent"
+RUNNING_TAG = "agent-running"
+
+
+class Worker:
+    """Single-process poll loop. One instance per process."""
+
+    def __init__(
+        self,
+        api_base: str | None = None,
+        session_store: SessionStore | None = None,
+        transcript_store: TranscriptStore | None = None,
+        spend_tracker: SpendTracker | None = None,
+        poll_seconds: float | None = None,
+        telegram_send=None,  # injectable for tests
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self.api_base = (api_base or os.environ.get("LIFEOS_API_URL", "http://localhost:8000")).rstrip("/")
+        self.session_store = session_store or SessionStore()
+        self.transcript_store = transcript_store or TranscriptStore()
+        self.spend_tracker = spend_tracker or SpendTracker(
+            daily_cap_dollars=settings.agent_daily_cap_dollars,
+        )
+        self.poll_seconds = poll_seconds if poll_seconds is not None else settings.agent_worker_poll_seconds
+        self._stop = False
+        # Telegram is optional — operator may not have configured it. The
+        # worker should still run end-to-end without crashing on a missing bot.
+        if telegram_send is None:
+            def _noop_telegram(text, chat_id=None):
+                return False
+            try:
+                from api.services.telegram import send_message
+                telegram_send = send_message
+            except Exception:  # pragma: no cover — defensive
+                telegram_send = _noop_telegram
+        self._telegram_send = telegram_send
+        self._owns_http_client = http_client is None
+        self._http = http_client or httpx.Client(timeout=10.0)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def stop(self) -> None:
+        """Mark the loop for graceful shutdown. Safe to call from a signal."""
+        self._stop = True
+
+    def run(self) -> None:
+        """Main loop. Runs until `stop()` is called or the process is killed."""
+        logger.info(
+            "agent worker starting (api=%s, poll=%ss, daily_cap=$%s)",
+            self.api_base, self.poll_seconds, self.spend_tracker.daily_cap_dollars,
+        )
+        while not self._stop:
+            try:
+                self.tick()
+            except Exception as exc:  # pragma: no cover — loop guard
+                logger.exception("worker tick failed: %s", exc)
+            # Sleep in small slices so SIGTERM is honored promptly.
+            slept = 0.0
+            while slept < self.poll_seconds and not self._stop:
+                step = min(1.0, self.poll_seconds - slept)
+                time.sleep(step)
+                slept += step
+        logger.info("agent worker stopped")
+        if self._owns_http_client:
+            self._http.close()
+
+    # ------------------------------------------------------------------
+    # One iteration
+    # ------------------------------------------------------------------
+
+    def tick(self) -> int:
+        """Process one poll cycle. Returns the number of tasks handled (for tests)."""
+        if not self.spend_tracker.can_start_task(0.0):
+            # Cap is zero or already exceeded — pause new claims this cycle.
+            logger.info("daily spend cap reached; skipping poll cycle")
+            return 0
+
+        candidates = self._list_agent_tasks()
+        handled = 0
+        for task in candidates:
+            task_id = task.get("id")
+            if not task_id:
+                continue
+            # Skip tasks we've already claimed in a previous run.
+            if self.session_store.get(task_id) is not None:
+                continue
+            if not self._claim(task_id):
+                continue
+            self._dispatch_noop(task)
+            handled += 1
+        return handled
+
+    # ------------------------------------------------------------------
+    # API helpers
+    # ------------------------------------------------------------------
+
+    def _list_agent_tasks(self) -> list[dict[str, Any]]:
+        """Fetch open `#agent` tasks from the API."""
+        try:
+            resp = self._http.get(
+                f"{self.api_base}/api/tasks",
+                params={"status": "todo", "tag": AGENT_TAG},
+            )
+            resp.raise_for_status()
+            return resp.json().get("tasks", [])
+        except Exception as exc:
+            logger.warning("failed to list agent tasks: %s", exc)
+            return []
+
+    def _swap_tag(self, task_id: str, from_tag: str, to_tag: str) -> bool:
+        try:
+            resp = self._http.post(
+                f"{self.api_base}/api/tasks/{task_id}/swap-tag",
+                params={"from": from_tag, "to": to_tag},
+            )
+            resp.raise_for_status()
+            return bool(resp.json().get("swapped"))
+        except Exception as exc:
+            logger.warning("swap_tag failed for %s: %s", task_id, exc)
+            return False
+
+    def _complete_task(self, task_id: str) -> bool:
+        try:
+            resp = self._http.put(f"{self.api_base}/api/tasks/{task_id}/complete")
+            resp.raise_for_status()
+            return True
+        except Exception as exc:
+            logger.warning("complete failed for %s: %s", task_id, exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # Claim + dispatch
+    # ------------------------------------------------------------------
+
+    def _claim(self, task_id: str) -> bool:
+        """Atomically swap `#agent` → `#agent-running` and record the session.
+
+        Returns True iff this worker won the race.
+        """
+        if not self._swap_tag(task_id, AGENT_TAG, RUNNING_TAG):
+            return False
+        try:
+            session = self.session_store.create(
+                task_id=task_id,
+                status=STATUS_CLAIMED,
+            )
+            self.transcript_store.append(
+                session.session_id,
+                "claim",
+                {"task_id": task_id, "worker": "agent-worker"},
+            )
+            return True
+        except Exception as exc:
+            # Already-claimed by a sibling worker, or DB hiccup. Try to un-do
+            # the tag swap so the task remains pickable; if that also fails the
+            # operator will see `#agent-running` and can manually re-tag.
+            logger.error("session create failed for %s: %s", task_id, exc)
+            self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG)
+            return False
+
+    def _dispatch_noop(self, task: dict[str, Any]) -> None:
+        """Placeholder dispatcher: marks the task complete without spending money.
+
+        Replaced in later issues by the real router + executor.
+        """
+        task_id = task["id"]
+        title = task.get("description", task_id)
+        session = self.session_store.get(task_id)
+        if session is None:
+            logger.error("no session for claimed task %s — skipping", task_id)
+            return
+        sid = session.session_id
+
+        self.session_store.update_status(task_id, STATUS_RUNNING)
+        self.transcript_store.append(sid, "noop_dispatch", {"title": title})
+
+        ok = self._complete_task(task_id)
+        if ok:
+            self.session_store.update_status(task_id, STATUS_COMPLETED)
+            self.transcript_store.append(sid, "noop_complete", {"title": title})
+            self._notify(f"✅ Agent worker (scaffolding): no-op completed task '{title}'")
+        else:
+            self.session_store.update_status(task_id, STATUS_FAILED)
+            self.transcript_store.append(sid, "complete_failed", {"title": title})
+            self._notify(f"⚠️ Agent worker (scaffolding): failed to mark task '{title}' complete")
+
+    def _notify(self, text: str) -> None:
+        try:
+            self._telegram_send(text)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("telegram notify failed: %s", exc)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.environ.get("LIFEOS_LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    worker = Worker()
+
+    def _handle_signal(signum, _frame):
+        logger.info("received signal %s; stopping after current tick", signum)
+        worker.stop()
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+    worker.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -89,6 +89,9 @@ class Worker:
             "agent worker starting (api=%s, poll=%ss, daily_cap=$%s)",
             self.api_base, self.poll_seconds, self.spend_tracker.daily_cap_dollars,
         )
+        # Recover any sessions left non-terminal by a previous crash before
+        # starting fresh poll cycles (issue #100 acceptance: restart-resumable).
+        self.resume_pending()
         while not self._stop:
             try:
                 self.tick()
@@ -105,14 +108,62 @@ class Worker:
             self._http.close()
 
     # ------------------------------------------------------------------
+    # Startup recovery
+    # ------------------------------------------------------------------
+
+    def resume_pending(self) -> int:
+        """Finalize any non-terminal sessions left behind by a previous crash.
+
+        At Issue B scope, the no-op dispatcher's only side effect is marking
+        the task complete via the API. So recovery is straightforward: for
+        each non-terminal session, retry the `complete` call and update the
+        session to a terminal state. Later issues will replace this with a
+        proper per-routing resume (managed-agent re-attach, local-loop
+        re-drive, etc.).
+        """
+        pending = self.session_store.list_non_terminal()
+        if not pending:
+            return 0
+        logger.info("resuming %d non-terminal session(s) from previous run", len(pending))
+        recovered = 0
+        for session in pending:
+            sid = session.session_id
+            self.transcript_store.append(sid, "resume_attempt", {"prior_status": session.status})
+            if self._complete_task(session.task_id):
+                self.session_store.update_status(session.task_id, STATUS_COMPLETED)
+                self.transcript_store.append(sid, "resume_completed", {})
+                self._notify(
+                    f"✅ Agent worker (scaffolding): recovered orphaned task "
+                    f"after restart (session {sid})"
+                )
+                recovered += 1
+            else:
+                # Roll the tag back so the task can be re-claimed next cycle.
+                self._swap_tag(session.task_id, RUNNING_TAG, AGENT_TAG)
+                self.session_store.update_status(session.task_id, STATUS_FAILED)
+                self.transcript_store.append(sid, "resume_failed", {})
+                self._notify(
+                    f"⚠️ Agent worker (scaffolding): could not finalize orphaned "
+                    f"task on resume — tag rolled back to #{AGENT_TAG} for retry"
+                )
+        return recovered
+
+    # ------------------------------------------------------------------
     # One iteration
     # ------------------------------------------------------------------
 
     def tick(self) -> int:
         """Process one poll cycle. Returns the number of tasks handled (for tests)."""
-        if not self.spend_tracker.can_start_task(0.0):
-            # Cap is zero or already exceeded — pause new claims this cycle.
-            logger.info("daily spend cap reached; skipping poll cycle")
+        # Use the configured per-task default budget as the "can I afford to
+        # start the cheapest task right now?" estimate. Calling with 0.0 would
+        # let claims through even at cap=0 — see SpendTracker.can_start_task
+        # for the pause semantics.
+        estimate = settings.agent_default_budget_dollars
+        if not self.spend_tracker.can_start_task(estimate):
+            logger.info(
+                "daily spend cap reached or paused (cap=$%s, today=$%.2f); skipping poll",
+                self.spend_tracker.daily_cap_dollars, self.spend_tracker.today_total(),
+            )
             return 0
 
         candidates = self._list_agent_tasks()
@@ -192,10 +243,16 @@ class Worker:
             return True
         except Exception as exc:
             # Already-claimed by a sibling worker, or DB hiccup. Try to un-do
-            # the tag swap so the task remains pickable; if that also fails the
-            # operator will see `#agent-running` and can manually re-tag.
+            # the tag swap so the task remains pickable.
             logger.error("session create failed for %s: %s", task_id, exc)
-            self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG)
+            if not self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG):
+                # Rollback failed — task is stuck at #agent-running. Notify so
+                # the operator can intervene before this silently strands work.
+                self._notify(
+                    f"⚠️ Agent worker: failed to claim task {task_id} and could "
+                    f"not roll back tag. Task stuck at #{RUNNING_TAG} — please "
+                    f"re-tag manually if you want it retried."
+                )
             return False
 
     def _dispatch_noop(self, task: dict[str, Any]) -> None:
@@ -220,9 +277,20 @@ class Worker:
             self.transcript_store.append(sid, "noop_complete", {"title": title})
             self._notify(f"✅ Agent worker (scaffolding): no-op completed task '{title}'")
         else:
+            # Completion API failed. Roll the tag back to #agent so the task is
+            # re-pickable next cycle (rather than stranded at #agent-running).
+            rolled_back = self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG)
             self.session_store.update_status(task_id, STATUS_FAILED)
-            self.transcript_store.append(sid, "complete_failed", {"title": title})
-            self._notify(f"⚠️ Agent worker (scaffolding): failed to mark task '{title}' complete")
+            self.transcript_store.append(
+                sid,
+                "complete_failed",
+                {"title": title, "tag_rolled_back": rolled_back},
+            )
+            msg = (
+                f"⚠️ Agent worker (scaffolding): failed to mark task '{title}' complete; "
+                f"{'re-tagged for retry' if rolled_back else 'tag still at #agent-running — please re-tag manually'}"
+            )
+            self._notify(msg)
 
     def _notify(self, text: str) -> None:
         try:

--- a/api/services/task_manager.py
+++ b/api/services/task_manager.py
@@ -206,6 +206,42 @@ class TaskManager:
             self._write_dashboard()
             return task
 
+    def swap_tag(self, task_id: str, from_tag: str, to_tag: str) -> bool:
+        """Atomically replace `from_tag` with `to_tag` on a task.
+
+        Returns True if the swap happened, False if either the task is gone
+        or `from_tag` is not present (already claimed / re-tagged).
+
+        Tags are compared with the leading `#` stripped, case-insensitively, to
+        match the rest of the codebase. The stored representation follows the
+        existing convention (no `#` prefix in `Task.tags`).
+        """
+        from_norm = from_tag.lstrip("#").lower()
+        to_norm = to_tag.lstrip("#")  # preserve operator-provided case
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return False
+
+            try:
+                idx = next(
+                    i for i, t in enumerate(task.tags)
+                    if t.lstrip("#").lower() == from_norm
+                )
+            except StopIteration:
+                return False
+
+            new_tags = list(task.tags)
+            new_tags[idx] = to_norm
+            task.tags = new_tags
+
+            new_line = _format_task_line(task)
+            _replace_line_in_file(Path(task.source_file), task.line_number, new_line)
+            self._save_index()
+            self._write_dashboard()
+            logger.info(f"swap_tag {task_id}: {from_norm} → {to_norm}")
+            return True
+
     def delete(self, task_id: str) -> bool:
         """Remove a task from its file and index."""
         with self._lock:

--- a/config/settings.py
+++ b/config/settings.py
@@ -94,6 +94,47 @@ class Settings(BaseSettings):
         description="Bearer token required by the MCP HTTP transport. Generate with "
                     "`openssl rand -hex 32`. Empty disables the HTTP transport."
     )
+
+    # Agent Worker — external worker that picks up #agent-tagged tasks.
+    # See docs/guides/agent-worker-setup.md and epic #98 for the full design.
+    agent_worker_poll_seconds: float = Field(
+        default=60.0,
+        alias="LIFEOS_AGENT_WORKER_POLL_SECONDS",
+        description="How often the agent worker polls for new #agent tasks."
+    )
+    agent_worker_autostart: bool = Field(
+        default=False,
+        alias="LIFEOS_AGENT_WORKER_AUTOSTART",
+        description="Enable systemd auto-start on boot for the agent worker. "
+                    "Off by default — opt-in via setup-systemd.sh."
+    )
+    agent_default_budget_dollars: float = Field(
+        default=5.0,
+        alias="LIFEOS_AGENT_DEFAULT_BUDGET_DOLLARS",
+        description="Default per-task dollar budget when the task title doesn't specify one."
+    )
+    agent_default_wall_seconds: int = Field(
+        default=14400,
+        alias="LIFEOS_AGENT_DEFAULT_WALL_SECONDS",
+        description="Default per-task wall-clock budget (seconds); 14400 = 4h."
+    )
+    agent_default_max_tokens: int = Field(
+        default=500_000,
+        alias="LIFEOS_AGENT_DEFAULT_MAX_TOKENS",
+        description="Default per-task token budget (input + output combined)."
+    )
+    agent_daily_cap_dollars: float = Field(
+        default=100.0,
+        alias="LIFEOS_AGENT_DAILY_CAP_DOLLARS",
+        description="Global daily cap across all agent tasks. New tasks are not "
+                    "claimed once today's cumulative spend would exceed this."
+    )
+    agent_clarification_timeout_hours: int = Field(
+        default=72,
+        alias="LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS",
+        description="How long an #agent-blocked task waits for a Telegram reply "
+                    "before being abandoned. Used by Issue F."
+    )
     local_llm_autostart: bool = Field(
         default=False,
         alias="LIFEOS_LOCAL_LLM_AUTOSTART",

--- a/config/systemd/lifeos-agent-worker.service
+++ b/config/systemd/lifeos-agent-worker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=LifeOS Agent Worker
+After=network.target lifeos-api.service
+Requires=lifeos-api.service
+
+[Service]
+Type=simple
+User=__USER__
+WorkingDirectory=__LIFEOS_DIR__
+EnvironmentFile=__LIFEOS_DIR__/.env
+ExecStart=__VENV__/bin/python -m api.services.agent_worker.worker
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:__LIFEOS_DIR__/logs/agent-worker.log
+StandardError=append:__LIFEOS_DIR__/logs/agent-worker.log
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -132,6 +132,50 @@ Hardening upgrade (deferred to a later issue): swap the bearer-token check for a
 
 ---
 
+## Step 5 — Enable the agent worker (Issue B)
+
+Issue B installs `lifeos-agent-worker.service`, which polls `/api/tasks` for `#agent`-tagged tasks. It's **off by default** so a fresh clone doesn't start consuming tasks before later issues add real execution.
+
+To enable:
+
+```bash
+# .env
+LIFEOS_AGENT_WORKER_AUTOSTART=true
+
+# Optional knobs (defaults shown)
+# LIFEOS_AGENT_WORKER_POLL_SECONDS=60
+# LIFEOS_AGENT_DEFAULT_BUDGET_DOLLARS=5.00
+# LIFEOS_AGENT_DAILY_CAP_DOLLARS=100.00
+```
+
+```bash
+sudo ./scripts/setup-systemd.sh
+sudo systemctl status lifeos-agent-worker
+tail -f logs/agent-worker.log
+```
+
+At Issue B's scope, claiming a task does nothing except mark it complete with a placeholder Telegram notification ("no-op completion"). Real execution arrives in Issue C (#101) for the local Gemma path and Issue D (#102) for the Claude managed-agents path.
+
+To smoke-test the claim path:
+
+```bash
+# Create a task with the #agent tag
+curl -X POST http://localhost:8000/api/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{"description":"scaffolding smoke test","tags":["agent"]}'
+
+# Within ~60s, the worker should:
+#   1. swap #agent → #agent-running on the task
+#   2. record a session row in data/agent_sessions.db
+#   3. append events to data/agent_transcripts/<session_id>.jsonl
+#   4. mark the task complete
+#   5. send a Telegram notification (if TELEGRAM_BOT_TOKEN is configured)
+```
+
+To pause new claims without stopping the worker, set `LIFEOS_AGENT_DAILY_CAP_DOLLARS=0` and restart — the worker keeps polling but refuses to claim anything new.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
@@ -141,6 +185,8 @@ Hardening upgrade (deferred to a later issue): swap the bearer-token check for a
 | 502/504 from the tunnel | The MCP HTTP service isn't running on the configured port | `systemctl status lifeos-mcp-http` and `curl http://127.0.0.1:8765/mcp` |
 | Gemma loads but responses look garbled | Chat template mismatch | Add `--chat-template gemma3` to `lifeos-llm.service` `ExecStart` |
 | `llama-server` crashes on Gemma | Insufficient VRAM, or stale cached model | Check `nvidia-smi`/`rocm-smi`; re-download with `llama-server -hf unsloth/gemma-4-26B-A4B-it-GGUF` once and confirm |
+| Agent worker logs "daily spend cap reached" | `LIFEOS_AGENT_DAILY_CAP_DOLLARS` is 0 or already exceeded today | Raise the cap or wait until local midnight |
+| Worker doesn't pick up a `#agent` task | Task isn't `status=todo`, or worker isn't enabled | `systemctl status lifeos-agent-worker`; `curl 'http://localhost:8000/api/tasks?status=todo&tag=agent'` |
 
 ---
 

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -51,11 +51,17 @@ _read_env() {
 LLM_MODEL=$(_read_env "LIFEOS_LLM_MODEL" "${LIFEOS_LLM_MODEL:-unsloth/gemma-4-26B-A4B-it-GGUF}")
 LLM_AUTOSTART=$(_read_env "LIFEOS_LOCAL_LLM_AUTOSTART" "false")
 MCP_BEARER_TOKEN=$(_read_env "LIFEOS_MCP_BEARER_TOKEN" "")
+AGENT_WORKER_AUTOSTART=$(_read_env "LIFEOS_AGENT_WORKER_AUTOSTART" "false")
 
 # Normalize boolean
 case "$(echo "$LLM_AUTOSTART" | tr '[:upper:]' '[:lower:]')" in
     true|1|yes) LLM_AUTOSTART="true" ;;
     *)          LLM_AUTOSTART="false" ;;
+esac
+
+case "$(echo "$AGENT_WORKER_AUTOSTART" | tr '[:upper:]' '[:lower:]')" in
+    true|1|yes) AGENT_WORKER_AUTOSTART="true" ;;
+    *)          AGENT_WORKER_AUTOSTART="false" ;;
 esac
 
 if [ "$LLM_AUTOSTART" = "true" ]; then
@@ -77,6 +83,7 @@ if [ -n "$MCP_BEARER_TOKEN" ]; then
 else
     echo "  MCP HTTP:   disabled (set LIFEOS_MCP_BEARER_TOKEN to enable)"
 fi
+echo "  Agent Worker: $AGENT_WORKER_AUTOSTART"
 echo ""
 
 # Install unit files with variable substitution
@@ -139,6 +146,19 @@ else
     echo "  lifeos-mcp-http: disabled (set LIFEOS_MCP_BEARER_TOKEN to enable)"
 fi
 
+# Agent worker is opt-in via LIFEOS_AGENT_WORKER_AUTOSTART. Off by default
+# so fresh clones don't start polling the task list with no preflight call
+# wired up. Issue B installs the no-op dispatcher; later issues add real
+# execution.
+if [ "$AGENT_WORKER_AUTOSTART" = "true" ]; then
+    systemctl enable --now lifeos-agent-worker.service
+    echo "  lifeos-agent-worker: $(systemctl is-active lifeos-agent-worker.service)"
+else
+    systemctl disable lifeos-agent-worker.service 2>/dev/null || true
+    systemctl stop lifeos-agent-worker.service 2>/dev/null || true
+    echo "  lifeos-agent-worker: disabled (set LIFEOS_AGENT_WORKER_AUTOSTART=true to enable)"
+fi
+
 # Install logrotate config with substitution
 LOGROTATE_SRC="$PROJECT_DIR/config/logrotate-lifeos.conf"
 if [ -f "$LOGROTATE_SRC" ]; then
@@ -153,7 +173,7 @@ echo ""
 echo "Installing sudoers rule for passwordless systemctl..."
 SUDOERS_FILE="/etc/sudoers.d/lifeos"
 TMP_SUDOERS=$(mktemp)
-echo "$REAL_USER ALL=(root) NOPASSWD: /usr/bin/systemctl start lifeos-api, /usr/bin/systemctl stop lifeos-api, /usr/bin/systemctl restart lifeos-api, /usr/bin/systemctl start lifeos-api.service, /usr/bin/systemctl stop lifeos-api.service, /usr/bin/systemctl restart lifeos-api.service, /usr/bin/systemctl start lifeos-llm, /usr/bin/systemctl stop lifeos-llm, /usr/bin/systemctl start lifeos-llm.service, /usr/bin/systemctl stop lifeos-llm.service, /usr/bin/systemctl start lifeos-mcp-http, /usr/bin/systemctl stop lifeos-mcp-http, /usr/bin/systemctl restart lifeos-mcp-http, /usr/bin/systemctl start lifeos-mcp-http.service, /usr/bin/systemctl stop lifeos-mcp-http.service, /usr/bin/systemctl restart lifeos-mcp-http.service" > "$TMP_SUDOERS"
+echo "$REAL_USER ALL=(root) NOPASSWD: /usr/bin/systemctl start lifeos-api, /usr/bin/systemctl stop lifeos-api, /usr/bin/systemctl restart lifeos-api, /usr/bin/systemctl start lifeos-api.service, /usr/bin/systemctl stop lifeos-api.service, /usr/bin/systemctl restart lifeos-api.service, /usr/bin/systemctl start lifeos-llm, /usr/bin/systemctl stop lifeos-llm, /usr/bin/systemctl start lifeos-llm.service, /usr/bin/systemctl stop lifeos-llm.service, /usr/bin/systemctl start lifeos-mcp-http, /usr/bin/systemctl stop lifeos-mcp-http, /usr/bin/systemctl restart lifeos-mcp-http, /usr/bin/systemctl start lifeos-mcp-http.service, /usr/bin/systemctl stop lifeos-mcp-http.service, /usr/bin/systemctl restart lifeos-mcp-http.service, /usr/bin/systemctl start lifeos-agent-worker, /usr/bin/systemctl stop lifeos-agent-worker, /usr/bin/systemctl restart lifeos-agent-worker, /usr/bin/systemctl start lifeos-agent-worker.service, /usr/bin/systemctl stop lifeos-agent-worker.service, /usr/bin/systemctl restart lifeos-agent-worker.service" > "$TMP_SUDOERS"
 if visudo -c -f "$TMP_SUDOERS" > /dev/null 2>&1; then
     mv "$TMP_SUDOERS" "$SUDOERS_FILE"
     chmod 440 "$SUDOERS_FILE"

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -1,0 +1,165 @@
+"""Worker poll-loop integration tests.
+
+Drives the worker against an in-process fake HTTP server (httpx MockTransport)
+so we exercise the full claim → dispatch → complete → notify path without
+spinning up FastAPI or hitting the real task store.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from api.services.agent_worker.session_store import (
+    STATUS_COMPLETED,
+    SessionStore,
+)
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import AGENT_TAG, RUNNING_TAG, Worker
+
+
+class FakeApi:
+    """Minimal in-memory stand-in for /api/tasks.
+
+    Exposes only what the worker calls: list, swap-tag, complete. Tracks
+    state so the test can assert tag transitions and completion.
+    """
+
+    def __init__(self, tasks: list[dict] | None = None):
+        # Each task is {id, description, status, tags}
+        self.tasks: dict[str, dict] = {t["id"]: t for t in (tasks or [])}
+        self.calls: list[tuple[str, str]] = []  # (method, path) for assertions
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append((request.method, request.url.path))
+        if request.method == "GET" and request.url.path == "/api/tasks":
+            tag = request.url.params.get("tag")
+            matched = [
+                t for t in self.tasks.values()
+                if t.get("status") == "todo" and (tag in t.get("tags", []) if tag else True)
+            ]
+            return httpx.Response(200, json={"tasks": matched, "total": len(matched)})
+
+        if request.method == "POST" and request.url.path.endswith("/swap-tag"):
+            task_id = request.url.path.split("/")[-2]
+            from_tag = request.url.params.get("from")
+            to_tag = request.url.params.get("to")
+            task = self.tasks.get(task_id)
+            if not task or from_tag not in task.get("tags", []):
+                return httpx.Response(200, json={"swapped": False, "reason": "tag not present"})
+            tags = list(task["tags"])
+            tags[tags.index(from_tag)] = to_tag
+            task["tags"] = tags
+            return httpx.Response(200, json={"swapped": True})
+
+        if request.method == "PUT" and request.url.path.endswith("/complete"):
+            task_id = request.url.path.split("/")[-2]
+            task = self.tasks.get(task_id)
+            if not task:
+                return httpx.Response(404)
+            task["status"] = "done"
+            return httpx.Response(200, json=task)
+
+        return httpx.Response(404)
+
+
+@pytest.fixture
+def fake_api() -> FakeApi:
+    return FakeApi(tasks=[
+        {"id": "task-1", "description": "do a thing", "status": "todo", "tags": ["agent"]},
+    ])
+
+
+@pytest.fixture
+def worker(tmp_path: Path, fake_api: FakeApi):
+    transport = httpx.MockTransport(fake_api.handler)
+    client = httpx.Client(transport=transport, base_url="http://api")
+    sent: list[str] = []
+    w = Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        http_client=client,
+    )
+    w._sent_telegram = sent  # type: ignore[attr-defined] — for test assertions
+    return w
+
+
+@pytest.mark.unit
+def test_worker_claims_and_completes_agent_task(worker: Worker, fake_api: FakeApi):
+    handled = worker.tick()
+    assert handled == 1
+
+    # Tag transitioned through #agent-running and the task is marked done.
+    task = fake_api.tasks["task-1"]
+    assert task["status"] == "done"
+    assert AGENT_TAG not in task["tags"]
+    # In Issue B the no-op dispatcher leaves the tag at #agent-running; this
+    # is the visible signal that the worker finished without real execution.
+    assert RUNNING_TAG in task["tags"]
+
+    # Session row + transcript both present.
+    sess = worker.session_store.get("task-1")
+    assert sess is not None
+    assert sess.status == STATUS_COMPLETED
+    events = [e["kind"] for e in worker.transcript_store.read(sess.session_id)]
+    assert events == ["claim", "noop_dispatch", "noop_complete"]
+
+    # Telegram notification sent.
+    sent = worker._sent_telegram  # type: ignore[attr-defined]
+    assert len(sent) == 1
+    assert "no-op completed" in sent[0]
+
+
+@pytest.mark.unit
+def test_worker_skips_already_claimed_tasks(worker: Worker, fake_api: FakeApi):
+    # First tick claims and completes.
+    worker.tick()
+    # Add the same task back with #agent tag (simulating a re-tag) and ensure
+    # the worker doesn't try to claim it again — its session row is still in
+    # the DB.
+    fake_api.tasks["task-1"]["tags"] = ["agent"]
+    fake_api.tasks["task-1"]["status"] = "todo"
+
+    handled = worker.tick()
+    assert handled == 0  # session already exists for task-1
+    # Task wasn't re-claimed; tag stays as the operator left it
+    assert "agent" in fake_api.tasks["task-1"]["tags"]
+
+
+@pytest.mark.unit
+def test_worker_loses_race_when_swap_tag_fails(worker: Worker, fake_api: FakeApi):
+    """If another worker (or operator) removed the #agent tag between list and swap,
+    swap_tag returns swapped=false. The worker should skip without creating a session."""
+    fake_api.tasks["task-1"]["tags"] = ["something-else"]  # no longer #agent
+
+    handled = worker.tick()
+    assert handled == 0
+    assert worker.session_store.get("task-1") is None
+
+
+@pytest.mark.unit
+def test_worker_pauses_at_daily_cap(tmp_path: Path, fake_api: FakeApi):
+    """Cap of 0 means no new claims even though tasks are available."""
+    transport = httpx.MockTransport(fake_api.handler)
+    client = httpx.Client(transport=transport, base_url="http://api")
+    w = Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=0.0),
+        poll_seconds=0.01,
+        telegram_send=lambda *a, **kw: True,
+        http_client=client,
+    )
+    # Force the cap to be effectively breached: any positive estimate fails.
+    w.spend_tracker.record(0.01)
+
+    handled = w.tick()
+    assert handled == 0
+    assert w.session_store.get("task-1") is None

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -145,7 +145,7 @@ def test_worker_loses_race_when_swap_tag_fails(worker: Worker, fake_api: FakeApi
 
 @pytest.mark.unit
 def test_worker_pauses_at_daily_cap(tmp_path: Path, fake_api: FakeApi):
-    """Cap of 0 means no new claims even though tasks are available."""
+    """Cap of 0 should pause new claims with no other state needed."""
     transport = httpx.MockTransport(fake_api.handler)
     client = httpx.Client(transport=transport, base_url="http://api")
     w = Worker(
@@ -157,9 +157,104 @@ def test_worker_pauses_at_daily_cap(tmp_path: Path, fake_api: FakeApi):
         telegram_send=lambda *a, **kw: True,
         http_client=client,
     )
-    # Force the cap to be effectively breached: any positive estimate fails.
-    w.spend_tracker.record(0.01)
 
     handled = w.tick()
     assert handled == 0
     assert w.session_store.get("task-1") is None
+
+
+@pytest.mark.unit
+def test_worker_rolls_back_tag_on_complete_failure(tmp_path: Path):
+    """If POST /complete fails, the worker should roll #agent-running → #agent so the next tick can retry."""
+    calls = {"complete_calls": 0}
+
+    class FailingApi(FakeApi):
+        def handler(self, request: httpx.Request) -> httpx.Response:
+            if request.method == "PUT" and request.url.path.endswith("/complete"):
+                calls["complete_calls"] += 1
+                return httpx.Response(503)
+            return super().handler(request)
+
+    api = FailingApi(tasks=[{"id": "task-1", "description": "x", "status": "todo", "tags": ["agent"]}])
+    transport = httpx.MockTransport(api.handler)
+    client = httpx.Client(transport=transport, base_url="http://api")
+    w = Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda *a, **kw: True,
+        http_client=client,
+    )
+
+    w.tick()
+    # Tag should be rolled back to #agent (so a future tick can re-attempt).
+    assert "agent" in api.tasks["task-1"]["tags"]
+    assert "agent-running" not in api.tasks["task-1"]["tags"]
+    # Session is marked failed so we don't try to re-resume on startup forever.
+    from api.services.agent_worker.session_store import STATUS_FAILED
+    assert w.session_store.get("task-1").status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_resume_pending_completes_orphaned_session(tmp_path: Path):
+    """On restart, a session left in STATUS_RUNNING should be finalized."""
+    api = FakeApi(tasks=[{"id": "task-1", "description": "x", "status": "todo", "tags": ["agent-running"]}])
+    transport = httpx.MockTransport(api.handler)
+    client = httpx.Client(transport=transport, base_url="http://api")
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    # Simulate a crash mid-dispatch: session row exists with STATUS_RUNNING.
+    from api.services.agent_worker.session_store import STATUS_RUNNING
+    store.create(task_id="task-1", status=STATUS_RUNNING)
+
+    sent: list[str] = []
+    w = Worker(
+        api_base="http://api",
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        http_client=client,
+    )
+    recovered = w.resume_pending()
+    assert recovered == 1
+    assert api.tasks["task-1"]["status"] == "done"
+    assert w.session_store.get("task-1").status == STATUS_COMPLETED
+    assert any("recovered orphaned task" in s for s in sent)
+
+
+@pytest.mark.unit
+def test_resume_pending_rolls_tag_back_when_completion_fails(tmp_path: Path):
+    """If completion still fails on resume, we mark FAILED and roll the tag back."""
+
+    class FailingApi(FakeApi):
+        def handler(self, request: httpx.Request) -> httpx.Response:
+            if request.method == "PUT" and request.url.path.endswith("/complete"):
+                return httpx.Response(503)
+            return super().handler(request)
+
+    api = FailingApi(tasks=[{"id": "task-1", "description": "x", "status": "todo", "tags": ["agent-running"]}])
+    transport = httpx.MockTransport(api.handler)
+    client = httpx.Client(transport=transport, base_url="http://api")
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    from api.services.agent_worker.session_store import STATUS_FAILED, STATUS_RUNNING
+    store.create(task_id="task-1", status=STATUS_RUNNING)
+
+    sent: list[str] = []
+    w = Worker(
+        api_base="http://api",
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        http_client=client,
+    )
+    recovered = w.resume_pending()
+    assert recovered == 0
+    assert w.session_store.get("task-1").status == STATUS_FAILED
+    assert "agent" in api.tasks["task-1"]["tags"]
+    assert "agent-running" not in api.tasks["task-1"]["tags"]
+    assert any("could not finalize" in s for s in sent)

--- a/tests/test_agent_worker_stores.py
+++ b/tests/test_agent_worker_stores.py
@@ -48,9 +48,10 @@ def test_session_store_get_missing_returns_none(tmp_path: Path):
 
 @pytest.mark.unit
 def test_session_store_rejects_duplicate_task_id(tmp_path: Path):
+    import sqlite3
     store = SessionStore(db_path=tmp_path / "sessions.db")
     store.create(task_id="t1")
-    with pytest.raises(Exception):
+    with pytest.raises(sqlite3.IntegrityError):
         store.create(task_id="t1")
 
 
@@ -154,9 +155,24 @@ def test_spend_tracker_can_start_at_exact_boundary(tmp_path: Path):
 
 @pytest.mark.unit
 def test_spend_tracker_zero_cap_denies_any_claim(tmp_path: Path):
+    """LIFEOS_AGENT_DAILY_CAP_DOLLARS=0 is the operator's pause signal."""
     tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=0.0)
-    assert tr.can_start_task(0.0)  # zero estimate at zero cap is allowed
+    assert not tr.can_start_task(0.0)
     assert not tr.can_start_task(0.01)
+
+
+@pytest.mark.unit
+def test_spend_tracker_negative_cap_treated_as_paused(tmp_path: Path):
+    tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=-1.0)
+    assert not tr.can_start_task(1.0)
+
+
+@pytest.mark.unit
+def test_spend_tracker_record_zero_is_noop(tmp_path: Path):
+    """record(0) should not create a daily_spend row or change totals."""
+    tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0)
+    assert tr.record(0.0) == 0.0
+    assert tr.today_total() == 0.0
 
 
 @pytest.mark.unit

--- a/tests/test_agent_worker_stores.py
+++ b/tests/test_agent_worker_stores.py
@@ -1,0 +1,187 @@
+"""Unit tests for the agent-worker stores (session, transcript, spend).
+
+Issue B scope. No LLM calls, no HTTP. Each test uses a temp directory so the
+real `data/` is never touched.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.session_store import (
+    STATUS_CLAIMED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    SessionStore,
+    new_session_id,
+)
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+# ---------------------------------------------------------------------------
+# SessionStore
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_session_store_create_and_get(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    s = store.create(task_id="t1", status=STATUS_CLAIMED, routing="local")
+    assert s.task_id == "t1"
+    assert s.status == STATUS_CLAIMED
+    assert s.routing == "local"
+
+    got = store.get("t1")
+    assert got is not None
+    assert got.session_id == s.session_id
+    assert got.routing == "local"
+
+
+@pytest.mark.unit
+def test_session_store_get_missing_returns_none(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    assert store.get("does-not-exist") is None
+
+
+@pytest.mark.unit
+def test_session_store_rejects_duplicate_task_id(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    store.create(task_id="t1")
+    with pytest.raises(Exception):
+        store.create(task_id="t1")
+
+
+@pytest.mark.unit
+def test_session_store_update_status(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    store.create(task_id="t1")
+    store.update_status("t1", STATUS_RUNNING)
+    assert store.get("t1").status == STATUS_RUNNING
+    store.update_status("t1", STATUS_COMPLETED)
+    assert store.get("t1").status == STATUS_COMPLETED
+
+
+@pytest.mark.unit
+def test_session_store_list_non_terminal(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    store.create(task_id="t1", status=STATUS_RUNNING)
+    store.create(task_id="t2", status=STATUS_COMPLETED)
+    store.create(task_id="t3", status=STATUS_FAILED)
+    store.create(task_id="t4", status=STATUS_CLAIMED)
+
+    pending = {s.task_id for s in store.list_non_terminal()}
+    assert pending == {"t1", "t4"}
+
+
+@pytest.mark.unit
+def test_new_session_id_is_unique():
+    seen = {new_session_id() for _ in range(100)}
+    assert len(seen) == 100
+    assert all(s.startswith("sess_") for s in seen)
+
+
+# ---------------------------------------------------------------------------
+# TranscriptStore
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_transcript_store_append_and_read(tmp_path: Path):
+    store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    sid = "sess_test123"
+    store.append(sid, "claim", {"task_id": "t1"})
+    store.append(sid, "noop_complete", {"title": "hello world"})
+
+    events = store.read(sid)
+    assert len(events) == 2
+    assert events[0]["kind"] == "claim"
+    assert events[0]["payload"]["task_id"] == "t1"
+    assert events[1]["kind"] == "noop_complete"
+    assert events[1]["payload"]["title"] == "hello world"
+
+
+@pytest.mark.unit
+def test_transcript_store_persists_across_instances(tmp_path: Path):
+    """Append-only JSONL — reopening the store should see prior events."""
+    dirpath = tmp_path / "transcripts"
+    a = TranscriptStore(transcripts_dir=dirpath)
+    a.append("sess_x", "first", {})
+
+    b = TranscriptStore(transcripts_dir=dirpath)
+    b.append("sess_x", "second", {})
+
+    events = b.read("sess_x")
+    assert [e["kind"] for e in events] == ["first", "second"]
+
+
+@pytest.mark.unit
+def test_transcript_store_read_missing_returns_empty(tmp_path: Path):
+    store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    assert store.read("sess_nope") == []
+
+
+@pytest.mark.unit
+def test_transcript_store_rejects_path_traversal(tmp_path: Path):
+    store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    with pytest.raises(ValueError):
+        store.append("../escape", "claim", {})
+    with pytest.raises(ValueError):
+        store.append("sub/dir", "claim", {})
+
+
+# ---------------------------------------------------------------------------
+# SpendTracker
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_spend_tracker_starts_empty(tmp_path: Path):
+    tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0)
+    assert tr.today_total() == 0.0
+    assert tr.can_start_task(50.0)
+
+
+@pytest.mark.unit
+def test_spend_tracker_can_start_at_exact_boundary(tmp_path: Path):
+    tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=10.0)
+    tr.record(5.0)
+    # 5 + 5 = 10 exactly = cap → allowed (cap is a ceiling we may reach).
+    assert tr.can_start_task(5.0)
+    # 5 + 5.01 > 10 → denied
+    assert not tr.can_start_task(5.01)
+
+
+@pytest.mark.unit
+def test_spend_tracker_zero_cap_denies_any_claim(tmp_path: Path):
+    tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=0.0)
+    assert tr.can_start_task(0.0)  # zero estimate at zero cap is allowed
+    assert not tr.can_start_task(0.01)
+
+
+@pytest.mark.unit
+def test_spend_tracker_record_accumulates(tmp_path: Path):
+    tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0)
+    tr.record(1.5)
+    tr.record(2.25)
+    assert tr.today_total() == pytest.approx(3.75)
+
+
+@pytest.mark.unit
+def test_spend_tracker_per_day_buckets(tmp_path: Path):
+    tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0)
+    today = date(2026, 1, 1)
+    tomorrow = today + timedelta(days=1)
+    tr.record(10.0, today=today)
+    tr.record(2.0, today=tomorrow)
+    assert tr.today_total(today=today) == pytest.approx(10.0)
+    assert tr.today_total(today=tomorrow) == pytest.approx(2.0)
+
+
+@pytest.mark.unit
+def test_spend_tracker_rejects_negative(tmp_path: Path):
+    tr = SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0)
+    with pytest.raises(ValueError):
+        tr.record(-1.0)
+    with pytest.raises(ValueError):
+        tr.can_start_task(-0.5)

--- a/tests/test_task_manager_swap_tag.py
+++ b/tests/test_task_manager_swap_tag.py
@@ -1,0 +1,80 @@
+"""Atomic tag-swap tests for TaskManager.
+
+Used by the external agent worker to claim `#agent` tasks exactly once even
+when multiple workers race. Storage is markdown-based with a single in-process
+lock, so the racing scenario is *two threads sharing one TaskManager* — which
+matches production where the worker hits the API server's singleton.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from api.services.task_manager import TaskManager
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> TaskManager:
+    vault = tmp_path / "vault"
+    index = tmp_path / "task_index.json"
+    return TaskManager(vault_path=vault, index_path=index)
+
+
+@pytest.mark.unit
+def test_swap_tag_swaps_when_present(manager: TaskManager):
+    task = manager.create("claim me", tags=["agent", "research"])
+    assert manager.swap_tag(task.id, "agent", "agent-running") is True
+
+    refreshed = manager.get(task.id)
+    assert "agent-running" in refreshed.tags
+    assert "agent" not in refreshed.tags
+    assert "research" in refreshed.tags  # other tags untouched
+
+
+@pytest.mark.unit
+def test_swap_tag_accepts_hash_prefix(manager: TaskManager):
+    task = manager.create("with hash", tags=["agent"])
+    assert manager.swap_tag(task.id, "#agent", "#agent-running") is True
+    refreshed = manager.get(task.id)
+    assert "agent-running" in refreshed.tags
+
+
+@pytest.mark.unit
+def test_swap_tag_returns_false_when_tag_absent(manager: TaskManager):
+    task = manager.create("no agent tag", tags=["research"])
+    assert manager.swap_tag(task.id, "agent", "agent-running") is False
+    # Task tags unchanged
+    assert manager.get(task.id).tags == ["research"]
+
+
+@pytest.mark.unit
+def test_swap_tag_returns_false_when_task_missing(manager: TaskManager):
+    assert manager.swap_tag("does-not-exist", "agent", "agent-running") is False
+
+
+@pytest.mark.unit
+def test_swap_tag_is_atomic_under_race(manager: TaskManager):
+    """Exactly one of N concurrent swap_tag calls on the same task wins."""
+    task = manager.create("racey", tags=["agent"])
+
+    n = 8
+    results: list[bool] = []
+    barrier = threading.Barrier(n)
+
+    def attempt():
+        barrier.wait()
+        results.append(manager.swap_tag(task.id, "agent", "agent-running"))
+
+    threads = [threading.Thread(target=attempt) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results.count(True) == 1, f"expected exactly one winner, got {results}"
+    # Final state: tag is swapped to "agent-running" exactly once.
+    final_tags = manager.get(task.id).tags
+    assert final_tags.count("agent-running") == 1
+    assert "agent" not in final_tags


### PR DESCRIPTION
## Summary
Issue B of the agent-worker series (epic #98). Builds the worker plumbing — long-running poll loop, atomic task claiming, SQLite-backed session store, append-only JSONL transcripts, daily \$-cap ledger — without spending any LLM money. A no-op dispatcher proves the round-trip: poll → claim (atomic tag-swap) → record session + transcript → no-op complete → Telegram notification. Real execution lands in Issue C (#101) for Gemma and Issue D (#102) for managed Opus.

Closes #100 · Relates to #98

## Test evidence
- `pytest tests/test_agent_worker_*.py tests/test_task_manager_swap_tag.py` — **25/25 passed** (stores, tracker, swap_tag race, worker loop)
- `pytest -m unit` via pre-push hook — **1215/1215 passed** in 86s (up from 1187 on \`main\`; 28 new tests, no regressions)
- Pre-existing \`test_summarizer.py::test_real_summary_generation\` still fails on \`main\` (Ollama-side, unrelated)

## Review focus
- **\`TaskManager.swap_tag\`** uses the existing in-process lock (\`self._lock\`) for the check-and-swap. The race test (\`tests/test_task_manager_swap_tag.py::test_swap_tag_is_atomic_under_race\`) launches 8 threads at a barrier and asserts exactly one winner. The worker calls this via \`POST /api/tasks/{id}/swap-tag?from=&to=\` so two worker processes serialize through the API's singleton.
- **\`SpendTracker\` boundary semantics** — the cap is an inclusive ceiling (\`total + estimate <= cap\` is allowed). Documented in the method docstring and tested at the boundary. \`record(0)\` is a no-op; negative values rejected.
- **\`Worker\` is signal-safe** — \`stop()\` is settable from a SIGTERM handler; \`run()\` sleeps in 1s slices so shutdown is prompt. \`tick()\` is the testable unit; \`run()\` is the daemon wrapper.
- **systemd unit is opt-in** via \`LIFEOS_AGENT_WORKER_AUTOSTART\` (default \`false\`). A fresh clone running \`sudo ./scripts/setup-systemd.sh\` will install the template but leave the unit disabled — no surprise polling. The sudoers rule was extended to cover start/stop/restart on the new unit.
- **Open-source hygiene** — no hardcoded paths or tokens in templates. Settings expose env-var overrides for every knob. Setup guide uses \`mcp.example.com\` placeholders. Worker survives missing Telegram config (\`send_message\` import falls back to a noop).
- **No LLM spend in this PR** — \`spend_tracker.record(0)\` is the only path called. Real spend accounting comes in C/D.

## Architectural notes
- \`SessionStore\` uses WAL mode and short-lived connections per call — safe for multi-thread / multi-process readers. SQLite serializes writers, which is the only guarantee we need for the daily-cap UPSERT.
- \`TranscriptStore\` is intentionally dumb append-only JSONL so multiple processes can write simultaneously without a coordinator (each session has a unique file).
- The worker hits the API over HTTP rather than importing \`TaskManager\` directly. This keeps the worker restartable without touching FastAPI startup and lets the existing in-process lock serialize \`swap_tag\` across worker + API requests.

## Manual smoke verification (operator follow-up)
1. \`LIFEOS_AGENT_WORKER_AUTOSTART=true\` in \`.env\`
2. \`sudo ./scripts/setup-systemd.sh\`
3. Create an \`#agent\`-tagged task via \`POST /api/tasks\`
4. Within ~60s, task should be marked \`done\` with a Telegram "no-op completed" message
5. Inspect \`data/agent_transcripts/<session_id>.jsonl\` for \`claim\` → \`noop_dispatch\` → \`noop_complete\` events