### PR TITLE
feat: agent worker picks up #agent tasks with status=urgent too

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -57,6 +57,13 @@ BLOCKED_TAG = "agent-blocked"
 FAILED_TAG = "agent-failed"
 BUDGET_EXCEEDED_TAG = "agent-budget-exceeded"
 
+# Task statuses that the worker will pick up for execution. `todo` is the
+# everyday-task default; `urgent` (Obsidian Tasks `[!]`) is for high-priority
+# items the operator wants run ahead of the queue — both should trigger the
+# agent if tagged `#agent`. The list API only accepts a single status per
+# request, so we fan out and dedupe.
+AGENT_PICKUP_STATUSES = ("todo", "urgent")
+
 
 class Worker:
     """Single-process poll loop. One instance per process."""
@@ -628,17 +635,30 @@ class Worker:
     # ------------------------------------------------------------------
 
     def _list_agent_tasks(self) -> list[dict[str, Any]]:
-        """Fetch open `#agent` tasks from the API."""
-        try:
-            resp = self._http.get(
-                f"{self.api_base}/api/tasks",
-                params={"status": "todo", "tag": AGENT_TAG},
-            )
-            resp.raise_for_status()
-            return resp.json().get("tasks", [])
-        except Exception as exc:
-            logger.warning("failed to list agent tasks: %s", exc)
-            return []
+        """Fetch open `#agent` tasks from the API.
+
+        The list endpoint only filters on a single status string, so we fan
+        out across `AGENT_PICKUP_STATUSES` (`todo` + `urgent` by default) and
+        dedupe by task id. A task that appears under both statuses in quick
+        succession is still claimed once.
+        """
+        seen: set[str] = set()
+        all_tasks: list[dict[str, Any]] = []
+        for status in AGENT_PICKUP_STATUSES:
+            try:
+                resp = self._http.get(
+                    f"{self.api_base}/api/tasks",
+                    params={"status": status, "tag": AGENT_TAG},
+                )
+                resp.raise_for_status()
+                for task in resp.json().get("tasks", []):
+                    tid = task.get("id")
+                    if tid and tid not in seen:
+                        seen.add(tid)
+                        all_tasks.append(task)
+            except Exception as exc:
+                logger.warning("failed to list agent tasks (status=%s): %s", status, exc)
+        return all_tasks
 
     def _swap_tag(self, task_id: str, from_tag: str, to_tag: str) -> bool:
         try:

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -50,9 +50,11 @@ class FakeApi:
     def handler(self, request: httpx.Request) -> httpx.Response:
         if request.method == "GET" and request.url.path == "/api/tasks":
             tag = request.url.params.get("tag")
+            status = request.url.params.get("status")
             matched = [
                 t for t in self.tasks.values()
-                if t.get("status") == "todo" and (tag in t.get("tags", []) if tag else True)
+                if (status is None or t.get("status") == status)
+                and (tag in t.get("tags", []) if tag else True)
             ]
             return httpx.Response(200, json={"tasks": matched, "total": len(matched)})
 
@@ -146,6 +148,63 @@ class _StubExecutor:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_worker_picks_up_urgent_status_tasks_too(tmp_path: Path):
+    """The Obsidian Tasks plugin distinguishes between `todo` (`[ ]`) and
+    `urgent` (`[!]`) statuses. Both should be eligible for #agent pickup —
+    the urgent status signals high-priority work the operator wants run
+    sooner, not 'skip the agent.'"""
+    api = FakeApi(tasks=[
+        {"id": "t-todo",   "description": "ordinary task",  "status": "todo",   "tags": ["agent", "local"]},
+        {"id": "t-urgent", "description": "urgent task",    "status": "urgent", "tags": ["agent", "local"]},
+        {"id": "t-other",  "description": "irrelevant",     "status": "todo",   "tags": ["other"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    # One tick should claim and dispatch both #agent tasks (todo + urgent).
+    handled = w.tick()
+    assert handled == 2
+    claimed_ids = {tid for tid, _ in executor.calls}
+    assert claimed_ids == {"t-todo", "t-urgent"}
+    # Both end at agent-completed
+    assert COMPLETED_TAG in api.tasks["t-todo"]["tags"]
+    assert COMPLETED_TAG in api.tasks["t-urgent"]["tags"]
+    # The non-#agent task is untouched
+    assert api.tasks["t-other"]["tags"] == ["other"]
+
+
+@pytest.mark.unit
+def test_worker_dedups_when_task_appears_under_both_statuses(tmp_path: Path):
+    """If a task somehow appears in both status='todo' and status='urgent'
+    response sets between fan-out calls (or if a later status query returns
+    a row already seen), the worker must claim it only once."""
+    # Construct a FakeApi that returns the same task for both status queries
+    # to simulate the edge case.
+    class _DupeApi(FakeApi):
+        def handler(self, request):
+            if request.method == "GET" and request.url.path == "/api/tasks":
+                tag = request.url.params.get("tag")
+                # Return the same task under any status query
+                matched = [
+                    t for t in self.tasks.values()
+                    if (tag in t.get("tags", []) if tag else True)
+                ]
+                return httpx.Response(200, json={"tasks": matched, "total": len(matched)})
+            return super().handler(request)
+
+    api = _DupeApi(tasks=[
+        {"id": "t1", "description": "dup", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="ok"))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    assert w.tick() == 1
+    assert len(executor.calls) == 1
+
 
 @pytest.mark.unit
 def test_dispatch_local_completes_and_marks_task_done(tmp_path: Path):


### PR DESCRIPTION
## Summary

The worker's `_list_agent_tasks` only queried `status=todo`, so `#agent`-tagged tasks marked **Urgent** (`[!]` in Obsidian Tasks — a first-class status in `task_manager.py`) were silently ignored. For an operator using urgent to flag high-priority work, this meant the most important `#agent` tasks never got picked up.

Fix: define `AGENT_PICKUP_STATUSES = ("todo", "urgent")` and fan out the list call across both statuses, deduping by task id. The `/api/tasks` endpoint only accepts a single status per request, so client-side fan-out is the minimal change that doesn't reshape the public API contract.

## Test evidence

- `pytest -m unit -k 'agent_worker' -q` — **176/176 passed** (2 new tests added)
- `ruff check` — clean

Two new tests in `test_agent_worker_loop.py`:
- `test_worker_picks_up_urgent_status_tasks_too` — happy path. One `todo` + one `urgent` `#agent` task both dispatch in a single tick; a non-`#agent` task is untouched.
- `test_worker_dedups_when_task_appears_under_both_statuses` — defensive dedup against any API quirk that returns the same row across multiple status queries.

Updated the existing FakeApi `/api/tasks` handler to actually filter on the `status` query param so the fan-out behavior is testable (previously it was hardcoded to `todo`).

## Review focus

- **Fan-out scope**: only `todo` and `urgent`. Notably NOT `in_progress` — that status is reserved for tasks an operator is currently working on themselves; we don't want the worker stealing those.
- **Single status param assumption**: confirmed `/api/tasks` and `task_manager.list_tasks` both take a single status value with exact-match filtering.
- **Order of fan-out**: `todo` first, `urgent` second. If both contain the same task, the `todo`-first entry wins (deterministic by Python set semantics).

## Companion doc patch

The docs PR #121 currently in flight had spec wording that implied `status=todo` only. A companion commit on that branch (`docs/agent-worker-system`) already updates both `docs/specs/product/agent-worker.md` and `docs/specs/technical/agent-worker.md` to reflect the new behavior so the merged docs match the implementation.