### PR TITLE
refactor: restructure all agent system prompts per Anthropic 4.6/4.7 best practices

### DIFF
--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -112,43 +112,87 @@ class ExecutorOutcome:
     init_failed_mcps: list[str] = field(default_factory=list)
 
 
+# Static portion of the system prompt — never changes between sessions. Kept
+# as a module-level constant so prompt caches can hit on it; the dynamic
+# per-session bits (expected output, soft budget) are appended at call time
+# and live in a small trailing section so cache invalidation is minimized.
+_SYSTEM_PROMPT_STATIC = """\
+<role>
+You are an autonomous task executor running inside LifeOS, the operator's
+personal-assistant system. You receive a single task from the operator's
+task list and complete it end to end without further input from them.
+</role>
+
+<environment>
+You run locally on the operator's machine. Your bash, read, write, edit,
+glob, and grep tools operate on the operator's actual filesystem. The
+`lifeos` MCP exposes the operator's structured personal data (calendar,
+gmail, drive, photos, contacts, financial transactions, notes, tasks,
+reminders, person profiles, conversation history).
+</environment>
+
+<mcp_routing>
+Default to the `lifeos` MCP for any personal-data query. It is faster and
+more accurate than scraping the filesystem directly. Use the standard
+`Read` / `Write` / `Edit` tools only for files outside the indexed data
+set (code, scratch notes, etc.). Use `Bash` for shell operations.
+</mcp_routing>
+
+<output_format>
+Every task must end with a final assistant turn containing a one-paragraph
+text summary. Tool calls alone are not a complete response. After your
+last tool call, produce a text turn that summarizes what you did and the
+key result. Be concrete: include specific names, counts, decisions, and
+links. Skip filler phrases.
+</output_format>
+
+<ambiguity>
+Do not ask clarifying questions during execution. If a task is genuinely
+ambiguous, make a reasonable assumption, do the work, and note the
+assumption in your final summary. If you cannot complete the task safely,
+say so plainly in your final response.
+</ambiguity>
+
+<inter_agent>
+Other agent sessions are visible via `lifeos_agent_transcript_read` and
+`lifeos_agent_sessions_list`. Spawn child agents with `lifeos_agent_spawn`,
+message them with `lifeos_agent_send`, check status with
+`lifeos_agent_check`. When you have nothing to do until specific children
+finish, call `lifeos_agent_yield_until(children=[...])` — this ends your
+session cleanly (no idle billing) and resumes you when the children are
+done. Prefer `yield_until` over polling.
+</inter_agent>
+
+<sleep>
+When you need to wait for external state to change with no child sessions
+to await, call the `sleep` tool rather than busy-looping.
+</sleep>"""
+
+
 def _system_prompt(session_id: str, expected_output: str, budget, parent_session_id: str | None = None) -> str:
     """System message for the executor agent.
 
-    Includes the inter-agent discovery guidance required by issue #103 §5 so
-    agents know they can spawn peers, message them, check status, and yield
-    until specific children complete (preferred over polling).
+    Structured per Anthropic's prompt-engineering best practices (XML
+    section tags, positive framing, explicit final-summary requirement).
+    Static content lives in `_SYSTEM_PROMPT_STATIC` to maximize prompt-
+    cache hits; only the small dynamic trailer changes per session.
+
+    `session_id` and `parent_session_id` are accepted for backwards
+    compatibility with the issue #103 §5 inter-agent flow but no longer
+    injected into the prompt body — the model can't act on either, and
+    both are tracked in `lifeos_agent_sessions_list` / transcripts.
     """
-    parent_clause = (
-        f" Your parent session is {parent_session_id}."
-        if parent_session_id else " You have no parent (top-level session)."
-    )
+    del session_id, parent_session_id  # logging-only artifacts, not for the model
+    wall = budget.get("wall_seconds")
+    max_tokens = budget.get("max_tokens")
+    max_dollars = budget.get("max_dollars")
+    dollars_str = f"~${max_dollars}" if max_dollars is not None else "unset"
     return (
-        "You are an autonomous agent running inside LifeOS, handling a single "
-        "task from the user's task manager. You have access to file, shell, "
-        "and LifeOS data tools. Work concisely and stop when the task is "
-        "complete — your final assistant turn (with no tool calls) is the "
-        f"answer the user will see.\n\n"
-        f"Your session_id is {session_id}.{parent_clause} Your expected output "
-        f"shape is `{expected_output}`. Your budget is "
-        f"wall={budget.get('wall_seconds')}s, "
-        f"max_tokens={budget.get('max_tokens')}, "
-        f"max_dollars=${budget.get('max_dollars')}.\n\n"
-        "## Inter-agent coordination\n"
-        "Transcripts of other agent sessions are available via "
-        "`lifeos_agent_transcript_read`. List active and recent sessions "
-        "with `lifeos_agent_sessions_list`. You can spawn child agents "
-        "(Claude or local) with `lifeos_agent_spawn`, message them with "
-        "`lifeos_agent_send`, and check their status with `lifeos_agent_check`. "
-        "If you have nothing else to do until specific children finish, call "
-        "`lifeos_agent_yield_until(children=[...])` — this is preferred over "
-        "polling, since it ends your session (no idle billing) and you'll be "
-        "automatically resumed with their results when they're done.\n\n"
-        "If you need to wait for external state to change with no children to "
-        "wait on, call the `sleep` tool rather than busy-looping. If you "
-        "cannot complete the task safely or have hit an ambiguity you cannot "
-        "resolve from context, say so plainly in your final response — do "
-        "not invent answers."
+        _SYSTEM_PROMPT_STATIC
+        + "\n\n<this_task>\n"
+        + f"expected_output={expected_output}; "
+        + f"soft budget ~{wall}s wall / ~{max_tokens} tokens / {dollars_str}.\n"
+        + "</this_task>"
     )
 
 

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -42,27 +42,29 @@ logger = logging.getLogger(__name__)
 def _user_message_for(task: dict, session_id: str, expected_output: str, budget: dict) -> str:
     """The initial user turn sent to a managed session.
 
-    Includes the task description, expected output shape, and the budget the
-    agent has to work within. The system prompt + persona + tools all live
-    in the agent preset (configured once in the Anthropic console), so this
-    message is purely task-specific.
+    Purely task-specific. Persona, ambiguity policy, and output-format
+    requirements all live in the agent preset (Anthropic console). The
+    `session_id` parameter is accepted for back-compat but not injected
+    into the message body — it's already in the session metadata and the
+    model can't act on it.
+
+    Budget is framed as a *soft* target: Anthropic doesn't enforce it
+    server-side, the worker kills the session externally on breach.
+    Saying "soft" prevents the model from over-regulating its own pacing.
     """
+    del session_id  # already in session metadata; not needed in the user message
     title = (task.get("description") or "").strip()
     context = task.get("context")
     max_dollars = budget.get("max_dollars")
-    dollars_str = f"${max_dollars}" if max_dollars is not None else "unset"
+    dollars_str = f"~${max_dollars}" if max_dollars is not None else "unset"
     parts = [f"Task: {title}"]
     if context:
         parts.append(f"Context: {context}")
     parts.append(
-        f"Constraints: expected_output={expected_output}, "
-        f"wall={budget.get('wall_seconds')}s, "
-        f"max_tokens={budget.get('max_tokens')}, "
-        f"max_dollars={dollars_str}. "
-        "If genuinely ambiguous, make a reasonable assumption, complete the task, "
-        "and note the assumption in your final reply."
+        f"expected_output={expected_output}; "
+        f"soft budget ~{budget.get('wall_seconds')}s wall / "
+        f"~{budget.get('max_tokens')} tokens / {dollars_str}."
     )
-    parts.append(f"lifeos_session_id={session_id}")
     return "\n\n".join(parts)
 
 

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -102,14 +102,21 @@ Rules:
        - "use claude", "with opus", "with claude opus", "with sonnet" → "claude"
     4) Otherwise, infer from capability cues in the title — tasks that
        require third-party cloud connectors should route to claude even
-       without an explicit cue. Trigger on mentions of:
-       - email actions: "gmail", "email", "inbox", "draft a reply",
-         "send an email", "superhuman"
-       - calendar actions: "calendar", "gcal", "schedule a meeting",
-         "events today", "free time", "book"
-       - drive / docs: "drive", "google doc", "spreadsheet", "shared doc"
-       - workplace systems: "slack", "asana", "ramp", "granola"
+       without an explicit cue. Use semantic judgment, not bare keyword
+       matching. Trigger only when the title clearly implies an action
+       against one of these systems:
+       - email actions: "search my gmail", "draft a reply", "send an
+         email", "check my inbox", "summarize my superhuman threads"
+       - calendar actions: "events today", "my calendar", "schedule a
+         meeting", "find free time on my calendar", "book a meeting"
+       - drive / docs: "google drive", "shared drive", "my drive", "a
+         google doc", "find a spreadsheet"
+       - workplace systems: "slack", "asana", "ramp", "granola" (these
+         only appear in workplace contexts; the bare word is usually safe)
        In each case set routing="claude"; routing_reason="implies <capability>".
+       Do NOT trigger on bare nouns where the meaning is ambiguous —
+       e.g., "drive home" (vehicle), "book recommendation" (literature),
+       "email signature design" (general design task).
     5) If none of the above match, set routing="ask" (the worker will
        ask the operator which model).
 - expected_output: classify what the agent will produce.

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -94,10 +94,24 @@ Reply with a single JSON object, no prose, matching this exact schema:
 Rules:
 - Default budget if the title doesn't specify one: wall_seconds={default_wall}, max_tokens={default_tokens}, max_dollars={default_dollars}.
 - Parse natural-language budget hints from the title: "5 min" / "30s" / "1h" → wall_seconds; "max $0.50" → max_dollars; "10k tokens" / "50000 tokens" → max_tokens. Be reasonable about unit conversions.
-- Routing precedence:
+- Routing precedence (apply in order; first match wins):
     1) If the tag list contains "local" → routing="local"; routing_reason="#local tag present".
-    2) Otherwise, look at the title for explicit cues — "with local agent", "using gemma", etc. → "local"; "use claude", "with opus", "with claude opus" → "claude".
-    3) If neither, set routing="ask" (the worker will ask the user which model).
+    2) If the tag list contains "cloud" → routing="claude"; routing_reason="#cloud tag present".
+    3) Otherwise, look at the title for explicit model cues:
+       - "with local agent", "using gemma" → "local"
+       - "use claude", "with opus", "with claude opus", "with sonnet" → "claude"
+    4) Otherwise, infer from capability cues in the title — tasks that
+       require third-party cloud connectors should route to claude even
+       without an explicit cue. Trigger on mentions of:
+       - email actions: "gmail", "email", "inbox", "draft a reply",
+         "send an email", "superhuman"
+       - calendar actions: "calendar", "gcal", "schedule a meeting",
+         "events today", "free time", "book"
+       - drive / docs: "drive", "google doc", "spreadsheet", "shared doc"
+       - workplace systems: "slack", "asana", "ramp", "granola"
+       In each case set routing="claude"; routing_reason="implies <capability>".
+    5) If none of the above match, set routing="ask" (the worker will
+       ask the operator which model).
 - expected_output: classify what the agent will produce.
     "text" = a written answer; "file" = creates/edits a file; "external_action" = sends an email, posts a message, schedules a meeting; "structured" = returns structured data the caller will parse.
 - ambiguity: set to non-null only if the title is genuinely underspecified for an autonomous agent (e.g., "reply to John" with no email/context). One question, not multiple.

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -193,18 +193,53 @@ name: LifeOS Worker
 description: Autonomous executor for #agent-tagged tasks from LifeOS.
 model: claude-sonnet-4-6
 system: |
-  You are an autonomous task executor running outside the operator's LifeOS
-  personal-assistant system. You receive tasks via the task list (tagged
-  #agent) and must complete them end to end without further input.
+  <role>
+  You are an autonomous task executor running outside the operator's
+  LifeOS personal-assistant system. You receive tasks tagged #agent from
+  the operator's task list and complete them end to end without further
+  input.
+  </role>
 
-  Your `bash`/`read`/`write`/`edit`/`glob`/`grep` tools act on an ephemeral
-  cloud container — use them as scratch space. To touch the operator's
-  persistent data, use the connected MCP servers (LifeOS for personal data,
-  Gmail/Cal/Drive/Superhuman for cloud productivity, plus any work MCPs).
+  <environment>
+  You run inside an Anthropic-managed cloud container, not on the
+  operator's machine. Your bash/read/write/edit/glob/grep tools operate
+  on the container's ephemeral filesystem — use them as scratch space.
+  Persistent data lives behind the attached MCP servers.
+  </environment>
 
-  Reply with one paragraph (1–4 sentences) summarizing what you did and the
-  key result. Be concrete. No filler. If a task is ambiguous, make a
-  reasonable assumption, complete it, and note the assumption.
+  <mcp_routing>
+  Default to the `lifeos` MCP for any personal data: calendar, gmail,
+  drive, photos, contacts, financial transactions, notes, tasks,
+  reminders, person profiles, conversation history. The `lifeos` MCP
+  wraps all of these and is faster than going through cloud-hosted
+  alternatives.
+
+  Use work-system MCPs (whichever are attached — slack, asana, ramp,
+  granola, etc.) when a task explicitly names that system; default to
+  `lifeos` otherwise. Use `web_search` / `web_fetch` for public web
+  content.
+  </mcp_routing>
+
+  <output_format>
+  Every task must end with a final assistant turn containing a
+  one-paragraph text summary. Tool calls alone are not a complete
+  response. After your last tool call, produce a text turn summarizing
+  what you did and the key result. Be concrete: include specific names,
+  counts, decisions, links. Skip filler phrases like "I have completed
+  the task." Match the operator's voice when drafting on their behalf:
+  direct, lowercase-leaning, no LinkedIn-speak.
+  </output_format>
+
+  <ambiguity>
+  Do not ask clarifying questions during execution. If a task is
+  genuinely ambiguous, make a reasonable assumption, do the work, and
+  note the assumption in your final summary.
+  </ambiguity>
+
+  <thinking>
+  Respond directly on simple lookups. Reserve extended thinking for
+  multi-step problems where it will meaningfully improve the answer.
+  </thinking>
 
 mcp_servers:
   - type: url
@@ -220,6 +255,8 @@ tools:
 
 skills: []
 ```
+
+The system prompt is structured per Anthropic's [prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) for Claude 4.6/4.7: XML section tags (literal instruction-following works better with explicit structure), positive framing, an explicit requirement to produce a final text turn after tool use (the model otherwise sometimes idles after a tool call without summarizing), and adaptive-thinking guidance.
 
 Every `mcp_servers` entry must have a matching `mcp_toolset` in `tools` (and vice versa) — the API rejects the agent definition otherwise. Save and copy the returned `agent_…` ID.
 

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -12,7 +12,9 @@ from pathlib import Path
 import pytest
 
 from api.services.agent_worker.local_executor import (
+    _SYSTEM_PROMPT_STATIC,
     LocalExecutor,
+    _system_prompt,
 )
 from api.services.agent_worker.pricing import cost_for
 from api.services.agent_worker.session_store import (
@@ -316,3 +318,103 @@ def test_pricing_unknown_model_falls_through_to_opus_rate():
     unknown = cost_for("typoed-model", 1000, 1000)
     opus = cost_for("claude-opus-4-7", 1000, 1000)
     assert unknown == pytest.approx(opus)
+
+
+# ---------------------------------------------------------------------------
+# System-prompt structure (issue #119 — Anthropic 4.6/4.7 best practices)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_system_prompt_uses_xml_section_tags():
+    """Anthropic recommends XML tags for system-prompt sections (literal
+    instruction-following in 4.7). Verify each major section is wrapped."""
+    for tag in ("<role>", "<environment>", "<mcp_routing>", "<output_format>",
+                "<ambiguity>", "<inter_agent>", "<sleep>", "<this_task>"):
+        assert tag in _system_prompt(
+            session_id="sess_x",
+            expected_output="text",
+            budget={"wall_seconds": 3600, "max_tokens": 5000, "max_dollars": 5.0},
+        ), f"missing XML section tag: {tag}"
+
+
+@pytest.mark.unit
+def test_system_prompt_requires_final_text_turn_after_tool_use():
+    """Issue #117 / #119: explicit requirement that the agent produces a
+    text summary turn after any tool use. Catches the 'idled without
+    agent.message' regression at the prompt level."""
+    prompt = _system_prompt(
+        session_id="sess_x",
+        expected_output="text",
+        budget={"wall_seconds": 3600, "max_tokens": 5000, "max_dollars": 5.0},
+    )
+    # Look for the canonical phrasing that triggers the behavior.
+    assert "Every task must end with a final assistant turn" in prompt
+    assert "Tool calls alone are not a complete response" in prompt
+
+
+@pytest.mark.unit
+def test_system_prompt_uses_positive_framing_for_ambiguity():
+    """Anthropic best practice: 'Tell Claude what to do instead of what
+    not to do'. The old prompt used 'do not invent answers' (negative)."""
+    prompt = _system_prompt(
+        session_id="sess_x",
+        expected_output="text",
+        budget={"wall_seconds": 3600, "max_tokens": 5000, "max_dollars": 5.0},
+    )
+    assert "do not invent" not in prompt.lower()
+    # Positive phrasing present (collapse whitespace so multi-line phrasing
+    # in the prompt doesn't trip the substring check):
+    import re
+    collapsed = re.sub(r"\s+", " ", prompt)
+    assert "make a reasonable assumption" in collapsed
+    assert "note the assumption" in collapsed
+
+
+@pytest.mark.unit
+def test_system_prompt_does_not_inject_session_id_into_body():
+    """session_id is a worker artifact, not actionable by the model.
+    Keeping it out of the prompt body maximizes prompt-cache hits."""
+    prompt = _system_prompt(
+        session_id="sess_abc123",
+        expected_output="text",
+        budget={"wall_seconds": 3600, "max_tokens": 5000, "max_dollars": 5.0},
+    )
+    assert "sess_abc123" not in prompt
+    assert "session_id" not in prompt
+
+
+@pytest.mark.unit
+def test_system_prompt_static_portion_is_cache_friendly():
+    """The static portion must not vary across sessions, only the trailing
+    `<this_task>` section. Two calls with different session args should
+    share the static prefix verbatim."""
+    a = _system_prompt(
+        session_id="sess_a", expected_output="text",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 0.5},
+    )
+    b = _system_prompt(
+        session_id="sess_b", expected_output="file",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+    )
+    # Both share the static prefix exactly.
+    assert a.startswith(_SYSTEM_PROMPT_STATIC)
+    assert b.startswith(_SYSTEM_PROMPT_STATIC)
+    # And differ only in the trailing per-task block.
+    assert a[:len(_SYSTEM_PROMPT_STATIC)] == b[:len(_SYSTEM_PROMPT_STATIC)]
+
+
+@pytest.mark.unit
+def test_system_prompt_carries_soft_budget_in_this_task_section():
+    """Dynamic per-task content goes in <this_task>. Budget is framed as
+    a soft target (worker enforces externally; model can't count cost)."""
+    prompt = _system_prompt(
+        session_id="sess_x", expected_output="text",
+        budget={"wall_seconds": 90, "max_tokens": 5000, "max_dollars": 0.25},
+    )
+    # <this_task> wraps the dynamic part
+    assert "<this_task>" in prompt
+    assert "expected_output=text" in prompt
+    assert "soft budget" in prompt
+    assert "~90s" in prompt
+    assert "~5000 tokens" in prompt
+    assert "~$0.25" in prompt

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -102,10 +102,19 @@ def test_start_creates_remote_session_with_agent_and_environment_ids(stores):
     assert cw["vault_ids"] == VAULT_IDS
     assert cw["metadata"]["lifeos_session_id"] == session.session_id
     assert cw["metadata"]["task_id"] == "t1"
-    # Initial message carries task description + budget/context
+    # Initial message carries task description + soft budget. Budget is
+    # framed as "soft" because Anthropic doesn't enforce it server-side;
+    # the worker kills the session externally on breach.
     assert "say hi" in cw["initial_message"]
     assert "expected_output=text" in cw["initial_message"]
-    assert "max_dollars=$5.0" in cw["initial_message"]
+    assert "soft budget" in cw["initial_message"]
+    assert "~$5.0" in cw["initial_message"]
+    # Ambiguity policy NOT duplicated here — it lives in the agent preset's
+    # system prompt (Anthropic console). User message stays task-specific.
+    assert "ambiguous" not in cw["initial_message"]
+    # session_id NOT in the user message — already in session metadata.
+    assert session.session_id not in cw["initial_message"]
+    assert "lifeos_session_id" not in cw["initial_message"]
     # NO inline system_prompt / model / mcp_servers / connectors
     assert "system_prompt" not in cw
     assert "model" not in cw

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -151,9 +151,10 @@ def test_preflight_prompt_recognizes_cloud_tag_as_mirror_of_local():
     """`#cloud` tag should route to claude — symmetric with `#local` → local.
     The rule lives in the prompt text Haiku consumes."""
     prompt = pf.build_preflight_prompt(title="anything", tags=["agent", "cloud"])
+    # Strong assertions: the literal rule text Haiku reads.
     assert 'tag list contains "cloud"' in prompt
-    assert '#cloud tag present' in prompt or '"#cloud tag present"' in prompt or 'cloud' in prompt
-    # Both directions should be documented in the rules
+    assert '#cloud tag present' in prompt
+    # Both directions documented in the rules
     assert '"local"' in prompt
     assert '"cloud"' in prompt
 

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -140,3 +140,46 @@ def test_preflight_budget_partial_uses_defaults():
     # max_tokens / max_dollars come from defaults — strictly positive
     assert result.budget.max_tokens > 0
     assert result.budget.max_dollars > 0
+
+
+# ---------------------------------------------------------------------------
+# Prompt-content tests — verify routing rules visible to Haiku (issue #119)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_preflight_prompt_recognizes_cloud_tag_as_mirror_of_local():
+    """`#cloud` tag should route to claude — symmetric with `#local` → local.
+    The rule lives in the prompt text Haiku consumes."""
+    prompt = pf.build_preflight_prompt(title="anything", tags=["agent", "cloud"])
+    assert 'tag list contains "cloud"' in prompt
+    assert '#cloud tag present' in prompt or '"#cloud tag present"' in prompt or 'cloud' in prompt
+    # Both directions should be documented in the rules
+    assert '"local"' in prompt
+    assert '"cloud"' in prompt
+
+
+@pytest.mark.unit
+def test_preflight_prompt_infers_claude_from_capability_phrases():
+    """Capability-implying phrases (gmail/calendar/drive/slack/etc.) should
+    cue claude routing without an explicit 'use claude' phrase. Live testing
+    today saw 3 tasks go to `ask` because of strict literal matching; this
+    rule fixes that."""
+    prompt = pf.build_preflight_prompt(title="search my gmail for ...", tags=["agent"])
+    # The capability-inference rule must mention each major surface
+    for keyword in ("gmail", "calendar", "drive", "slack"):
+        assert keyword in prompt.lower(), f"missing capability inference for: {keyword}"
+    # And explicitly state the routing decision
+    assert "claude" in prompt.lower()
+
+
+@pytest.mark.unit
+def test_preflight_prompt_includes_ordered_precedence():
+    """Routing precedence must be clearly ordered (tags first, explicit cues
+    second, capability inference third, ask as final fallback)."""
+    prompt = pf.build_preflight_prompt(title="x", tags=["agent"])
+    assert "precedence" in prompt.lower() or "apply in order" in prompt.lower() or "first match wins" in prompt.lower()
+    # All four ladder steps present
+    assert "#local" in prompt or "tag list contains \"local\"" in prompt
+    assert "use claude" in prompt
+    assert "capability" in prompt.lower() or "infer from capability" in prompt.lower()
+    assert "ask" in prompt.lower()


### PR DESCRIPTION
## Summary

Restructures all four model-facing prompts in the agent worker against [Anthropic's official prompt-engineering guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) for Claude 4.6/4.7 and the [Hermes Function-Calling](https://github.com/NousResearch/Hermes-Function-Calling) open-source reference. The most important change: making the "final text turn after tool use" requirement explicit in both system prompts — this is the systemic fix for the empty-Telegram regression patched at the code level in #118.

Closes #119.

## What changed

**Cloud agent preset** (Anthropic console, bumped to v3 via API):
- Full XML-structured prompt: `<role>`, `<environment>`, `<mcp_routing>`, `<output_format>`, `<ambiguity>`, `<thinking>` sections
- Explicit final-summary requirement
- MCP routing guidance (default to `lifeos`)
- Adaptive-thinking guidance ("respond directly on simple lookups")
- YAML copy lives in `docs/guides/agent-worker-setup.md` for fresh clones

**Local Gemma `_system_prompt`** (`local_executor.py`):
- Matching XML section structure (`<role>`, `<environment>`, `<mcp_routing>`, `<output_format>`, `<ambiguity>`, `<inter_agent>`, `<sleep>`)
- **Static portion extracted to module-level `_SYSTEM_PROMPT_STATIC`** so prompt caches don't invalidate every session — only the small trailing `<this_task>` block varies
- `session_id` and `parent_session_id` dropped from the prompt body (worker artifacts; the model can't act on either; both still tracked in `sessions_list` / transcripts via the inter-agent tools)
- Negative framing flipped to positive (was "do not invent answers" → now "if you cannot complete the task safely, say so plainly")
- Default-to-`lifeos` MCP routing guidance

**Cloud per-task user message** (`managed_executor._user_message_for`):
- Slimmed: ambiguity policy removed (already in the system prompt), `lifeos_session_id=` line removed (already in API session metadata)
- Budget reframed with `~` soft-target prefixes so the model doesn't over-regulate its own pacing

**Preflight prompt** (`preflight._PREFLIGHT_INSTRUCTIONS`):
- Added `#cloud` tag as the explicit mirror of `#local` (operator can force cloud routing via tag now)
- Added capability-implying-phrase inference: "search my gmail", "check my calendar", "send a slack message", etc. → claude. Live testing today saw three tasks go to `ask` route because of overly literal matching; this rule fixes the pattern.

## Test evidence

```
pytest -m unit -k 'agent_worker' -q                 — 174/174 passed
ruff check api/services/agent_worker/ tests/       — clean
```

New tests:
- **Local executor** (6): XML sections present, final-summary requirement language present, positive ambiguity framing, no `session_id` in prompt body, cache-friendly static/dynamic split, soft-budget framing in `<this_task>`
- **Preflight** (3): `#cloud` tag rule present, capability-inference rules present for each major surface (gmail/calendar/drive/slack), ordered routing precedence documented
- **Managed executor** (updated existing assertions): ambiguity not duplicated in user message, `session_id` not present in message body, "soft budget" framing asserted

Live API update applied during implementation: agent preset bumped from version 2 → version 3.

## Review focus

- **Cache-friendliness of `_SYSTEM_PROMPT_STATIC`** — verify the module-level constant doesn't capture any per-session state. The dynamic `<this_task>` block is the only thing that varies. Test `test_system_prompt_static_portion_is_cache_friendly` locks this in.
- **Capability-inference rules** in the preflight prompt — currently lists email/calendar/drive/workplace systems. Anything missing? Risk is over-routing to claude for ambiguous cases like "summarize this" (no destination implied) — verify the rule fires only on clearly cloud-bound capabilities.
- **XML tag overhead vs minimalism** — Anthropic's docs example is one sentence; our cloud preset is now ~600 tokens. Trade-off is intentional (literal-instruction-following in 4.7 + the documented final-summary bug needs explicit handling), but flag if you'd rather lean shorter.
- **Operator-agnostic language** — no proper nouns or personal data in the diff. Verified by grep.
- **Soft-budget framing** — the model no longer sees a hard `$5.00` budget; it sees `~$5.00`. If you want the model to be more aggressive about staying under budget, this softening might be too soft. Flag if so.

## Operator follow-up

The cloud agent preset has already been updated via API (version 3). No manual console action needed. If you want to revert: archive version 3 or post a version update with the prior `system` content.
