### PR TITLE
docs: add agent-worker specs, README section, navigation cross-links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ LifeOS is a self-hosted AI assistant that indexes personal data (notes, emails, 
 | What does the code structure look like? | [specs/technical/architecture.md](docs/specs/technical/architecture.md) |
 | How does hybrid search work internally? | [specs/technical/search-indexing.md](docs/specs/technical/search-indexing.md) |
 | How is perf traced and monitored? | [specs/technical/observability.md](docs/specs/technical/observability.md) |
+| What does `#agent` do? | [specs/product/agent-worker.md](docs/specs/product/agent-worker.md) |
+| How does the agent worker work internally? | [specs/technical/agent-worker.md](docs/specs/technical/agent-worker.md) |
+| How do I set up the agent worker? | [guides/agent-worker-setup.md](docs/guides/agent-worker-setup.md) |
 | How do I set up the project? | [guides/installation.md](docs/guides/installation.md) |
 | What scripts are available? | [guides/scripts.md](docs/guides/scripts.md) |
 | Why does LifeOS exist? What guides decisions? | [vision/philosophy.md](docs/vision/philosophy.md) |
@@ -201,6 +204,8 @@ Quick-reference guardrails for all contributors. These complement the Developmen
 | `README.md` | Architecture overview with diagrams |
 | `api/services/perf_trace.py` | Request-level performance tracing (spans, SQLite) |
 | `api/routes/perf.py` | Performance trace query API |
+| `api/services/agent_worker/` | Autonomous worker for `#agent`-tagged tasks (local Gemma or cloud Claude via Managed Agents) |
+| `mcp_server.py` | MCP server — stdio for Claude Code + HTTP transport for Managed Agents (54 tools) |
 | `tests/test_perf_benchmark.py` | Benchmark suite for query performance and quality |
 
 | Script | Purpose |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ You can also interface with it for general queries in the same way you'd interac
 
 ---
 
+## Hand Off Tasks to an Autonomous Agent
+
+LifeOS includes an external **agent worker** that picks up tasks you've tagged `#agent` and completes them end-to-end while you're doing something else. Add a line to your task list and walk away — the agent runs it, completes it, marks the task done in your vault, and pings you on Telegram with the result.
+
+```
+- [ ] TODO Summarize my unread emails from the partnership channel and reply with the top 3 by importance #agent
+- [ ] TODO Find every meeting where we discussed the Q3 launch and list attendees #agent #local
+- [ ] TODO Draft a follow-up to last week's intro with Acme. Budget $0.25 #agent
+```
+
+What you get:
+
+- **Hands-free completion.** Tag a task and forget it. Telegram tells you when it's done, what it did, and what it cost.
+- **Choose your model.** `#local` routes to your self-hosted Gemma — free, private, fast on workstation-class GPUs. `#cloud` routes to Anthropic's Claude on Managed Agents — slower per-token but pairs with Gmail / Calendar / Drive / Slack / Asana / Ramp connectors out of the box. No tag and the agent infers from the title: tasks that obviously need cloud connectors ("draft an email", "check my calendar") route to Claude; everything else can run locally.
+- **Budgets you can put in the title.** "max $0.50", "5 min", "10k tokens" — parsed in natural language by a tiny preflight pass. Daily and per-task caps enforced from outside the agent loop, so the model can't override them. There's a global daily $-ceiling backstop.
+- **Asks for help when stuck.** Genuinely ambiguous tasks ("reply to Alex") get pushed to Telegram with one targeted question. Reply with Telegram's reply feature and the agent resumes. If you don't answer within 72 hours (configurable), the task is parked and you get a heads-up.
+- **Spawns its own teammates.** Agents can spawn child sessions (`lifeos_agent_spawn`), message them, and yield until they finish — preferred over polling, because yielding ends the session cleanly (no idle billing on cloud) and resumes automatically when children complete. Useful for fan-out research, multi-step pipelines, "go do X and Y in parallel" workflows.
+- **Full audit trail.** Every tool call, every model turn, every cost delta lands in `data/agent_transcripts/<session_id>.jsonl`. Telegram completion summaries point at it if anything looks off.
+- **Restart-safe.** The worker is signal-clean. Crash mid-task and the next start rolls non-terminal sessions back to `#agent` for retry, or resumes any cloud sessions that are still running on Anthropic's side.
+
+Set up: [Agent Worker Setup](docs/guides/agent-worker-setup.md). Full reference: [Product](docs/specs/product/agent-worker.md) · [Technical](docs/specs/technical/agent-worker.md).
+
+---
+
 ## Quick Links
 
 | Getting Started | Guides | Reference |
@@ -49,8 +73,9 @@ You can also interface with it for general queries in the same way you'd interac
 | [Installation](docs/guides/installation.md) | [Google OAuth](docs/guides/google-oauth.md) | [API Reference](docs/specs/product/api-reference.md) |
 | [Configuration](docs/guides/configuration.md) | [Slack Integration](docs/guides/slack-integration.md) | [Scripts](docs/guides/scripts.md) |
 | [First Run](docs/guides/first-run.md) | [Task Management](docs/specs/product/task-management.md) | [Troubleshooting](docs/guides/troubleshooting.md) |
-|  | [Reminders](docs/guides/reminders.md) | |
+|  | [Reminders](docs/guides/reminders.md) | [Agent Worker](docs/specs/product/agent-worker.md) |
 |  | [Launchd Setup](docs/guides/launchd-setup.md) (macOS) | |
+|  | [Agent Worker Setup](docs/guides/agent-worker-setup.md) | |
 
 ---
 
@@ -302,12 +327,15 @@ flowchart LR
 - [API Reference](docs/specs/product/api-reference.md) - API endpoints and MCP tools
 - [Data & Sync](docs/specs/technical/data-and-sync.md) - Sync pipeline and data sources
 - [Search & Indexing](docs/specs/technical/search-indexing.md) - Hybrid search internals
+- [Agent Worker — Technical](docs/specs/technical/agent-worker.md) - Autonomous worker for #agent tasks
 - [Frontend](docs/specs/technical/frontend.md) - UI components
 
 ### Product
 - [Chat UI](docs/specs/product/chat-ui.md)
 - [CRM UI](docs/specs/product/crm-ui.md)
 - [MCP Tools](docs/specs/product/mcp-tools.md)
+- [Agent Worker](docs/specs/product/agent-worker.md) - Hands-free task completion via `#agent`
+- [Task Management](docs/specs/product/task-management.md) - Obsidian Tasks integration
 
 ### Architecture Decisions
 - [ADR Index](docs/adr/) - Why we chose Python/FastAPI, ChromaDB, hybrid search, and more

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -47,7 +47,9 @@ Cost for that task: usually under $0.10 on Claude Sonnet 4.6, free on local Gemm
 
 ## Task conventions
 
-The agent worker triggers on tasks that have the `#agent` tag. Optional sub-tags steer routing:
+The agent worker triggers on tasks that have the `#agent` tag and a pickup-eligible status — `todo` (`[ ]`) or `urgent` (`[!]`). Marking a `#agent` task as urgent in Obsidian doesn't skip the worker; it just signals high priority within your queue. Other statuses (`in_progress`, `done`, `cancelled`, `deferred`, `blocked`) are left alone.
+
+Optional sub-tags steer routing:
 
 | Tag | Effect |
 |-----|--------|

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -1,0 +1,182 @@
+# Agent Worker
+
+> **Status:** Complete
+> **Owner:** Agent Worker
+> **Last Updated:** 2026-05-26
+
+LifeOS includes an external **agent worker** that picks up tasks you've tagged `#agent` and completes them autonomously — running locally on a self-hosted LLM or on Anthropic's Managed Agents cloud, with budget caps you can specify in the task title and full audit transcripts on every run. When the agent finishes (or gets stuck), it notifies you on Telegram. If it has a question mid-run, it asks via Telegram and waits for your reply.
+
+The point is hands-free task completion for the long tail of small chores that aren't worth a conversation but are worth doing: "draft a follow-up to last week's intro thread," "summarize my unread emails from the partnership channel," "find every meeting where we discussed the Q3 launch."
+
+---
+
+## Table of Contents
+
+1. [Quick example](#quick-example)
+2. [Task conventions](#task-conventions)
+3. [Routing — local vs cloud](#routing--local-vs-cloud)
+4. [Budgets](#budgets)
+5. [Tag lifecycle](#tag-lifecycle)
+6. [Telegram interactions](#telegram-interactions)
+7. [Capability boundaries](#capability-boundaries)
+8. [Safety model](#safety-model)
+9. [Configuration knobs](#configuration-knobs)
+10. [Related Documents](#related-documents)
+
+---
+
+## Quick example
+
+You add this line anywhere in your Obsidian Tasks file:
+
+```
+- [ ] TODO Summarize my unread emails from the partnership channel and reply with the top 3 by importance #agent
+```
+
+Within a poll cycle (default 60s), the worker:
+
+1. Runs a Haiku preflight to parse the task — budget, routing, expected output, sanity check
+2. Atomically swaps the tag to `#agent-running` (so two workers can't claim the same task)
+3. Routes the task — to your local Gemma model or to Claude on Managed Agents — depending on tags, title cues, or capability inference
+4. Lets the agent execute: tool calls, MCP servers, web search, file I/O, the full kit
+5. On completion: marks the task done in your vault, swaps the tag to `#agent-completed`, and sends you a one-paragraph Telegram summary with the actual result
+
+Cost for that task: usually under $0.10 on Claude Sonnet 4.6, free on local Gemma. The full transcript (every tool call, every model turn) lands in `data/agent_transcripts/<session_id>.jsonl` for later review.
+
+---
+
+## Task conventions
+
+The agent worker triggers on tasks that have the `#agent` tag. Optional sub-tags steer routing:
+
+| Tag | Effect |
+|-----|--------|
+| `#agent` | Required. Marks the task as eligible for autonomous execution. |
+| `#local` | Forces routing to your local LLM (Gemma by default). No API spend. Subject to local model capability. |
+| `#cloud` | Forces routing to Anthropic Managed Agents (Claude). Required for tasks that need cloud connectors. |
+
+Without `#local` or `#cloud`, the preflight infers routing from the title. Phrases like "draft an email", "check my calendar", "search my gmail" infer cloud (those need connectors). Phrases like "with local agent" or "using gemma" force local. If the title gives no signal, the worker pauses the task at `#agent-blocked` and asks you on Telegram which model to use.
+
+---
+
+## Routing — local vs cloud
+
+| | Local (Gemma) | Cloud (Claude) |
+|---|---|---|
+| **Best for** | Tasks against local files + LifeOS MCP. Privacy-sensitive work. | Tasks that touch Gmail / Calendar / Drive / Slack / Asana / etc. via cloud connectors. |
+| **Speed** | ~50 tok/s on a workstation GPU; first-token latency dominated by load | ~70+ tok/s sustained, but session-create round-trip + container provisioning |
+| **Cost** | Effectively free (electricity) | Sonnet 4.6: ~$3 / 1M input tokens, $15 / 1M output. Plus $0.08/hour session-hour overhead. |
+| **Tools available** | Bash, Read, Write, Edit, Glob, Grep, WebSearch, WebFetch, sleep + LifeOS MCP + inter-agent tools | Bash, Read, Write, Edit, Glob, Grep, web_search, web_fetch + LifeOS MCP + all your Vault-connected MCPs (cloud productivity, work tools) |
+| **Filesystem reach** | Operator's actual machine — agent can touch your real files | Anthropic-managed ephemeral container by default; self-hosted sandbox planned for future |
+| **Failure modes** | Model capability limits, GPU OOM | Per-task billing, MCP init failures, Anthropic rate limits |
+
+---
+
+## Budgets
+
+You can put a budget in the task title. The preflight parses natural-language hints:
+
+| Title fragment | Parsed as |
+|---|---|
+| `5 min` / `30s` / `1h` | `wall_seconds` |
+| `max $0.50` / `budget $1.00` | `max_dollars` |
+| `10k tokens` / `50000 tokens` | `max_tokens` |
+
+If no budget appears in the title, defaults from `.env` apply (default `$5.00`, `~4 hours wall`, `500k tokens`). The worker enforces all three caps externally — it kills the session when any is breached and the task lands at `#agent-budget-exceeded`.
+
+There's also a global daily $-cap (`LIFEOS_AGENT_DAILY_CAP_DOLLARS`, default `$100`). When the day's accumulated cost crosses the cap, the worker stops claiming new tasks until the next local midnight. Tasks already running aren't killed.
+
+---
+
+## Tag lifecycle
+
+A `#agent` task transitions through these states:
+
+```
+#agent                    (your starting tag)
+   ↓ claimed
+#agent-running            (worker has picked it up)
+   ↓ terminal
+#agent-completed          (success — task is also marked `done`)
+   or
+#agent-failed             (executor crashed / preflight rejected / runtime error)
+   or
+#agent-budget-exceeded    (hit a token / wall / dollar cap)
+   or
+#agent-blocked            (waiting on you via Telegram, or required setup is missing)
+```
+
+To re-run a terminal task, swap the tag back to `#agent` (Obsidian: edit the line; API: `POST /api/tasks/{id}/swap-tag?from=agent-failed&to=agent`). The full prior transcript stays in `data/agent_transcripts/`.
+
+---
+
+## Telegram interactions
+
+The agent worker uses your existing Telegram bot (no second bot needed). Three message types:
+
+1. **Completion notifications** — one paragraph summarizing what the agent did, the key result, total tokens + cost + active seconds. If a tool failed mid-run, the summary includes a footer listing the affected MCPs.
+
+2. **Clarification requests** — if the preflight can't determine routing OR if a task title is genuinely ambiguous (e.g., "reply to Alex" with no email reference), the worker pauses the task at `#agent-blocked` and asks one targeted question on Telegram. Reply by using Telegram's native reply feature (long-press the bot's message, hit Reply). The worker picks up your answer within the next poll cycle and resumes.
+
+3. **Failure notifications** — short message naming the task and the failure reason, plus a transcript path so you can debug. Examples: "task X failed: managed_create_session 4xx" or "task Y hit its budget (max_dollars)".
+
+Default clarification timeout is 72 hours (`LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS`). After that the task is abandoned permanently and you get a Telegram heads-up. The transcript is preserved.
+
+---
+
+## Capability boundaries
+
+### What the agent can do
+
+- Read or write any file the operator can (filesystem, vault, scratch space)
+- Run any shell command the operator can
+- Call any MCP server attached to the agent — for the cloud path, that includes whatever you've configured in your Anthropic Vault (LifeOS MCP, Gmail, Calendar, Drive, Slack, etc.); for local, that's whatever the local MCP exposes
+- Search the web, fetch URLs
+- Spawn child agent sessions, message them, wait for them — see [Inter-agent coordination](../technical/agent-worker.md#inter-agent-coordination) in the technical spec
+- Sleep / yield — pause and resume later without burning idle compute
+
+### What the agent can't do
+
+- Make decisions you didn't authorize — every task starts from a tag you wrote
+- Charge you beyond your configured budgets — both per-task and daily caps enforced externally
+- Run without your knowing — every run lands a Telegram message
+- Persist state beyond the worker's SQLite (sessions, transcripts, daily spend ledger)
+
+---
+
+## Safety model
+
+The agent runs with the operator's full filesystem and shell access — no sandbox. This is intentional and consistent with the rest of LifeOS (you trust it with your data); see the [Design Principles](../../../AGENTS.md#development-principles) section in the project AGENTS doc. Four overlapping protections keep things sane:
+
+1. **Haiku preflight sanity check** — flags obviously destructive titles (`rm -rf /`, "delete all my data") and parks them at `#agent-failed` before the executor sees them.
+2. **Daily $-cap** — backstop against runaway loops; pauses all new claims when crossed.
+3. **Per-task budgets** — enforced from outside the agent loop, so the model can't override them.
+4. **Telegram notification on every terminal state** — you find out quickly if something runs that shouldn't have.
+
+Operators should still audit `#agent`-tagged tasks before they reach the worker (your task list is the queue), keep budgets set, and treat agent-touchable secrets the same as operator-touchable secrets.
+
+---
+
+## Configuration knobs
+
+All in `.env` — see [`agent-worker-setup.md`](../../guides/agent-worker-setup.md) for the full operator walkthrough. Most-used:
+
+| Var | Purpose | Default |
+|---|---|---|
+| `LIFEOS_AGENT_WORKER_AUTOSTART` | Enable the worker on boot | `false` |
+| `LIFEOS_AGENT_DAILY_CAP_DOLLARS` | Global daily $-cap (set to 0 to pause new claims) | `100.00` |
+| `LIFEOS_AGENT_DEFAULT_BUDGET_DOLLARS` | Default per-task $-cap when title doesn't specify | `5.00` |
+| `LIFEOS_AGENT_WORKER_POLL_SECONDS` | Polling interval | `60` |
+| `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` | Telegram-clarification wait before abandoning | `72` |
+| `LIFEOS_AGENT_MANAGED_MODEL` | Informational; actual model lives in the cloud preset | `claude-sonnet-4-6` |
+
+---
+
+## Related Documents
+
+- [Agent Worker — Technical](../technical/agent-worker.md) — Architecture, executors, prompts, state machine, restart resumability
+- [Agent Worker — Setup](../../guides/agent-worker-setup.md) — Operator setup (Gemma swap, MCP HTTP transport, Vault provisioning, agent preset)
+- [Task Management](task-management.md) — How `#agent` tasks live alongside regular tasks in the Obsidian Tasks plugin
+- [MCP Tools](mcp-tools.md) — The `lifeos_agent_*` family for inter-agent coordination
+- [API Reference](api-reference.md) — `POST /api/tasks/{id}/swap-tag` and other task endpoints the worker uses
+- [Architecture](../technical/architecture.md) — Where the worker fits in the broader code structure

--- a/docs/specs/product/mcp-tools.md
+++ b/docs/specs/product/mcp-tools.md
@@ -502,3 +502,4 @@ See `mcp_server.py` for implementation details:
 
 - [API Reference](api-reference.md) -- Full API endpoint contracts
 - [Chat UI](chat-ui.md) -- Chat interface that uses the same tools
+- [Agent Worker](agent-worker.md) -- The `lifeos_agent_*` family extends the MCP catalog for inter-agent coordination (spawn / send / check / yield_until / kill / transcript_read / sessions_list / user_ask)

--- a/docs/specs/product/task-management.md
+++ b/docs/specs/product/task-management.md
@@ -173,3 +173,4 @@ The dashboard uses Obsidian Tasks plugin queries and updates automatically as ta
 
 - [API Reference](api-reference.md) -- Task API endpoint contracts
 - [Reminders Guide](../../guides/reminders.md) -- Reminder system (task-reminder linking)
+- [Agent Worker](agent-worker.md) -- Tasks tagged `#agent` are picked up by the autonomous worker for hands-free completion

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -1,0 +1,356 @@
+# Agent Worker — Technical
+
+> **Status:** Complete
+> **Owner:** Agent Worker
+> **Last Updated:** 2026-05-26
+
+Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
+
+---
+
+## Table of Contents
+
+1. [Architecture overview](#architecture-overview)
+2. [Component layout](#component-layout)
+3. [Lifecycle of a task](#lifecycle-of-a-task)
+4. [Session state machine](#session-state-machine)
+5. [Preflight](#preflight)
+6. [Local executor (Gemma path)](#local-executor-gemma-path)
+7. [Managed executor (Claude path)](#managed-executor-claude-path)
+8. [System prompts](#system-prompts)
+9. [Inter-agent coordination](#inter-agent-coordination)
+10. [Budget enforcement](#budget-enforcement)
+11. [Restart resumability](#restart-resumability)
+12. [Telegram clarification flow](#telegram-clarification-flow)
+13. [Transcripts](#transcripts)
+14. [Configuration surface](#configuration-surface)
+15. [Related Documents](#related-documents)
+
+---
+
+## Architecture overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         Operator's task list                             │
+│                    (Obsidian markdown, #agent tag)                       │
+└──────────────────────────────┬──────────────────────────────────────────┘
+                               │ HTTP poll (60s)
+                               ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     lifeos-agent-worker.service                          │
+│   - Single-threaded poll loop                                            │
+│   - SQLite state (sessions, transcripts, daily spend)                    │
+│   - Telegram client (notifications + clarifications)                     │
+└────┬───────────────────┬────────────────────────────────┬───────────────┘
+     │                   │                                │
+     │ Haiku preflight   │ Local executor                 │ Managed executor
+     ▼                   ▼                                ▼
+┌─────────┐    ┌──────────────────────┐    ┌──────────────────────────────┐
+│Anthropic│    │  llama-server (local)│    │ Anthropic Managed Agents API │
+│ Haiku   │    │  Gemma 4 26B         │    │  api.anthropic.com/v1/       │
+│ classify│    │  + LifeOS MCP        │    │  sessions/events             │
+└─────────┘    │  + Bash/Read/Write   │    │ + cloud container            │
+               │  + inter-agent tools │    │ + Vault MCPs (LifeOS, Gmail, │
+               └──────────────────────┘    │   Calendar, Drive, Slack…)   │
+                                           └──────────────────────────────┘
+```
+
+The worker is a stand-alone Python process (`python -m api.services.agent_worker.worker`) managed by a systemd unit. It does **not** import the FastAPI app — all task operations go through `/api/tasks` HTTP. This keeps the worker trivially restartable and lets the API layer own task-list locking.
+
+---
+
+## Component layout
+
+All code lives in `api/services/agent_worker/`:
+
+| File | Responsibility |
+|---|---|
+| `worker.py` | Main poll loop, claim/dispatch, startup resume, signal handling, Telegram delivery, completion summaries |
+| `preflight.py` | Haiku-based classifier (budget parsing, routing, ambiguity, sanity) |
+| `local_executor.py` | Agent loop against a local LLM (llama-server / Gemma 4 by default) |
+| `managed_executor.py` | Lifecycle wrapper around a Managed Agents session — `start()` → `poll()` → `_finalize_remote()` |
+| `managed_driver.py` | HTTP wrapper for `api.anthropic.com/v1/sessions` + events endpoint + session-state fan-out |
+| `session_store.py` | SQLite schema + accessors (sessions, daily_spend, sleeps, pending_messages, pending_questions, managed_cursor) |
+| `spend_tracker.py` | Daily $-cap ledger; pause semantics when cap ≤ 0 |
+| `transcript_store.py` | Append-only JSONL per `session_id` at `data/agent_transcripts/` |
+| `tools.py` | `STANDARD_TOOLS` (Read/Write/Edit/Bash/Glob/Grep/WebFetch/WebSearch/sleep) + `ToolRegistry` combining standard + inter-agent + MCP tools |
+| `inter_agent.py` | `lifeos_agent_*` family — spawn, send, check, yield_until, kill, transcript_read, sessions_list, user_ask |
+| `pricing.py` | Per-model $/token table; `MANAGED_SESSION_HOUR_OVERHEAD = $0.08` |
+| `router.py` | Thin local-vs-claude dispatch helper |
+
+External boundaries:
+
+- **HTTP**: `/api/tasks` for task CRUD, `/api/tasks/{id}/swap-tag` for atomic tag transitions, the Telegram Bot API for notifications.
+- **LLM**: `https://api.anthropic.com/v1` for Haiku preflight + Managed Agents API; `http://localhost:8080` (llama-server) for local execution.
+- **MCP**: `https://<host>/mcp` for the LifeOS MCP HTTP transport (used by Managed Agents and other remote MCP clients), and stdio MCP for local Claude Code.
+
+---
+
+## Lifecycle of a task
+
+```
+poll → spend tracker check (`can_start_task(default_budget)`)
+     → wake sleeping sessions whose timer expired
+     → poll managed sessions for state advancement
+     → resume yielded-for-children sessions if children done
+     → dispatch spawned sessions (drain pending_messages)
+     → process clarification answers (Telegram replies)
+     → timeout stale clarifications (default 72h)
+     → list /api/tasks?status=todo&tag=agent
+     → for each candidate:
+         atomic swap #agent → #agent-running   (race-free via swap-tag API)
+         create session row + transcript "claim" event
+         run preflight (Haiku) → PreflightResult
+             routing in {local, claude, ask}
+             expected_output in {text, file, external_action, structured}
+             ambiguity: question | null
+             sane: bool
+         dispatch on routing:
+             local  → LocalExecutor.execute(session, task)
+             claude → ManagedExecutor.start(session, task)
+             ask    → Telegram clarification, park at #agent-blocked
+         on terminal outcome:
+             COMPLETED → mark task done in vault + swap to #agent-completed
+             FAILED / BUDGET_EXCEEDED → swap to matching tag
+             BLOCKED → Telegram clarification + leave for human
+             YIELDED → leave for sleeps loop to wake at wake_at
+         notify operator (Telegram) on terminal states
+```
+
+---
+
+## Session state machine
+
+`SessionStore.sessions` row statuses, with valid transitions:
+
+```
+            ┌─────────┐
+            │ CLAIMED │ (worker won the tag-swap race)
+            └────┬────┘
+                 │ preflight + dispatch
+                 ▼
+            ┌─────────┐
+            │ RUNNING │
+            └────┬────┘
+                 ├────► COMPLETED  (terminal — task done)
+                 ├────► FAILED      (terminal — executor error, sanity reject, etc.)
+                 ├────► BUDGET_EXCEEDED  (terminal — wall/tokens/dollars cap)
+                 ├────► BLOCKED     (waiting on Telegram, or Managed Agents not configured)
+                 └────► YIELDED     (sleep tool / yield_until — wake on timer or child completion)
+```
+
+Each session also tracks `routing`, `budget`, `expected_output`, `total_input_tokens`, `total_output_tokens`, `total_dollars`, `managed_agent_session_id`, `started_at`, `parent_session_id`, `root_session_id`, `spawn_depth` (for lineage budgets), and `yield_waiting_for` (when in `YIELDED` from `yield_until`).
+
+---
+
+## Preflight
+
+The preflight is a single Haiku call (`claude-haiku-4-5` by default) that classifies a task before executor dispatch. Cheap (~$0.001) and fast (~1s). Returns:
+
+```python
+@dataclass
+class PreflightResult:
+    budget: PreflightBudget         # parsed from title or default
+    routing: str                    # local | claude | ask
+    routing_reason: str
+    expected_output: str            # text | file | external_action | structured
+    ambiguity: PreflightAmbiguity | None
+    sane: bool
+    sane_reason: str
+    raw: dict                       # the parsed JSON for debugging
+```
+
+Routing precedence (per the prompt instructions):
+
+1. `#local` tag → routing=local
+2. `#cloud` tag → routing=claude
+3. Title contains explicit model cue ("use claude", "with opus", "using gemma") → claude / local
+4. Title contains capability-implying phrase ("search my gmail", "google drive", "send a slack message", etc.) → claude (those tools require cloud connectors)
+5. Otherwise → ask (worker pauses the task and asks via Telegram)
+
+Hardening: response is parsed defensively (handles `` ```json `` fences, partial schemas, missing keys, exceptions). On any parse failure the result defaults to `sane=false` so the worker parks the task rather than running with garbage.
+
+---
+
+## Local executor (Gemma path)
+
+`LocalExecutor.execute(session, task) -> ExecutorOutcome`. Wraps an agent loop against an OpenAI-compatible local LLM server (llama-server with `unsloth/gemma-4-26B-A4B-it-GGUF` by default).
+
+Per-turn flow:
+
+1. Check budgets at top-of-loop — kill with `STATUS_BUDGET_EXCEEDED` if `total_tokens >= max_tokens` OR `total_dollars >= max_dollars` OR `wall_seconds_elapsed >= wall_seconds` OR lineage budget breached. Cascade-kill descendants on lineage breach.
+2. Build the message list (system prompt + prior user/assistant/tool_result turns).
+3. Call the local LLM with the tool catalog (`STANDARD_HANDLERS` + `lifeos_agent_*` inter-agent tools + LifeOS MCP tools, all in OpenAI format).
+4. Parse response — handles both OpenAI `{"function": {"name", "arguments"}}` and Anthropic `{"name", "input"}` shapes via `_normalize_tool_calls`.
+5. If response has tool_calls: dispatch each to `ToolRegistry`, append `tool_result` turns, loop.
+6. If no tool_calls and content is non-empty: finalize with `STATUS_COMPLETED` + `final_text`.
+7. If tool emitted a yield (sleep: `yield_seconds > 0`; `yield_until`: `yield_seconds == -1`): set `STATUS_YIELDED` and return — the worker's sleep / yield-resumption loops take over.
+
+Cost: 0 dollars (`local` model maps to $0 in `pricing.py`). Wall-time enforcement still applies.
+
+---
+
+## Managed executor (Claude path)
+
+`ManagedExecutor.start(session, task)` creates a remote Managed Agents session and returns `STATUS_RUNNING`. The worker's `_poll_managed_sessions` then calls `poll(session)` each tick until terminal.
+
+Session creation body (only fields actually used; the agent preset holds persona / tools / MCPs / system prompt):
+
+```json
+{
+  "agent": "agent_…",
+  "environment_id": "env_…",
+  "vault_ids": ["vlt_…"],
+  "metadata": {"lifeos_session_id": "sess_…", "task_id": "…"},
+  "title": "<first 100 chars of task description>"
+}
+```
+
+Plus a follow-up `POST /v1/sessions/{id}/events` with the initial user message (`Task: …` + soft budget constraints).
+
+State polling fans out to two endpoints (live API doesn't embed events in the session-state response):
+
+- `GET /v1/sessions/{id}` → status + cumulative `usage`. Treats `status: "idle"` as the canonical successful terminal.
+- `GET /v1/sessions/{id}/events?after=<cursor>` → event stream (`agent.message`, `agent.tool_use`, `session.status_idle`, `session.error`, etc.). Paginates while `has_more=true`.
+
+Synthesized terminal status precedence:
+
+1. Non-init `session.error` events → status=`failed` (cascading failure, can't lose it).
+2. Raw status in `TERMINAL_REMOTE_STATUSES` → use raw.
+3. `session.status_idle` event → status=`completed`.
+4. Otherwise → still running.
+
+Cost accounting: delta-tracks token spend each poll using `pricing.cost_for(model, …)` and adds `(wall_seconds / 3600) × $0.08` session-hour overhead. Mid-flight budget breach kills the remote session via `DELETE /v1/sessions/{id}` and finalizes locally.
+
+### MCP-init failure handling
+
+The Managed Agents API emits `session.error` events at session-start for any MCP that fails to initialize (URL doesn't match a Vault credential, OAuth invalid, host unreachable, etc.). These are **informational** — the agent works around the missing MCP. The driver filters `mcp_authentication_failed_error` / `mcp_connection_failed_error` types out of the failed-status synthesis. Affected MCP names are persisted in `managed_cursor.init_failed_mcps_json` (across polls, since they fire on the first batch but the session may not idle until later) and surfaced as a footer in the completion Telegram summary.
+
+### Empty-final-text carry-forward
+
+`agent.message` events with the agent's final text can arrive in an earlier poll batch than the `session.status_idle` event. The driver's per-batch `_extract_final_text` would return `None` on the idle-only batch. The executor mitigates this by caching `final_text` to `managed_cursor.final_text` on every poll where the driver returns a non-None value, and reading it back at finalize.
+
+---
+
+## System prompts
+
+All four model-facing prompts are structured per [Anthropic's Claude 4.6/4.7 prompt-engineering best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) — XML section tags, positive framing, explicit final-summary requirement after tool use.
+
+| Prompt | Location | Audience |
+|---|---|---|
+| Cloud agent preset | Anthropic console (versioned; current v3) | Claude Sonnet 4.6 on Managed Agents |
+| Local Gemma `_system_prompt` | `local_executor.py` (`_SYSTEM_PROMPT_STATIC` + per-task `<this_task>` trailer) | Gemma 4 26B |
+| Cloud per-task user message | `managed_executor.py` (`_user_message_for`) | Initial user turn for each managed session |
+| Haiku preflight prompt | `preflight.py` (`_PREFLIGHT_INSTRUCTIONS`) | Claude Haiku classifier |
+
+Cache strategy: the local executor's static portion is a module-level constant so prompt caches don't invalidate between sessions; only the small trailing `<this_task>` block (expected_output + soft budget) varies.
+
+The cloud preset YAML is mirrored verbatim in [`guides/agent-worker-setup.md`](../../guides/agent-worker-setup.md) for fresh-clone operators.
+
+---
+
+## Inter-agent coordination
+
+Local agents can spawn child sessions and coordinate via the `lifeos_agent_*` tool family:
+
+| Tool | Purpose |
+|---|---|
+| `lifeos_agent_spawn` | Create a new agent session (local or claude). Returns `session_id`. |
+| `lifeos_agent_send` | Post a message to a child session's queue. |
+| `lifeos_agent_check` | Poll a child's current state. |
+| `lifeos_agent_yield_until` | Pause the caller until specific children reach terminal state — preferred over polling (no idle billing). |
+| `lifeos_agent_kill` | Terminate a child early. |
+| `lifeos_agent_transcript_read` | Read another session's transcript. |
+| `lifeos_agent_sessions_list` | List active + recent sessions. |
+| `lifeos_agent_user_ask` | Pause and ask the operator a clarifying question via Telegram (reply-threaded). |
+
+Security: lineage checks ensure a session can only message / kill / yield-on its own descendants (rooted at `root_session_id`).
+
+Lineage budgets: every session tracks `root_session_id` + `spawn_depth`. Budget breaches at any descendant cascade-kill the entire lineage. Limits configurable via `LIFEOS_AGENT_MAX_SPAWN_DEPTH`, `LIFEOS_AGENT_MAX_DESCENDANTS_PER_ROOT`, `LIFEOS_AGENT_MAX_CONCURRENT_LOCAL`, `LIFEOS_AGENT_MAX_CONCURRENT_MANAGED`.
+
+---
+
+## Budget enforcement
+
+Four overlapping layers, executed in this order:
+
+1. **Daily $-cap** — `SpendTracker.can_start_task(estimated)` short-circuits to False when `daily_cap_dollars <= 0` (operator pause). Otherwise blocks new claims when accumulated day spend ≥ cap.
+2. **Per-task token / wall / dollar caps** — checked at the top of every executor turn (local) or every poll (managed).
+3. **Lineage caps** — for child sessions, the entire lineage's combined spend is checked against any ancestor's `max_dollars`. Breach cascade-kills the lineage.
+4. **Remote (cloud only)** — when the worker detects a mid-flight breach for a managed session, it calls `DELETE /v1/sessions/{id}` to stop Anthropic-side billing immediately.
+
+---
+
+## Restart resumability
+
+The worker is signal-safe and crash-resumable. `resume_pending()` runs on startup and scans non-terminal sessions:
+
+- `YIELDED` with a `sleeps` row → leave alone (sleeps loop wakes it on schedule).
+- `BLOCKED` → leave alone (waiting on Telegram reply or operator unblock).
+- Anything else (`CLAIMED` / `RUNNING` mid-execution) → roll tag back from `#agent-running` to `#agent`, mark session `FAILED` in the DB, notify operator.
+
+A managed session's `managed_agent_session_id` is durable across worker restarts — on resume the worker reattaches via `GET /v1/sessions/{id}` and continues polling from `managed_cursor.last_event_id`.
+
+---
+
+## Telegram clarification flow
+
+When the worker needs operator input mid-task — preflight routing=ask, ambiguity question, or `lifeos_agent_user_ask` mid-loop — it:
+
+1. Sends a Telegram message via `send_message_capture_id()` (returns the Telegram `message_id`).
+2. Persists `(session_id, telegram_message_id, question)` in `pending_questions`.
+3. Swaps the tag to `#agent-blocked` and parks the session.
+4. For managed sessions: also calls `driver.kill_session` to stop session-hour billing while waiting.
+
+When the operator replies (using Telegram's native reply feature), the bot's `_maybe_deposit_agent_answer()` hook intercepts the `reply_to_message_id` and calls `SessionStore.deposit_answer()`. The worker's `_process_clarification_answers()` runs each tick, picks up answered questions, parses the answer (for routing questions: extracts `local` / `claude` from free-text), updates the session, and re-dispatches.
+
+For local sessions, the parent session resumes via the existing pending_messages drain.
+For managed sessions, a new remote session is created with the resolved routing.
+
+Clarifications older than `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` (default 72h) are abandoned with a Telegram heads-up; the transcript stays preserved.
+
+---
+
+## Transcripts
+
+Every session has an append-only JSONL transcript at `data/agent_transcripts/<session_id>.jsonl`. Each line is one event:
+
+```json
+{"ts": 1779800000.0, "kind": "claim", "data": {"task_id": "abc"}}
+{"ts": 1779800001.5, "kind": "preflight_result", "data": {...}}
+{"ts": 1779800003.2, "kind": "llm_turn", "data": {"role": "assistant", "content": "...", "tool_calls": [...]}}
+{"ts": 1779800004.1, "kind": "tool_dispatch", "data": {"name": "Bash", "input": {...}, "result": "..."}}
+{"ts": 1779800010.4, "kind": "managed_event_agent.message", "data": {...}}
+{"ts": 1779800012.8, "kind": "managed_completed", "data": {"final_chars": 240, "init_failed_mcps": []}}
+```
+
+Transcripts are append-only and survive worker restarts. They're the audit trail of choice — Telegram summaries point at them when a task lands at `#agent-failed` or produces an unexpectedly empty completion.
+
+---
+
+## Configuration surface
+
+Full reference in [`agent-worker-setup.md`](../../guides/agent-worker-setup.md). Categories:
+
+| Group | Vars |
+|---|---|
+| Worker lifecycle | `LIFEOS_AGENT_WORKER_AUTOSTART`, `LIFEOS_AGENT_WORKER_POLL_SECONDS` |
+| Budgets | `LIFEOS_AGENT_DAILY_CAP_DOLLARS`, `LIFEOS_AGENT_DEFAULT_BUDGET_DOLLARS`, `LIFEOS_AGENT_DEFAULT_WALL_SECONDS`, `LIFEOS_AGENT_DEFAULT_MAX_TOKENS` |
+| Preflight | `LIFEOS_AGENT_PREFLIGHT_MODEL` |
+| Managed Agents (cloud) | `LIFEOS_AGENT_PRESET_ID`, `LIFEOS_AGENT_ENVIRONMENT_ID`, `LIFEOS_AGENT_VAULT_ID`, `LIFEOS_AGENT_MANAGED_MODEL`, `ANTHROPIC_API_KEY` |
+| MCP HTTP transport | `LIFEOS_MCP_HTTP_URL`, `LIFEOS_MCP_BEARER_TOKEN`, `LIFEOS_MCP_HTTP_HOST`, `LIFEOS_MCP_HTTP_PORT` |
+| Inter-agent caps | `LIFEOS_AGENT_MAX_SPAWN_DEPTH`, `LIFEOS_AGENT_MAX_DESCENDANTS_PER_ROOT`, `LIFEOS_AGENT_MAX_CONCURRENT_LOCAL`, `LIFEOS_AGENT_MAX_CONCURRENT_MANAGED` |
+| Telegram clarifications | `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` |
+
+---
+
+## Related Documents
+
+- [Agent Worker — Product](../product/agent-worker.md) — What `#agent` does, consumer view
+- [Agent Worker — Setup](../../guides/agent-worker-setup.md) — Operator setup walkthrough
+- [Task Management](../product/task-management.md) — How `#agent` tasks sit alongside regular tasks
+- [MCP Tools](../product/mcp-tools.md) — Standard MCP catalog including `lifeos_agent_*` family
+- [API Reference](../product/api-reference.md) — Task endpoints the worker uses (`/api/tasks/{id}/swap-tag`, `/api/tasks/{id}/complete`)
+- [Architecture](architecture.md) — Where the worker fits in the broader code structure
+- [Observability](observability.md) — Tracing, perf, and logging patterns the worker uses

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -97,7 +97,7 @@ poll → spend tracker check (`can_start_task(default_budget)`)
      → dispatch spawned sessions (drain pending_messages)
      → process clarification answers (Telegram replies)
      → timeout stale clarifications (default 72h)
-     → list /api/tasks?status=todo&tag=agent
+     → list /api/tasks across AGENT_PICKUP_STATUSES (`todo` + `urgent`), tag=agent, dedupe by id
      → for each candidate:
          atomic swap #agent → #agent-running   (race-free via swap-tag API)
          create session row + transcript "claim" event


### PR DESCRIPTION
## Summary

The agent worker shipped across many PRs (#98 epic + #100–#110 + #113 / #115 / #118 / #120) but never got consumer-facing or engineering documentation in the standard `docs/specs/` tree. Operator setup lived in `docs/guides/agent-worker-setup.md` and in-code docs in `api/services/agent_worker/AGENTS.md`, but the rest of the doc surface (navigation tables, README value-prop, product/technical specs) didn't know the feature existed.

This PR closes that gap. Docs-only — no code changes.

## What changed

**New specs (both follow the established product/technical split):**
- `docs/specs/product/agent-worker.md` — consumer view: what `#agent` does, tag conventions, routing (local vs cloud), budgets, tag lifecycle, Telegram interactions, capability boundaries, safety model
- `docs/specs/technical/agent-worker.md` — engineering view: architecture diagram, component layout, lifecycle, session state machine, preflight + executors + driver, system-prompt strategy, inter-agent coordination, four-layer budget enforcement, restart resumability, Telegram clarification flow, transcripts, config surface

**Existing docs updated:**
- `README.md` — new **"Hand Off Tasks to an Autonomous Agent"** section (value-prop focused, additive — no rewrites elsewhere). Added agent-worker rows to Quick Links table and Documentation index.
- `AGENTS.md` — 3 new rows in "What question → which doc" navigation; `api/services/agent_worker/` + `mcp_server.py` added to Key Files.
- `docs/specs/product/task-management.md` Related Documents — cross-link to agent-worker.
- `docs/specs/product/mcp-tools.md` Related Documents — cross-link mentioning the `lifeos_agent_*` family.

## Operator-agnostic verified

This is open-source — all new content uses "the operator" / "the operator's data" / synthetic examples. No proper nouns, no personal info. Verified by grep against the diff.

## Why this PR is docs-only

The user explicitly asked for additive doc work — no rewrites of existing content except targeted tweaks (cross-links, navigation rows). README's existing sections, the technical specs for other systems, and the product specs for other features are untouched.

## Test evidence

```
git diff … | grep -i 'nathan\|nbramia'  → no matches
```

No code changes, so no test suite changes. Standard markdown linting via the pre-commit hook reported nothing.

## Review focus

- **Tone match** with existing specs (`data-and-sync.md`, `task-management.md`, `mcp-tools.md`) — frontmatter, table of contents, related-documents footer, synthetic data, no task lists in specs
- **Navigation completeness** — three navigation entries (product + technical + setup) cover the three question shapes a reader is likely to arrive with
- **README section placement** — sits between "What You Can Do" and "Quick Links" for top-of-page visibility; the existing "What You Can Do" mentions agent-worker-adjacent capabilities indirectly ("I just saw an error in the sync, can you investigate and get it fixed?") but doesn't claim this specific feature
- **Operator-agnostic language** in both new specs

## Related work

- Closes the documentation arm of the agent-worker epic [#98](https://github.com/nbramia/LifeOS/issues/98)
- Mirrors the in-code AGENTS.md at `api/services/agent_worker/AGENTS.md` (developer-facing, code-adjacent) — the new specs are for users and operators rather than developers
