### PR TITLE
fix: managed_driver terminal-state detection — idle + events endpoint + 4xx body

### DIFF
--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -215,11 +215,15 @@ class ManagedAgentsDriver:
         if events:
             last_event_id = events[-1].get("id")
 
-        # Synthesize a terminal status from events when the status field hasn't
-        # transitioned yet. `idle` (raw) wins on its own; otherwise we look at
-        # events for status_idle / session.error.
+        # Resolve final status. A `session.error` in the batch must win over
+        # a raw `idle`, otherwise the session reports completed and the
+        # cascading failure is silently lost. `_synthesize_status_from_events`
+        # returns "failed" if ANY error event is present, else "completed"
+        # if any idle event, else None.
         synthesized = _synthesize_status_from_events(events)
-        if raw_status in TERMINAL_REMOTE_STATUSES:
+        if synthesized == "failed":
+            status = "failed"
+        elif raw_status in TERMINAL_REMOTE_STATUSES:
             status = raw_status
         elif synthesized:
             status = synthesized
@@ -244,33 +248,64 @@ class ManagedAgentsDriver:
             error_reason=error_reason,
         )
 
+    # Hard cap on pagination loop in `list_events` — protects against a
+    # misbehaving API or runaway session producing millions of events. 1000
+    # pages × the API's page size is far more than any real session will
+    # ever generate; if we hit this we'd rather drop and warn than hang.
+    _MAX_EVENTS_PAGES = 1000
+
     def list_events(
         self,
         session_id: str,
         after_id: str | None = None,
     ) -> list[dict]:
-        """Fetch new session events since `after_id` (or all if None).
+        """Fetch all new session events since `after_id` (or all if None).
 
         `GET /v1/sessions/{id}/events?after=<cursor>` returns
-        `{"data": [{"id", "type", "payload"|"content"|"error", ...}, ...]}`.
-        Returns the raw event list; callers (e.g. `get_session_state`) handle
-        the cursor advance and synthesis logic.
+        `{"data": [{"id", "type", "payload"|"content"|"error", ...}, ...],
+          "first_id", "last_id", "has_more"}`. Loops while `has_more=True`
+        so the caller never silently loses the tail of a paginated batch —
+        without this, a session that produced more events than the API page
+        size between polls would have its terminal `agent.message` dropped
+        and the Telegram completion summary would be wrong.
+
+        Returns the raw event list (concatenated across pages); callers
+        (e.g. `get_session_state`) handle the cursor advance and synthesis.
         """
-        params: dict[str, str] = {}
-        if after_id:
-            params[self.EVENT_CURSOR_PARAM] = after_id
-        resp = self._client.get(
-            f"{self.base_url}/sessions/{session_id}/events",
-            headers=self._headers(),
-            params=params,
+        all_events: list[dict] = []
+        cursor = after_id
+        for _ in range(self._MAX_EVENTS_PAGES):
+            params: dict[str, str] = {}
+            if cursor:
+                params[self.EVENT_CURSOR_PARAM] = cursor
+            resp = self._client.get(
+                f"{self.base_url}/sessions/{session_id}/events",
+                headers=self._headers(),
+                params=params,
+            )
+            if resp.status_code == 404:
+                # Session deleted mid-poll. Caller's status fetch already
+                # turned this into "cancelled"; return what we have.
+                return all_events
+            self._raise_for_status_with_body(resp)
+            data = resp.json()
+            page = data.get("data", []) or []
+            all_events.extend(page)
+            if not data.get("has_more"):
+                return all_events
+            if not page:
+                # Defensive: has_more=True but empty page would loop forever.
+                logger.warning("list_events: has_more=true with empty page; stopping")
+                return all_events
+            cursor = page[-1].get("id")
+            if not cursor:
+                logger.warning("list_events: has_more=true but last event has no id; stopping")
+                return all_events
+        logger.warning(
+            "list_events: hit pagination cap (%d pages) for session %s",
+            self._MAX_EVENTS_PAGES, session_id,
         )
-        if resp.status_code == 404:
-            # Session deleted mid-poll. Caller's status fetch already turned
-            # this into "cancelled"; return empty events so we don't crash.
-            return []
-        self._raise_for_status_with_body(resp)
-        data = resp.json()
-        return data.get("data", []) or []
+        return all_events
 
     def post_user_message(self, session_id: str, content: str) -> None:
         """Post a user turn to a running session.
@@ -308,10 +343,14 @@ class ManagedAgentsDriver:
         if 400 <= resp.status_code < 500:
             # Truncate to avoid unbounded log volume from a misbehaving API.
             body_preview = (resp.text or "")[:2048]
+            # `resp.request` is set by real transports including MockTransport,
+            # but defensively guard against hand-constructed Response objects.
+            req = getattr(resp, "request", None)
+            method = getattr(req, "method", "?") if req is not None else "?"
+            path = getattr(getattr(req, "url", None), "path", "?") if req is not None else "?"
             logger.warning(
                 "Managed Agents %s %s → %d: %s",
-                resp.request.method, resp.request.url.path,
-                resp.status_code, body_preview,
+                method, path, resp.status_code, body_preview,
             )
         resp.raise_for_status()
 
@@ -320,12 +359,15 @@ class ManagedAgentsDriver:
 
         Best-effort: errors are logged but never raised, because callers use
         this for cleanup paths where re-raising would mask the original cause.
+        4xx response bodies are still surfaced via the standard helper before
+        the exception is swallowed.
         """
         try:
-            self._client.delete(
+            resp = self._client.delete(
                 f"{self.base_url}/sessions/{session_id}",
                 headers=self._headers(),
             )
+            self._raise_for_status_with_body(resp)
         except Exception as exc:
             logger.warning("kill_session %s failed: %s (reason=%s)", session_id, exc, reason)
 

--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -43,12 +43,13 @@ from api.services.agent_worker.pricing import (
 logger = logging.getLogger(__name__)
 
 
-# Terminal session statuses synthesized by `ManagedAgentsDriver.get_session_state`
-# from the event stream. The Managed Agents docs only document event types
-# explicitly (session.status_idle = success, session.error = failure). We map
-# those to a stable status string here so the executor can compare against a
-# fixed set regardless of how the API evolves.
+# Terminal session statuses returned by `GET /v1/sessions/{id}`. The Managed
+# Agents API reports `"idle"` when the agent has finished and has nothing more
+# to do — that's the canonical success terminal. We keep `"completed"` in the
+# set too as a synthesized alias (from `session.status_idle` events when the
+# session.status field hasn't transitioned yet — observed in live testing).
 TERMINAL_REMOTE_STATUSES = frozenset({
+    "idle",
     "completed",
     "failed",
     "cancelled",
@@ -160,7 +161,7 @@ class ManagedAgentsDriver:
             headers=self._headers(),
             json=body,
         )
-        resp.raise_for_status()
+        self._raise_for_status_with_body(resp)
         data = resp.json()
         sid = data.get("id") or data.get("session_id")
         if not sid:
@@ -176,22 +177,24 @@ class ManagedAgentsDriver:
         session_id: str,
         since_event_id: str | None = None,
     ) -> ManagedSessionState:
-        """Poll a session's current state + any events since `since_event_id`.
+        """Poll a session's current state — status + cumulative usage + new events.
 
-        Aggregates events into a stable status string. Per the Managed Agents
-        event docs, terminal signals come via events:
-          - `session.status_idle` → agent finished; status="completed"
-          - `session.error` → fatal; status="failed"
-        The status field on the response is forwarded directly when it falls
-        in `TERMINAL_REMOTE_STATUSES`; otherwise we synthesize from events.
+        Live API responses (confirmed 2026-05-26) split the data across two endpoints:
+          - `GET /v1/sessions/{id}` returns `{status, usage, ...}` but NOT events.
+            The `status` field reports `"running"` until the agent finishes, then
+            transitions to `"idle"` (Anthropic's terminal-success value).
+          - `GET /v1/sessions/{id}/events` returns `{data: [...], first_id,
+            last_id, has_more}` — the canonical event stream. `agent.message`,
+            `session.error`, `session.status_idle`, etc. all live here.
+
+        This method calls both and merges. `since_event_id` is the cursor against
+        the events endpoint. The status response also carries a 404 → cancelled
+        signal (DELETEd sessions return 404 on subsequent polls).
         """
-        params: dict[str, str] = {}
-        if since_event_id:
-            params[self.EVENT_CURSOR_PARAM] = since_event_id
+        # 1. Session status + usage
         resp = self._client.get(
             f"{self.base_url}/sessions/{session_id}",
             headers=self._headers(),
-            params=params,
         )
         # Treat 404 as "cancelled" — that's how a DELETEd session appears on
         # subsequent polls.
@@ -201,20 +204,27 @@ class ManagedAgentsDriver:
                 status="cancelled",
                 error_reason="session not found (likely deleted)",
             )
-        resp.raise_for_status()
+        self._raise_for_status_with_body(resp)
         data = resp.json()
-
-        events = data.get("events", []) or []
         usage = data.get("usage", {}) or {}
+        raw_status = str(data.get("status", "running")).lower()
+
+        # 2. New events since cursor (separate endpoint)
+        events = self.list_events(session_id, after_id=since_event_id)
         last_event_id: str | None = None
         if events:
             last_event_id = events[-1].get("id")
 
-        # Synthesize a terminal status from events when the response doesn't
-        # provide a definitive one.
-        raw_status = str(data.get("status", "running")).lower()
+        # Synthesize a terminal status from events when the status field hasn't
+        # transitioned yet. `idle` (raw) wins on its own; otherwise we look at
+        # events for status_idle / session.error.
         synthesized = _synthesize_status_from_events(events)
-        status = synthesized if synthesized else raw_status
+        if raw_status in TERMINAL_REMOTE_STATUSES:
+            status = raw_status
+        elif synthesized:
+            status = synthesized
+        else:
+            status = raw_status
 
         # Concatenate text content from agent.message events as `final_text`.
         # The most recent agent.message before an idle event is "the answer".
@@ -233,6 +243,34 @@ class ManagedAgentsDriver:
             final_text=final_text,
             error_reason=error_reason,
         )
+
+    def list_events(
+        self,
+        session_id: str,
+        after_id: str | None = None,
+    ) -> list[dict]:
+        """Fetch new session events since `after_id` (or all if None).
+
+        `GET /v1/sessions/{id}/events?after=<cursor>` returns
+        `{"data": [{"id", "type", "payload"|"content"|"error", ...}, ...]}`.
+        Returns the raw event list; callers (e.g. `get_session_state`) handle
+        the cursor advance and synthesis logic.
+        """
+        params: dict[str, str] = {}
+        if after_id:
+            params[self.EVENT_CURSOR_PARAM] = after_id
+        resp = self._client.get(
+            f"{self.base_url}/sessions/{session_id}/events",
+            headers=self._headers(),
+            params=params,
+        )
+        if resp.status_code == 404:
+            # Session deleted mid-poll. Caller's status fetch already turned
+            # this into "cancelled"; return empty events so we don't crash.
+            return []
+        self._raise_for_status_with_body(resp)
+        data = resp.json()
+        return data.get("data", []) or []
 
     def post_user_message(self, session_id: str, content: str) -> None:
         """Post a user turn to a running session.
@@ -253,6 +291,28 @@ class ManagedAgentsDriver:
             headers=self._headers(),
             json=body,
         )
+        self._raise_for_status_with_body(resp)
+
+    @staticmethod
+    def _raise_for_status_with_body(resp: httpx.Response) -> None:
+        """Like `resp.raise_for_status()` but logs the response body for 4xx
+        errors before raising. The default httpx behavior hides the body, which
+        makes beta-API schema mismatches opaque to operators.
+
+        Safe to log: response bodies for 4xx errors carry the API's validation
+        message (e.g. "MCP server host(s) blocked by environment network policy").
+        API keys live in REQUEST headers, not in response bodies.
+        """
+        if resp.is_success:
+            return
+        if 400 <= resp.status_code < 500:
+            # Truncate to avoid unbounded log volume from a misbehaving API.
+            body_preview = (resp.text or "")[:2048]
+            logger.warning(
+                "Managed Agents %s %s → %d: %s",
+                resp.request.method, resp.request.url.path,
+                resp.status_code, body_preview,
+            )
         resp.raise_for_status()
 
     def kill_session(self, session_id: str, reason: str = "") -> None:

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -241,7 +241,11 @@ class ManagedExecutor:
         # Session-hour overhead has already been booked incrementally in
         # poll(), so finalize doesn't need to add anything more — just record
         # the terminal status.
-        if state.status == "completed":
+        # The Managed Agents API reports a successful terminal as `"idle"`
+        # (live-confirmed 2026-05-26). `"completed"` is kept here as a
+        # synthesized alias for forward-compat in case the API later transitions
+        # status fields between the two.
+        if state.status in ("idle", "completed"):
             # `state.final_text` reflects only events in *this* poll batch. If
             # the agent.message arrived in a prior batch and only the idle
             # event arrived now, fall back to the cached value persisted by
@@ -249,7 +253,7 @@ class ManagedExecutor:
             final_text = state.final_text or self.session_store.get_managed_final_text(session.task_id) or ""
             self.session_store.update_status(session.task_id, STATUS_COMPLETED)
             self.transcript_store.append(session.session_id, "managed_completed",
-                                         {"final_chars": len(final_text)})
+                                         {"final_chars": len(final_text), "remote_status": state.status})
             return ExecutorOutcome(status=STATUS_COMPLETED, final_text=final_text)
 
         if state.status == "budget_exceeded":

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -170,7 +170,9 @@ curl -X POST "https://api.anthropic.com/v1/vaults/$VAULT_ID/credentials" \
 
 Workspace → Environments → New → Cloud.
 
-> **Set `networking.type` to `unrestricted` at creation time.** The console UI defaults to `limited` mode with `allow_mcp_servers: false`, which blocks every MCP host and yields `400 MCP server host(s) blocked by environment network policy` on every session create. If you already created the environment with the default and want to fix it without recreating, `POST` (not PATCH — that returns 405) the config update:
+> **Set `networking.type` to `unrestricted` at creation time.** The console UI defaults to `limited` mode with `allow_mcp_servers: false`, which blocks every MCP host and yields `400 MCP server host(s) blocked by environment network policy` on every session create. If you already created the environment with the default and want to fix it without recreating, `POST` (not PATCH — that returns 405) the config update.
+>
+> **Caveat:** the body below sends a complete `config` object that replaces the existing config wholesale. If you've also set `init_script`, package lists, or env vars, GET the current config first and merge before POSTing. For a fresh environment with only `networking` set, this single command is fine:
 > ```bash
 > curl -X POST "https://api.anthropic.com/v1/environments/$ENV_ID" \
 >   -H "x-api-key: $ANTHROPIC_API_KEY" \

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -144,18 +144,43 @@ Hardening upgrade (deferred to a later issue): swap the bearer-token check for a
 
 ### 1. Create the Vault
 
-Workspace → Vaults → New Vault. Copy the `vlt_…` ID. Add OAuth credentials for whichever first-party connectors you want the agent to use (Gmail, Google Calendar, Google Drive, Superhuman) and any custom MCPs (Slack, Ramp, Granola, Asana, etc.). Each Vault entry stores the credential against the MCP server's URL — that exact URL must match what you put in the agent preset.
+Workspace → Vaults → New Vault. Copy the `vlt_…` ID. Add credentials for whichever first-party connectors you want the agent to use (Gmail, Google Calendar, Google Drive, Superhuman) and any custom MCPs (Slack, Ramp, Granola, Asana, etc.).
 
-Also add the LifeOS MCP as a custom Vault MCP entry:
-```
-Name: lifeos
-URL: https://<your-mcp-hostname>/mcp
-Header: Authorization = Bearer <LIFEOS_MCP_BEARER_TOKEN from Step 2>
+> **URL byte-match is required.** Each Vault credential stores against an `mcp_server_url`. When the agent connects to an MCP at runtime, Anthropic matches the agent preset's `mcp_servers.url` against the Vault entry's `mcp_server_url` byte-for-byte (no trailing slash, exact subdomain, exact path). If the URLs differ at all, you'll see `MCP server '<name>' initialize failed: no credential is stored for this server URL` in the session-error stream. Copy URLs by paste rather than re-typing.
+
+The LifeOS MCP needs a `static_bearer` credential. The console UI may default to OAuth flow; if you don't see a "static bearer" option, add it via the API:
+
+```bash
+curl -X POST "https://api.anthropic.com/v1/vaults/$VAULT_ID/credentials" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "content-type: application/json" \
+  -d "{
+    \"display_name\": \"LifeOS MCP\",
+    \"auth\": {
+      \"type\": \"static_bearer\",
+      \"mcp_server_url\": \"https://<your-mcp-hostname>/mcp\",
+      \"token\": \"<LIFEOS_MCP_BEARER_TOKEN from Step 2>\"
+    }
+  }"
 ```
 
 ### 2. Create the cloud Environment
 
-Workspace → Environments → New → Cloud (default network policy is fine). Copy the `env_…` ID.
+Workspace → Environments → New → Cloud.
+
+> **Set `networking.type` to `unrestricted` at creation time.** The console UI defaults to `limited` mode with `allow_mcp_servers: false`, which blocks every MCP host and yields `400 MCP server host(s) blocked by environment network policy` on every session create. If you already created the environment with the default and want to fix it without recreating, `POST` (not PATCH — that returns 405) the config update:
+> ```bash
+> curl -X POST "https://api.anthropic.com/v1/environments/$ENV_ID" \
+>   -H "x-api-key: $ANTHROPIC_API_KEY" \
+>   -H "anthropic-version: 2023-06-01" \
+>   -H "anthropic-beta: managed-agents-2026-04-01" \
+>   -H "content-type: application/json" \
+>   -d '{"config":{"type":"cloud","networking":{"type":"unrestricted"}}}'
+> ```
+
+Copy the `env_…` ID.
 
 ### 3. Create the Agent preset
 

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -11,6 +11,7 @@ is in beta and the schema may shift.
 from __future__ import annotations
 
 import json
+import logging
 
 import httpx
 import pytest
@@ -301,6 +302,65 @@ def test_get_session_state_synthesizes_failed_from_error_event():
 
 
 @pytest.mark.unit
+def test_get_session_state_prefers_failed_when_raw_idle_and_event_error():
+    """Regression guard: when the status endpoint reports raw `"idle"` and the
+    events endpoint contains a `session.error`, the error must win. Otherwise
+    a cascading failure resolves to STATUS_COMPLETED and the reason is lost."""
+    handler = _make_session_handler(
+        status_body={"status": "idle", "usage": {}},
+        events=[
+            {"id": "evt_1", "type": "session.error",
+             "payload": {"message": "mcp init blew up after idle"}},
+        ],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.status == "failed"
+    assert state.error_reason == "mcp init blew up after idle"
+
+
+@pytest.mark.unit
+def test_list_events_paginates_through_has_more():
+    """list_events must follow `has_more=true` and concatenate pages, otherwise
+    a session that produced more events than the API page size between polls
+    would lose the tail (including the terminal agent.message)."""
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(dict(request.url.params))
+        cursor = request.url.params.get("after")
+        if cursor is None:
+            return httpx.Response(200, json={
+                "data": [{"id": "evt_1", "type": "x"}, {"id": "evt_2", "type": "y"}],
+                "has_more": True,
+            })
+        if cursor == "evt_2":
+            return httpx.Response(200, json={
+                "data": [{"id": "evt_3", "type": "z"}, {"id": "evt_4", "type": "agent.message",
+                                                         "content": [{"type": "text", "text": "done"}]}],
+                "has_more": False,
+            })
+        raise AssertionError(f"unexpected cursor: {cursor}")
+
+    events = _build_driver(handler).list_events("sess")
+    assert [e["id"] for e in events] == ["evt_1", "evt_2", "evt_3", "evt_4"]
+    # First call: no cursor; second call: cursor = last id of first page.
+    assert calls[0] == {}
+    assert calls[1] == {"after": "evt_2"}
+
+
+@pytest.mark.unit
+def test_list_events_stops_on_empty_page_with_has_more_to_prevent_infinite_loop():
+    """Defensive: a misbehaving API that returns `has_more=true` with an empty
+    `data` array must not loop forever."""
+    def handler(request):
+        return httpx.Response(200, json={"data": [], "has_more": True})
+
+    # Should return [] and log a warning, not loop indefinitely.
+    events = _build_driver(handler).list_events("sess")
+    assert events == []
+
+
+@pytest.mark.unit
 def test_get_session_state_prefers_failed_when_idle_and_error_in_same_batch():
     """If both `session.status_idle` and `session.error` arrive in one poll
     batch, error wins — operator needs the actionable signal. Order in the
@@ -422,7 +482,6 @@ def test_4xx_response_body_is_logged_before_raising(caplog):
             "error": {"message": "MCP server host(s) blocked by environment network policy"},
         })
 
-    import logging
     with caplog.at_level(logging.WARNING):
         with pytest.raises(httpx.HTTPStatusError):
             _build_driver(handler).create_session(

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -32,6 +32,27 @@ def _build_driver(handler):
     )
 
 
+def _make_session_handler(*, status_body=None, events=None, status_code=200, events_code=200):
+    """Build a handler that routes GET /sessions/{id} to a status response and
+    GET /sessions/{id}/events to an events response. POST routes return 200 OK.
+
+    Mirrors the live API surface where state lives at two endpoints. Helper
+    keeps each test focused on what it's actually asserting.
+    """
+    status_body = status_body if status_body is not None else {"status": "running", "usage": {}}
+    events = events if events is not None else []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "GET" and path.endswith("/events"):
+            return httpx.Response(events_code, json={"data": events, "has_more": False})
+        if request.method == "GET":
+            return httpx.Response(status_code, json=status_body)
+        return httpx.Response(200, json={"ok": True})
+
+    return handler
+
+
 # ---------------------------------------------------------------------------
 # Auth + headers
 # ---------------------------------------------------------------------------
@@ -185,21 +206,29 @@ def test_create_session_posts_initial_message_when_provided():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.unit
-def test_get_session_state_parses_basic_response():
+def test_get_session_state_calls_both_endpoints_and_merges():
+    """Status comes from GET /sessions/{id}; events come from GET /sessions/{id}/events.
+    Driver fans out to both and merges into one ManagedSessionState."""
+    calls = []
+
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.method == "GET"
-        assert request.url.path.endswith("/sessions/sess_abc")
-        return httpx.Response(200, json={
-            "id": "sess_abc",
-            "status": "running",
-            "events": [
-                {"id": "evt_1", "type": "agent.message", "content": [{"type": "text", "text": "hi"}]},
+        calls.append(request.url.path)
+        if request.url.path.endswith("/events"):
+            return httpx.Response(200, json={"data": [
+                {"id": "evt_1", "type": "agent.message",
+                 "content": [{"type": "text", "text": "hi"}]},
                 {"id": "evt_2", "type": "agent.tool_use", "payload": {"name": "Bash"}},
-            ],
+            ]})
+        return httpx.Response(200, json={
+            "id": "sess_abc", "status": "running",
             "usage": {"input_tokens": 100, "output_tokens": 40},
         })
 
     state = _build_driver(handler).get_session_state("sess_abc")
+    # Both endpoints hit
+    assert any(p.endswith("/sessions/sess_abc") for p in calls)
+    assert any(p.endswith("/sessions/sess_abc/events") for p in calls)
+    # Status from /sessions/{id}, events from /sessions/{id}/events — merged
     assert state.session_id == "sess_abc"
     assert state.status == "running"
     assert state.last_event_id == "evt_2"
@@ -209,31 +238,48 @@ def test_get_session_state_parses_basic_response():
 
 
 @pytest.mark.unit
-def test_get_session_state_uses_after_cursor():
-    captured = {}
+def test_get_session_state_idle_status_is_terminal():
+    """The Managed Agents API reports `status=idle` when the agent is done.
+    Driver forwards that verbatim (no synthesis needed) — it's already in
+    TERMINAL_REMOTE_STATUSES."""
+    handler = _make_session_handler(
+        status_body={"status": "idle", "usage": {"input_tokens": 3, "output_tokens": 42}},
+        events=[],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.status == "idle"
+
+
+@pytest.mark.unit
+def test_get_session_state_uses_after_cursor_on_events_endpoint():
+    """The cursor (since_event_id) goes to the /events query, not /sessions/{id}."""
+    captured = {"status_params": None, "events_params": None}
 
     def handler(request: httpx.Request) -> httpx.Response:
-        captured["params"] = dict(request.url.params)
-        return httpx.Response(200, json={"status": "running", "events": [], "usage": {}})
+        if request.url.path.endswith("/events"):
+            captured["events_params"] = dict(request.url.params)
+            return httpx.Response(200, json={"data": []})
+        captured["status_params"] = dict(request.url.params)
+        return httpx.Response(200, json={"status": "running", "usage": {}})
 
     _build_driver(handler).get_session_state("sess_abc", since_event_id="evt_7")
-    assert captured["params"]["after"] == "evt_7"
+    assert captured["events_params"]["after"] == "evt_7"
+    # Status endpoint never gets the cursor — it's an events-only concept
+    assert captured["status_params"] == {}
 
 
 @pytest.mark.unit
 def test_get_session_state_synthesizes_completed_from_idle_event():
-    """When raw status doesn't say "completed", but an idle event arrived, we synthesize."""
-    def handler(request):
-        return httpx.Response(200, json={
-            "status": "running",  # API hasn't transitioned status yet
-            "events": [
-                {"id": "evt_1", "type": "agent.message",
-                 "content": [{"type": "text", "text": "all done!"}]},
-                {"id": "evt_2", "type": "session.status_idle"},
-            ],
-            "usage": {"input_tokens": 50, "output_tokens": 80},
-        })
-
+    """When status field hasn't transitioned yet but an idle event arrived,
+    we synthesize completed."""
+    handler = _make_session_handler(
+        status_body={"status": "running", "usage": {"input_tokens": 50, "output_tokens": 80}},
+        events=[
+            {"id": "evt_1", "type": "agent.message",
+             "content": [{"type": "text", "text": "all done!"}]},
+            {"id": "evt_2", "type": "session.status_idle"},
+        ],
+    )
     state = _build_driver(handler).get_session_state("sess")
     assert state.status == "completed"
     assert state.final_text == "all done!"
@@ -242,16 +288,13 @@ def test_get_session_state_synthesizes_completed_from_idle_event():
 
 @pytest.mark.unit
 def test_get_session_state_synthesizes_failed_from_error_event():
-    def handler(request):
-        return httpx.Response(200, json={
-            "status": "running",
-            "events": [
-                {"id": "evt_1", "type": "session.error",
-                 "payload": {"message": "MCP server unreachable"}},
-            ],
-            "usage": {},
-        })
-
+    handler = _make_session_handler(
+        status_body={"status": "running", "usage": {}},
+        events=[
+            {"id": "evt_1", "type": "session.error",
+             "payload": {"message": "MCP server unreachable"}},
+        ],
+    )
     state = _build_driver(handler).get_session_state("sess")
     assert state.status == "failed"
     assert state.error_reason == "MCP server unreachable"
@@ -262,32 +305,24 @@ def test_get_session_state_prefers_failed_when_idle_and_error_in_same_batch():
     """If both `session.status_idle` and `session.error` arrive in one poll
     batch, error wins — operator needs the actionable signal. Order in the
     batch doesn't matter."""
-    def handler_idle_first(request):
-        return httpx.Response(200, json={
-            "status": "running",
-            "events": [
-                {"id": "evt_1", "type": "session.status_idle"},
-                {"id": "evt_2", "type": "session.error",
-                 "payload": {"message": "post-idle cascade failure"}},
-            ],
-            "usage": {},
-        })
-
+    handler_idle_first = _make_session_handler(
+        events=[
+            {"id": "evt_1", "type": "session.status_idle"},
+            {"id": "evt_2", "type": "session.error",
+             "payload": {"message": "post-idle cascade failure"}},
+        ],
+    )
     state = _build_driver(handler_idle_first).get_session_state("sess")
     assert state.status == "failed"
     assert state.error_reason == "post-idle cascade failure"
 
-    def handler_error_first(request):
-        return httpx.Response(200, json={
-            "status": "running",
-            "events": [
-                {"id": "evt_1", "type": "session.error",
-                 "payload": {"message": "pre-idle failure"}},
-                {"id": "evt_2", "type": "session.status_idle"},
-            ],
-            "usage": {},
-        })
-
+    handler_error_first = _make_session_handler(
+        events=[
+            {"id": "evt_1", "type": "session.error",
+             "payload": {"message": "pre-idle failure"}},
+            {"id": "evt_2", "type": "session.status_idle"},
+        ],
+    )
     state = _build_driver(handler_error_first).get_session_state("sess")
     assert state.status == "failed"
     assert state.error_reason == "pre-idle failure"
@@ -295,21 +330,18 @@ def test_get_session_state_prefers_failed_when_idle_and_error_in_same_batch():
 
 @pytest.mark.unit
 def test_get_session_state_concatenates_text_blocks_from_latest_message():
-    def handler(request):
-        return httpx.Response(200, json={
-            "status": "completed",
-            "events": [
-                {"id": "evt_1", "type": "agent.message",
-                 "content": [{"type": "text", "text": "draft 1"}]},
-                {"id": "evt_2", "type": "agent.message",
-                 "content": [
-                     {"type": "text", "text": "final "},
-                     {"type": "text", "text": "answer"},
-                 ]},
-            ],
-            "usage": {},
-        })
-
+    handler = _make_session_handler(
+        status_body={"status": "idle", "usage": {}},
+        events=[
+            {"id": "evt_1", "type": "agent.message",
+             "content": [{"type": "text", "text": "draft 1"}]},
+            {"id": "evt_2", "type": "agent.message",
+             "content": [
+                 {"type": "text", "text": "final "},
+                 {"type": "text", "text": "answer"},
+             ]},
+        ],
+    )
     state = _build_driver(handler).get_session_state("sess")
     assert state.final_text == "final answer"
 
@@ -326,10 +358,20 @@ def test_get_session_state_treats_404_as_cancelled():
 
 
 @pytest.mark.unit
-def test_get_session_state_no_events_no_final_text():
+def test_list_events_returns_empty_on_404():
+    """Race: session deleted between status fetch and events fetch.
+    list_events returns [] so the caller doesn't crash; the caller's
+    parallel 404 on /sessions/{id} already produced the "cancelled" state."""
     def handler(request):
-        return httpx.Response(200, json={"status": "running", "events": [], "usage": {}})
+        return httpx.Response(404, text="not found")
 
+    events = _build_driver(handler).list_events("sess_gone", after_id="evt_x")
+    assert events == []
+
+
+@pytest.mark.unit
+def test_get_session_state_no_events_no_final_text():
+    handler = _make_session_handler(events=[])
     state = _build_driver(handler).get_session_state("sess")
     assert state.final_text is None
     assert state.error_reason is None
@@ -368,6 +410,28 @@ def test_post_user_message_raises_on_http_error():
 
     with pytest.raises(httpx.HTTPStatusError):
         _build_driver(handler).post_user_message("sess", "x")
+
+
+@pytest.mark.unit
+def test_4xx_response_body_is_logged_before_raising(caplog):
+    """Operators need to see the API's validation message ("MCP server host(s)
+    blocked by environment network policy", etc.). Default httpx behavior hides
+    the body. We log it at WARNING with the response status and path."""
+    def handler(request):
+        return httpx.Response(400, json={
+            "error": {"message": "MCP server host(s) blocked by environment network policy"},
+        })
+
+    import logging
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(httpx.HTTPStatusError):
+            _build_driver(handler).create_session(
+                agent_id="agent_x", environment_id="env_y",
+            )
+
+    # Body keyword appears in the warning log
+    assert any("MCP server host(s) blocked" in record.getMessage() for record in caplog.records)
+    assert any("400" in record.getMessage() for record in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -234,6 +234,29 @@ def test_poll_finalizes_completed(stores):
 
 
 @pytest.mark.unit
+def test_poll_finalizes_idle_status_as_completed(stores):
+    """The Managed Agents API reports successful terminal as `"idle"` (not
+    `"completed"`). Executor must treat both as STATUS_COMPLETED."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="idle",  # ← live API uses this verbatim
+            last_event_id="evt_done",
+            new_events=[{"id": "evt_done", "type": "session.status_idle"}],
+            total_input_tokens=3, total_output_tokens=42,
+            final_text="42 tasks.",
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_COMPLETED
+    assert outcome.final_text == "42 tasks."
+    assert store.get("t1").status == STATUS_COMPLETED
+
+
+@pytest.mark.unit
 def test_poll_carries_final_text_forward_across_cursor_batches(stores):
     """`get_session_state` uses an event cursor, so consecutive polls only
     return events since the last seen id. If the final `agent.message` lands


### PR DESCRIPTION
## Summary

Three driver bugs surfaced during live smoke testing of the #113 cloud path — sessions ran successfully and agents produced real answers, but the worker never detected the terminal signal, so tasks never reached `#agent-completed`. This PR fixes all three.

Closes #114.

## What changed

1. **`"idle"` is the real terminal status** (not `"completed"`). Added to `TERMINAL_REMOTE_STATUSES`; executor `_finalize_remote` treats it as `STATUS_COMPLETED`. `"completed"` kept as a synthesized alias for forward-compat.
2. **Events live at `/sessions/{id}/events`**, not in the session payload. New `ManagedAgentsDriver.list_events(session_id, after_id)`; `get_session_state` now calls both endpoints and merges, with the cursor advancing against the events endpoint. The carry-forward cache from #113 was inert until this fix because no `agent.message` events ever reached `_extract_final_text`.
3. **4xx response bodies are now logged before raising.** New `_raise_for_status_with_body` helper emits the API's validation message at WARNING when a 4xx hits, applied to all driver-side HTTP calls. Operators no longer need to manually `curl` to diagnose beta-API schema mismatches.

Doc updates (`docs/guides/agent-worker-setup.md`):
- URL byte-match requirement between Vault credentials and the agent preset's `mcp_servers.url`
- `static_bearer` credential creation via API (the console UI may not expose this option for custom MCPs)
- Environment networking gotcha: defaults to `"limited"`, must be `"unrestricted"` or every session-create 400s
- The `POST`-as-update trick for environment config (`PATCH` returns 405)

## Test evidence

```
pytest tests/test_agent_worker_managed_driver.py    — 26/26 passed
pytest tests/test_agent_worker_managed_executor.py  — 16/16 passed
pytest -m unit -k 'agent_worker'                    — 155/155 passed
ruff check                                          — clean
```

Driver tests fully refactored: each test now uses a handler that routes on path (status vs events endpoint), via a new `_make_session_handler` helper. New tests cover idle-as-terminal, the dual-endpoint fan-out, the cursor going to `/events`, and the 4xx body-logging behavior.

Live smoke evidence motivating each fix:
- Bug 1: session `sesn_01E5PbanfhnAfdcBe2VQxA6F` sat at `"status": "idle"` for 5+ minutes while our code kept polling
- Bug 2: same session had 11 events at `/events` but `events_count: 0` on the session payload
- Bug 3: a 400 from `/sessions` came back with `"MCP server host(s) blocked by environment network policy"` but the worker log only showed `HTTPStatusError`

## Review focus

- **The new `list_events` + `get_session_state` fan-out.** Two GETs per poll instead of one — verify the cursor logic isn't misaligned (cursor lives on `/events` only).
- **Status precedence** in `get_session_state`: raw `status` from `/sessions/{id}` if it's in `TERMINAL_REMOTE_STATUSES`, else event-synthesized status, else raw fallback. Makes sure a raw `"idle"` doesn't get overridden by an in-batch synthesis result.
- **`_raise_for_status_with_body` body truncation** (2048 chars). Tight enough to avoid log bloat from a misbehaving API; loose enough to capture full validation messages we've seen so far.
- **Tests pass `events: []` on the status response now.** Confirmed live API doesn't include events there, but if a future release does, the merge logic prefers `/events` data — verify that's the right precedence.

## Operator follow-up (out of scope for this PR)

- Re-OAuth Gmail and Cal in the Anthropic console. Both still return `"server URL not found"` on initialize even though Vault URLs match the agent preset byte-for-byte. Likely incomplete OAuth handshake; delete + re-add the connector. All other 7 MCPs (LifeOS, Drive, Superhuman, Ramp, Slack, Granola, Asana) work correctly after this PR.
