### PR TITLE
fix: declared agent output dir + inter-agent caller_session_id schema + injection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,12 @@
 # before being abandoned permanently. Used by Issue F.
 # LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS=72
 
+# Vault-relative directory where agent-created artifacts land (long-output
+# spillover from the worker, and Markdown/CSV notes the local agent writes
+# directly). Joined under LIFEOS_VAULT_PATH. Operator can move this
+# anywhere their Obsidian vault expects to find captured work.
+# LIFEOS_AGENT_OUTPUT_DIR=LifeOS/Tasks/Agent Output
+
 # Managed Agents (Claude-routed #agent tasks). See docs/guides/agent-worker-setup.md
 # for the one-time console setup. All three of the following must be set for
 # the worker to attempt cloud sessions — otherwise non-#local #agent tasks

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -102,104 +102,98 @@ def _err(message: str, code: str = "error") -> dict:
 # Tool definitions (Anthropic format) — shared by local and managed agents.
 # ---------------------------------------------------------------------------
 
+# Every inter-agent tool requires `caller_session_id` — the calling agent's
+# own session id, which it should pass from the `lifeos_session_id` field
+# in its task brief / user message. The MCP HTTP layer (cloud path) can't
+# infer this server-side because the request crosses a process boundary;
+# the local dispatcher does inject it from context, overriding whatever
+# the agent passes. Declaring it required in the schema teaches the cloud
+# agent to include it.
+_CALLER_PROP = {
+    "type": "string",
+    "description": "Your own session_id, copied verbatim from the "
+                   "`lifeos_session_id=` field in your task brief.",
+}
+
+
+def _with_caller(props: dict, required: list[str]) -> dict:
+    """Inject `caller_session_id` into a tool schema."""
+    new_props = {"caller_session_id": _CALLER_PROP, **props}
+    return {
+        "type": "object",
+        "properties": new_props,
+        "required": ["caller_session_id"] + list(required),
+    }
+
+
 INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
         "name": "lifeos_agent_spawn",
         "description": "Spawn a child agent session that runs in parallel. Returns immediately with a `child_session_id` you can monitor with `lifeos_agent_check` or wait on with `lifeos_agent_yield_until`. Budget is drawn from your remaining lineage budget.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "prompt": {"type": "string", "description": "Task description for the child agent"},
-                "model": {"type": "string", "enum": ["claude", "local"], "description": "Which executor to run the child on"},
-                "max_dollars": {"type": "number", "description": "Optional per-child dollar budget"},
-                "max_tokens": {"type": "integer", "description": "Optional per-child token budget"},
-                "wall_seconds": {"type": "integer", "description": "Optional per-child wall-clock budget"},
-                "expected_output": {"type": "string", "enum": ["text", "file", "external_action", "structured"]},
-            },
-            "required": ["prompt", "model"],
-        },
+        "input_schema": _with_caller({
+            "prompt": {"type": "string", "description": "Task description for the child agent"},
+            "model": {"type": "string", "enum": ["claude", "local"], "description": "Which executor to run the child on"},
+            "max_dollars": {"type": "number", "description": "Optional per-child dollar budget"},
+            "max_tokens": {"type": "integer", "description": "Optional per-child token budget"},
+            "wall_seconds": {"type": "integer", "description": "Optional per-child wall-clock budget"},
+            "expected_output": {"type": "string", "enum": ["text", "file", "external_action", "structured"]},
+        }, required=["prompt", "model"]),
     },
     {
         "name": "lifeos_agent_send",
         "description": "Append a user-role message to another agent session. For sessions that are yielded or sleeping, the message is queued and delivered on resume.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "session_id": {"type": "string"},
-                "message": {"type": "string"},
-            },
-            "required": ["session_id", "message"],
-        },
+        "input_schema": _with_caller({
+            "session_id": {"type": "string"},
+            "message": {"type": "string"},
+        }, required=["session_id", "message"]),
     },
     {
         "name": "lifeos_agent_check",
         "description": "Non-blocking status of an agent session: current status, tokens/dollars used, last activity. Use for short-polling; prefer `lifeos_agent_yield_until` for waits >1 minute.",
-        "input_schema": {
-            "type": "object",
-            "properties": {"session_id": {"type": "string"}},
-            "required": ["session_id"],
-        },
+        "input_schema": _with_caller({
+            "session_id": {"type": "string"},
+        }, required=["session_id"]),
     },
     {
         "name": "lifeos_agent_yield_until",
         "description": "Pause yourself until all listed children reach a terminal state. Your current session ends; when the condition is met, a fresh resumed session is created with the children's outputs injected as a new user turn. This is the preferred wait primitive — no idle billing.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "children": {"type": "array", "items": {"type": "string"}, "description": "session_ids to wait on"},
-                "reason": {"type": "string", "description": "Why you're yielding (one short sentence)"},
-            },
-            "required": ["children"],
-        },
+        "input_schema": _with_caller({
+            "children": {"type": "array", "items": {"type": "string"}, "description": "session_ids to wait on"},
+            "reason": {"type": "string", "description": "Why you're yielding (one short sentence)"},
+        }, required=["children"]),
     },
     {
         "name": "lifeos_agent_kill",
         "description": "Terminate a descendant session. Only allowed on sessions whose lineage descends from yours.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "session_id": {"type": "string"},
-                "reason": {"type": "string"},
-            },
-            "required": ["session_id"],
-        },
+        "input_schema": _with_caller({
+            "session_id": {"type": "string"},
+            "reason": {"type": "string"},
+        }, required=["session_id"]),
     },
     {
         "name": "lifeos_agent_transcript_read",
         "description": "Read the event log (JSONL transcript) of any agent session — your own, a child's, or any sibling/peer.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "session_id": {"type": "string"},
-                "since_turn": {"type": "integer", "description": "Optional: skip events before this index"},
-            },
-            "required": ["session_id"],
-        },
+        "input_schema": _with_caller({
+            "session_id": {"type": "string"},
+            "since_turn": {"type": "integer", "description": "Optional: skip events before this index"},
+        }, required=["session_id"]),
     },
     {
         "name": "lifeos_agent_sessions_list",
         "description": "List recent agent sessions, optionally filtered by status / routing / parent.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string"},
-                "routing": {"type": "string", "enum": ["claude", "local"]},
-                "parent_session_id": {"type": "string"},
-                "limit": {"type": "integer"},
-            },
-            "required": [],
-        },
+        "input_schema": _with_caller({
+            "status": {"type": "string"},
+            "routing": {"type": "string", "enum": ["claude", "local"]},
+            "parent_session_id": {"type": "string"},
+            "limit": {"type": "integer"},
+        }, required=[]),
     },
     {
         "name": "lifeos_agent_user_ask",
         "description": "Ask the operator a clarifying question via Telegram and pause until they reply. Your session ends; the worker resumes it (with the user's answer injected as a new user turn) once the reply arrives. Use sparingly — only when you genuinely cannot proceed without operator input.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "question": {"type": "string", "description": "The question to ask the operator. Keep it short and specific."},
-            },
-            "required": ["question"],
-        },
+        "input_schema": _with_caller({
+            "question": {"type": "string", "description": "The question to ask the operator. Keep it short and specific."},
+        }, required=["question"]),
     },
 ]
 

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -189,6 +189,11 @@ tool call, produce a text turn that summarizes what you did and the key
 result. Be concrete: include specific names, counts, decisions, and
 links. Skip filler phrases.
 
+Critically: your final turn must report results, not intentions. Never
+end with "I'll do X next" or "let me now Y" — those are promises, not
+completions. If you genuinely need more turns, take them now; only end
+the session when the task is actually done.
+
 The summary is delivered to the operator via Telegram, which does NOT
 render Markdown tables, headings (`#`), or code-block borders nicely.
 Prefer prose, bullets, and bold/italic emphasis. Avoid pipe-table
@@ -198,15 +203,16 @@ When the natural output is longer than a few short paragraphs, or is
 inherently tabular (a list of rows with multiple columns), or is a
 deliverable the operator will reuse (a report, draft, plan, comparison),
 create an artifact and link to it in your summary rather than dumping
-the body inline:
-  - **Notes / reports / drafts**: write a Markdown file directly to the
-    vault using the `Write` tool, with a path like
-    `$LIFEOS_VAULT_PATH/Inbox/<descriptive-name>.md`. The operator's
-    Obsidian sync will pick it up automatically.
-  - **Tabular data**: write a CSV under `$LIFEOS_VAULT_PATH/Inbox/`.
+the body inline. Vault artifacts go in the `output_dir` path provided
+in this_task — same location the worker's spillover uses, so everything
+the operator's agents produce lands in one consistent folder.
+  - **Notes / reports / drafts**: write a Markdown file with `Write` to
+    `<output_dir>/<YYYY-MM-DD>-<descriptive-slug>.md`. Obsidian picks
+    it up automatically.
+  - **Tabular data**: write a CSV under the same `<output_dir>`.
     Avoid Markdown pipe tables in either Telegram or vault notes.
   - **Inline summary**: a 1–3 sentence Telegram message that says what
-    you did and the full path to the artifact (`/Users/.../Inbox/foo.md`).
+    you did and the full path to the artifact.
 </output_format>
 
 <ambiguity>
@@ -247,7 +253,7 @@ def _system_prompt(session_id: str, expected_output: str, budget, parent_session
     injected into the prompt body — the model can't act on either, and
     both are tracked in `lifeos_agent_sessions_list` / transcripts.
     """
-    del session_id, parent_session_id  # logging-only artifacts, not for the model
+    del parent_session_id  # logging-only, not for the model
     wall = budget.get("wall_seconds")
     max_tokens = budget.get("max_tokens")
     max_dollars = budget.get("max_dollars")
@@ -257,10 +263,13 @@ def _system_prompt(session_id: str, expected_output: str, budget, parent_session
     # calendar / task / due-date data. Inject the operator's local date
     # so day-relative reasoning works.
     today = _today()
+    output_dir = _output_dir()
     return (
         _SYSTEM_PROMPT_STATIC
         + "\n\n<this_task>\n"
         + f"today={today}; "
+        + f"lifeos_session_id={session_id}; "
+        + f"output_dir={output_dir}; "
         + f"expected_output={expected_output}; "
         + f"soft budget ~{wall}s wall / ~{max_tokens} tokens / {dollars_str}.\n"
         + "</this_task>"
@@ -272,6 +281,22 @@ def _today() -> str:
     from datetime import datetime
     now = datetime.now().astimezone()
     return now.strftime("%Y-%m-%d (%A)")
+
+
+def _output_dir() -> str:
+    """Resolved absolute path where the agent should write artifacts. Joins
+    `LIFEOS_VAULT_PATH` with `LIFEOS_AGENT_OUTPUT_DIR` so the local agent
+    and the worker's spillover land in the same folder."""
+    from pathlib import Path
+    from config.settings import settings as _settings
+    vault = _settings.vault_path
+    if not vault:
+        return _settings.agent_output_dir  # vault-relative only
+    try:
+        vault = vault.expanduser() if hasattr(vault, "expanduser") else Path(vault)
+    except Exception:
+        vault = Path(str(vault))
+    return str(Path(vault) / _settings.agent_output_dir)
 
 
 def _user_message_for(task: dict) -> str:

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -43,16 +43,18 @@ def _user_message_for(task: dict, session_id: str, expected_output: str, budget:
     """The initial user turn sent to a managed session.
 
     Purely task-specific. Persona, ambiguity policy, and output-format
-    requirements all live in the agent preset (Anthropic console). The
-    `session_id` parameter is accepted for back-compat but not injected
-    into the message body — it's already in the session metadata and the
-    model can't act on it.
+    requirements all live in the agent preset (Anthropic console).
 
     Budget is framed as a *soft* target: Anthropic doesn't enforce it
     server-side, the worker kills the session externally on breach.
     Saying "soft" prevents the model from over-regulating its own pacing.
+
+    `lifeos_session_id` is injected so the agent can pass it as
+    `caller_session_id` when invoking any `lifeos_agent_*` tool over
+    the LifeOS MCP — that field is required by the dispatcher and
+    can't be inferred server-side because the request crosses a
+    process boundary.
     """
-    del session_id  # already in session metadata; not needed in the user message
     title = (task.get("description") or "").strip()
     context = task.get("context")
     max_dollars = budget.get("max_dollars")
@@ -60,12 +62,9 @@ def _user_message_for(task: dict, session_id: str, expected_output: str, budget:
     parts = [f"Task: {title}"]
     if context:
         parts.append(f"Context: {context}")
-    # Inject the operator's local date. The cloud model has its own
-    # training cutoff and Anthropic does not inject "today" into managed
-    # sessions; without this, day-relative reasoning on calendar / tasks
-    # picks an arbitrary date inside the cutoff window.
     parts.append(
         f"today={_today()}; "
+        f"lifeos_session_id={session_id}; "
         f"expected_output={expected_output}; "
         f"soft budget ~{budget.get('wall_seconds')}s wall / "
         f"~{budget.get('max_tokens')} tokens / {dollars_str}."

--- a/api/services/agent_worker/tools.py
+++ b/api/services/agent_worker/tools.py
@@ -312,7 +312,14 @@ class ToolRegistry:
         if self._inter_ctx is not None:
             from api.services.agent_worker import inter_agent
             if inter_agent.is_inter_agent_tool(name):
-                payload = inter_agent.dispatch(self._inter_ctx, name, arguments or {})
+                # The local executor knows the caller's session_id via
+                # context — ignore whatever the agent passed for that
+                # field and use the authoritative value. The schema
+                # declares caller_session_id required (so cloud agents
+                # over MCP HTTP can supply it); for local we override.
+                args = dict(arguments or {})
+                args["caller_session_id"] = self._inter_ctx.caller_session_id
+                payload = inter_agent.dispatch(self._inter_ctx, name, args)
                 # `yield_until` and `lifeos_agent_user_ask` both end the executor
                 # turn — the first waits for child completion, the second for
                 # a Telegram reply.

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1277,9 +1277,10 @@ class Worker:
         a truncated inline summary so the operator never loses content
         entirely.
 
-        File layout: `<vault>/Inbox/Agent Output/<YYYY-MM-DD>-<slug>.md`.
-        Inbox is the standard landing folder for Obsidian setups and
-        keeps these next to other unsorted captures.
+        File layout: `<vault>/<LIFEOS_AGENT_OUTPUT_DIR>/<YYYY-MM-DD>-<slug>.md`.
+        The output dir is operator-configurable via `LIFEOS_AGENT_OUTPUT_DIR`
+        (default `LifeOS/Tasks/Agent Output`) so spillover and the local
+        executor's direct vault writes land in the same place.
         """
         from datetime import datetime
         import re
@@ -1296,7 +1297,7 @@ class Worker:
         slug = re.sub(r"[^A-Za-z0-9]+", "-", title).strip("-").lower()[:60] or session.task_id
         today = datetime.now().astimezone().strftime("%Y-%m-%d")
         filename = f"{today}-{slug}.md"
-        folder = "Inbox/Agent Output"
+        folder = settings.agent_output_dir
 
         try:
             target_dir = vault_root / folder

--- a/config/settings.py
+++ b/config/settings.py
@@ -135,6 +135,14 @@ class Settings(BaseSettings):
         description="How long an #agent-blocked task waits for a Telegram reply "
                     "before being abandoned. Used by Issue F."
     )
+    agent_output_dir: str = Field(
+        default="LifeOS/Tasks/Agent Output",
+        alias="LIFEOS_AGENT_OUTPUT_DIR",
+        description="Vault-relative directory where agent-created artifacts "
+                    "(Markdown notes, CSVs) land. The local executor writes "
+                    "here directly; the worker's spillover for long outputs "
+                    "also writes here. Path is joined under LIFEOS_VAULT_PATH."
+    )
     agent_preflight_model: str = Field(
         default="claude-haiku-4-5",
         alias="LIFEOS_AGENT_PREFLIGHT_MODEL",

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -231,6 +231,11 @@ system: |-
   counts, decisions, links. Skip filler phrases like "I have completed
   the task." Match the operator's voice when drafting on their behalf:
   direct, lowercase-leaning, no LinkedIn-speak.
+
+  Critically: your final turn must report results, not intentions. Never
+  end with "I'll do X next" or "let me now Y" — those are promises, not
+  completions. If you genuinely need more turns, take them now; only end
+  the session when the task is actually done.
   </output_format>
 
   <ambiguity>
@@ -240,6 +245,17 @@ system: |-
   persistent — your goal is to make the experience delightful for the
   user. Just note the assumptions made in your final summary.
   </ambiguity>
+
+  <inter_agent>
+  You can spawn child agents for parallel sub-work via the `lifeos` MCP:
+  `lifeos_agent_spawn` (create), `lifeos_agent_check` (poll),
+  `lifeos_agent_yield_until` (pause until children finish — preferred
+  over polling, no idle billing), `lifeos_agent_kill` (terminate),
+  `lifeos_agent_transcript_read`, `lifeos_agent_sessions_list`,
+  `lifeos_agent_user_ask`. Every one of these tools requires
+  `caller_session_id` — pass the `lifeos_session_id` value from the
+  task brief above verbatim, on every inter-agent call.
+  </inter_agent>
 
   <thinking>
   Respond directly on simple lookups. Reserve extended thinking for

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -522,16 +522,23 @@ def test_system_prompt_uses_positive_framing_for_ambiguity():
 
 
 @pytest.mark.unit
-def test_system_prompt_does_not_inject_session_id_into_body():
-    """session_id is a worker artifact, not actionable by the model.
-    Keeping it out of the prompt body maximizes prompt-cache hits."""
+def test_system_prompt_injects_session_id_into_dynamic_block_only():
+    """The agent needs its own session_id to pass as `caller_session_id`
+    when calling inter-agent tools (the dispatcher requires it; MCP HTTP
+    can't infer it server-side). The id lands in the dynamic <this_task>
+    trailer, not the cached static block — so cache invalidation stays
+    confined to per-session changes already happening there (today, budget)."""
     prompt = _system_prompt(
         session_id="sess_abc123",
         expected_output="text",
         budget={"wall_seconds": 3600, "max_tokens": 5000, "max_dollars": 5.0},
     )
-    assert "sess_abc123" not in prompt
-    assert "session_id" not in prompt
+    # session id appears in the dynamic <this_task> section
+    assert "lifeos_session_id=sess_abc123" in prompt
+    # but the static portion stays cache-clean: no session_id leakage
+    static, _, dynamic = prompt.partition("<this_task>")
+    assert "sess_abc123" not in static
+    assert "lifeos_session_id" not in static
 
 
 @pytest.mark.unit

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -775,8 +775,10 @@ def test_completion_spills_to_vault_when_over_cap(tmp_path: Path, monkeypatch):
     assert "obsidian://" in msg
     # The full body is NOT inlined verbatim
     assert long_text not in msg
-    # The vault file exists with the expected structure
-    out_dir = vault / "Inbox" / "Agent Output"
+    # The vault file exists in the configured agent-output dir
+    # (LIFEOS_AGENT_OUTPUT_DIR; defaults to "LifeOS/Tasks/Agent Output").
+    from config.settings import settings as _settings
+    out_dir = vault / _settings.agent_output_dir
     md_files = list(out_dir.glob("*.md"))
     assert len(md_files) == 1, f"expected one spillover file; got {md_files}"
     body = md_files[0].read_text(encoding="utf-8")

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -119,9 +119,11 @@ def test_start_creates_remote_session_with_agent_and_environment_ids(stores):
     # Ambiguity policy NOT duplicated here — it lives in the agent preset's
     # system prompt (Anthropic console). User message stays task-specific.
     assert "ambiguous" not in cw["initial_message"]
-    # session_id NOT in the user message — already in session metadata.
-    assert session.session_id not in cw["initial_message"]
-    assert "lifeos_session_id" not in cw["initial_message"]
+    # session_id IS injected as `lifeos_session_id=…` so the cloud agent
+    # can pass it as `caller_session_id` on inter-agent tool calls. The
+    # MCP HTTP layer can't infer the caller server-side (cross-process),
+    # so the agent must supply it explicitly.
+    assert f"lifeos_session_id={session.session_id}" in cw["initial_message"]
     # NO inline system_prompt / model / mcp_servers / connectors
     assert "system_prompt" not in cw
     assert "model" not in cw


### PR DESCRIPTION
## Summary

Three threads from the live multi-agent test (`16692902`) that exposed real bugs:

### 1. Declared, configurable vault output dir

Spillover + local agent direct-vault-writes were landing in `Inbox/Agent Output`, hardcoded in two places and not where you expected (`LifeOS/Tasks/Agent Output`). Adds `LIFEOS_AGENT_OUTPUT_DIR` (default `LifeOS/Tasks/Agent Output`). The worker's `_spill_to_vault` reads it from settings; the local executor's system prompt advertises `output_dir=<resolved-full-path>` in the dynamic `<this_task>` block so the local agent writes to the same place. `.env.example` documents the new var.

### 2. Inter-agent `caller_session_id` was undeclared but required

**Multi-agent test diagnosis**: the cloud agent called `lifeos_agent_spawn` four times with `caller_session_id='primary'` (a hallucinated literal); every spawn failed silently with `"caller_session_id is required for inter-agent tools"`; agent gave up and tried to do the work sequentially.

Root cause: `mcp_server.py:1016` requires `caller_session_id` in args (the MCP HTTP layer can't infer it server-side — it's a cross-process boundary), but the tool schemas in `inter_agent.py` didn't declare the field. The agent had no way to know it needed to pass it. Fixes:
- All 8 `lifeos_agent_*` schemas declare `caller_session_id` as a required string (via a `_with_caller` helper that wraps the existing property dicts).
- Cloud per-task user message injects `lifeos_session_id=<sid>` — the value the agent should copy into `caller_session_id` on every inter-agent call.
- Cloud preset YAML in `docs/guides/agent-worker-setup.md` gains an `<inter_agent>` block telling the agent to pass it verbatim on every call (operator follow-up: re-import the preset to land this in the console).
- Local executor system prompt also injects `lifeos_session_id=<sid>` in `<this_task>` for symmetry.
- Local tool dispatcher (`tools.py`) defensively overrides whatever the agent passes with the ctx-known caller, so the local path's spawn behavior doesn't depend on the agent reading the schema correctly.

### 3. "Report results, not intentions"

Same multi-agent test — once spawn failed, the agent emitted "I'll run both analyses directly" as its `agent.message`, Anthropic ended the turn, worker marked COMPLETED with that promise-shape text as the operator-facing summary. Both system prompts (cloud preset YAML in the doc + local executor) now include a `<output_format>` line telling the agent never to end with "I'll do X next" — promises aren't completions. If more turns are needed, take them now.

## Test evidence

- 191 agent_worker unit tests pass
- Updated assertions for the system_prompt/user_message changes (session_id now intentionally present in the dynamic block, not the cached static portion); spillover test reads the configured dir from `settings.agent_output_dir`

## Review focus

- `_with_caller` helper centralizes the schema augmentation so all 8 inter-agent tools stay consistent
- Local dispatcher override of `caller_session_id` makes the spawn flow robust regardless of what the agent passes — that's the right invariant for the local path where the worker authoritatively knows the session id
- `_output_dir()` helper in `local_executor.py` joins `LIFEOS_VAULT_PATH` + `LIFEOS_AGENT_OUTPUT_DIR` and is called per session so changing the env var doesn't require a worker restart for new sessions (existing sessions cache their dynamic block in conversation history)

## Operator follow-up

Re-import the updated cloud preset YAML from `docs/guides/agent-worker-setup.md` (Step 4b → "3. Create the Agent preset") into the Anthropic console — that lands the new `<inter_agent>` and `<output_format>` "report results not intentions" lines on the cloud agent.