### PR TITLE
feat: cloud yield-and-resume for multi-agent + smarter empty-final recovery

### DIFF
--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -395,6 +395,47 @@ def yield_until(ctx: InterAgentContext, args: dict) -> dict:
     ctx.transcript_store.append(caller.session_id, "yield", {
         "children": children, "reason": args.get("reason", ""),
     })
+
+    # For cloud callers: kill the remote Anthropic session NOW. Without
+    # this the cloud agent keeps running on Anthropic's side after the
+    # tool returns — the tool result `{"yielded":true}` doesn't break
+    # the server's generation loop, so the agent will do "extra"
+    # post-yield work (which is what caused the 30KB threads-JSON dump
+    # to become a user-facing completion message in the multi-agent
+    # test of 2026-05-27). When children finish, the worker creates a
+    # *fresh* managed session for the resume — see
+    # `_resume_yielded_for_children` in worker.py.
+    if caller.routing == "claude" and caller.managed_agent_session_id:
+        if ctx.managed_driver is not None:
+            try:
+                ctx.managed_driver.kill_session(
+                    caller.managed_agent_session_id,
+                    reason="yield_until",
+                )
+                ctx.transcript_store.append(
+                    caller.session_id, "yield_killed_remote",
+                    {"remote_id": caller.managed_agent_session_id},
+                )
+            except Exception as exc:
+                # Non-fatal: the cloud agent may have already exited the
+                # turn naturally. Log and continue — the worker's resume
+                # path doesn't depend on the kill succeeding.
+                logger.warning(
+                    "yield_until kill_session failed for %s: %s",
+                    caller.managed_agent_session_id, exc,
+                )
+        else:
+            # Driver not wired into the context. Worker-side ticks will
+            # see this session as yielded; the next poll cycle of the
+            # remote session will eventually pick up the end_turn that
+            # Anthropic emits naturally — but until then the cloud agent
+            # may keep working post-yield.
+            logger.warning(
+                "yield_until: no managed_driver in context to kill remote "
+                "session %s — cloud agent may continue running post-yield",
+                caller.managed_agent_session_id,
+            )
+
     return _ok({"yielded": True, "waiting_on": children})
 
 

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -42,6 +42,7 @@ from api.services.agent_worker.session_store import (
     Session,
     SessionStore,
 )
+from api.services.agent_worker.managed_executor import _sanitize_title as _managed_sanitize_title
 from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
 from api.services.interaction_store import build_obsidian_link
@@ -67,6 +68,37 @@ def _worker_label(routing: str | None) -> str:
     if routing == ROUTE_CLAUDE:
         return "Cloud agent worker"
     return "Agent worker"
+
+
+def _is_readable_tool_result(text: str) -> bool:
+    """Heuristic: is this tool result useful to dump inline as the
+    operator-facing completion body? Skip raw JSON dumps (list_threads,
+    gmail_search payloads) and oversized text — those become unreadable
+    walls of `{"threads":[…]}` in Telegram. Prefer text-shaped results
+    that the agent itself would have written (e.g. a drafted email,
+    a short calendar summary)."""
+    if not text:
+        return False
+    head = text.lstrip()[:5]
+    if head.startswith(("{", "[")):
+        return False  # JSON-shaped — agent should have summarized
+    if len(text) > 1500:
+        return False  # too big to inline; tool-call summary is friendlier
+    return True
+
+
+def _iter_transcript(path):
+    """Yield decoded JSON events from a session transcript, skipping
+    malformed lines. Used by recovery helpers to scan without raising."""
+    import json as _json
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                yield _json.loads(line)
+            except _json.JSONDecodeError:
+                continue
 
 
 AGENT_TAG = "agent"
@@ -305,30 +337,24 @@ class Worker:
                 "id": session.task_id, "description": session.task_id,
             }
 
-            # Managed yield-resume isn't supported yet — short-circuit with a
-            # clear failure rather than scrambling the local message history
-            # for nothing.
-            if session.routing != "local":
+            # Build the resume turn — same shape for local and cloud, but
+            # cloud also pulls each child's final_text (from the managed_cursor
+            # cache populated during the children's runs) since the cloud
+            # parent's fresh session won't have access to the children's
+            # transcripts on its own.
+            resume_message = self._build_resume_message(session, task, child_sessions)
+
+            if session.routing == ROUTE_CLAUDE:
+                ok = self._resume_cloud_parent(session, task, child_sessions, resume_message)
+                if not ok:
+                    # _resume_cloud_parent already marked failed + logged.
+                    continue
+                self.session_store.set_yield_waiting_for(session.task_id, None)
                 self.transcript_store.append(
-                    session.session_id, "managed_yield_resume_unsupported", {},
-                )
-                self._mark_failed(
-                    session, task,
-                    "managed yield-and-resume not yet supported (children "
-                    "finished but parent cannot resume)",
+                    session.session_id, "resume_after_children_cloud",
+                    {"children": children},
                 )
                 continue
-
-            # Build the resume turn, then commit state updates only after we
-            # know the executor returned cleanly. This keeps the session
-            # restartable if the executor crashes mid-resume.
-            summary_lines = ["Children completed:"]
-            for c in child_sessions:
-                tokens = (c.total_input_tokens or 0) + (c.total_output_tokens or 0)
-                summary_lines.append(
-                    f"- {c.session_id} [{c.status}] — {tokens} tokens, ${c.total_dollars:.2f}"
-                )
-            resume_message = "\n".join(summary_lines)
 
             executor = self._get_local_executor(caller_session_id=session.session_id)
             try:
@@ -1276,24 +1302,168 @@ class Worker:
                                 )
                                 tool_results.append((tool_name, text))
 
-            if tool_results:
-                # Most recent result wins.
-                _, text = tool_results[-1]
-                cap = _INLINE_SUMMARY_MAX_CHARS - 200
-                if len(text) > cap:
-                    text = text[:cap].rsplit(" ", 1)[0] + "…"
-                return text
+            # Prefer the last result whose body is human-readable. A raw
+            # JSON dump from list_threads / gmail_search is worse than
+            # useless inline — operators got a 30KB threads payload as
+            # their "completion message" when the agent idled after one
+            # of those calls. Surface a tool-call summary instead.
+            for tool_name, text in reversed(tool_results):
+                if _is_readable_tool_result(text):
+                    cap = _INLINE_SUMMARY_MAX_CHARS - 200
+                    if len(text) > cap:
+                        text = text[:cap].rsplit(" ", 1)[0] + "…"
+                    return text
 
-            if tool_calls:
-                # Local executor doesn't capture body in transcript; at
-                # least name the work that happened so the operator
-                # knows it wasn't a no-op.
-                last = tool_calls[-1]
-                return f"(last tool called: `{last}` — see transcript for arguments)"
+            # All recent tool results were JSON / oversized. Fall through
+            # to a compact tool-call list so the operator at least knows
+            # what the agent did, with a transcript pointer for full audit.
+            managed_tool_names: list[str] = []
+            for d in _iter_transcript(self.transcript_store.dir / f"{session_id}.jsonl"):
+                kind = d.get("kind", "")
+                payload = d.get("payload", {}) or {}
+                if kind in ("managed_event_agent.mcp_tool_use",
+                            "managed_event_agent.tool_use"):
+                    managed_tool_names.append(
+                        str(payload.get("name") or payload.get("mcp_server_name") or "tool")
+                    )
+            names = managed_tool_names or tool_calls
+            if names:
+                # De-duplicate adjacent repeats but keep order.
+                summary = []
+                for n in names:
+                    if not summary or summary[-1] != n:
+                        summary.append(n)
+                joined = ", ".join(summary[-8:])
+                return (
+                    f"(agent did work but ended without a text reply. "
+                    f"Tools called: {joined}. See transcript for detail.)"
+                )
         except Exception as exc:
             logger.warning("recover_result_from_transcript failed for %s: %s",
                           session_id, exc)
         return ""
+
+    def _build_resume_message(
+        self,
+        session: Session,
+        task: dict[str, Any],
+        child_sessions: list[Session],
+    ) -> str:
+        """Compose the user turn injected when a parent resumes after its
+        yield_until children terminate. The local executor sees this as
+        the next user message in conversation history (which still
+        carries the parent's prior turns). The cloud parent gets a fresh
+        Anthropic session and only sees this message — so it must carry
+        the original task description plus each child's output.
+        """
+        parts: list[str] = []
+        original = (task.get("description") or "").strip()
+        if session.routing == ROUTE_CLAUDE and original:
+            # Cloud resume: fresh session — restate the original task so
+            # the agent has the goal. Local already has it in history.
+            parts.append(f"Resuming after spawned children finished.\n\nOriginal task: {original}")
+        else:
+            parts.append("Spawned children completed — incorporate their outputs.")
+        parts.append("")
+        parts.append("Children:")
+        for c in child_sessions:
+            tokens = (c.total_input_tokens or 0) + (c.total_output_tokens or 0)
+            header = f"- [{c.status}] {c.session_id} — {tokens} tokens, ${c.total_dollars:.4f}"
+            parts.append(header)
+            body = self._child_final_text(c)
+            if body:
+                # Cap each child body so the combined message stays
+                # well under any per-message limits.
+                if len(body) > 6000:
+                    body = body[:6000].rsplit(" ", 1)[0] + "…"
+                parts.append("  output:")
+                for line in body.splitlines():
+                    parts.append(f"  {line}")
+        return "\n".join(parts)
+
+    def _child_final_text(self, child: Session) -> str:
+        """Pull the child's final_text from the cache (cloud) or transcript
+        (local). Returns empty string if the child produced no final text."""
+        # Cloud children persist final_text via managed_cursor.final_text.
+        try:
+            cached = self.session_store.get_managed_final_text(child.task_id)
+        except Exception:
+            cached = None
+        if cached:
+            return cached
+        # Fallback: scan the transcript for a `completed` or `managed_completed`
+        # event with non-empty `final_text`.
+        path = self.transcript_store.dir / f"{child.session_id}.jsonl"
+        last_text = ""
+        for d in _iter_transcript(path):
+            kind = d.get("kind", "")
+            payload = d.get("payload", {}) or {}
+            if kind in ("completed", "managed_completed"):
+                ft = payload.get("final_text") or ""
+                if ft:
+                    last_text = ft
+        return last_text
+
+    def _resume_cloud_parent(
+        self,
+        session: Session,
+        task: dict[str, Any],
+        child_sessions: list[Session],
+        resume_message: str,
+    ) -> bool:
+        """Create a fresh Anthropic session for a yielded cloud parent.
+
+        The old session was killed when `yield_until` fired (see
+        inter_agent.yield_until). The new session inherits the same
+        agent_preset / environment / vault but starts with a clean
+        message history; we hand it the original task + children's
+        outputs as the initial user turn so it can aggregate.
+        Returns True on success, False after marking the session
+        failed (so the caller can `continue`).
+        """
+        managed = self._get_managed_executor()
+        if managed is None or managed.driver is None:
+            self._mark_failed(
+                session, task,
+                "cloud yield-resume requires Managed Agents configured",
+            )
+            return False
+        # Reset cursor + drop the old remote id so the new session starts
+        # fresh on Anthropic's side.
+        self.session_store.reset_managed_cursor(session.task_id)
+        try:
+            new_remote_id = managed.driver.create_session(
+                agent_id=managed.agent_id,
+                environment_id=managed.environment_id,
+                vault_ids=managed.vault_ids,
+                initial_message=resume_message,
+                metadata={
+                    "lifeos_session_id": session.session_id,
+                    "task_id": session.task_id,
+                    "resume_after_children": True,
+                },
+                title=_managed_sanitize_title(task.get("description") or ""),
+            )
+        except Exception as exc:
+            logger.error(
+                "cloud yield-resume create_session failed for %s: %s",
+                session.task_id, type(exc).__name__,
+            )
+            self.transcript_store.append(
+                session.session_id, "managed_resume_create_failed",
+                {"error_type": type(exc).__name__},
+            )
+            self._mark_failed(
+                session, task, f"cloud yield-resume create_session failed: {type(exc).__name__}",
+            )
+            return False
+        self.session_store.set_managed_session_id(session.task_id, new_remote_id)
+        self.session_store.update_status(session.task_id, STATUS_RUNNING)
+        self.transcript_store.append(session.session_id, "managed_resume_created", {
+            "remote_id": new_remote_id,
+            "child_count": len(child_sessions),
+        })
+        return True
 
     def _spill_to_vault(
         self, session: Session, task: dict[str, Any], final_text: str,

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -236,6 +236,13 @@ system: |-
   end with "I'll do X next" or "let me now Y" — those are promises, not
   completions. If you genuinely need more turns, take them now; only end
   the session when the task is actually done.
+
+  The summary is delivered to the operator via Telegram, which does NOT
+  render Markdown tables, headings (`#`), or code-block borders nicely.
+  Prefer prose, bullets, and bold/italic emphasis. Avoid pipe-table
+  syntax — write a short list with "Title — value" lines instead. When
+  the natural output is a wide multi-column table, write it to a Google
+  Doc/Sheet via the attached drive MCP and link to it from the summary.
   </output_format>
 
   <ambiguity>

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1028,6 +1028,23 @@ class LifeOSMCPServer:
         except Exception as e:
             return {"error": f"inter-agent stack unavailable: {e}"}
 
+        # Wire a ManagedAgentsDriver into the context so `yield_until`
+        # from a cloud caller can kill the remote session immediately
+        # (otherwise Anthropic's session keeps generating post-yield).
+        # Best-effort: if credentials aren't set, leave the driver None
+        # and the handler logs a warning rather than failing.
+        managed_driver = None
+        try:
+            if _settings.anthropic_api_key:
+                from api.services.agent_worker.managed_driver import (
+                    ManagedAgentsDriver,
+                )
+                managed_driver = ManagedAgentsDriver(
+                    api_key=_settings.anthropic_api_key,
+                )
+        except Exception as exc:
+            logger.warning("inter-agent: managed_driver init failed: %s", exc)
+
         ctx = InterAgentContext(
             session_store=SessionStore(),
             transcript_store=TranscriptStore(),
@@ -1038,6 +1055,7 @@ class LifeOSMCPServer:
                 max_concurrent_local=_settings.agent_max_concurrent_local,
                 max_concurrent_managed=_settings.agent_max_concurrent_managed,
             ),
+            managed_driver=managed_driver,
         )
         return inter_dispatch(ctx, tool_name, arguments)
 

--- a/tests/test_agent_worker_inter_agent.py
+++ b/tests/test_agent_worker_inter_agent.py
@@ -259,6 +259,68 @@ def test_yield_until_rejects_empty_list(ctx):
     assert result["error"] == "invalid_arg"
 
 
+@pytest.mark.unit
+def test_yield_until_kills_remote_session_for_cloud_caller(store, transcript):
+    """Live bug: a cloud parent calling yield_until kept burning Anthropic
+    tokens AFTER the yield because the tool only updated local state.
+    Now the handler must call driver.kill_session() so the remote session
+    stops generating immediately."""
+    cloud_parent = store.create(
+        task_id="cloud_p", status=STATUS_RUNNING, routing="claude",
+    )
+    store.set_managed_session_id("cloud_p", "sesn_remote_xyz")
+    cloud_parent = store.get("cloud_p")
+
+    child = store.create(
+        task_id="c", status=STATUS_RUNNING, routing="claude",
+        parent_session_id=cloud_parent.session_id,
+        root_session_id=cloud_parent.session_id,
+        spawn_depth=1,
+    )
+
+    killed: list[tuple[str, str]] = []
+    class _FakeDriver:
+        def kill_session(self, session_id, reason=""):
+            killed.append((session_id, reason))
+
+    ctx = InterAgentContext(
+        store, transcript, cloud_parent.session_id, Caps(),
+        managed_driver=_FakeDriver(),
+    )
+    result = dispatch(ctx, "lifeos_agent_yield_until", {
+        "children": [child.session_id], "reason": "waiting on child",
+    })
+    assert result["ok"]
+    # The remote session got killed; local state still records the yield.
+    assert killed == [("sesn_remote_xyz", "yield_until")]
+    assert store.get("cloud_p").status == STATUS_YIELDED
+
+
+@pytest.mark.unit
+def test_yield_until_local_caller_does_not_kill_remote(store, transcript):
+    """Local sessions have no remote handle — yield_until should not
+    attempt to kill anything (and should not crash when managed_driver
+    is None, which is the local-executor's default context shape)."""
+    local_parent = store.create(
+        task_id="local_p", status=STATUS_RUNNING, routing="local",
+    )
+    child = store.create(
+        task_id="c", status=STATUS_RUNNING, routing="local",
+        parent_session_id=local_parent.session_id,
+        root_session_id=local_parent.session_id,
+        spawn_depth=1,
+    )
+    ctx = InterAgentContext(
+        store, transcript, local_parent.session_id, Caps(),
+        managed_driver=None,
+    )
+    result = dispatch(ctx, "lifeos_agent_yield_until", {
+        "children": [child.session_id],
+    })
+    assert result["ok"]
+    assert store.get("local_p").status == STATUS_YIELDED
+
+
 # ---------------------------------------------------------------------------
 # kill
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -487,6 +487,159 @@ def test_completion_summary_omits_footer_when_no_init_failures(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_cloud_yield_resume_creates_fresh_managed_session_with_children_output(tmp_path: Path):
+    """Live bug: cloud parents that called yield_until ended up in FAILED
+    because `_resume_yielded_for_children` short-circuited non-local
+    routings. Now we create a fresh Anthropic session, pass the original
+    task + each child's final_text as the initial user message, and let
+    the parent's poll loop pick it up via the new managed_session_id."""
+    from api.services.agent_worker.session_store import STATUS_RUNNING, STATUS_YIELDED, STATUS_COMPLETED
+    api = FakeApi(tasks=[
+        {"id": "p1", "description": "Compare gmail vs slack — aggregate child outputs",
+         "status": "in_progress", "tags": [RUNNING_TAG, "cloud"]},
+    ])
+    # Track what the driver was asked to do.
+    create_calls: list[dict] = []
+    class _StubDriver:
+        def create_session(self, **kwargs):
+            create_calls.append(kwargs)
+            return "sesn_new_remote_id"
+    class _StubManagedExec:
+        agent_id = "agent_x"
+        environment_id = "env_x"
+        vault_ids = ["vlt_x"]
+        driver = _StubDriver()
+        def start(self, session, task):
+            return ExecutorOutcome(status=STATUS_RUNNING)
+        def poll(self, session):
+            return ExecutorOutcome(status=STATUS_RUNNING)
+
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude"),
+                     local_executor=_StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED)))
+    w._managed_executor = _StubManagedExec()  # type: ignore[assignment]
+
+    # Construct a cloud parent that's yielded waiting on two children.
+    parent = w.session_store.create(
+        task_id="p1", routing="claude", status=STATUS_YIELDED,
+        expected_output="structured",
+    )
+    w.session_store.set_managed_session_id("p1", "sesn_old_remote")
+    c1 = w.session_store.create(
+        task_id="spawn_c1", routing="claude", status=STATUS_COMPLETED,
+        parent_session_id=parent.session_id, root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    c2 = w.session_store.create(
+        task_id="spawn_c2", routing="claude", status=STATUS_COMPLETED,
+        parent_session_id=parent.session_id, root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    # Cache each child's final_text as managed children do post-completion.
+    w.session_store.set_managed_final_text(c1.task_id, "Gmail: 1,451 emails received in April.")
+    w.session_store.set_managed_final_text(c2.task_id, "Slack: 230 messages sent in April.")
+    w.session_store.set_yield_waiting_for("p1", [c1.session_id, c2.session_id])
+
+    w._resume_yielded_for_children()
+
+    assert len(create_calls) == 1, "should have created exactly one fresh managed session"
+    call = create_calls[0]
+    msg = call["initial_message"]
+    # Original task is restated for the fresh session (no prior history).
+    assert "Compare gmail vs slack" in msg
+    # Both children's outputs are in the resume message.
+    assert "Gmail: 1,451 emails received" in msg
+    assert "Slack: 230 messages sent" in msg
+    # Both child session_ids show up in the [status] header lines.
+    assert c1.session_id in msg
+    assert c2.session_id in msg
+    # Parent session row now points at the new remote id.
+    refreshed = w.session_store.get("p1")
+    assert refreshed.managed_agent_session_id == "sesn_new_remote_id"
+    # Status flipped to RUNNING; yield_waiting_for cleared.
+    assert refreshed.status == STATUS_RUNNING
+    assert not refreshed.yield_waiting_for
+    # No Telegram messages leaked during the resume.
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent == []
+
+
+@pytest.mark.unit
+def test_recovery_skips_json_tool_results_and_summarizes_tool_calls(tmp_path: Path):
+    """Live bug: a cloud agent idled after calling list_threads (which
+    returned a 30KB JSON payload). The recovery code surfaced that raw
+    JSON as the operator-facing completion body — unreadable. Now we
+    skip JSON-shaped or oversize results and fall back to a compact
+    "tools called: X, Y, Z" summary."""
+    from api.services.agent_worker.transcript_store import TranscriptStore as _TS
+
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "compare gmail vs slack",
+         "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    sess = w.session_store.create(task_id="t1", routing="local",
+                                   expected_output="text")
+    ts = _TS(transcripts_dir=tmp_path / "transcripts")
+    ts.append(sess.session_id, "managed_event_agent.mcp_tool_use",
+              {"name": "lifeos_gmail_search"})
+    ts.append(sess.session_id, "managed_event_agent.mcp_tool_use",
+              {"name": "lifeos_agent_spawn"})
+    # Last tool result is a giant JSON dump — recovery must skip it.
+    json_dump = '{"threads":[' + ('{"id":"x"},' * 500) + '{"id":"end"}]}'
+    ts.append(sess.session_id, "managed_event_agent.mcp_tool_result", {
+        "is_error": False,
+        "content": [{"type": "text", "text": json_dump}],
+    })
+    msg = w._completion_summary(sess, {"id": "t1", "description": "compare"},
+                                executor.outcome)
+    # JSON body NOT inlined.
+    assert json_dump[:50] not in msg
+    assert '{"threads"' not in msg
+    # Instead, surface tool-call summary mentioning the calls.
+    assert "Tools called" in msg
+    assert "lifeos_gmail_search" in msg
+    assert "lifeos_agent_spawn" in msg
+
+
+@pytest.mark.unit
+def test_recovery_inlines_short_text_tool_result(tmp_path: Path):
+    """Sanity check the other branch: when the last tool result IS short
+    and text-shaped (e.g. lifeos_gmail_draft returned a few-hundred-char
+    summary), inline it — that's the genuine "show what the agent did"
+    case from PR #130."""
+    from api.services.agent_worker.transcript_store import TranscriptStore as _TS
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "draft", "status": "todo",
+         "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    sess = w.session_store.create(task_id="t1", routing="local",
+                                   expected_output="text")
+    ts = _TS(transcripts_dir=tmp_path / "transcripts")
+    ts.append(sess.session_id, "managed_event_agent.mcp_tool_result", {
+        "is_error": False,
+        "content": [{"type": "text",
+                     "text": "Draft created — to: kevin@example.com, "
+                             "subject: Apologies for delay"}],
+    })
+    msg = w._completion_summary(sess, {"id": "t1", "description": "draft"},
+                                executor.outcome)
+    assert "Draft created" in msg
+    assert "Tools called" not in msg
+
+
+@pytest.mark.unit
 def test_spawned_child_failure_does_not_telegram_the_operator(tmp_path: Path):
     """Live bug: a spawned child session's `create_session` 4xx'd, and the
     worker fired a failure notification to operator Telegram with the


### PR DESCRIPTION
## Summary

Live multi-agent test (`sess_93c1dab6b2144a4e`) on 2026-05-27 exposed two architectural gaps in the cloud yield_until flow plus a recovery-code bug:

### 1. `yield_until` didn't actually pause cloud sessions

The handler only updated local DB state (`set_yield_waiting_for` + `STATUS_YIELDED`). The tool returned `{"yielded": true}` as a tool result — but Anthropic's server-side generation loop doesn't stop on tool results. The cloud agent kept running, decided to "just do it directly," called `list_threads` itself, got a 30KB threads JSON, then idled with no final text. That JSON became the operator's completion message via the empty-final recovery path.

Fix: `inter_agent.yield_until` now calls `ctx.managed_driver.kill_session(remote_id)` when the caller is cloud. The remote session stops generating immediately. Best-effort — failed kill is logged but not raised.

`mcp_server._handle_inter_agent` now populates `InterAgentContext.managed_driver` from `settings.anthropic_api_key` so cloud callers of yield_until actually have a driver to use.

### 2. Cloud parents couldn't resume after children finished

`_resume_yielded_for_children` had a TODO: cloud parents got `_mark_failed("managed yield-and-resume not yet supported")`. Now implemented properly:

- New `_resume_cloud_parent(...)` creates a fresh Anthropic session via `driver.create_session(...)` with the resume message as the initial user turn
- Parent session row swaps `managed_agent_session_id` to the new remote, status flips to RUNNING, `_poll_managed_sessions` picks it up
- Resume message restates the original task (fresh session has no prior history) plus each child's output
- Each child's body sourced from `managed_cursor.final_text` (cloud children) or transcript's last `completed`/`managed_completed` event (local children)
- Each child body capped at 6KB so the combined resume message stays under message limits

### 3. Recovery surfaced raw JSON dumps as completion messages

`_recover_result_from_transcript` was surfacing the last tool result verbatim. When that was a 30KB JSON payload, the operator got an unreadable wall of `{"threads":[…]}`. New `_is_readable_tool_result(text)` heuristic skips:
- Results whose head starts with `{` or `[` (JSON-shaped — the agent should have summarized)
- Anything over 1.5KB

Recovery falls through to a compact "Tools called: X, Y, Z" summary that names the work without dumping its byproducts.

### 4. Cloud preset doc — re-added "no Markdown tables in Telegram"

Dropped when mirroring the operator's console edit in PR #131. Re-added in the `<output_format>` block with specific guidance to write wide tabular data to a Google Doc/Sheet via the drive MCP. **Operator needs to re-import the preset to land this in the console.**

## Test evidence

- 199 agent_worker unit tests pass (5 new)
- `test_yield_until_kills_remote_session_for_cloud_caller` — driver kill_session called with the remote id; local state still records the yield
- `test_yield_until_local_caller_does_not_kill_remote` — local-only path, no managed_driver in ctx, no crash
- `test_cloud_yield_resume_creates_fresh_managed_session_with_children_output` — verifies the full resume flow: driver.create_session called once; initial_message contains task + both child outputs + child session_ids; new remote id stored; status RUNNING; yield_waiting_for cleared; no Telegram leak
- `test_recovery_skips_json_tool_results_and_summarizes_tool_calls` — 30KB JSON repro; assert NOT inlined, "Tools called: …" surfaces instead
- `test_recovery_inlines_short_text_tool_result` — sanity check the other branch (short text DOES inline)

## Review focus

- The cloud yield-resume creates a **new** Anthropic session — Anthropic doesn't support pause/resume of a session, so we accept the implication that the agent loses its tool-use history. The resume message carries the children's outputs as text so the agent can still aggregate
- `_build_resume_message` produces the same shape for local and cloud, but cloud's path also restates the original task (because the fresh session has no prior history); local's path doesn't need to (existing conversation history has it)
- `_child_final_text` prefers the `managed_cursor.final_text` cache when present (set by the children's own completion events); transcript-scan fallback handles local children
- `_is_readable_tool_result` uses two cheap heuristics. JSON shape is the primary signal; size cap (1.5KB) is the backup. We don't try to parse — that'd add latency and the heuristic is good enough for the live failure cases
- `mcp_server.py` MCP HTTP service restart will fire on this commit (post-commit hook detects mcp_server.py changed), so the cloud agent's next inter-agent call uses the populated driver

## Operator follow-up

Re-import the updated cloud preset YAML from `docs/guides/agent-worker-setup.md` (Step 4b → "3. Create the Agent preset") into the Anthropic console. That lands the "no Markdown tables in Telegram" guidance on the cloud agent. The rest of this PR works without operator action.

## Out of scope (filed separately)

- The 50-email cap the agent hit on personal Gmail came from two unrelated places:
  - `lifeos_gmail_search` MCP formatter only shows top-10 emails (top-5 with bodies), and the MCP tool schema doesn't expose `max_results`
  - Superhuman's `list_threads` has a 50-per-page cap and the child agent only paginated 3 cursor steps
- These are MCP-tool issues, separate from the agent worker. Worth a small follow-up PR if you want accurate monthly counts