### PR TITLE
fix: don't telegram operator on spawned-child terminal events; sanitize managed-session title

### DIFF
--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -79,6 +79,34 @@ def _today() -> str:
     return now.strftime("%Y-%m-%d (%A)")
 
 
+def _sanitize_title(text: str) -> str | None:
+    """Strip Unicode control / format chars from a session title.
+
+    Live bug: spawned children's titles came from the parent's freeform
+    spawn prompt, which included `\\n` newlines. Anthropic 400'd with
+    `"title: must not contain Unicode control or format characters"`.
+    We collapse any whitespace-control chars to single spaces, drop other
+    control / format codepoints entirely, then trim to 100 chars (the
+    title field is for display only). Returns None for an empty result
+    so the API uses the model's default.
+    """
+    import unicodedata
+    if not text:
+        return None
+    cleaned_chars: list[str] = []
+    for c in text:
+        cat = unicodedata.category(c)
+        if cat in ("Cc", "Cf"):  # control / format
+            if c in (" ", "\t", "\n", "\r") or c.isspace():
+                if cleaned_chars and cleaned_chars[-1] != " ":
+                    cleaned_chars.append(" ")
+            # else: drop entirely
+        else:
+            cleaned_chars.append(c)
+    cleaned = "".join(cleaned_chars).strip()[:100]
+    return cleaned or None
+
+
 class ManagedExecutor:
     """Coordinates a Managed Agents session from create through terminal event.
 
@@ -137,7 +165,7 @@ class ManagedExecutor:
                     task, sid, session.expected_output or "text", budget,
                 ),
                 metadata={"lifeos_session_id": sid, "task_id": session.task_id},
-                title=(task.get("description") or "")[:100] or None,
+                title=_sanitize_title(task.get("description") or ""),
             )
         except Exception as exc:
             # Log without exc_info — httpx exceptions can attach the request

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1058,55 +1058,82 @@ class Worker:
     def _handle_outcome(self, session: Session, task: dict[str, Any], outcome) -> None:
         title = task.get("description", session.task_id)
         sid = session.session_id
+        # Spawned children belong to the parent agent's flow — their
+        # terminal state is consumed by `_resume_yielded_for_children`.
+        # The operator should only ever see Telegram notifications for
+        # the ROOT session (the one tied to a #agent task in the vault).
+        # Without this guard, a child's failure / completion message
+        # leaks to the operator with the parent's internal prompt as
+        # the "task description" — confusing and operator-irrelevant.
+        is_spawned = bool(session.parent_session_id)
 
         if outcome.status == STATUS_COMPLETED:
-            self._complete_task(session.task_id)  # mark `done` in the vault
-            # Swap the tag so the task surfaces as #agent-completed for symmetry
-            # with the failed / budget-exceeded / blocked terminal tags. Failure
-            # of the swap is non-critical — _swap_tag logs and the task is
-            # already marked done in the vault.
-            self._swap_tag(session.task_id, RUNNING_TAG, COMPLETED_TAG)
-            # Send via the with-id sender so we can match a future Telegram
-            # reply to this completion message and resume the task as a
-            # follow-up turn (e.g., "now turn this into a .md in my vault").
-            # When the with-id sender returns None (bot not configured, or
-            # a test stub that doesn't capture ids) fall back to the plain
-            # _notify path so the operator at least sees the result.
-            body = self._completion_summary(session, task, outcome)
-            sent_id = self._telegram_send_with_id(body)
-            if sent_id is None:
-                self._notify(body)
+            if not is_spawned:
+                self._complete_task(session.task_id)  # mark `done` in the vault
+                # Swap the tag so the task surfaces as #agent-completed for symmetry
+                # with the failed / budget-exceeded / blocked terminal tags. Failure
+                # of the swap is non-critical — _swap_tag logs and the task is
+                # already marked done in the vault.
+                self._swap_tag(session.task_id, RUNNING_TAG, COMPLETED_TAG)
+                # Send via the with-id sender so we can match a future Telegram
+                # reply to this completion message and resume the task as a
+                # follow-up turn (e.g., "now turn this into a .md in my vault").
+                # When the with-id sender returns None (bot not configured, or
+                # a test stub that doesn't capture ids) fall back to the plain
+                # _notify path so the operator at least sees the result.
+                body = self._completion_summary(session, task, outcome)
+                sent_id = self._telegram_send_with_id(body)
+                if sent_id is None:
+                    self._notify(body)
+                else:
+                    try:
+                        self.session_store.register_completion_followup(
+                            session_id=sid,
+                            task_id=session.task_id,
+                            sent_message_id=sent_id,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "register_completion_followup failed for %s: %s",
+                            session.task_id, exc,
+                        )
             else:
-                try:
-                    self.session_store.register_completion_followup(
-                        session_id=sid,
-                        task_id=session.task_id,
-                        sent_message_id=sent_id,
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "register_completion_followup failed for %s: %s",
-                        session.task_id, exc,
-                    )
+                # Child completion — record only; parent picks it up via yield_until.
+                self.transcript_store.append(sid, "child_completed_internal", {
+                    "parent_session_id": session.parent_session_id,
+                    "final_chars": len(outcome.final_text or ""),
+                })
             return
 
         label = _worker_label(session.routing)
         if outcome.status == STATUS_BUDGET_EXCEEDED:
-            self._swap_tag(session.task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
-            self._set_task_status(session.task_id, "cancelled")
-            self._notify(
-                f"⚠️ {label}: task '{title}' hit its budget ({outcome.reason}). "
-                f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
-            )
+            if not is_spawned:
+                self._swap_tag(session.task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
+                self._set_task_status(session.task_id, "cancelled")
+                self._notify(
+                    f"⚠️ {label}: task '{title}' hit its budget ({outcome.reason}). "
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                )
+            else:
+                self.transcript_store.append(sid, "child_budget_exceeded_internal", {
+                    "parent_session_id": session.parent_session_id,
+                    "reason": outcome.reason,
+                })
             return
 
         if outcome.status == STATUS_FAILED:
-            self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
-            self._set_task_status(session.task_id, "cancelled")
-            self._notify(
-                f"⚠️ {label}: task '{title}' failed: {outcome.reason}. "
-                f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
-            )
+            if not is_spawned:
+                self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
+                self._set_task_status(session.task_id, "cancelled")
+                self._notify(
+                    f"⚠️ {label}: task '{title}' failed: {outcome.reason}. "
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                )
+            else:
+                self.transcript_store.append(sid, "child_failed_internal", {
+                    "parent_session_id": session.parent_session_id,
+                    "reason": outcome.reason,
+                })
             return
 
         if outcome.status == STATUS_YIELDED:
@@ -1325,10 +1352,15 @@ class Worker:
 
     def _mark_failed(self, session: Session, task: dict[str, Any], reason: str) -> None:
         title = task.get("description", session.task_id)
-        self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
-        self._set_task_status(session.task_id, "cancelled")
         self.session_store.update_status(session.task_id, STATUS_FAILED)
         self.transcript_store.append(session.session_id, "failed", {"reason": reason})
+        # Spawned children flow back through `_resume_yielded_for_children`;
+        # don't poke the vault tag system and don't ping Telegram (see
+        # `_handle_outcome` for the full reasoning).
+        if session.parent_session_id:
+            return
+        self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
+        self._set_task_status(session.task_id, "cancelled")
         self._notify(f"⚠️ {_worker_label(session.routing)}: task '{title}' failed: {reason}")
 
     def _mark_blocked(self, session: Session, task: dict[str, Any], question: str) -> None:

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -487,6 +487,81 @@ def test_completion_summary_omits_footer_when_no_init_failures(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_spawned_child_failure_does_not_telegram_the_operator(tmp_path: Path):
+    """Live bug: a spawned child session's `create_session` 4xx'd, and the
+    worker fired a failure notification to operator Telegram with the
+    parent's full multi-line prompt as the "task title". Children are
+    parent-internal — their terminal status flows back through
+    `_resume_yielded_for_children`, not Telegram."""
+    from api.services.agent_worker.session_store import STATUS_RUNNING
+    api = FakeApi(tasks=[])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_FAILED, reason="create_session failed: HTTPStatusError",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+
+    # Construct a spawned-child session by hand. parent_session_id is what
+    # marks it as not-a-root.
+    parent = w.session_store.create(
+        task_id="parent_task", routing="claude", expected_output="text",
+        status=STATUS_RUNNING,
+    )
+    child = w.session_store.create(
+        task_id="spawn_child", routing="claude", expected_output="structured",
+        status=STATUS_RUNNING,
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+
+    # Trigger the failure handler directly as the dispatch path would.
+    w._handle_outcome(
+        child,
+        {"id": child.task_id, "description": "You are analyzing WORK Gmail activity…"},
+        ExecutorOutcome(status=STATUS_FAILED, reason="create_session failed: HTTPStatusError"),
+    )
+
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent == [], f"spawned child failure leaked to operator: {sent}"
+
+
+@pytest.mark.unit
+def test_spawned_child_completion_does_not_telegram_the_operator(tmp_path: Path):
+    """Same invariant for the COMPLETED branch — children's outputs are
+    aggregated by the parent's yield_until resumption, not surfaced to
+    Telegram individually."""
+    from api.services.agent_worker.session_store import STATUS_RUNNING
+    api = FakeApi(tasks=[])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="child output",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    parent = w.session_store.create(
+        task_id="parent_task", routing="local", expected_output="text",
+        status=STATUS_RUNNING,
+    )
+    child = w.session_store.create(
+        task_id="spawn_child", routing="local", expected_output="structured",
+        status=STATUS_RUNNING,
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    w._handle_outcome(
+        child, {"id": child.task_id, "description": "child prompt"},
+        ExecutorOutcome(status=STATUS_COMPLETED, final_text="child output"),
+    )
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    sent_ids = w._sent_with_ids  # type: ignore[attr-defined]
+    assert sent == [], f"child completion leaked via _notify: {sent}"
+    assert sent_ids == [], f"child completion leaked via _telegram_send_with_id: {sent_ids}"
+
+
+@pytest.mark.unit
 def test_followup_reply_reopens_completed_session_and_reruns_with_new_turn(tmp_path: Path):
     """Live bug repro: the operator replied to a completion message
     ("turn this into a .md in my vault") and the response had no context.

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -487,6 +487,38 @@ def test_cancelled_status_uses_distinct_telegram_reason(stores):
 
 
 @pytest.mark.unit
+def test_sanitize_title_strips_newlines_and_control_chars():
+    """Live repro: spawn prompt contained `\\n` newlines, Anthropic 400'd
+    with `"title: must not contain Unicode control or format characters"`.
+    The sanitizer must collapse whitespace control chars (newlines, tabs)
+    to single spaces and drop other control / format codepoints."""
+    from api.services.agent_worker.managed_executor import _sanitize_title
+
+    # Multi-line spawn prompt (common from cloud parent agents).
+    multiline = "You are analyzing WORK Gmail.\n\nStrategy:\n1. Foo\n2. Bar"
+    out = _sanitize_title(multiline)
+    assert out is not None
+    assert "\n" not in out
+    assert "\r" not in out
+    assert "\t" not in out
+    assert out.startswith("You are analyzing WORK Gmail.")
+    # Collapsed double-newline becomes a single space, not two.
+    assert "  " not in out
+
+    # Empty / whitespace-only → None so the API uses its default.
+    assert _sanitize_title("") is None
+    assert _sanitize_title(None) is None
+    assert _sanitize_title("\n\n\t\r") is None
+
+    # Length cap at 100 chars.
+    long = "x" * 500
+    assert len(_sanitize_title(long)) == 100
+
+    # Non-control unicode is preserved (em-dashes, curly quotes, etc.).
+    assert _sanitize_title("Compare — last month's data") == "Compare — last month's data"
+
+
+@pytest.mark.unit
 def test_poll_returns_running_on_transient_driver_error(stores):
     store, session, transcript = stores
     store.set_managed_session_id("t1", "sess_remote")


### PR DESCRIPTION
## Summary

Two issues from the live multi-agent test (`f4019729` → spawned `sess_af7ec5b917024ea8` + `sess_bb20e1f6e4bb473d`).

### 1. Spawned-child terminal events were leaking to operator Telegram

Live bug: the Gmail child of the multi-agent test failed at `create_session`, and the operator received a Telegram message titled with the parent's entire multi-paragraph spawn prompt as the "task description": `⚠️ Cloud agent worker: task 'You are analyzing WORK Gmail activity for last month (April 2026...)' failed: ...`

That message should never have left the worker. Children are parent-internal — their COMPLETED / FAILED / BUDGET_EXCEEDED status flows back through `_resume_yielded_for_children`, and the parent's `yield_until` resumption aggregates child outputs into the parent's next user turn. Only the ROOT session (the one tied to a real `#agent` task in the vault) should ever produce Telegram notifications.

Fix: `_handle_outcome` and `_mark_failed` now branch on `session.parent_session_id`. If set: record a `child_*_internal` transcript event and return. Skip the vault tag swap (the synthetic `spawn_xxx` task_id isn't a real vault task anyway), skip `_set_task_status`, skip Telegram.

### 2. `title:` field 400'd on spawn prompts containing newlines

Live bug: Anthropic's `POST /v1/sessions` returned `400: {"error":{"message":"title: must not contain Unicode control or format characters"}}` because the spawn child's title (= parent's freeform spawn prompt) contained `\n` newlines. The body-logging helper made this diagnosable; before today's PR #131 logging changes it would have been silent.

Fix: new `_sanitize_title(text)` helper in `managed_executor.py` collapses whitespace controls (newlines, tabs, CR) to single spaces, drops other Unicode Cc/Cf codepoints, trims to 100 chars (the title field is display-only), and returns None for empty so the API uses its default. Non-control Unicode (em-dashes, curly quotes, etc.) is preserved.

## Test evidence

- 194 agent_worker unit tests pass (3 new)
- `test_spawned_child_failure_does_not_telegram_the_operator` — constructs a spawned child + drives `_handle_outcome` with FAILED; asserts `sent == []`
- `test_spawned_child_completion_does_not_telegram_the_operator` — same for COMPLETED
- `test_sanitize_title_strips_newlines_and_control_chars` — repros the 400 input + happy-path Unicode preservation

## Review focus

- The `parent_session_id` guard is on `session`, not `task` — the dispatch path for spawned sessions passes a synthetic task dict with `description=<spawn prompt>`, so the session-side check is the reliable invariant
- Title sanitizer uses Unicode `category()[0]` to drop Cc/Cf but preserves Cs/Cn/etc. — em-dash, curly quotes, accented letters, emoji all pass through. Newlines collapse to a single space (not multiple) so the title stays compact
- `_mark_failed` still records the transcript event + updates session_store status for spawned children — internal bookkeeping the parent's resume relies on; just doesn't ping Telegram or vault

## Operator follow-up

None — fully code-only. Your in-flight `f4019729` task is still waiting on the surviving child `sess_bb20e1f6e4bb473d` to terminate (currently running). When it does, the parent's yield_until will resume and you'll get a single completion notification — no more child leaks.