### PR TITLE
fix: teach orchestrator the agent-worker tag conventions

### DIFF
--- a/api/services/claude_orchestrator.py
+++ b/api/services/claude_orchestrator.py
@@ -148,6 +148,15 @@ Note: Monthly financial summaries are also synced to the vault at Personal/Finan
 
 Action tools:
 - lifeos_task_create/list/update/complete/delete: Manage Obsidian tasks.
+  When the user asks for a task to be done autonomously by an "agent" (or
+  by "the cloud agent" / "the local agent"), pass tags=["agent"] to route
+  it to the external agent worker. Optional sub-tags steer routing:
+  ["agent", "local"] forces local Gemma; ["agent", "cloud"] forces cloud
+  Claude. Never use "agent-running", "agent-completed", "agent-failed",
+  "agent-blocked", or "agent-budget-exceeded" — those are state tags the
+  worker SETS during execution. Setting them at creation hides the task
+  from the worker. The worker polls for tag="agent" only.
+  Use status="urgent" if the user signals urgency; "todo" is the default.
 - lifeos_reminder_create/list/delete: Manage scheduled Telegram reminders.
 - lifeos_gmail_draft: Create a draft email in Gmail (not sent, user reviews first).
 - lifeos_calendar_create: Create a Google Calendar event. Invite emails sent to attendees. [CLARIFY] with user before creating.


### PR DESCRIPTION
## Summary

The chat orchestrator (Claude calling `lifeos_task_create` from a Telegram message) was creating agent-bound tasks with the wrong tags — observed live as a task tagged `#agent-running` instead of `#agent #cloud` after the user asked it to dispatch a task to the cloud agent.

Root cause: the system prompt's task-tool description didn't tell the LLM that:
1. Routing to the agent worker is gated on the literal `agent` tag, and
2. Tags like `agent-running` / `agent-completed` / `agent-failed` / `agent-blocked` / `agent-budget-exceeded` are state tags the **worker sets during execution** — setting them at creation time hides the task from the worker entirely (worker polls for `tag="agent"`).

Adds explicit guidance to the task tool description in `_SYSTEM_PROMPT`:
- Use `["agent"]` / `["agent","local"]` / `["agent","cloud"]` for routing
- Never set the state tags at creation
- Use `status="urgent"` when the user signals urgency

## Test evidence

Docstring-level prompt change; no new code paths. Full unit suite passes (201 tests). Live verification will happen the next time a user dispatches an agent task via Telegram.

## Review focus

- The prompt addition is positively framed ("use X / Y / Z") per Anthropic's prompt-engineering guidance (matches the recent restructure in #120)
- Explicitly enumerates which tags are forbidden at creation time and *why* (worker-set state, not user intent) — terser framing risked the LLM treating the forbidden list as exhaustive of valid options

## Related work

- Companion to #122 (worker now picks up status="urgent" too — orchestrator now knows to set it)
- Companion to #117/#118/#120 — the agent-worker prompt design line