### PR TITLE
fix: restart lifeos-mcp-http on mcp_server.py change; persist final_text in transcripts

### DIFF
--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -469,8 +469,12 @@ class LocalExecutor:
 
     def _finalize_completed(self, session, final_text: str) -> ExecutorOutcome:
         self.session_store.update_status(session.task_id, STATUS_COMPLETED)
+        # Persist the body, not just the length. The final text is also sent
+        # to Telegram, but the transcript is the only durable record an
+        # operator can grep later to see what an agent actually said.
         self.transcript_store.append(
-            session.session_id, "completed", {"final_chars": len(final_text or "")}
+            session.session_id, "completed",
+            {"final_chars": len(final_text or ""), "final_text": final_text or ""},
         )
         return ExecutorOutcome(status=STATUS_COMPLETED, final_text=final_text or "")
 

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -271,9 +271,16 @@ class ManagedExecutor:
             # poll().
             final_text = state.final_text or self.session_store.get_managed_final_text(session.task_id) or ""
             self.session_store.update_status(session.task_id, STATUS_COMPLETED)
+            # Persist the body alongside its length. The final text is also
+            # sent to Telegram, but the transcript is the only durable record
+            # an operator can grep later to audit what an agent actually said.
+            # For cloud sessions the agent.message event is also in the
+            # transcript verbatim, but it's wrapped in a managed_event_… line
+            # — keeping the parsed text here is materially easier to grep.
             self.transcript_store.append(
                 session.session_id, "managed_completed",
                 {"final_chars": len(final_text),
+                 "final_text": final_text,
                  "remote_status": state.status,
                  "init_failed_mcps": list(state.init_failed_mcps)},
             )

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -36,14 +36,32 @@ if [ -z "$_LIFEOS_SKIP_DATE_NORMALIZE" ]; then
     fi
 fi
 
-# Only restart server if api/ or config/ files were changed
-CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD -- api/ config/)
+# Restart the API server if api/ or config/ files changed. server.sh
+# restarts lifeos-api, which cascades to lifeos-agent-worker via
+# `Requires=lifeos-api.service` in its unit file.
+CHANGED_API=$(git diff-tree --no-commit-id --name-only -r HEAD -- api/ config/)
 
-if [ -n "$CHANGED" ]; then
+if [ -n "$CHANGED_API" ]; then
     if [ -x "./scripts/server.sh" ]; then
         nohup ./scripts/server.sh restart > /tmp/lifeos-server-restart.log 2>&1 &
         echo "Server restart triggered (log: /tmp/lifeos-server-restart.log)"
     fi
-else
+fi
+
+# Restart lifeos-mcp-http when mcp_server.py changes. The HTTP MCP service
+# runs `mcp_server.py` as its own process — it shares no in-memory state
+# with lifeos-api, so it does NOT cascade from the api restart. Cloud
+# agents connect to this service exclusively. The sudoers allowlist
+# installed by setup-systemd.sh permits passwordless restart.
+CHANGED_MCP=$(git diff-tree --no-commit-id --name-only -r HEAD -- mcp_server.py)
+
+if [ -n "$CHANGED_MCP" ]; then
+    if systemctl list-unit-files lifeos-mcp-http.service &>/dev/null; then
+        nohup sudo systemctl restart lifeos-mcp-http >> /tmp/lifeos-server-restart.log 2>&1 &
+        echo "MCP HTTP service restart triggered (mcp_server.py changed)"
+    fi
+fi
+
+if [ -z "$CHANGED_API" ] && [ -z "$CHANGED_MCP" ]; then
     echo "No server restart needed"
 fi


### PR DESCRIPTION
## Summary

Two operator-polish fixes surfaced when I re-ran the E2E #agent #cloud test immediately after PR #125 merged.

### 1. Post-commit hook missed `lifeos-mcp-http` restart

`mcp_server.py` is loaded by three runtime contexts:
- `lifeos-api` (in-process, via `api/main.py`)
- `lifeos-agent-worker` (in-process, via `tools.py` → `LifeOSMCPServer`)
- **`lifeos-mcp-http`** (its own process — the HTTP transport that cloud agents connect to over Tailscale)

The agent-worker cascades from API restart via `Requires=lifeos-api.service` in its unit file. The mcp-http service only has `Wants=lifeos-api.service`, which does NOT propagate restarts. So after PR #125 merged, the **local** agent picked up the new calendar formatter immediately (because the worker was restarted via Requires=), but the **cloud** agent kept seeing the old "Untitled" / "No time" output because mcp-http was still running pre-PR code from this morning.

Fix: extend `scripts/post-commit` to also detect `mcp_server.py` changes and restart `lifeos-mcp-http` via sudo (sudoers allowlist installed by `setup-systemd.sh` already permits this passwordlessly).

### 2. `final_text` only existed in Telegram, not the transcript

The executors' `completed` transcript events recorded only `final_chars` (length), not the body. The actual text was sent to Telegram once and then lived nowhere durable. Now both `local_executor` and `managed_executor` write `final_text` into the transcript alongside the length. The managed path also has the agent.message event verbatim in `managed_event_…` form, but having the parsed text in the `completed` event is materially easier to grep.

## Test evidence

- `tests/test_agent_worker_local_executor.py` + `test_agent_worker_managed_executor.py` — 36 passed
- The fix is most visible by manual inspection: `lifeos-mcp-http` was confirmed running stale code from 10:25 AM via `systemctl show lifeos-mcp-http --property=ExecMainStartTimestamp` against the merge time of 19:38 PM

## Review focus

- The `nohup sudo systemctl restart lifeos-mcp-http` invocation goes to the same log file as the main restart, so operator inspection has one place to look
- The `systemctl list-unit-files lifeos-mcp-http.service` guard ensures the hook is harmless on installations where the operator hasn't enabled the HTTP MCP service (LIFEOS_MCP_BEARER_TOKEN unset case from setup-systemd.sh)
- `final_text` in the transcript: both call sites now consistent — when extending in future, do not split a "summary" field across multiple events