### PR TITLE
fix: route-aware label, vault spillover, less-eager preflight, re-seed on clarification resume

### DIFF
--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -274,8 +274,12 @@ class LocalExecutor:
     def execute(self, session, task: dict) -> ExecutorOutcome:
         """Run the agent loop for one session.
 
-        - If `messages` table is empty for this session, seed the conversation
-          with a system message and a user turn built from the task.
+        - If the conversation has never been seeded with a system prompt
+          (e.g., preflight blocked for ambiguity before the executor ran,
+          and the worker is now resuming after a Telegram clarification
+          reply), seed it now and keep any pre-existing messages (the
+          injected user answer) at the end so the agent sees both the
+          original task and the operator's clarification.
         - Loops until the model produces a final answer, the budget is hit,
           a tool yields (sleep), or an error.
         """
@@ -283,8 +287,22 @@ class LocalExecutor:
         budget = session.budget or {}
         self.session_store.update_status(session.task_id, STATUS_RUNNING)
 
-        if not self.session_store.get_messages(sid):
+        existing = self.session_store.get_messages(sid)
+        has_system = any(m.get("role") == "system" for m in existing)
+        if not has_system:
+            # First execution OR a resume from a preflight-blocked session
+            # that never seeded. The worker may have pre-injected a user
+            # "answer" message; seed cleanly with system+task first, then
+            # re-append the answer so the model sees both the original
+            # task and the operator's clarification in the right order.
+            preexisting = list(existing)
+            self.session_store.clear_messages(sid)
             self._seed_conversation(session, task, budget)
+            for m in preexisting:
+                role = m.get("role")
+                content = m.get("content", "")
+                if role in ("user", "assistant"):
+                    self.session_store.append_message(sid, role, content)
 
         while True:
             # Wall-clock budget check — uses cumulative active seconds, not

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -121,7 +121,7 @@ Rules:
        ask the operator which model).
 - expected_output: classify what the agent will produce.
     "text" = a written answer; "file" = creates/edits a file; "external_action" = sends an email, posts a message, schedules a meeting; "structured" = returns structured data the caller will parse.
-- ambiguity: set to non-null only if the title is genuinely underspecified for an autonomous agent (e.g., "reply to John" with no email/context). One question, not multiple.
+- ambiguity: leave null in nearly all cases. The agent is autonomous and is expected to make reasonable assumptions, try one approach, and fall back to another if the first didn't work. Only set non-null when the title would *prevent* the agent from acting at all — e.g., "reply to John" with no John in scope, or "send the contract to her" with no antecedent for "her". Method-of-execution questions ("should I use web search or local data?", "which calendar?", "what format?") are NOT ambiguity — the agent picks one and adapts. 
 - sane: set to false ONLY for empty/garbage titles or obviously destructive shapes (e.g., "rm -rf /", "delete all my data"). Mundane tasks are sane.
 
 Tag list and title follow. Return ONLY the JSON.

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -528,6 +528,21 @@ class SessionStore:
             ).fetchall()
         return [{"role": r["role"], "content": json.loads(r["content_json"])} for r in rows]
 
+    def clear_messages(self, session_id: str) -> None:
+        """Remove all stored messages for a session.
+
+        Used by the local executor when resuming a session that was blocked
+        at preflight before being seeded — the worker pre-injected the
+        operator's clarification answer, but no system / task message
+        exists. The executor clears, re-seeds with system+task, then
+        re-appends the answer so the conversation arrives in the right
+        order.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM messages WHERE session_id = ?", (session_id,),
+            )
+
     # ------------------------------------------------------------------
     # Sleeps (yield / wake)
     # ------------------------------------------------------------------

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -44,10 +44,29 @@ from api.services.agent_worker.session_store import (
 )
 from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.interaction_store import build_obsidian_link
 from config.settings import settings
 
 
 logger = logging.getLogger(__name__)
+
+# Inline-summary cap. Telegram allows ~4096 chars; we leave headroom for
+# the worker's header (icon + title + token/cost line) and any footer
+# (init-failed MCPs). Above this we spill the body to a vault note and
+# put just a 1-line preview + obsidian:// link in the Telegram message.
+_INLINE_SUMMARY_MAX_CHARS = 2000
+
+
+def _worker_label(routing: str | None) -> str:
+    """Telegram-message prefix that names the route — operator wants to
+    know at a glance whether a result came from local Gemma or cloud
+    Claude. Defaults to the generic "Agent worker" when the routing
+    isn't known yet (e.g., startup recovery messages)."""
+    if routing == ROUTE_LOCAL:
+        return "Local agent worker"
+    if routing == ROUTE_CLAUDE:
+        return "Cloud agent worker"
+    return "Agent worker"
 
 
 AGENT_TAG = "agent"
@@ -207,7 +226,7 @@ class Worker:
             self._swap_tag(session.task_id, RUNNING_TAG, AGENT_TAG)
             self.session_store.update_status(session.task_id, STATUS_FAILED)
             self._notify(
-                f"⚠️ Agent worker: task left in {session.status!r} from a prior "
+                f"⚠️ {_worker_label(session.routing)}: task left in {session.status!r} from a prior "
                 f"run could not be safely resumed — tag rolled back to "
                 f"#{AGENT_TAG} for retry. Transcript: "
                 f"data/agent_transcripts/{sid}.jsonl"
@@ -561,8 +580,10 @@ class Worker:
             self.transcript_store.append(q["session_id"], "clarification_timed_out", {
                 "question_id": q["id"],
             })
+            stale_session = self.session_store.get_by_session_id(q["session_id"])
+            label = _worker_label(stale_session.routing if stale_session else None)
             self._notify(
-                f"⏰ Agent worker: task is still waiting on your reply.\n\n"
+                f"⏰ {label}: task is still waiting on your reply.\n\n"
                 f"Question: {q['question'][:300]}\n\n"
                 f"(Task remains at #{BLOCKED_TAG}. Reply to the original "
                 f"question to unblock, or re-tag with #{AGENT_TAG} to retry.)"
@@ -624,7 +645,7 @@ class Worker:
                 self.session_store.update_status(session.task_id, STATUS_FAILED)
                 self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
                 self._notify(
-                    f"⚠️ Agent worker: error while resuming sleeping task "
+                    f"⚠️ {_worker_label(session.routing)}: error while resuming sleeping task "
                     f"'{task.get('description', session.task_id)}': {exc}"
                 )
                 continue
@@ -892,7 +913,7 @@ class Worker:
                 self.session_store.update_status(task_id, STATUS_BLOCKED)
                 self.transcript_store.append(sid, "managed_not_configured", {})
                 self._notify(
-                    f"⏸ Agent worker: task '{title}' routed to Claude but "
+                    f"⏸ {_worker_label(ROUTE_CLAUDE)}: task '{title}' routed to Claude but "
                     f"Managed Agents isn't configured. Set ANTHROPIC_API_KEY, "
                     f"LIFEOS_AGENT_PRESET_ID, and LIFEOS_AGENT_ENVIRONMENT_ID "
                     f"in .env (see docs/guides/agent-worker-setup.md for the "
@@ -932,10 +953,11 @@ class Worker:
             self._notify(self._completion_summary(session, task, outcome))
             return
 
+        label = _worker_label(session.routing)
         if outcome.status == STATUS_BUDGET_EXCEEDED:
             self._swap_tag(session.task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
             self._notify(
-                f"⚠️ Agent worker: task '{title}' hit its budget ({outcome.reason}). "
+                f"⚠️ {label}: task '{title}' hit its budget ({outcome.reason}). "
                 f"Transcript: data/agent_transcripts/{sid}.jsonl"
             )
             return
@@ -943,7 +965,7 @@ class Worker:
         if outcome.status == STATUS_FAILED:
             self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
             self._notify(
-                f"⚠️ Agent worker: task '{title}' failed: {outcome.reason}. "
+                f"⚠️ {label}: task '{title}' failed: {outcome.reason}. "
                 f"Transcript: data/agent_transcripts/{sid}.jsonl"
             )
             return
@@ -963,6 +985,7 @@ class Worker:
         active_s = int(refreshed.total_active_seconds or 0)
         expected = refreshed.expected_output or "text"
         title = task.get("description", session.task_id)
+        label = _worker_label(refreshed.routing or session.routing)
 
         # Body: prefer the agent's final text. When it's empty (the agent
         # used a tool and idled without summarizing — sometimes happens with
@@ -970,15 +993,34 @@ class Worker:
         # operator can inspect what the agent actually did instead of seeing
         # a blank message. The transcript captures every tool call.
         final_text = (outcome.final_text or "").strip()
-        if final_text:
-            result_blurb = final_text
-            if len(result_blurb) > 600:
-                result_blurb = result_blurb[:600] + "…"
-        else:
+        if not final_text:
             result_blurb = (
                 f"(agent idled without a final text reply — check transcript at "
                 f"data/agent_transcripts/{session.session_id}.jsonl for tool-use detail)"
             )
+        elif len(final_text) <= _INLINE_SUMMARY_MAX_CHARS:
+            result_blurb = final_text
+        else:
+            # Spill the full body to a vault note and link to it instead of
+            # truncating mid-answer. The agent's system prompts now ask the
+            # agent itself to create artifacts for long outputs, but the
+            # operator-facing UX shouldn't depend on the agent following
+            # that guidance: any over-length response gets spilled here.
+            spillover = self._spill_to_vault(session, task, final_text)
+            if spillover is None:
+                # Vault not configured or write failed — preserve the old
+                # behavior so the operator still gets *something* readable.
+                result_blurb = final_text[:_INLINE_SUMMARY_MAX_CHARS] + "…"
+            else:
+                rel_path, obsidian_url = spillover
+                preview = final_text.split("\n\n", 1)[0].strip()
+                if len(preview) > 400:
+                    preview = preview[:400].rsplit(" ", 1)[0] + "…"
+                result_blurb = (
+                    f"{preview}\n\n"
+                    f"Full answer saved to vault: {rel_path}\n"
+                    f"Open: {obsidian_url}"
+                )
 
         # Footer: when some MCP servers failed to initialize during the session,
         # list them so the operator can fix or remove the broken connectors from
@@ -989,17 +1031,71 @@ class Worker:
             footer = f"\n\nNote: {len(init_failed)} MCP server(s) unavailable this session: {', '.join(init_failed)}"
 
         return (
-            f"✅ Agent worker: completed '{title}' "
+            f"✅ {label}: completed '{title}' "
             f"({expected}) — {tokens:,} tokens, ${refreshed.total_dollars:.2f}, "
             f"{active_s}s active.\n\n{result_blurb}{footer}"
         )
+
+    def _spill_to_vault(
+        self, session: Session, task: dict[str, Any], final_text: str,
+    ) -> tuple[str, str] | None:
+        """Write the agent's full response to a vault Markdown file and
+        return (vault-relative path, obsidian:// URL). Returns None when
+        the vault path is unset or the write fails — caller falls back to
+        a truncated inline summary so the operator never loses content
+        entirely.
+
+        File layout: `<vault>/Inbox/Agent Output/<YYYY-MM-DD>-<slug>.md`.
+        Inbox is the standard landing folder for Obsidian setups and
+        keeps these next to other unsorted captures.
+        """
+        from datetime import datetime
+        import re
+
+        vault_root = settings.vault_path
+        if not vault_root:
+            return None
+        try:
+            vault_root = vault_root.expanduser() if hasattr(vault_root, "expanduser") else vault_root
+        except Exception:
+            return None
+
+        title = (task.get("description") or session.task_id).strip()
+        slug = re.sub(r"[^A-Za-z0-9]+", "-", title).strip("-").lower()[:60] or session.task_id
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
+        filename = f"{today}-{slug}.md"
+        folder = "Inbox/Agent Output"
+
+        try:
+            target_dir = vault_root / folder
+            target_dir.mkdir(parents=True, exist_ok=True)
+            file_path = target_dir / filename
+            # Frontmatter gives Obsidian / Dataview something to query on
+            # without changing how the body renders.
+            frontmatter = (
+                "---\n"
+                f"task: {title}\n"
+                f"session_id: {session.session_id}\n"
+                f"routing: {session.routing or 'unknown'}\n"
+                f"created: {today}\n"
+                "source: agent-worker\n"
+                "---\n\n"
+            )
+            file_path.write_text(frontmatter + final_text, encoding="utf-8")
+        except Exception as exc:
+            logger.warning("vault spillover write failed for %s: %s", session.task_id, exc)
+            return None
+
+        rel_path = f"{folder}/{filename}"
+        obsidian_url = build_obsidian_link(str(file_path), str(vault_root))
+        return (rel_path, obsidian_url)
 
     def _mark_failed(self, session: Session, task: dict[str, Any], reason: str) -> None:
         title = task.get("description", session.task_id)
         self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
         self.session_store.update_status(session.task_id, STATUS_FAILED)
         self.transcript_store.append(session.session_id, "failed", {"reason": reason})
-        self._notify(f"⚠️ Agent worker: task '{title}' failed: {reason}")
+        self._notify(f"⚠️ {_worker_label(session.routing)}: task '{title}' failed: {reason}")
 
     def _mark_blocked(self, session: Session, task: dict[str, Any], question: str) -> None:
         title = task.get("description", session.task_id)
@@ -1027,7 +1123,7 @@ class Worker:
         # Issue F: send the question with reply-threading enabled so the user's
         # reply lands in pending_questions.answer and the worker resumes.
         body = (
-            f"⏸ Agent worker: task '{title}' needs your input.\n\n"
+            f"⏸ {_worker_label(session.routing)}: task '{title}' needs your input.\n\n"
             f"{question}\n\n"
             "Reply to this message to answer."
         )

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -99,6 +99,53 @@ def _make_executor(session_store, transcript_dir, llm):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.unit
+def test_executor_reseeds_with_original_task_when_resuming_after_blocked_clarification(
+    tmp_path: Path, fake_session,
+):
+    """Repro of the live bug: preflight blocks for ambiguity → executor
+    never runs → worker resumes by appending only the user's answer →
+    executor saw a 1-message history that wasn't the task ("Web Searches")
+    and acted on it as if it were the task. After the fix, executor
+    detects the missing system role, clears, re-seeds with system +
+    original task, and re-appends the answer in the right order."""
+    store, session = fake_session
+    sid = session.session_id
+
+    # Worker has pre-injected the operator's Telegram reply, but seeding
+    # never happened. Conversation has exactly one orphan user message.
+    store.append_message(sid, "user", "(user answered via Telegram) Web Searches")
+
+    llm = _ScriptedLLM([
+        _FakeResponse(text="Done with task using web search.", usage=_FakeUsage(40, 20)),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    outcome = executor.execute(
+        session,
+        {"id": "t1", "description": "Summarize professional background of Julia Barnes"},
+    )
+
+    assert outcome.status == STATUS_COMPLETED
+    # First (and only) LLM call must see: system, then user-task, then user-answer.
+    first_call = llm.calls[0]
+    system_text = first_call["system"]
+    msgs = first_call["messages"]
+    assert system_text and "<role>" in system_text, "system prompt was missing"
+    # Build a flat sequence of (role, text-substring) to assert order.
+    roles_and_text = [(m["role"], m["content"] if isinstance(m["content"], str) else "") for m in msgs]
+    # Drop tool_result-shaped messages — only care about textual ones here.
+    text_only = [(r, t) for r, t in roles_and_text if t]
+    assert text_only[0][0] == "user"
+    assert "Julia Barnes" in text_only[0][1] and "Task:" in text_only[0][1]
+    # The user's answer comes AFTER the task message, not before.
+    answer_idx = next(i for i, (r, t) in enumerate(text_only) if "Web Searches" in t)
+    task_idx = next(i for i, (r, t) in enumerate(text_only) if "Julia Barnes" in t)
+    assert task_idx < answer_idx, (
+        "user answer must come after the seeded task message — out of "
+        f"order would re-introduce the live bug. Got: {text_only}"
+    )
+
+
+@pytest.mark.unit
 def test_executor_completes_when_model_returns_text_only(tmp_path: Path, fake_session):
     store, session = fake_session
     llm = _ScriptedLLM([

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -464,6 +464,130 @@ def test_completion_summary_omits_footer_when_no_init_failures(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_completion_label_says_local_for_local_routing(tmp_path: Path):
+    """Operator wants to know at a glance whether a result came from local
+    Gemma or cloud Claude — the worker label is route-aware."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "task", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="done",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent
+    assert "Local agent worker" in sent[0]
+    assert "Cloud agent worker" not in sent[0]
+
+
+@pytest.mark.unit
+def test_completion_inline_summary_kept_when_under_cap(tmp_path: Path):
+    """A short final_text is delivered inline — no spillover to vault."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "summarize", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    # Just under the 2000-char inline cap
+    short_text = "Here is the answer. " * 50  # 1000 chars
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text=short_text,
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent
+    assert short_text.strip() in sent[0]
+    assert "Full answer saved to vault" not in sent[0]
+    assert "obsidian://" not in sent[0]
+
+
+@pytest.mark.unit
+def test_completion_spills_to_vault_when_over_cap(tmp_path: Path, monkeypatch):
+    """When final_text is >2000 chars, the worker writes the full body
+    to the vault and replaces the inline blob with a short preview +
+    obsidian:// link. The operator should never see a mid-paragraph
+    truncation again."""
+    from config.settings import settings as _settings
+    vault = tmp_path / "MyVault"
+    monkeypatch.setattr(_settings, "vault_path", vault, raising=False)
+
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "Big report on Julia",
+         "status": "todo", "tags": ["agent", "cloud"]},
+    ])
+    long_text = (
+        "Julia Barnes is the CEO of The Movement Cooperative.\n\n"
+        + ("Paragraph body content that goes on and on. " * 80)  # ~3200 chars
+    )
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text=long_text,
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude"),
+                     local_executor=executor)  # used for unrelated paths
+    # Force the local path so we can drive the completion through _StubExecutor.
+    # Use routing="local" on the preflight so the worker takes the local branch
+    # while still exercising the cap logic.
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent, "expected a Telegram notification"
+    msg = sent[0]
+    # The inline preview is short (≤400 chars after first paragraph break)
+    assert "Julia Barnes is the CEO" in msg
+    # Spillover markers present
+    assert "Full answer saved to vault" in msg
+    assert "obsidian://" in msg
+    # The full body is NOT inlined verbatim
+    assert long_text not in msg
+    # The vault file exists with the expected structure
+    out_dir = vault / "Inbox" / "Agent Output"
+    md_files = list(out_dir.glob("*.md"))
+    assert len(md_files) == 1, f"expected one spillover file; got {md_files}"
+    body = md_files[0].read_text(encoding="utf-8")
+    # Frontmatter then the full text
+    assert body.startswith("---\n")
+    assert "task: Big report on Julia" in body
+    assert "Paragraph body content that goes on and on." in body
+
+
+@pytest.mark.unit
+def test_completion_falls_back_to_truncation_when_vault_unset(tmp_path: Path, monkeypatch):
+    """If `LIFEOS_VAULT_PATH` is unset (fresh install), the worker can't
+    spill — it falls back to truncating the inline text so the operator
+    still sees something instead of a write error."""
+    from config.settings import settings as _settings
+    monkeypatch.setattr(_settings, "vault_path", None, raising=False)
+
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "report", "status": "todo",
+         "tags": ["agent", "local"]},
+    ])
+    long_text = "X" * 3000
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text=long_text,
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent
+    msg = sent[0]
+    # Truncated, with the ellipsis sentinel
+    assert "…" in msg or "..." in msg
+    # No vault references
+    assert "vault" not in msg.lower()
+    assert "obsidian://" not in msg
+
+
+@pytest.mark.unit
 def test_managed_executor_constructed_with_full_credentials(tmp_path: Path, monkeypatch):
     """When API key + agent_preset_id + agent_environment_id + agent_vault_id
     are all set, the worker constructs a ManagedExecutor with each ID flowing

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -174,6 +174,22 @@ def test_preflight_prompt_infers_claude_from_capability_phrases():
 
 
 @pytest.mark.unit
+def test_preflight_prompt_says_method_questions_are_not_ambiguity():
+    """Repro of the live bug: preflight was flagging "summarize Julia's
+    background" as ambiguous because the agent could use either local
+    docs or web search. The prompt now tells the classifier that
+    method-of-execution choices are NEVER ambiguity — the agent picks
+    one and adapts. Without this guidance Haiku over-blocks."""
+    prompt = pf.build_preflight_prompt(title="anything", tags=["agent"])
+    lowered = prompt.lower()
+    assert "method-of-execution" in lowered or "method of execution" in lowered
+    # The classifier must be told these aren't ambiguity (NOT / NEVER).
+    assert "not ambiguity" in lowered or "never ambiguity" in lowered
+    # And the prefer-null guidance must be in there too
+    assert "leave null" in lowered or "prefer null" in lowered
+
+
+@pytest.mark.unit
 def test_preflight_prompt_includes_ordered_precedence():
     """Routing precedence must be clearly ordered (tags first, explicit cues
     second, capability inference third, ask as final fallback)."""


### PR DESCRIPTION
## Summary

Four related fixes surfaced by live agent runs.

### 1. Telegram label says "Local agent worker" / "Cloud agent worker"

Was just "Agent worker" — the operator wants to know at a glance whether a result came from local Gemma or cloud Claude. The label is route-aware in every notify site that has `session.routing` available; pre-claim notifications (e.g., claim-failed) keep the generic "Agent worker" since the route isn't decided yet.

### 2. Vault spillover replaces the 600-char inline truncation

The cloud agent on session f8d6e069 produced a great 1506-char Julia Barnes summary; the worker chopped it at 600 chars with "…". Fix: when `final_text` exceeds 2000 chars, write the full body to `$LIFEOS_VAULT_PATH/Inbox/Agent Output/<YYYY-MM-DD>-<slug>.md` with frontmatter (task / session_id / routing / created), and the Telegram message becomes a short preview + `obsidian://open?vault=…&file=…` URL. The agent's own prompts (from #127) already tell the agent to spill long output itself; this is a worker-side safety net so the operator never sees a mid-paragraph cutoff regardless of whether the agent followed that guidance. Falls back to inline truncation only when the vault path is unset (fresh install).

### 3. Preflight ambiguity guidance is less eager

Local session 3f4a9d80 was blocked at preflight asking "should the agent search the web or use local context?" — that's a method-of-execution choice, not a missing-information choice. The classifier prompt now explicitly tells Haiku:
- Method-of-execution questions ("should I use web search?", "which calendar?", "what format?") are NOT ambiguity — the agent picks one and adapts
- Only block when the title would PREVENT the agent from acting at all (missing antecedent like "reply to her" with no "her" in scope)
- When unsure, leave null

### 4. Re-seed on clarification resume

Once the operator answered "Web Searches" on the same blocked session 3f4a9d80, the resumed local executor saw a 1-message conversation history that was just "(user answered via Telegram) Web Searches" — no system prompt, no original task. Local Gemma interpreted that as the entire query and did a Gmail search for the literal string "Web Search". Fix: the local executor now detects the missing system role on entry, clears the orphan message(s), re-seeds with `_system_prompt` + the original task `_user_message_for`, then re-appends any pre-existing user messages so the conversation arrives in the right order. New `SessionStore.clear_messages(session_id)` supports this.

## Test evidence

- 94 agent_worker unit tests pass (4 new: route-aware label, inline-under-cap, vault-spillover-over-cap, vault-unset fallback, plus the re-seed and preflight assertions)
- The vault spillover test asserts the spilled .md exists at the expected path, has frontmatter, and that the Telegram message contains a short preview + `obsidian://` URL
- The re-seed test is structured as a repro of the live bug: it pre-injects a "user answered" message exactly as the worker would, runs `executor.execute`, and asserts the LLM sees system → user-task → user-answer in that order

## Review focus

- `_spill_to_vault` placement: file written under `Inbox/Agent Output/` so it follows operators' standard "stuff lands in Inbox" Obsidian convention. Frontmatter is intentionally minimal (task, session_id, routing, created, source) so future Dataview queries are obvious
- The 2000-char cap is a soft threshold — Telegram allows 4096 but we leave headroom for the header (icon + title + token/cost line) and the init-failed-MCPs footer
- `clear_messages` is destructive — only called on the very narrow path where `has_system=False` (executor never ran for this session). The pre-existing user messages are captured into a list before the delete, then re-appended in order
- Preflight prompt edit is in the dynamic-formatted block; cached portion unchanged