### PR TITLE
feat: Managed Agents driver + Vault setup (D of F)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,14 @@
 # before being abandoned permanently. Used by Issue F.
 # LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS=72
 
+# Managed Agents (Claude-routed #agent tasks). See docs/guides/agent-worker-setup.md
+# Step 4b for the one-time Vault provisioning. Empty values keep the worker
+# from attempting Claude-routed tasks — they get parked at #agent-blocked instead.
+# LIFEOS_AGENT_MANAGED_MODEL=claude-opus-4-7
+# LIFEOS_AGENT_VAULT_ID=
+# LIFEOS_AGENT_CONNECTORS=gmail,google-calendar,google-drive,superhuman,zapier
+# LIFEOS_MCP_HTTP_URL=https://mcp.example.com/mcp
+
 # =============================================================================
 # EMBEDDING MODEL — sentence-transformers (cached locally)
 # =============================================================================

--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -1,0 +1,240 @@
+"""Wrapper for Anthropic Managed Agents — the Claude-routed execution path.
+
+Managed Agents (https://platform.claude.com/docs/en/managed-agents/overview,
+launched April 2026) hosts the agent loop on Anthropic's infrastructure. The
+worker posts a task as a session and polls events until terminal. Session
+state, tool execution, and MCP tunneling all live server-side; we only see
+the event stream + cost accounting.
+
+This module is intentionally minimal:
+- Polling-based event consumption (not SSE) — simpler to drive from the
+  single-threaded worker loop, easier to test, recoverable across restarts.
+- Endpoint shapes documented inline. **Operator must verify the API shape
+  matches their account when first deploying** — Managed Agents is in beta
+  and the schema may shift.
+- All HTTP calls go through an injectable `httpx.Client` so tests use
+  `MockTransport` and never hit the live API.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from api.services.agent_worker.pricing import (
+    MANAGED_SESSION_HOUR_OVERHEAD,
+    cost_for,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Terminal session statuses returned by the Managed Agents API.
+# Operator: verify these match the values your account actually emits.
+TERMINAL_REMOTE_STATUSES = frozenset({
+    "completed",
+    "failed",
+    "cancelled",
+    "budget_exceeded",
+})
+
+
+@dataclass
+class ManagedSessionState:
+    """Materialized view of a remote Managed Agents session."""
+    session_id: str
+    status: str
+    last_event_id: str | None = None
+    new_events: list[dict] = field(default_factory=list)
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    final_text: str | None = None
+    error_reason: str | None = None
+
+
+class ManagedAgentsDriver:
+    """Minimal HTTP wrapper for the Managed Agents control plane."""
+
+    DEFAULT_BASE_URL = "https://platform.claude.com/v1/managed-agents"
+    DEFAULT_VERSION_HEADER = "managed-agents-2026-04-01"
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = DEFAULT_BASE_URL,
+        version_header: str = DEFAULT_VERSION_HEADER,
+        http_client: httpx.Client | None = None,
+        timeout: float = 30.0,
+        vault_id: str | None = None,
+    ):
+        if not api_key:
+            raise ValueError("ManagedAgentsDriver requires an api_key")
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.version_header = version_header
+        self.vault_id = vault_id
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.Client(timeout=timeout)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "x-api-key": self.api_key,
+            "anthropic-version": self.version_header,
+            "content-type": "application/json",
+        }
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def create_session(
+        self,
+        *,
+        system_prompt: str,
+        user_message: str,
+        model: str,
+        mcp_servers: list[dict] | None = None,
+        connectors: list[str] | None = None,
+        max_tokens: int | None = None,
+        max_dollars: float | None = None,
+        max_wall_seconds: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Create a managed session and return its remote session_id.
+
+        Body shape (per docs.anthropic.com/managed-agents/quickstart):
+            {
+              "model": "claude-opus-4-7",
+              "vault_id": "<vault_id>",
+              "system_prompt": "...",
+              "initial_message": "...",
+              "mcp_servers": [{"name": ..., "url": ..., "headers": {...}}],
+              "connectors": ["gmail", "google-calendar", ...],
+              "max_tokens": 500000,
+              "max_dollars": 5.0,
+              "max_wall_seconds": 14400
+            }
+        """
+        body: dict[str, Any] = {
+            "model": model,
+            "system_prompt": system_prompt,
+            "initial_message": user_message,
+        }
+        if self.vault_id:
+            body["vault_id"] = self.vault_id
+        if mcp_servers:
+            body["mcp_servers"] = mcp_servers
+        if connectors:
+            body["connectors"] = connectors
+        if max_tokens is not None:
+            body["max_tokens"] = int(max_tokens)
+        if max_dollars is not None:
+            body["max_dollars"] = float(max_dollars)
+        if max_wall_seconds is not None:
+            body["max_wall_seconds"] = int(max_wall_seconds)
+        if metadata:
+            body["metadata"] = metadata
+
+        resp = self._client.post(
+            f"{self.base_url}/sessions",
+            headers=self._headers(),
+            json=body,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        sid = data.get("session_id") or data.get("id")
+        if not sid:
+            raise RuntimeError(f"Managed Agents response missing session id: {data!r}")
+        return sid
+
+    def get_session_state(
+        self,
+        session_id: str,
+        since_event_id: str | None = None,
+    ) -> ManagedSessionState:
+        """Poll a session's current state + any events since `since_event_id`.
+
+        Response shape (per docs.anthropic.com/managed-agents/sessions):
+            {
+              "session_id": "...",
+              "status": "running | completed | failed | cancelled | budget_exceeded",
+              "events": [
+                {"id": "evt_...", "type": "...", "payload": {...}, "ts": ...},
+                ...
+              ],
+              "usage": {"input_tokens": int, "output_tokens": int},
+              "final_text": "..." | null,
+              "error": {"message": "..."} | null
+            }
+        """
+        params = {}
+        if since_event_id:
+            params["since"] = since_event_id
+        resp = self._client.get(
+            f"{self.base_url}/sessions/{session_id}",
+            headers=self._headers(),
+            params=params,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        events = data.get("events", []) or []
+        usage = data.get("usage", {}) or {}
+        error = data.get("error") or {}
+        last_event_id: str | None = None
+        if events:
+            last_event_id = events[-1].get("id")
+        return ManagedSessionState(
+            session_id=session_id,
+            status=data.get("status", "running"),
+            last_event_id=last_event_id,
+            new_events=events,
+            total_input_tokens=int(usage.get("input_tokens", 0)),
+            total_output_tokens=int(usage.get("output_tokens", 0)),
+            final_text=data.get("final_text"),
+            error_reason=str(error.get("message", "")) if error else None,
+        )
+
+    def post_user_message(self, session_id: str, content: str) -> None:
+        """Resume a paused session with a user turn. Used in Issue F when
+        the operator answers a clarifying question via Telegram.
+        """
+        resp = self._client.post(
+            f"{self.base_url}/sessions/{session_id}/messages",
+            headers=self._headers(),
+            json={"role": "user", "content": content},
+        )
+        resp.raise_for_status()
+
+    def kill_session(self, session_id: str, reason: str = "") -> None:
+        """Terminate a session early — used for budget breach / cascade-kill."""
+        try:
+            self._client.delete(
+                f"{self.base_url}/sessions/{session_id}",
+                headers=self._headers(),
+                params={"reason": reason} if reason else None,
+            )
+        except Exception as exc:
+            logger.warning("kill_session %s failed: %s", session_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Cost helper
+# ---------------------------------------------------------------------------
+
+def managed_session_cost(
+    model: str,
+    tokens_in: int,
+    tokens_out: int,
+    wall_seconds: float,
+) -> float:
+    """Total $ for a managed session: token cost + session-hour overhead."""
+    tokens = cost_for(model, tokens_in, tokens_out)
+    overhead = (wall_seconds / 3600.0) * MANAGED_SESSION_HOUR_OVERHEAD
+    return tokens + overhead

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -1,0 +1,214 @@
+"""Manages the lifecycle of a Claude-routed (Managed Agents) session.
+
+Mirrors `LocalExecutor` in shape so the worker can treat both paths uniformly:
+
+  - `start(session, task) -> ExecutorOutcome` — creates the remote session,
+    returns immediately with status STATUS_RUNNING so the tick loop can move on
+  - `poll(session) -> ExecutorOutcome` — fetches events accumulated since the
+    last poll, mirrors to the transcript, updates token + dollar totals, and
+    finalizes if the remote session reached a terminal state
+
+The poll-based design (instead of long-lived SSE) keeps the worker single-
+threaded and trivially restartable: state is in the DB, the only client-side
+context needed is `last_event_id` for the resume cursor.
+"""
+from __future__ import annotations
+
+import logging
+import time
+
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.managed_driver import (
+    TERMINAL_REMOTE_STATUSES,
+    ManagedAgentsDriver,
+)
+from api.services.agent_worker.pricing import (
+    MANAGED_SESSION_HOUR_OVERHEAD,
+    cost_for,
+)
+from api.services.agent_worker.session_store import (
+    STATUS_BUDGET_EXCEEDED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+logger = logging.getLogger(__name__)
+
+
+# Status reported in `transcript`/`metadata` between create and the first
+# completed-event. Stored in `sessions.metadata` (not implemented for Issue D
+# scope) or kept implicit via the row's status field.
+META_LAST_EVENT_ID = "managed_last_event_id"
+
+
+def _system_prompt(session_id: str, expected_output: str, budget) -> str:
+    """System prompt for managed agents — same shape as the local executor's."""
+    return (
+        "You are an autonomous agent running inside LifeOS via Anthropic "
+        "Managed Agents, handling a single task from the user's task manager. "
+        "You have access to LifeOS data via the attached MCP server, plus "
+        "the standard Managed Agents tools (file, shell, web). Work concisely "
+        "and stop when the task is complete — your final assistant turn (with "
+        f"no tool calls) is the answer the user will see.\n\n"
+        f"Your session_id is {session_id}. Your expected output shape is "
+        f"`{expected_output}`. Your budget is wall={budget.get('wall_seconds')}s, "
+        f"max_tokens={budget.get('max_tokens')}, max_dollars=${budget.get('max_dollars')}.\n"
+        "If you cannot complete the task safely or have hit an ambiguity you "
+        "cannot resolve from context, say so plainly in your final response."
+    )
+
+
+def _user_message_for(task: dict) -> str:
+    title = (task.get("description") or "").strip()
+    context = task.get("context")
+    parts = [f"Task: {title}"]
+    if context:
+        parts.append(f"Context: {context}")
+    parts.append("Please complete this task using the tools available.")
+    return "\n\n".join(parts)
+
+
+class ManagedExecutor:
+    """Coordinates a Managed Agents session from create through terminal event."""
+
+    def __init__(
+        self,
+        session_store: SessionStore,
+        transcript_store: TranscriptStore,
+        driver: ManagedAgentsDriver,
+        model: str = "claude-opus-4-7",
+        mcp_servers: list[dict] | None = None,
+        connectors: list[str] | None = None,
+    ):
+        self.session_store = session_store
+        self.transcript_store = transcript_store
+        self.driver = driver
+        self.model = model
+        # Operator-provided MCP servers (LifeOS HTTP endpoint, etc.) and
+        # connector slugs (gmail, google-calendar, etc.). Passed through to
+        # the Managed Agents API on session create.
+        self.mcp_servers = mcp_servers or []
+        self.connectors = connectors or []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self, session, task: dict) -> ExecutorOutcome:
+        """Create the remote session and return immediately.
+
+        On success: STATUS_RUNNING with `managed_agent_session_id` populated.
+        On failure (network, API rejection, etc.): STATUS_FAILED.
+        """
+        sid = session.session_id
+        budget = session.budget or {}
+        self.session_store.update_status(session.task_id, STATUS_RUNNING)
+        self.transcript_store.append(sid, "managed_start", {"model": self.model})
+
+        try:
+            remote_id = self.driver.create_session(
+                system_prompt=_system_prompt(sid, session.expected_output or "text", budget),
+                user_message=_user_message_for(task),
+                model=self.model,
+                mcp_servers=self.mcp_servers,
+                connectors=self.connectors,
+                max_tokens=budget.get("max_tokens"),
+                max_dollars=budget.get("max_dollars"),
+                max_wall_seconds=budget.get("wall_seconds"),
+                metadata={"lifeos_session_id": sid, "task_id": session.task_id},
+            )
+        except Exception as exc:
+            logger.exception("managed create_session failed for %s: %s", sid, exc)
+            self.session_store.update_status(session.task_id, STATUS_FAILED)
+            self.transcript_store.append(sid, "managed_create_failed", {"error": str(exc)})
+            return ExecutorOutcome(status=STATUS_FAILED, reason=f"create_session failed: {exc}")
+
+        self.session_store.set_managed_session_id(session.task_id, remote_id)
+        self.transcript_store.append(sid, "managed_created", {"remote_id": remote_id})
+        # Mark as STATUS_RUNNING but with a remote handle attached. The
+        # worker's tick loop will pick it up via _poll_managed_sessions on
+        # subsequent ticks.
+        return ExecutorOutcome(status=STATUS_RUNNING)
+
+    def poll(self, session) -> ExecutorOutcome:
+        """Fetch new events from the remote session and advance state.
+
+        Returns an ExecutorOutcome reflecting the current state:
+        - STATUS_RUNNING — no terminal event yet (worker continues polling)
+        - STATUS_COMPLETED / STATUS_FAILED / STATUS_BUDGET_EXCEEDED — terminal
+        """
+        if not session.managed_agent_session_id:
+            return ExecutorOutcome(status=STATUS_FAILED, reason="no managed_agent_session_id")
+
+        sid = session.session_id
+        remote_id = session.managed_agent_session_id
+        last_event_id = self.session_store.get_managed_last_event_id(session.task_id)
+
+        try:
+            state = self.driver.get_session_state(remote_id, since_event_id=last_event_id)
+        except Exception as exc:
+            # Transient errors: keep going, try again next poll. Don't kill
+            # the session here — operator may want to retry.
+            logger.warning("managed poll failed for %s: %s", remote_id, exc)
+            return ExecutorOutcome(status=STATUS_RUNNING, reason=f"poll error: {exc}")
+
+        # Mirror events to transcript + update budget accounting.
+        for event in state.new_events:
+            self.transcript_store.append(sid, f"managed_event_{event.get('type', 'unknown')}", event)
+
+        # Compute incremental token spend (state has absolute totals).
+        delta_in = max(0, state.total_input_tokens - (session.total_input_tokens or 0))
+        delta_out = max(0, state.total_output_tokens - (session.total_output_tokens or 0))
+        if delta_in or delta_out:
+            self.session_store.record_spend(
+                session.task_id, delta_in, delta_out,
+                cost_for(self.model, delta_in, delta_out),
+            )
+
+        # Session-hour overhead: charge for the time elapsed since session start
+        # (or last_activity_at — close enough for cost accounting).
+        wall_so_far = max(0, int(time.time()) - int(session.started_at))
+        hourly_dollars = (wall_so_far / 3600.0) * MANAGED_SESSION_HOUR_OVERHEAD
+        # Replace any prior session-hour charge; we don't have a clean delta
+        # so just track the active portion in total_active_seconds.
+        self.session_store.record_active_seconds(session.task_id, wall_so_far - (session.total_active_seconds or 0))
+
+        if state.last_event_id:
+            self.session_store.set_managed_last_event_id(session.task_id, state.last_event_id)
+
+        # Terminal handling.
+        if state.status in TERMINAL_REMOTE_STATUSES:
+            return self._finalize_remote(session, state, hourly_dollars)
+
+        return ExecutorOutcome(status=STATUS_RUNNING)
+
+    # ------------------------------------------------------------------
+    # Finalize
+    # ------------------------------------------------------------------
+
+    def _finalize_remote(self, session, state, hourly_dollars: float) -> ExecutorOutcome:
+        # Final cost reconciliation: charge any outstanding session-hour
+        # overhead by adding it to total_dollars one last time.
+        self.session_store.add_session_hour_overhead(session.task_id, hourly_dollars)
+
+        if state.status == "completed":
+            self.session_store.update_status(session.task_id, STATUS_COMPLETED)
+            self.transcript_store.append(session.session_id, "managed_completed",
+                                         {"final_chars": len(state.final_text or "")})
+            return ExecutorOutcome(status=STATUS_COMPLETED, final_text=state.final_text or "")
+
+        if state.status == "budget_exceeded":
+            self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
+            self.transcript_store.append(session.session_id, "managed_budget_exceeded", {})
+            return ExecutorOutcome(status=STATUS_BUDGET_EXCEEDED,
+                                   reason=state.error_reason or "remote budget exceeded")
+
+        # cancelled or failed
+        self.session_store.update_status(session.task_id, STATUS_FAILED)
+        reason = state.error_reason or f"remote status={state.status}"
+        self.transcript_store.append(session.session_id, "managed_failed", {"reason": reason})
+        return ExecutorOutcome(status=STATUS_FAILED, reason=reason)

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -39,14 +39,10 @@ from api.services.agent_worker.transcript_store import TranscriptStore
 logger = logging.getLogger(__name__)
 
 
-# Status reported in `transcript`/`metadata` between create and the first
-# completed-event. Stored in `sessions.metadata` (not implemented for Issue D
-# scope) or kept implicit via the row's status field.
-META_LAST_EVENT_ID = "managed_last_event_id"
-
-
 def _system_prompt(session_id: str, expected_output: str, budget) -> str:
     """System prompt for managed agents — same shape as the local executor's."""
+    max_dollars = budget.get("max_dollars")
+    dollars_str = f"${max_dollars}" if max_dollars is not None else "unset"
     return (
         "You are an autonomous agent running inside LifeOS via Anthropic "
         "Managed Agents, handling a single task from the user's task manager. "
@@ -56,7 +52,7 @@ def _system_prompt(session_id: str, expected_output: str, budget) -> str:
         f"no tool calls) is the answer the user will see.\n\n"
         f"Your session_id is {session_id}. Your expected output shape is "
         f"`{expected_output}`. Your budget is wall={budget.get('wall_seconds')}s, "
-        f"max_tokens={budget.get('max_tokens')}, max_dollars=${budget.get('max_dollars')}.\n"
+        f"max_tokens={budget.get('max_tokens')}, max_dollars={dollars_str}.\n"
         "If you cannot complete the task safely or have hit an ambiguity you "
         "cannot resolve from context, say so plainly in your final response."
     )
@@ -68,7 +64,6 @@ def _user_message_for(task: dict) -> str:
     parts = [f"Task: {title}"]
     if context:
         parts.append(f"Context: {context}")
-    parts.append("Please complete this task using the tools available.")
     return "\n\n".join(parts)
 
 
@@ -122,10 +117,12 @@ class ManagedExecutor:
                 metadata={"lifeos_session_id": sid, "task_id": session.task_id},
             )
         except Exception as exc:
-            logger.exception("managed create_session failed for %s: %s", sid, exc)
+            # Log without exc_info — httpx exceptions can attach the request
+            # object whose headers include the API key.
+            logger.error("managed create_session failed for %s: %s", sid, type(exc).__name__)
             self.session_store.update_status(session.task_id, STATUS_FAILED)
-            self.transcript_store.append(sid, "managed_create_failed", {"error": str(exc)})
-            return ExecutorOutcome(status=STATUS_FAILED, reason=f"create_session failed: {exc}")
+            self.transcript_store.append(sid, "managed_create_failed", {"error_type": type(exc).__name__})
+            return ExecutorOutcome(status=STATUS_FAILED, reason=f"create_session failed: {type(exc).__name__}")
 
         self.session_store.set_managed_session_id(session.task_id, remote_id)
         self.transcript_store.append(sid, "managed_created", {"remote_id": remote_id})
@@ -156,45 +153,81 @@ class ManagedExecutor:
             logger.warning("managed poll failed for %s: %s", remote_id, exc)
             return ExecutorOutcome(status=STATUS_RUNNING, reason=f"poll error: {exc}")
 
-        # Mirror events to transcript + update budget accounting.
+        # Mirror events to transcript.
         for event in state.new_events:
             self.transcript_store.append(sid, f"managed_event_{event.get('type', 'unknown')}", event)
 
-        # Compute incremental token spend (state has absolute totals).
+        # 1. Token spend delta — compare absolute remote totals to our row.
         delta_in = max(0, state.total_input_tokens - (session.total_input_tokens or 0))
         delta_out = max(0, state.total_output_tokens - (session.total_output_tokens or 0))
+        token_delta_dollars = cost_for(self.model, delta_in, delta_out)
         if delta_in or delta_out:
             self.session_store.record_spend(
-                session.task_id, delta_in, delta_out,
-                cost_for(self.model, delta_in, delta_out),
+                session.task_id, delta_in, delta_out, token_delta_dollars,
             )
 
-        # Session-hour overhead: charge for the time elapsed since session start
-        # (or last_activity_at — close enough for cost accounting).
-        wall_so_far = max(0, int(time.time()) - int(session.started_at))
-        hourly_dollars = (wall_so_far / 3600.0) * MANAGED_SESSION_HOUR_OVERHEAD
-        # Replace any prior session-hour charge; we don't have a clean delta
-        # so just track the active portion in total_active_seconds.
-        self.session_store.record_active_seconds(session.task_id, wall_so_far - (session.total_active_seconds or 0))
+        # 2. Session-hour overhead delta — we only want to add what's accrued
+        # since the last poll. The driver doesn't tell us total wall time, so
+        # we derive it from `started_at` and book the *delta* over the
+        # already-accrued figure stored on the row.
+        wall_so_far = max(0.0, time.time() - float(session.started_at))
+        cumulative_hourly = (wall_so_far / 3600.0) * MANAGED_SESSION_HOUR_OVERHEAD
+        prior_hourly = self.session_store.get_accrued_session_hour_dollars(session.task_id)
+        hourly_delta = max(0.0, cumulative_hourly - prior_hourly)
+        if hourly_delta > 0:
+            self.session_store.add_session_hour_overhead(session.task_id, hourly_delta)
+            self.session_store.set_accrued_session_hour_dollars(session.task_id, cumulative_hourly)
+
+        # 3. Mid-run budget breach: kill the remote session before it racks
+        # up more cost. The check uses the refreshed in-flight totals so the
+        # session-hour delta we just booked is included.
+        budget = session.budget or {}
+        refreshed = self.session_store.get(session.task_id)
+        breach = self._budget_breach(refreshed, budget)
+        if breach:
+            try:
+                self.driver.kill_session(remote_id, reason=f"budget_exceeded:{breach}")
+            except Exception as exc:  # pragma: no cover — best-effort kill
+                logger.warning("kill_session %s failed: %s", remote_id, exc)
+            self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
+            self.transcript_store.append(sid, "budget_exceeded", {"kind": breach, "source": "client"})
+            return ExecutorOutcome(status=STATUS_BUDGET_EXCEEDED, reason=f"budget exceeded ({breach})")
 
         if state.last_event_id:
             self.session_store.set_managed_last_event_id(session.task_id, state.last_event_id)
 
         # Terminal handling.
         if state.status in TERMINAL_REMOTE_STATUSES:
-            return self._finalize_remote(session, state, hourly_dollars)
+            return self._finalize_remote(session, state)
 
         return ExecutorOutcome(status=STATUS_RUNNING)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _budget_breach(refreshed_session, budget: dict) -> str | None:
+        """Return the budget kind that was exceeded, or None."""
+        if not budget:
+            return None
+        if budget.get("max_tokens"):
+            used = (refreshed_session.total_input_tokens or 0) + (refreshed_session.total_output_tokens or 0)
+            if used >= budget["max_tokens"]:
+                return "max_tokens"
+        if budget.get("max_dollars") is not None:
+            if (refreshed_session.total_dollars or 0) >= budget["max_dollars"]:
+                return "max_dollars"
+        return None
 
     # ------------------------------------------------------------------
     # Finalize
     # ------------------------------------------------------------------
 
-    def _finalize_remote(self, session, state, hourly_dollars: float) -> ExecutorOutcome:
-        # Final cost reconciliation: charge any outstanding session-hour
-        # overhead by adding it to total_dollars one last time.
-        self.session_store.add_session_hour_overhead(session.task_id, hourly_dollars)
-
+    def _finalize_remote(self, session, state) -> ExecutorOutcome:
+        # Session-hour overhead has already been booked incrementally in
+        # poll(), so finalize doesn't need to add anything more — just record
+        # the terminal status.
         if state.status == "completed":
             self.session_store.update_status(session.task_id, STATUS_COMPLETED)
             self.transcript_store.append(session.session_id, "managed_completed",
@@ -207,7 +240,13 @@ class ManagedExecutor:
             return ExecutorOutcome(status=STATUS_BUDGET_EXCEEDED,
                                    reason=state.error_reason or "remote budget exceeded")
 
-        # cancelled or failed
+        if state.status == "cancelled":
+            self.session_store.update_status(session.task_id, STATUS_FAILED)
+            reason = state.error_reason or "session cancelled remotely"
+            self.transcript_store.append(session.session_id, "managed_cancelled", {"reason": reason})
+            return ExecutorOutcome(status=STATUS_FAILED, reason=f"cancelled: {reason}")
+
+        # failed (or unknown terminal)
         self.session_store.update_status(session.task_id, STATUS_FAILED)
         reason = state.error_reason or f"remote status={state.status}"
         self.transcript_store.append(session.session_id, "managed_failed", {"reason": reason})

--- a/api/services/agent_worker/pricing.py
+++ b/api/services/agent_worker/pricing.py
@@ -6,11 +6,15 @@ https://www.anthropic.com/pricing as of 2026-05. Update when models change.
 For the local backend, both rates are 0 — compute is "free" (operator paid
 upfront for the hardware). Time and tokens are still tracked for budget
 enforcement, but they don't contribute to the dollar budget or the daily cap.
-
-Managed Agents (Issue D) adds a flat session-hour overhead alongside tokens;
-that lives in `managed_driver.py`, not here.
 """
 from __future__ import annotations
+
+
+# Anthropic Managed Agents charge a flat per-session-hour overhead on top of
+# standard token rates (per https://platform.claude.com/docs/en/managed-agents/overview,
+# announced April 2026). Long-idle sessions accrue this even when nothing is
+# happening, which motivates the yield-and-resume pattern in Issue E.
+MANAGED_SESSION_HOUR_OVERHEAD: float = 0.08
 
 
 # Dollars per token. Keys match the model id strings used by the routers.

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -106,6 +106,15 @@ CREATE TABLE IF NOT EXISTS sleeps (
     wake_at       INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_sleeps_wake ON sleeps(wake_at);
+
+-- Cursor + bookkeeping for Managed Agents sessions. One row per task_id with
+-- the last event id we've ingested + the cumulative session-hour dollars
+-- already booked into the sessions row's total_dollars. Issue D.
+CREATE TABLE IF NOT EXISTS managed_cursor (
+    task_id                          TEXT PRIMARY KEY,
+    last_event_id                    TEXT,
+    accrued_session_hour_dollars     REAL NOT NULL DEFAULT 0.0
+);
 """
 
 
@@ -307,16 +316,9 @@ class SessionStore:
                 (float(dollars), _now(), task_id),
             )
 
-    # Lightweight key/value cursor for managed sessions; stored alongside the
-    # session row to avoid a second table. The schema already has unused space
-    # for this — we piggyback on `expected_output` for the per-row pattern but
-    # the cursor is logically separate, so use a tiny dedicated table.
+    # Managed Agents cursor (defined in _SCHEMA so no schema-on-write needed).
     def set_managed_last_event_id(self, task_id: str, event_id: str) -> None:
         with self._connect() as conn:
-            conn.executescript(
-                "CREATE TABLE IF NOT EXISTS managed_cursor ("
-                "task_id TEXT PRIMARY KEY, last_event_id TEXT NOT NULL);"
-            )
             conn.execute(
                 "INSERT INTO managed_cursor (task_id, last_event_id) VALUES (?, ?) "
                 "ON CONFLICT(task_id) DO UPDATE SET last_event_id = excluded.last_event_id",
@@ -325,15 +327,33 @@ class SessionStore:
 
     def get_managed_last_event_id(self, task_id: str) -> str | None:
         with self._connect() as conn:
-            try:
-                row = conn.execute(
-                    "SELECT last_event_id FROM managed_cursor WHERE task_id = ?",
-                    (task_id,),
-                ).fetchone()
-            except sqlite3.OperationalError:
-                # Table doesn't exist yet — no cursor recorded.
-                return None
+            row = conn.execute(
+                "SELECT last_event_id FROM managed_cursor WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
         return row["last_event_id"] if row else None
+
+    def get_accrued_session_hour_dollars(self, task_id: str) -> float:
+        """Dollars already booked into total_dollars for session-hour overhead.
+
+        Used by the managed executor to compute the incremental session-hour
+        delta to add on each poll, avoiding double-counting.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT accrued_session_hour_dollars FROM managed_cursor WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+        return float(row[0]) if row else 0.0
+
+    def set_accrued_session_hour_dollars(self, task_id: str, dollars: float) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO managed_cursor (task_id, accrued_session_hour_dollars) "
+                "VALUES (?, ?) "
+                "ON CONFLICT(task_id) DO UPDATE SET accrued_session_hour_dollars = excluded.accrued_session_hour_dollars",
+                (task_id, float(dollars)),
+            )
 
     def record_active_seconds(self, task_id: str, seconds: float) -> None:
         """Add to a session's cumulative active-execution seconds.

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -220,6 +220,18 @@ class SessionStore:
             ).fetchall()
         return [self._row_to_session(r) for r in rows]
 
+    def list_active_managed(self) -> list[Session]:
+        """Sessions with a remote Managed Agents id that haven't terminated."""
+        placeholders = ",".join("?" for _ in TERMINAL_STATUSES)
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM sessions "
+                f"WHERE managed_agent_session_id IS NOT NULL "
+                f"AND status NOT IN ({placeholders})",
+                tuple(TERMINAL_STATUSES),
+            ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
     def list_non_terminal(self) -> list[Session]:
         """Return sessions that the worker may still need to act on after restart."""
         placeholders = ",".join("?" for _ in TERMINAL_STATUSES)
@@ -274,6 +286,54 @@ class SessionStore:
                 """,
                 (tokens_in, tokens_out, dollars, _now(), task_id),
             )
+
+    def set_managed_session_id(self, task_id: str, managed_id: str) -> None:
+        """Attach a remote Managed Agents session_id to a local session."""
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE sessions SET managed_agent_session_id = ?, last_activity_at = ? "
+                "WHERE task_id = ?",
+                (managed_id, _now(), task_id),
+            )
+
+    def add_session_hour_overhead(self, task_id: str, dollars: float) -> None:
+        """Add Managed Agents session-hour overhead to the dollar counter."""
+        if dollars <= 0:
+            return
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE sessions SET total_dollars = total_dollars + ?, last_activity_at = ? "
+                "WHERE task_id = ?",
+                (float(dollars), _now(), task_id),
+            )
+
+    # Lightweight key/value cursor for managed sessions; stored alongside the
+    # session row to avoid a second table. The schema already has unused space
+    # for this — we piggyback on `expected_output` for the per-row pattern but
+    # the cursor is logically separate, so use a tiny dedicated table.
+    def set_managed_last_event_id(self, task_id: str, event_id: str) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                "CREATE TABLE IF NOT EXISTS managed_cursor ("
+                "task_id TEXT PRIMARY KEY, last_event_id TEXT NOT NULL);"
+            )
+            conn.execute(
+                "INSERT INTO managed_cursor (task_id, last_event_id) VALUES (?, ?) "
+                "ON CONFLICT(task_id) DO UPDATE SET last_event_id = excluded.last_event_id",
+                (task_id, event_id),
+            )
+
+    def get_managed_last_event_id(self, task_id: str) -> str | None:
+        with self._connect() as conn:
+            try:
+                row = conn.execute(
+                    "SELECT last_event_id FROM managed_cursor WHERE task_id = ?",
+                    (task_id,),
+                ).fetchone()
+            except sqlite3.OperationalError:
+                # Table doesn't exist yet — no cursor recorded.
+                return None
+        return row["last_event_id"] if row else None
 
     def record_active_seconds(self, task_id: str, seconds: float) -> None:
         """Add to a session's cumulative active-execution seconds.

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -37,6 +37,7 @@ from api.services.agent_worker.session_store import (
     STATUS_CLAIMED,
     STATUS_COMPLETED,
     STATUS_FAILED,
+    STATUS_RUNNING,
     STATUS_YIELDED,
     Session,
     SessionStore,
@@ -68,8 +69,9 @@ class Worker:
         poll_seconds: float | None = None,
         telegram_send=None,  # injectable for tests
         http_client: httpx.Client | None = None,
-        preflight_caller=None,  # injectable; defaults to Anthropic Haiku
-        local_executor=None,    # injectable LocalExecutor for tests
+        preflight_caller=None,    # injectable; defaults to Anthropic Haiku
+        local_executor=None,      # injectable LocalExecutor for tests
+        managed_executor=None,    # injectable ManagedExecutor for tests
     ) -> None:
         self.api_base = (api_base or os.environ.get("LIFEOS_API_URL", "http://localhost:8000")).rstrip("/")
         self.session_store = session_store or SessionStore()
@@ -94,6 +96,7 @@ class Worker:
         self._http = http_client or httpx.Client(timeout=10.0)
         self._preflight_caller = preflight_caller  # None → use Anthropic SDK by default
         self._local_executor = local_executor  # lazily instantiated on first use
+        self._managed_executor = managed_executor  # lazily instantiated on first claude task
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -187,6 +190,8 @@ class Worker:
 
         # First, resume any sleeping sessions whose wake time has arrived.
         self._wake_sleeping_sessions()
+        # Then poll any in-flight Managed Agents sessions for new events.
+        self._poll_managed_sessions()
 
         candidates = self._list_agent_tasks()
         handled = 0
@@ -202,6 +207,28 @@ class Worker:
             self._dispatch(task)
             handled += 1
         return handled
+
+    def _poll_managed_sessions(self) -> None:
+        """Advance all in-flight Managed Agents sessions one polling step."""
+        active = self.session_store.list_active_managed()
+        if not active:
+            return
+        managed = self._get_managed_executor()
+        if managed is None:
+            return  # operator removed credentials between starts; sessions are stuck
+        for session in active:
+            task = self._fetch_task(session.task_id) or {
+                "id": session.task_id,
+                "description": session.task_id,
+            }
+            try:
+                outcome = managed.poll(session)
+            except Exception as exc:
+                logger.exception("managed.poll crashed for %s: %s", session.task_id, exc)
+                self._mark_failed(session, task, f"managed poll crashed: {exc}")
+                continue
+            if outcome.status != STATUS_RUNNING:
+                self._handle_outcome(session, task, outcome)
 
     def _wake_sleeping_sessions(self) -> None:
         """Resume any sessions whose `sleeps` row has expired."""
@@ -317,6 +344,44 @@ class Worker:
             )
         return self._local_executor
 
+    def _get_managed_executor(self):
+        """Return the cached ManagedExecutor, lazily constructed.
+
+        Returns None if Managed Agents isn't configured (no api_key or vault_id) —
+        the dispatcher then parks the task at #agent-blocked with an operator-
+        facing explanation.
+        """
+        if self._managed_executor is not None:
+            return self._managed_executor
+        api_key = settings.anthropic_api_key
+        vault_id = settings.agent_vault_id
+        if not api_key or not vault_id:
+            return None
+        from api.services.agent_worker.managed_driver import ManagedAgentsDriver
+        from api.services.agent_worker.managed_executor import ManagedExecutor
+        driver = ManagedAgentsDriver(
+            api_key=api_key,
+            vault_id=vault_id,
+        )
+        # Default MCP server list: operator's LifeOS MCP endpoint if configured.
+        mcp_servers: list[dict[str, Any]] = []
+        if settings.mcp_http_url and settings.mcp_bearer_token:
+            mcp_servers.append({
+                "name": "lifeos",
+                "url": settings.mcp_http_url,
+                "headers": {"Authorization": f"Bearer {settings.mcp_bearer_token}"},
+            })
+        connectors = [c.strip() for c in (settings.agent_connectors or "").split(",") if c.strip()]
+        self._managed_executor = ManagedExecutor(
+            session_store=self.session_store,
+            transcript_store=self.transcript_store,
+            driver=driver,
+            model=settings.agent_managed_model,
+            mcp_servers=mcp_servers,
+            connectors=connectors,
+        )
+        return self._managed_executor
+
     def _fetch_task(self, task_id: str) -> dict[str, Any] | None:
         try:
             resp = self._http.get(f"{self.api_base}/api/tasks/{task_id}")
@@ -411,20 +476,31 @@ class Worker:
             self._handle_outcome(session, task, outcome)
             return
 
-        # Claude route: deferred to Issue D. Park at #agent-blocked rather
-        # than re-tagging to #agent — same blocked semantics as ambiguity /
-        # sanity / routing-ask, and the operator can drop the block tag when
-        # Issue D is installed to retry.
+        # Claude route: hand off to Managed Agents.
         if pre.routing == ROUTE_CLAUDE:
-            self._swap_tag(task_id, RUNNING_TAG, BLOCKED_TAG)
-            self.session_store.update_status(task_id, STATUS_BLOCKED)
-            self.transcript_store.append(sid, "claude_routing_deferred", {})
-            self._notify(
-                f"⏸ Agent worker: task '{title}' routed to Claude but the "
-                f"Managed Agents driver isn't installed yet (Issue D). Task "
-                f"parked at #{BLOCKED_TAG} — retag with #{AGENT_TAG} once "
-                f"Issue D ships."
-            )
+            managed = self._get_managed_executor()
+            if managed is None:
+                # Operator hasn't configured Managed Agents (no API key or vault).
+                self._swap_tag(task_id, RUNNING_TAG, BLOCKED_TAG)
+                self.session_store.update_status(task_id, STATUS_BLOCKED)
+                self.transcript_store.append(sid, "managed_not_configured", {})
+                self._notify(
+                    f"⏸ Agent worker: task '{title}' routed to Claude but "
+                    f"Managed Agents isn't configured. Set ANTHROPIC_API_KEY "
+                    f"and LIFEOS_AGENT_VAULT_ID in .env, then retag with "
+                    f"#{AGENT_TAG}."
+                )
+                return
+            try:
+                outcome = managed.start(session, task)
+            except Exception as exc:
+                logger.exception("managed.start crashed for %s: %s", task_id, exc)
+                self._mark_failed(session, task, f"managed start crashed: {exc}")
+                return
+            # Don't finalize on START — the session is running remotely.
+            # `_poll_managed_sessions` in the next tick will pick it up.
+            if outcome.status == STATUS_FAILED:
+                self._handle_outcome(session, task, outcome)
             return
 
         # Should not reach here — routing was validated in preflight.

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -221,12 +221,20 @@ class Worker:
                 "id": session.task_id,
                 "description": session.task_id,
             }
+            pre_dollars = session.total_dollars or 0.0
             try:
                 outcome = managed.poll(session)
             except Exception as exc:
                 logger.exception("managed.poll crashed for %s: %s", session.task_id, exc)
                 self._mark_failed(session, task, f"managed poll crashed: {exc}")
                 continue
+            # Push the per-poll dollar delta into the daily ledger so the
+            # global cap reflects in-flight managed cost, not just claim-time
+            # estimates.
+            refreshed = self.session_store.get(session.task_id)
+            delta_dollars = max(0.0, (refreshed.total_dollars or 0.0) - pre_dollars) if refreshed else 0.0
+            if delta_dollars > 0:
+                self.spend_tracker.record(delta_dollars)
             if outcome.status != STATUS_RUNNING:
                 self._handle_outcome(session, task, outcome)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -141,6 +141,33 @@ class Settings(BaseSettings):
         description="Anthropic model used for the Haiku preflight call that "
                     "classifies #agent tasks (budget, routing, ambiguity, sanity)."
     )
+    agent_managed_model: str = Field(
+        default="claude-opus-4-7",
+        alias="LIFEOS_AGENT_MANAGED_MODEL",
+        description="Anthropic model the Managed Agents executor uses for "
+                    "Claude-routed #agent tasks."
+    )
+    agent_vault_id: str = Field(
+        default="",
+        alias="LIFEOS_AGENT_VAULT_ID",
+        description="Managed Agents Vault id holding OAuth credentials for "
+                    "Gmail / Calendar / Drive / Superhuman / Zapier. Created "
+                    "in the Anthropic console; see docs/guides/agent-worker-setup.md."
+    )
+    agent_connectors: str = Field(
+        default="",
+        alias="LIFEOS_AGENT_CONNECTORS",
+        description="Comma-separated list of Managed Agents Connector slugs to "
+                    "attach to every Claude-routed session (e.g. "
+                    "'gmail,google-calendar,google-drive,superhuman,zapier')."
+    )
+    mcp_http_url: str = Field(
+        default="",
+        alias="LIFEOS_MCP_HTTP_URL",
+        description="Public hostname for the LifeOS MCP HTTP transport "
+                    "(e.g. 'https://mcp.example.com/mcp'). Required for "
+                    "Managed Agents to reach LifeOS data."
+    )
     local_llm_autostart: bool = Field(
         default=False,
         alias="LIFEOS_LOCAL_LLM_AUTOSTART",

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -234,6 +234,7 @@ The Haiku preflight sanity-check is the only guard against destructive-shaped ta
 | `llama-server` crashes on Gemma | Insufficient VRAM, or stale cached model | Check `nvidia-smi`/`rocm-smi`; re-download with `llama-server -hf unsloth/gemma-4-26B-A4B-it-GGUF` once and confirm |
 | Agent worker logs "daily spend cap reached" | `LIFEOS_AGENT_DAILY_CAP_DOLLARS` is 0 or already exceeded today | Raise the cap or wait until local midnight |
 | Worker doesn't pick up a `#agent` task | Task isn't `status=todo`, or worker isn't enabled | `systemctl status lifeos-agent-worker`; `curl 'http://localhost:8000/api/tasks?status=todo&tag=agent'` |
+| Managed Agents session stuck running | Worker can't reach the API, or the remote session is genuinely long | Find the `managed_agent_session_id` in `data/agent_sessions.db` (`SELECT task_id, session_id, managed_agent_session_id FROM sessions WHERE status='running'`). Cancel via the Anthropic console, or `curl -X DELETE -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: managed-agents-2026-04-01" https://platform.claude.com/v1/managed-agents/sessions/<remote_id>`. The worker's next poll will see the cancelled status and finalize. |
 
 ---
 

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -132,6 +132,40 @@ Hardening upgrade (deferred to a later issue): swap the bearer-token check for a
 
 ---
 
+## Step 4b — Provision the Managed Agents Vault (Claude path, Issue D)
+
+`#agent` tasks (without `#local`) route to Claude on Anthropic's [Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) platform. Anthropic stores OAuth credentials for cloud connectors (Gmail, Calendar, Drive, Superhuman, Zapier) in a **Vault** that's separate from Claude.ai — existing Claude.ai OAuth doesn't transfer.
+
+> **Beta caveat:** Managed Agents launched April 2026 and the request/response schemas are still evolving. If a request fails with a 4xx, check the [Anthropic console](https://platform.claude.com) for the current schema and update `api/services/agent_worker/managed_driver.py` accordingly.
+
+One-time setup:
+
+1. **Create a Vault** in the Anthropic console (Settings → Vaults → New Vault). Copy the Vault ID.
+2. **Authenticate connectors** you want available to agents. From the Vault page, click "Add Connector" and OAuth into each of: Gmail, Google Calendar, Google Drive, Superhuman Mail, Zapier. (Slack, Asana out of scope for v1.)
+3. **Add the LifeOS MCP server** as a Vault connector. Use the Cloudflare Tunnel hostname from Step 4 and the bearer token from Step 2, e.g.:
+   ```
+   Name: lifeos
+   URL: https://mcp.example.com/mcp
+   Header: Authorization = Bearer <token>
+   ```
+4. **Write the IDs to `.env`:**
+   ```bash
+   LIFEOS_AGENT_VAULT_ID=vlt_<your_vault_id>
+   LIFEOS_MCP_HTTP_URL=https://mcp.example.com/mcp
+   LIFEOS_AGENT_CONNECTORS=gmail,google-calendar,google-drive,superhuman,zapier
+   ANTHROPIC_API_KEY=sk-ant-...   # already required for the Haiku preflight
+   ```
+5. **Restart the worker:**
+   ```bash
+   sudo systemctl restart lifeos-agent-worker
+   ```
+
+Without `LIFEOS_AGENT_VAULT_ID`, Claude-routed tasks park at `#agent-blocked` with an explanatory Telegram notification — the worker does not attempt to call the API without credentials.
+
+The Vault holds **only OAuth refresh tokens**. Live data (Obsidian, photos, monarch, calendar index, etc.) is read live from LifeOS MCP on every agent call — nothing is snapshotted into Anthropic's side.
+
+---
+
 ## Step 5 — Enable the agent worker (Issue B)
 
 Issue B installs `lifeos-agent-worker.service`, which polls `/api/tasks` for `#agent`-tagged tasks. It's **off by default** so a fresh clone doesn't start consuming tasks before later issues add real execution.

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -20,6 +20,7 @@ from api.services.agent_worker.session_store import (
     STATUS_BUDGET_EXCEEDED,
     STATUS_COMPLETED,
     STATUS_FAILED,
+    STATUS_RUNNING,
     STATUS_YIELDED,
     SessionStore,
 )
@@ -265,12 +266,12 @@ def test_claude_routing_with_managed_executor_starts_and_polls(tmp_path: Path):
             self.start_calls += 1
             # Simulate driver attaching a remote id.
             store_for_session.set_managed_session_id(session.task_id, "sess_remote_42")
-            return ExecutorOutcome(status="running")
+            return ExecutorOutcome(status=STATUS_RUNNING)
 
         def poll(self, session):
             self.poll_calls += 1
             if self.poll_calls < 2:
-                return ExecutorOutcome(status="running")
+                return ExecutorOutcome(status=STATUS_RUNNING)
             return ExecutorOutcome(status=STATUS_COMPLETED, final_text="here's the summary")
 
     transport = httpx.MockTransport(api.handler)

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -226,15 +226,17 @@ def test_executor_budget_exceeded_sets_budget_exceeded_tag(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_claude_routing_defers_to_issue_d_with_blocked_tag(tmp_path: Path):
-    """Claude-routed tasks land in #agent-blocked (same as other parked
-    states) until Issue D installs the managed-agents driver."""
+def test_claude_routing_without_managed_credentials_blocks(tmp_path: Path):
+    """Without Managed Agents credentials configured the worker parks Claude-
+    routed tasks at #agent-blocked. Same UX as ambiguity / sanity / ask."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "summarize", "status": "todo", "tags": ["agent"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     preflight = _golden_preflight(routing="claude")
     w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    # Sanity check: settings.agent_vault_id is empty in the test env, so
+    # _get_managed_executor returns None and the worker takes the not-configured branch.
     w.tick()
 
     assert executor.calls == []
@@ -243,6 +245,67 @@ def test_claude_routing_defers_to_issue_d_with_blocked_tag(tmp_path: Path):
     assert RUNNING_TAG not in api.tasks["t1"]["tags"]
     sent = w._sent_telegram  # type: ignore[attr-defined]
     assert any("Managed Agents" in s for s in sent)
+
+
+@pytest.mark.unit
+def test_claude_routing_with_managed_executor_starts_and_polls(tmp_path: Path):
+    """When Managed Agents is configured, the worker delegates to the
+    managed executor: `start` on first tick (status=RUNNING) and `poll` on
+    subsequent ticks until terminal."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "summarize my inbox", "status": "todo", "tags": ["agent"]},
+    ])
+
+    class _StubManagedExecutor:
+        def __init__(self):
+            self.start_calls = 0
+            self.poll_calls = 0
+
+        def start(self, session, task):
+            self.start_calls += 1
+            # Simulate driver attaching a remote id.
+            store_for_session.set_managed_session_id(session.task_id, "sess_remote_42")
+            return ExecutorOutcome(status="running")
+
+        def poll(self, session):
+            self.poll_calls += 1
+            if self.poll_calls < 2:
+                return ExecutorOutcome(status="running")
+            return ExecutorOutcome(status=STATUS_COMPLETED, final_text="here's the summary")
+
+    transport = httpx.MockTransport(api.handler)
+    client = httpx.Client(transport=transport, base_url="http://api")
+    store_for_session = SessionStore(db_path=tmp_path / "sessions.db")
+    sent: list[str] = []
+    managed = _StubManagedExecutor()
+    w = Worker(
+        api_base="http://api",
+        session_store=store_for_session,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        http_client=client,
+        preflight_caller=_golden_preflight(routing="claude"),
+        local_executor=_StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="")),
+        managed_executor=managed,
+    )
+
+    # Tick 1: claim → preflight → managed.start. Task still #agent-running.
+    w.tick()
+    assert managed.start_calls == 1
+    assert managed.poll_calls == 0
+    assert RUNNING_TAG in api.tasks["t1"]["tags"]
+    assert api.tasks["t1"]["status"] == "todo"
+    # Tick 2: managed.poll → still running.
+    w.tick()
+    assert managed.poll_calls == 1
+    assert RUNNING_TAG in api.tasks["t1"]["tags"]
+    # Tick 3: managed.poll → completed → tag swap + Telegram + mark done.
+    w.tick()
+    assert managed.poll_calls == 2
+    assert api.tasks["t1"]["status"] == "done"
+    assert any("here's the summary" in s for s in sent)
 
 
 @pytest.mark.unit

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -1,0 +1,212 @@
+"""Tests for ManagedAgentsDriver — HTTP request shape + parsing.
+
+These don't hit the real Managed Agents API; we wire `httpx.MockTransport`
+that asserts the request shape and returns canned responses, so the test
+verifies our client matches the documented schema. **Operator should still
+smoke-test against a real account** because the API is in beta.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from api.services.agent_worker.managed_driver import (
+    ManagedAgentsDriver,
+    managed_session_cost,
+)
+from api.services.agent_worker.pricing import MANAGED_SESSION_HOUR_OVERHEAD
+
+
+def _build_driver(handler, *, vault_id="vlt_test"):
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    return ManagedAgentsDriver(
+        api_key="sk-test",
+        base_url="http://test/v1/managed-agents",
+        http_client=client,
+        vault_id=vault_id,
+    )
+
+
+@pytest.mark.unit
+def test_driver_requires_api_key():
+    with pytest.raises(ValueError):
+        ManagedAgentsDriver(api_key="")
+
+
+@pytest.mark.unit
+def test_create_session_request_shape_and_returns_id():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"session_id": "sess_remote_xyz"})
+
+    driver = _build_driver(handler)
+    sid = driver.create_session(
+        system_prompt="be useful",
+        user_message="say hi",
+        model="claude-opus-4-7",
+        mcp_servers=[{"name": "lifeos", "url": "http://mcp"}],
+        connectors=["gmail"],
+        max_tokens=1000,
+        max_dollars=2.0,
+        max_wall_seconds=300,
+    )
+    assert sid == "sess_remote_xyz"
+    assert captured["url"].endswith("/sessions")
+    assert captured["headers"]["x-api-key"] == "sk-test"
+    body = captured["body"]
+    assert body["model"] == "claude-opus-4-7"
+    assert body["system_prompt"] == "be useful"
+    assert body["initial_message"] == "say hi"
+    assert body["vault_id"] == "vlt_test"
+    assert body["mcp_servers"] == [{"name": "lifeos", "url": "http://mcp"}]
+    assert body["connectors"] == ["gmail"]
+    assert body["max_tokens"] == 1000
+    assert body["max_dollars"] == 2.0
+    assert body["max_wall_seconds"] == 300
+
+
+@pytest.mark.unit
+def test_create_session_raises_when_id_missing():
+    def handler(request):
+        return httpx.Response(200, json={"foo": "bar"})
+
+    driver = _build_driver(handler)
+    with pytest.raises(RuntimeError, match="missing session id"):
+        driver.create_session(
+            system_prompt="x", user_message="y", model="claude-opus-4-7",
+        )
+
+
+@pytest.mark.unit
+def test_create_session_raises_on_http_error():
+    def handler(request):
+        return httpx.Response(500, text="server error")
+
+    driver = _build_driver(handler)
+    with pytest.raises(httpx.HTTPStatusError):
+        driver.create_session(system_prompt="x", user_message="y", model="m")
+
+
+@pytest.mark.unit
+def test_get_session_state_parses_full_response():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path.endswith("/sessions/sess_abc")
+        return httpx.Response(200, json={
+            "session_id": "sess_abc",
+            "status": "running",
+            "events": [
+                {"id": "evt_1", "type": "agent.message", "payload": {"text": "hi"}},
+                {"id": "evt_2", "type": "tool.call", "payload": {"tool": "Bash"}},
+            ],
+            "usage": {"input_tokens": 100, "output_tokens": 40},
+            "final_text": None,
+            "error": None,
+        })
+
+    driver = _build_driver(handler)
+    state = driver.get_session_state("sess_abc")
+    assert state.session_id == "sess_abc"
+    assert state.status == "running"
+    assert state.last_event_id == "evt_2"
+    assert len(state.new_events) == 2
+    assert state.total_input_tokens == 100
+    assert state.total_output_tokens == 40
+    assert state.final_text is None
+    assert state.error_reason is None
+
+
+@pytest.mark.unit
+def test_get_session_state_uses_since_cursor():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={
+            "status": "running", "events": [], "usage": {}, "final_text": None, "error": None,
+        })
+
+    driver = _build_driver(handler)
+    driver.get_session_state("sess_abc", since_event_id="evt_7")
+    assert captured["params"]["since"] == "evt_7"
+
+
+@pytest.mark.unit
+def test_get_session_state_parses_terminal_with_final_text_and_error():
+    def handler(request):
+        return httpx.Response(200, json={
+            "status": "completed", "events": [], "usage": {"input_tokens": 50, "output_tokens": 80},
+            "final_text": "done!", "error": None,
+        })
+
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.status == "completed"
+    assert state.final_text == "done!"
+    assert state.total_output_tokens == 80
+
+
+@pytest.mark.unit
+def test_get_session_state_failed_carries_error_message():
+    def handler(request):
+        return httpx.Response(200, json={
+            "status": "failed", "events": [], "usage": {},
+            "final_text": None, "error": {"message": "remote tool crashed"},
+        })
+
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.status == "failed"
+    assert state.error_reason == "remote tool crashed"
+
+
+@pytest.mark.unit
+def test_post_user_message_request_shape():
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"ok": True})
+
+    _build_driver(handler).post_user_message("sess", "and here is the answer")
+    assert captured["method"] == "POST"
+    assert captured["body"] == {"role": "user", "content": "and here is the answer"}
+
+
+@pytest.mark.unit
+def test_kill_session_uses_delete_and_swallows_errors():
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        return httpx.Response(204)
+
+    _build_driver(handler).kill_session("sess", reason="budget")
+    assert captured["method"] == "DELETE"
+
+    # And the error path is swallowed (logged, not raised).
+    def boom(request):
+        return httpx.Response(500)
+
+    _build_driver(boom).kill_session("sess")  # must not raise
+
+
+@pytest.mark.unit
+def test_managed_session_cost_includes_overhead():
+    cost = managed_session_cost("claude-opus-4-7", 1000, 1000, wall_seconds=3600)
+    # 1k input ($0.015) + 1k output ($0.075) + 1 hr * $0.08
+    expected = 0.015 + 0.075 + MANAGED_SESSION_HOUR_OVERHEAD
+    assert cost == pytest.approx(expected)
+
+
+@pytest.mark.unit
+def test_managed_session_cost_partial_hour():
+    # 30 minutes of session-hour overhead.
+    cost = managed_session_cost("local", 0, 0, wall_seconds=1800)
+    assert cost == pytest.approx(0.5 * MANAGED_SESSION_HOUR_OVERHEAD)

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -84,12 +84,17 @@ def test_start_creates_remote_session_and_attaches_id(stores):
 
 @pytest.mark.unit
 def test_start_handles_create_failure(stores):
+    """create_session failure path masks the exception args (which may contain
+    request details / API key) and surfaces only the exception type name."""
     store, session, transcript = stores
     driver = _FakeDriver(create_raises=RuntimeError("403"))
     executor = ManagedExecutor(store, transcript, driver=driver)
     outcome = executor.start(session, {"id": "t1", "description": "x"})
     assert outcome.status == STATUS_FAILED
-    assert "403" in outcome.reason
+    # Exception args (which may contain headers/API key) are NOT surfaced —
+    # only the type name.
+    assert "RuntimeError" in outcome.reason
+    assert "403" not in outcome.reason
     assert store.get("t1").status == STATUS_FAILED
 
 
@@ -226,6 +231,82 @@ def test_poll_records_session_hour_overhead_on_completion(stores):
     # session ran for ~0 seconds in test, so overhead is ~$0 — but the path
     # exists. Verify total_dollars is a non-negative number (not None).
     assert store.get("t1").total_dollars >= 0
+
+
+@pytest.mark.unit
+def test_poll_kills_remote_session_on_token_budget_breach(stores):
+    store, session, transcript = stores
+    # Tighten the budget so the first poll exceeds it.
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100, "max_dollars": 100.0},
+        expected_output="text",
+    )
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_x",
+            new_events=[],
+            total_input_tokens=120, total_output_tokens=0,  # exceeds 100-token cap
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "max_tokens" in outcome.reason
+    # Remote session was killed.
+    assert driver.kills, "expected driver.kill_session to be called"
+    assert driver.kills[0][0] == "sess_remote"
+
+
+@pytest.mark.unit
+def test_poll_kills_remote_session_on_dollar_budget_breach(stores):
+    store, session, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 1_000_000, "max_dollars": 0.001},
+        expected_output="text",
+    )
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 100 input tokens * Opus rate ($15/M) = $0.0015 — just over $0.001 cap.
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_x",
+            new_events=[],
+            total_input_tokens=100, total_output_tokens=0,
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver, model="claude-opus-4-7")
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "max_dollars" in outcome.reason
+    assert driver.kills
+
+
+@pytest.mark.unit
+def test_cancelled_status_uses_distinct_telegram_reason(stores):
+    """`cancelled` and `failed` both map to STATUS_FAILED internally but the
+    reason text is distinct so the operator can tell them apart."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="cancelled",
+            last_event_id="evt_c", new_events=[],
+            total_input_tokens=0, total_output_tokens=0,
+            error_reason="operator pressed cancel",
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_FAILED
+    assert "cancelled" in outcome.reason
+    assert "operator pressed cancel" in outcome.reason
 
 
 @pytest.mark.unit

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -1,0 +1,250 @@
+"""ManagedExecutor lifecycle tests — create → poll → terminal.
+
+Driver is mocked at the class level (not via HTTP) so we exercise the
+executor's orchestration logic — transcript mirroring, budget accounting,
+state machine transitions — without depending on the API surface.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.managed_driver import ManagedSessionState
+from api.services.agent_worker.managed_executor import ManagedExecutor
+from api.services.agent_worker.session_store import (
+    STATUS_BUDGET_EXCEEDED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+class _FakeDriver:
+    """Records calls and returns scripted state objects."""
+
+    def __init__(self, *, create_returns="sess_remote", state_responses=None, create_raises=None):
+        self.create_returns = create_returns
+        self.state_responses = list(state_responses or [])
+        self.create_raises = create_raises
+        self.kills: list[tuple[str, str]] = []
+        self.created_with: dict | None = None
+        self.poll_calls: list[tuple[str, str | None]] = []
+
+    def create_session(self, **kwargs):
+        self.created_with = kwargs
+        if self.create_raises:
+            raise self.create_raises
+        return self.create_returns
+
+    def get_session_state(self, session_id, since_event_id=None):
+        self.poll_calls.append((session_id, since_event_id))
+        if not self.state_responses:
+            raise AssertionError("driver poll called with no scripted responses")
+        return self.state_responses.pop(0)
+
+    def kill_session(self, session_id, reason=""):
+        self.kills.append((session_id, reason))
+
+
+@pytest.fixture
+def stores(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    store.create(
+        task_id="t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+        expected_output="text",
+    )
+    session = store.get("t1")
+    transcript = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    return store, session, transcript
+
+
+@pytest.mark.unit
+def test_start_creates_remote_session_and_attaches_id(stores):
+    store, session, transcript = stores
+    driver = _FakeDriver(create_returns="sess_remote_42")
+    executor = ManagedExecutor(store, transcript, driver=driver, model="claude-opus-4-7")
+
+    outcome = executor.start(session, {"id": "t1", "description": "say hi"})
+    assert outcome.status == STATUS_RUNNING
+    refreshed = store.get("t1")
+    assert refreshed.managed_agent_session_id == "sess_remote_42"
+    # System prompt + initial message routed through the driver
+    assert "expected output shape is `text`" in driver.created_with["system_prompt"]
+    assert "say hi" in driver.created_with["user_message"]
+    # Budget passed through
+    assert driver.created_with["max_wall_seconds"] == 3600
+    assert driver.created_with["max_tokens"] == 100_000
+    assert driver.created_with["max_dollars"] == 5.0
+
+
+@pytest.mark.unit
+def test_start_handles_create_failure(stores):
+    store, session, transcript = stores
+    driver = _FakeDriver(create_raises=RuntimeError("403"))
+    executor = ManagedExecutor(store, transcript, driver=driver)
+    outcome = executor.start(session, {"id": "t1", "description": "x"})
+    assert outcome.status == STATUS_FAILED
+    assert "403" in outcome.reason
+    assert store.get("t1").status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_poll_returns_running_when_remote_still_running(stores):
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running",
+            last_event_id="evt_1",
+            new_events=[{"id": "evt_1", "type": "agent.message", "payload": {"text": "thinking"}}],
+            total_input_tokens=10, total_output_tokens=5,
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver)
+
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_RUNNING
+
+    # Tokens / cursor recorded
+    refreshed = store.get("t1")
+    assert refreshed.total_input_tokens == 10
+    assert refreshed.total_output_tokens == 5
+    assert store.get_managed_last_event_id("t1") == "evt_1"
+
+    events = [e["kind"] for e in transcript.read(session.session_id)]
+    assert "managed_event_agent.message" in events
+
+
+@pytest.mark.unit
+def test_poll_uses_since_cursor_on_subsequent_calls(stores):
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[{"id": "evt_1", "type": "x"}],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_2",
+            new_events=[{"id": "evt_2", "type": "y"}],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver)
+    executor.poll(session)
+    # Reload session to pick up the cursor.
+    session = store.get("t1")
+    executor.poll(session)
+    # First call: since=None; second call: since=evt_1.
+    assert driver.poll_calls == [("sess_remote", None), ("sess_remote", "evt_1")]
+
+
+@pytest.mark.unit
+def test_poll_finalizes_completed(stores):
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="completed",
+            last_event_id="evt_done",
+            new_events=[{"id": "evt_done", "type": "session.completed", "payload": {}}],
+            total_input_tokens=200, total_output_tokens=100,
+            final_text="The answer is 42.",
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_COMPLETED
+    assert outcome.final_text == "The answer is 42."
+    assert store.get("t1").status == STATUS_COMPLETED
+
+
+@pytest.mark.unit
+def test_poll_finalizes_budget_exceeded(stores):
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="budget_exceeded",
+            last_event_id="evt_bx", new_events=[],
+            total_input_tokens=0, total_output_tokens=0,
+            error_reason="hit max_tokens",
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "max_tokens" in outcome.reason
+
+
+@pytest.mark.unit
+def test_poll_finalizes_failed_with_error_reason(stores):
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="failed",
+            last_event_id="evt_fail", new_events=[],
+            total_input_tokens=0, total_output_tokens=0,
+            error_reason="tool dispatch crashed",
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_FAILED
+    assert outcome.reason == "tool dispatch crashed"
+    assert store.get("t1").status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_poll_records_session_hour_overhead_on_completion(stores):
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="completed",
+            last_event_id="evt_done", new_events=[],
+            total_input_tokens=0, total_output_tokens=0,
+            final_text="ok",
+        ),
+    ])
+    executor = ManagedExecutor(store, transcript, driver=driver)
+    executor.poll(session)
+    # session ran for ~0 seconds in test, so overhead is ~$0 — but the path
+    # exists. Verify total_dollars is a non-negative number (not None).
+    assert store.get("t1").total_dollars >= 0
+
+
+@pytest.mark.unit
+def test_poll_returns_running_on_transient_driver_error(stores):
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+
+    class _CrashingDriver(_FakeDriver):
+        def get_session_state(self, *a, **kw):
+            raise httpx_timeout()
+
+    def httpx_timeout():
+        import httpx
+        return httpx.TimeoutException("temporary network blip")
+
+    executor = ManagedExecutor(store, transcript, driver=_CrashingDriver())
+    outcome = executor.poll(session)
+    # Transient errors don't kill the session — worker retries next tick.
+    assert outcome.status == STATUS_RUNNING
+    # Session not yet marked terminal.
+    assert store.get("t1").status != STATUS_FAILED


### PR DESCRIPTION
## Summary
Issue D of the agent-worker series (epic #98). Wires the Claude execution path that Issue C parked at \`#agent-blocked\` — a polling-based driver for [Anthropic Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview), a \`ManagedExecutor\` that mirrors \`LocalExecutor\`'s shape, and a tick-loop poll step that advances in-flight remote sessions each cycle. The Vault provisioning is documented as operator follow-up (Step 4b in the setup guide). Both \`#agent\` (Claude) and \`#agent #local\` (Gemma) paths are now end-to-end.

Closes #102 · Relates to #98

## Test evidence
- \`pytest tests/test_agent_worker_*.py\` — **90/90 passed** (+21 new: 12 driver, 9 executor; updated worker integration test)
- Pre-push hook full unit suite — **1285/1285 passed** (was 1260)

## Review focus
- **Beta caveat is loud and clear** — Managed Agents launched April 2026 (post my training cutoff). Endpoint shapes documented inline in \`managed_driver.py\` with a "operator must verify against your account" note in both the module docstring and the setup guide.
- **Polling, not SSE** — single-threaded worker drives one poll step per tick per active session. State is in the DB (`managed_agent_session_id`, \`managed_cursor.last_event_id\`), restart-safe.
- **Transient errors don't kill sessions** — \`poll\` returns \`STATUS_RUNNING\` on HTTP/network blips so the worker retries next tick. Tested with \`test_poll_returns_running_on_transient_driver_error\`.
- **Cost model** — \`pricing.MANAGED_SESSION_HOUR_OVERHEAD = 0.08\` plus standard token rates via \`cost_for\`. The session-hour overhead is the design rationale for the yield-and-resume pattern in Issue E.
- **Credentials gate** — without \`LIFEOS_AGENT_VAULT_ID\` and \`ANTHROPIC_API_KEY\`, the worker parks Claude tasks at \`#agent-blocked\` with a clear "configure Managed Agents" Telegram message rather than crashing.
- **MCP connector wiring** — \`Worker._get_managed_executor\` builds the LifeOS MCP server entry automatically from \`LIFEOS_MCP_HTTP_URL\` + \`LIFEOS_MCP_BEARER_TOKEN\` (Issue A). Operator adds connector slugs via \`LIFEOS_AGENT_CONNECTORS\`.
- **No new third-party deps** — driver uses existing \`httpx\`.

## Out of scope
- Inter-agent \`lifeos_agent_*\` tools (#103 — E)
- Telegram clarification round-trip via reply-threading (#104 — F)
- Slack / Asana connectors (deferred per epic design)
- SSE streaming (polling is sufficient for an MVP; can upgrade later)

## Manual smoke verification (operator follow-up)
1. Create a Managed Agents Vault, OAuth into Gmail/Calendar/Drive/Superhuman/Zapier
2. Add the LifeOS MCP HTTP endpoint as a Vault connector with bearer header
3. Set \`LIFEOS_AGENT_VAULT_ID\`, \`LIFEOS_AGENT_CONNECTORS\`, \`LIFEOS_MCP_HTTP_URL\` in \`.env\`
4. \`sudo systemctl restart lifeos-agent-worker\`
5. Create a task: \`POST /api/tasks {"description": "find Granola notes from last Monday's standup", "tags": ["agent"]}\`
6. Within ~minutes: Telegram completion summary with what was found