### PR TITLE
fix: operator timezone everywhere + Telegram-friendly output + artifact creation guidance

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -359,17 +359,17 @@ Return a JSON object with these fields:
 - "schedule_type": "once" for one-time, "cron" for recurring
 - "schedule_value": For "once" use ISO datetime (e.g., "2026-02-07T18:00:00-05:00"). For "cron" use cron expression (e.g., "0 18 * * *" for daily at 6pm)
 - "message_content": The reminder message to send (include any URLs mentioned)
-- "timezone": The timezone mentioned or implied (default to "America/New_York" for ET/Eastern)
+- "timezone": The IANA timezone mentioned or implied. Default to "{settings.timezone}" when none is given.
 
 IMPORTANT:
 - If no specific time is mentioned, use the time hint provided above
 - If the time hint shows tomorrow at 9am, use that as the schedule_value
-- Daily at 6pm ET = "0 18 * * *"
+- Daily at 6pm = "0 18 * * *"
 - Every weekday at 9am = "0 9 * * 1-5"
 - Convert times to 24-hour format for cron. 6pm = 18, 9am = 9, etc.
 
 Return ONLY valid JSON, no other text. Example:
-{{"name": "Library Book Reminder", "schedule_type": "once", "schedule_value": "2026-02-09T09:00:00-05:00", "message_content": "Return the library book", "timezone": "America/New_York"}}"""
+{{"name": "Library Book Reminder", "schedule_type": "once", "schedule_value": "2026-02-09T09:00:00-05:00", "message_content": "Return the library book", "timezone": "{settings.timezone}"}}"""
 
     try:
         synthesizer = get_synthesizer()

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -14,7 +14,9 @@ from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
-EASTERN = ZoneInfo("America/New_York")
+# The operator's local timezone, from `LIFEOS_TIMEZONE` (defaults to
+# America/New_York). Used to format message timestamps in tool output.
+LOCAL_TZ = ZoneInfo(settings.timezone)
 
 # ---------------------------------------------------------------------------
 # Tool definitions (Anthropic schema)
@@ -667,7 +669,7 @@ async def _tool_search_email(inp: dict) -> str:
         date_str = ""
         if m.date:
             try:
-                date_str = m.date.astimezone(EASTERN).strftime("%Y-%m-%d %I:%M %p ET")
+                date_str = m.date.astimezone(LOCAL_TZ).strftime("%Y-%m-%d %I:%M %p %Z")
             except Exception:
                 date_str = str(m.date)[:16]
         acct = f"[{m.source_account}]" if m.source_account else ""

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -129,6 +129,11 @@ glob, and grep tools operate on the operator's actual filesystem. The
 `lifeos` MCP exposes the operator's structured personal data (calendar,
 gmail, drive, photos, contacts, financial transactions, notes, tasks,
 reminders, person profiles, conversation history).
+
+The operator's vault path is in the `LIFEOS_VAULT_PATH` environment
+variable — run `echo "$LIFEOS_VAULT_PATH"` via Bash if you need the
+literal value. Markdown notes written under that path become Obsidian
+notes the operator can read on their phone immediately.
 </environment>
 
 <mcp_routing>
@@ -139,11 +144,30 @@ set (code, scratch notes, etc.). Use `Bash` for shell operations.
 </mcp_routing>
 
 <output_format>
-Every task must end with a final assistant turn containing a one-paragraph
-text summary. Tool calls alone are not a complete response. After your
-last tool call, produce a text turn that summarizes what you did and the
-key result. Be concrete: include specific names, counts, decisions, and
+Every task must end with a final assistant turn containing a text
+summary. Tool calls alone are not a complete response. After your last
+tool call, produce a text turn that summarizes what you did and the key
+result. Be concrete: include specific names, counts, decisions, and
 links. Skip filler phrases.
+
+The summary is delivered to the operator via Telegram, which does NOT
+render Markdown tables, headings (`#`), or code-block borders nicely.
+Prefer prose, bullets, and bold/italic emphasis. Avoid pipe-table
+syntax — write a short list with "Title — date/time" lines instead.
+
+When the natural output is longer than a few short paragraphs, or is
+inherently tabular (a list of rows with multiple columns), or is a
+deliverable the operator will reuse (a report, draft, plan, comparison),
+create an artifact and link to it in your summary rather than dumping
+the body inline:
+  - **Notes / reports / drafts**: write a Markdown file directly to the
+    vault using the `Write` tool, with a path like
+    `$LIFEOS_VAULT_PATH/Inbox/<descriptive-name>.md`. The operator's
+    Obsidian sync will pick it up automatically.
+  - **Tabular data**: write a CSV under `$LIFEOS_VAULT_PATH/Inbox/`.
+    Avoid Markdown pipe tables in either Telegram or vault notes.
+  - **Inline summary**: a 1–3 sentence Telegram message that says what
+    you did and the full path to the artifact (`/Users/.../Inbox/foo.md`).
 </output_format>
 
 <ambiguity>

--- a/api/services/calendar.py
+++ b/api/services/calendar.py
@@ -5,18 +5,22 @@ Fetches and indexes calendar events from Google Calendar.
 """
 import logging
 from datetime import datetime, timedelta, timezone
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from typing import Optional
 from zoneinfo import ZoneInfo
 
 from googleapiclient.discovery import build
 
 from api.services.google_auth import get_google_auth, GoogleAccount
+from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
-# Local timezone
-LOCAL_TZ = ZoneInfo("America/Los_Angeles")
+# The operator's local timezone, from `LIFEOS_TIMEZONE` (defaults to
+# America/New_York). All event formatting goes through this — calendar
+# events arrive from Google with their own tzinfo and we convert to the
+# operator's local zone for human-readable strings.
+LOCAL_TZ = ZoneInfo(settings.timezone)
 
 
 @dataclass

--- a/api/services/meeting_prep.py
+++ b/api/services/meeting_prep.py
@@ -7,18 +7,21 @@ with relevant notes, past meetings, and attendee information from the vault.
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Optional
 from zoneinfo import ZoneInfo
 
-from api.services.calendar import get_calendar_service, CalendarEvent, format_event_time
+from api.services.calendar import get_calendar_service, CalendarEvent
 from api.services.google_auth import get_configured_accounts
 from api.services.hybrid_search import get_hybrid_search
+from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
-# Local timezone for date handling
-LOCAL_TZ = ZoneInfo("America/Los_Angeles")
+# The operator's local timezone, from `LIFEOS_TIMEZONE` (defaults to
+# America/New_York). Used to anchor relative date parsing — "today" /
+# "tomorrow" / "this week" must be interpreted in the operator's zone.
+LOCAL_TZ = ZoneInfo(settings.timezone)
 
 
 @dataclass

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -221,13 +221,34 @@ system: |
   </mcp_routing>
 
   <output_format>
-  Every task must end with a final assistant turn containing a
-  one-paragraph text summary. Tool calls alone are not a complete
-  response. After your last tool call, produce a text turn summarizing
-  what you did and the key result. Be concrete: include specific names,
-  counts, decisions, links. Skip filler phrases like "I have completed
-  the task." Match the operator's voice when drafting on their behalf:
-  direct, lowercase-leaning, no LinkedIn-speak.
+  Every task must end with a final assistant turn containing a text
+  summary. Tool calls alone are not a complete response. After your last
+  tool call, produce a text turn summarizing what you did and the key
+  result. Be concrete: include specific names, counts, decisions, links.
+  Skip filler phrases like "I have completed the task." Match the
+  operator's voice when drafting on their behalf: direct, lowercase-
+  leaning, no LinkedIn-speak.
+
+  The summary is delivered to the operator via Telegram, which does NOT
+  render Markdown tables, headings (`#`), or code-block borders nicely.
+  Prefer prose, bullets, and bold/italic emphasis. Avoid pipe-table
+  syntax — write a short list with "Title — date/time" lines instead.
+
+  When the natural output is longer than a few short paragraphs, or is
+  inherently tabular (a list of rows with multiple columns), or is a
+  deliverable the operator will reuse (a report, draft, plan, comparison),
+  create an artifact in a persistent store and link to it in your summary
+  rather than dumping the body inline:
+    - Your Bash/Write tools target the container's ephemeral filesystem
+      and won't persist — never tell the operator to "see /tmp/foo.md"
+      because that file is gone the moment your session ends.
+    - **Reports / drafts / notes** → create a Google Doc via the
+      `google_drive` MCP (or whatever doc-creation MCP is attached) and
+      include the share URL in your summary.
+    - **Tabular data** → create a Google Sheet via the same MCP. Never
+      use Markdown pipe tables.
+    - **Inline summary** → a 1–3 sentence Telegram message saying what
+      you did and the artifact URL.
   </output_format>
 
   <ambiguity>


### PR DESCRIPTION
## Summary

Three issues surfaced when reviewing the agent's actual Telegram messages from the E2E retests.

### 1. Hardcoded `America/Los_Angeles` in calendar/meeting_prep

`calendar.py` and `meeting_prep.py` both had `LOCAL_TZ = ZoneInfo("America/Los_Angeles")`, ignoring `settings.timezone` (which defaults to `America/New_York`). Result: 8 PM Eastern events rendered as 5 PM (3 hours behind). `agent_tools.py` had hardcoded `EASTERN = ZoneInfo("America/New_York")` with a literal "ET" suffix in the strftime, and `chat.py`'s reminder-extraction prompt had two hardcoded "America/New_York" strings. All four now interpolate `settings.timezone`. Same memory class as the broader open-source invariant.

### 2. Telegram doesn't render Markdown tables

Both executors' system prompts (local in `local_executor.py`, cloud in the YAML at `docs/guides/agent-worker-setup.md`) now tell the agent to use prose + bullets instead of pipe tables, with concrete examples. Headings and code-block borders also call out as problematic.

### 3. No artifact-creation guidance for longer outputs

Neither prompt told the agent what to do when the natural output is longer than a Telegram message or is inherently tabular. Now:
- **Local agent** → "write a Markdown/CSV under `$LIFEOS_VAULT_PATH/Inbox/` and link to it in your summary." The local Write tool hits the operator's actual filesystem, so vault writes persist and Obsidian picks them up immediately.
- **Cloud agent** → "your Bash/Write tools target an ephemeral container — create a Google Doc/Sheet via the attached `google_drive` MCP and include the share URL instead." Stops agents from telling the operator to "see /tmp/foo.md" which evaporates.

## Test evidence

- Full unit suite: 1378 passed (2 pre-existing integration-test flakes against the live LLM, unrelated)
- agent_worker focused: 87 passed
- Verified the timezone fix on a live `/api/calendar/upcoming` call after `lifeos-api` restart

## Review focus

- The 4-file timezone scrub uses the same pattern everywhere: `ZoneInfo(settings.timezone)` with `%Z` in strftime so the abbreviation tracks the zone
- Local artifact guidance is concrete (`$LIFEOS_VAULT_PATH/Inbox/<name>.md`) — the cloud version is deliberately more abstract because the cloud preset can't know which doc-creation MCP the operator has attached
- Also removes a handful of pre-existing unused imports the ruff hook caught when these files were touched. Listed in the commit body

## Operator follow-up

Re-import the updated cloud preset YAML from `docs/guides/agent-worker-setup.md` (Step 4b → "3. Create the Agent preset") into the Anthropic console. This bumps the preset to a new version with the Telegram + artifact guidance.