### PR TITLE
feat: Haiku preflight + local Gemma executor (C of F)

### DIFF
--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -48,6 +48,57 @@ MAX_TOOL_CALLS_PER_TURN = 16
 PER_TURN_MAX_TOKENS = 4096
 
 
+def _normalize_tool_calls(raw_calls) -> list[dict]:
+    """Normalize tool_calls into Anthropic-shape dicts.
+
+    `LocalLLMClient` returns raw OpenAI-format calls
+    (`{"id": ..., "type": "function", "function": {"name": ..., "arguments": "<json>"}}`).
+    `AnthropicLLMClient` returns Anthropic-shape `_ToolUseBlock` instances
+    or dicts with `name`/`input`. The executor wants a single shape so the
+    dispatcher and persistence layer stay simple. This function detects the
+    shape and produces `{"id", "name", "input"}` dicts in all cases.
+    """
+    if not raw_calls:
+        return []
+    normalized: list[dict] = []
+    for call in raw_calls:
+        # Anthropic-shape: object/dict with a `.name` and `.input`.
+        anth_name = getattr(call, "name", None)
+        anth_input = getattr(call, "input", None)
+        if anth_name and anth_input is not None:
+            normalized.append({
+                "id": getattr(call, "id", "") or f"call_{uuid.uuid4().hex[:12]}",
+                "name": anth_name,
+                "input": anth_input or {},
+            })
+            continue
+        if isinstance(call, dict):
+            if "function" in call and isinstance(call["function"], dict):
+                # OpenAI-shape — `arguments` is a JSON string.
+                func = call["function"]
+                args_raw = func.get("arguments", "{}")
+                if isinstance(args_raw, str):
+                    try:
+                        args = json.loads(args_raw)
+                    except json.JSONDecodeError:
+                        args = {}
+                else:
+                    args = args_raw or {}
+                normalized.append({
+                    "id": call.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                    "name": func.get("name", ""),
+                    "input": args,
+                })
+            elif "name" in call:
+                # Anthropic-shape dict.
+                normalized.append({
+                    "id": call.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                    "name": call["name"],
+                    "input": call.get("input") or {},
+                })
+    return normalized
+
+
 @dataclass
 class ExecutorOutcome:
     """What happened during a single `execute(session)` invocation."""
@@ -123,49 +174,53 @@ class LocalExecutor:
         """
         sid = session.session_id
         budget = session.budget or {}
-        wall_deadline = self._wall_deadline(session, budget)
         self.session_store.update_status(session.task_id, STATUS_RUNNING)
 
         if not self.session_store.get_messages(sid):
             self._seed_conversation(session, task, budget)
 
         while True:
-            # Wall-clock budget check.
-            if wall_deadline and time.time() > wall_deadline:
-                return self._finalize_budget_exceeded(session, "wall_seconds")
-
-            # Token budget check.
+            # Wall-clock budget check — uses cumulative active seconds, not
+            # wall-from-start (so sleeps don't eat into the run budget).
             updated = self.session_store.get(session.task_id)
+            if budget.get("wall_seconds"):
+                if (updated.total_active_seconds or 0) >= budget["wall_seconds"]:
+                    return self._finalize_budget_exceeded(session, "wall_seconds")
             tokens_used = (updated.total_input_tokens or 0) + (updated.total_output_tokens or 0)
             if budget.get("max_tokens") and tokens_used >= budget["max_tokens"]:
                 return self._finalize_budget_exceeded(session, "max_tokens")
-            # Dollar budget (local is $0 but the path is exercised for parity).
             if budget.get("max_dollars") is not None and (updated.total_dollars or 0) >= budget["max_dollars"]:
                 return self._finalize_budget_exceeded(session, "max_dollars")
 
+            turn_start = time.time()
             try:
                 response = self._call_llm(sid)
             except Exception as exc:
                 logger.exception("local executor LLM call failed: %s", exc)
+                # Charge the time we spent trying so the budget reflects real
+                # work even on failure.
+                self.session_store.record_active_seconds(session.task_id, time.time() - turn_start)
                 return self._finalize_failed(session, f"LLM call failed: {exc}")
 
-            self._persist_assistant_turn(sid, response)
-            self._record_spend(session, response)
+            # Normalize tool_calls to a single shape (OpenAI ↔ Anthropic).
+            normalized_calls = _normalize_tool_calls(response.tool_calls)
+            truncated_calls = normalized_calls[:MAX_TOOL_CALLS_PER_TURN]
 
-            tool_calls = response.tool_calls or []
-            if not tool_calls:
+            self._persist_assistant_turn(sid, response, truncated_calls)
+            self._record_spend(session, response)
+            self.session_store.record_active_seconds(session.task_id, time.time() - turn_start)
+
+            if not truncated_calls:
                 # Final answer — no more tool calls expected.
                 return self._finalize_completed(session, response.text)
 
             yielded_seconds: int | None = None
             tool_results: list[dict] = []
-            for i, call in enumerate(tool_calls[:MAX_TOOL_CALLS_PER_TURN]):
-                name = getattr(call, "name", None) or call.get("name", "")
-                args = getattr(call, "input", None) or call.get("input", {})
-                call_id = (getattr(call, "id", None)
-                           or call.get("id")
-                           or f"call_{uuid.uuid4().hex[:12]}")
-                result: ToolResult = self.tools.dispatch(name, args or {})
+            for call in truncated_calls:
+                name = call["name"]
+                args = call["input"]
+                call_id = call["id"]
+                result: ToolResult = self.tools.dispatch(name, args)
                 self.transcript_store.append(
                     sid,
                     "tool_call",
@@ -186,6 +241,20 @@ class LocalExecutor:
                     yielded_seconds = result.yield_seconds
                     # Stop dispatching further tools this turn — we're going to yield.
                     break
+
+            # If the agent yielded mid-turn, we may have fewer tool_results
+            # than persisted tool_use blocks. Pad with synthetic results so
+            # the next turn satisfies Anthropic's 1:1 invariant.
+            if yielded_seconds is not None and len(tool_results) < len(truncated_calls):
+                already_handled = {tr["tool_use_id"] for tr in tool_results}
+                for call in truncated_calls:
+                    if call["id"] not in already_handled:
+                        tool_results.append({
+                            "type": "tool_result",
+                            "tool_use_id": call["id"],
+                            "content": "skipped — sibling tool requested a sleep yield first",
+                            "is_error": False,
+                        })
 
             # Persist the tool_results as a user-role turn (Anthropic convention).
             self.session_store.append_message(sid, "user", tool_results)
@@ -226,22 +295,19 @@ class LocalExecutor:
             tools=self.tools.definitions(),
         )
 
-    def _persist_assistant_turn(self, session_id: str, response) -> None:
-        # Build an Anthropic-style content list mixing text + tool_use blocks.
+    def _persist_assistant_turn(self, session_id: str, response, normalized_calls: list[dict]) -> None:
+        """Persist the assistant turn using the *truncated* normalized call list
+        so tool_use and tool_result block counts stay 1:1 in later turns.
+        """
         content_blocks: list[dict] = []
         if response.text:
             content_blocks.append({"type": "text", "text": response.text})
-        for call in (response.tool_calls or []):
-            name = getattr(call, "name", None) or call.get("name", "")
-            args = getattr(call, "input", None) or call.get("input", {})
-            call_id = (getattr(call, "id", None)
-                       or call.get("id")
-                       or f"call_{uuid.uuid4().hex[:12]}")
+        for call in normalized_calls:
             content_blocks.append({
                 "type": "tool_use",
-                "id": call_id,
-                "name": name,
-                "input": args,
+                "id": call["id"],
+                "name": call["name"],
+                "input": call["input"],
             })
         usage = getattr(response, "usage", None)
         tokens_in = getattr(usage, "input_tokens", 0) if usage else 0
@@ -263,12 +329,6 @@ class LocalExecutor:
     # ------------------------------------------------------------------
     # Finalizers
     # ------------------------------------------------------------------
-
-    def _wall_deadline(self, session, budget: dict) -> float | None:
-        wall = budget.get("wall_seconds")
-        if not wall:
-            return None
-        return float(session.started_at) + float(wall)
 
     def _finalize_completed(self, session, final_text: str) -> ExecutorOutcome:
         self.session_store.update_status(session.task_id, STATUS_COMPLETED)

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -1,0 +1,299 @@
+"""Local agent loop for #agent #local tasks.
+
+The executor drives one session of conversation with the local llama-server
+(Gemma in this LifeOS) through `llm_client.LocalLLMClient`. Each turn:
+
+  1. Load the session's prior messages from the DB
+  2. Call the LLM with the tool catalog
+  3. Persist the assistant turn + token usage
+  4. Check wall + token budgets — kill the loop on breach
+  5. If the model produced tool calls, dispatch each, append tool_result
+     blocks to the conversation, and loop
+  6. If the model produced a final text answer, mark the session complete
+
+Sleep is a "yield": the executor writes a `sleeps` row, returns
+`ExecutorOutcome(status="sleeping", ...)`, and the worker's main loop wakes
+the session at the requested time by calling `execute(session)` again.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+
+from api.services.agent_worker.pricing import cost_for
+from api.services.agent_worker.session_store import (
+    STATUS_BUDGET_EXCEEDED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    STATUS_YIELDED,
+    SessionStore,
+)
+from api.services.agent_worker.tools import ToolRegistry, ToolResult
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+logger = logging.getLogger(__name__)
+
+
+# Per-turn ceiling on tool calls. Prevents a single broken turn from
+# exhausting tools forever before the budget check fires.
+MAX_TOOL_CALLS_PER_TURN = 16
+
+# Per-LLM-call max_tokens cap. The real ceiling is the session's token
+# budget; this is just the per-request ask so we don't burn cap in one go.
+PER_TURN_MAX_TOKENS = 4096
+
+
+@dataclass
+class ExecutorOutcome:
+    """What happened during a single `execute(session)` invocation."""
+    status: str   # one of STATUS_COMPLETED / STATUS_FAILED / STATUS_BUDGET_EXCEEDED / STATUS_YIELDED
+    final_text: str = ""
+    reason: str = ""
+    wake_at: int | None = None   # set when status == STATUS_YIELDED (sleep)
+
+
+def _system_prompt(session_id: str, expected_output: str, budget) -> str:
+    """System message for the executor agent."""
+    return (
+        "You are an autonomous agent running inside LifeOS, handling a single "
+        "task from the user's task manager. You have access to file, shell, "
+        "and LifeOS data tools. Work concisely and stop when the task is "
+        "complete — your final assistant turn (with no tool calls) is the "
+        f"answer the user will see.\n\n"
+        f"Your session_id is {session_id}. Your expected output shape is "
+        f"`{expected_output}`. Your budget is wall={budget.get('wall_seconds')}s, "
+        f"max_tokens={budget.get('max_tokens')}, max_dollars=${budget.get('max_dollars')}.\n\n"
+        "If you need to wait for external state to change, call the `sleep` "
+        "tool rather than busy-looping. If you cannot complete the task "
+        "safely or have hit an ambiguity you cannot resolve from context, "
+        "say so plainly in your final response — do not invent answers."
+    )
+
+
+def _user_message_for(task: dict) -> str:
+    """Build the opening user turn from the task description."""
+    title = (task.get("description") or "").strip()
+    context = task.get("context")
+    parts = [f"Task: {title}"]
+    if context:
+        parts.append(f"Context: {context}")
+    parts.append("Please complete this task using the tools available.")
+    return "\n\n".join(parts)
+
+
+class LocalExecutor:
+    """Drives one turn or one yielded resumption per call to `execute`."""
+
+    def __init__(
+        self,
+        session_store: SessionStore,
+        transcript_store: TranscriptStore,
+        tool_registry: ToolRegistry | None = None,
+        llm_client=None,
+        model_name: str = "local",
+    ):
+        self.session_store = session_store
+        self.transcript_store = transcript_store
+        # Lazy-imported to keep test surface small.
+        if tool_registry is None:
+            tool_registry = ToolRegistry()
+        self.tools = tool_registry
+        if llm_client is None:
+            from api.services.llm_client import LocalLLMClient
+            llm_client = LocalLLMClient()
+        self.llm = llm_client
+        self.model_name = model_name
+
+    # ------------------------------------------------------------------
+    # Entry points
+    # ------------------------------------------------------------------
+
+    def execute(self, session, task: dict) -> ExecutorOutcome:
+        """Run the agent loop for one session.
+
+        - If `messages` table is empty for this session, seed the conversation
+          with a system message and a user turn built from the task.
+        - Loops until the model produces a final answer, the budget is hit,
+          a tool yields (sleep), or an error.
+        """
+        sid = session.session_id
+        budget = session.budget or {}
+        wall_deadline = self._wall_deadline(session, budget)
+        self.session_store.update_status(session.task_id, STATUS_RUNNING)
+
+        if not self.session_store.get_messages(sid):
+            self._seed_conversation(session, task, budget)
+
+        while True:
+            # Wall-clock budget check.
+            if wall_deadline and time.time() > wall_deadline:
+                return self._finalize_budget_exceeded(session, "wall_seconds")
+
+            # Token budget check.
+            updated = self.session_store.get(session.task_id)
+            tokens_used = (updated.total_input_tokens or 0) + (updated.total_output_tokens or 0)
+            if budget.get("max_tokens") and tokens_used >= budget["max_tokens"]:
+                return self._finalize_budget_exceeded(session, "max_tokens")
+            # Dollar budget (local is $0 but the path is exercised for parity).
+            if budget.get("max_dollars") is not None and (updated.total_dollars or 0) >= budget["max_dollars"]:
+                return self._finalize_budget_exceeded(session, "max_dollars")
+
+            try:
+                response = self._call_llm(sid)
+            except Exception as exc:
+                logger.exception("local executor LLM call failed: %s", exc)
+                return self._finalize_failed(session, f"LLM call failed: {exc}")
+
+            self._persist_assistant_turn(sid, response)
+            self._record_spend(session, response)
+
+            tool_calls = response.tool_calls or []
+            if not tool_calls:
+                # Final answer — no more tool calls expected.
+                return self._finalize_completed(session, response.text)
+
+            yielded_seconds: int | None = None
+            tool_results: list[dict] = []
+            for i, call in enumerate(tool_calls[:MAX_TOOL_CALLS_PER_TURN]):
+                name = getattr(call, "name", None) or call.get("name", "")
+                args = getattr(call, "input", None) or call.get("input", {})
+                call_id = (getattr(call, "id", None)
+                           or call.get("id")
+                           or f"call_{uuid.uuid4().hex[:12]}")
+                result: ToolResult = self.tools.dispatch(name, args or {})
+                self.transcript_store.append(
+                    sid,
+                    "tool_call",
+                    {
+                        "tool": name,
+                        "arguments": args,
+                        "is_error": result.is_error,
+                        "output_chars": len(result.output),
+                    },
+                )
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": call_id,
+                    "content": result.output,
+                    "is_error": result.is_error,
+                })
+                if result.yield_seconds is not None:
+                    yielded_seconds = result.yield_seconds
+                    # Stop dispatching further tools this turn — we're going to yield.
+                    break
+
+            # Persist the tool_results as a user-role turn (Anthropic convention).
+            self.session_store.append_message(sid, "user", tool_results)
+
+            if yielded_seconds is not None:
+                return self._finalize_sleeping(session, yielded_seconds)
+
+    # ------------------------------------------------------------------
+    # Conversation persistence
+    # ------------------------------------------------------------------
+
+    def _seed_conversation(self, session, task: dict, budget: dict) -> None:
+        sid = session.session_id
+        system = _system_prompt(sid, session.expected_output or "text", budget)
+        # We store the system message as a "system" role row so future calls
+        # can rebuild the conversation; the LLM client API takes system
+        # separately so we strip it when calling.
+        self.session_store.append_message(sid, "system", system)
+        self.session_store.append_message(sid, "user", _user_message_for(task))
+        self.transcript_store.append(sid, "seed", {"task_id": session.task_id})
+
+    def _call_llm(self, session_id: str):
+        history = self.session_store.get_messages(session_id)
+        # Separate the system message from the user/assistant/tool history.
+        system_text = ""
+        messages_for_llm: list[dict] = []
+        for entry in history:
+            if entry["role"] == "system":
+                content = entry["content"]
+                system_text = content if isinstance(content, str) else json.dumps(content)
+            else:
+                messages_for_llm.append(entry)
+
+        return self.llm.create(
+            messages=messages_for_llm,
+            system=system_text or None,
+            max_tokens=PER_TURN_MAX_TOKENS,
+            tools=self.tools.definitions(),
+        )
+
+    def _persist_assistant_turn(self, session_id: str, response) -> None:
+        # Build an Anthropic-style content list mixing text + tool_use blocks.
+        content_blocks: list[dict] = []
+        if response.text:
+            content_blocks.append({"type": "text", "text": response.text})
+        for call in (response.tool_calls or []):
+            name = getattr(call, "name", None) or call.get("name", "")
+            args = getattr(call, "input", None) or call.get("input", {})
+            call_id = (getattr(call, "id", None)
+                       or call.get("id")
+                       or f"call_{uuid.uuid4().hex[:12]}")
+            content_blocks.append({
+                "type": "tool_use",
+                "id": call_id,
+                "name": name,
+                "input": args,
+            })
+        usage = getattr(response, "usage", None)
+        tokens_in = getattr(usage, "input_tokens", 0) if usage else 0
+        tokens_out = getattr(usage, "output_tokens", 0) if usage else 0
+        self.session_store.append_message(
+            session_id, "assistant", content_blocks,
+            tokens_in=tokens_in, tokens_out=tokens_out,
+        )
+
+    def _record_spend(self, session, response) -> None:
+        usage = getattr(response, "usage", None)
+        if not usage:
+            return
+        tokens_in = getattr(usage, "input_tokens", 0)
+        tokens_out = getattr(usage, "output_tokens", 0)
+        dollars = cost_for(self.model_name, tokens_in, tokens_out)
+        self.session_store.record_spend(session.task_id, tokens_in, tokens_out, dollars)
+
+    # ------------------------------------------------------------------
+    # Finalizers
+    # ------------------------------------------------------------------
+
+    def _wall_deadline(self, session, budget: dict) -> float | None:
+        wall = budget.get("wall_seconds")
+        if not wall:
+            return None
+        return float(session.started_at) + float(wall)
+
+    def _finalize_completed(self, session, final_text: str) -> ExecutorOutcome:
+        self.session_store.update_status(session.task_id, STATUS_COMPLETED)
+        self.transcript_store.append(
+            session.session_id, "completed", {"final_chars": len(final_text or "")}
+        )
+        return ExecutorOutcome(status=STATUS_COMPLETED, final_text=final_text or "")
+
+    def _finalize_failed(self, session, reason: str) -> ExecutorOutcome:
+        self.session_store.update_status(session.task_id, STATUS_FAILED)
+        self.transcript_store.append(session.session_id, "failed", {"reason": reason})
+        return ExecutorOutcome(status=STATUS_FAILED, reason=reason)
+
+    def _finalize_budget_exceeded(self, session, kind: str) -> ExecutorOutcome:
+        self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
+        self.transcript_store.append(
+            session.session_id, "budget_exceeded", {"kind": kind}
+        )
+        return ExecutorOutcome(status=STATUS_BUDGET_EXCEEDED, reason=f"budget exceeded ({kind})")
+
+    def _finalize_sleeping(self, session, seconds: int) -> ExecutorOutcome:
+        wake_at = int(time.time()) + int(seconds)
+        self.session_store.add_sleep(session.session_id, wake_at=wake_at)
+        self.session_store.update_status(session.task_id, STATUS_YIELDED)
+        self.transcript_store.append(
+            session.session_id, "sleep", {"seconds": int(seconds), "wake_at": wake_at}
+        )
+        return ExecutorOutcome(status=STATUS_YIELDED, wake_at=wake_at)

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -1,0 +1,250 @@
+"""Haiku preflight call that classifies an #agent task before execution.
+
+A single, cheap Claude Haiku call returns structured JSON describing:
+- the budget the task should run with (parsed from natural-language hints)
+- which executor to use (local Gemma vs. Claude Opus vs. ask the user)
+- whether the title is ambiguous (and what clarifying question to ask)
+- the expected output shape (used to phrase the completion notification)
+- a sanity flag (garbage / destructive titles get parked rather than run)
+
+The model is pinned to `claude-haiku-4-5` by default via
+`LIFEOS_AGENT_PREFLIGHT_MODEL`. The function takes a callable
+`call_llm(prompt) -> str` so tests can inject a stub instead of mocking the
+SDK; production wiring lives in `_default_llm_caller`.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Callable
+
+from config.settings import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+# Routing destinations. Anything else from the model is treated as `ask`.
+ROUTE_LOCAL = "local"
+ROUTE_CLAUDE = "claude"
+ROUTE_ASK = "ask"
+
+# Allowed expected-output shapes. Used to phrase the final Telegram summary.
+OUTPUT_KINDS = ("text", "file", "external_action", "structured")
+
+
+@dataclass
+class PreflightBudget:
+    wall_seconds: int
+    max_tokens: int
+    max_dollars: float
+
+
+@dataclass
+class PreflightAmbiguity:
+    question: str
+
+
+@dataclass
+class PreflightResult:
+    budget: PreflightBudget
+    routing: str  # one of ROUTE_LOCAL / ROUTE_CLAUDE / ROUTE_ASK
+    routing_reason: str
+    expected_output: str
+    ambiguity: PreflightAmbiguity | None = None
+    sane: bool = True
+    sane_reason: str = ""
+    raw: dict = field(default_factory=dict)  # the parsed JSON for debugging
+
+
+# ---------------------------------------------------------------------------
+# Defaults + prompt
+# ---------------------------------------------------------------------------
+
+def _defaults() -> PreflightBudget:
+    return PreflightBudget(
+        wall_seconds=settings.agent_default_wall_seconds,
+        max_tokens=settings.agent_default_max_tokens,
+        max_dollars=settings.agent_default_budget_dollars,
+    )
+
+
+_PREFLIGHT_INSTRUCTIONS = """\
+You are the preflight classifier for an external agent worker. Given a task
+title (and tag list) from a user's task manager, decide how it should run.
+
+Reply with a single JSON object, no prose, matching this exact schema:
+
+{{
+  "budget": {{
+    "wall_seconds": <int>,
+    "max_tokens": <int>,
+    "max_dollars": <float>
+  }},
+  "routing": "local" | "claude" | "ask",
+  "routing_reason": "<one short sentence>",
+  "expected_output": "text" | "file" | "external_action" | "structured",
+  "ambiguity": null | {{"question": "<one clarifying question>"}},
+  "sane": <true|false>,
+  "sane_reason": "<one short sentence; empty string if sane>"
+}}
+
+Rules:
+- Default budget if the title doesn't specify one: wall_seconds={default_wall}, max_tokens={default_tokens}, max_dollars={default_dollars}.
+- Parse natural-language budget hints from the title: "5 min" / "30s" / "1h" → wall_seconds; "max $0.50" → max_dollars; "10k tokens" / "50000 tokens" → max_tokens. Be reasonable about unit conversions.
+- Routing precedence:
+    1) If the tag list contains "local" → routing="local"; routing_reason="#local tag present".
+    2) Otherwise, look at the title for explicit cues — "with local agent", "using gemma", etc. → "local"; "use claude", "with opus", "with claude opus" → "claude".
+    3) If neither, set routing="ask" (the worker will ask the user which model).
+- expected_output: classify what the agent will produce.
+    "text" = a written answer; "file" = creates/edits a file; "external_action" = sends an email, posts a message, schedules a meeting; "structured" = returns structured data the caller will parse.
+- ambiguity: set to non-null only if the title is genuinely underspecified for an autonomous agent (e.g., "reply to John" with no email/context). One question, not multiple.
+- sane: set to false ONLY for empty/garbage titles or obviously destructive shapes (e.g., "rm -rf /", "delete all my data"). Mundane tasks are sane.
+
+Tag list and title follow. Return ONLY the JSON.
+"""
+
+
+def build_preflight_prompt(title: str, tags: list[str]) -> str:
+    defaults = _defaults()
+    instructions = _PREFLIGHT_INSTRUCTIONS.format(
+        default_wall=defaults.wall_seconds,
+        default_tokens=defaults.max_tokens,
+        default_dollars=defaults.max_dollars,
+    )
+    return f"{instructions}\nTAGS: {tags}\nTITLE: {title.strip()}"
+
+
+# ---------------------------------------------------------------------------
+# Parsing the model's reply
+# ---------------------------------------------------------------------------
+
+_JSON_BLOCK = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def parse_preflight_response(text: str) -> PreflightResult:
+    """Parse the LLM's reply into a PreflightResult.
+
+    Hardens against the common failure modes: ```json``` fences, leading prose,
+    missing keys, wrong types. On any parse failure we return a "sane=false"
+    result so the worker parks the task rather than running with junk.
+    """
+    raw: dict = {}
+    try:
+        match = _JSON_BLOCK.search(text)
+        if not match:
+            raise ValueError("no JSON object in preflight reply")
+        raw = json.loads(match.group(0))
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.warning("preflight reply unparseable: %s; reply was: %r", exc, text[:300])
+        defaults = _defaults()
+        return PreflightResult(
+            budget=defaults,
+            routing=ROUTE_ASK,
+            routing_reason="preflight could not parse classifier output",
+            expected_output="text",
+            ambiguity=None,
+            sane=False,
+            sane_reason=f"preflight parse error: {exc}",
+            raw={},
+        )
+
+    defaults = _defaults()
+    budget_raw = raw.get("budget") or {}
+    budget = PreflightBudget(
+        wall_seconds=int(budget_raw.get("wall_seconds", defaults.wall_seconds)),
+        max_tokens=int(budget_raw.get("max_tokens", defaults.max_tokens)),
+        max_dollars=float(budget_raw.get("max_dollars", defaults.max_dollars)),
+    )
+
+    routing = raw.get("routing", ROUTE_ASK)
+    if routing not in (ROUTE_LOCAL, ROUTE_CLAUDE, ROUTE_ASK):
+        routing = ROUTE_ASK
+
+    expected_output = raw.get("expected_output", "text")
+    if expected_output not in OUTPUT_KINDS:
+        expected_output = "text"
+
+    ambiguity = None
+    amb_raw = raw.get("ambiguity")
+    if isinstance(amb_raw, dict) and amb_raw.get("question"):
+        ambiguity = PreflightAmbiguity(question=str(amb_raw["question"]))
+
+    return PreflightResult(
+        budget=budget,
+        routing=routing,
+        routing_reason=str(raw.get("routing_reason", "")),
+        expected_output=expected_output,
+        ambiguity=ambiguity,
+        sane=bool(raw.get("sane", True)),
+        sane_reason=str(raw.get("sane_reason", "")),
+        raw=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+PreflightCaller = Callable[[str], str]
+
+
+def _default_llm_caller(prompt: str) -> str:
+    """Production caller: hit the Anthropic API via the existing llm_client."""
+    # Import inside the function so tests that monkeypatch run_preflight don't
+    # need the Anthropic SDK installed.
+    from api.services.llm_client import AnthropicLLMClient
+
+    client = AnthropicLLMClient(model=settings.agent_preflight_model)
+    response = client.create(
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=1024,
+        temperature=0.0,
+    )
+    return response.text
+
+
+def run_preflight(
+    title: str,
+    tags: list[str] | None = None,
+    caller: PreflightCaller | None = None,
+) -> PreflightResult:
+    """Run the Haiku preflight call. Returns a defensible PreflightResult even
+    on errors (sane=False routing=ask) so the worker can always make a decision.
+    """
+    tags_list = list(tags or [])
+    # Short-circuit: empty title is always unsafe, no need to spend a Haiku call.
+    if not title.strip():
+        defaults = _defaults()
+        return PreflightResult(
+            budget=defaults,
+            routing=ROUTE_ASK,
+            routing_reason="empty title",
+            expected_output="text",
+            ambiguity=None,
+            sane=False,
+            sane_reason="task title is empty",
+            raw={},
+        )
+
+    call = caller or _default_llm_caller
+    prompt = build_preflight_prompt(title, tags_list)
+    try:
+        reply = call(prompt)
+    except Exception as exc:
+        logger.warning("preflight LLM call failed: %s", exc)
+        defaults = _defaults()
+        return PreflightResult(
+            budget=defaults,
+            routing=ROUTE_ASK,
+            routing_reason="preflight LLM call failed",
+            expected_output="text",
+            ambiguity=None,
+            sane=False,
+            sane_reason=f"preflight error: {exc}",
+            raw={},
+        )
+
+    return parse_preflight_response(reply)

--- a/api/services/agent_worker/pricing.py
+++ b/api/services/agent_worker/pricing.py
@@ -1,0 +1,40 @@
+"""Per-model pricing for budget enforcement.
+
+Prices are dollars per token. The Anthropic figures match
+https://www.anthropic.com/pricing as of 2026-05. Update when models change.
+
+For the local backend, both rates are 0 — compute is "free" (operator paid
+upfront for the hardware). Time and tokens are still tracked for budget
+enforcement, but they don't contribute to the dollar budget or the daily cap.
+
+Managed Agents (Issue D) adds a flat session-hour overhead alongside tokens;
+that lives in `managed_driver.py`, not here.
+"""
+from __future__ import annotations
+
+
+# Dollars per token. Keys match the model id strings used by the routers.
+PRICING: dict[str, dict[str, float]] = {
+    # Claude 4.7 / 4.6 / 4.5 share the same prices per their respective tiers.
+    "claude-opus-4-7":   {"input": 15.0e-6, "output": 75.0e-6},
+    "claude-opus-4-6":   {"input": 15.0e-6, "output": 75.0e-6},
+    "claude-sonnet-4-6": {"input":  3.0e-6, "output": 15.0e-6},
+    "claude-sonnet-4-5": {"input":  3.0e-6, "output": 15.0e-6},
+    "claude-haiku-4-5":  {"input":  0.8e-6, "output":  4.0e-6},
+
+    # Local backend (llama-server) — compute is free.
+    "local":             {"input": 0.0,     "output": 0.0},
+}
+
+
+def cost_for(model: str, tokens_in: int, tokens_out: int) -> float:
+    """Return the dollar cost of a single LLM call.
+
+    Unknown models fall through to a conservative Opus-rate estimate so a
+    typo can't accidentally suppress budget enforcement. Logging is the
+    caller's responsibility.
+    """
+    rates = PRICING.get(model)
+    if rates is None:
+        rates = PRICING["claude-opus-4-7"]
+    return tokens_in * rates["input"] + tokens_out * rates["output"]

--- a/api/services/agent_worker/router.py
+++ b/api/services/agent_worker/router.py
@@ -1,0 +1,44 @@
+"""Routes a task to the appropriate executor based on preflight output.
+
+Issue C wires only the `local` branch. `claude` rolls the tag back to
+`#agent` and logs; Issue D adds the managed-agents driver and finishes the
+wiring. `ask` is handled before routing by the worker — preflight returns
+`routing="ask"` and the worker sends a clarification + parks the task as
+`#agent-blocked` without ever invoking the router.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from api.services.agent_worker.local_executor import ExecutorOutcome, LocalExecutor
+from api.services.agent_worker.preflight import ROUTE_CLAUDE, ROUTE_LOCAL
+
+
+logger = logging.getLogger(__name__)
+
+
+def dispatch(
+    session,
+    task: dict[str, Any],
+    *,
+    local_executor: LocalExecutor,
+    on_claude_unavailable: Callable[[], None] | None = None,
+) -> ExecutorOutcome | None:
+    """Run the executor for `session`. Returns the outcome, or None when the
+    routing destination isn't implemented yet (caller decides how to handle).
+    """
+    routing = session.routing
+    if routing == ROUTE_LOCAL:
+        return local_executor.execute(session, task)
+
+    if routing == ROUTE_CLAUDE:
+        logger.info(
+            "Claude routing not yet implemented (Issue D) — leaving task for later"
+        )
+        if on_claude_unavailable is not None:
+            on_claude_unavailable()
+        return None
+
+    logger.warning("router: unknown routing %r — skipping", routing)
+    return None

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -56,6 +56,7 @@ class Session:
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_dollars: float = 0.0
+    total_active_seconds: float = 0.0
 
 
 _SCHEMA = """
@@ -70,6 +71,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     total_input_tokens        INTEGER NOT NULL DEFAULT 0,
     total_output_tokens       INTEGER NOT NULL DEFAULT 0,
     total_dollars             REAL    NOT NULL DEFAULT 0.0,
+    total_active_seconds      REAL    NOT NULL DEFAULT 0.0,
     expected_output           TEXT,
     parent_session_id         TEXT,
     managed_agent_session_id  TEXT
@@ -273,6 +275,23 @@ class SessionStore:
                 (tokens_in, tokens_out, dollars, _now(), task_id),
             )
 
+    def record_active_seconds(self, task_id: str, seconds: float) -> None:
+        """Add to a session's cumulative active-execution seconds.
+
+        Active seconds exclude sleep time — this is the duration of LLM calls
+        + tool dispatch, used by the wall-clock budget check. A session that
+        spends 8 hours sleeping but only 5 minutes actually running has
+        total_active_seconds ≈ 300, not 28800.
+        """
+        if seconds <= 0:
+            return
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE sessions SET total_active_seconds = total_active_seconds + ?, "
+                "last_activity_at = ? WHERE task_id = ?",
+                (float(seconds), _now(), task_id),
+            )
+
     # ------------------------------------------------------------------
     # Messages (local-path conversation log)
     # ------------------------------------------------------------------
@@ -281,28 +300,37 @@ class SessionStore:
         self,
         session_id: str,
         role: str,
-        content: dict | list,
+        content: dict | list | str,
         tokens_in: int = 0,
         tokens_out: int = 0,
     ) -> int:
-        """Append one message; return its 0-based turn_index."""
+        """Append one message; return its 0-based turn_index.
+
+        Uses a single INSERT that computes the next turn_index inside the
+        statement, so concurrent appends from sibling worker processes
+        (Issue E) can't pick the same index — SQLite serializes the write.
+        """
         with self._connect() as conn:
-            row = conn.execute(
-                "SELECT COALESCE(MAX(turn_index), -1) + 1 AS next_index "
-                "FROM messages WHERE session_id = ?",
-                (session_id,),
-            ).fetchone()
-            turn_index = int(row["next_index"])
             conn.execute(
                 """
                 INSERT INTO messages (
                     session_id, turn_index, role, content_json,
                     tokens_in, tokens_out, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                )
+                SELECT ?, COALESCE(MAX(turn_index), -1) + 1, ?, ?, ?, ?, ?
+                FROM messages WHERE session_id = ?
                 """,
-                (session_id, turn_index, role, json.dumps(content), tokens_in, tokens_out, _now()),
+                (
+                    session_id, role, json.dumps(content),
+                    tokens_in, tokens_out, _now(),
+                    session_id,
+                ),
             )
-        return turn_index
+            row = conn.execute(
+                "SELECT MAX(turn_index) AS i FROM messages WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        return int(row["i"])
 
     def get_messages(self, session_id: str) -> list[dict]:
         """Return all messages in order as {role, content} dicts ready for the LLM."""
@@ -352,6 +380,11 @@ class SessionStore:
             total_input_tokens=row["total_input_tokens"],
             total_output_tokens=row["total_output_tokens"],
             total_dollars=row["total_dollars"],
+            total_active_seconds=(
+                row["total_active_seconds"]
+                if "total_active_seconds" in row.keys()
+                else 0.0
+            ),
             expected_output=row["expected_output"],
             parent_session_id=row["parent_session_id"],
             managed_agent_session_id=row["managed_agent_session_id"],

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -81,6 +81,29 @@ CREATE TABLE IF NOT EXISTS daily_spend (
     date           TEXT PRIMARY KEY,
     total_dollars  REAL NOT NULL DEFAULT 0.0
 );
+
+-- Conversation log for local-path sessions. Managed sessions store messages
+-- in the JSONL transcript instead (their authoritative state lives on the
+-- Anthropic side).
+CREATE TABLE IF NOT EXISTS messages (
+    session_id    TEXT NOT NULL,
+    turn_index    INTEGER NOT NULL,
+    role          TEXT NOT NULL,
+    content_json  TEXT NOT NULL,
+    tokens_in     INTEGER NOT NULL DEFAULT 0,
+    tokens_out    INTEGER NOT NULL DEFAULT 0,
+    created_at    INTEGER NOT NULL,
+    PRIMARY KEY (session_id, turn_index)
+);
+CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
+
+-- Sleep wake-ups. A session with a row here is "yielded": the worker's main
+-- loop scans this table and resumes the session when wake_at <= now().
+CREATE TABLE IF NOT EXISTS sleeps (
+    session_id    TEXT PRIMARY KEY,
+    wake_at       INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sleeps_wake ON sleeps(wake_at);
 """
 
 
@@ -204,6 +227,117 @@ class SessionStore:
                 tuple(TERMINAL_STATUSES),
             ).fetchall()
         return [self._row_to_session(r) for r in rows]
+
+    def set_routing_and_budget(
+        self,
+        task_id: str,
+        routing: str | None,
+        budget: dict | None,
+        expected_output: str | None = None,
+    ) -> None:
+        """Update routing decision and budget after the preflight call."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE sessions
+                SET routing = ?, budget_json = ?, expected_output = ?, last_activity_at = ?
+                WHERE task_id = ?
+                """,
+                (
+                    routing,
+                    json.dumps(budget) if budget else None,
+                    expected_output,
+                    _now(),
+                    task_id,
+                ),
+            )
+
+    def record_spend(
+        self,
+        task_id: str,
+        tokens_in: int,
+        tokens_out: int,
+        dollars: float,
+    ) -> None:
+        """Add to a session's cumulative token + dollar counters."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE sessions
+                SET total_input_tokens  = total_input_tokens  + ?,
+                    total_output_tokens = total_output_tokens + ?,
+                    total_dollars       = total_dollars       + ?,
+                    last_activity_at    = ?
+                WHERE task_id = ?
+                """,
+                (tokens_in, tokens_out, dollars, _now(), task_id),
+            )
+
+    # ------------------------------------------------------------------
+    # Messages (local-path conversation log)
+    # ------------------------------------------------------------------
+
+    def append_message(
+        self,
+        session_id: str,
+        role: str,
+        content: dict | list,
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+    ) -> int:
+        """Append one message; return its 0-based turn_index."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COALESCE(MAX(turn_index), -1) + 1 AS next_index "
+                "FROM messages WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            turn_index = int(row["next_index"])
+            conn.execute(
+                """
+                INSERT INTO messages (
+                    session_id, turn_index, role, content_json,
+                    tokens_in, tokens_out, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (session_id, turn_index, role, json.dumps(content), tokens_in, tokens_out, _now()),
+            )
+        return turn_index
+
+    def get_messages(self, session_id: str) -> list[dict]:
+        """Return all messages in order as {role, content} dicts ready for the LLM."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT role, content_json FROM messages "
+                "WHERE session_id = ? ORDER BY turn_index ASC",
+                (session_id,),
+            ).fetchall()
+        return [{"role": r["role"], "content": json.loads(r["content_json"])} for r in rows]
+
+    # ------------------------------------------------------------------
+    # Sleeps (yield / wake)
+    # ------------------------------------------------------------------
+
+    def add_sleep(self, session_id: str, wake_at: int) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO sleeps (session_id, wake_at) VALUES (?, ?)",
+                (session_id, int(wake_at)),
+            )
+
+    def remove_sleep(self, session_id: str) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM sleeps WHERE session_id = ?", (session_id,))
+
+    def due_sleeps(self, now_ts: int | None = None) -> list[str]:
+        """Return session_ids whose wake time has arrived."""
+        ts = now_ts if now_ts is not None else _now()
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT session_id FROM sleeps WHERE wake_at <= ? ORDER BY wake_at ASC",
+                (ts,),
+            ).fetchall()
+        return [r["session_id"] for r in rows]
 
     @staticmethod
     def _row_to_session(row: sqlite3.Row) -> Session:

--- a/api/services/agent_worker/tools.py
+++ b/api/services/agent_worker/tools.py
@@ -1,0 +1,321 @@
+"""Tool catalog and dispatcher for the local executor.
+
+The local executor exposes a small fixed set of operating-system tools
+(Read/Write/Edit/Bash/WebFetch/WebSearch) plus the full LifeOS MCP tool
+surface proxied through `LifeOSMCPServer._call_api`. The agent sees Anthropic-
+style tool definitions; the dispatcher routes calls to Python handlers.
+
+WebSearch is stubbed — LifeOS doesn't ship a built-in search backend in
+Issue C. The tool definition is exposed so the agent knows the affordance
+exists; the handler returns a structured "not configured" reply so the
+agent can pivot rather than hang.
+
+No sandboxing per the user's design decision: the worker runs with the
+operator's full filesystem and shell access. This is intentional and is
+called out in `AGENTS.md` and the setup guide.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+# How much of a file we'll surface to the model at once. Beyond this we
+# truncate with a footer pointing at the file path so the agent can re-read.
+_MAX_READ_BYTES = 200_000
+_MAX_BASH_OUTPUT_BYTES = 32_000
+_MAX_WEBFETCH_BYTES = 200_000
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions (Anthropic format)
+# ---------------------------------------------------------------------------
+
+STANDARD_TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "Read",
+        "description": "Read the contents of a file from the operator's filesystem. Pass an absolute path. Returns the text content (truncated for large files).",
+        "input_schema": {
+            "type": "object",
+            "properties": {"file_path": {"type": "string", "description": "Absolute path to a file"}},
+            "required": ["file_path"],
+        },
+    },
+    {
+        "name": "Write",
+        "description": "Write (or overwrite) a file. Pass an absolute path and the new content. Existing parents must already exist.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "content": {"type": "string"},
+            },
+            "required": ["file_path", "content"],
+        },
+    },
+    {
+        "name": "Edit",
+        "description": "Replace an exact substring in a file. The old_string must appear exactly once in the file.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "old_string": {"type": "string"},
+                "new_string": {"type": "string"},
+            },
+            "required": ["file_path", "old_string", "new_string"],
+        },
+    },
+    {
+        "name": "Bash",
+        "description": "Run a shell command (sh/bash) and return its stdout + stderr. No sandbox. Long output is truncated.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+                "timeout_seconds": {"type": "integer", "default": 60},
+            },
+            "required": ["command"],
+        },
+    },
+    {
+        "name": "WebFetch",
+        "description": "Fetch a URL and return the body as text. Large responses are truncated.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"url": {"type": "string"}},
+            "required": ["url"],
+        },
+    },
+    {
+        "name": "WebSearch",
+        "description": "Run a web search. NOTE: this LifeOS install does not yet have a search backend configured. The tool returns 'not configured' until a backend is wired up.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "sleep",
+        "description": "Yield control until a number of seconds has elapsed. The session is paused (not idle-billed) and the worker resumes it when the timer expires. Use this when waiting on an external state change rather than busy-looping.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "seconds": {"type": "integer", "minimum": 1},
+                "reason": {"type": "string", "description": "Why you're sleeping (one short sentence)"},
+            },
+            "required": ["seconds"],
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch results
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ToolResult:
+    """Output of a single tool call."""
+    output: str         # what the agent sees
+    is_error: bool = False
+    yield_seconds: int | None = None  # set by `sleep` to instruct the executor
+
+
+# ---------------------------------------------------------------------------
+# Standard tool handlers
+# ---------------------------------------------------------------------------
+
+def _tool_read(args: dict) -> ToolResult:
+    file_path = args.get("file_path", "")
+    if not file_path:
+        return ToolResult("Read requires file_path", is_error=True)
+    p = Path(file_path)
+    if not p.exists():
+        return ToolResult(f"file not found: {file_path}", is_error=True)
+    if not p.is_file():
+        return ToolResult(f"not a file: {file_path}", is_error=True)
+    try:
+        data = p.read_bytes()
+    except Exception as e:
+        return ToolResult(f"read failed: {e}", is_error=True)
+    if len(data) > _MAX_READ_BYTES:
+        text = data[:_MAX_READ_BYTES].decode("utf-8", errors="replace")
+        text += f"\n\n[truncated: file is {len(data)} bytes; showed first {_MAX_READ_BYTES}]"
+        return ToolResult(text)
+    return ToolResult(data.decode("utf-8", errors="replace"))
+
+
+def _tool_write(args: dict) -> ToolResult:
+    file_path = args.get("file_path", "")
+    content = args.get("content", "")
+    if not file_path:
+        return ToolResult("Write requires file_path", is_error=True)
+    p = Path(file_path)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    except Exception as e:
+        return ToolResult(f"write failed: {e}", is_error=True)
+    return ToolResult(f"wrote {len(content)} bytes to {file_path}")
+
+
+def _tool_edit(args: dict) -> ToolResult:
+    file_path = args.get("file_path", "")
+    old = args.get("old_string", "")
+    new = args.get("new_string", "")
+    if not file_path or not old:
+        return ToolResult("Edit requires file_path and a non-empty old_string", is_error=True)
+    p = Path(file_path)
+    if not p.exists():
+        return ToolResult(f"file not found: {file_path}", is_error=True)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except Exception as e:
+        return ToolResult(f"read failed: {e}", is_error=True)
+    count = text.count(old)
+    if count == 0:
+        return ToolResult("old_string not found in file", is_error=True)
+    if count > 1:
+        return ToolResult(
+            f"old_string occurs {count} times — must be unique; widen the context",
+            is_error=True,
+        )
+    try:
+        p.write_text(text.replace(old, new, 1), encoding="utf-8")
+    except Exception as e:
+        return ToolResult(f"write failed: {e}", is_error=True)
+    return ToolResult(f"replaced 1 occurrence in {file_path}")
+
+
+def _tool_bash(args: dict) -> ToolResult:
+    command = args.get("command", "")
+    timeout = int(args.get("timeout_seconds", 60))
+    if not command:
+        return ToolResult("Bash requires command", is_error=True)
+    try:
+        completed = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return ToolResult(f"command timed out after {timeout}s", is_error=True)
+    except Exception as e:
+        return ToolResult(f"command failed to start: {e}", is_error=True)
+    out = completed.stdout or ""
+    err = completed.stderr or ""
+    combined = out
+    if err:
+        combined += "\n[stderr]\n" + err
+    if len(combined) > _MAX_BASH_OUTPUT_BYTES:
+        combined = combined[:_MAX_BASH_OUTPUT_BYTES] + "\n\n[truncated]"
+    if completed.returncode != 0:
+        return ToolResult(f"exit {completed.returncode}\n{combined}", is_error=True)
+    return ToolResult(combined or "(no output)")
+
+
+def _tool_webfetch(args: dict) -> ToolResult:
+    url = args.get("url", "")
+    if not url:
+        return ToolResult("WebFetch requires url", is_error=True)
+    try:
+        resp = httpx.get(url, timeout=20.0, follow_redirects=True)
+        resp.raise_for_status()
+    except Exception as e:
+        return ToolResult(f"fetch failed: {e}", is_error=True)
+    text = resp.text or ""
+    if len(text) > _MAX_WEBFETCH_BYTES:
+        text = text[:_MAX_WEBFETCH_BYTES] + "\n\n[truncated]"
+    return ToolResult(text)
+
+
+def _tool_websearch(args: dict) -> ToolResult:
+    # Search backend is intentionally not configured in Issue C. We surface
+    # the tool so the agent can plan around it, but calling it returns a
+    # structured "not configured" message rather than failing silently.
+    return ToolResult(
+        "WebSearch is not configured on this LifeOS install. "
+        "Use WebFetch with a specific URL, or pivot to a different approach.",
+        is_error=True,
+    )
+
+
+STANDARD_HANDLERS: dict[str, Callable[[dict], ToolResult]] = {
+    "Read": _tool_read,
+    "Write": _tool_write,
+    "Edit": _tool_edit,
+    "Bash": _tool_bash,
+    "WebFetch": _tool_webfetch,
+    "WebSearch": _tool_websearch,
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool registry — combines standard tools with LifeOS MCP tools
+# ---------------------------------------------------------------------------
+
+class ToolRegistry:
+    """Collects standard tools + LifeOS MCP tools into a unified dispatcher.
+
+    The LifeOS MCP tools come from instantiating `LifeOSMCPServer` (a
+    self-contained class with `.tools` and `._call_api()`). Doing so is cheap
+    and avoids duplicating the curated endpoint catalog.
+    """
+
+    def __init__(self, lifeos_mcp_server=None):
+        if lifeos_mcp_server is None:
+            # Lazy import — keeps the test surface light when MCP isn't needed.
+            from mcp_server import LifeOSMCPServer
+            lifeos_mcp_server = LifeOSMCPServer()
+        self._mcp = lifeos_mcp_server
+        self._mcp_tool_names: set[str] = {t["name"] for t in self._mcp.tools}
+
+    def definitions(self) -> list[dict[str, Any]]:
+        """Anthropic-format tool definitions for the agent's system message."""
+        return STANDARD_TOOLS + list(self._mcp.tools)
+
+    def dispatch(self, name: str, arguments: dict) -> ToolResult:
+        """Run one tool call. Returns a ToolResult."""
+        # `sleep` is special: tell the executor to yield rather than producing
+        # immediate output.
+        if name == "sleep":
+            seconds = max(1, int(arguments.get("seconds", 60)))
+            reason = arguments.get("reason", "")
+            return ToolResult(
+                output=f"sleeping {seconds}s — {reason}" if reason else f"sleeping {seconds}s",
+                yield_seconds=seconds,
+            )
+
+        handler = STANDARD_HANDLERS.get(name)
+        if handler is not None:
+            try:
+                return handler(arguments)
+            except Exception as e:  # pragma: no cover — defensive
+                logger.exception("tool %s raised: %s", name, e)
+                return ToolResult(f"tool {name} crashed: {e}", is_error=True)
+
+        if name in self._mcp_tool_names:
+            try:
+                data = self._mcp._call_api(name, arguments)
+                formatted = self._mcp._format_response(name, data)
+                # MCP _call_api signals errors by returning a dict with an
+                # "error" key — surface that as an error result.
+                is_error = isinstance(data, dict) and "error" in data
+                return ToolResult(formatted, is_error=is_error)
+            except Exception as e:
+                logger.exception("LifeOS MCP tool %s raised: %s", name, e)
+                return ToolResult(f"tool {name} crashed: {e}", is_error=True)
+
+        return ToolResult(f"unknown tool: {name}", is_error=True)

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -411,15 +411,19 @@ class Worker:
             self._handle_outcome(session, task, outcome)
             return
 
-        # Claude route: deferred to Issue D. Roll the tag back and notify.
+        # Claude route: deferred to Issue D. Park at #agent-blocked rather
+        # than re-tagging to #agent — same blocked semantics as ambiguity /
+        # sanity / routing-ask, and the operator can drop the block tag when
+        # Issue D is installed to retry.
         if pre.routing == ROUTE_CLAUDE:
-            self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG)
+            self._swap_tag(task_id, RUNNING_TAG, BLOCKED_TAG)
             self.session_store.update_status(task_id, STATUS_BLOCKED)
             self.transcript_store.append(sid, "claude_routing_deferred", {})
             self._notify(
-                f"⏸ Agent worker: task '{title}' routed to Claude but Managed "
-                f"Agents driver isn't installed yet (Issue D). Task left at "
-                f"#{AGENT_TAG} for when D ships."
+                f"⏸ Agent worker: task '{title}' routed to Claude but the "
+                f"Managed Agents driver isn't installed yet (Issue D). Task "
+                f"parked at #{BLOCKED_TAG} — retag with #{AGENT_TAG} once "
+                f"Issue D ships."
             )
             return
 
@@ -465,7 +469,9 @@ class Worker:
     def _completion_summary(self, session: Session, task: dict[str, Any], outcome) -> str:
         refreshed = self.session_store.get(session.task_id) or session
         tokens = (refreshed.total_input_tokens or 0) + (refreshed.total_output_tokens or 0)
-        wall = int(time.time()) - int(refreshed.started_at)
+        # Use active seconds (excludes sleeps) so the figure reflects real
+        # work, not wall time since the session was first created.
+        active_s = int(refreshed.total_active_seconds or 0)
         expected = refreshed.expected_output or "text"
         title = task.get("description", session.task_id)
         result_blurb = (outcome.final_text or "(no text response)").strip()
@@ -474,7 +480,7 @@ class Worker:
         return (
             f"✅ Agent worker: completed '{title}' "
             f"({expected}) — {tokens:,} tokens, ${refreshed.total_dollars:.2f}, "
-            f"{wall}s wall.\n\n{result_blurb}"
+            f"{active_s}s active.\n\n{result_blurb}"
         )
 
     def _mark_failed(self, session: Session, task: dict[str, Any], reason: str) -> None:

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1,10 +1,13 @@
 """Main poll loop for the LifeOS agent worker.
 
-Issue B scope (this file): claim `#agent` tasks atomically via the API,
-record a session row + transcript event, run a no-op dispatcher, mark the
-session complete, and notify via Telegram. Later issues replace the no-op
-dispatcher with real LLM execution (C/D), inter-agent coordination (E), and
-the clarification round-trip (F).
+Per-tick flow:
+  - wake any sessions whose sleep timer has expired
+  - check the daily spend cap
+  - list todo+#agent tasks from the API
+  - for each unclaimed candidate: atomic tag swap, preflight, route
+    (local → run on Gemma; claude → defer to Issue D; ask/ambiguous → block)
+  - on terminal outcomes, swap to the matching #agent-* status tag and
+    notify via Telegram
 
 The worker is a stand-alone process (`python -m api.services.agent_worker.worker`)
 managed by the `lifeos-agent-worker.service` systemd unit. It does not import
@@ -21,11 +24,21 @@ from typing import Any
 
 import httpx
 
+from api.services.agent_worker.preflight import (
+    ROUTE_ASK,
+    ROUTE_CLAUDE,
+    ROUTE_LOCAL,
+    PreflightResult,
+    run_preflight,
+)
 from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
+    STATUS_BUDGET_EXCEEDED,
     STATUS_CLAIMED,
     STATUS_COMPLETED,
     STATUS_FAILED,
-    STATUS_RUNNING,
+    STATUS_YIELDED,
+    Session,
     SessionStore,
 )
 from api.services.agent_worker.spend_tracker import SpendTracker
@@ -38,6 +51,9 @@ logger = logging.getLogger(__name__)
 
 AGENT_TAG = "agent"
 RUNNING_TAG = "agent-running"
+BLOCKED_TAG = "agent-blocked"
+FAILED_TAG = "agent-failed"
+BUDGET_EXCEEDED_TAG = "agent-budget-exceeded"
 
 
 class Worker:
@@ -52,6 +68,8 @@ class Worker:
         poll_seconds: float | None = None,
         telegram_send=None,  # injectable for tests
         http_client: httpx.Client | None = None,
+        preflight_caller=None,  # injectable; defaults to Anthropic Haiku
+        local_executor=None,    # injectable LocalExecutor for tests
     ) -> None:
         self.api_base = (api_base or os.environ.get("LIFEOS_API_URL", "http://localhost:8000")).rstrip("/")
         self.session_store = session_store or SessionStore()
@@ -74,6 +92,8 @@ class Worker:
         self._telegram_send = telegram_send
         self._owns_http_client = http_client is None
         self._http = http_client or httpx.Client(timeout=10.0)
+        self._preflight_caller = preflight_caller  # None → use Anthropic SDK by default
+        self._local_executor = local_executor  # lazily instantiated on first use
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -112,40 +132,39 @@ class Worker:
     # ------------------------------------------------------------------
 
     def resume_pending(self) -> int:
-        """Finalize any non-terminal sessions left behind by a previous crash.
+        """Finalize sessions left non-terminal by a previous crash.
 
-        At Issue B scope, the no-op dispatcher's only side effect is marking
-        the task complete via the API. So recovery is straightforward: for
-        each non-terminal session, retry the `complete` call and update the
-        session to a terminal state. Later issues will replace this with a
-        proper per-routing resume (managed-agent re-attach, local-loop
-        re-drive, etc.).
+        - STATUS_YIELDED with a `sleeps` row: leave alone — the wake-up loop
+          in `tick()` will pick it up at the right time.
+        - STATUS_RUNNING / STATUS_CLAIMED / STATUS_BLOCKED: mark FAILED and
+          roll the tag back to #agent so the operator can retry. We can't
+          safely re-enter a partially-driven LLM conversation without risking
+          duplicate side effects (file writes, API calls, etc.).
         """
         pending = self.session_store.list_non_terminal()
         if not pending:
             return 0
-        logger.info("resuming %d non-terminal session(s) from previous run", len(pending))
         recovered = 0
         for session in pending:
             sid = session.session_id
-            self.transcript_store.append(sid, "resume_attempt", {"prior_status": session.status})
-            if self._complete_task(session.task_id):
-                self.session_store.update_status(session.task_id, STATUS_COMPLETED)
-                self.transcript_store.append(sid, "resume_completed", {})
-                self._notify(
-                    f"✅ Agent worker (scaffolding): recovered orphaned task "
-                    f"after restart (session {sid})"
-                )
-                recovered += 1
-            else:
-                # Roll the tag back so the task can be re-claimed next cycle.
-                self._swap_tag(session.task_id, RUNNING_TAG, AGENT_TAG)
-                self.session_store.update_status(session.task_id, STATUS_FAILED)
-                self.transcript_store.append(sid, "resume_failed", {})
-                self._notify(
-                    f"⚠️ Agent worker (scaffolding): could not finalize orphaned "
-                    f"task on resume — tag rolled back to #{AGENT_TAG} for retry"
-                )
+            # Sleeping sessions are healthy — main loop will wake them.
+            if session.status == STATUS_YIELDED:
+                continue
+            # Blocked sessions are waiting on the user; leave alone.
+            if session.status == STATUS_BLOCKED:
+                continue
+            self.transcript_store.append(sid, "resume_failed", {"prior_status": session.status})
+            self._swap_tag(session.task_id, RUNNING_TAG, AGENT_TAG)
+            self.session_store.update_status(session.task_id, STATUS_FAILED)
+            self._notify(
+                f"⚠️ Agent worker: task left in {session.status!r} from a prior "
+                f"run could not be safely resumed — tag rolled back to "
+                f"#{AGENT_TAG} for retry. Transcript: "
+                f"data/agent_transcripts/{sid}.jsonl"
+            )
+            recovered += 1
+        if recovered:
+            logger.info("rolled back %d non-resumable session(s) on startup", recovered)
         return recovered
 
     # ------------------------------------------------------------------
@@ -166,6 +185,9 @@ class Worker:
             )
             return 0
 
+        # First, resume any sleeping sessions whose wake time has arrived.
+        self._wake_sleeping_sessions()
+
         candidates = self._list_agent_tasks()
         handled = 0
         for task in candidates:
@@ -177,9 +199,40 @@ class Worker:
                 continue
             if not self._claim(task_id):
                 continue
-            self._dispatch_noop(task)
+            self._dispatch(task)
             handled += 1
         return handled
+
+    def _wake_sleeping_sessions(self) -> None:
+        """Resume any sessions whose `sleeps` row has expired."""
+
+        due = self.session_store.due_sleeps()
+        if not due:
+            return
+        for session_id in due:
+            session = self.session_store.get_by_session_id(session_id)
+            if session is None:
+                # Defensive — stale sleep row referencing a deleted session.
+                self.session_store.remove_sleep(session_id)
+                continue
+            self.session_store.remove_sleep(session_id)
+            self.transcript_store.append(session_id, "wake", {})
+            # Re-fetch the task description from the API so the conversation
+            # context stays accurate (someone may have edited the title).
+            task = self._fetch_task(session.task_id) or {"id": session.task_id, "description": ""}
+            executor = self._get_local_executor()
+            try:
+                outcome = executor.execute(session, task)
+            except Exception as exc:
+                logger.exception("wake execute failed for %s: %s", session_id, exc)
+                self.session_store.update_status(session.task_id, STATUS_FAILED)
+                self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
+                self._notify(
+                    f"⚠️ Agent worker: error while resuming sleeping task "
+                    f"'{task.get('description', session.task_id)}': {exc}"
+                )
+                continue
+            self._handle_outcome(session, task, outcome)
 
     # ------------------------------------------------------------------
     # API helpers
@@ -255,42 +308,193 @@ class Worker:
                 )
             return False
 
-    def _dispatch_noop(self, task: dict[str, Any]) -> None:
-        """Placeholder dispatcher: marks the task complete without spending money.
+    def _get_local_executor(self):
+        if self._local_executor is None:
+            from api.services.agent_worker.local_executor import LocalExecutor
+            self._local_executor = LocalExecutor(
+                session_store=self.session_store,
+                transcript_store=self.transcript_store,
+            )
+        return self._local_executor
 
-        Replaced in later issues by the real router + executor.
-        """
+    def _fetch_task(self, task_id: str) -> dict[str, Any] | None:
+        try:
+            resp = self._http.get(f"{self.api_base}/api/tasks/{task_id}")
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            logger.warning("fetch_task %s failed: %s", task_id, exc)
+            return None
+
+    def _dispatch(self, task: dict[str, Any]) -> None:
+        """Run preflight + route the task to the appropriate executor."""
         task_id = task["id"]
         title = task.get("description", task_id)
         session = self.session_store.get(task_id)
-        if session is None:
+        if session is None:  # pragma: no cover — _claim just inserted it
             logger.error("no session for claimed task %s — skipping", task_id)
             return
         sid = session.session_id
 
-        self.session_store.update_status(task_id, STATUS_RUNNING)
-        self.transcript_store.append(sid, "noop_dispatch", {"title": title})
+        # Preflight: budget, routing, ambiguity, sanity.
+        try:
+            pre: PreflightResult = run_preflight(
+                title=title,
+                tags=task.get("tags", []),
+                caller=self._preflight_caller,
+            )
+        except Exception as exc:
+            logger.exception("preflight crashed for %s: %s", task_id, exc)
+            self._mark_failed(session, task, f"preflight crashed: {exc}")
+            return
 
-        ok = self._complete_task(task_id)
-        if ok:
-            self.session_store.update_status(task_id, STATUS_COMPLETED)
-            self.transcript_store.append(sid, "noop_complete", {"title": title})
-            self._notify(f"✅ Agent worker (scaffolding): no-op completed task '{title}'")
-        else:
-            # Completion API failed. Roll the tag back to #agent so the task is
-            # re-pickable next cycle (rather than stranded at #agent-running).
-            rolled_back = self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG)
-            self.session_store.update_status(task_id, STATUS_FAILED)
-            self.transcript_store.append(
-                sid,
-                "complete_failed",
-                {"title": title, "tag_rolled_back": rolled_back},
+        self.transcript_store.append(sid, "preflight", {
+            "routing": pre.routing,
+            "routing_reason": pre.routing_reason,
+            "expected_output": pre.expected_output,
+            "ambiguity": pre.ambiguity.question if pre.ambiguity else None,
+            "sane": pre.sane,
+            "sane_reason": pre.sane_reason,
+            "budget": {
+                "wall_seconds": pre.budget.wall_seconds,
+                "max_tokens": pre.budget.max_tokens,
+                "max_dollars": pre.budget.max_dollars,
+            },
+        })
+
+        # Persist routing + budget onto the session row for the executor to see.
+        budget_json = {
+            "wall_seconds": pre.budget.wall_seconds,
+            "max_tokens": pre.budget.max_tokens,
+            "max_dollars": pre.budget.max_dollars,
+        }
+        self.session_store.set_routing_and_budget(
+            task_id,
+            routing=pre.routing,
+            budget=budget_json,
+            expected_output=pre.expected_output,
+        )
+        session = self.session_store.get(task_id)  # refresh
+
+        # Sanity gate.
+        if not pre.sane:
+            self._mark_failed(
+                session, task,
+                f"preflight flagged task as unsafe to run: {pre.sane_reason}",
             )
-            msg = (
-                f"⚠️ Agent worker (scaffolding): failed to mark task '{title}' complete; "
-                f"{'re-tagged for retry' if rolled_back else 'tag still at #agent-running — please re-tag manually'}"
+            return
+
+        # Ambiguity / ask-routing → block on user input (Issue F closes this loop).
+        question_parts: list[str] = []
+        if pre.ambiguity:
+            question_parts.append(pre.ambiguity.question)
+        if pre.routing == ROUTE_ASK:
+            question_parts.append(
+                "Should I run this on the local Gemma model or on Claude Opus? "
+                "Reply 'local' or 'claude'."
             )
-            self._notify(msg)
+        if question_parts:
+            self._mark_blocked(session, task, " ".join(question_parts))
+            return
+
+        # Local route: run the executor.
+        if pre.routing == ROUTE_LOCAL:
+            executor = self._get_local_executor()
+            try:
+                outcome = executor.execute(session, task)
+            except Exception as exc:
+                logger.exception("local executor crashed for %s: %s", task_id, exc)
+                self._mark_failed(session, task, f"executor crashed: {exc}")
+                return
+            self._handle_outcome(session, task, outcome)
+            return
+
+        # Claude route: deferred to Issue D. Roll the tag back and notify.
+        if pre.routing == ROUTE_CLAUDE:
+            self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG)
+            self.session_store.update_status(task_id, STATUS_BLOCKED)
+            self.transcript_store.append(sid, "claude_routing_deferred", {})
+            self._notify(
+                f"⏸ Agent worker: task '{title}' routed to Claude but Managed "
+                f"Agents driver isn't installed yet (Issue D). Task left at "
+                f"#{AGENT_TAG} for when D ships."
+            )
+            return
+
+        # Should not reach here — routing was validated in preflight.
+        self._mark_failed(session, task, f"unknown routing: {pre.routing}")
+
+    # ------------------------------------------------------------------
+    # Outcome handling (shared between fresh dispatch and sleep wake-up)
+    # ------------------------------------------------------------------
+
+    def _handle_outcome(self, session: Session, task: dict[str, Any], outcome) -> None:
+        title = task.get("description", session.task_id)
+        sid = session.session_id
+
+        if outcome.status == STATUS_COMPLETED:
+            self._complete_task(session.task_id)  # mark `done` in the vault
+            self._notify(self._completion_summary(session, task, outcome))
+            return
+
+        if outcome.status == STATUS_BUDGET_EXCEEDED:
+            self._swap_tag(session.task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
+            self._notify(
+                f"⚠️ Agent worker: task '{title}' hit its budget ({outcome.reason}). "
+                f"Transcript: data/agent_transcripts/{sid}.jsonl"
+            )
+            return
+
+        if outcome.status == STATUS_FAILED:
+            self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
+            self._notify(
+                f"⚠️ Agent worker: task '{title}' failed: {outcome.reason}. "
+                f"Transcript: data/agent_transcripts/{sid}.jsonl"
+            )
+            return
+
+        if outcome.status == STATUS_YIELDED:
+            # Session is sleeping. The transcript already records "sleep".
+            # No Telegram on yield — operator only hears about terminal states.
+            return
+
+        logger.warning("unhandled outcome status %r for %s", outcome.status, session.task_id)
+
+    def _completion_summary(self, session: Session, task: dict[str, Any], outcome) -> str:
+        refreshed = self.session_store.get(session.task_id) or session
+        tokens = (refreshed.total_input_tokens or 0) + (refreshed.total_output_tokens or 0)
+        wall = int(time.time()) - int(refreshed.started_at)
+        expected = refreshed.expected_output or "text"
+        title = task.get("description", session.task_id)
+        result_blurb = (outcome.final_text or "(no text response)").strip()
+        if len(result_blurb) > 600:
+            result_blurb = result_blurb[:600] + "…"
+        return (
+            f"✅ Agent worker: completed '{title}' "
+            f"({expected}) — {tokens:,} tokens, ${refreshed.total_dollars:.2f}, "
+            f"{wall}s wall.\n\n{result_blurb}"
+        )
+
+    def _mark_failed(self, session: Session, task: dict[str, Any], reason: str) -> None:
+        title = task.get("description", session.task_id)
+        self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
+        self.session_store.update_status(session.task_id, STATUS_FAILED)
+        self.transcript_store.append(session.session_id, "failed", {"reason": reason})
+        self._notify(f"⚠️ Agent worker: task '{title}' failed: {reason}")
+
+    def _mark_blocked(self, session: Session, task: dict[str, Any], question: str) -> None:
+        title = task.get("description", session.task_id)
+        self._swap_tag(session.task_id, RUNNING_TAG, BLOCKED_TAG)
+        self.session_store.update_status(session.task_id, STATUS_BLOCKED)
+        self.transcript_store.append(session.session_id, "blocked", {"question": question})
+        # In Issue F this becomes a reply-threaded message and the reply
+        # resumes the task. For now it's one-way.
+        self._notify(
+            f"⏸ Agent worker: task '{title}' needs your input.\n\n{question}\n\n"
+            f"(Re-tag the task with #{AGENT_TAG} once you've added the answer in the task title or context.)"
+        )
 
     def _notify(self, text: str) -> None:
         try:

--- a/config/settings.py
+++ b/config/settings.py
@@ -135,6 +135,12 @@ class Settings(BaseSettings):
         description="How long an #agent-blocked task waits for a Telegram reply "
                     "before being abandoned. Used by Issue F."
     )
+    agent_preflight_model: str = Field(
+        default="claude-haiku-4-5",
+        alias="LIFEOS_AGENT_PREFLIGHT_MODEL",
+        description="Anthropic model used for the Haiku preflight call that "
+                    "classifies #agent tasks (budget, routing, ambiguity, sanity)."
+    )
     local_llm_autostart: bool = Field(
         default=False,
         alias="LIFEOS_LOCAL_LLM_AUTOSTART",

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -174,6 +174,19 @@ curl -X POST http://localhost:8000/api/tasks \
 
 To pause new claims without stopping the worker, set `LIFEOS_AGENT_DAILY_CAP_DOLLARS=0` and restart — the worker keeps polling but refuses to claim anything new.
 
+### Security model
+
+By design, the local executor (Issue C) runs `Bash`, `Read`, `Write`, `Edit`, and `WebFetch` with **no sandbox** — the agent has the same filesystem and shell access as the operator. This is intentional (see [AGENTS.md § Design Principles](../../AGENTS.md)) and means an agent task can:
+
+- Read or modify any file the operator can read or modify
+- Execute arbitrary shell commands (including `rm`, `curl`, etc.)
+- Fetch any URL the host can reach (SSRF surface — an internal HTTP service accessible from the host is reachable to the agent)
+
+The Haiku preflight sanity-check is the only guard against destructive-shaped tasks. Operators should:
+- Audit `#agent`-tagged tasks before they reach the worker (look at your task list)
+- Keep the daily $-cap set so even a runaway loop can't burn unlimited budget
+- Treat agent-touchable secrets the same as operator-touchable secrets
+
 ---
 
 ## Troubleshooting

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -1,0 +1,239 @@
+"""Local executor agent-loop tests.
+
+The executor is driven against a fake LLM that returns scripted responses
+(text + tool_calls), so each test exercises one turn-shape: simple
+completion, multi-turn with tools, budget breach, sleep yield, error.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.local_executor import (
+    LocalExecutor,
+)
+from api.services.agent_worker.pricing import cost_for
+from api.services.agent_worker.session_store import (
+    STATUS_BUDGET_EXCEEDED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_YIELDED,
+    SessionStore,
+)
+from api.services.agent_worker.tools import ToolRegistry
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+
+
+@dataclass
+class _FakeResponse:
+    text: str = ""
+    usage: _FakeUsage = None
+    tool_calls: list = None
+    model: str = "local"
+    finish_reason: str = ""
+
+
+class _ScriptedLLM:
+    """A fake LLM that returns successive scripted responses on each call."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def create(self, messages, *, system=None, max_tokens, tools=None, temperature=None):
+        self.calls.append({
+            "messages": messages, "system": system, "tools": tools,
+            "max_tokens": max_tokens,
+        })
+        if not self._responses:
+            raise AssertionError("LLM was called more times than scripted")
+        return self._responses.pop(0)
+
+
+class _FakeMCPServer:
+    tools: list[dict] = []
+    def _call_api(self, name, args): return {}
+    def _format_response(self, name, data): return ""
+
+
+@pytest.fixture
+def fake_session(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    store.create(
+        task_id="t1",
+        routing="local",
+        budget={"wall_seconds": 3600, "max_tokens": 5_000, "max_dollars": 5.0},
+        expected_output="text",
+    )
+    session = store.get("t1")
+    return store, session
+
+
+def _make_executor(session_store, transcript_dir, llm):
+    return LocalExecutor(
+        session_store=session_store,
+        transcript_store=TranscriptStore(transcripts_dir=transcript_dir),
+        tool_registry=ToolRegistry(lifeos_mcp_server=_FakeMCPServer()),
+        llm_client=llm,
+        model_name="local",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_executor_completes_when_model_returns_text_only(tmp_path: Path, fake_session):
+    store, session = fake_session
+    llm = _ScriptedLLM([
+        _FakeResponse(text="The date is May 26, 2026.", usage=_FakeUsage(50, 20)),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    outcome = executor.execute(session, {"id": "t1", "description": "what's the date"})
+    assert outcome.status == STATUS_COMPLETED
+    assert "May 26" in outcome.final_text
+    # One LLM call only — no tools required.
+    assert len(llm.calls) == 1
+    refreshed = store.get("t1")
+    assert refreshed.total_input_tokens == 50
+    assert refreshed.total_output_tokens == 20
+
+
+@pytest.mark.unit
+def test_executor_runs_tool_then_completes(tmp_path: Path, fake_session):
+    store, session = fake_session
+    # First response: agent calls Bash. Second response: agent finalizes.
+    llm = _ScriptedLLM([
+        _FakeResponse(
+            text="",
+            usage=_FakeUsage(40, 10),
+            tool_calls=[{
+                "id": "call_1",
+                "name": "Bash",
+                "input": {"command": "echo hi"},
+            }],
+        ),
+        _FakeResponse(text="Output was 'hi'.", usage=_FakeUsage(30, 15)),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    outcome = executor.execute(session, {"id": "t1", "description": "echo hi"})
+    assert outcome.status == STATUS_COMPLETED
+    # Second call should include the tool result as a user turn.
+    second_msgs = llm.calls[1]["messages"]
+    assert any(
+        isinstance(m["content"], list)
+        and m["content"]
+        and isinstance(m["content"][0], dict)
+        and m["content"][0].get("type") == "tool_result"
+        for m in second_msgs
+    )
+
+
+@pytest.mark.unit
+def test_executor_yields_on_sleep_tool(tmp_path: Path, fake_session):
+    store, session = fake_session
+    llm = _ScriptedLLM([
+        _FakeResponse(
+            text="",
+            usage=_FakeUsage(20, 10),
+            tool_calls=[{"id": "c1", "name": "sleep", "input": {"seconds": 5, "reason": "wait"}}],
+        ),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    outcome = executor.execute(session, {"id": "t1", "description": "wait for it"})
+    assert outcome.status == STATUS_YIELDED
+    assert outcome.wake_at is not None
+    # A sleeps row should exist for this session.
+    assert session.session_id in store.due_sleeps(now_ts=outcome.wake_at + 1)
+
+
+@pytest.mark.unit
+def test_executor_kills_loop_on_token_budget(tmp_path: Path):
+    """One call exceeds the budget; the next loop iteration's check kills us."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    store.create(
+        task_id="t1",
+        routing="local",
+        budget={"wall_seconds": 3600, "max_tokens": 50, "max_dollars": 5.0},
+        expected_output="text",
+    )
+    session = store.get("t1")
+    # First call spends 60 tokens — over the 50-token cap. The top-of-loop
+    # check kills before the second call is attempted.
+    llm = _ScriptedLLM([
+        _FakeResponse(
+            text="",
+            usage=_FakeUsage(40, 20),
+            tool_calls=[{"id": "c1", "name": "Bash", "input": {"command": "echo a"}}],
+        ),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    outcome = executor.execute(session, {"id": "t1", "description": "loop"})
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "max_tokens" in outcome.reason
+    assert len(llm.calls) == 1
+
+
+@pytest.mark.unit
+def test_executor_marks_failed_on_llm_exception(tmp_path: Path, fake_session):
+    store, session = fake_session
+
+    class _Boom:
+        def create(self, **kw):
+            raise RuntimeError("llama-server unreachable")
+
+    executor = _make_executor(store, tmp_path / "transcripts", _Boom())
+    outcome = executor.execute(session, {"id": "t1", "description": "x"})
+    assert outcome.status == STATUS_FAILED
+    assert "llama-server unreachable" in outcome.reason
+    assert store.get("t1").status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_executor_records_local_spend_is_zero_dollars(tmp_path: Path, fake_session):
+    store, session = fake_session
+    llm = _ScriptedLLM([
+        _FakeResponse(text="done.", usage=_FakeUsage(1234, 567)),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    executor.execute(session, {"id": "t1", "description": "x"})
+    refreshed = store.get("t1")
+    assert refreshed.total_input_tokens == 1234
+    assert refreshed.total_output_tokens == 567
+    # Local model is $0/token — total_dollars stays 0 even with many tokens.
+    assert refreshed.total_dollars == pytest.approx(0.0)
+
+
+@pytest.mark.unit
+def test_pricing_table_local_is_free():
+    assert cost_for("local", 1_000_000, 1_000_000) == pytest.approx(0.0)
+
+
+@pytest.mark.unit
+def test_pricing_table_opus_uses_correct_rates():
+    # 1k input + 1k output of Opus = $0.015 + $0.075 = $0.09
+    cost = cost_for("claude-opus-4-7", 1000, 1000)
+    assert cost == pytest.approx(0.015 + 0.075)
+
+
+@pytest.mark.unit
+def test_pricing_unknown_model_falls_through_to_opus_rate():
+    """Conservative: unknown model = highest plausible price (so budgets stay
+    enforced rather than silently suppressed by a typo)."""
+    unknown = cost_for("typoed-model", 1000, 1000)
+    opus = cost_for("claude-opus-4-7", 1000, 1000)
+    assert unknown == pytest.approx(opus)

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -219,6 +219,85 @@ def test_executor_records_local_spend_is_zero_dollars(tmp_path: Path, fake_sessi
 
 
 @pytest.mark.unit
+def test_executor_normalizes_openai_tool_calls(tmp_path: Path, fake_session):
+    """LocalLLMClient emits OpenAI-format tool_calls; the executor must convert.
+
+    Without normalization, the dispatcher receives `name=""` and routes to
+    "unknown tool", breaking the agent loop on every real tool call.
+    """
+    store, session = fake_session
+    openai_shape_call = {
+        "id": "call_abc",
+        "type": "function",
+        "function": {
+            "name": "Bash",
+            "arguments": '{"command": "echo normalized"}',
+        },
+    }
+    llm = _ScriptedLLM([
+        _FakeResponse(text="", usage=_FakeUsage(20, 10), tool_calls=[openai_shape_call]),
+        _FakeResponse(text="ok", usage=_FakeUsage(5, 5)),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    outcome = executor.execute(session, {"id": "t1", "description": "x"})
+    assert outcome.status == STATUS_COMPLETED
+    # The dispatcher should have received the right tool name + args.
+    second_msgs = llm.calls[1]["messages"]
+    tool_result = next(
+        b for m in second_msgs if isinstance(m["content"], list)
+        for b in m["content"]
+        if isinstance(b, dict) and b.get("type") == "tool_result"
+    )
+    assert "normalized" in tool_result["content"]
+
+
+@pytest.mark.unit
+def test_executor_tracks_active_seconds_not_wall(tmp_path: Path, fake_session):
+    """A completed turn should bump total_active_seconds — used for wall budget."""
+    store, session = fake_session
+    llm = _ScriptedLLM([
+        _FakeResponse(text="done.", usage=_FakeUsage(10, 5)),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    executor.execute(session, {"id": "t1", "description": "x"})
+    refreshed = store.get("t1")
+    assert refreshed.total_active_seconds > 0
+
+
+@pytest.mark.unit
+def test_executor_truncates_persisted_tool_use_to_match_dispatch(tmp_path: Path):
+    """If MAX_TOOL_CALLS_PER_TURN truncates dispatch, the persisted assistant
+    turn must drop the surplus tool_use blocks so the next turn has 1:1
+    tool_use ↔ tool_result counts."""
+    from api.services.agent_worker.local_executor import MAX_TOOL_CALLS_PER_TURN
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    store.create(task_id="t1", routing="local",
+                 budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+                 expected_output="text")
+    session = store.get("t1")
+    too_many = [
+        {"id": f"c{i}", "name": "Bash", "input": {"command": "true"}}
+        for i in range(MAX_TOOL_CALLS_PER_TURN + 5)
+    ]
+    llm = _ScriptedLLM([
+        _FakeResponse(text="", usage=_FakeUsage(5, 5), tool_calls=too_many),
+        _FakeResponse(text="ok", usage=_FakeUsage(5, 5)),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    executor.execute(session, {"id": "t1", "description": "x"})
+    # Second LLM call's messages must have matching tool_use / tool_result counts.
+    second_msgs = llm.calls[1]["messages"]
+    assistant_msg = next(m for m in second_msgs if m["role"] == "assistant")
+    user_msg = next(m for m in second_msgs if m["role"] == "user"
+                    and isinstance(m["content"], list)
+                    and m["content"] and isinstance(m["content"][0], dict)
+                    and m["content"][0].get("type") == "tool_result")
+    use_count = sum(1 for b in assistant_msg["content"] if isinstance(b, dict) and b.get("type") == "tool_use")
+    result_count = len(user_msg["content"])
+    assert use_count == result_count == MAX_TOOL_CALLS_PER_TURN
+
+
+@pytest.mark.unit
 def test_pricing_table_local_is_free():
     assert cost_for("local", 1_000_000, 1_000_000) == pytest.approx(0.0)
 

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -1,39 +1,50 @@
 """Worker poll-loop integration tests.
 
 Drives the worker against an in-process fake HTTP server (httpx MockTransport)
-so we exercise the full claim → dispatch → complete → notify path without
-spinning up FastAPI or hitting the real task store.
+and a stub preflight caller. Each test exercises one outcome of the dispatch
+machine: local completion, ambiguity → blocked, sanity → failed, daily cap
+pause, sleeps wake-up.
 """
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
 import pytest
 
+from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
     STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_YIELDED,
     SessionStore,
 )
 from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
-from api.services.agent_worker.worker import AGENT_TAG, RUNNING_TAG, Worker
+from api.services.agent_worker.worker import (
+    AGENT_TAG,
+    BLOCKED_TAG,
+    BUDGET_EXCEEDED_TAG,
+    FAILED_TAG,
+    RUNNING_TAG,
+    Worker,
+)
 
+
+# ---------------------------------------------------------------------------
+# Fake API
+# ---------------------------------------------------------------------------
 
 class FakeApi:
-    """Minimal in-memory stand-in for /api/tasks.
+    """In-memory stand-in for /api/tasks."""
 
-    Exposes only what the worker calls: list, swap-tag, complete. Tracks
-    state so the test can assert tag transitions and completion.
-    """
-
-    def __init__(self, tasks: list[dict] | None = None):
-        # Each task is {id, description, status, tags}
-        self.tasks: dict[str, dict] = {t["id"]: t for t in (tasks or [])}
-        self.calls: list[tuple[str, str]] = []  # (method, path) for assertions
+    def __init__(self, tasks=None):
+        self.tasks = {t["id"]: t for t in (tasks or [])}
 
     def handler(self, request: httpx.Request) -> httpx.Response:
-        self.calls.append((request.method, request.url.path))
         if request.method == "GET" and request.url.path == "/api/tasks":
             tag = request.url.params.get("tag")
             matched = [
@@ -62,19 +73,18 @@ class FakeApi:
             task["status"] = "done"
             return httpx.Response(200, json=task)
 
+        if request.method == "GET" and "/api/tasks/" in request.url.path:
+            task_id = request.url.path.split("/")[-1]
+            task = self.tasks.get(task_id)
+            if not task:
+                return httpx.Response(404)
+            return httpx.Response(200, json=task)
+
         return httpx.Response(404)
 
 
-@pytest.fixture
-def fake_api() -> FakeApi:
-    return FakeApi(tasks=[
-        {"id": "task-1", "description": "do a thing", "status": "todo", "tags": ["agent"]},
-    ])
-
-
-@pytest.fixture
-def worker(tmp_path: Path, fake_api: FakeApi):
-    transport = httpx.MockTransport(fake_api.handler)
+def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_executor):
+    transport = httpx.MockTransport(api.handler)
     client = httpx.Client(transport=transport, base_url="http://api")
     sent: list[str] = []
     w = Worker(
@@ -85,69 +95,199 @@ def worker(tmp_path: Path, fake_api: FakeApi):
         poll_seconds=0.01,
         telegram_send=lambda text, chat_id=None: sent.append(text) or True,
         http_client=client,
+        preflight_caller=preflight_caller,
+        local_executor=local_executor,
     )
-    w._sent_telegram = sent  # type: ignore[attr-defined] — for test assertions
+    w._sent_telegram = sent  # type: ignore[attr-defined]
     return w
 
 
-@pytest.mark.unit
-def test_worker_claims_and_completes_agent_task(worker: Worker, fake_api: FakeApi):
-    handled = worker.tick()
-    assert handled == 1
-
-    # Tag transitioned through #agent-running and the task is marked done.
-    task = fake_api.tasks["task-1"]
-    assert task["status"] == "done"
-    assert AGENT_TAG not in task["tags"]
-    # In Issue B the no-op dispatcher leaves the tag at #agent-running; this
-    # is the visible signal that the worker finished without real execution.
-    assert RUNNING_TAG in task["tags"]
-
-    # Session row + transcript both present.
-    sess = worker.session_store.get("task-1")
-    assert sess is not None
-    assert sess.status == STATUS_COMPLETED
-    events = [e["kind"] for e in worker.transcript_store.read(sess.session_id)]
-    assert events == ["claim", "noop_dispatch", "noop_complete"]
-
-    # Telegram notification sent.
-    sent = worker._sent_telegram  # type: ignore[attr-defined]
-    assert len(sent) == 1
-    assert "no-op completed" in sent[0]
+def _golden_preflight(routing="local", ambiguity=None, sane=True, sane_reason=""):
+    payload = {
+        "budget": {"wall_seconds": 3600, "max_tokens": 5000, "max_dollars": 5.0},
+        "routing": routing,
+        "routing_reason": f"test stub: routing={routing}",
+        "expected_output": "text",
+        "ambiguity": ambiguity,
+        "sane": sane,
+        "sane_reason": sane_reason,
+    }
+    return lambda prompt: json.dumps(payload)
 
 
-@pytest.mark.unit
-def test_worker_skips_already_claimed_tasks(worker: Worker, fake_api: FakeApi):
-    # First tick claims and completes.
-    worker.tick()
-    # Add the same task back with #agent tag (simulating a re-tag) and ensure
-    # the worker doesn't try to claim it again — its session row is still in
-    # the DB.
-    fake_api.tasks["task-1"]["tags"] = ["agent"]
-    fake_api.tasks["task-1"]["status"] = "todo"
+@dataclass
+class _StubExecutor:
+    """Pretends to be a LocalExecutor — returns a canned outcome."""
 
-    handled = worker.tick()
-    assert handled == 0  # session already exists for task-1
-    # Task wasn't re-claimed; tag stays as the operator left it
-    assert "agent" in fake_api.tasks["task-1"]["tags"]
+    outcome: ExecutorOutcome
+    calls: list = None
 
+    def __post_init__(self):
+        self.calls = []
+
+    def execute(self, session, task):
+        self.calls.append((session.task_id, task.get("description")))
+        return self.outcome
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 @pytest.mark.unit
-def test_worker_loses_race_when_swap_tag_fails(worker: Worker, fake_api: FakeApi):
-    """If another worker (or operator) removed the #agent tag between list and swap,
-    swap_tag returns swapped=false. The worker should skip without creating a session."""
-    fake_api.tasks["task-1"]["tags"] = ["something-else"]  # no longer #agent
-
-    handled = worker.tick()
-    assert handled == 0
-    assert worker.session_store.get("task-1") is None
+def test_dispatch_local_completes_and_marks_task_done(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "hello there", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="hi back"))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    assert w.tick() == 1
+    assert api.tasks["t1"]["status"] == "done"
+    assert executor.calls == [("t1", "hello there")]
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent and "completed 'hello there'" in sent[0]
+    assert "hi back" in sent[0]
 
 
 @pytest.mark.unit
-def test_worker_pauses_at_daily_cap(tmp_path: Path, fake_api: FakeApi):
-    """Cap of 0 should pause new claims with no other state needed."""
-    transport = httpx.MockTransport(fake_api.handler)
+def test_ambiguous_title_lands_in_blocked(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run"))
+    preflight = _golden_preflight(
+        routing="local",
+        ambiguity={"question": "Which John — John Doe or John Smith?"},
+    )
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    # Executor should not have been invoked.
+    assert executor.calls == []
+    # Task gets the blocked tag.
+    assert BLOCKED_TAG in api.tasks["t1"]["tags"]
+    assert AGENT_TAG not in api.tasks["t1"]["tags"]
+    # Session status reflects blocked.
+    assert w.session_store.get("t1").status == STATUS_BLOCKED
+    # Telegram message includes the question.
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert any("Which John" in s for s in sent)
+
+
+@pytest.mark.unit
+def test_routing_ask_lands_in_blocked_with_model_question(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "research dolphins", "status": "todo", "tags": ["agent"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    preflight = _golden_preflight(routing="ask")
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    assert executor.calls == []
+    assert BLOCKED_TAG in api.tasks["t1"]["tags"]
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert any("local" in s.lower() and "claude" in s.lower() for s in sent)
+
+
+@pytest.mark.unit
+def test_insane_task_lands_in_failed(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "rm -rf /", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    preflight = _golden_preflight(routing="local", sane=False, sane_reason="destructive")
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    assert executor.calls == []
+    assert FAILED_TAG in api.tasks["t1"]["tags"]
+    assert w.session_store.get("t1").status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_executor_budget_exceeded_sets_budget_exceeded_tag(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "long task", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status="budget_exceeded", reason="budget exceeded (max_tokens)",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    assert BUDGET_EXCEEDED_TAG in api.tasks["t1"]["tags"]
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert any("hit its budget" in s for s in sent)
+
+
+@pytest.mark.unit
+def test_claude_routing_defers_to_issue_d_and_rolls_tag_back(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "summarize", "status": "todo", "tags": ["agent"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    preflight = _golden_preflight(routing="claude")
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    # Claude path isn't built yet — tag rolls back to #agent for retry once Issue D ships.
+    assert executor.calls == []
+    assert AGENT_TAG in api.tasks["t1"]["tags"]
+    assert RUNNING_TAG not in api.tasks["t1"]["tags"]
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert any("Managed Agents" in s for s in sent)
+
+
+@pytest.mark.unit
+def test_sleep_yield_does_not_mark_terminal(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "wait for it", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_YIELDED, wake_at=99999999999,  # far future
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+
+    # Task should remain at #agent-running while the session sleeps; no Telegram on yield.
+    assert RUNNING_TAG in api.tasks["t1"]["tags"]
+    assert api.tasks["t1"]["status"] == "todo"
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent == []
+
+
+@pytest.mark.unit
+def test_worker_skips_already_claimed_tasks(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "hi", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    # Re-tag back to #agent and verify the worker doesn't claim it again.
+    api.tasks["t1"]["tags"] = ["agent", "local"]
+    api.tasks["t1"]["status"] = "todo"
+    assert w.tick() == 0
+    # Executor was called exactly once across both ticks.
+    assert len(executor.calls) == 1
+
+
+@pytest.mark.unit
+def test_worker_pauses_at_daily_cap(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "x", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    transport = httpx.MockTransport(api.handler)
     client = httpx.Client(transport=transport, base_url="http://api")
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     w = Worker(
         api_base="http://api",
         session_store=SessionStore(db_path=tmp_path / "sessions.db"),
@@ -156,105 +296,8 @@ def test_worker_pauses_at_daily_cap(tmp_path: Path, fake_api: FakeApi):
         poll_seconds=0.01,
         telegram_send=lambda *a, **kw: True,
         http_client=client,
+        preflight_caller=_golden_preflight(routing="local"),
+        local_executor=executor,
     )
-
-    handled = w.tick()
-    assert handled == 0
-    assert w.session_store.get("task-1") is None
-
-
-@pytest.mark.unit
-def test_worker_rolls_back_tag_on_complete_failure(tmp_path: Path):
-    """If POST /complete fails, the worker should roll #agent-running → #agent so the next tick can retry."""
-    calls = {"complete_calls": 0}
-
-    class FailingApi(FakeApi):
-        def handler(self, request: httpx.Request) -> httpx.Response:
-            if request.method == "PUT" and request.url.path.endswith("/complete"):
-                calls["complete_calls"] += 1
-                return httpx.Response(503)
-            return super().handler(request)
-
-    api = FailingApi(tasks=[{"id": "task-1", "description": "x", "status": "todo", "tags": ["agent"]}])
-    transport = httpx.MockTransport(api.handler)
-    client = httpx.Client(transport=transport, base_url="http://api")
-    w = Worker(
-        api_base="http://api",
-        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
-        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
-        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
-        poll_seconds=0.01,
-        telegram_send=lambda *a, **kw: True,
-        http_client=client,
-    )
-
-    w.tick()
-    # Tag should be rolled back to #agent (so a future tick can re-attempt).
-    assert "agent" in api.tasks["task-1"]["tags"]
-    assert "agent-running" not in api.tasks["task-1"]["tags"]
-    # Session is marked failed so we don't try to re-resume on startup forever.
-    from api.services.agent_worker.session_store import STATUS_FAILED
-    assert w.session_store.get("task-1").status == STATUS_FAILED
-
-
-@pytest.mark.unit
-def test_resume_pending_completes_orphaned_session(tmp_path: Path):
-    """On restart, a session left in STATUS_RUNNING should be finalized."""
-    api = FakeApi(tasks=[{"id": "task-1", "description": "x", "status": "todo", "tags": ["agent-running"]}])
-    transport = httpx.MockTransport(api.handler)
-    client = httpx.Client(transport=transport, base_url="http://api")
-    store = SessionStore(db_path=tmp_path / "sessions.db")
-    # Simulate a crash mid-dispatch: session row exists with STATUS_RUNNING.
-    from api.services.agent_worker.session_store import STATUS_RUNNING
-    store.create(task_id="task-1", status=STATUS_RUNNING)
-
-    sent: list[str] = []
-    w = Worker(
-        api_base="http://api",
-        session_store=store,
-        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
-        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
-        poll_seconds=0.01,
-        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
-        http_client=client,
-    )
-    recovered = w.resume_pending()
-    assert recovered == 1
-    assert api.tasks["task-1"]["status"] == "done"
-    assert w.session_store.get("task-1").status == STATUS_COMPLETED
-    assert any("recovered orphaned task" in s for s in sent)
-
-
-@pytest.mark.unit
-def test_resume_pending_rolls_tag_back_when_completion_fails(tmp_path: Path):
-    """If completion still fails on resume, we mark FAILED and roll the tag back."""
-
-    class FailingApi(FakeApi):
-        def handler(self, request: httpx.Request) -> httpx.Response:
-            if request.method == "PUT" and request.url.path.endswith("/complete"):
-                return httpx.Response(503)
-            return super().handler(request)
-
-    api = FailingApi(tasks=[{"id": "task-1", "description": "x", "status": "todo", "tags": ["agent-running"]}])
-    transport = httpx.MockTransport(api.handler)
-    client = httpx.Client(transport=transport, base_url="http://api")
-    store = SessionStore(db_path=tmp_path / "sessions.db")
-    from api.services.agent_worker.session_store import STATUS_FAILED, STATUS_RUNNING
-    store.create(task_id="task-1", status=STATUS_RUNNING)
-
-    sent: list[str] = []
-    w = Worker(
-        api_base="http://api",
-        session_store=store,
-        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
-        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
-        poll_seconds=0.01,
-        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
-        http_client=client,
-    )
-    recovered = w.resume_pending()
-    assert recovered == 0
-    assert w.session_store.get("task-1").status == STATUS_FAILED
-    assert "agent" in api.tasks["task-1"]["tags"]
-    assert "agent-running" not in api.tasks["task-1"]["tags"]
-    assert any("could not finalize" in s for s in sent)
+    assert w.tick() == 0
+    assert executor.calls == []

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -17,6 +17,7 @@ import pytest
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
+    STATUS_BUDGET_EXCEEDED,
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_YIELDED,
@@ -213,7 +214,7 @@ def test_executor_budget_exceeded_sets_budget_exceeded_tag(tmp_path: Path):
         {"id": "t1", "description": "long task", "status": "todo", "tags": ["agent", "local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
-        status="budget_exceeded", reason="budget exceeded (max_tokens)",
+        status=STATUS_BUDGET_EXCEEDED, reason="budget exceeded (max_tokens)",
     ))
     w = _make_worker(tmp_path, api,
                      preflight_caller=_golden_preflight(routing="local"),
@@ -225,7 +226,9 @@ def test_executor_budget_exceeded_sets_budget_exceeded_tag(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_claude_routing_defers_to_issue_d_and_rolls_tag_back(tmp_path: Path):
+def test_claude_routing_defers_to_issue_d_with_blocked_tag(tmp_path: Path):
+    """Claude-routed tasks land in #agent-blocked (same as other parked
+    states) until Issue D installs the managed-agents driver."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "summarize", "status": "todo", "tags": ["agent"]},
     ])
@@ -234,9 +237,9 @@ def test_claude_routing_defers_to_issue_d_and_rolls_tag_back(tmp_path: Path):
     w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
     w.tick()
 
-    # Claude path isn't built yet — tag rolls back to #agent for retry once Issue D ships.
     assert executor.calls == []
-    assert AGENT_TAG in api.tasks["t1"]["tags"]
+    assert BLOCKED_TAG in api.tasks["t1"]["tags"]
+    assert AGENT_TAG not in api.tasks["t1"]["tags"]
     assert RUNNING_TAG not in api.tasks["t1"]["tags"]
     sent = w._sent_telegram  # type: ignore[attr-defined]
     assert any("Managed Agents" in s for s in sent)

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -1,0 +1,142 @@
+"""Preflight unit tests — parsing, defaults, error handling.
+
+These exercise the parser and the public `run_preflight` entry point against
+canned LLM replies. The real Haiku call is mocked via the `caller` parameter.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from api.services.agent_worker import preflight as pf
+
+
+def _stub(reply: str):
+    """Build a caller that always returns `reply`."""
+    return lambda prompt: reply
+
+
+def _golden_reply(**overrides) -> str:
+    base = {
+        "budget": {"wall_seconds": 14400, "max_tokens": 500000, "max_dollars": 5.0},
+        "routing": "local",
+        "routing_reason": "#local tag present",
+        "expected_output": "text",
+        "ambiguity": None,
+        "sane": True,
+        "sane_reason": "",
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+@pytest.mark.unit
+def test_run_preflight_returns_parsed_result():
+    result = pf.run_preflight(title="echo the date", tags=["agent", "local"], caller=_stub(_golden_reply()))
+    assert result.sane is True
+    assert result.routing == pf.ROUTE_LOCAL
+    assert result.budget.max_dollars == pytest.approx(5.0)
+    assert result.expected_output == "text"
+    assert result.ambiguity is None
+
+
+@pytest.mark.unit
+def test_preflight_routing_claude():
+    reply = _golden_reply(routing="claude", routing_reason="title says 'use claude opus'")
+    result = pf.run_preflight(title="use claude opus to summarize", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_CLAUDE
+
+
+@pytest.mark.unit
+def test_preflight_routing_ask_when_unspecified():
+    reply = _golden_reply(routing="ask", routing_reason="no tag and no title cue")
+    result = pf.run_preflight(title="research dolphins", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_ASK
+
+
+@pytest.mark.unit
+def test_preflight_ambiguity_populated():
+    reply = _golden_reply(
+        ambiguity={"question": "Which John — John Doe or John Smith?"},
+    )
+    result = pf.run_preflight(title="reply to John", tags=["agent", "local"], caller=_stub(reply))
+    assert result.ambiguity is not None
+    assert "John" in result.ambiguity.question
+
+
+@pytest.mark.unit
+def test_preflight_sanity_failure_passed_through():
+    reply = _golden_reply(sane=False, sane_reason="destructive: 'rm -rf /'")
+    result = pf.run_preflight(title="rm -rf /", tags=["agent"], caller=_stub(reply))
+    assert result.sane is False
+    assert "destructive" in result.sane_reason
+
+
+@pytest.mark.unit
+def test_preflight_handles_json_in_code_fence():
+    """Some models like to wrap output in ```json fences."""
+    inner = _golden_reply()
+    reply = f"Here you go:\n```json\n{inner}\n```\n"
+    result = pf.run_preflight(title="something", tags=["agent", "local"], caller=_stub(reply))
+    assert result.sane is True
+    assert result.routing == pf.ROUTE_LOCAL
+
+
+@pytest.mark.unit
+def test_preflight_unparseable_reply_defaults_to_unsafe_ask():
+    result = pf.run_preflight(title="x", tags=["agent"], caller=_stub("totally not json"))
+    assert result.sane is False
+    assert result.routing == pf.ROUTE_ASK
+
+
+@pytest.mark.unit
+def test_preflight_caller_exception_defaults_to_unsafe_ask():
+    def boom(prompt):
+        raise RuntimeError("haiku is down")
+
+    result = pf.run_preflight(title="x", tags=["agent"], caller=boom)
+    assert result.sane is False
+    assert "haiku is down" in result.sane_reason
+    assert result.routing == pf.ROUTE_ASK
+
+
+@pytest.mark.unit
+def test_preflight_empty_title_short_circuits_without_llm_call():
+    """An empty title is always unsafe — don't bother spending a Haiku call."""
+    calls = []
+
+    def fail(prompt):
+        calls.append(prompt)
+        raise AssertionError("LLM should not have been called for empty title")
+
+    result = pf.run_preflight(title="   ", tags=["agent"], caller=fail)
+    assert result.sane is False
+    assert calls == []
+
+
+@pytest.mark.unit
+def test_preflight_invalid_routing_value_falls_back_to_ask():
+    reply = _golden_reply(routing="invalid-value")
+    result = pf.run_preflight(title="x", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_ASK
+
+
+@pytest.mark.unit
+def test_preflight_invalid_expected_output_falls_back_to_text():
+    reply = _golden_reply(expected_output="hologram")
+    result = pf.run_preflight(title="x", tags=["agent", "local"], caller=_stub(reply))
+    assert result.expected_output == "text"
+
+
+@pytest.mark.unit
+def test_preflight_budget_partial_uses_defaults():
+    """Missing budget fields fall back to settings defaults — not zero."""
+    reply = json.dumps({"budget": {"wall_seconds": 60}, "routing": "local",
+                        "routing_reason": "x", "expected_output": "text",
+                        "ambiguity": None, "sane": True, "sane_reason": ""})
+    result = pf.run_preflight(title="x", tags=["agent", "local"], caller=_stub(reply))
+    assert result.budget.wall_seconds == 60
+    # max_tokens / max_dollars come from defaults — strictly positive
+    assert result.budget.max_tokens > 0
+    assert result.budget.max_dollars > 0

--- a/tests/test_agent_worker_tools.py
+++ b/tests/test_agent_worker_tools.py
@@ -1,0 +1,194 @@
+"""Standard-tool handler tests for the local executor.
+
+LifeOS MCP proxying is covered indirectly via the registry; we don't spin up
+the full MCP catalog here. The standard tools (Read/Write/Edit/Bash/WebFetch)
+have well-defined inputs and are exercised directly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.tools import (
+    STANDARD_HANDLERS,
+    ToolRegistry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Read / Write / Edit
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_read_returns_contents(tmp_path: Path):
+    p = tmp_path / "hi.txt"
+    p.write_text("hello", encoding="utf-8")
+    r = STANDARD_HANDLERS["Read"]({"file_path": str(p)})
+    assert not r.is_error
+    assert r.output == "hello"
+
+
+@pytest.mark.unit
+def test_read_missing_file(tmp_path: Path):
+    r = STANDARD_HANDLERS["Read"]({"file_path": str(tmp_path / "nope.txt")})
+    assert r.is_error
+    assert "not found" in r.output
+
+
+@pytest.mark.unit
+def test_read_requires_path():
+    r = STANDARD_HANDLERS["Read"]({})
+    assert r.is_error
+
+
+@pytest.mark.unit
+def test_write_creates_parent_dirs(tmp_path: Path):
+    target = tmp_path / "sub" / "deep" / "out.txt"
+    r = STANDARD_HANDLERS["Write"]({"file_path": str(target), "content": "bye"})
+    assert not r.is_error
+    assert target.read_text() == "bye"
+
+
+@pytest.mark.unit
+def test_edit_replaces_unique_occurrence(tmp_path: Path):
+    p = tmp_path / "f.txt"
+    p.write_text("alpha beta gamma", encoding="utf-8")
+    r = STANDARD_HANDLERS["Edit"]({
+        "file_path": str(p), "old_string": "beta", "new_string": "BETA",
+    })
+    assert not r.is_error
+    assert p.read_text() == "alpha BETA gamma"
+
+
+@pytest.mark.unit
+def test_edit_requires_unique_match(tmp_path: Path):
+    p = tmp_path / "f.txt"
+    p.write_text("dup dup", encoding="utf-8")
+    r = STANDARD_HANDLERS["Edit"]({
+        "file_path": str(p), "old_string": "dup", "new_string": "x",
+    })
+    assert r.is_error
+    assert "occurs 2 times" in r.output
+
+
+@pytest.mark.unit
+def test_edit_old_string_not_found(tmp_path: Path):
+    p = tmp_path / "f.txt"
+    p.write_text("hello world", encoding="utf-8")
+    r = STANDARD_HANDLERS["Edit"]({
+        "file_path": str(p), "old_string": "nope", "new_string": "x",
+    })
+    assert r.is_error
+
+
+# ---------------------------------------------------------------------------
+# Bash
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_bash_captures_stdout():
+    r = STANDARD_HANDLERS["Bash"]({"command": "echo hi"})
+    assert not r.is_error
+    assert "hi" in r.output
+
+
+@pytest.mark.unit
+def test_bash_returns_error_on_nonzero():
+    r = STANDARD_HANDLERS["Bash"]({"command": "exit 7"})
+    assert r.is_error
+    assert "exit 7" in r.output
+
+
+@pytest.mark.unit
+def test_bash_timeout():
+    # Use a short timeout — we don't actually want to sleep 60s in tests.
+    r = STANDARD_HANDLERS["Bash"]({"command": "sleep 3", "timeout_seconds": 1})
+    assert r.is_error
+    assert "timed out" in r.output
+
+
+# ---------------------------------------------------------------------------
+# WebSearch stub
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_websearch_returns_not_configured():
+    r = STANDARD_HANDLERS["WebSearch"]({"query": "anything"})
+    assert r.is_error
+    assert "not configured" in r.output
+
+
+# ---------------------------------------------------------------------------
+# Registry / dispatch
+# ---------------------------------------------------------------------------
+
+class _FakeMCPServer:
+    """Minimal stand-in for LifeOSMCPServer — exposes one fake LifeOS tool."""
+
+    def __init__(self, response):
+        self.tools = [
+            {
+                "name": "lifeos_fake",
+                "description": "test tool",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+        ]
+        self._response = response
+
+    def _call_api(self, name, arguments):
+        return self._response
+
+    def _format_response(self, name, data):
+        return f"formatted: {data}"
+
+
+@pytest.mark.unit
+def test_registry_dispatches_to_standard_handler(tmp_path: Path):
+    reg = ToolRegistry(lifeos_mcp_server=_FakeMCPServer({"ok": True}))
+    r = reg.dispatch("Bash", {"command": "echo from-registry"})
+    assert not r.is_error
+    assert "from-registry" in r.output
+
+
+@pytest.mark.unit
+def test_registry_proxies_lifeos_tool():
+    reg = ToolRegistry(lifeos_mcp_server=_FakeMCPServer({"hits": 3}))
+    r = reg.dispatch("lifeos_fake", {})
+    assert not r.is_error
+    assert "hits" in r.output
+
+
+@pytest.mark.unit
+def test_registry_lifeos_tool_error_surfaced():
+    reg = ToolRegistry(lifeos_mcp_server=_FakeMCPServer({"error": "boom"}))
+    r = reg.dispatch("lifeos_fake", {})
+    assert r.is_error
+    assert "boom" in r.output
+
+
+@pytest.mark.unit
+def test_registry_sleep_returns_yield_seconds():
+    reg = ToolRegistry(lifeos_mcp_server=_FakeMCPServer({}))
+    r = reg.dispatch("sleep", {"seconds": 30, "reason": "waiting on CI"})
+    assert r.yield_seconds == 30
+    assert "waiting on CI" in r.output
+
+
+@pytest.mark.unit
+def test_registry_unknown_tool_is_error():
+    reg = ToolRegistry(lifeos_mcp_server=_FakeMCPServer({}))
+    r = reg.dispatch("DoesNotExist", {})
+    assert r.is_error
+    assert "unknown" in r.output
+
+
+@pytest.mark.unit
+def test_registry_definitions_includes_standard_and_mcp():
+    reg = ToolRegistry(lifeos_mcp_server=_FakeMCPServer({}))
+    names = {t["name"] for t in reg.definitions()}
+    # Standard tools
+    for n in ("Read", "Write", "Edit", "Bash", "WebFetch", "WebSearch", "sleep"):
+        assert n in names
+    # LifeOS tool
+    assert "lifeos_fake" in names


### PR DESCRIPTION
## Summary
Issue C of the agent-worker series (epic #98). Replaces Issue B's no-op dispatcher with a real two-stage pipeline: a cheap Claude Haiku preflight call classifies each task (budget / routing / ambiguity / sanity / expected output), then a real agent loop on the local Gemma model executes via \`llm_client.LocalLLMClient\` with budget-enforced tool use. The Claude path is intentionally deferred to Issue D — it routes correctly but rolls the tag back to \`#agent\` and notifies. The \`#agent #local\` path is now end-to-end functional.

Closes #101 · Relates to #98

## Test evidence
- \`pytest tests/test_agent_worker_*.py tests/test_task_manager_swap_tag.py\` — **70/70 passed** (preflight 12, tools 17, executor 9, worker 9, stores 18, swap_tag 5)
- Pre-push hook full unit suite — **1260/1260 passed** (was 1220 on \`main\`; +40 new tests, no regressions)
- Pre-existing \`test_summarizer.py::test_real_summary_generation\` still fails on \`main\` (Ollama side, unrelated)

## Review focus
- **Preflight hardening** — `preflight.py:parse_preflight_response` defends against \`\`\`json\`\`\` fences, partial schemas, exceptions, and invalid routing/expected_output values. Failure modes always return \`sane=False routing=ask\` so the worker parks the task rather than running on junk.
- **Budget enforcement is external** — \`local_executor.execute\` checks token + wall + dollar at the top of each turn against the DB row, not via LLM self-report. Kill is graceful: status set to \`STATUS_BUDGET_EXCEEDED\`, transcript event recorded, tag swapped.
- **Sleep yield** — \`sleep(seconds)\` writes a \`sleeps\` row, returns \`ExecutorOutcome(status=STATUS_YIELDED, wake_at=...)\`, and \`Worker._wake_sleeping_sessions()\` resumes the executor at the right time. No idle billing in the cloud-managed case (Issue D will use the same primitive).
- **LifeOS MCP proxy via \`LifeOSMCPServer\`** — \`ToolRegistry\` instantiates the existing MCP server class and re-uses its \`tools\` list + \`_call_api\` + \`_format_response\`, so there's no duplication of the curated endpoint catalog. Standard tools (Read/Write/Edit/Bash/WebFetch) are minimal but functional.
- **WebSearch is a structured stub** — LifeOS doesn't ship a search backend. The tool is exposed so the agent can plan around it; calling it returns a clear \"not configured\" error rather than silently failing.
- **Pricing table is conservative** — \`pricing.cost_for\` falls through to Opus rates for unknown models so a typo can't accidentally suppress enforcement.
- **Worker outcome dispatch** — \`_handle_outcome\` centralizes terminal-state Telegram notifications and tag swaps. Sleep yields produce no Telegram (operator only hears about terminal states).
- **\`resume_pending\` semantics changed** — sleeping sessions are left alone (main loop wakes them); blocked sessions stay blocked (Issue F closes the loop); only RUNNING/CLAIMED get rolled back to \`#agent\` for retry. We can't safely re-enter a partial LLM conversation without risking duplicate side effects.

## What this enables
- \`#agent #local\` tasks now run end-to-end on Gemma with Telegram completion summaries
- Title cues without tags route correctly: \"with claude\" → claude (parked for D); \"using gemma\" → local
- Ambiguous tasks (\"reply to John\") land in \`#agent-blocked\` with the question via Telegram (one-way until F)
- Routing-ask tasks (no \`#local\`, no cue) also blocked with model-choice question
- Sleeping sessions correctly yield and resume across worker restarts
- Daily \$-cap kill-switch (\`LIFEOS_AGENT_DAILY_CAP_DOLLARS=0\`) works end-to-end

## Out of scope (covered in later issues)
- Managed Agents driver / Claude path execution (#102 — D)
- Inter-agent \`lifeos_agent_*\` tools, lineage budgets (#103 — E)
- Telegram clarification round-trip via reply-threading (#104 — F)
- WebSearch backend (depends on operator-side API key; not in v1 scope)

## Manual smoke verification (operator follow-up)
1. \`sudo systemctl restart lifeos-llm\` (Gemma must be running)
2. \`sudo systemctl restart lifeos-agent-worker\` (after rebuild)
3. Create a task: \`POST /api/tasks {"description": "echo the current date", "tags": ["agent", "local"]}\`
4. Within ~60s, expect a Telegram message like \"✅ Agent worker: completed 'echo the current date' (text) — N tokens, \$0.00, Ns wall.\\n\\nMay 26, 2026.\"