### PR TITLE
fix: calendar_upcoming formatter + inject today's date for both executors

### DIFF
--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -187,13 +187,26 @@ def _system_prompt(session_id: str, expected_output: str, budget, parent_session
     max_tokens = budget.get("max_tokens")
     max_dollars = budget.get("max_dollars")
     dollars_str = f"~${max_dollars}" if max_dollars is not None else "unset"
+    # The local LLM has a fixed training cutoff; without today's date it
+    # hallucinates plausible-looking but wrong dates when interpreting
+    # calendar / task / due-date data. Inject the operator's local date
+    # so day-relative reasoning works.
+    today = _today()
     return (
         _SYSTEM_PROMPT_STATIC
         + "\n\n<this_task>\n"
+        + f"today={today}; "
         + f"expected_output={expected_output}; "
         + f"soft budget ~{wall}s wall / ~{max_tokens} tokens / {dollars_str}.\n"
         + "</this_task>"
     )
+
+
+def _today() -> str:
+    """Local today as YYYY-MM-DD (weekday). Module-level for test override."""
+    from datetime import datetime
+    now = datetime.now().astimezone()
+    return now.strftime("%Y-%m-%d (%A)")
 
 
 def _user_message_for(task: dict) -> str:

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -60,12 +60,24 @@ def _user_message_for(task: dict, session_id: str, expected_output: str, budget:
     parts = [f"Task: {title}"]
     if context:
         parts.append(f"Context: {context}")
+    # Inject the operator's local date. The cloud model has its own
+    # training cutoff and Anthropic does not inject "today" into managed
+    # sessions; without this, day-relative reasoning on calendar / tasks
+    # picks an arbitrary date inside the cutoff window.
     parts.append(
+        f"today={_today()}; "
         f"expected_output={expected_output}; "
         f"soft budget ~{budget.get('wall_seconds')}s wall / "
         f"~{budget.get('max_tokens')} tokens / {dollars_str}."
     )
     return "\n\n".join(parts)
+
+
+def _today() -> str:
+    """Local today as YYYY-MM-DD (weekday). Module-level for test override."""
+    from datetime import datetime
+    now = datetime.now().astimezone()
+    return now.strftime("%Y-%m-%d (%A)")
 
 
 class ManagedExecutor:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1174,9 +1174,19 @@ class LifeOSMCPServer:
                 return "No events found."
             text = f"Found {len(events)} events:\n\n"
             for e in events[:10]:
-                text += f"- **{e.get('summary', 'Untitled')}**\n"
-                text += f"  When: {e.get('start', 'No time')}\n"
-                if attendees := e.get('attendees'):
+                title = e.get("title") or e.get("summary") or "Untitled"
+                text += f"- **{title}**\n"
+                # Prefer the human-formatted strings when present; fall back
+                # to raw ISO timestamps so consumers always get something.
+                start = e.get("start_formatted") or e.get("start_time") or e.get("start") or "No time"
+                end = e.get("end_formatted") or e.get("end_time") or e.get("end")
+                if end and end != start:
+                    text += f"  When: {start} – {end}\n"
+                else:
+                    text += f"  When: {start}\n"
+                if location := e.get("location"):
+                    text += f"  Where: {location}\n"
+                if attendees := e.get("attendees"):
                     text += f"  With: {', '.join(attendees[:3])}\n"
             return text
 

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -418,3 +418,19 @@ def test_system_prompt_carries_soft_budget_in_this_task_section():
     assert "~90s" in prompt
     assert "~5000 tokens" in prompt
     assert "~$0.25" in prompt
+
+
+@pytest.mark.unit
+def test_system_prompt_includes_today_for_day_relative_reasoning():
+    """The local model has a fixed training cutoff. Without today's date
+    it hallucinates plausible-looking but wrong dates when the task
+    involves calendar / due-date reasoning. End-to-end test caught
+    Gemma using 2025-05-14 on a 2026-05-26 calendar lookup."""
+    import re
+    prompt = _system_prompt(
+        session_id="sess_x", expected_output="text",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 0.5},
+    )
+    # today=YYYY-MM-DD (Weekday) inside <this_task>
+    m = re.search(r"today=(\d{4}-\d{2}-\d{2}) \([A-Z][a-z]+day\)", prompt)
+    assert m is not None, f"expected today=YYYY-MM-DD (Weekday); got: {prompt[-300:]}"

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -109,6 +109,13 @@ def test_start_creates_remote_session_with_agent_and_environment_ids(stores):
     assert "expected_output=text" in cw["initial_message"]
     assert "soft budget" in cw["initial_message"]
     assert "~$5.0" in cw["initial_message"]
+    # Today's date is injected for day-relative reasoning. Anthropic does
+    # not inject "today" into managed sessions, and the model has a fixed
+    # training cutoff — without this, calendar/due-date interpretation
+    # picks an arbitrary date inside the cutoff window.
+    import re
+    assert re.search(r"today=\d{4}-\d{2}-\d{2} \([A-Z][a-z]+day\)", cw["initial_message"]), \
+        cw["initial_message"][-300:]
     # Ambiguity policy NOT duplicated here — it lives in the agent preset's
     # system prompt (Anthropic console). User message stays task-specific.
     assert "ambiguous" not in cw["initial_message"]


### PR DESCRIPTION
## Summary

End-to-end testing of the same task across `#agent #cloud` and `#agent #local` surfaced two bugs in the agent worker stack.

**1. `lifeos_calendar_upcoming` MCP formatter read wrong fields.** It used `e["summary"]` and `e["start"]`, but the `/api/calendar/upcoming` response returns `title`, `start_time`/`end_time`, and `start_formatted`/`end_formatted`. Every upcoming event came back as "Untitled" with "No time". Cloud agent worked around it by pivoting to the Superhuman MCP; local Gemma had no fallback and produced garbled output referencing made-up dates.

Fix: read `title || summary || "Untitled"`, prefer the human-formatted strings when present, fall back to ISO timestamps. Also surface location when set, and show an end time only when distinct from start (so all-day single events stay tidy).

**2. Neither executor injected today's date.** Local Gemma reasoned about the calendar using `2025-05-14` (somewhere inside its training cutoff) instead of today (2026-05-26). The cloud agent dodged it accidentally because the Superhuman MCP echoes "(today)" in its responses. Without that crutch, day-relative reasoning broke.

Fix: prepend `today=YYYY-MM-DD (Weekday)` to the per-task `<this_task>` block (local) and the initial user message (cloud). Single concrete fact, ~25 characters — kept short so the local prompt cache invalidates only on day boundaries.

## Test evidence

- `tests/test_mcp_server.py` — 14 passed
- `tests/test_agent_worker_local_executor.py` + `test_agent_worker_managed_executor.py` — 36 passed, including new `test_system_prompt_includes_today_for_day_relative_reasoning` and an `assert re.search(r"today=...")` in the existing cloud start test
- Full agent_worker + mcp_server unit suites: 87 passed
- Will retest end-to-end against fresh #agent #cloud and #agent #local tasks after merge

## Review focus

- The formatter now does field fall-throughs (`title || summary`, `start_formatted || start_time || start`) — the legacy field names stay readable in case some upstream caller still returns the old shape
- Today's date is appended to the *dynamic* `<this_task>` trailer (already per-session); doesn't perturb the static cache-friendly portion
- `_today()` helper is module-level so tests can monkeypatch if needed; uses `astimezone()` so the operator's local timezone wins, not UTC

## Related

- Surfaced by manual E2E test session — companion to the `#117/#118/#120/#122/#123/#124` polish line