### PR TITLE
fix: events-endpoint pagination + cursor reset on session start

### DIFF
--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -98,11 +98,6 @@ class ManagedAgentsDriver:
     DEFAULT_BASE_URL = "https://api.anthropic.com/v1"
     DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
     DEFAULT_ANTHROPIC_BETA = "managed-agents-2026-04-01"
-    # Query-param key for the event-stream cursor on GET /sessions/{id}. Doc
-    # terminology has varied between SDK previews ("after" vs "since"); kept
-    # as a class constant so future API renames are a one-line change.
-    EVENT_CURSOR_PARAM = "after"
-
     def __init__(
         self,
         api_key: str,
@@ -280,25 +275,34 @@ class ManagedAgentsDriver:
         session_id: str,
         after_id: str | None = None,
     ) -> list[dict]:
-        """Fetch all new session events since `after_id` (or all if None).
+        """Fetch session events, optionally filtered to those after `after_id`.
 
-        `GET /v1/sessions/{id}/events?after=<cursor>` returns
-        `{"data": [{"id", "type", "payload"|"content"|"error", ...}, ...],
-          "first_id", "last_id", "has_more"}`. Loops while `has_more=True`
-        so the caller never silently loses the tail of a paginated batch —
-        without this, a session that produced more events than the API page
-        size between polls would have its terminal `agent.message` dropped
-        and the Telegram completion summary would be wrong.
+        Anthropic's `GET /v1/sessions/{id}/events` endpoint does NOT accept an
+        event-id cursor — confirmed live by a 400 error message listing valid
+        params as `created_at[gt|gte|lt|lte], limit, order, page, types[]`.
+        The docs' canonical pattern for "give me events newer than X" is to
+        list all events and dedupe client-side by id (see the reconnect
+        example at /docs/en/managed-agents/events-and-streaming).
 
-        Returns the raw event list (concatenated across pages); callers
-        (e.g. `get_session_state`) handle the cursor advance and synthesis.
+        We follow that pattern: fetch all pages with `order=asc` so events
+        arrive in chronological order, then filter to ids strictly greater
+        than `after_id`. Event IDs are ULIDs (`sevt_…`) which sort
+        lexicographically by time, so a string compare gives the right
+        ordering without parsing.
+
+        Trade-off: each poll re-fetches the full event history. Anthropic's
+        per-org rate limit is 600 read/min so this is fine at LifeOS's
+        scale; if a session ever produces enough events that the re-fetch
+        becomes expensive, switch to `created_at[gt]` with the persisted
+        timestamp of the last seen event.
         """
         all_events: list[dict] = []
-        cursor = after_id
+        seen_event_ids: set[str] = set()
+        page_num = 1
         for _ in range(self._MAX_EVENTS_PAGES):
-            params: dict[str, str] = {}
-            if cursor:
-                params[self.EVENT_CURSOR_PARAM] = cursor
+            params: dict[str, str] = {"order": "asc"}
+            if page_num > 1:
+                params["page"] = str(page_num)
             resp = self._client.get(
                 f"{self.base_url}/sessions/{session_id}/events",
                 headers=self._headers(),
@@ -307,26 +311,34 @@ class ManagedAgentsDriver:
             if resp.status_code == 404:
                 # Session deleted mid-poll. Caller's status fetch already
                 # turned this into "cancelled"; return what we have.
-                return all_events
+                return [e for e in all_events if not after_id or e.get("id", "") > after_id]
             self._raise_for_status_with_body(resp)
             data = resp.json()
             page = data.get("data", []) or []
-            all_events.extend(page)
+            # Dedup within this list call — paginated responses occasionally
+            # repeat boundary events. Doesn't address cross-poll dedupe; the
+            # caller's after_id filter below handles that.
+            for ev in page:
+                eid = ev.get("id")
+                if eid and eid not in seen_event_ids:
+                    seen_event_ids.add(eid)
+                    all_events.append(ev)
             if not data.get("has_more"):
-                return all_events
+                break
             if not page:
-                # Defensive: has_more=True but empty page would loop forever.
                 logger.warning("list_events: has_more=true with empty page; stopping")
-                return all_events
-            cursor = page[-1].get("id")
-            if not cursor:
-                logger.warning("list_events: has_more=true but last event has no id; stopping")
-                return all_events
-        logger.warning(
-            "list_events: hit pagination cap (%d pages) for session %s",
-            self._MAX_EVENTS_PAGES, session_id,
-        )
-        return all_events
+                break
+            page_num += 1
+        else:
+            logger.warning(
+                "list_events: hit pagination cap (%d pages) for session %s",
+                self._MAX_EVENTS_PAGES, session_id,
+            )
+        if not after_id:
+            return all_events
+        # Client-side cursor: ULID lex-sort = chronological. Strict > so we
+        # don't reprocess the last-seen event on the next poll.
+        return [e for e in all_events if e.get("id", "") > after_id]
 
     def post_user_message(self, session_id: str, content: str) -> None:
         """Post a user turn to a running session.

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -109,6 +109,11 @@ class ManagedExecutor:
         sid = session.session_id
         budget = session.budget or {}
         self.session_store.update_status(session.task_id, STATUS_RUNNING)
+        # Drop any cursor state from a prior session on this task_id. Without
+        # this, the new session's first poll would carry a stale last_event_id
+        # belonging to a now-defunct remote session and the events endpoint
+        # would 400 on every subsequent poll.
+        self.session_store.reset_managed_cursor(session.task_id)
         self.transcript_store.append(sid, "managed_start",
                                      {"agent_id": self.agent_id, "environment_id": self.environment_id})
 

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -372,6 +372,18 @@ class SessionStore:
                 (managed_id, _now(), task_id),
             )
 
+    def reset_managed_cursor(self, task_id: str) -> None:
+        """Drop any managed-cursor state for a task before a fresh session.
+
+        Without this, deleting a session row and re-claiming the same task_id
+        (e.g., operator re-arming a task after manual cleanup) would leak the
+        prior session's `last_event_id` into the new session's poll cursor —
+        triggering a 400 on the events endpoint because the new session has
+        never seen that id.
+        """
+        with self._connect() as conn:
+            conn.execute("DELETE FROM managed_cursor WHERE task_id = ?", (task_id,))
+
     def add_session_hour_overhead(self, task_id: str, dollars: float) -> None:
         """Add Managed Agents session-hour overhead to the dollar counter."""
         if dollars <= 0:

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -252,20 +252,32 @@ def test_get_session_state_idle_status_is_terminal():
 
 
 @pytest.mark.unit
-def test_get_session_state_uses_after_cursor_on_events_endpoint():
-    """The cursor (since_event_id) goes to the /events query, not /sessions/{id}."""
-    captured = {"status_params": None, "events_params": None}
+def test_get_session_state_filters_events_by_id_client_side():
+    """The events endpoint doesn't accept an event-id cursor (verified live —
+    the API returns a 400 listing valid params as created_at[gt|gte|lt|lte],
+    limit, order, page, types[]). Per the docs' reconnect pattern, we list
+    all events with order=asc and filter client-side by id > since_event_id."""
+    captured = {"events_params": None, "status_params": None}
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path.endswith("/events"):
             captured["events_params"] = dict(request.url.params)
-            return httpx.Response(200, json={"data": []})
+            # Return events with ULID-like ids — strictly sortable by id.
+            return httpx.Response(200, json={"data": [
+                {"id": "sevt_001", "type": "x"},
+                {"id": "sevt_007", "type": "y"},  # this one is at the cursor
+                {"id": "sevt_009", "type": "z"},  # only this should survive
+            ]})
         captured["status_params"] = dict(request.url.params)
         return httpx.Response(200, json={"status": "running", "usage": {}})
 
-    _build_driver(handler).get_session_state("sess_abc", since_event_id="evt_7")
-    assert captured["events_params"]["after"] == "evt_7"
-    # Status endpoint never gets the cursor — it's an events-only concept
+    state = _build_driver(handler).get_session_state("sess_abc", since_event_id="sevt_007")
+    # The /events call uses `order=asc` and NO `after` param (which the API rejects).
+    assert captured["events_params"].get("order") == "asc"
+    assert "after" not in captured["events_params"]
+    # Client-side filter: only events strictly greater than the cursor id.
+    assert [e["id"] for e in state.new_events] == ["sevt_009"]
+    # Status endpoint never gets the cursor — it's an events-only concept.
     assert captured["status_params"] == {}
 
 
@@ -385,30 +397,34 @@ def test_get_session_state_prefers_failed_when_raw_idle_and_event_error():
 def test_list_events_paginates_through_has_more():
     """list_events must follow `has_more=true` and concatenate pages, otherwise
     a session that produced more events than the API page size between polls
-    would lose the tail (including the terminal agent.message)."""
+    would lose the tail (including the terminal agent.message). Pagination
+    uses the `page=` query param (the only id-based cursor Anthropic accepts
+    is rejected; see test_get_session_state_filters_events_by_id_client_side)."""
     calls = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         calls.append(dict(request.url.params))
-        cursor = request.url.params.get("after")
-        if cursor is None:
+        page = request.url.params.get("page")
+        if page is None:
             return httpx.Response(200, json={
-                "data": [{"id": "evt_1", "type": "x"}, {"id": "evt_2", "type": "y"}],
+                "data": [{"id": "sevt_001", "type": "x"}, {"id": "sevt_002", "type": "y"}],
                 "has_more": True,
             })
-        if cursor == "evt_2":
+        if page == "2":
             return httpx.Response(200, json={
-                "data": [{"id": "evt_3", "type": "z"}, {"id": "evt_4", "type": "agent.message",
-                                                         "content": [{"type": "text", "text": "done"}]}],
+                "data": [{"id": "sevt_003", "type": "z"},
+                         {"id": "sevt_004", "type": "agent.message",
+                          "content": [{"type": "text", "text": "done"}]}],
                 "has_more": False,
             })
-        raise AssertionError(f"unexpected cursor: {cursor}")
+        raise AssertionError(f"unexpected page: {page}")
 
     events = _build_driver(handler).list_events("sess")
-    assert [e["id"] for e in events] == ["evt_1", "evt_2", "evt_3", "evt_4"]
-    # First call: no cursor; second call: cursor = last id of first page.
-    assert calls[0] == {}
-    assert calls[1] == {"after": "evt_2"}
+    assert [e["id"] for e in events] == ["sevt_001", "sevt_002", "sevt_003", "sevt_004"]
+    # First call: page=1 implicit (no page param); second: page=2.
+    # Both calls also include order=asc.
+    assert calls[0] == {"order": "asc"}
+    assert calls[1] == {"order": "asc", "page": "2"}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Two cursor-related bugs were stranding cloud agent sessions that took more than one poll cycle to complete.

**1. Events endpoint 400s on `after=<event_id>`.** Verified live — `GET /v1/sessions/{id}/events` rejects an event-id cursor with a 400 listing valid params as `created_at[gt|gte|lt|lte], limit, order, page, types[]`. Per Anthropic's reconnect-pattern docs (`/docs/en/managed-agents/events-and-streaming`), the canonical pattern is to fetch the full event list with `order=asc` and dedupe client-side by id. Event ids are ULIDs (`sevt_…`) which sort lexicographically by time, so a string compare gives correct ordering. Pagination now uses the `page=` query param.

Trade-off: each poll re-fetches the full event history for the session. At LifeOS's rate (~one event per few seconds) and Anthropic's 600 read/min per-org limit, this is fine. If a session ever produces enough events that re-fetch cost matters, switch to `created_at[gt]` with the persisted timestamp of the last seen event.

**2. Stale `managed_cursor` leaks across sessions on the same `task_id`.** When the operator manually clears a session row and the worker re-claims the task (e.g., after debugging a stuck session), the prior session's `last_event_id` was leaking into the new session's poll cursor. The new session has never seen that id, so the events endpoint 400s on every subsequent poll. Fixed by `session_store.reset_managed_cursor(task_id)` called from `ManagedExecutor.start()`.

## Test evidence

- New test `test_get_session_state_filters_events_by_id_client_side` asserts the events call carries `order=asc`, has no `after` param, and the returned `new_events` are correctly filtered by id > cursor.
- `test_list_events_paginates_through_has_more` rewritten to assert `page=2` pagination instead of `after=evt_2`.
- All 68 agent_worker unit tests pass: `pytest tests/test_agent_worker_managed_driver.py tests/test_agent_worker_managed_executor.py tests/test_agent_worker_loop.py`.
- Full unit suite: 2159 passed (4 pre-existing failures unrelated — settings defaults drift + vault-data integrity tests).

## Review focus

- `list_events` in `managed_driver.py` — pagination loop reads `has_more`, follows pages with `page=N`, dedupes within a single call, then applies the client-side id filter on the concatenated result
- `reset_managed_cursor` placement at the top of `ManagedExecutor.start()` — runs *before* the transcript-store append so a fresh session can't observe the prior session's cursor even briefly
- The reasoning in the `list_events` docstring explaining why we don't pass `after=`