### PR TITLE
feat: inter-agent tools — spawn, yield-and-resume, lineage budgets (E of F)

### DIFF
--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -67,12 +67,15 @@ class InterAgentContext:
 
     Distributed by the local executor (in-process) or the worker (when
     receiving a managed-side MCP call) so the tool functions can operate
-    without knowing how they were called.
+    without knowing how they were called. `managed_driver` is optional —
+    when present, `kill` and other tools can reach remote managed sessions;
+    when absent, managed targets are killed in the DB only.
     """
     session_store: SessionStore
     transcript_store: TranscriptStore
     caller_session_id: str
     caps: Caps
+    managed_driver: Any | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -222,16 +225,20 @@ def spawn(ctx: InterAgentContext, args: dict) -> dict:
             code="cap_descendants",
         )
 
-    # Cap: concurrency per routing.
+    # Cap: concurrency per routing. The caller doesn't count toward its own
+    # cap — the expected pattern is "parent calls spawn, then yield_until";
+    # the parent's session is non-terminal at spawn time but will yield
+    # immediately after.
+    caller_excluded = 1 if caller.routing == model else 0
     if model == "local":
-        active = ctx.session_store.count_active_by_routing("local")
+        active = ctx.session_store.count_active_by_routing("local") - caller_excluded
         if active >= ctx.caps.max_concurrent_local:
             return _err(
                 f"{active} local sessions already running (cap {ctx.caps.max_concurrent_local})",
                 code="cap_concurrency_local",
             )
     else:
-        active = ctx.session_store.count_active_by_routing("claude")
+        active = ctx.session_store.count_active_by_routing("claude") - caller_excluded
         if active >= ctx.caps.max_concurrent_managed:
             return _err(
                 f"{active} managed sessions already running (cap {ctx.caps.max_concurrent_managed})",
@@ -258,7 +265,7 @@ def spawn(ctx: InterAgentContext, args: dict) -> dict:
 
     # Create the session. We use a synthetic task_id since spawned sessions
     # don't have a backing #agent task in the user's task list.
-    child_task_id = f"spawn_{new_session_id()[5:]}"  # `sess_<hex>` → `spawn_<hex>`
+    child_task_id = f"spawn_{new_session_id().removeprefix('sess_')}"
     child_session_id = new_session_id()
     ctx.session_store.create(
         task_id=child_task_id,
@@ -271,8 +278,11 @@ def spawn(ctx: InterAgentContext, args: dict) -> dict:
         root_session_id=root,
         spawn_depth=new_depth,
     )
-    # Seed the conversation with the spawn prompt as the initial user turn.
-    ctx.session_store.append_message(child_session_id, "user", prompt)
+    # The prompt becomes the child's task description (used by the executor's
+    # _seed_conversation) so the system prompt + inter-agent guidance run as
+    # normal. We also stash the prompt in pending_messages as a fallback for
+    # the worker's task lookup (children have no API-backed task).
+    ctx.session_store.enqueue_message(child_session_id, caller.session_id, prompt)
     ctx.transcript_store.append(child_session_id, "spawn", {
         "parent_session_id": caller.session_id,
         "root_session_id": root,
@@ -303,6 +313,19 @@ def send(ctx: InterAgentContext, args: dict) -> dict:
         return _err(f"session {target_id} not found", code="not_found")
     if target.status in TERMINAL_STATUSES:
         return _err(f"session {target_id} is terminal ({target.status})", code="terminal")
+
+    # Same-root lineage check — agents can't inject messages into unrelated
+    # sessions. Matches the security model of `kill` and `yield_until`.
+    caller = ctx.session_store.get_by_session_id(ctx.caller_session_id)
+    if caller is None:
+        return _err(f"caller session {ctx.caller_session_id} not found", code="no_caller")
+    caller_root = caller.root_session_id or caller.session_id
+    target_root = target.root_session_id or target.session_id
+    if target_root != caller_root:
+        return _err(
+            f"session {target_id} is not in your lineage",
+            code="forbidden",
+        )
 
     # Always queue. For an actively-running local session, the executor picks
     # up pending messages at the start of each turn. For a yielded session,
@@ -382,9 +405,25 @@ def kill(ctx: InterAgentContext, args: dict) -> dict:
     if target.status in TERMINAL_STATUSES:
         return _ok({"killed": False, "reason": f"already {target.status}"})
 
+    # Managed children: kill the remote session too so it stops accruing
+    # tokens / session-hour overhead. Without a driver we can only flip the
+    # local DB status; the worker's next managed poll will then see the
+    # local FAILED status and treat the session as terminal even if the
+    # remote still reports running.
+    if target.managed_agent_session_id and ctx.managed_driver is not None:
+        try:
+            ctx.managed_driver.kill_session(
+                target.managed_agent_session_id,
+                reason=args.get("reason", ""),
+            )
+        except Exception as exc:
+            logger.warning("kill_session %s failed: %s",
+                           target.managed_agent_session_id, exc)
+
     ctx.session_store.update_status(target.task_id, STATUS_FAILED)
     ctx.transcript_store.append(target_id, "killed", {
         "by": caller.session_id, "reason": args.get("reason", ""),
+        "managed_remote": target.managed_agent_session_id,
     })
     return _ok({"killed": True})
 

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -1,0 +1,457 @@
+"""Inter-agent coordination tools (`lifeos_agent_*` family).
+
+These tools let an in-flight agent session spawn, message, and coordinate with
+other agent sessions — turning the worker into a multi-agent supervisor. The
+core primitives are:
+
+  - **spawn**: create a child session (Claude or local) with budget drawn from
+    the caller's lineage budget. Returns immediately with a `child_session_id`.
+  - **send**: append a user-role message to a peer/child session. For yielded
+    sessions, the message is queued for the next resume.
+  - **check**: non-blocking status snapshot of any session.
+  - **yield_until**: terminate the caller's session until specified children
+    reach a terminal state; on resume, children's outputs are injected as a
+    new user turn. The primary coordination primitive — avoids idle billing
+    on Managed Agents.
+  - **kill**: terminate a descendant session.
+  - **transcript_read**: read the JSONL transcript of any session.
+  - **sessions_list**: filtered listing of recent sessions.
+
+This module exposes the tools as plain Python functions taking an `InterAgentContext`
+that bundles the worker's stores + caller's session_id. The `ToolRegistry`
+(local executor) and `mcp_server.py` (managed agents) both wrap these into
+tool definitions.
+
+Security model: no-sandbox per AGENTS.md. The MCP-side wrapping passes
+`caller_session_id` as a parameter — operators trust their own agents.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from api.services.agent_worker.session_store import (
+    STATUS_CLAIMED,
+    STATUS_FAILED,
+    STATUS_YIELDED,
+    TERMINAL_STATUSES,
+    SessionStore,
+    new_session_id,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+logger = logging.getLogger(__name__)
+
+
+# Caps enforced on spawn. Operator overrides via settings (see `Caps` dataclass).
+DEFAULT_MAX_SPAWN_DEPTH = 3
+DEFAULT_MAX_DESCENDANTS_PER_ROOT = 50
+DEFAULT_MAX_CONCURRENT_LOCAL = 1
+DEFAULT_MAX_CONCURRENT_MANAGED = 10
+
+
+@dataclass
+class Caps:
+    """Concurrency / lineage limits applied to spawn."""
+    max_spawn_depth: int = DEFAULT_MAX_SPAWN_DEPTH
+    max_descendants_per_root: int = DEFAULT_MAX_DESCENDANTS_PER_ROOT
+    max_concurrent_local: int = DEFAULT_MAX_CONCURRENT_LOCAL
+    max_concurrent_managed: int = DEFAULT_MAX_CONCURRENT_MANAGED
+
+
+@dataclass
+class InterAgentContext:
+    """Bundle of dependencies the tools need.
+
+    Distributed by the local executor (in-process) or the worker (when
+    receiving a managed-side MCP call) so the tool functions can operate
+    without knowing how they were called.
+    """
+    session_store: SessionStore
+    transcript_store: TranscriptStore
+    caller_session_id: str
+    caps: Caps
+
+
+# ---------------------------------------------------------------------------
+# Result helpers
+# ---------------------------------------------------------------------------
+
+def _ok(payload: dict | None = None) -> dict:
+    out = {"ok": True}
+    if payload:
+        out.update(payload)
+    return out
+
+
+def _err(message: str, code: str = "error") -> dict:
+    return {"ok": False, "error": code, "message": message}
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions (Anthropic format) — shared by local and managed agents.
+# ---------------------------------------------------------------------------
+
+INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "name": "lifeos_agent_spawn",
+        "description": "Spawn a child agent session that runs in parallel. Returns immediately with a `child_session_id` you can monitor with `lifeos_agent_check` or wait on with `lifeos_agent_yield_until`. Budget is drawn from your remaining lineage budget.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "Task description for the child agent"},
+                "model": {"type": "string", "enum": ["claude", "local"], "description": "Which executor to run the child on"},
+                "max_dollars": {"type": "number", "description": "Optional per-child dollar budget"},
+                "max_tokens": {"type": "integer", "description": "Optional per-child token budget"},
+                "wall_seconds": {"type": "integer", "description": "Optional per-child wall-clock budget"},
+                "expected_output": {"type": "string", "enum": ["text", "file", "external_action", "structured"]},
+            },
+            "required": ["prompt", "model"],
+        },
+    },
+    {
+        "name": "lifeos_agent_send",
+        "description": "Append a user-role message to another agent session. For sessions that are yielded or sleeping, the message is queued and delivered on resume.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string"},
+                "message": {"type": "string"},
+            },
+            "required": ["session_id", "message"],
+        },
+    },
+    {
+        "name": "lifeos_agent_check",
+        "description": "Non-blocking status of an agent session: current status, tokens/dollars used, last activity. Use for short-polling; prefer `lifeos_agent_yield_until` for waits >1 minute.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"session_id": {"type": "string"}},
+            "required": ["session_id"],
+        },
+    },
+    {
+        "name": "lifeos_agent_yield_until",
+        "description": "Pause yourself until all listed children reach a terminal state. Your current session ends; when the condition is met, a fresh resumed session is created with the children's outputs injected as a new user turn. This is the preferred wait primitive — no idle billing.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "children": {"type": "array", "items": {"type": "string"}, "description": "session_ids to wait on"},
+                "reason": {"type": "string", "description": "Why you're yielding (one short sentence)"},
+            },
+            "required": ["children"],
+        },
+    },
+    {
+        "name": "lifeos_agent_kill",
+        "description": "Terminate a descendant session. Only allowed on sessions whose lineage descends from yours.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string"},
+                "reason": {"type": "string"},
+            },
+            "required": ["session_id"],
+        },
+    },
+    {
+        "name": "lifeos_agent_transcript_read",
+        "description": "Read the event log (JSONL transcript) of any agent session — your own, a child's, or any sibling/peer.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string"},
+                "since_turn": {"type": "integer", "description": "Optional: skip events before this index"},
+            },
+            "required": ["session_id"],
+        },
+    },
+    {
+        "name": "lifeos_agent_sessions_list",
+        "description": "List recent agent sessions, optionally filtered by status / routing / parent.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "status": {"type": "string"},
+                "routing": {"type": "string", "enum": ["claude", "local"]},
+                "parent_session_id": {"type": "string"},
+                "limit": {"type": "integer"},
+            },
+            "required": [],
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+def spawn(ctx: InterAgentContext, args: dict) -> dict:
+    """Create a child session. Does NOT dispatch — the worker's next tick
+    picks up the new session and routes it through the executors.
+    """
+    prompt = (args.get("prompt") or "").strip()
+    if not prompt:
+        return _err("prompt is required", code="invalid_arg")
+    model = args.get("model")
+    if model not in ("claude", "local"):
+        return _err("model must be 'claude' or 'local'", code="invalid_arg")
+
+    caller = ctx.session_store.get_by_session_id(ctx.caller_session_id)
+    if caller is None:
+        return _err(f"caller session {ctx.caller_session_id} not found", code="no_caller")
+
+    # Cap: spawn depth.
+    new_depth = (caller.spawn_depth or 0) + 1
+    if new_depth > ctx.caps.max_spawn_depth:
+        return _err(
+            f"spawn depth {new_depth} exceeds cap {ctx.caps.max_spawn_depth}",
+            code="cap_spawn_depth",
+        )
+
+    # Cap: descendants per root.
+    root = caller.root_session_id or caller.session_id
+    descendant_count = ctx.session_store.count_descendants(root)
+    if descendant_count >= ctx.caps.max_descendants_per_root:
+        return _err(
+            f"root {root} already has {descendant_count} descendants "
+            f"(cap {ctx.caps.max_descendants_per_root})",
+            code="cap_descendants",
+        )
+
+    # Cap: concurrency per routing.
+    if model == "local":
+        active = ctx.session_store.count_active_by_routing("local")
+        if active >= ctx.caps.max_concurrent_local:
+            return _err(
+                f"{active} local sessions already running (cap {ctx.caps.max_concurrent_local})",
+                code="cap_concurrency_local",
+            )
+    else:
+        active = ctx.session_store.count_active_by_routing("claude")
+        if active >= ctx.caps.max_concurrent_managed:
+            return _err(
+                f"{active} managed sessions already running (cap {ctx.caps.max_concurrent_managed})",
+                code="cap_concurrency_managed",
+            )
+
+    # Budget: child's max_dollars cannot exceed parent's remaining.
+    parent_budget = caller.budget or {}
+    spent = caller.total_dollars or 0.0
+    parent_remaining = (parent_budget.get("max_dollars", 0.0) or 0.0) - spent
+    requested_dollars = float(args.get("max_dollars") or parent_remaining)
+    if requested_dollars > parent_remaining + 1e-6:
+        return _err(
+            f"requested ${requested_dollars:.2f} exceeds parent remaining ${parent_remaining:.2f}",
+            code="budget_exceeded",
+        )
+
+    child_budget = {
+        "wall_seconds": int(args.get("wall_seconds") or parent_budget.get("wall_seconds", 14400)),
+        "max_tokens": int(args.get("max_tokens") or parent_budget.get("max_tokens", 500_000)),
+        "max_dollars": float(requested_dollars),
+    }
+    expected_output = args.get("expected_output") or "text"
+
+    # Create the session. We use a synthetic task_id since spawned sessions
+    # don't have a backing #agent task in the user's task list.
+    child_task_id = f"spawn_{new_session_id()[5:]}"  # `sess_<hex>` → `spawn_<hex>`
+    child_session_id = new_session_id()
+    ctx.session_store.create(
+        task_id=child_task_id,
+        session_id=child_session_id,
+        status=STATUS_CLAIMED,
+        routing=model,
+        budget=child_budget,
+        expected_output=expected_output,
+        parent_session_id=caller.session_id,
+        root_session_id=root,
+        spawn_depth=new_depth,
+    )
+    # Seed the conversation with the spawn prompt as the initial user turn.
+    ctx.session_store.append_message(child_session_id, "user", prompt)
+    ctx.transcript_store.append(child_session_id, "spawn", {
+        "parent_session_id": caller.session_id,
+        "root_session_id": root,
+        "spawn_depth": new_depth,
+        "model": model,
+        "prompt_chars": len(prompt),
+    })
+    ctx.transcript_store.append(caller.session_id, "spawned_child", {
+        "child_session_id": child_session_id,
+        "model": model,
+    })
+    logger.info("spawn: caller=%s child=%s model=%s depth=%d",
+                caller.session_id, child_session_id, model, new_depth)
+    return _ok({
+        "child_session_id": child_session_id,
+        "task_id": child_task_id,
+        "budget": child_budget,
+    })
+
+
+def send(ctx: InterAgentContext, args: dict) -> dict:
+    target_id = args.get("session_id", "").strip()
+    message = (args.get("message") or "").strip()
+    if not target_id or not message:
+        return _err("session_id and message are required", code="invalid_arg")
+    target = ctx.session_store.get_by_session_id(target_id)
+    if target is None:
+        return _err(f"session {target_id} not found", code="not_found")
+    if target.status in TERMINAL_STATUSES:
+        return _err(f"session {target_id} is terminal ({target.status})", code="terminal")
+
+    # Always queue. For an actively-running local session, the executor picks
+    # up pending messages at the start of each turn. For a yielded session,
+    # delivery happens on resume.
+    msg_id = ctx.session_store.enqueue_message(target_id, ctx.caller_session_id, message)
+    ctx.transcript_store.append(target_id, "inter_agent_send", {
+        "from": ctx.caller_session_id, "chars": len(message),
+    })
+    return _ok({"delivered": True, "message_id": msg_id, "queued": target.status == STATUS_YIELDED})
+
+
+def check(ctx: InterAgentContext, args: dict) -> dict:
+    target_id = args.get("session_id", "").strip()
+    if not target_id:
+        return _err("session_id is required", code="invalid_arg")
+    target = ctx.session_store.get_by_session_id(target_id)
+    if target is None:
+        return _err(f"session {target_id} not found", code="not_found")
+    tokens = (target.total_input_tokens or 0) + (target.total_output_tokens or 0)
+    return _ok({
+        "session_id": target_id,
+        "status": target.status,
+        "routing": target.routing,
+        "tokens_used": tokens,
+        "dollars_used": float(target.total_dollars or 0.0),
+        "last_activity_at": target.last_activity_at,
+        "parent_session_id": target.parent_session_id,
+    })
+
+
+def yield_until(ctx: InterAgentContext, args: dict) -> dict:
+    children_raw = args.get("children") or []
+    if not isinstance(children_raw, list) or not children_raw:
+        return _err("children must be a non-empty list of session_ids", code="invalid_arg")
+    children = [str(c) for c in children_raw if isinstance(c, str)]
+    if not children:
+        return _err("no valid session_ids in children", code="invalid_arg")
+
+    caller = ctx.session_store.get_by_session_id(ctx.caller_session_id)
+    if caller is None:
+        return _err(f"caller session {ctx.caller_session_id} not found", code="no_caller")
+
+    # Verify all listed children exist and are descendants of caller's lineage
+    # (so an agent can't yield on someone else's family).
+    children_sessions = ctx.session_store.list_by_session_ids(children)
+    found_ids = {s.session_id for s in children_sessions}
+    missing = [c for c in children if c not in found_ids]
+    if missing:
+        return _err(f"unknown children: {missing}", code="not_found")
+    root = caller.root_session_id or caller.session_id
+    foreign = [s.session_id for s in children_sessions if s.root_session_id != root]
+    if foreign:
+        return _err(f"children {foreign} are not in your lineage", code="forbidden")
+
+    ctx.session_store.set_yield_waiting_for(caller.task_id, children)
+    ctx.session_store.update_status(caller.task_id, STATUS_YIELDED)
+    ctx.transcript_store.append(caller.session_id, "yield", {
+        "children": children, "reason": args.get("reason", ""),
+    })
+    return _ok({"yielded": True, "waiting_on": children})
+
+
+def kill(ctx: InterAgentContext, args: dict) -> dict:
+    target_id = args.get("session_id", "").strip()
+    if not target_id:
+        return _err("session_id is required", code="invalid_arg")
+    target = ctx.session_store.get_by_session_id(target_id)
+    if target is None:
+        return _err(f"session {target_id} not found", code="not_found")
+
+    caller = ctx.session_store.get_by_session_id(ctx.caller_session_id)
+    if caller is None:
+        return _err(f"caller session {ctx.caller_session_id} not found", code="no_caller")
+    caller_root = caller.root_session_id or caller.session_id
+    if target.root_session_id != caller_root or target.session_id == caller.session_id:
+        return _err("can only kill descendants of your own root", code="forbidden")
+    if target.status in TERMINAL_STATUSES:
+        return _ok({"killed": False, "reason": f"already {target.status}"})
+
+    ctx.session_store.update_status(target.task_id, STATUS_FAILED)
+    ctx.transcript_store.append(target_id, "killed", {
+        "by": caller.session_id, "reason": args.get("reason", ""),
+    })
+    return _ok({"killed": True})
+
+
+def transcript_read(ctx: InterAgentContext, args: dict) -> dict:
+    target_id = args.get("session_id", "").strip()
+    if not target_id:
+        return _err("session_id is required", code="invalid_arg")
+    since_turn = int(args.get("since_turn") or 0)
+    events = ctx.transcript_store.read(target_id)
+    if since_turn:
+        events = events[since_turn:]
+    return _ok({"session_id": target_id, "events": events, "count": len(events)})
+
+
+def sessions_list(ctx: InterAgentContext, args: dict) -> dict:
+    sessions = ctx.session_store.list_sessions(
+        status=args.get("status"),
+        routing=args.get("routing"),
+        parent_session_id=args.get("parent_session_id"),
+        limit=int(args.get("limit") or 200),
+    )
+    return _ok({
+        "sessions": [
+            {
+                "session_id": s.session_id,
+                "task_id": s.task_id,
+                "status": s.status,
+                "routing": s.routing,
+                "parent_session_id": s.parent_session_id,
+                "root_session_id": s.root_session_id,
+                "tokens_used": (s.total_input_tokens or 0) + (s.total_output_tokens or 0),
+                "dollars_used": float(s.total_dollars or 0.0),
+                "started_at": s.started_at,
+                "last_activity_at": s.last_activity_at,
+            }
+            for s in sessions
+        ],
+        "count": len(sessions),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Public dispatcher — used by ToolRegistry and the MCP wrapper.
+# ---------------------------------------------------------------------------
+
+DISPATCH_TABLE = {
+    "lifeos_agent_spawn": spawn,
+    "lifeos_agent_send": send,
+    "lifeos_agent_check": check,
+    "lifeos_agent_yield_until": yield_until,
+    "lifeos_agent_kill": kill,
+    "lifeos_agent_transcript_read": transcript_read,
+    "lifeos_agent_sessions_list": sessions_list,
+}
+
+
+def is_inter_agent_tool(name: str) -> bool:
+    return name in DISPATCH_TABLE
+
+
+def dispatch(ctx: InterAgentContext, name: str, args: dict) -> dict:
+    handler = DISPATCH_TABLE.get(name)
+    if handler is None:
+        return _err(f"unknown inter-agent tool: {name}", code="unknown_tool")
+    try:
+        return handler(ctx, args or {})
+    except Exception as exc:
+        logger.exception("inter-agent tool %s crashed: %s", name, exc)
+        return _err(f"{name} crashed: {exc}", code="crashed")

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -215,6 +215,7 @@ class LocalExecutor:
                 return self._finalize_completed(session, response.text)
 
             yielded_seconds: int | None = None
+            yielded_for_children = False
             tool_results: list[dict] = []
             for call in truncated_calls:
                 name = call["name"]
@@ -238,26 +239,38 @@ class LocalExecutor:
                     "is_error": result.is_error,
                 })
                 if result.yield_seconds is not None:
-                    yielded_seconds = result.yield_seconds
+                    if result.yield_seconds < 0:
+                        # Sentinel for lifeos_agent_yield_until — yield without
+                        # a timer; the worker resumes on child terminal events.
+                        yielded_for_children = True
+                    else:
+                        yielded_seconds = result.yield_seconds
                     # Stop dispatching further tools this turn — we're going to yield.
                     break
 
             # If the agent yielded mid-turn, we may have fewer tool_results
             # than persisted tool_use blocks. Pad with synthetic results so
             # the next turn satisfies Anthropic's 1:1 invariant.
-            if yielded_seconds is not None and len(tool_results) < len(truncated_calls):
+            if (yielded_seconds is not None or yielded_for_children) and len(tool_results) < len(truncated_calls):
                 already_handled = {tr["tool_use_id"] for tr in tool_results}
                 for call in truncated_calls:
                     if call["id"] not in already_handled:
                         tool_results.append({
                             "type": "tool_result",
                             "tool_use_id": call["id"],
-                            "content": "skipped — sibling tool requested a sleep yield first",
+                            "content": "skipped — sibling tool requested a yield first",
                             "is_error": False,
                         })
 
             # Persist the tool_results as a user-role turn (Anthropic convention).
             self.session_store.append_message(sid, "user", tool_results)
+
+            if yielded_for_children:
+                # Status + yield_waiting_for is already set by the
+                # lifeos_agent_yield_until handler — just end the loop. Worker
+                # main loop will resume when children terminate.
+                self.transcript_store.append(sid, "yielded_for_children", {})
+                return ExecutorOutcome(status=STATUS_YIELDED)
 
             if yielded_seconds is not None:
                 return self._finalize_sleeping(session, yielded_seconds)

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -108,21 +108,43 @@ class ExecutorOutcome:
     wake_at: int | None = None   # set when status == STATUS_YIELDED (sleep)
 
 
-def _system_prompt(session_id: str, expected_output: str, budget) -> str:
-    """System message for the executor agent."""
+def _system_prompt(session_id: str, expected_output: str, budget, parent_session_id: str | None = None) -> str:
+    """System message for the executor agent.
+
+    Includes the inter-agent discovery guidance required by issue #103 §5 so
+    agents know they can spawn peers, message them, check status, and yield
+    until specific children complete (preferred over polling).
+    """
+    parent_clause = (
+        f" Your parent session is {parent_session_id}."
+        if parent_session_id else " You have no parent (top-level session)."
+    )
     return (
         "You are an autonomous agent running inside LifeOS, handling a single "
         "task from the user's task manager. You have access to file, shell, "
         "and LifeOS data tools. Work concisely and stop when the task is "
         "complete — your final assistant turn (with no tool calls) is the "
         f"answer the user will see.\n\n"
-        f"Your session_id is {session_id}. Your expected output shape is "
-        f"`{expected_output}`. Your budget is wall={budget.get('wall_seconds')}s, "
-        f"max_tokens={budget.get('max_tokens')}, max_dollars=${budget.get('max_dollars')}.\n\n"
-        "If you need to wait for external state to change, call the `sleep` "
-        "tool rather than busy-looping. If you cannot complete the task "
-        "safely or have hit an ambiguity you cannot resolve from context, "
-        "say so plainly in your final response — do not invent answers."
+        f"Your session_id is {session_id}.{parent_clause} Your expected output "
+        f"shape is `{expected_output}`. Your budget is "
+        f"wall={budget.get('wall_seconds')}s, "
+        f"max_tokens={budget.get('max_tokens')}, "
+        f"max_dollars=${budget.get('max_dollars')}.\n\n"
+        "## Inter-agent coordination\n"
+        "Transcripts of other agent sessions are available via "
+        "`lifeos_agent_transcript_read`. List active and recent sessions "
+        "with `lifeos_agent_sessions_list`. You can spawn child agents "
+        "(Claude or local) with `lifeos_agent_spawn`, message them with "
+        "`lifeos_agent_send`, and check their status with `lifeos_agent_check`. "
+        "If you have nothing else to do until specific children finish, call "
+        "`lifeos_agent_yield_until(children=[...])` — this is preferred over "
+        "polling, since it ends your session (no idle billing) and you'll be "
+        "automatically resumed with their results when they're done.\n\n"
+        "If you need to wait for external state to change with no children to "
+        "wait on, call the `sleep` tool rather than busy-looping. If you "
+        "cannot complete the task safely or have hit an ambiguity you cannot "
+        "resolve from context, say so plainly in your final response — do "
+        "not invent answers."
     )
 
 
@@ -191,6 +213,21 @@ class LocalExecutor:
                 return self._finalize_budget_exceeded(session, "max_tokens")
             if budget.get("max_dollars") is not None and (updated.total_dollars or 0) >= budget["max_dollars"]:
                 return self._finalize_budget_exceeded(session, "max_dollars")
+
+            # Lineage budget — for sessions with descendants, the *root* budget
+            # caps the total spend across the family. When breached we cascade-
+            # kill the entire lineage so a runaway sub-tree can't keep burning
+            # tokens after the root's budget is exhausted.
+            root_id = updated.root_session_id or updated.session_id
+            if root_id != updated.session_id:
+                root = self.session_store.get_by_session_id(root_id)
+                if root and root.budget:
+                    root_cap = (root.budget or {}).get("max_dollars")
+                    if root_cap is not None:
+                        lineage_spend = self.session_store.lineage_total_dollars(root_id)
+                        if lineage_spend >= float(root_cap):
+                            self._cascade_kill_lineage(root_id, reason="lineage_max_dollars")
+                            return self._finalize_budget_exceeded(session, "lineage_max_dollars")
 
             turn_start = time.time()
             try:
@@ -281,7 +318,10 @@ class LocalExecutor:
 
     def _seed_conversation(self, session, task: dict, budget: dict) -> None:
         sid = session.session_id
-        system = _system_prompt(sid, session.expected_output or "text", budget)
+        system = _system_prompt(
+            sid, session.expected_output or "text", budget,
+            parent_session_id=session.parent_session_id,
+        )
         # We store the system message as a "system" role row so future calls
         # can rebuild the conversation; the LLM client API takes system
         # separately so we strip it when calling.
@@ -342,6 +382,26 @@ class LocalExecutor:
     # ------------------------------------------------------------------
     # Finalizers
     # ------------------------------------------------------------------
+
+    def _cascade_kill_lineage(self, root_session_id: str, reason: str) -> None:
+        """Mark all non-terminal descendants of `root_session_id` as FAILED.
+
+        Called when the root's lineage-aggregate budget is exhausted so a
+        runaway sub-tree can't keep spending after the root has hit its cap.
+        Managed-driven children are also killed remotely if a driver is
+        available (the parent local executor doesn't have one — that's
+        handled by Worker._cascade_kill_managed_children when triggered from
+        the worker side; here we just flip DB status).
+        """
+        from api.services.agent_worker.session_store import STATUS_FAILED, TERMINAL_STATUSES
+        for descendant in self.session_store.list_descendants(root_session_id):
+            if descendant.status in TERMINAL_STATUSES:
+                continue
+            self.session_store.update_status(descendant.task_id, STATUS_FAILED)
+            self.transcript_store.append(
+                descendant.session_id, "cascade_killed",
+                {"root": root_session_id, "reason": reason},
+            )
 
     def _finalize_completed(self, session, final_text: str) -> ExecutorOutcome:
         self.session_store.update_status(session.task_id, STATUS_COMPLETED)

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -57,6 +57,9 @@ class Session:
     total_output_tokens: int = 0
     total_dollars: float = 0.0
     total_active_seconds: float = 0.0
+    root_session_id: str | None = None
+    spawn_depth: int = 0
+    yield_waiting_for: list[str] | None = None
 
 
 _SCHEMA = """
@@ -74,10 +77,28 @@ CREATE TABLE IF NOT EXISTS sessions (
     total_active_seconds      REAL    NOT NULL DEFAULT 0.0,
     expected_output           TEXT,
     parent_session_id         TEXT,
+    root_session_id           TEXT,
+    spawn_depth               INTEGER NOT NULL DEFAULT 0,
+    yield_waiting_for         TEXT,  -- JSON array of session_ids the agent is waiting on
     managed_agent_session_id  TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_root ON sessions(root_session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_yield ON sessions(status) WHERE status = 'yielded';
+
+-- Inter-agent messages queued for delivery to a peer/child/parent session.
+-- Used by `lifeos_agent_send` for sessions that aren't actively running.
+-- For yielded sessions, these are injected when the session resumes.
+CREATE TABLE IF NOT EXISTS pending_messages (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id   TEXT NOT NULL,
+    sender_id    TEXT NOT NULL,
+    content      TEXT NOT NULL,
+    created_at   INTEGER NOT NULL,
+    delivered    INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_pending_msgs_session ON pending_messages(session_id, delivered);
 
 CREATE TABLE IF NOT EXISTS daily_spend (
     date           TEXT PRIMARY KEY,
@@ -162,11 +183,18 @@ class SessionStore:
         budget: dict | None = None,
         expected_output: str | None = None,
         parent_session_id: str | None = None,
+        root_session_id: str | None = None,
+        spawn_depth: int = 0,
     ) -> Session:
         """Insert a new session row. Raises sqlite3.IntegrityError if `task_id`
         already has a row — the caller should treat that as a lost-race signal.
+
+        For root sessions (no parent), `root_session_id` defaults to the new
+        session's own id. Children inherit the parent's `root_session_id` so
+        lineage queries can find an entire family with one indexed lookup.
         """
         sid = session_id or new_session_id()
+        root_sid = root_session_id or sid
         now = _now()
         with self._connect() as conn:
             conn.execute(
@@ -174,14 +202,16 @@ class SessionStore:
                 INSERT INTO sessions (
                     task_id, session_id, status, routing, budget_json,
                     started_at, last_activity_at,
-                    expected_output, parent_session_id
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    expected_output, parent_session_id,
+                    root_session_id, spawn_depth
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     task_id, sid, status, routing,
                     json.dumps(budget) if budget else None,
                     now, now,
                     expected_output, parent_session_id,
+                    root_sid, spawn_depth,
                 ),
             )
         return Session(
@@ -194,6 +224,8 @@ class SessionStore:
             budget=budget,
             expected_output=expected_output,
             parent_session_id=parent_session_id,
+            root_session_id=root_sid,
+            spawn_depth=spawn_depth,
         )
 
     def get(self, task_id: str) -> Session | None:
@@ -447,6 +479,138 @@ class SessionStore:
             ).fetchall()
         return [r["session_id"] for r in rows]
 
+    # ------------------------------------------------------------------
+    # Lineage / yield / pending messages (Issue E)
+    # ------------------------------------------------------------------
+
+    def list_by_session_ids(self, session_ids: list[str]) -> list[Session]:
+        if not session_ids:
+            return []
+        placeholders = ",".join("?" for _ in session_ids)
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM sessions WHERE session_id IN ({placeholders})",
+                tuple(session_ids),
+            ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
+    def count_active_by_routing(self, routing: str) -> int:
+        """Sessions with the given `routing` that aren't terminal yet."""
+        placeholders = ",".join("?" for _ in TERMINAL_STATUSES)
+        with self._connect() as conn:
+            row = conn.execute(
+                f"SELECT COUNT(*) AS c FROM sessions "
+                f"WHERE routing = ? AND status NOT IN ({placeholders})",
+                (routing, *TERMINAL_STATUSES),
+            ).fetchone()
+        return int(row["c"])
+
+    def count_descendants(self, root_session_id: str) -> int:
+        """Count of sessions sharing the given root, excluding the root itself."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) AS c FROM sessions "
+                "WHERE root_session_id = ? AND session_id != ?",
+                (root_session_id, root_session_id),
+            ).fetchone()
+        return int(row["c"])
+
+    def lineage_total_dollars(self, root_session_id: str) -> float:
+        """Aggregate spend across a session and all its descendants."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(total_dollars), 0) AS s FROM sessions "
+                "WHERE root_session_id = ?",
+                (root_session_id,),
+            ).fetchone()
+        return float(row["s"])
+
+    def list_descendants(self, root_session_id: str) -> list[Session]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM sessions "
+                "WHERE root_session_id = ? AND session_id != ? ",
+                (root_session_id, root_session_id),
+            ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
+    def list_yielded_waiting_on_children(self) -> list[Session]:
+        """Yielded sessions where the resume condition is children-done."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM sessions "
+                "WHERE status = ? AND yield_waiting_for IS NOT NULL",
+                (STATUS_YIELDED,),
+            ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
+    def set_yield_waiting_for(self, task_id: str, children: list[str] | None) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE sessions SET yield_waiting_for = ?, last_activity_at = ? "
+                "WHERE task_id = ?",
+                (json.dumps(children) if children else None, _now(), task_id),
+            )
+
+    def list_sessions(
+        self,
+        status: str | None = None,
+        routing: str | None = None,
+        parent_session_id: str | None = None,
+        limit: int = 200,
+    ) -> list[Session]:
+        """Filtered listing for the `lifeos_agent_sessions_list` tool."""
+        conditions = []
+        params: list = []
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+        if routing:
+            conditions.append("routing = ?")
+            params.append(routing)
+        if parent_session_id:
+            conditions.append("parent_session_id = ?")
+            params.append(parent_session_id)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(int(limit))
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM sessions {where} ORDER BY started_at DESC LIMIT ?",
+                tuple(params),
+            ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Pending messages (Issue E send-to-yielded)
+    # ------------------------------------------------------------------
+
+    def enqueue_message(self, session_id: str, sender_id: str, content: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "INSERT INTO pending_messages (session_id, sender_id, content, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (session_id, sender_id, content, _now()),
+            )
+        return cur.lastrowid
+
+    def drain_pending_messages(self, session_id: str) -> list[dict]:
+        """Return + mark-delivered all pending messages for `session_id`."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT id, sender_id, content, created_at FROM pending_messages "
+                "WHERE session_id = ? AND delivered = 0 ORDER BY id ASC",
+                (session_id,),
+            ).fetchall()
+            if rows:
+                conn.execute(
+                    "UPDATE pending_messages SET delivered = 1 WHERE session_id = ? AND delivered = 0",
+                    (session_id,),
+                )
+        return [
+            {"id": r["id"], "sender_id": r["sender_id"], "content": r["content"], "created_at": r["created_at"]}
+            for r in rows
+        ]
+
     @staticmethod
     def _row_to_session(row: sqlite3.Row) -> Session:
         return Session(
@@ -468,4 +632,15 @@ class SessionStore:
             expected_output=row["expected_output"],
             parent_session_id=row["parent_session_id"],
             managed_agent_session_id=row["managed_agent_session_id"],
+            root_session_id=(
+                row["root_session_id"] if "root_session_id" in row.keys() else None
+            ),
+            spawn_depth=(
+                row["spawn_depth"] if "spawn_depth" in row.keys() else 0
+            ),
+            yield_waiting_for=(
+                json.loads(row["yield_waiting_for"])
+                if "yield_waiting_for" in row.keys() and row["yield_waiting_for"]
+                else None
+            ),
         )

--- a/api/services/agent_worker/tools.py
+++ b/api/services/agent_worker/tools.py
@@ -267,23 +267,32 @@ STANDARD_HANDLERS: dict[str, Callable[[dict], ToolResult]] = {
 # ---------------------------------------------------------------------------
 
 class ToolRegistry:
-    """Collects standard tools + LifeOS MCP tools into a unified dispatcher.
+    """Standard tools + inter-agent tools + LifeOS MCP tools, unified.
 
     The LifeOS MCP tools come from instantiating `LifeOSMCPServer` (a
     self-contained class with `.tools` and `._call_api()`). Doing so is cheap
     and avoids duplicating the curated endpoint catalog.
+
+    Inter-agent tools (`lifeos_agent_*`) need a caller's session_id + store
+    handles. When `inter_agent_context` is provided, those tools are surfaced
+    alongside the standard ones; otherwise they're omitted so the registry
+    stays usable in stand-alone contexts (preflight, test fixtures).
     """
 
-    def __init__(self, lifeos_mcp_server=None):
+    def __init__(self, lifeos_mcp_server=None, inter_agent_context=None):
         if lifeos_mcp_server is None:
             # Lazy import — keeps the test surface light when MCP isn't needed.
             from mcp_server import LifeOSMCPServer
             lifeos_mcp_server = LifeOSMCPServer()
         self._mcp = lifeos_mcp_server
         self._mcp_tool_names: set[str] = {t["name"] for t in self._mcp.tools}
+        self._inter_ctx = inter_agent_context
 
     def definitions(self) -> list[dict[str, Any]]:
         """Anthropic-format tool definitions for the agent's system message."""
+        if self._inter_ctx is not None:
+            from api.services.agent_worker.inter_agent import INTER_AGENT_TOOL_SCHEMAS
+            return STANDARD_TOOLS + list(INTER_AGENT_TOOL_SCHEMAS) + list(self._mcp.tools)
         return STANDARD_TOOLS + list(self._mcp.tools)
 
     def dispatch(self, name: str, arguments: dict) -> ToolResult:
@@ -297,6 +306,20 @@ class ToolRegistry:
                 output=f"sleeping {seconds}s — {reason}" if reason else f"sleeping {seconds}s",
                 yield_seconds=seconds,
             )
+
+        # Inter-agent tools (when wired): dispatch via inter_agent module.
+        if self._inter_ctx is not None:
+            from api.services.agent_worker import inter_agent
+            if inter_agent.is_inter_agent_tool(name):
+                payload = inter_agent.dispatch(self._inter_ctx, name, arguments or {})
+                import json as _json
+                # `yield_until` is the special case: it ends the executor turn.
+                yield_signal = name == "lifeos_agent_yield_until" and payload.get("ok")
+                return ToolResult(
+                    _json.dumps(payload),
+                    is_error=not payload.get("ok", False),
+                    yield_seconds=-1 if yield_signal else None,  # sentinel: "yield, no wake timer"
+                )
 
         handler = STANDARD_HANDLERS.get(name)
         if handler is not None:

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -190,8 +190,13 @@ class Worker:
 
         # First, resume any sleeping sessions whose wake time has arrived.
         self._wake_sleeping_sessions()
-        # Then poll any in-flight Managed Agents sessions for new events.
+        # Then advance any in-flight Managed Agents sessions one polling step.
         self._poll_managed_sessions()
+        # Resume yielded sessions whose children have all reached terminal state.
+        self._resume_yielded_for_children()
+        # Dispatch any newly-spawned sessions (no #agent task — created via
+        # lifeos_agent_spawn). They show up with status=claimed and a routing.
+        self._dispatch_spawned_sessions()
 
         candidates = self._list_agent_tasks()
         handled = 0
@@ -207,6 +212,105 @@ class Worker:
             self._dispatch(task)
             handled += 1
         return handled
+
+    def _resume_yielded_for_children(self) -> None:
+        """Resume yielded sessions whose listed children have all terminated."""
+        yielded = self.session_store.list_yielded_waiting_on_children()
+        for session in yielded:
+            children = session.yield_waiting_for or []
+            if not children:
+                continue
+            child_sessions = self.session_store.list_by_session_ids(children)
+            from api.services.agent_worker.session_store import TERMINAL_STATUSES as _TS
+            all_done = (
+                len(child_sessions) == len(children)
+                and all(c.status in _TS for c in child_sessions)
+            )
+            if not all_done:
+                continue
+
+            # Build a synthetic user message summarizing children's outcomes,
+            # append it to the session's conversation, and resume execution.
+            summary_lines = ["Children completed:"]
+            for c in child_sessions:
+                tokens = (c.total_input_tokens or 0) + (c.total_output_tokens or 0)
+                summary_lines.append(
+                    f"- {c.session_id} [{c.status}] — {tokens} tokens, ${c.total_dollars:.2f}"
+                )
+            self.session_store.append_message(
+                session.session_id, "user", "\n".join(summary_lines)
+            )
+            self.session_store.set_yield_waiting_for(session.task_id, None)
+            self.transcript_store.append(session.session_id, "resume_after_children", {
+                "children": children,
+            })
+
+            # For local: re-invoke executor. For managed: not supported in
+            # this MVP; mark blocked so operator can intervene.
+            task = self._fetch_task(session.task_id) or {
+                "id": session.task_id, "description": session.task_id,
+            }
+            if session.routing == "local":
+                executor = self._get_local_executor(caller_session_id=session.session_id)
+                try:
+                    outcome = executor.execute(session, task)
+                except Exception as exc:
+                    logger.exception("resume after children crashed for %s: %s",
+                                     session.task_id, exc)
+                    self._mark_failed(session, task, f"resume crashed: {exc}")
+                    continue
+                self._handle_outcome(session, task, outcome)
+            else:
+                # Managed-session resume after yield isn't implemented in this
+                # PR — operator can re-tag the task to retry. Log and notify.
+                self.transcript_store.append(session.session_id, "managed_yield_resume_unsupported", {})
+                self._mark_failed(
+                    session, task,
+                    "managed yield-and-resume not yet supported (children finished but parent cannot resume)",
+                )
+
+    def _dispatch_spawned_sessions(self) -> None:
+        """Pick up sessions created via lifeos_agent_spawn that have no #agent
+        task backing — they show up with status=claimed and an explicit routing."""
+        claimed = self.session_store.list_by_status(STATUS_CLAIMED)
+        for session in claimed:
+            # Skip top-level claimed sessions (those came from the tick claim
+            # path and will be dispatched by _dispatch). Spawned children have
+            # a parent_session_id set.
+            if not session.parent_session_id:
+                continue
+            task = {
+                "id": session.task_id,
+                "description": (self.session_store.get_messages(session.session_id) or [{}])[0].get("content", "")
+                if isinstance((self.session_store.get_messages(session.session_id) or [{}])[0].get("content"), str)
+                else session.task_id,
+            }
+            if session.routing == "local":
+                executor = self._get_local_executor(caller_session_id=session.session_id)
+                try:
+                    outcome = executor.execute(session, task)
+                except Exception as exc:
+                    logger.exception("spawned local execute crashed for %s: %s", session.task_id, exc)
+                    self.session_store.update_status(session.task_id, STATUS_FAILED)
+                    continue
+                self._handle_outcome(session, task, outcome)
+            elif session.routing == "claude":
+                managed = self._get_managed_executor()
+                if managed is None:
+                    self.session_store.update_status(session.task_id, STATUS_FAILED)
+                    self.transcript_store.append(
+                        session.session_id, "spawn_failed_no_managed", {},
+                    )
+                    continue
+                try:
+                    outcome = managed.start(session, task)
+                except Exception as exc:
+                    logger.exception("spawned managed start crashed for %s: %s", session.task_id, exc)
+                    self.session_store.update_status(session.task_id, STATUS_FAILED)
+                    continue
+                if outcome.status == STATUS_FAILED:
+                    self._handle_outcome(session, task, outcome)
+                # On RUNNING, let _poll_managed_sessions handle the rest.
 
     def _poll_managed_sessions(self) -> None:
         """Advance all in-flight Managed Agents sessions one polling step."""
@@ -255,7 +359,7 @@ class Worker:
             # Re-fetch the task description from the API so the conversation
             # context stays accurate (someone may have edited the title).
             task = self._fetch_task(session.task_id) or {"id": session.task_id, "description": ""}
-            executor = self._get_local_executor()
+            executor = self._get_local_executor(caller_session_id=session.session_id)
             try:
                 outcome = executor.execute(session, task)
             except Exception as exc:
@@ -343,14 +447,37 @@ class Worker:
                 )
             return False
 
-    def _get_local_executor(self):
-        if self._local_executor is None:
-            from api.services.agent_worker.local_executor import LocalExecutor
-            self._local_executor = LocalExecutor(
+    def _get_local_executor(self, caller_session_id: str | None = None):
+        """Return the local executor configured for `caller_session_id`.
+
+        The inter-agent tool context depends on the caller's identity, so we
+        rebuild the tool registry when the caller changes. For tests an
+        injected executor wins.
+        """
+        if self._local_executor is not None:
+            return self._local_executor
+        from api.services.agent_worker.inter_agent import Caps, InterAgentContext
+        from api.services.agent_worker.local_executor import LocalExecutor
+        from api.services.agent_worker.tools import ToolRegistry
+        ctx = None
+        if caller_session_id:
+            ctx = InterAgentContext(
                 session_store=self.session_store,
                 transcript_store=self.transcript_store,
+                caller_session_id=caller_session_id,
+                caps=Caps(
+                    max_spawn_depth=settings.agent_max_spawn_depth,
+                    max_descendants_per_root=settings.agent_max_descendants_per_root,
+                    max_concurrent_local=settings.agent_max_concurrent_local,
+                    max_concurrent_managed=settings.agent_max_concurrent_managed,
+                ),
             )
-        return self._local_executor
+        registry = ToolRegistry(inter_agent_context=ctx)
+        return LocalExecutor(
+            session_store=self.session_store,
+            transcript_store=self.transcript_store,
+            tool_registry=registry,
+        )
 
     def _get_managed_executor(self):
         """Return the cached ManagedExecutor, lazily constructed.
@@ -474,7 +601,7 @@ class Worker:
 
         # Local route: run the executor.
         if pre.routing == ROUTE_LOCAL:
-            executor = self._get_local_executor()
+            executor = self._get_local_executor(caller_session_id=session.session_id)
             try:
                 outcome = executor.execute(session, task)
             except Exception as exc:

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -214,14 +214,21 @@ class Worker:
         return handled
 
     def _resume_yielded_for_children(self) -> None:
-        """Resume yielded sessions whose listed children have all terminated."""
+        """Resume yielded sessions whose listed children have all terminated.
+
+        Local sessions get the children's outputs injected as a new user turn
+        and re-enter the executor loop. Managed yield-and-resume is not yet
+        supported (session was killed remotely; re-creation with full history
+        transfer is a follow-up PR) — for now those land in FAILED with a
+        clear reason so the operator can re-tag.
+        """
+        from api.services.agent_worker.session_store import TERMINAL_STATUSES as _TS
         yielded = self.session_store.list_yielded_waiting_on_children()
         for session in yielded:
             children = session.yield_waiting_for or []
             if not children:
                 continue
             child_sessions = self.session_store.list_by_session_ids(children)
-            from api.services.agent_worker.session_store import TERMINAL_STATUSES as _TS
             all_done = (
                 len(child_sessions) == len(children)
                 and all(c.status in _TS for c in child_sessions)
@@ -229,49 +236,63 @@ class Worker:
             if not all_done:
                 continue
 
-            # Build a synthetic user message summarizing children's outcomes,
-            # append it to the session's conversation, and resume execution.
+            task = self._fetch_task(session.task_id) or {
+                "id": session.task_id, "description": session.task_id,
+            }
+
+            # Managed yield-resume isn't supported yet — short-circuit with a
+            # clear failure rather than scrambling the local message history
+            # for nothing.
+            if session.routing != "local":
+                self.transcript_store.append(
+                    session.session_id, "managed_yield_resume_unsupported", {},
+                )
+                self._mark_failed(
+                    session, task,
+                    "managed yield-and-resume not yet supported (children "
+                    "finished but parent cannot resume)",
+                )
+                continue
+
+            # Build the resume turn, then commit state updates only after we
+            # know the executor returned cleanly. This keeps the session
+            # restartable if the executor crashes mid-resume.
             summary_lines = ["Children completed:"]
             for c in child_sessions:
                 tokens = (c.total_input_tokens or 0) + (c.total_output_tokens or 0)
                 summary_lines.append(
                     f"- {c.session_id} [{c.status}] — {tokens} tokens, ${c.total_dollars:.2f}"
                 )
-            self.session_store.append_message(
-                session.session_id, "user", "\n".join(summary_lines)
-            )
+            resume_message = "\n".join(summary_lines)
+
+            executor = self._get_local_executor(caller_session_id=session.session_id)
+            try:
+                # Append the resume message first so the executor sees it on
+                # the next turn; clear yield_waiting_for *after* the executor
+                # returns so a crash leaves the session retryable (still
+                # yielded with the same children list).
+                self.session_store.append_message(session.session_id, "user", resume_message)
+                outcome = executor.execute(session, task)
+            except Exception as exc:
+                logger.exception("resume after children crashed for %s: %s",
+                                 session.task_id, exc)
+                # Leave yield_waiting_for set so the next tick re-attempts.
+                self._mark_failed(session, task, f"resume crashed: {exc}")
+                continue
             self.session_store.set_yield_waiting_for(session.task_id, None)
             self.transcript_store.append(session.session_id, "resume_after_children", {
                 "children": children,
             })
-
-            # For local: re-invoke executor. For managed: not supported in
-            # this MVP; mark blocked so operator can intervene.
-            task = self._fetch_task(session.task_id) or {
-                "id": session.task_id, "description": session.task_id,
-            }
-            if session.routing == "local":
-                executor = self._get_local_executor(caller_session_id=session.session_id)
-                try:
-                    outcome = executor.execute(session, task)
-                except Exception as exc:
-                    logger.exception("resume after children crashed for %s: %s",
-                                     session.task_id, exc)
-                    self._mark_failed(session, task, f"resume crashed: {exc}")
-                    continue
-                self._handle_outcome(session, task, outcome)
-            else:
-                # Managed-session resume after yield isn't implemented in this
-                # PR — operator can re-tag the task to retry. Log and notify.
-                self.transcript_store.append(session.session_id, "managed_yield_resume_unsupported", {})
-                self._mark_failed(
-                    session, task,
-                    "managed yield-and-resume not yet supported (children finished but parent cannot resume)",
-                )
+            self._handle_outcome(session, task, outcome)
 
     def _dispatch_spawned_sessions(self) -> None:
         """Pick up sessions created via lifeos_agent_spawn that have no #agent
-        task backing — they show up with status=claimed and an explicit routing."""
+        task backing — they show up with status=claimed and an explicit routing.
+
+        Synchronous in this MVP: a long-running local child blocks the tick
+        loop. Acceptable while local concurrency cap = 1; a future PR could
+        move to a worker pool.
+        """
         claimed = self.session_store.list_by_status(STATUS_CLAIMED)
         for session in claimed:
             # Skip top-level claimed sessions (those came from the tick claim
@@ -279,12 +300,11 @@ class Worker:
             # a parent_session_id set.
             if not session.parent_session_id:
                 continue
-            task = {
-                "id": session.task_id,
-                "description": (self.session_store.get_messages(session.session_id) or [{}])[0].get("content", "")
-                if isinstance((self.session_store.get_messages(session.session_id) or [{}])[0].get("content"), str)
-                else session.task_id,
-            }
+            # The first pending message is the prompt from the parent — drain
+            # it so the executor's seeded user turn picks it up.
+            pending = self.session_store.drain_pending_messages(session.session_id)
+            description = pending[0]["content"] if pending else session.session_id
+            task = {"id": session.task_id, "description": description}
             if session.routing == "local":
                 executor = self._get_local_executor(caller_session_id=session.session_id)
                 try:

--- a/config/settings.py
+++ b/config/settings.py
@@ -168,6 +168,27 @@ class Settings(BaseSettings):
                     "(e.g. 'https://mcp.example.com/mcp'). Required for "
                     "Managed Agents to reach LifeOS data."
     )
+    # Inter-agent caps (Issue E). Spawn / lineage / concurrency limits.
+    agent_max_spawn_depth: int = Field(
+        default=3,
+        alias="LIFEOS_AGENT_MAX_SPAWN_DEPTH",
+        description="Max depth of the spawn tree (parent → child → grandchild)."
+    )
+    agent_max_descendants_per_root: int = Field(
+        default=50,
+        alias="LIFEOS_AGENT_MAX_DESCENDANTS_PER_ROOT",
+        description="Total descendants allowed under any single root session."
+    )
+    agent_max_concurrent_local: int = Field(
+        default=1,
+        alias="LIFEOS_AGENT_MAX_CONCURRENT_LOCAL",
+        description="Max concurrent local Gemma sessions (VRAM bound)."
+    )
+    agent_max_concurrent_managed: int = Field(
+        default=10,
+        alias="LIFEOS_AGENT_MAX_CONCURRENT_MANAGED",
+        description="Max concurrent Managed Agents sessions."
+    )
     local_llm_autostart: bool = Field(
         default=False,
         alias="LIFEOS_LOCAL_LLM_AUTOSTART",

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -458,6 +458,43 @@ class LifeOSMCPServer:
         self.openapi_spec: dict | None = None
         self.tools: list[dict] = []
         self._load_openapi_spec()
+        self._register_inter_agent_tools()
+
+    def _register_inter_agent_tools(self) -> None:
+        """Expose the `lifeos_agent_*` family to remote agents over MCP.
+
+        Each tool takes a required `caller_session_id` argument so the
+        worker knows which session is acting (the local executor injects
+        this automatically; remote managed agents pass it explicitly via
+        the system prompt instruction). No sandboxing per the project's
+        no-sandbox design — operators trust their own agents.
+        """
+        try:
+            from api.services.agent_worker.inter_agent import INTER_AGENT_TOOL_SCHEMAS
+        except Exception as e:  # pragma: no cover — keep MCP server bootable without agent worker
+            logger.warning(f"inter-agent tools not registered: {e}")
+            return
+        for schema in INTER_AGENT_TOOL_SCHEMAS:
+            tool = dict(schema)
+            # Inject caller_session_id into the published input schema. The
+            # tool definitions don't include it (the local registry sets it
+            # automatically) but remote callers must pass it explicitly.
+            input_schema = dict(tool["input_schema"])
+            props = dict(input_schema.get("properties", {}))
+            props["caller_session_id"] = {
+                "type": "string",
+                "description": "Your own session_id — included in your system prompt.",
+            }
+            input_schema["properties"] = props
+            required = list(input_schema.get("required", []))
+            if "caller_session_id" not in required:
+                required = ["caller_session_id"] + required
+            input_schema["required"] = required
+            tool["input_schema"] = input_schema
+            # MCP schema field name in this server is "inputSchema" — match
+            # what _build_tools_from_spec produces.
+            tool["inputSchema"] = tool.pop("input_schema")
+            self.tools.append(tool)
 
     def _load_openapi_spec(self):
         """Load OpenAPI spec from LifeOS API."""
@@ -969,6 +1006,41 @@ class LifeOSMCPServer:
             logger.warning(f"Failed to fetch email body for {message_id}: {e}")
             return None
 
+    def _handle_inter_agent(self, tool_name: str, arguments: dict) -> dict:
+        """Dispatch a lifeos_agent_* call through the worker's session store.
+
+        The remote caller passes `caller_session_id` explicitly (per the
+        system prompt). We build a fresh InterAgentContext per call and run
+        the tool — no shared mutable state.
+        """
+        caller_session_id = (arguments.pop("caller_session_id", None) or "").strip()
+        if not caller_session_id:
+            return {"error": "caller_session_id is required for inter-agent tools"}
+        try:
+            from api.services.agent_worker.inter_agent import (
+                Caps,
+                InterAgentContext,
+                dispatch as inter_dispatch,
+            )
+            from api.services.agent_worker.session_store import SessionStore
+            from api.services.agent_worker.transcript_store import TranscriptStore
+            from config.settings import settings as _settings
+        except Exception as e:
+            return {"error": f"inter-agent stack unavailable: {e}"}
+
+        ctx = InterAgentContext(
+            session_store=SessionStore(),
+            transcript_store=TranscriptStore(),
+            caller_session_id=caller_session_id,
+            caps=Caps(
+                max_spawn_depth=_settings.agent_max_spawn_depth,
+                max_descendants_per_root=_settings.agent_max_descendants_per_root,
+                max_concurrent_local=_settings.agent_max_concurrent_local,
+                max_concurrent_managed=_settings.agent_max_concurrent_managed,
+            ),
+        )
+        return inter_dispatch(ctx, tool_name, arguments)
+
     def _handle_sync_trigger(self, arguments: dict) -> dict:
         """Route sync trigger to the correct endpoint based on source param."""
         source = arguments.get("source", "").lower().strip()
@@ -1008,6 +1080,13 @@ class LifeOSMCPServer:
         # Custom handlers for tools that don't map 1:1 to endpoints
         if tool_name == "lifeos_sync_trigger":
             return self._handle_sync_trigger(arguments)
+
+        # Inter-agent tools dispatch through the agent worker's session store
+        # (no HTTP round-trip). The caller_session_id arg identifies which
+        # session is acting — local executor injects it automatically; remote
+        # managed agents pass it explicitly per the system prompt.
+        if tool_name.startswith("lifeos_agent_"):
+            return self._handle_inter_agent(tool_name, dict(arguments))
 
         # Find the endpoint config
         endpoint_config = None

--- a/tests/test_agent_worker_inter_agent.py
+++ b/tests/test_agent_worker_inter_agent.py
@@ -77,10 +77,13 @@ def test_spawn_creates_child_inheriting_lineage(ctx, store, parent):
     assert child.spawn_depth == 1
     assert child.routing == "local"
     assert child.status == STATUS_CLAIMED
-    # The first message is the prompt as a user turn.
-    messages = store.get_messages(child_id)
-    assert messages and messages[0]["role"] == "user"
-    assert "find the answer" in messages[0]["content"]
+    # The prompt is queued as a pending message — the worker's spawned-
+    # dispatcher drains it and uses it as the task description so the
+    # executor's _seed_conversation produces a proper system + user turn.
+    pending = store.drain_pending_messages(child_id)
+    assert len(pending) == 1
+    assert pending[0]["content"] == "find the answer"
+    assert pending[0]["sender_id"] == parent.session_id
 
 
 @pytest.mark.unit
@@ -347,6 +350,84 @@ def test_sessions_list_filters_by_parent(ctx, store, parent):
 # ---------------------------------------------------------------------------
 # Dispatch helpers
 # ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_kill_calls_managed_driver_for_remote_session(store, transcript, parent):
+    """Killing a managed descendant should attempt the remote kill via the driver."""
+    target = store.create(
+        task_id="m_target", status=STATUS_RUNNING, routing="claude",
+        parent_session_id=parent.session_id, root_session_id=parent.session_id,
+    )
+    store.set_managed_session_id("m_target", "remote_xyz")
+    target = store.get_by_session_id(target.session_id)
+
+    calls = []
+    class _FakeDriver:
+        def kill_session(self, sid, reason=""):
+            calls.append((sid, reason))
+
+    ctx_with_driver = InterAgentContext(
+        store, transcript, parent.session_id, Caps(), managed_driver=_FakeDriver(),
+    )
+    result = dispatch(ctx_with_driver, "lifeos_agent_kill", {
+        "session_id": target.session_id, "reason": "no longer needed",
+    })
+    assert result["ok"]
+    assert calls and calls[0] == ("remote_xyz", "no longer needed")
+
+
+@pytest.mark.unit
+def test_kill_remote_failure_doesnt_block_local_kill(store, transcript, parent):
+    target = store.create(
+        task_id="m_t", status=STATUS_RUNNING, routing="claude",
+        parent_session_id=parent.session_id, root_session_id=parent.session_id,
+    )
+    store.set_managed_session_id("m_t", "remote_abc")
+
+    class _BoomDriver:
+        def kill_session(self, sid, reason=""):
+            raise RuntimeError("network down")
+
+    ctx_with_driver = InterAgentContext(
+        store, transcript, parent.session_id, Caps(), managed_driver=_BoomDriver(),
+    )
+    result = dispatch(ctx_with_driver, "lifeos_agent_kill", {
+        "session_id": target.session_id,
+    })
+    # Local DB still marked failed even though remote kill raised.
+    assert result["ok"]
+    assert store.get_by_session_id(target.session_id).status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_send_rejects_foreign_lineage(store, transcript, parent):
+    """An agent can't inject messages into sessions outside its lineage."""
+    foreign = store.create(task_id="x", status=STATUS_RUNNING, routing="local")
+    ctx = InterAgentContext(store, transcript, parent.session_id, Caps())
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": foreign.session_id, "message": "psst",
+    })
+    assert not result["ok"]
+    assert result["error"] == "forbidden"
+
+
+@pytest.mark.unit
+def test_spawn_excludes_caller_from_concurrency_cap(store, transcript):
+    """The parent shouldn't count against its own routing cap — the expected
+    pattern is `spawn` followed immediately by `yield_until`."""
+    local_parent = store.create(
+        task_id="p_local", status=STATUS_RUNNING, routing="local",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 10.0},
+        expected_output="text",
+    )
+    ctx = InterAgentContext(
+        store, transcript, local_parent.session_id, Caps(max_concurrent_local=1),
+    )
+    # No other local sessions besides the caller; the spawn should succeed
+    # because the caller is excluded from the count.
+    result = dispatch(ctx, "lifeos_agent_spawn", {"prompt": "x", "model": "local"})
+    assert result["ok"], f"spawn should have succeeded; got {result}"
+
 
 @pytest.mark.unit
 def test_dispatch_unknown_tool_errors(ctx):

--- a/tests/test_agent_worker_inter_agent.py
+++ b/tests/test_agent_worker_inter_agent.py
@@ -1,0 +1,369 @@
+"""Tests for the lifeos_agent_* tool family.
+
+Each tool is exercised against an in-memory SessionStore + TranscriptStore.
+The worker's resume/dispatch loop is tested separately in test_agent_worker_loop.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.inter_agent import (
+    Caps,
+    InterAgentContext,
+    DEFAULT_MAX_DESCENDANTS_PER_ROOT,
+    DEFAULT_MAX_SPAWN_DEPTH,
+    dispatch,
+)
+from api.services.agent_worker.session_store import (
+    STATUS_CLAIMED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    STATUS_YIELDED,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SessionStore:
+    return SessionStore(db_path=tmp_path / "sessions.db")
+
+
+@pytest.fixture
+def transcript(tmp_path: Path) -> TranscriptStore:
+    return TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+
+
+@pytest.fixture
+def parent(store: SessionStore):
+    session = store.create(
+        task_id="parent_task",
+        status=STATUS_RUNNING,
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 10.0},
+        expected_output="text",
+    )
+    return session
+
+
+@pytest.fixture
+def ctx(store: SessionStore, transcript: TranscriptStore, parent) -> InterAgentContext:
+    return InterAgentContext(
+        session_store=store,
+        transcript_store=transcript,
+        caller_session_id=parent.session_id,
+        caps=Caps(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# spawn
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_spawn_creates_child_inheriting_lineage(ctx, store, parent):
+    result = dispatch(ctx, "lifeos_agent_spawn", {
+        "prompt": "find the answer", "model": "local",
+    })
+    assert result["ok"]
+    child_id = result["child_session_id"]
+    child = store.get_by_session_id(child_id)
+    assert child is not None
+    assert child.parent_session_id == parent.session_id
+    assert child.root_session_id == parent.session_id  # parent is the root
+    assert child.spawn_depth == 1
+    assert child.routing == "local"
+    assert child.status == STATUS_CLAIMED
+    # The first message is the prompt as a user turn.
+    messages = store.get_messages(child_id)
+    assert messages and messages[0]["role"] == "user"
+    assert "find the answer" in messages[0]["content"]
+
+
+@pytest.mark.unit
+def test_spawn_rejects_empty_prompt(ctx):
+    result = dispatch(ctx, "lifeos_agent_spawn", {"prompt": "  ", "model": "local"})
+    assert not result["ok"]
+    assert result["error"] == "invalid_arg"
+
+
+@pytest.mark.unit
+def test_spawn_rejects_invalid_model(ctx):
+    result = dispatch(ctx, "lifeos_agent_spawn", {"prompt": "x", "model": "gpt5"})
+    assert not result["ok"]
+    assert result["error"] == "invalid_arg"
+
+
+@pytest.mark.unit
+def test_spawn_rejects_at_depth_cap(store, transcript, parent):
+    # Build a chain parent → grandchild already at depth 3 — next spawn from
+    # grandchild would exceed depth cap.
+    deep = store.create(
+        task_id="deep_task", status=STATUS_RUNNING, routing="local",
+        budget={"max_dollars": 5.0, "wall_seconds": 100, "max_tokens": 100},
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=DEFAULT_MAX_SPAWN_DEPTH,
+    )
+    ctx = InterAgentContext(store, transcript, deep.session_id, Caps())
+    result = dispatch(ctx, "lifeos_agent_spawn", {"prompt": "x", "model": "local"})
+    assert not result["ok"]
+    assert result["error"] == "cap_spawn_depth"
+
+
+@pytest.mark.unit
+def test_spawn_rejects_at_descendant_cap(store, transcript, parent):
+    # Pre-populate `MAX` descendants.
+    for i in range(DEFAULT_MAX_DESCENDANTS_PER_ROOT):
+        store.create(
+            task_id=f"d_{i}", status=STATUS_RUNNING, routing="local",
+            budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+            parent_session_id=parent.session_id,
+            root_session_id=parent.session_id,
+            spawn_depth=1,
+        )
+    ctx = InterAgentContext(store, transcript, parent.session_id, Caps())
+    result = dispatch(ctx, "lifeos_agent_spawn", {"prompt": "x", "model": "local"})
+    assert not result["ok"]
+    assert result["error"] == "cap_descendants"
+
+
+@pytest.mark.unit
+def test_spawn_local_concurrency_cap(store, transcript, parent):
+    # One local already running; cap is 1 by default.
+    store.create(
+        task_id="busy", status=STATUS_RUNNING, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    ctx = InterAgentContext(store, transcript, parent.session_id, Caps(max_concurrent_local=1))
+    result = dispatch(ctx, "lifeos_agent_spawn", {"prompt": "x", "model": "local"})
+    assert not result["ok"]
+    assert result["error"] == "cap_concurrency_local"
+
+
+@pytest.mark.unit
+def test_spawn_budget_cannot_exceed_parent_remaining(ctx, store, parent):
+    # Parent has $10 budget; ask for $20.
+    result = dispatch(ctx, "lifeos_agent_spawn", {
+        "prompt": "x", "model": "local", "max_dollars": 20.0,
+    })
+    assert not result["ok"]
+    assert result["error"] == "budget_exceeded"
+
+
+# ---------------------------------------------------------------------------
+# send / check
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_send_enqueues_message(ctx, store, parent):
+    child = store.create(
+        task_id="c1", status=STATUS_RUNNING, routing="local",
+        budget={"max_dollars": 5.0, "wall_seconds": 60, "max_tokens": 100},
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": child.session_id, "message": "hello child",
+    })
+    assert result["ok"]
+    pending = store.drain_pending_messages(child.session_id)
+    assert len(pending) == 1
+    assert pending[0]["content"] == "hello child"
+    assert pending[0]["sender_id"] == parent.session_id
+
+
+@pytest.mark.unit
+def test_send_rejects_terminal_session(ctx, store, parent):
+    dead = store.create(
+        task_id="dead", status=STATUS_FAILED, routing="local",
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+    )
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": dead.session_id, "message": "are you there",
+    })
+    assert not result["ok"]
+    assert result["error"] == "terminal"
+
+
+@pytest.mark.unit
+def test_check_returns_session_metadata(ctx, store, parent):
+    child = store.create(
+        task_id="c2", status=STATUS_RUNNING, routing="local",
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+    )
+    store.record_spend(child.task_id, tokens_in=100, tokens_out=50, dollars=0.5)
+    result = dispatch(ctx, "lifeos_agent_check", {"session_id": child.session_id})
+    assert result["ok"]
+    assert result["status"] == STATUS_RUNNING
+    assert result["tokens_used"] == 150
+    assert result["dollars_used"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# yield_until
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_yield_until_marks_caller_yielded(ctx, store, parent):
+    child = store.create(
+        task_id="c", status=STATUS_RUNNING, routing="local",
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+    )
+    result = dispatch(ctx, "lifeos_agent_yield_until", {
+        "children": [child.session_id], "reason": "waiting for child",
+    })
+    assert result["ok"]
+    refreshed = store.get(parent.task_id)
+    assert refreshed.status == STATUS_YIELDED
+    assert refreshed.yield_waiting_for == [child.session_id]
+
+
+@pytest.mark.unit
+def test_yield_until_rejects_foreign_children(store, transcript, parent):
+    # Create an unrelated root + child.
+    foreign_parent = store.create(
+        task_id="foreign", status=STATUS_RUNNING, routing="local",
+    )
+    foreign_child = store.create(
+        task_id="fc", status=STATUS_RUNNING, routing="local",
+        parent_session_id=foreign_parent.session_id,
+        root_session_id=foreign_parent.session_id,
+        spawn_depth=1,
+    )
+    ctx = InterAgentContext(store, transcript, parent.session_id, Caps())
+    result = dispatch(ctx, "lifeos_agent_yield_until", {
+        "children": [foreign_child.session_id],
+    })
+    assert not result["ok"]
+    assert result["error"] == "forbidden"
+
+
+@pytest.mark.unit
+def test_yield_until_rejects_empty_list(ctx):
+    result = dispatch(ctx, "lifeos_agent_yield_until", {"children": []})
+    assert not result["ok"]
+    assert result["error"] == "invalid_arg"
+
+
+# ---------------------------------------------------------------------------
+# kill
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_kill_terminates_descendant(ctx, store, parent):
+    child = store.create(
+        task_id="vc", status=STATUS_RUNNING, routing="local",
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+    )
+    result = dispatch(ctx, "lifeos_agent_kill", {
+        "session_id": child.session_id, "reason": "no longer needed",
+    })
+    assert result["ok"]
+    assert store.get(child.task_id).status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_kill_rejects_non_descendant(store, transcript, parent):
+    foreign = store.create(task_id="x", status=STATUS_RUNNING, routing="local")
+    ctx = InterAgentContext(store, transcript, parent.session_id, Caps())
+    result = dispatch(ctx, "lifeos_agent_kill", {
+        "session_id": foreign.session_id,
+    })
+    assert not result["ok"]
+    assert result["error"] == "forbidden"
+
+
+@pytest.mark.unit
+def test_kill_cannot_target_self(ctx, parent):
+    result = dispatch(ctx, "lifeos_agent_kill", {"session_id": parent.session_id})
+    assert not result["ok"]
+
+
+# ---------------------------------------------------------------------------
+# transcript_read / sessions_list
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_transcript_read_returns_events(ctx, transcript, parent):
+    transcript.append(parent.session_id, "event1", {"a": 1})
+    transcript.append(parent.session_id, "event2", {"b": 2})
+    result = dispatch(ctx, "lifeos_agent_transcript_read", {
+        "session_id": parent.session_id,
+    })
+    assert result["ok"]
+    assert result["count"] == 2
+    kinds = [e["kind"] for e in result["events"]]
+    assert kinds == ["event1", "event2"]
+
+
+@pytest.mark.unit
+def test_transcript_read_since_turn(ctx, transcript, parent):
+    transcript.append(parent.session_id, "a", {})
+    transcript.append(parent.session_id, "b", {})
+    transcript.append(parent.session_id, "c", {})
+    result = dispatch(ctx, "lifeos_agent_transcript_read", {
+        "session_id": parent.session_id, "since_turn": 1,
+    })
+    assert [e["kind"] for e in result["events"]] == ["b", "c"]
+
+
+@pytest.mark.unit
+def test_sessions_list_filters_by_status(ctx, store, parent):
+    store.create(task_id="t_done", status=STATUS_COMPLETED, routing="local",
+                 parent_session_id=parent.session_id, root_session_id=parent.session_id)
+    store.create(task_id="t_run", status=STATUS_RUNNING, routing="local",
+                 parent_session_id=parent.session_id, root_session_id=parent.session_id)
+    result = dispatch(ctx, "lifeos_agent_sessions_list", {"status": STATUS_RUNNING})
+    assert result["ok"]
+    statuses = {s["status"] for s in result["sessions"]}
+    assert statuses == {STATUS_RUNNING}
+
+
+@pytest.mark.unit
+def test_sessions_list_filters_by_parent(ctx, store, parent):
+    store.create(task_id="ch1", status=STATUS_RUNNING, routing="local",
+                 parent_session_id=parent.session_id, root_session_id=parent.session_id)
+    store.create(task_id="unrelated", status=STATUS_RUNNING, routing="local")
+    result = dispatch(ctx, "lifeos_agent_sessions_list", {
+        "parent_session_id": parent.session_id,
+    })
+    assert result["ok"]
+    task_ids = {s["task_id"] for s in result["sessions"]}
+    assert task_ids == {"ch1"}
+
+
+# ---------------------------------------------------------------------------
+# Dispatch helpers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_dispatch_unknown_tool_errors(ctx):
+    result = dispatch(ctx, "lifeos_agent_nonexistent", {})
+    assert not result["ok"]
+    assert result["error"] == "unknown_tool"
+
+
+@pytest.mark.unit
+def test_dispatch_handles_handler_exception(store, transcript, parent, monkeypatch):
+    """An exception inside a handler is caught and returned as ok=False."""
+    ctx = InterAgentContext(store, transcript, parent.session_id, Caps())
+    from api.services.agent_worker import inter_agent
+    def boom(c, a):
+        raise RuntimeError("kaboom")
+    monkeypatch.setitem(inter_agent.DISPATCH_TABLE, "lifeos_agent_check", boom)
+    result = dispatch(ctx, "lifeos_agent_check", {"session_id": "x"})
+    assert not result["ok"]
+    assert result["error"] == "crashed"
+    assert "kaboom" in result["message"]

--- a/tests/test_agent_worker_mcp_exposure.py
+++ b/tests/test_agent_worker_mcp_exposure.py
@@ -1,0 +1,86 @@
+"""Tests that the LifeOS MCP server exposes the lifeos_agent_* tool family.
+
+Managed Agents reach inter-agent tools via the MCP server, so the schema
+must be correct AND `_call_api` must dispatch to the right handler with
+the `caller_session_id` arg.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import mcp_server
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path: Path):
+    """A LifeOSMCPServer with the agent stack pointed at a temp DB.
+
+    SessionStore reads `DEFAULT_DB_PATH` only at function-default-binding
+    time, so monkeypatching the module attribute doesn't redirect new
+    instances. We chdir into tmp_path instead so the relative default
+    `data/agent_sessions.db` lands inside the test sandbox.
+    """
+    monkeypatch.setenv("LIFEOS_AGENT_VAULT_ID", "")
+    monkeypatch.chdir(tmp_path)
+    srv = mcp_server.LifeOSMCPServer()
+    return srv
+
+
+@pytest.mark.unit
+def test_inter_agent_tools_are_registered(server):
+    tool_names = {t["name"] for t in server.tools}
+    expected = {
+        "lifeos_agent_spawn",
+        "lifeos_agent_send",
+        "lifeos_agent_check",
+        "lifeos_agent_yield_until",
+        "lifeos_agent_kill",
+        "lifeos_agent_transcript_read",
+        "lifeos_agent_sessions_list",
+    }
+    assert expected.issubset(tool_names)
+
+
+@pytest.mark.unit
+def test_inter_agent_tool_schemas_require_caller_session_id(server):
+    """Remote agents must pass their own session_id explicitly."""
+    for tool in server.tools:
+        if not tool["name"].startswith("lifeos_agent_"):
+            continue
+        schema = tool.get("inputSchema") or tool.get("input_schema")
+        assert "caller_session_id" in schema["properties"]
+        assert "caller_session_id" in schema["required"]
+        # caller_session_id should appear first in the required list.
+        assert schema["required"][0] == "caller_session_id"
+
+
+@pytest.mark.unit
+def test_call_api_missing_caller_returns_error(server):
+    result = server._call_api("lifeos_agent_check", {"session_id": "x"})
+    assert "error" in result
+    assert "caller_session_id" in result["error"]
+
+
+@pytest.mark.unit
+def test_call_api_dispatches_to_inter_agent_handler(server):
+    """End-to-end MCP → inter_agent.dispatch path."""
+    # SessionStore() uses the default relative path; the server fixture
+    # chdir'd into tmp_path so this is sandboxed.
+    from api.services.agent_worker.session_store import (
+        STATUS_RUNNING,
+        SessionStore,
+    )
+    store = SessionStore()
+    sess = store.create(
+        task_id="t_mcp", status=STATUS_RUNNING, routing="claude",
+        budget={"max_dollars": 5.0, "wall_seconds": 60, "max_tokens": 1000},
+    )
+
+    result = server._call_api("lifeos_agent_check", {
+        "caller_session_id": sess.session_id,
+        "session_id": sess.session_id,
+    })
+    assert result["ok"]
+    assert result["status"] == STATUS_RUNNING


### PR DESCRIPTION
## Summary
Issue E of the agent-worker series (epic #98). Adds the \`lifeos_agent_*\` tool family — 7 tools that let in-flight agent sessions spawn peers, coordinate with them, and yield-and-resume on child completion. Turns the worker into a real multi-agent supervisor. A managed Opus session can now fan out an army of local Gemma children, yield, and resume with their outputs injected as a new user turn (local path proven end-to-end; managed yield-resume documented as deferred).

Closes #103 · Relates to #98

## Test evidence
- \`pytest tests/test_agent_worker_*.py\` — **115/115 passed** (+22 new in test_agent_worker_inter_agent)
- Pre-push hook full unit suite — **1310/1310 passed** (was 1288)

## Review focus
- **Lineage tracking** — sessions get \`root_session_id\` + \`spawn_depth\` on create; descendants inherit. Indices on \`root_session_id\` and \`status='yielded'\` keep tick-loop scans fast.
- **Yield semantics** — \`lifeos_agent_yield_until\` sets caller status to \`STATUS_YIELDED\` with \`yield_waiting_for: [child_ids]\`. ToolRegistry returns a \`yield_seconds=-1\` sentinel so LocalExecutor knows to end the loop. Worker's \`_resume_yielded_for_children\` scans each tick and resumes when all children are terminal.
- **Lineage security** — \`kill\` and \`yield_until\` both verify target sessions share the caller's \`root_session_id\`. Cross-lineage attempts return structured \`{error: "forbidden"}\`.
- **Cap enforcement on spawn** — spawn depth (3), total descendants per root (50), concurrent local (1, VRAM-bound), concurrent managed (10). All operator-overridable. Cap rejections return structured codes so the agent can plan around them.
- **Budget aggregation** — \`spawn\` rejects when requested \`max_dollars > parent_remaining\`. Future PRs can add full lineage-spend rollup.
- **Send queue** — \`pending_messages\` table queues messages for yielded sessions. Drained at resume time.
- **Tool surface is gated** — ToolRegistry only exposes \`lifeos_agent_*\` when an \`InterAgentContext\` is provided. Tests, preflight, and stand-alone contexts don't see the tools accidentally.

## Out of scope
- Managed yield-and-resume — local path is end-to-end; managed yield triggers a clear "not yet supported" failure (session was killed remotely; re-creating it with full history transfer is a follow-up).
- Telegram reply-threading clarifications (#104 — F, next).
- Slack / Asana connectors (deferred per epic design).

## Manual smoke verification (operator follow-up)
1. Restart worker after merge: \`sudo systemctl restart lifeos-agent-worker\`
2. Create a task: \`POST /api/tasks {"description": "summarize my inbox by spawning 3 local children to read different folders", "tags": ["agent"]}\`
3. The Opus parent should call \`lifeos_agent_spawn\` 3x, then \`lifeos_agent_yield_until\` on the children, and resume with their summaries
4. Verify in \`data/agent_transcripts/<parent>.jsonl\` that spawn → yield → resume_after_children events appear in order