### PR TITLE
fix: don't fail cloud sessions on MCP init errors + transcript pointer for empty summaries

### DIFF
--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -21,7 +21,7 @@ import json
 import logging
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from api.services.agent_worker.pricing import cost_for
 from api.services.agent_worker.session_store import (
@@ -106,6 +106,10 @@ class ExecutorOutcome:
     final_text: str = ""
     reason: str = ""
     wake_at: int | None = None   # set when status == STATUS_YIELDED (sleep)
+    # Managed-agents-only: MCP servers that failed to initialize during the
+    # remote session. Worker uses this to append a footer to the completion
+    # summary so the operator knows which connectors are broken.
+    init_failed_mcps: list[str] = field(default_factory=list)
 
 
 def _system_prompt(session_id: str, expected_output: str, budget, parent_session_id: str | None = None) -> str:

--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -68,6 +68,23 @@ class ManagedSessionState:
     total_output_tokens: int = 0
     final_text: str | None = None
     error_reason: str | None = None
+    # MCP servers that failed to initialize during this session — informational,
+    # not necessarily fatal. The agent may still complete the task using the
+    # MCPs that did succeed. Surfaced to the operator in the completion summary
+    # so they can fix or remove the broken connectors.
+    init_failed_mcps: list[str] = field(default_factory=list)
+
+
+# `session.error.error.type` values for MCP server initialization failures —
+# the connector failed at handshake time (server unreachable, OAuth missing,
+# URL doesn't match a Vault credential, etc.). These don't indicate a failed
+# agent run; the agent works around the missing tool. Filtered out of the
+# terminal-failed synthesis so an idle session with init errors lands at
+# `#agent-completed` instead of `#agent-failed`.
+_MCP_INIT_FAILURE_TYPES = frozenset({
+    "mcp_authentication_failed_error",
+    "mcp_connection_failed_error",
+})
 
 
 class ManagedAgentsDriver:
@@ -215,11 +232,11 @@ class ManagedAgentsDriver:
         if events:
             last_event_id = events[-1].get("id")
 
-        # Resolve final status. A `session.error` in the batch must win over
-        # a raw `idle`, otherwise the session reports completed and the
-        # cascading failure is silently lost. `_synthesize_status_from_events`
-        # returns "failed" if ANY error event is present, else "completed"
-        # if any idle event, else None.
+        # Resolve final status. A non-init `session.error` (runtime / cascade
+        # failure) wins over raw `idle` so cascading failures aren't lost as
+        # silent successes. MCP init failures are excluded from the failed
+        # synthesis — see `_synthesize_status_from_events` and
+        # `_MCP_INIT_FAILURE_TYPES`.
         synthesized = _synthesize_status_from_events(events)
         if synthesized == "failed":
             status = "failed"
@@ -237,6 +254,9 @@ class ManagedAgentsDriver:
         # Surface error message from session.error events.
         error_reason = _extract_error_reason(events)
 
+        # Names of MCPs that failed to initialize — informational footer.
+        init_failed_mcps = _extract_init_failed_mcps(events)
+
         return ManagedSessionState(
             session_id=session_id,
             status=status,
@@ -246,6 +266,7 @@ class ManagedAgentsDriver:
             total_output_tokens=int(usage.get("output_tokens", 0)),
             final_text=final_text,
             error_reason=error_reason,
+            init_failed_mcps=init_failed_mcps,
         )
 
     # Hard cap on pagination loop in `list_events` — protects against a
@@ -379,24 +400,57 @@ class ManagedAgentsDriver:
 def _synthesize_status_from_events(events: list[dict]) -> str | None:
     """Map event-stream signals to a terminal status string, or None.
 
-    Scans the full batch before deciding so we prefer `"failed"` when both
-    `session.error` and `session.status_idle` appear together — error is the
-    actionable signal for operators. Returning `"completed"` on first idle
-    (the prior behavior) silently swallowed cascading errors.
+    `session.error` events are split into two classes:
+      - MCP init failures (`mcp_authentication_failed_error`,
+        `mcp_connection_failed_error`) — informational. The agent works
+        around the missing tool; the session can still complete cleanly.
+        These DO NOT trigger terminal-failed.
+      - Other errors (tool dispatch crashes, lifecycle failures, etc.) —
+        treated as terminal-failed because the agent couldn't recover.
+
+    Precedence: non-init `session.error` (failed) > `session.status_idle`
+    (completed). This preserves the cascading-failure detection while not
+    over-failing sessions whose only error noise is broken connectors.
     """
     has_idle = False
-    has_error = False
+    has_runtime_error = False
     for ev in events:
         et = ev.get("type", "")
         if et == "session.status_idle":
             has_idle = True
         elif et == "session.error":
-            has_error = True
-    if has_error:
+            err_type = (ev.get("error") or {}).get("type") or ev.get("error_type", "")
+            if err_type not in _MCP_INIT_FAILURE_TYPES:
+                has_runtime_error = True
+    if has_runtime_error:
         return "failed"
     if has_idle:
         return "completed"
     return None
+
+
+def _extract_init_failed_mcps(events: list[dict]) -> list[str]:
+    """Return the names of MCP servers that failed to initialize.
+
+    Used to surface the failed connectors in the completion summary so the
+    operator can fix or remove them from the agent preset. Init failures
+    don't fail the session per `_synthesize_status_from_events`, so the
+    operator's only signal is this list in the Telegram message.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for ev in events:
+        if ev.get("type") != "session.error":
+            continue
+        err = ev.get("error") or {}
+        err_type = err.get("type") or ev.get("error_type", "")
+        if err_type not in _MCP_INIT_FAILURE_TYPES:
+            continue
+        name = err.get("mcp_server_name") or ev.get("mcp_server_name") or ""
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
 
 
 def _extract_final_text(events: list[dict]) -> str | None:

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -252,9 +252,17 @@ class ManagedExecutor:
             # poll().
             final_text = state.final_text or self.session_store.get_managed_final_text(session.task_id) or ""
             self.session_store.update_status(session.task_id, STATUS_COMPLETED)
-            self.transcript_store.append(session.session_id, "managed_completed",
-                                         {"final_chars": len(final_text), "remote_status": state.status})
-            return ExecutorOutcome(status=STATUS_COMPLETED, final_text=final_text)
+            self.transcript_store.append(
+                session.session_id, "managed_completed",
+                {"final_chars": len(final_text),
+                 "remote_status": state.status,
+                 "init_failed_mcps": list(state.init_failed_mcps)},
+            )
+            return ExecutorOutcome(
+                status=STATUS_COMPLETED,
+                final_text=final_text,
+                init_failed_mcps=list(state.init_failed_mcps),
+            )
 
         if state.status == "budget_exceeded":
             self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -943,13 +943,35 @@ class Worker:
         active_s = int(refreshed.total_active_seconds or 0)
         expected = refreshed.expected_output or "text"
         title = task.get("description", session.task_id)
-        result_blurb = (outcome.final_text or "(no text response)").strip()
-        if len(result_blurb) > 600:
-            result_blurb = result_blurb[:600] + "…"
+
+        # Body: prefer the agent's final text. When it's empty (the agent
+        # used a tool and idled without summarizing — sometimes happens with
+        # Sonnet on tight-budget tasks), surface a transcript pointer so the
+        # operator can inspect what the agent actually did instead of seeing
+        # a blank message. The transcript captures every tool call.
+        final_text = (outcome.final_text or "").strip()
+        if final_text:
+            result_blurb = final_text
+            if len(result_blurb) > 600:
+                result_blurb = result_blurb[:600] + "…"
+        else:
+            result_blurb = (
+                f"(agent idled without a final text reply — check transcript at "
+                f"data/agent_transcripts/{session.session_id}.jsonl for tool-use detail)"
+            )
+
+        # Footer: when some MCP servers failed to initialize during the session,
+        # list them so the operator can fix or remove the broken connectors from
+        # the agent preset. Only populated by the managed (cloud) path.
+        init_failed = getattr(outcome, "init_failed_mcps", None) or []
+        footer = ""
+        if init_failed:
+            footer = f"\n\nNote: {len(init_failed)} MCP server(s) unavailable this session: {', '.join(init_failed)}"
+
         return (
             f"✅ Agent worker: completed '{title}' "
             f"({expected}) — {tokens:,} tokens, ${refreshed.total_dollars:.2f}, "
-            f"{active_s}s active.\n\n{result_blurb}"
+            f"{active_s}s active.\n\n{result_blurb}{footer}"
         )
 
     def _mark_failed(self, session: Session, task: dict[str, Any], reason: str) -> None:

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -331,6 +331,80 @@ def test_claude_routing_with_managed_executor_starts_and_polls(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_completion_summary_uses_transcript_pointer_when_final_text_empty(tmp_path: Path):
+    """When the agent idles without producing an `agent.message` (sometimes
+    happens after a tool call on tight budgets), Telegram surfaces a
+    transcript pointer instead of an empty body so the operator can inspect
+    what actually happened."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    # final_text="" simulates the empty-text path.
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent, "expected a completion notification"
+    msg = sent[0]
+    # Pointer to transcript path
+    assert "data/agent_transcripts/" in msg
+    assert ".jsonl" in msg
+    # No literal "(no text response)" — that placeholder is deprecated in favor
+    # of the transcript pointer.
+    assert "(no text response)" not in msg
+
+
+@pytest.mark.unit
+def test_completion_summary_includes_init_failed_mcps_footer(tmp_path: Path):
+    """When the managed executor reports MCPs that failed to initialize,
+    the completion summary appends a "Note: N MCP server(s) unavailable"
+    footer so the operator can fix or remove the broken connectors."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "summarize my calendar", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED,
+        final_text="Two events today: standup at 10am and review at 3pm.",
+        init_failed_mcps=["gmail", "gcal"],
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent
+    msg = sent[0]
+    # Real reply is preserved
+    assert "Two events today" in msg
+    # Footer is appended
+    assert "Note:" in msg
+    assert "2 MCP server(s) unavailable" in msg
+    assert "gmail" in msg
+    assert "gcal" in msg
+
+
+@pytest.mark.unit
+def test_completion_summary_omits_footer_when_no_init_failures(tmp_path: Path):
+    """No footer noise when all MCPs initialized cleanly."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "answer the question", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="42.", init_failed_mcps=[],
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent
+    assert "Note:" not in sent[0]
+    assert "MCP server(s) unavailable" not in sent[0]
+
+
+@pytest.mark.unit
 def test_managed_executor_constructed_with_full_credentials(tmp_path: Path, monkeypatch):
     """When API key + agent_preset_id + agent_environment_id + agent_vault_id
     are all set, the worker constructs a ManagedExecutor with each ID flowing

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -302,6 +302,69 @@ def test_get_session_state_synthesizes_failed_from_error_event():
 
 
 @pytest.mark.unit
+def test_get_session_state_completes_when_only_mcp_init_errors_with_idle():
+    """MCP init errors (`mcp_authentication_failed_error`,
+    `mcp_connection_failed_error`) are informational — they fire when a connector
+    is unreachable at session-start. The agent works around the missing MCP and
+    finishes cleanly using the others. Session must NOT be marked failed."""
+    handler = _make_session_handler(
+        status_body={"status": "idle", "usage": {"input_tokens": 3, "output_tokens": 89}},
+        events=[
+            {"id": "evt_1", "type": "session.error",
+             "error": {"type": "mcp_connection_failed_error",
+                       "mcp_server_name": "gmail",
+                       "message": "server URL not found"}},
+            {"id": "evt_2", "type": "session.error",
+             "error": {"type": "mcp_authentication_failed_error",
+                       "mcp_server_name": "gcal",
+                       "message": "no credential stored"}},
+            {"id": "evt_3", "type": "agent.mcp_tool_use"},
+            {"id": "evt_4", "type": "session.status_idle"},
+        ],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.status == "idle"  # raw status forwarded, not overridden by errors
+    assert state.init_failed_mcps == ["gmail", "gcal"]
+
+
+@pytest.mark.unit
+def test_get_session_state_still_fails_on_non_init_session_error():
+    """Non-MCP-init errors (runtime tool crashes, lifecycle failures, etc.)
+    still trigger terminal-failed. Cascading-failure detection from the prior
+    fix is preserved for the cases that actually need it."""
+    handler = _make_session_handler(
+        status_body={"status": "idle", "usage": {}},
+        events=[
+            {"id": "evt_1", "type": "session.error",
+             "error": {"type": "tool_dispatch_error",
+                       "message": "the agent's bash tool crashed"}},
+            {"id": "evt_2", "type": "session.status_idle"},
+        ],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.status == "failed"
+    # tool_dispatch_error is NOT an init failure type — not classified as such.
+    assert state.init_failed_mcps == []
+
+
+@pytest.mark.unit
+def test_get_session_state_dedupes_init_failed_mcp_names():
+    """Same MCP firing two init errors (e.g., retry exhausted) only shows once."""
+    handler = _make_session_handler(
+        status_body={"status": "idle", "usage": {}},
+        events=[
+            {"id": "evt_1", "type": "session.error",
+             "error": {"type": "mcp_connection_failed_error", "mcp_server_name": "gmail"}},
+            {"id": "evt_2", "type": "session.error",
+             "error": {"type": "mcp_connection_failed_error", "mcp_server_name": "gmail"}},
+            {"id": "evt_3", "type": "session.status_idle"},
+        ],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.init_failed_mcps == ["gmail"]
+
+
+@pytest.mark.unit
 def test_get_session_state_prefers_failed_when_raw_idle_and_event_error():
     """Regression guard: when the status endpoint reports raw `"idle"` and the
     events endpoint contains a `session.error`, the error must win. Otherwise

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -234,6 +234,30 @@ def test_poll_finalizes_completed(stores):
 
 
 @pytest.mark.unit
+def test_poll_propagates_init_failed_mcps_to_outcome(stores):
+    """Managed executor must surface init_failed_mcps from the driver state
+    through to the ExecutorOutcome so the worker's completion summary can
+    include the footer."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="idle",
+            last_event_id="evt_done",
+            new_events=[{"id": "evt_done", "type": "session.status_idle"}],
+            total_input_tokens=10, total_output_tokens=20,
+            final_text="ok",
+            init_failed_mcps=["gmail", "gcal"],
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_COMPLETED
+    assert outcome.init_failed_mcps == ["gmail", "gcal"]
+
+
+@pytest.mark.unit
 def test_poll_finalizes_idle_status_as_completed(stores):
     """The Managed Agents API reports successful terminal as `"idle"` (not
     `"completed"`). Executor must treat both as STATUS_COMPLETED."""


### PR DESCRIPTION
## Summary

Two product issues surfaced during live smoke testing after #115 merged. Cloud sessions ran successfully but landed at `#agent-failed` because of informational MCP-init errors, and when the agent idled without a final text turn the Telegram summary was empty. This PR fixes both.

Closes #116, closes #117.

## What changed

### #116 — MCP init errors no longer fail otherwise-successful sessions

PR #115's round-1 fix made any `session.error` in the batch trigger terminal-failed. Live observation: `mcp_authentication_failed_error` / `mcp_connection_failed_error` events fire at session-init for unreachable connectors. The agent works around missing MCPs and finishes using the others — those sessions should land at `#agent-completed`, not `#agent-failed`.

`_synthesize_status_from_events` now splits `session.error` into two classes:
- **Init failures** (`mcp_*_failed_error` types) — informational. Don't trigger failed. Surfaced via a new `init_failed_mcps` list on `ManagedSessionState`.
- **Runtime errors** (anything else, including `session.error` without an explicit type) — still trigger failed. The cascading-failure detection from #115's round-1 review is preserved for the cases that actually need it.

New `_extract_init_failed_mcps` helper returns deduped MCP names.

### #117 — Completion summary handles empty final_text + lists failed MCPs

When the agent uses a tool and idles without producing an `agent.message` (observed twice with Sonnet on tight-budget tasks), the Telegram summary was empty. Now points at the transcript path:

> ✅ Agent worker: completed 'do the thing' (text) — 92 tokens, $0.00, 12s active.
>
> (agent idled without a final text reply — check transcript at data/agent_transcripts/sess_…jsonl for tool-use detail)

When `init_failed_mcps` is non-empty, appends a footer so the operator can fix or remove the broken connectors:

> Note: 2 MCP server(s) unavailable this session: gmail, gcal

`ExecutorOutcome` gains an `init_failed_mcps` field (defaults to empty list — local-executor path unaffected). `ManagedExecutor`'s success branch propagates `state.init_failed_mcps` through.

## Test evidence

```
pytest tests/test_agent_worker_managed_driver.py    — 32/32 passed (3 new)
pytest tests/test_agent_worker_managed_executor.py  — 17/17 passed (1 new)
pytest tests/test_agent_worker_loop.py              — 17/17 passed (3 new)
pytest -m unit -k 'agent_worker'                    — 165/165 passed
ruff check                                          — clean
```

New tests cover:
- Init-only errors with idle → completes (not fails) and populates `init_failed_mcps`
- Non-init `session.error` → still fails (regression guard for the #115 cascading-failure fix)
- Same MCP firing two init errors → name deduped
- Init failures propagate from driver → executor → outcome
- Empty `final_text` → Telegram contains a transcript pointer (not the old `(no text response)` placeholder)
- Non-empty `init_failed_mcps` → footer appended
- Empty `init_failed_mcps` → no footer noise

## Review focus

- **Init-failure type list** in `_MCP_INIT_FAILURE_TYPES` (`managed_driver.py`). Currently `mcp_authentication_failed_error` and `mcp_connection_failed_error`. If the API adds new init-failure variants we'd want to extend this. Verify against the docs.
- **`session.error` without an explicit `type` field still triggers failed.** Defensive default: unknown error types are runtime errors, not init noise. This preserves the original cascading-failure regression guard from #115 round 1.
- **`init_failed_mcps` on `ExecutorOutcome`.** Lives on the shared dataclass but only the managed path populates it. Local executor leaves it empty — confirmed by existing local tests still passing without modification.
- **Telegram footer wording**: `"Note: N MCP server(s) unavailable this session: …"` — flag if a different wording would be clearer for the operator.
- **Transcript pointer format**: `data/agent_transcripts/{session_id}.jsonl` — matches the path convention used elsewhere in the worker. Operator can follow this directly without further translation.

## Companion operator action

Issue #117 also flagged that the agent preset's system prompt should explicitly require a final-summary turn after tool use (so empty `final_text` happens less often). That's a one-line edit in the Anthropic console (Workspace → Agents → LifeOS Worker). This PR handles the code-side fallback when it does happen; the operator-side prompt update is separate.

## Out of scope

- Re-OAuth or re-add of broken Gmail / Cal connectors. The operator removed those from the agent preset (now at version 2) so this isn't blocking — sessions no longer see those init failures regardless.
- Self-hosted sandbox support — still tracked in #111, blocked on this fix landing only by ordering.
