### PR TITLE
feat: Telegram clarifications via return-and-resume (F of F)

### DIFF
--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -72,7 +72,7 @@ class InterAgentContext:
     when present, `kill` and other tools can reach remote managed sessions;
     when absent, managed targets are killed in the DB only.
 
-    `worker_handle` is optional; when present, `lifeos_user_ask` can route
+    `worker_handle` is optional; when present, `lifeos_agent_user_ask` can route
     a clarifying question through the worker's Telegram pipeline.
     """
     session_store: SessionStore
@@ -191,7 +191,7 @@ INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
         },
     },
     {
-        "name": "lifeos_user_ask",
+        "name": "lifeos_agent_user_ask",
         "description": "Ask the operator a clarifying question via Telegram and pause until they reply. Your session ends; the worker resumes it (with the user's answer injected as a new user turn) once the reply arrives. Use sparingly — only when you genuinely cannot proceed without operator input.",
         "input_schema": {
             "type": "object",
@@ -497,7 +497,7 @@ def user_ask(ctx: InterAgentContext, args: dict) -> dict:
         return _err(f"caller session {ctx.caller_session_id} not found", code="no_caller")
     if ctx.worker_handle is None:
         return _err(
-            "lifeos_user_ask is only available inside a running session",
+            "lifeos_agent_user_ask is only available inside a running session",
             code="no_worker",
         )
 
@@ -528,7 +528,7 @@ DISPATCH_TABLE = {
     "lifeos_agent_kill": kill,
     "lifeos_agent_transcript_read": transcript_read,
     "lifeos_agent_sessions_list": sessions_list,
-    "lifeos_user_ask": user_ask,
+    "lifeos_agent_user_ask": user_ask,
 }
 
 

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
     STATUS_CLAIMED,
     STATUS_FAILED,
     STATUS_YIELDED,
@@ -70,12 +71,16 @@ class InterAgentContext:
     without knowing how they were called. `managed_driver` is optional —
     when present, `kill` and other tools can reach remote managed sessions;
     when absent, managed targets are killed in the DB only.
+
+    `worker_handle` is optional; when present, `lifeos_user_ask` can route
+    a clarifying question through the worker's Telegram pipeline.
     """
     session_store: SessionStore
     transcript_store: TranscriptStore
     caller_session_id: str
     caps: Caps
     managed_driver: Any | None = None
+    worker_handle: Any | None = None  # Worker — circular import avoided
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +188,17 @@ INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
                 "limit": {"type": "integer"},
             },
             "required": [],
+        },
+    },
+    {
+        "name": "lifeos_user_ask",
+        "description": "Ask the operator a clarifying question via Telegram and pause until they reply. Your session ends; the worker resumes it (with the user's answer injected as a new user turn) once the reply arrives. Use sparingly — only when you genuinely cannot proceed without operator input.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "question": {"type": "string", "description": "The question to ask the operator. Keep it short and specific."},
+            },
+            "required": ["question"],
         },
     },
 ]
@@ -470,6 +486,40 @@ def sessions_list(ctx: InterAgentContext, args: dict) -> dict:
 # Public dispatcher — used by ToolRegistry and the MCP wrapper.
 # ---------------------------------------------------------------------------
 
+def user_ask(ctx: InterAgentContext, args: dict) -> dict:
+    """Agent-initiated Telegram clarification. Marks the caller blocked and
+    queues the question with the user via the worker."""
+    question = (args.get("question") or "").strip()
+    if not question:
+        return _err("question is required", code="invalid_arg")
+    caller = ctx.session_store.get_by_session_id(ctx.caller_session_id)
+    if caller is None:
+        return _err(f"caller session {ctx.caller_session_id} not found", code="no_caller")
+    if ctx.worker_handle is None:
+        return _err(
+            "lifeos_user_ask is only available inside a running session",
+            code="no_worker",
+        )
+
+    sent_id = ctx.worker_handle.ask_user_via_telegram(
+        session_id=caller.session_id,
+        task_id=caller.task_id,
+        question=question,
+    )
+    if sent_id is None:
+        return _err(
+            "could not send Telegram message — bot token may not be configured",
+            code="telegram_unavailable",
+        )
+
+    # Mark the caller blocked so the worker stops driving its loop.
+    ctx.session_store.update_status(caller.task_id, STATUS_BLOCKED)
+    ctx.transcript_store.append(caller.session_id, "user_ask", {
+        "sent_message_id": sent_id, "question_chars": len(question),
+    })
+    return _ok({"asked": True, "sent_message_id": sent_id, "blocked": True})
+
+
 DISPATCH_TABLE = {
     "lifeos_agent_spawn": spawn,
     "lifeos_agent_send": send,
@@ -478,6 +528,7 @@ DISPATCH_TABLE = {
     "lifeos_agent_kill": kill,
     "lifeos_agent_transcript_read": transcript_read,
     "lifeos_agent_sessions_list": sessions_list,
+    "lifeos_user_ask": user_ask,
 }
 
 

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -303,10 +303,13 @@ class LocalExecutor:
             self.session_store.append_message(sid, "user", tool_results)
 
             if yielded_for_children:
-                # Status + yield_waiting_for is already set by the
-                # lifeos_agent_yield_until handler — just end the loop. Worker
-                # main loop will resume when children terminate.
-                self.transcript_store.append(sid, "yielded_for_children", {})
+                # Status is already set by the calling tool — either
+                # lifeos_agent_yield_until (children case) or
+                # lifeos_agent_user_ask (Telegram clarification case). Distinguish
+                # in the transcript by whether yield_waiting_for is populated.
+                refreshed = self.session_store.get(session.task_id)
+                kind = "yielded_for_children" if refreshed.yield_waiting_for else "yielded_for_user"
+                self.transcript_store.append(sid, kind, {})
                 return ExecutorOutcome(status=STATUS_YIELDED)
 
             if yielded_seconds is not None:

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -100,6 +100,26 @@ CREATE TABLE IF NOT EXISTS pending_messages (
 );
 CREATE INDEX IF NOT EXISTS idx_pending_msgs_session ON pending_messages(session_id, delivered);
 
+-- Open clarification questions sent to the operator via Telegram (Issue F).
+-- The listener hook in telegram.py matches incoming reply_to_message ids
+-- against `sent_message_id` and deposits the answer. Worker.tick scans for
+-- answered+unprocessed rows to resume sessions, and for timed-out rows to
+-- send a follow-up nudge.
+CREATE TABLE IF NOT EXISTS pending_questions (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id        TEXT NOT NULL,
+    task_id           TEXT NOT NULL,
+    question          TEXT NOT NULL,
+    sent_message_id   INTEGER NOT NULL,
+    sent_at           INTEGER NOT NULL,
+    answer            TEXT,
+    answered_at       INTEGER,
+    processed         INTEGER NOT NULL DEFAULT 0,
+    timed_out         INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_pq_message_id ON pending_questions(sent_message_id);
+CREATE INDEX IF NOT EXISTS idx_pq_open ON pending_questions(answered_at, processed, timed_out);
+
 CREATE TABLE IF NOT EXISTS daily_spend (
     date           TEXT PRIMARY KEY,
     total_dollars  REAL NOT NULL DEFAULT 0.0
@@ -610,6 +630,90 @@ class SessionStore:
             {"id": r["id"], "sender_id": r["sender_id"], "content": r["content"], "created_at": r["created_at"]}
             for r in rows
         ]
+
+    # ------------------------------------------------------------------
+    # Pending clarification questions (Issue F)
+    # ------------------------------------------------------------------
+
+    def create_pending_question(
+        self,
+        session_id: str,
+        task_id: str,
+        question: str,
+        sent_message_id: int,
+    ) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO pending_questions (
+                    session_id, task_id, question, sent_message_id, sent_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (session_id, task_id, question, int(sent_message_id), _now()),
+            )
+        return cur.lastrowid
+
+    def deposit_answer(self, sent_message_id: int, answer: str) -> bool:
+        """Record an answer for an open question, keyed by Telegram message_id.
+
+        Returns True if a matching open question was found and updated; False
+        otherwise (so the listener can fall through to the chat pipeline).
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id FROM pending_questions "
+                "WHERE sent_message_id = ? AND answered_at IS NULL AND timed_out = 0",
+                (int(sent_message_id),),
+            ).fetchone()
+            if not row:
+                return False
+            conn.execute(
+                "UPDATE pending_questions "
+                "SET answer = ?, answered_at = ? WHERE id = ?",
+                (answer, _now(), row["id"]),
+            )
+        return True
+
+    def get_question_by_message_id(self, sent_message_id: int) -> dict | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM pending_questions WHERE sent_message_id = ?",
+                (int(sent_message_id),),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def list_answered_unprocessed_questions(self) -> list[dict]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM pending_questions "
+                "WHERE answered_at IS NOT NULL AND processed = 0",
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def mark_question_processed(self, question_id: int) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE pending_questions SET processed = 1 WHERE id = ?",
+                (int(question_id),),
+            )
+
+    def list_timed_out_questions(self, before_ts: int) -> list[dict]:
+        """Open questions sent before `before_ts` that haven't been answered
+        or already nudged."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM pending_questions "
+                "WHERE answered_at IS NULL AND timed_out = 0 AND sent_at < ?",
+                (int(before_ts),),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def mark_question_timed_out(self, question_id: int) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE pending_questions SET timed_out = 1 WHERE id = ?",
+                (int(question_id),),
+            )
 
     @staticmethod
     def _row_to_session(row: sqlite3.Row) -> Session:

--- a/api/services/agent_worker/tools.py
+++ b/api/services/agent_worker/tools.py
@@ -16,6 +16,7 @@ called out in `AGENTS.md` and the setup guide.
 """
 from __future__ import annotations
 
+import json
 import logging
 import subprocess
 from dataclasses import dataclass
@@ -312,11 +313,15 @@ class ToolRegistry:
             from api.services.agent_worker import inter_agent
             if inter_agent.is_inter_agent_tool(name):
                 payload = inter_agent.dispatch(self._inter_ctx, name, arguments or {})
-                import json as _json
-                # `yield_until` is the special case: it ends the executor turn.
-                yield_signal = name == "lifeos_agent_yield_until" and payload.get("ok")
+                # `yield_until` and `lifeos_user_ask` both end the executor
+                # turn — the first waits for child completion, the second for
+                # a Telegram reply.
+                yield_signal = (
+                    name in ("lifeos_agent_yield_until", "lifeos_user_ask")
+                    and payload.get("ok")
+                )
                 return ToolResult(
-                    _json.dumps(payload),
+                    json.dumps(payload),
                     is_error=not payload.get("ok", False),
                     yield_seconds=-1 if yield_signal else None,  # sentinel: "yield, no wake timer"
                 )

--- a/api/services/agent_worker/tools.py
+++ b/api/services/agent_worker/tools.py
@@ -313,11 +313,11 @@ class ToolRegistry:
             from api.services.agent_worker import inter_agent
             if inter_agent.is_inter_agent_tool(name):
                 payload = inter_agent.dispatch(self._inter_ctx, name, arguments or {})
-                # `yield_until` and `lifeos_user_ask` both end the executor
+                # `yield_until` and `lifeos_agent_user_ask` both end the executor
                 # turn — the first waits for child completion, the second for
                 # a Telegram reply.
                 yield_signal = (
-                    name in ("lifeos_agent_yield_until", "lifeos_user_ask")
+                    name in ("lifeos_agent_yield_until", "lifeos_agent_user_ask")
                     and payload.get("ok")
                 )
                 return ToolResult(

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -386,6 +386,11 @@ class Worker:
         answered+unprocessed questions, inject the answer as a user turn
         into the conversation, swap the task tag back to `#agent-running`,
         and re-invoke the appropriate executor.
+
+        Special case for routing-ask: when the session's routing is "ask",
+        the answer tells us which model to use. We parse "local"/"claude"
+        out of the answer text and update session.routing accordingly
+        before dispatching.
         """
         answered = self.session_store.list_answered_unprocessed_questions()
         for q in answered:
@@ -397,16 +402,45 @@ class Worker:
                 self.session_store.mark_question_processed(q["id"])
                 continue
 
+            answer = q["answer"] or ""
+
+            # Routing-ask resolution: if session.routing == "ask", the answer
+            # should contain "local" or "claude". Update the session's routing
+            # before dispatching so the right executor handles the resume.
+            if session.routing == "ask":
+                resolved = self._parse_routing_answer(answer)
+                if resolved is None:
+                    # Couldn't parse — re-ask. Mark processed but send a new
+                    # clarification asking specifically for the model name.
+                    self.session_store.mark_question_processed(q["id"])
+                    self.transcript_store.append(session_id, "routing_ask_unparseable", {
+                        "answer_chars": len(answer),
+                    })
+                    self.ask_user_via_telegram(
+                        session_id, task_id,
+                        "I couldn't tell which model you wanted. "
+                        "Please reply 'local' or 'claude'.",
+                    )
+                    continue
+                self.session_store.set_routing_and_budget(
+                    task_id, routing=resolved,
+                    budget=session.budget, expected_output=session.expected_output,
+                )
+                self.transcript_store.append(session_id, "routing_resolved", {
+                    "from": "ask", "to": resolved,
+                })
+                # Refresh the session view so downstream code sees the new routing.
+                session = self.session_store.get_by_session_id(session_id)
+
             # Inject the answer as a user message.
             self.session_store.append_message(
                 session_id, "user",
-                f"(user answered via Telegram) {q['answer']}",
+                f"(user answered via Telegram) {answer}",
             )
             self.transcript_store.append(session_id, "clarification_answered", {
                 "question_id": q["id"],
-                "answer_chars": len(q["answer"] or ""),
+                "answer_chars": len(answer),
             })
-            self.session_store.mark_question_processed(q["id"])
             self._swap_tag(task_id, BLOCKED_TAG, RUNNING_TAG)
             self.session_store.update_status(task_id, STATUS_RUNNING)
 
@@ -419,13 +453,39 @@ class Worker:
                     logger.exception(
                         "clarification resume crashed for %s: %s", task_id, exc,
                     )
+                    # Leave question unprocessed so retry can be attempted.
                     self._mark_failed(session, task, f"clarification resume crashed: {exc}")
                     continue
+                # Only mark processed once the executor returns cleanly — if
+                # the worker crashes mid-execute, the question stays open and
+                # the next tick re-attempts the resume.
+                self.session_store.mark_question_processed(q["id"])
                 self._handle_outcome(session, task, outcome)
+            elif session.routing == "claude":
+                managed = self._get_managed_executor()
+                if managed is None:
+                    self.session_store.mark_question_processed(q["id"])
+                    self._mark_failed(
+                        session, task,
+                        "claude route resolved but Managed Agents isn't configured",
+                    )
+                    continue
+                try:
+                    outcome = managed.start(session, task)
+                except Exception as exc:
+                    logger.exception(
+                        "clarification resume claude.start crashed for %s: %s", task_id, exc,
+                    )
+                    self._mark_failed(session, task, f"clarification resume crashed: {exc}")
+                    continue
+                self.session_store.mark_question_processed(q["id"])
+                if outcome.status == STATUS_FAILED:
+                    self._handle_outcome(session, task, outcome)
+                # otherwise: managed session is now running, _poll_managed_sessions takes over
             else:
-                # Managed clarification resume isn't supported in this MVP for
-                # the same reason as managed yield-resume — needs session
-                # re-creation with history transfer.
+                # Other managed-side clarification (mid-loop lifeos_agent_user_ask):
+                # not yet supported because the original session was killed.
+                self.session_store.mark_question_processed(q["id"])
                 self.transcript_store.append(
                     session_id, "managed_clarification_resume_unsupported", {},
                 )
@@ -433,6 +493,25 @@ class Worker:
                     session, task,
                     "managed clarification resume not yet supported",
                 )
+
+    @staticmethod
+    def _parse_routing_answer(answer: str) -> str | None:
+        """Best-effort parse of a "local" / "claude" answer from a free-text
+        Telegram reply. Returns "local", "claude", or None when ambiguous.
+
+        Handles combined ambiguity+routing replies like "1. John Doe 2. local"
+        by scanning for the model keyword anywhere in the text. If both
+        keywords appear, returns the one occurring later (operator's most
+        recent statement wins).
+        """
+        if not answer:
+            return None
+        lowered = answer.lower()
+        local_idx = max(lowered.rfind("local"), lowered.rfind("gemma"))
+        claude_idx = max(lowered.rfind("claude"), lowered.rfind("opus"))
+        if local_idx < 0 and claude_idx < 0:
+            return None
+        return "local" if local_idx > claude_idx else "claude"
 
     def _timeout_stale_clarifications(self) -> None:
         """Send a one-time nudge for clarifications older than the configured
@@ -850,6 +929,23 @@ class Worker:
         self._swap_tag(session.task_id, RUNNING_TAG, BLOCKED_TAG)
         self.session_store.update_status(session.task_id, STATUS_BLOCKED)
         self.transcript_store.append(session.session_id, "blocked", {"question": question})
+
+        # If the blocked session has a running remote Managed Agents session,
+        # kill it now so session-hour billing stops during the (potentially
+        # 3-day) clarification wait. Managed resume after kill isn't supported
+        # in this MVP — the operator effectively retries by re-tagging once
+        # they reply.
+        if session.managed_agent_session_id:
+            managed = self._get_managed_executor()
+            if managed is not None and managed.driver is not None:
+                try:
+                    managed.driver.kill_session(
+                        session.managed_agent_session_id,
+                        reason="blocked_for_clarification",
+                    )
+                except Exception as exc:
+                    logger.warning("kill_session %s on block failed: %s",
+                                   session.managed_agent_session_id, exc)
 
         # Issue F: send the question with reply-threading enabled so the user's
         # reply lands in pending_questions.answer and the worker resumes.

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -68,6 +68,7 @@ class Worker:
         spend_tracker: SpendTracker | None = None,
         poll_seconds: float | None = None,
         telegram_send=None,  # injectable for tests
+        telegram_send_with_id=None,  # injectable; returns sent message_id (or None)
         http_client: httpx.Client | None = None,
         preflight_caller=None,    # injectable; defaults to Anthropic Haiku
         local_executor=None,      # injectable LocalExecutor for tests
@@ -92,6 +93,17 @@ class Worker:
             except Exception:  # pragma: no cover — defensive
                 telegram_send = _noop_telegram
         self._telegram_send = telegram_send
+        # Default the "with id" sender to the real Telegram module; tests
+        # inject a fake that returns a deterministic message_id (or None).
+        if telegram_send_with_id is None:
+            def _noop_with_id(text):
+                return None
+            try:
+                from api.services.telegram import send_message_capture_id
+                telegram_send_with_id = send_message_capture_id
+            except Exception:
+                telegram_send_with_id = _noop_with_id
+        self._telegram_send_with_id = telegram_send_with_id
         self._owns_http_client = http_client is None
         self._http = http_client or httpx.Client(timeout=10.0)
         self._preflight_caller = preflight_caller  # None → use Anthropic SDK by default
@@ -197,6 +209,10 @@ class Worker:
         # Dispatch any newly-spawned sessions (no #agent task — created via
         # lifeos_agent_spawn). They show up with status=claimed and a routing.
         self._dispatch_spawned_sessions()
+        # Resume blocked sessions whose Telegram clarifications have arrived.
+        self._process_clarification_answers()
+        # Timeout long-unanswered clarifications.
+        self._timeout_stale_clarifications()
 
         candidates = self._list_agent_tasks()
         handled = 0
@@ -362,6 +378,113 @@ class Worker:
             if outcome.status != STATUS_RUNNING:
                 self._handle_outcome(session, task, outcome)
 
+    def _process_clarification_answers(self) -> None:
+        """Resume blocked sessions whose Telegram clarifications arrived.
+
+        The Telegram listener (api/services/telegram.py) deposits user
+        replies into `pending_questions.answer`. Each tick we drain any
+        answered+unprocessed questions, inject the answer as a user turn
+        into the conversation, swap the task tag back to `#agent-running`,
+        and re-invoke the appropriate executor.
+        """
+        answered = self.session_store.list_answered_unprocessed_questions()
+        for q in answered:
+            session_id = q["session_id"]
+            task_id = q["task_id"]
+            session = self.session_store.get_by_session_id(session_id)
+            if session is None:
+                # Stale — session was deleted? Mark processed so we don't loop.
+                self.session_store.mark_question_processed(q["id"])
+                continue
+
+            # Inject the answer as a user message.
+            self.session_store.append_message(
+                session_id, "user",
+                f"(user answered via Telegram) {q['answer']}",
+            )
+            self.transcript_store.append(session_id, "clarification_answered", {
+                "question_id": q["id"],
+                "answer_chars": len(q["answer"] or ""),
+            })
+            self.session_store.mark_question_processed(q["id"])
+            self._swap_tag(task_id, BLOCKED_TAG, RUNNING_TAG)
+            self.session_store.update_status(task_id, STATUS_RUNNING)
+
+            task = self._fetch_task(task_id) or {"id": task_id, "description": task_id}
+            if session.routing == "local":
+                executor = self._get_local_executor(caller_session_id=session_id)
+                try:
+                    outcome = executor.execute(session, task)
+                except Exception as exc:
+                    logger.exception(
+                        "clarification resume crashed for %s: %s", task_id, exc,
+                    )
+                    self._mark_failed(session, task, f"clarification resume crashed: {exc}")
+                    continue
+                self._handle_outcome(session, task, outcome)
+            else:
+                # Managed clarification resume isn't supported in this MVP for
+                # the same reason as managed yield-resume — needs session
+                # re-creation with history transfer.
+                self.transcript_store.append(
+                    session_id, "managed_clarification_resume_unsupported", {},
+                )
+                self._mark_failed(
+                    session, task,
+                    "managed clarification resume not yet supported",
+                )
+
+    def _timeout_stale_clarifications(self) -> None:
+        """Send a one-time nudge for clarifications older than the configured
+        timeout. The task stays at #agent-blocked permanently after that — the
+        operator can manually re-tag with #agent to retry.
+        """
+        timeout_seconds = settings.agent_clarification_timeout_hours * 3600
+        cutoff = int(time.time()) - timeout_seconds
+        stale = self.session_store.list_timed_out_questions(cutoff)
+        for q in stale:
+            self.session_store.mark_question_timed_out(q["id"])
+            self.transcript_store.append(q["session_id"], "clarification_timed_out", {
+                "question_id": q["id"],
+            })
+            self._notify(
+                f"⏰ Agent worker: task is still waiting on your reply.\n\n"
+                f"Question: {q['question'][:300]}\n\n"
+                f"(Task remains at #{BLOCKED_TAG}. Reply to the original "
+                f"question to unblock, or re-tag with #{AGENT_TAG} to retry.)"
+            )
+
+    def ask_user_via_telegram(
+        self,
+        session_id: str,
+        task_id: str,
+        question: str,
+    ) -> int | None:
+        """Send a clarification question via Telegram and record the
+        sent_message_id so the reply-thread hook can match it back.
+
+        Returns the Telegram message_id (or None if Telegram isn't configured
+        — caller should mark the session blocked anyway since we can't ask).
+        """
+        try:
+            sent_id = self._telegram_send_with_id(question)
+        except Exception as exc:
+            logger.warning(f"ask_user_via_telegram failed: {exc}")
+            return None
+        if sent_id is None:
+            return None
+        self.session_store.create_pending_question(
+            session_id=session_id,
+            task_id=task_id,
+            question=question,
+            sent_message_id=sent_id,
+        )
+        self.transcript_store.append(session_id, "clarification_sent", {
+            "sent_message_id": sent_id,
+            "question_chars": len(question),
+        })
+        return sent_id
+
     def _wake_sleeping_sessions(self) -> None:
         """Resume any sessions whose `sleeps` row has expired."""
 
@@ -491,6 +614,7 @@ class Worker:
                     max_concurrent_local=settings.agent_max_concurrent_local,
                     max_concurrent_managed=settings.agent_max_concurrent_managed,
                 ),
+                worker_handle=self,
             )
         registry = ToolRegistry(inter_agent_context=ctx)
         return LocalExecutor(
@@ -726,12 +850,21 @@ class Worker:
         self._swap_tag(session.task_id, RUNNING_TAG, BLOCKED_TAG)
         self.session_store.update_status(session.task_id, STATUS_BLOCKED)
         self.transcript_store.append(session.session_id, "blocked", {"question": question})
-        # In Issue F this becomes a reply-threaded message and the reply
-        # resumes the task. For now it's one-way.
-        self._notify(
-            f"⏸ Agent worker: task '{title}' needs your input.\n\n{question}\n\n"
-            f"(Re-tag the task with #{AGENT_TAG} once you've added the answer in the task title or context.)"
+
+        # Issue F: send the question with reply-threading enabled so the user's
+        # reply lands in pending_questions.answer and the worker resumes.
+        body = (
+            f"⏸ Agent worker: task '{title}' needs your input.\n\n"
+            f"{question}\n\n"
+            "Reply to this message to answer."
         )
+        sent_id = self.ask_user_via_telegram(
+            session.session_id, session.task_id, body,
+        )
+        if sent_id is None:
+            # Telegram not configured — fall back to the legacy one-way
+            # message so the operator at least sees the question.
+            self._notify(body)
 
     def _notify(self, text: str) -> None:
         try:

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -112,6 +112,43 @@ class TypingIndicator:
                 pass
 
 
+def send_message_capture_id(text: str, chat_id: str = None) -> int | None:
+    """Send a message and return its Telegram `message_id` (or None on failure).
+
+    Used by the agent worker to track clarification questions so reply-
+    threaded answers can be matched back to the right pending question.
+    Falls back to plain text if Markdown parse fails. Returns the id from
+    the first sent chunk so reply-threading lands on the start of the
+    question.
+    """
+    if not settings.telegram_enabled:
+        return None
+    chat_id = chat_id or settings.telegram_chat_id
+    text = _clean_markdown_for_telegram(text)
+    first_id: int | None = None
+    for part in _split_message(text):
+        try:
+            resp = httpx.post(
+                _telegram_url("sendMessage"),
+                json={"chat_id": chat_id, "text": part, "parse_mode": "Markdown"},
+                timeout=30.0,
+            )
+            if resp.status_code != 200:
+                resp = httpx.post(
+                    _telegram_url("sendMessage"),
+                    json={"chat_id": chat_id, "text": part},
+                    timeout=30.0,
+                )
+            if resp.status_code == 200 and first_id is None:
+                payload = resp.json()
+                first_id = (payload.get("result") or {}).get("message_id")
+            elif resp.status_code != 200:
+                logger.error(f"Telegram send failed: {resp.status_code} {resp.text[:200]}")
+        except Exception as e:
+            logger.error(f"Telegram send error: {e}")
+    return first_id
+
+
 def send_message(text: str, chat_id: str = None) -> bool:
     """
     Send a message via Telegram (synchronous).
@@ -457,6 +494,21 @@ class TelegramBotListener:
             await asyncio.sleep(2)
             return []
 
+    def _maybe_deposit_agent_answer(self, reply_to_message_id: int, text: str) -> bool:
+        """If `reply_to_message_id` matches an open agent-worker clarification
+        question, record the answer and short-circuit the chat pipeline.
+
+        Importing the session store lazily keeps the chat-only deployment
+        path workable even when the agent worker package isn't initialized.
+        """
+        try:
+            from api.services.agent_worker.session_store import SessionStore
+            store = SessionStore()
+            return store.deposit_answer(reply_to_message_id, text)
+        except Exception as exc:
+            logger.warning(f"agent-worker deposit_answer failed: {exc}")
+            return False
+
     async def _handle_update(self, update: dict):
         """Process a single Telegram update."""
         message = update.get("message")
@@ -481,6 +533,14 @@ class TelegramBotListener:
 
         if not text:
             return
+
+        # Agent-worker clarification hook (Issue F). If this message is a
+        # reply-thread to a previously-sent clarification question, deposit
+        # the answer and short-circuit — don't route to the chat pipeline.
+        reply_to = message.get("reply_to_message")
+        if reply_to and reply_to.get("message_id"):
+            if self._maybe_deposit_agent_answer(int(reply_to["message_id"]), text):
+                return
 
         logger.info(f"Telegram message: {text[:100]}")
 

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -8,7 +8,7 @@ End-to-end:
   3. Worker tick scans answered+unprocessed, injects the answer as a user
      turn, swaps tag back to #agent-running, resumes the local executor.
 
-Also covers `lifeos_user_ask` (agent-initiated clarification) and the
+Also covers `lifeos_agent_user_ask` (agent-initiated clarification) and the
 3-day timeout path.
 """
 from __future__ import annotations
@@ -190,6 +190,108 @@ def test_unmatched_reply_does_not_deposit(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_stale_answered_question_doesnt_redeposit(tmp_path: Path):
+    """Second reply to an already-answered question falls through to chat."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    sess = store.create(
+        task_id="t", status=STATUS_BLOCKED, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+    )
+    store.create_pending_question(
+        session_id=sess.session_id, task_id="t",
+        question="?", sent_message_id=7,
+    )
+    assert store.deposit_answer(7, "first") is True
+    # Second attempt against the same message_id finds nothing open.
+    assert store.deposit_answer(7, "second") is False
+    q = store.get_question_by_message_id(7)
+    assert q["answer"] == "first"
+
+
+@pytest.mark.unit
+def test_routing_ask_local_reply_routes_to_local_executor(tmp_path: Path):
+    """Routing-ask resume: user reply 'local' must run the local executor."""
+
+    def routing_ask_preflight():
+        import json
+        def _caller(prompt):
+            return json.dumps({
+                "budget": {"wall_seconds": 3600, "max_tokens": 1000, "max_dollars": 5.0},
+                "routing": "ask", "routing_reason": "no model hint",
+                "expected_output": "text",
+                "ambiguity": None, "sane": True, "sane_reason": "",
+            })
+        return _caller
+
+    api = FakeApi([{"id": "t1", "description": "research dolphins", "status": "todo", "tags": ["agent"]}])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="ok"))
+    w = _make_worker(tmp_path, api, preflight_caller=routing_ask_preflight(), local_executor=executor)
+    w.tick()
+
+    # Task is blocked, routing=ask.
+    blocked = w.session_store.list_sessions(status=STATUS_BLOCKED)[0]
+    assert blocked.routing == "ask"
+
+    # User replies "local".
+    msg_id, _ = w._sent_with_ids[0]
+    w.session_store.deposit_answer(msg_id, "use local please")
+
+    # Resume tick — routing gets resolved to "local" and executor runs.
+    w.tick()
+    assert executor.calls, "local executor should have been invoked"
+    refreshed = w.session_store.get(blocked.task_id)
+    assert refreshed.routing == "local"
+
+
+@pytest.mark.unit
+def test_routing_ask_unparseable_reply_reasks(tmp_path: Path):
+    """If the user's reply doesn't contain local/claude, ask again."""
+    def routing_ask_preflight():
+        import json
+        def _caller(prompt):
+            return json.dumps({
+                "budget": {"wall_seconds": 3600, "max_tokens": 1000, "max_dollars": 5.0},
+                "routing": "ask", "routing_reason": "x",
+                "expected_output": "text",
+                "ambiguity": None, "sane": True, "sane_reason": "",
+            })
+        return _caller
+
+    api = FakeApi([{"id": "t1", "description": "x", "status": "todo", "tags": ["agent"]}])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    w = _make_worker(tmp_path, api, preflight_caller=routing_ask_preflight(), local_executor=executor)
+    w.tick()
+
+    msg_id, _ = w._sent_with_ids[0]
+    w.session_store.deposit_answer(msg_id, "yeah whatever you like")
+
+    w.tick()
+    # Executor not invoked — we re-asked.
+    assert executor.calls == []
+    # A second Telegram message was sent (the re-ask).
+    assert len(w._sent_with_ids) >= 2
+    second_text = w._sent_with_ids[1][1].lower()
+    assert "local" in second_text and "claude" in second_text
+
+
+@pytest.mark.unit
+def test_routing_answer_parser_combined_replies():
+    """Best-effort parse of combined ambiguity+routing replies."""
+    from api.services.agent_worker.worker import Worker
+    parse = Worker._parse_routing_answer
+    assert parse("local") == "local"
+    assert parse("CLAUDE please") == "claude"
+    assert parse("use opus") == "claude"
+    assert parse("gemma is fine") == "local"
+    # Combined: ambiguity answer first, model second.
+    assert parse("1. John Doe 2. local") == "local"
+    assert parse("It's John Doe, and let's use claude") == "claude"
+    # Neither keyword → None.
+    assert parse("yes do it") is None
+    assert parse("") is None
+
+
+@pytest.mark.unit
 def test_timeout_marks_question_and_nudges(tmp_path: Path):
     """A question older than the timeout gets `timed_out=1` + a follow-up nudge."""
     api = FakeApi([{"id": "t1", "description": "x", "status": "todo", "tags": ["agent-blocked"]}])
@@ -219,8 +321,8 @@ def test_timeout_marks_question_and_nudges(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_lifeos_user_ask_blocks_and_records_question(tmp_path: Path):
-    """An agent calling `lifeos_user_ask` should park the session and record
+def test_lifeos_agent_user_ask_blocks_and_records_question(tmp_path: Path):
+    """An agent calling `lifeos_agent_user_ask` should park the session and record
     a pending_question that the user can reply-thread to."""
     api = FakeApi([])
     store = SessionStore(db_path=tmp_path / "sessions.db")
@@ -257,7 +359,7 @@ def test_lifeos_user_ask_blocks_and_records_question(tmp_path: Path):
         caps=Caps(),
         worker_handle=w,
     )
-    result = dispatch(ctx, "lifeos_user_ask", {"question": "Should I delete the file?"})
+    result = dispatch(ctx, "lifeos_agent_user_ask", {"question": "Should I delete the file?"})
     assert result["ok"]
     assert result["blocked"]
     assert store.get("active_t").status == STATUS_BLOCKED
@@ -269,7 +371,7 @@ def test_lifeos_user_ask_blocks_and_records_question(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_lifeos_user_ask_fails_when_telegram_unavailable(tmp_path: Path):
+def test_lifeos_agent_user_ask_fails_when_telegram_unavailable(tmp_path: Path):
     """If the worker can't send (no Telegram config), the tool returns an error
     rather than blocking the session in an unrecoverable state."""
     api = FakeApi([])
@@ -302,7 +404,7 @@ def test_lifeos_user_ask_fails_when_telegram_unavailable(tmp_path: Path):
         caps=Caps(),
         worker_handle=w,
     )
-    result = dispatch(ctx, "lifeos_user_ask", {"question": "anyone home?"})
+    result = dispatch(ctx, "lifeos_agent_user_ask", {"question": "anyone home?"})
     assert not result["ok"]
     assert result["error"] == "telegram_unavailable"
     # Session NOT blocked (operator-facing failure mode).

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -1,0 +1,309 @@
+"""Tests for the Telegram clarification round-trip (Issue F).
+
+End-to-end:
+  1. Preflight flags ambiguity → worker sends a Telegram question and captures
+     `sent_message_id`, parks task at #agent-blocked.
+  2. User replies (reply-threaded). The listener's deposit hook updates
+     pending_questions.answer.
+  3. Worker tick scans answered+unprocessed, injects the answer as a user
+     turn, swaps tag back to #agent-running, resumes the local executor.
+
+Also covers `lifeos_user_ask` (agent-initiated clarification) and the
+3-day timeout path.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
+    STATUS_COMPLETED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import (
+    BLOCKED_TAG,
+    Worker,
+)
+
+
+class FakeApi:
+    def __init__(self, tasks):
+        self.tasks = {t["id"]: t for t in tasks}
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "GET" and path == "/api/tasks":
+            tag = request.url.params.get("tag")
+            matched = [t for t in self.tasks.values()
+                       if t.get("status") == "todo" and (tag in t.get("tags", []) if tag else True)]
+            return httpx.Response(200, json={"tasks": matched, "total": len(matched)})
+        if request.method == "POST" and path.endswith("/swap-tag"):
+            tid = path.split("/")[-2]
+            f = request.url.params.get("from")
+            to = request.url.params.get("to")
+            t = self.tasks.get(tid)
+            if not t or f not in t.get("tags", []):
+                return httpx.Response(200, json={"swapped": False})
+            tags = list(t["tags"])
+            tags[tags.index(f)] = to
+            t["tags"] = tags
+            return httpx.Response(200, json={"swapped": True})
+        if request.method == "PUT" and path.endswith("/complete"):
+            tid = path.split("/")[-2]
+            t = self.tasks.get(tid)
+            if not t:
+                return httpx.Response(404)
+            t["status"] = "done"
+            return httpx.Response(200, json=t)
+        if request.method == "GET" and "/api/tasks/" in path:
+            tid = path.split("/")[-1]
+            t = self.tasks.get(tid)
+            return httpx.Response(200, json=t) if t else httpx.Response(404)
+        return httpx.Response(404)
+
+
+class _StubExecutor:
+    def __init__(self, outcome):
+        self.outcome = outcome
+        self.calls = []
+    def execute(self, session, task):
+        self.calls.append((session.task_id, task.get("description")))
+        return self.outcome
+
+
+def _make_worker(tmp_path, api, *, preflight_caller, local_executor):
+    transport = httpx.MockTransport(api.handler)
+    client = httpx.Client(transport=transport, base_url="http://api")
+    sent: list[str] = []
+    sent_with_ids: list[tuple[int, str]] = []
+    def _send_with_id(text):
+        sent.append(text)
+        msg_id = 1000 + len(sent_with_ids)
+        sent_with_ids.append((msg_id, text))
+        return msg_id
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    w = Worker(
+        api_base="http://api",
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        telegram_send_with_id=_send_with_id,
+        http_client=client,
+        preflight_caller=preflight_caller,
+        local_executor=local_executor,
+    )
+    w._sent = sent  # type: ignore[attr-defined]
+    w._sent_with_ids = sent_with_ids  # type: ignore[attr-defined]
+    return w
+
+
+def _ambiguity_preflight():
+    """Preflight that flags every task as ambiguous."""
+    def _caller(prompt):
+        import json
+        return json.dumps({
+            "budget": {"wall_seconds": 3600, "max_tokens": 1000, "max_dollars": 5.0},
+            "routing": "local", "routing_reason": "test",
+            "expected_output": "text",
+            "ambiguity": {"question": "Which John — Doe or Smith?"},
+            "sane": True, "sane_reason": "",
+        })
+    return _caller
+
+
+def _local_ok_preflight():
+    def _caller(prompt):
+        import json
+        return json.dumps({
+            "budget": {"wall_seconds": 3600, "max_tokens": 1000, "max_dollars": 5.0},
+            "routing": "local", "routing_reason": "test",
+            "expected_output": "text",
+            "ambiguity": None, "sane": True, "sane_reason": "",
+        })
+    return _caller
+
+
+@pytest.mark.unit
+def test_ambiguous_task_sends_clarification_with_tracked_id(tmp_path: Path):
+    api = FakeApi([{"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent"]}])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    w = _make_worker(tmp_path, api, preflight_caller=_ambiguity_preflight(), local_executor=executor)
+    w.tick()
+
+    # Task is blocked, executor was NOT invoked.
+    assert BLOCKED_TAG in api.tasks["t1"]["tags"]
+    assert executor.calls == []
+
+    # A pending question is recorded with the captured sent_message_id.
+    sessions = w.session_store.list_sessions(status=STATUS_BLOCKED)
+    assert sessions
+    blocked = sessions[0]
+    msg_id, body = w._sent_with_ids[0]
+    q = w.session_store.get_question_by_message_id(msg_id)
+    assert q is not None
+    assert q["session_id"] == blocked.session_id
+    assert q["answered_at"] is None
+    assert "Which John" in q["question"]
+
+
+@pytest.mark.unit
+def test_reply_threaded_answer_resumes_blocked_session(tmp_path: Path):
+    """End-to-end: ambiguous → answered → resumed → completed."""
+    api = FakeApi([{"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent"]}])
+    # First call: returns "ambiguous". After resume, preflight isn't called
+    # again — the executor handles the rest.
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="emailed Doe"))
+    w = _make_worker(tmp_path, api, preflight_caller=_ambiguity_preflight(), local_executor=executor)
+    w.tick()
+
+    # Operator answers via Telegram (deposit by message_id).
+    msg_id, _ = w._sent_with_ids[0]
+    deposited = w.session_store.deposit_answer(msg_id, "John Doe")
+    assert deposited
+
+    # Next tick should resume the session.
+    w.tick()
+    assert executor.calls, "executor should have been invoked on resume"
+    # Task now done.
+    assert api.tasks["t1"]["status"] == "done"
+    # And the question is processed.
+    q = w.session_store.get_question_by_message_id(msg_id)
+    assert q["processed"] == 1
+
+
+@pytest.mark.unit
+def test_unmatched_reply_does_not_deposit(tmp_path: Path):
+    """A reply-threaded message that doesn't match any open question is a no-op."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    # No questions in the DB.
+    assert store.deposit_answer(999, "stray answer") is False
+
+
+@pytest.mark.unit
+def test_timeout_marks_question_and_nudges(tmp_path: Path):
+    """A question older than the timeout gets `timed_out=1` + a follow-up nudge."""
+    api = FakeApi([{"id": "t1", "description": "x", "status": "todo", "tags": ["agent-blocked"]}])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    # Create a session and an already-stale pending question by hand.
+    session = w.session_store.create(
+        task_id="t1", status=STATUS_BLOCKED, routing="local",
+        budget={"wall_seconds": 60, "max_tokens": 100, "max_dollars": 1.0},
+    )
+    qid = w.session_store.create_pending_question(
+        session_id=session.session_id, task_id="t1",
+        question="Which John?", sent_message_id=42,
+    )
+    # Backdate the sent_at by 4 days so it's past the 72h default cutoff.
+    with w.session_store._connect() as conn:
+        conn.execute(
+            "UPDATE pending_questions SET sent_at = ? WHERE id = ?",
+            (int(time.time()) - 4 * 86400, qid),
+        )
+
+    w._timeout_stale_clarifications()
+    refreshed = w.session_store.get_question_by_message_id(42)
+    assert refreshed["timed_out"] == 1
+    assert any("still waiting on your reply" in s for s in w._sent)
+
+
+@pytest.mark.unit
+def test_lifeos_user_ask_blocks_and_records_question(tmp_path: Path):
+    """An agent calling `lifeos_user_ask` should park the session and record
+    a pending_question that the user can reply-thread to."""
+    api = FakeApi([])
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    session = store.create(
+        task_id="active_t", status=STATUS_RUNNING, routing="local",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 1.0},
+    )
+    sent_with_ids: list[tuple[int, str]] = []
+    def _send_with_id(text):
+        msg_id = 5000 + len(sent_with_ids)
+        sent_with_ids.append((msg_id, text))
+        return msg_id
+
+    w = Worker(
+        api_base="http://api",
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda *a, **kw: True,
+        telegram_send_with_id=_send_with_id,
+        http_client=httpx.Client(transport=httpx.MockTransport(api.handler), base_url="http://api"),
+    )
+
+    from api.services.agent_worker.inter_agent import (
+        Caps,
+        InterAgentContext,
+        dispatch,
+    )
+    ctx = InterAgentContext(
+        session_store=store,
+        transcript_store=w.transcript_store,
+        caller_session_id=session.session_id,
+        caps=Caps(),
+        worker_handle=w,
+    )
+    result = dispatch(ctx, "lifeos_user_ask", {"question": "Should I delete the file?"})
+    assert result["ok"]
+    assert result["blocked"]
+    assert store.get("active_t").status == STATUS_BLOCKED
+    # And the worker recorded a pending question with the captured message id.
+    msg_id, _ = sent_with_ids[0]
+    q = store.get_question_by_message_id(msg_id)
+    assert q is not None
+    assert q["task_id"] == "active_t"
+
+
+@pytest.mark.unit
+def test_lifeos_user_ask_fails_when_telegram_unavailable(tmp_path: Path):
+    """If the worker can't send (no Telegram config), the tool returns an error
+    rather than blocking the session in an unrecoverable state."""
+    api = FakeApi([])
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    session = store.create(
+        task_id="t", status=STATUS_RUNNING, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+    )
+
+    w = Worker(
+        api_base="http://api",
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda *a, **kw: True,
+        telegram_send_with_id=lambda text: None,  # simulates Telegram off
+        http_client=httpx.Client(transport=httpx.MockTransport(api.handler), base_url="http://api"),
+    )
+
+    from api.services.agent_worker.inter_agent import (
+        Caps,
+        InterAgentContext,
+        dispatch,
+    )
+    ctx = InterAgentContext(
+        session_store=store,
+        transcript_store=w.transcript_store,
+        caller_session_id=session.session_id,
+        caps=Caps(),
+        worker_handle=w,
+    )
+    result = dispatch(ctx, "lifeos_user_ask", {"question": "anyone home?"})
+    assert not result["ok"]
+    assert result["error"] == "telegram_unavailable"
+    # Session NOT blocked (operator-facing failure mode).
+    assert store.get("t").status == STATUS_RUNNING

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -89,6 +89,14 @@ def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_execut
     transport = httpx.MockTransport(api.handler)
     client = httpx.Client(transport=transport, base_url="http://api")
     sent: list[str] = []
+    # Capturing sender for clarification questions — records the text and
+    # returns a deterministic message_id so reply-threading can be tested.
+    sent_with_ids: list[tuple[int, str]] = []
+    def _fake_send_with_id(text):
+        sent.append(text)
+        msg_id = len(sent_with_ids) + 1000
+        sent_with_ids.append((msg_id, text))
+        return msg_id
     w = Worker(
         api_base="http://api",
         session_store=SessionStore(db_path=tmp_path / "sessions.db"),
@@ -96,11 +104,13 @@ def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_execut
         spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
         poll_seconds=0.01,
         telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        telegram_send_with_id=_fake_send_with_id,
         http_client=client,
         preflight_caller=preflight_caller,
         local_executor=local_executor,
     )
     w._sent_telegram = sent  # type: ignore[attr-defined]
+    w._sent_with_ids = sent_with_ids  # type: ignore[attr-defined]
     return w
 
 


### PR DESCRIPTION
## Summary
Final issue of the agent-worker series (epic #98). Closes the human-in-the-loop dimension: ambiguous tasks and routing-ask cases now send Telegram messages with reply-threading; the operator's reply matches back to the pending question and the session resumes with the answer injected as a user turn. Adds \`lifeos_user_ask\` for agent-initiated mid-loop clarifications. After this, the full flow described in #98 works end-to-end.

Closes #104 · Relates to #98

## Test evidence
- \`pytest tests/test_agent_worker_*.py\` — **129/129 passed** (+11 new in test_agent_worker_clarifications)
- Pre-push hook full unit suite — **1324/1324 passed** (was 1318)

## Review focus
- **Reply-threading hook** in \`api/services/telegram.py:_handle_update\` is at the top of the handler, before chat-pipeline routing. Unmatched replies fall through to chat unchanged (regression-safe). The hook is wrapped in a try/except + lazy import so the chat-only deployment path is unaffected when the agent worker DB isn't initialized.
- **\`send_message_capture_id\`** returns the message_id of the first sent chunk so reply-threading lands at the start of the question even when long messages are split.
- **\`deposit_answer\`** keys on \`sent_message_id\` and returns False if no open question matches — the listener uses that to decide whether to short-circuit.
- **Worker \`_process_clarification_answers\`** runs each tick, drains answered+unprocessed questions, injects the answer as a user turn (\`(user answered via Telegram) {answer}\`), swaps tag back to \`#agent-running\`, re-invokes the local executor.
- **Timeout path** in \`_timeout_stale_clarifications\` is one-shot: marks \`timed_out=1\` and sends a single nudge. Task stays at \`#agent-blocked\`; operator re-tags to retry.
- **\`lifeos_user_ask\`** parks the session and returns a yield sentinel so the executor ends the loop. The tool returns \`error: telegram_unavailable\` if no bot configured — session NOT blocked in that case.
- **Injectable Telegram senders** (\`telegram_send\`, \`telegram_send_with_id\`) for tests so the suite doesn't send real messages on the host.

## What completes after this PR
The full flow described in epic #98:
1. Tag task \`#agent\` → worker claims atomically (Issue B)
2. Haiku preflight classifies budget / routing / ambiguity (Issue C)
3. Local Gemma OR Anthropic Managed Agents executes (Issues C+D)
4. Agent can spawn children, coordinate via yield-and-resume (Issue E)
5. Agent can ask the operator a clarifying question via Telegram; reply resumes the session (Issue F — this PR)
6. Completion sends a one-paragraph Telegram summary

## Out of scope (still deferred for follow-up)
- Managed yield-and-resume / clarification-resume — local path is end-to-end; managed cases fail with a clear "not supported" reason. Both depend on Managed-Agents session re-creation with history transfer.

## Manual smoke verification (operator follow-up)
1. \`sudo systemctl restart lifeos-agent-worker\`
2. Create an ambiguous task: \`POST /api/tasks {"description": "reply to John", "tags": ["agent", "local"]}\`
3. Expect a Telegram message ending with "Reply to this message to answer."
4. Tap reply, type "John Doe", send
5. Within ~60s the worker should resume, complete the task, and send a completion summary