### PR TITLE
fix: startup recovery should not telegram-leak spawned children

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -246,12 +246,20 @@ class Worker:
             if session.status == STATUS_BLOCKED:
                 continue
             self.transcript_store.append(sid, "resume_failed", {"prior_status": session.status})
+            self.session_store.update_status(session.task_id, STATUS_FAILED)
+            # Spawned children belong to a parent's lineage — they have no
+            # backing vault task (`spawn_xxx` task_id is synthetic), so
+            # tag/status updates are no-ops, and the operator-facing
+            # rollback notification should not fire (PR #132 invariant:
+            # children's terminal state stays parent-internal).
+            if session.parent_session_id:
+                recovered += 1
+                continue
             self._swap_tag(session.task_id, RUNNING_TAG, AGENT_TAG)
             # Rolling back to #agent — return the vault checkbox to "todo"
             # so the operator sees the task as un-started rather than stuck
             # in "in_progress".
             self._set_task_status(session.task_id, "todo")
-            self.session_store.update_status(session.task_id, STATUS_FAILED)
             self._notify(
                 f"⚠️ {_worker_label(session.routing)}: task left in {session.status!r} from a prior "
                 f"run could not be safely resumed — tag rolled back to "

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -640,6 +640,45 @@ def test_recovery_inlines_short_text_tool_result(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_resume_pending_does_not_telegram_for_spawned_children(tmp_path: Path):
+    """Live bug: after a worker restart, the startup-recovery path saw a
+    spawned child stuck in RUNNING, rolled it back, and pinged the
+    operator with the parent-internal child id. Per PR #132 invariant,
+    children's terminal state should never reach Telegram."""
+    from api.services.agent_worker.session_store import STATUS_RUNNING
+    api = FakeApi(tasks=[
+        {"id": "root_task", "description": "root", "status": "in_progress",
+         "tags": [RUNNING_TAG, "cloud"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude"),
+                     local_executor=executor)
+    parent = w.session_store.create(
+        task_id="root_task", routing="claude", status=STATUS_RUNNING,
+        expected_output="text",
+    )
+    # Spawned child stuck in RUNNING — would-be subject of the recovery path.
+    w.session_store.create(
+        task_id="spawn_orphan", routing="claude", status=STATUS_RUNNING,
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    orphan = w.session_store.get("spawn_orphan")
+    n = w.resume_pending()
+    assert n == 2, "both sessions should be marked failed by recovery"
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    # Exactly one notification — for the root, not the spawned child.
+    assert len(sent) == 1, f"expected only the root's recovery notify; got {sent}"
+    # The child's session_id (which goes into the transcript path of the
+    # notify) must NOT appear — proves the spawned child stayed silent.
+    assert orphan.session_id not in sent[0]
+    # Notify is for a single session — the root's id should appear.
+    assert parent.session_id in sent[0]
+
+
+@pytest.mark.unit
 def test_spawned_child_failure_does_not_telegram_the_operator(tmp_path: Path):
     """Live bug: a spawned child session's `create_session` 4xx'd, and the
     worker fired a failure notification to operator Telegram with the


### PR DESCRIPTION
## Summary

Live bug repro: PR #135 merged → post-commit hook restarted `lifeos-mcp-http`, which cascaded `lifeos-agent-worker` restart via its `Requires=lifeos-api` unit dependency → worker's `resume_pending()` found `sess_5c2f1077dacb4e98` stuck in STATUS_RUNNING and pinged me with:

> ⚠️ Cloud agent worker: task left in 'running' from a prior run could not be safely resumed — tag rolled back to #agent for retry. Transcript: …

But that session was a **spawned child** of a previous multi-agent test. PR #132 added the `if session.parent_session_id` guard to `_handle_outcome` and `_mark_failed`, but I missed this third notify site in `resume_pending()`. Same class of leak.

## Fix

Add the same guard. For spawned children:
- Still mark the session FAILED in session_store (so `_resume_yielded_for_children` can see it as terminal if it ever runs)
- Skip the vault tag swap (synthetic `spawn_xxx` task_id has no vault row anyway)
- Skip the vault checkbox status update
- Skip the Telegram notify

## Test evidence

- 200 agent_worker unit tests pass (1 new)
- `test_resume_pending_does_not_telegram_for_spawned_children` — repro: root session + spawned child both stuck in RUNNING, `resume_pending()` marks both FAILED but only sends ONE Telegram message (for the root); the child's session_id is verified absent from the notify text

## Review focus

- Recovery still records the `resume_failed` transcript event for children — that's internal bookkeeping, the parent's resume mechanism may want to see it
- Returns `recovered += 1; continue` early so the spawned-child path falls all the way through without touching the vault or Telegram