### PR TITLE
feat: read-only agent activity visualization at /agents

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -32,7 +32,7 @@ from fastapi.exceptions import RequestValidationError
 from pathlib import Path
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, tasks, monarch, jobs, perf
+from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, tasks, monarch, jobs, perf, agents
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -196,6 +196,7 @@ app.include_router(tasks.router)
 app.include_router(monarch.router)
 app.include_router(jobs.router)
 app.include_router(perf.router)
+app.include_router(agents.router)
 
 # Serve static files
 web_dir = Path(__file__).parent.parent / "web"
@@ -627,6 +628,15 @@ async def crm_page():
     if crm_path.exists():
         return FileResponse(str(crm_path))
     return {"message": "CRM page not found"}
+
+
+@app.get("/agents")
+async def agents_page():
+    """Serve the agent activity visualization UI."""
+    agents_path = Path(__file__).parent.parent / "web" / "agents.html"
+    if agents_path.exists():
+        return FileResponse(str(agents_path))
+    return {"message": "Agents page not found"}
 
 
 @app.get("/crm/{path:path}")

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -33,10 +33,11 @@ router = APIRouter(prefix="/api/agents", tags=["agents"])
 _session_store: SessionStore | None = None
 _transcript_store: TranscriptStore | None = None
 
-# Labels are derived from transcript events (first claim/seed/spawn) and don't
-# change for the lifetime of a session, so cache by session_id to avoid
-# re-scanning transcripts on every snapshot tick.
+# Labels are stable once derived from a non-fallback source, so cache to avoid
+# re-deriving on every snapshot tick. Capped to bound memory if the process
+# accumulates a lot of session IDs over a long uptime.
 _label_cache: dict[str, str] = {}
+_LABEL_CACHE_MAX = 500
 
 # Transcript tail size used for snapshot summary fields. Capping keeps SSE
 # tick cost bounded for sessions with long transcripts.
@@ -46,7 +47,16 @@ _SUMMARY_TAIL = 100
 _SNAPSHOT_LIMIT = 200
 
 
-_ERROR_KINDS = frozenset({"failed", "managed_failed", "child_failed_internal"})
+# Event kinds that count as errors. Includes operator/peer-initiated kills
+# because the frontend renders them as failures and the count chip should
+# match. The endswith check picks up future `*_failed`/`*_error` kinds.
+_ERROR_KINDS = frozenset({
+    "failed",
+    "managed_failed",
+    "child_failed_internal",
+    "killed",
+    "cascade_killed",
+})
 
 
 def _get_session_store() -> SessionStore:
@@ -74,11 +84,13 @@ def _label_for_session(s: Session, events: list[dict[str, Any]]) -> str:
     if cached is not None:
         return cached
 
-    label = s.task_id or s.session_id
+    label: str | None = None
+
+    # Future-proof: if a transcript event ever carries a description directly
+    # (e.g. via a future enrichment in worker._claim), use it.
     for ev in events[:5]:
-        kind = ev.get("kind", "")
         payload = ev.get("payload") or {}
-        if kind in ("claim", "seed", "spawn"):
+        if ev.get("kind") in ("claim", "seed", "spawn"):
             desc = (
                 payload.get("description")
                 or payload.get("task_description")
@@ -88,10 +100,34 @@ def _label_for_session(s: Session, events: list[dict[str, Any]]) -> str:
                 label = str(desc)
                 break
 
+    # Real worker `claim`/`seed` payloads today only carry `task_id`, so for
+    # root sessions look the task description up via the TaskManager. This
+    # call is cheap (in-memory dict in the singleton) and the result is
+    # cached below.
+    if label is None and s.parent_session_id is None and s.task_id:
+        try:
+            from api.services.task_manager import get_task_manager
+
+            task = get_task_manager().get(s.task_id)
+            if task is not None and task.description:
+                label = task.description
+        except Exception as exc:  # noqa: BLE001 — defensive: never break the snapshot on label lookup
+            logger.debug("task_manager lookup failed for %s: %s", s.task_id, exc)
+
+    # Only cache when we found a real label — never the fallback, so a snapshot
+    # tick that races the `claim` append doesn't poison the cache.
+    found = label is not None
+    if label is None:
+        label = s.task_id or s.session_id
     label = label.strip().replace("\n", " ")
     if len(label) > 60:
         label = label[:57] + "…"
-    _label_cache[s.session_id] = label
+
+    if found:
+        if len(_label_cache) >= _LABEL_CACHE_MAX:
+            # Drop one arbitrary entry to keep the cache bounded.
+            _label_cache.pop(next(iter(_label_cache)))
+        _label_cache[s.session_id] = label
     return label
 
 

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,0 +1,275 @@
+"""Read-only agent activity visualization endpoints.
+
+Powers the `/agents` UI: a live graph of in-flight and recently-completed
+agent worker sessions, plus per-session transcript tailing. See
+`docs/specs/technical/agent-worker.md` and issue #133.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import StreamingResponse
+
+from api.services.agent_worker.session_store import (
+    TERMINAL_STATUSES,
+    Session,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/agents", tags=["agents"])
+
+
+# Module-level lazy singletons. Tests monkeypatch these directly so they can
+# point the endpoints at temp-dir-backed stores without hitting the real data
+# directory.
+_session_store: SessionStore | None = None
+_transcript_store: TranscriptStore | None = None
+
+# Labels are derived from transcript events (first claim/seed/spawn) and don't
+# change for the lifetime of a session, so cache by session_id to avoid
+# re-scanning transcripts on every snapshot tick.
+_label_cache: dict[str, str] = {}
+
+# Transcript tail size used for snapshot summary fields. Capping keeps SSE
+# tick cost bounded for sessions with long transcripts.
+_SUMMARY_TAIL = 100
+
+# How many sessions to list per snapshot. Sessions are returned newest-first.
+_SNAPSHOT_LIMIT = 200
+
+
+_ERROR_KINDS = frozenset({"failed", "managed_failed", "child_failed_internal"})
+
+
+def _get_session_store() -> SessionStore:
+    global _session_store
+    if _session_store is None:
+        _session_store = SessionStore()
+    return _session_store
+
+
+def _get_transcript_store() -> TranscriptStore:
+    global _transcript_store
+    if _transcript_store is None:
+        _transcript_store = TranscriptStore()
+    return _transcript_store
+
+
+def _is_error_kind(kind: str) -> bool:
+    if kind in _ERROR_KINDS:
+        return True
+    return kind.endswith("_failed") or kind.endswith("_error")
+
+
+def _label_for_session(s: Session, events: list[dict[str, Any]]) -> str:
+    cached = _label_cache.get(s.session_id)
+    if cached is not None:
+        return cached
+
+    label = s.task_id or s.session_id
+    for ev in events[:5]:
+        kind = ev.get("kind", "")
+        payload = ev.get("payload") or {}
+        if kind in ("claim", "seed", "spawn"):
+            desc = (
+                payload.get("description")
+                or payload.get("task_description")
+                or payload.get("prompt")
+            )
+            if desc:
+                label = str(desc)
+                break
+
+    label = label.strip().replace("\n", " ")
+    if len(label) > 60:
+        label = label[:57] + "…"
+    _label_cache[s.session_id] = label
+    return label
+
+
+def _summarize_events(events: list[dict[str, Any]]) -> dict[str, Any]:
+    tool_call_count = 0
+    error_count = 0
+    last_event_kind = ""
+    for ev in events:
+        kind = str(ev.get("kind", ""))
+        if kind == "tool_call":
+            tool_call_count += 1
+        if _is_error_kind(kind):
+            error_count += 1
+        last_event_kind = kind
+    return {
+        "tool_call_count": tool_call_count,
+        "error_count": error_count,
+        "last_event_kind": last_event_kind,
+    }
+
+
+def _session_to_dict(s: Session, transcript: TranscriptStore) -> dict[str, Any]:
+    try:
+        events = transcript.read(s.session_id)
+    except Exception as exc:  # noqa: BLE001 — defensive: read should never break the snapshot
+        logger.warning("transcript read failed for %s: %s", s.session_id, exc)
+        events = []
+    tail = events[-_SUMMARY_TAIL:] if len(events) > _SUMMARY_TAIL else events
+    summary = _summarize_events(tail)
+    return {
+        "session_id": s.session_id,
+        "task_id": s.task_id,
+        "status": s.status,
+        "routing": s.routing,
+        "parent_session_id": s.parent_session_id,
+        "root_session_id": s.root_session_id,
+        "spawn_depth": s.spawn_depth,
+        "yield_waiting_for": s.yield_waiting_for or [],
+        "managed_agent_session_id": s.managed_agent_session_id,
+        "started_at": s.started_at,
+        "last_activity_at": s.last_activity_at,
+        "total_input_tokens": s.total_input_tokens,
+        "total_output_tokens": s.total_output_tokens,
+        "total_dollars": round(s.total_dollars, 6),
+        "total_active_seconds": round(s.total_active_seconds, 3),
+        "expected_output": s.expected_output,
+        "label": _label_for_session(s, events),
+        "last_event_kind": summary["last_event_kind"],
+        "tool_call_count": summary["tool_call_count"],
+        "error_count": summary["error_count"],
+    }
+
+
+def _build_snapshot() -> dict[str, Any]:
+    session_store = _get_session_store()
+    transcript_store = _get_transcript_store()
+    sessions = session_store.list_sessions(limit=_SNAPSHOT_LIMIT)
+    session_dicts = [_session_to_dict(s, transcript_store) for s in sessions]
+    edges = [
+        {"from": s.parent_session_id, "to": s.session_id, "type": "spawn"}
+        for s in sessions
+        if s.parent_session_id
+    ]
+    return {
+        "sessions": session_dicts,
+        "edges": edges,
+        "generated_at": int(time.time()),
+    }
+
+
+@router.get("/snapshot")
+async def get_snapshot() -> dict[str, Any]:
+    """Full current snapshot of agent sessions + spawn edges."""
+    return _build_snapshot()
+
+
+@router.get("/sessions/{session_id}/events")
+async def get_session_events(
+    session_id: str,
+    limit: int = Query(200, ge=1, le=2000),
+) -> dict[str, Any]:
+    """Recent transcript events for one session (paginated tail)."""
+    transcript_store = _get_transcript_store()
+    try:
+        events = transcript_store.read(session_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    tail = events[-limit:] if len(events) > limit else events
+    return {"session_id": session_id, "events": tail, "total": len(events)}
+
+
+@router.get("/stream")
+async def stream_snapshots() -> StreamingResponse:
+    """SSE stream emitting a full snapshot every ~2 seconds."""
+
+    async def generate():
+        yield ": ok\n\n"
+        while True:
+            try:
+                snap = _build_snapshot()
+                yield f"event: snapshot\ndata: {json.dumps(snap)}\n\n"
+            except Exception as exc:  # noqa: BLE001 — keep the stream alive on errors
+                logger.warning("snapshot stream tick failed: %s", exc)
+                yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
+            await asyncio.sleep(2.0)
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
+@router.get("/sessions/{session_id}/stream")
+async def stream_session_transcript(
+    session_id: str,
+    backfill: int = Query(50, ge=0, le=500),
+) -> StreamingResponse:
+    """Per-session SSE: backfill last N events, then live-tail the JSONL file.
+
+    Closes cleanly when the session reaches a terminal status.
+    """
+    transcript_store = _get_transcript_store()
+    session_store = _get_session_store()
+
+    # Validate session_id up-front via the store's path protection — fail fast
+    # before opening the streaming response.
+    try:
+        transcript_store._path(session_id)  # raises ValueError on traversal
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    async def generate():
+        yield ": ok\n\n"
+        try:
+            events = transcript_store.read(session_id)
+        except Exception as exc:  # noqa: BLE001
+            yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
+            return
+        tail = events[-backfill:] if backfill and len(events) > backfill else events
+        for ev in tail:
+            yield f"event: transcript_event\ndata: {json.dumps(ev)}\n\n"
+
+        line_count = len(events)
+        last_heartbeat = time.time()
+        terminal_check_at = 0.0
+        while True:
+            await asyncio.sleep(1.0)
+            try:
+                events = transcript_store.read(session_id)
+            except Exception:
+                events = []
+            if len(events) > line_count:
+                for ev in events[line_count:]:
+                    yield f"event: transcript_event\ndata: {json.dumps(ev)}\n\n"
+                line_count = len(events)
+                last_heartbeat = time.time()
+            elif time.time() - last_heartbeat >= 15.0:
+                yield ": heartbeat\n\n"
+                last_heartbeat = time.time()
+
+            # Check terminal status at most every ~5s to avoid hammering the DB.
+            now = time.time()
+            if now - terminal_check_at >= 5.0:
+                terminal_check_at = now
+                try:
+                    s = session_store.get_by_session_id(session_id)
+                    if s and s.status in TERMINAL_STATUSES:
+                        yield (
+                            "event: closed\n"
+                            f"data: {json.dumps({'session_id': session_id, 'status': s.status})}\n\n"
+                        )
+                        return
+                except Exception:  # noqa: BLE001
+                    pass
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )

--- a/tests/test_agent_viz_api.py
+++ b/tests/test_agent_viz_api.py
@@ -168,6 +168,113 @@ def test_per_session_stream_rejects_traversal(client, stores):
 
 
 @pytest.mark.unit
+def test_per_session_stream_emits_events_before_close(client, stores):
+    """Verifies the stream emits transcript_event chunks before the terminal close event."""
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t-mid", status=STATUS_RUNNING)
+    transcript_store.append(s.session_id, "claim", {"description": "Running session"})
+    transcript_store.append(s.session_id, "tool_call", {"name": "lifeos_search"})
+    session_store.update_status("t-mid", STATUS_COMPLETED)
+
+    transcript_seen = False
+    closed = False
+    with client.stream("GET", f"/api/agents/sessions/{s.session_id}/stream?backfill=5") as resp:
+        assert resp.status_code == 200
+        for chunk in resp.iter_text():
+            if "event: transcript_event" in chunk and not closed:
+                transcript_seen = True
+            if "event: closed" in chunk:
+                closed = True
+                break
+    assert transcript_seen, "transcript_event chunks should arrive before the close event"
+    assert closed, "stream should emit event: closed when the session is terminal"
+
+
+@pytest.mark.unit
+def test_label_falls_back_to_task_manager_for_root_sessions(client, stores, monkeypatch):
+    """When transcript events don't carry a description (the real worker case),
+    the label should come from the task manager rather than being cached as
+    the task_id fallback."""
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t-tm", status=STATUS_RUNNING)
+    # Real worker emits this payload — no description.
+    transcript_store.append(s.session_id, "claim", {"task_id": "t-tm", "worker": "agent-worker"})
+
+    # Stub the task manager so the label lookup hits a known value.
+    class StubTask:
+        description = "Review the Q4 budget"
+
+    class StubManager:
+        def get(self, task_id):
+            return StubTask() if task_id == "t-tm" else None
+
+    monkeypatch.setattr(
+        "api.services.task_manager.get_task_manager",
+        lambda: StubManager(),
+    )
+
+    r = client.get("/api/agents/snapshot")
+    sess = next(x for x in r.json()["sessions"] if x["session_id"] == s.session_id)
+    assert sess["label"] == "Review the Q4 budget"
+
+
+@pytest.mark.unit
+def test_error_count_includes_killed_kinds(client, stores):
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t-killed", status=STATUS_RUNNING)
+    transcript_store.append(s.session_id, "tool_call", {"name": "lifeos_search"})
+    transcript_store.append(s.session_id, "killed", {"by": "operator"})
+    transcript_store.append(s.session_id, "cascade_killed", {"reason": "parent killed"})
+
+    r = client.get("/api/agents/snapshot")
+    sess = next(x for x in r.json()["sessions"] if x["session_id"] == s.session_id)
+    assert sess["error_count"] == 2
+    assert sess["tool_call_count"] == 1
+
+
+@pytest.mark.unit
+def test_label_cache_does_not_pin_fallback(client, stores, monkeypatch):
+    """If the first snapshot tick fires before any descriptive event lands,
+    the fallback (`task_id`) must not get cached. A subsequent tick with the
+    real label available should pick it up."""
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t-race", status=STATUS_RUNNING)
+    # No transcript yet — simulate the race.
+
+    class _MissingManager:
+        def get(self, task_id):
+            return None
+
+    monkeypatch.setattr(
+        "api.services.task_manager.get_task_manager",
+        lambda: _MissingManager(),
+    )
+
+    r1 = client.get("/api/agents/snapshot")
+    sess1 = next(x for x in r1.json()["sessions"] if x["session_id"] == s.session_id)
+    assert sess1["label"] == "t-race"  # fallback to task_id
+
+    # Now the real description becomes available (later claim event lands, OR
+    # task_manager would resolve it). The cache must NOT have pinned the
+    # fallback, so the new label takes effect.
+    class _StubTask:
+        description = "Real label arrives late"
+
+    class _StubManager:
+        def get(self, task_id):
+            return _StubTask()
+
+    monkeypatch.setattr(
+        "api.services.task_manager.get_task_manager",
+        lambda: _StubManager(),
+    )
+
+    r2 = client.get("/api/agents/snapshot")
+    sess2 = next(x for x in r2.json()["sessions"] if x["session_id"] == s.session_id)
+    assert sess2["label"] == "Real label arrives late"
+
+
+@pytest.mark.unit
 def test_snapshot_filters_yield_waiting_for(client, stores):
     """Ensure yield_waiting_for survives JSON round-trip as an array."""
     session_store, transcript_store = stores

--- a/tests/test_agent_viz_api.py
+++ b/tests/test_agent_viz_api.py
@@ -1,0 +1,193 @@
+"""API tests for the read-only agent activity visualization (issue #133).
+
+Covers /api/agents/snapshot, /api/agents/sessions/{sid}/events, and the
+per-session SSE transcript tail. Uses temp-dir-backed stores via monkeypatch
+so the real data/ directory is never touched.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
+    STATUS_COMPLETED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    """Point the agents route at temp-dir-backed stores for the duration of the test."""
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    # Clear the label cache so labels are recomputed against the test fixtures.
+    agents_route._label_cache.clear()
+    yield session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+@pytest.mark.unit
+def test_snapshot_empty(client, stores):
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["sessions"] == []
+    assert body["edges"] == []
+    assert "generated_at" in body
+
+
+@pytest.mark.unit
+def test_snapshot_sessions_and_edges(client, stores):
+    session_store, transcript_store = stores
+    parent = session_store.create(task_id="root-task", status=STATUS_RUNNING, routing="claude")
+    # Spawned child under the same root.
+    child = session_store.create(
+        task_id="child-task",
+        status=STATUS_RUNNING,
+        routing="local",
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    transcript_store.append(parent.session_id, "claim", {"description": "Synthesize the briefing"})
+    transcript_store.append(parent.session_id, "tool_call", {"name": "lifeos_search"})
+    transcript_store.append(parent.session_id, "tool_call", {"name": "lifeos_calendar_upcoming"})
+    transcript_store.append(child.session_id, "spawn", {"prompt": "Sub-task: find conflicts"})
+    transcript_store.append(child.session_id, "tool_call", {"name": "lifeos_search"})
+    transcript_store.append(child.session_id, "managed_failed", {"reason": "synthetic test"})
+
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    body = r.json()
+    sessions = {s["session_id"]: s for s in body["sessions"]}
+    assert parent.session_id in sessions
+    assert child.session_id in sessions
+
+    parent_s = sessions[parent.session_id]
+    assert parent_s["label"] == "Synthesize the briefing"
+    assert parent_s["tool_call_count"] == 2
+    assert parent_s["error_count"] == 0
+    assert parent_s["last_event_kind"] == "tool_call"
+    assert parent_s["routing"] == "claude"
+
+    child_s = sessions[child.session_id]
+    assert child_s["tool_call_count"] == 1
+    # `managed_failed` should be counted as an error.
+    assert child_s["error_count"] == 1
+    assert child_s["last_event_kind"] == "managed_failed"
+
+    edges = body["edges"]
+    assert {"from": parent.session_id, "to": child.session_id, "type": "spawn"} in edges
+
+
+@pytest.mark.unit
+def test_events_endpoint_returns_tail(client, stores):
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t1", status=STATUS_RUNNING)
+    for i in range(10):
+        transcript_store.append(s.session_id, "tool_call", {"i": i})
+
+    r = client.get(f"/api/agents/sessions/{s.session_id}/events?limit=3")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 10
+    assert len(body["events"]) == 3
+    # Tail should be the most-recent 3, in order.
+    assert [ev["payload"]["i"] for ev in body["events"]] == [7, 8, 9]
+
+
+@pytest.mark.unit
+def test_events_endpoint_rejects_traversal(client, stores):
+    r = client.get("/api/agents/sessions/..%2Fetc/events")
+    # FastAPI normalizes %2F so the traversal token reaches the handler;
+    # either 400 (validation) or 404 (path mismatch) is acceptable so long as
+    # the endpoint does not return file contents from outside the transcripts dir.
+    assert r.status_code in (400, 404)
+
+    # Direct traversal segment in the session_id parameter.
+    r2 = client.get("/api/agents/sessions/foo..bar/events")
+    assert r2.status_code == 400
+
+
+@pytest.mark.unit
+def test_events_endpoint_missing_session(client, stores):
+    r = client.get("/api/agents/sessions/missing-session/events")
+    assert r.status_code == 200
+    assert r.json() == {"session_id": "missing-session", "events": [], "total": 0}
+
+
+@pytest.mark.unit
+def test_per_session_stream_backfill_and_terminate_on_completed(client, stores):
+    """Verify the per-session SSE stream sends backfill events and closes on terminal status."""
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t1", status=STATUS_RUNNING)
+    transcript_store.append(s.session_id, "claim", {"description": "Test session"})
+    transcript_store.append(s.session_id, "tool_call", {"name": "lifeos_search"})
+
+    # Mark the session terminal so the stream closes promptly when the
+    # terminal-check fires inside the generator.
+    session_store.update_status("t1", STATUS_COMPLETED)
+
+    with client.stream("GET", f"/api/agents/sessions/{s.session_id}/stream?backfill=5") as resp:
+        assert resp.status_code == 200
+        chunks: list[str] = []
+        # Collect output until the stream closes (it should, after the
+        # generator hits the terminal-status check). Bail out defensively
+        # after a reasonable amount of data.
+        for chunk in resp.iter_text():
+            chunks.append(chunk)
+            if "event: closed" in chunk:
+                break
+            if sum(len(c) for c in chunks) > 50_000:
+                pytest.fail("stream did not close on terminal status")
+        body = "".join(chunks)
+        assert "event: transcript_event" in body
+        assert '"kind": "claim"' in body
+        assert '"kind": "tool_call"' in body
+        assert "event: closed" in body
+
+
+@pytest.mark.unit
+def test_per_session_stream_rejects_traversal(client, stores):
+    r = client.get("/api/agents/sessions/foo..bar/stream")
+    assert r.status_code == 400
+
+
+@pytest.mark.unit
+def test_snapshot_filters_yield_waiting_for(client, stores):
+    """Ensure yield_waiting_for survives JSON round-trip as an array."""
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t1", status=STATUS_BLOCKED)
+    session_store.set_yield_waiting_for(s.task_id, ["child-1", "child-2"])
+
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    sess = next(x for x in r.json()["sessions"] if x["session_id"] == s.session_id)
+    assert sess["yield_waiting_for"] == ["child-1", "child-2"]
+
+
+@pytest.mark.unit
+def test_label_truncates_long_descriptions(client, stores):
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t1", status=STATUS_RUNNING)
+    long_desc = "x" * 200
+    transcript_store.append(s.session_id, "claim", {"description": long_desc})
+
+    r = client.get("/api/agents/snapshot")
+    sess = r.json()["sessions"][0]
+    assert len(sess["label"]) <= 60
+    assert sess["label"].endswith("…")

--- a/web/agents.html
+++ b/web/agents.html
@@ -1,0 +1,544 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Agents · LifeOS</title>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+<script src="https://cdn.jsdelivr.net/npm/vis-network@9.1.9/standalone/umd/vis-network.min.js"></script>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  :root {
+    --bg-primary: #0a0a0f;
+    --bg-secondary: #12121a;
+    --bg-card: #1a1a24;
+    --bg-elev: #20202c;
+    --text-primary: #e8e8ed;
+    --text-secondary: #8888a0;
+    --text-dim: #5a5a6e;
+    --accent: #6366f1;
+    --border: #2a2a3a;
+    --running: #34d399;
+    --running-glow: rgba(52, 211, 153, 0.45);
+    --claimed: #60a5fa;
+    --yielded: #fbbf24;
+    --blocked: #fb923c;
+    --completed: #6b7280;
+    --failed: #f87171;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    min-height: 100vh;
+    overflow: hidden;
+  }
+  header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-secondary);
+    height: 56px;
+  }
+  header h1 {
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+  header h1 a {
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+  header h1 .crumb {
+    color: var(--text-dim);
+    font-weight: 400;
+    margin: 0 0.5rem;
+  }
+  .chips {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-left: auto;
+  }
+  .chip {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+  }
+  .chip strong { color: var(--text-primary); font-weight: 600; margin-right: 0.25rem; }
+  .chip.running strong { color: var(--running); }
+  .chip.blocked strong { color: var(--blocked); }
+  .chip.spend strong { color: var(--accent); }
+  .filters {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.5rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.8rem;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+  }
+  .filters label { display: flex; align-items: center; gap: 0.35rem; cursor: pointer; }
+  .filters select {
+    background: var(--bg-card);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem;
+  }
+  main {
+    display: grid;
+    grid-template-columns: 1fr 360px;
+    height: calc(100vh - 56px - 41px);
+  }
+  #graph {
+    background: var(--bg-primary);
+    position: relative;
+    overflow: hidden;
+  }
+  #graph .empty-state {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    gap: 0.5rem;
+    pointer-events: none;
+  }
+  #graph .empty-state .icon { font-size: 2.5rem; opacity: 0.5; }
+  #graph .empty-state .label { font-size: 0.95rem; }
+  #graph .empty-state .hint { font-size: 0.8rem; color: var(--text-dim); }
+  aside.panel {
+    background: var(--bg-secondary);
+    border-left: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .panel-header {
+    padding: 1rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .panel-header .label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    word-break: break-word;
+  }
+  .panel-header .meta {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    margin-top: 0.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.75rem;
+  }
+  .panel-header .meta .badge {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    padding: 0.1rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.7rem;
+  }
+  .badge.status-running { color: var(--running); border-color: var(--running); }
+  .badge.status-claimed { color: var(--claimed); border-color: var(--claimed); }
+  .badge.status-yielded { color: var(--yielded); border-color: var(--yielded); }
+  .badge.status-blocked { color: var(--blocked); border-color: var(--blocked); }
+  .badge.status-completed { color: var(--completed); border-color: var(--completed); }
+  .badge.status-failed,
+  .badge.status-budget_exceeded { color: var(--failed); border-color: var(--failed); }
+  .panel-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-dim);
+    padding: 2rem;
+    text-align: center;
+    font-size: 0.85rem;
+  }
+  .events {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem;
+  }
+  .event {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.45rem 0.6rem;
+    margin-bottom: 0.4rem;
+    font-size: 0.78rem;
+    line-height: 1.35;
+    animation: fadeIn 0.3s ease;
+  }
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .event.kind-tool_call { border-left: 2px solid var(--accent); }
+  .event.kind-failed,
+  .event.kind-managed_failed,
+  .event.kind-child_failed_internal,
+  .event.kind-killed,
+  .event.kind-cascade_killed { border-left: 2px solid var(--failed); }
+  .event.kind-spawn,
+  .event.kind-spawned_child { border-left: 2px solid var(--claimed); }
+  .event.kind-final { border-left: 2px solid var(--running); }
+  .event .kind {
+    color: var(--text-primary);
+    font-weight: 600;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+  }
+  .event .ts {
+    color: var(--text-dim);
+    font-size: 0.68rem;
+    margin-left: 0.5rem;
+  }
+  .event .payload {
+    color: var(--text-secondary);
+    margin-top: 0.2rem;
+    word-break: break-word;
+    white-space: pre-wrap;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.7rem;
+    max-height: 8rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .panel-close {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    float: right;
+  }
+  .panel-close:hover { background: var(--bg-card); color: var(--text-primary); }
+  .live-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--running);
+    box-shadow: 0 0 6px var(--running-glow);
+    margin-right: 0.4rem;
+    animation: pulse 1.4s ease-in-out infinite;
+    vertical-align: middle;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(0.85); }
+  }
+  @media (max-width: 800px) {
+    main {
+      grid-template-columns: 1fr;
+      grid-template-rows: 1fr auto;
+    }
+    aside.panel {
+      max-height: 50vh;
+      border-left: none;
+      border-top: 1px solid var(--border);
+    }
+    .chips { display: none; }
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1><a href="/">LifeOS</a><span class="crumb">›</span>Agents</h1>
+  <div class="chips" id="chips">
+    <span class="chip running">running <strong id="chip-running">0</strong></span>
+    <span class="chip blocked">blocked <strong id="chip-blocked">0</strong></span>
+    <span class="chip">recent <strong id="chip-recent">0</strong></span>
+    <span class="chip spend">spend <strong id="chip-spend">$0.00</strong></span>
+  </div>
+</header>
+<div class="filters">
+  <label><input type="checkbox" id="filter-terminal" /> show terminal</label>
+  <label>route
+    <select id="filter-route">
+      <option value="all">all</option>
+      <option value="local">local</option>
+      <option value="claude">claude</option>
+    </select>
+  </label>
+  <label>status
+    <select id="filter-status">
+      <option value="all">all</option>
+      <option value="running">running</option>
+      <option value="claimed">claimed</option>
+      <option value="yielded">yielded</option>
+      <option value="blocked">blocked</option>
+      <option value="completed">completed</option>
+      <option value="failed">failed</option>
+    </select>
+  </label>
+  <span style="margin-left:auto;color:var(--text-dim);font-size:0.75rem" id="connection-state">connecting…</span>
+</div>
+<main>
+  <section id="graph">
+    <div class="empty-state" id="empty-state">
+      <div class="icon">🛠️</div>
+      <div class="label">No agent sessions yet</div>
+      <div class="hint">Sessions will appear here when an <code>#agent</code> task is claimed.</div>
+    </div>
+  </section>
+  <aside class="panel" id="panel">
+    <div class="panel-empty" id="panel-empty">Click a node to inspect its transcript.</div>
+  </aside>
+</main>
+
+<script>
+(() => {
+  const STATUS_COLORS = {
+    running:   '#34d399',
+    claimed:   '#60a5fa',
+    yielded:   '#fbbf24',
+    blocked:   '#fb923c',
+    completed: '#6b7280',
+    failed:    '#f87171',
+    budget_exceeded: '#f87171',
+  };
+  const TERMINAL = new Set(['completed', 'failed', 'budget_exceeded']);
+
+  const filterTerminalEl = document.getElementById('filter-terminal');
+  const filterRouteEl = document.getElementById('filter-route');
+  const filterStatusEl = document.getElementById('filter-status');
+  const connStateEl = document.getElementById('connection-state');
+  const emptyStateEl = document.getElementById('empty-state');
+  const panelEl = document.getElementById('panel');
+
+  let allSessions = [];
+  let allEdges = [];
+  let selectedSessionId = null;
+  let transcriptES = null;
+
+  const graphEl = document.getElementById('graph');
+  const nodes = new vis.DataSet([]);
+  const edges = new vis.DataSet([]);
+  const network = new vis.Network(graphEl, { nodes, edges }, {
+    physics: {
+      enabled: true,
+      stabilization: { iterations: 80 },
+      barnesHut: { gravitationalConstant: -2200, springLength: 110 },
+    },
+    interaction: { hover: true, tooltipDelay: 200 },
+    edges: { arrows: 'to', color: { color: '#3a3a4a', highlight: '#6366f1' }, smooth: { type: 'cubicBezier' } },
+    nodes: {
+      shape: 'dot',
+      size: 18,
+      borderWidth: 2,
+      color: { background: '#1a1a24', border: '#2a2a3a' },
+      font: { color: '#e8e8ed', size: 12, face: 'system-ui' },
+    },
+  });
+
+  network.on('click', (params) => {
+    if (params.nodes && params.nodes.length > 0) {
+      openPanel(params.nodes[0]);
+    }
+  });
+
+  function applyFilters(sessions) {
+    const showTerm = filterTerminalEl.checked;
+    const route = filterRouteEl.value;
+    const status = filterStatusEl.value;
+    return sessions.filter(s => {
+      if (!showTerm && TERMINAL.has(s.status)) return false;
+      if (route !== 'all') {
+        const r = s.routing || 'local';
+        if (r !== route) return false;
+      }
+      if (status !== 'all' && s.status !== status) return false;
+      return true;
+    });
+  }
+
+  function routingLabel(routing) {
+    if (!routing || routing === 'local') return 'Local';
+    return 'Claude';
+  }
+
+  function nodeFor(s) {
+    const color = STATUS_COLORS[s.status] || '#6b7280';
+    const isRunning = s.status === 'running';
+    const isBlocked = s.status === 'blocked';
+    return {
+      id: s.session_id,
+      label: s.label || s.session_id.slice(0, 8),
+      title: [
+        s.label,
+        `status: ${s.status}`,
+        `routing: ${routingLabel(s.routing)}`,
+        `tokens: ${s.total_input_tokens} in / ${s.total_output_tokens} out`,
+        `cost: $${(s.total_dollars || 0).toFixed(4)}`,
+        `active: ${(s.total_active_seconds || 0).toFixed(1)}s`,
+        s.last_event_kind ? `last: ${s.last_event_kind}` : null,
+      ].filter(Boolean).join('\n'),
+      color: {
+        background: isRunning ? color : '#1a1a24',
+        border: color,
+        highlight: { background: color, border: color },
+      },
+      borderWidth: isBlocked ? 4 : 2,
+      shadow: isRunning ? { enabled: true, color: color, size: 16, x: 0, y: 0 } : false,
+      font: { color: '#e8e8ed' },
+    };
+  }
+
+  function renderGraph(sessions, snapshotEdges) {
+    const visible = applyFilters(sessions);
+    const visibleIds = new Set(visible.map(s => s.session_id));
+    const nextNodes = visible.map(nodeFor);
+    const nextEdges = snapshotEdges
+      .filter(e => visibleIds.has(e.from) && visibleIds.has(e.to))
+      .map(e => ({ id: `${e.from}->${e.to}`, from: e.from, to: e.to }));
+    nodes.clear();
+    edges.clear();
+    nodes.add(nextNodes);
+    edges.add(nextEdges);
+
+    emptyStateEl.style.display = visible.length === 0 ? '' : 'none';
+    updateChips(sessions);
+  }
+
+  function updateChips(sessions) {
+    const running = sessions.filter(s => s.status === 'running').length;
+    const blocked = sessions.filter(s => s.status === 'blocked').length;
+    const recent = sessions.filter(s => s.status === 'completed').length;
+    const spend = sessions.reduce((acc, s) => acc + (s.total_dollars || 0), 0);
+    document.getElementById('chip-running').textContent = running;
+    document.getElementById('chip-blocked').textContent = blocked;
+    document.getElementById('chip-recent').textContent = recent;
+    document.getElementById('chip-spend').textContent = '$' + spend.toFixed(2);
+  }
+
+  function applySnapshot(snap) {
+    allSessions = snap.sessions || [];
+    allEdges = snap.edges || [];
+    renderGraph(allSessions, allEdges);
+    // Re-render panel header if the selected session updated.
+    if (selectedSessionId) {
+      const s = allSessions.find(x => x.session_id === selectedSessionId);
+      if (s) renderPanelHeader(s);
+    }
+  }
+
+  // --- Side panel ---
+  function renderPanelHeader(s) {
+    const live = !TERMINAL.has(s.status);
+    panelEl.innerHTML = `
+      <div class="panel-header">
+        <button class="panel-close" aria-label="Close" id="panel-close">×</button>
+        <div class="label">${escapeHtml(s.label || s.session_id)}</div>
+        <div class="meta">
+          ${live ? '<span class="live-dot" title="live"></span>' : ''}
+          <span class="badge status-${s.status}">${s.status}</span>
+          <span class="badge">${routingLabel(s.routing)}</span>
+          <span class="badge">$${(s.total_dollars || 0).toFixed(4)}</span>
+          <span class="badge">${s.total_input_tokens}↓ / ${s.total_output_tokens}↑</span>
+          ${s.spawn_depth ? `<span class="badge">depth ${s.spawn_depth}</span>` : ''}
+        </div>
+      </div>
+      <div class="events" id="events"></div>
+    `;
+    document.getElementById('panel-close').onclick = closePanel;
+  }
+
+  function closePanel() {
+    selectedSessionId = null;
+    if (transcriptES) { transcriptES.close(); transcriptES = null; }
+    panelEl.innerHTML = '<div class="panel-empty" id="panel-empty">Click a node to inspect its transcript.</div>';
+  }
+
+  function openPanel(sessionId) {
+    if (transcriptES) { transcriptES.close(); transcriptES = null; }
+    selectedSessionId = sessionId;
+    const s = allSessions.find(x => x.session_id === sessionId);
+    if (!s) return;
+    renderPanelHeader(s);
+
+    // Backfill then live tail.
+    fetch(`/api/agents/sessions/${encodeURIComponent(sessionId)}/events?limit=200`)
+      .then(r => r.json())
+      .then(payload => {
+        (payload.events || []).forEach(ev => appendEvent(ev, false));
+        // Now open live SSE.
+        const es = new EventSource(`/api/agents/sessions/${encodeURIComponent(sessionId)}/stream?backfill=0`);
+        transcriptES = es;
+        es.addEventListener('transcript_event', e => {
+          try { appendEvent(JSON.parse(e.data), true); } catch (_) {}
+        });
+        es.addEventListener('closed', () => { es.close(); });
+        es.onerror = () => {}; // browser auto-retries
+      })
+      .catch(err => {
+        const e = document.getElementById('events');
+        if (e) e.innerHTML = `<div class="event">Failed to load events: ${escapeHtml(String(err))}</div>`;
+      });
+  }
+
+  function appendEvent(ev, live) {
+    const container = document.getElementById('events');
+    if (!container) return;
+    const kind = String(ev.kind || '');
+    const ts = ev.ts ? new Date(ev.ts * 1000).toLocaleTimeString() : '';
+    const payload = ev.payload ? JSON.stringify(ev.payload, null, 0) : '';
+    const truncated = payload.length > 240 ? payload.slice(0, 240) + '…' : payload;
+    const div = document.createElement('div');
+    div.className = `event kind-${kind}`;
+    div.innerHTML = `
+      <div><span class="kind">${escapeHtml(kind)}</span><span class="ts">${escapeHtml(ts)}</span></div>
+      ${payload ? `<div class="payload">${escapeHtml(truncated)}</div>` : ''}
+    `;
+    if (live) {
+      container.prepend(div);
+    } else {
+      container.appendChild(div);
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // --- Filters ---
+  [filterTerminalEl, filterRouteEl, filterStatusEl].forEach(el =>
+    el.addEventListener('change', () => renderGraph(allSessions, allEdges))
+  );
+
+  // --- Initial load + stream ---
+  fetch('/api/agents/snapshot')
+    .then(r => r.json())
+    .then(applySnapshot)
+    .catch(err => { connStateEl.textContent = 'failed: ' + err; });
+
+  const snapshotES = new EventSource('/api/agents/stream');
+  snapshotES.onopen = () => { connStateEl.textContent = 'live'; };
+  snapshotES.onerror = () => { connStateEl.textContent = 'reconnecting…'; };
+  snapshotES.addEventListener('snapshot', e => {
+    try { applySnapshot(JSON.parse(e.data)); } catch (_) {}
+  });
+})();
+</script>
+</body>
+</html>

--- a/web/agents.html
+++ b/web/agents.html
@@ -441,14 +441,15 @@
   // --- Side panel ---
   function renderPanelHeader(s) {
     const live = !TERMINAL.has(s.status);
+    const safeStatus = escapeAttr(s.status);
     panelEl.innerHTML = `
       <div class="panel-header">
         <button class="panel-close" aria-label="Close" id="panel-close">×</button>
         <div class="label">${escapeHtml(s.label || s.session_id)}</div>
         <div class="meta">
           ${live ? '<span class="live-dot" title="live"></span>' : ''}
-          <span class="badge status-${s.status}">${s.status}</span>
-          <span class="badge">${routingLabel(s.routing)}</span>
+          <span class="badge status-${safeStatus}">${escapeHtml(s.status)}</span>
+          <span class="badge">${escapeHtml(routingLabel(s.routing))}</span>
           <span class="badge">$${(s.total_dollars || 0).toFixed(4)}</span>
           <span class="badge">${s.total_input_tokens}↓ / ${s.total_output_tokens}↑</span>
           ${s.spawn_depth ? `<span class="badge">depth ${s.spawn_depth}</span>` : ''}
@@ -492,7 +493,11 @@
       });
   }
 
-  function appendEvent(ev, live) {
+  // appendEvent always renders newest-on-top so backfill and live additions
+  // share the same visual order. Backfill is delivered oldest-first, so we
+  // prepend each one as it arrives, leaving the chronologically-newest event
+  // at the top by the time live tail begins.
+  function appendEvent(ev, _live) {
     const container = document.getElementById('events');
     if (!container) return;
     const kind = String(ev.kind || '');
@@ -500,16 +505,15 @@
     const payload = ev.payload ? JSON.stringify(ev.payload, null, 0) : '';
     const truncated = payload.length > 240 ? payload.slice(0, 240) + '…' : payload;
     const div = document.createElement('div');
-    div.className = `event kind-${kind}`;
+    // classList.add validates token shape — defense-in-depth even though
+    // `kind` is server-controlled today.
+    div.classList.add('event');
+    if (kind) div.classList.add(`kind-${kind.replace(/[^a-zA-Z0-9_-]/g, '_')}`);
     div.innerHTML = `
       <div><span class="kind">${escapeHtml(kind)}</span><span class="ts">${escapeHtml(ts)}</span></div>
       ${payload ? `<div class="payload">${escapeHtml(truncated)}</div>` : ''}
     `;
-    if (live) {
-      container.prepend(div);
-    } else {
-      container.appendChild(div);
-    }
+    container.prepend(div);
   }
 
   function escapeHtml(s) {
@@ -519,6 +523,13 @@
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
+  }
+
+  // For values that go into HTML attribute positions via template strings.
+  // Restricts to a known-safe charset so attribute-context injection is
+  // structurally impossible.
+  function escapeAttr(s) {
+    return String(s).replace(/[^a-zA-Z0-9_-]/g, '_');
   }
 
   // --- Filters ---

--- a/web/home.html
+++ b/web/home.html
@@ -58,7 +58,7 @@
 
         .cards {
             display: grid;
-            grid-template-columns: repeat(2, 1fr);
+            grid-template-columns: repeat(3, 1fr);
             gap: 1.5rem;
         }
 
@@ -147,10 +147,16 @@
                 <div class="card-title">CRM</div>
                 <div class="card-description">Manage relationships and view your network</div>
             </a>
+
+            <a href="/agents" class="card">
+                <div class="card-icon">🛠️</div>
+                <div class="card-title">Agents</div>
+                <div class="card-description">See what your agents are working on right now</div>
+            </a>
         </div>
 
         <p class="keyboard-hint">
-            Press <kbd>1</kbd> for Chat or <kbd>2</kbd> for CRM
+            Press <kbd>1</kbd> for Chat, <kbd>2</kbd> for CRM, or <kbd>3</kbd> for Agents
         </p>
     </div>
 
@@ -158,6 +164,7 @@
         document.addEventListener('keydown', (e) => {
             if (e.key === '1') window.location.href = '/chat';
             if (e.key === '2') window.location.href = '/crm';
+            if (e.key === '3') window.location.href = '/agents';
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary

Adds a live `/agents` page showing agent worker sessions as a graph plus a per-session transcript side panel.

Closes #133.

- **Backend** (`api/routes/agents.py`): four endpoints under `/api/agents` — `snapshot`, per-session `events?limit=N`, global SSE `stream` (~2s cadence snapshots), and per-session SSE `sessions/{id}/stream` (transcript tail that backfills + live-tails the JSONL and closes on terminal status).
- **Frontend** (`web/agents.html`): vanilla HTML/JS using vis-network via CDN (matching the existing CRM/D3 pattern). Status colors, routing badge, live-tailing transcript panel with fade-in animation, top summary chips, route/status/terminal filters, responsive layout (panel becomes bottom drawer on narrow screens).
- **Wiring**: third "Agents" card on `web/home.html`, `/agents` static route in `api/main.py`, router registered.
- **Tests** (`tests/test_agent_viz_api.py`): 9 new tests — empty snapshot, sessions+edges, events tail/limit, traversal rejection, missing-session 200-empty, per-session stream backfill + terminal close, yield_waiting_for round-trip, label truncation.

## Test evidence

- `~/.venvs/lifeos/bin/python -m pytest tests/test_agent_viz_api.py` → 9 passed
- Full unit suite: 1411 passed, 1 pre-existing unrelated failure (`test_summarizer.py::test_real_summary_generation` fails on clean tree too).

## Review focus

- Per-session SSE generator: terminal-status polling cadence (5s), heartbeat cadence (15s), client-disconnect handling.
- Label cache invalidation — current design assumes labels are stable for the life of a session; cleared at module reload but never mid-session.
- `transcript_store._path()` access from the SSE handler — used as the validation hook before opening the streaming response, as called out in the issue body.
- vis-network from CDN vs. local vendoring (issue acknowledges CDN is acceptable for MVP).

## Note for integration branch run

PR base is `feat/agent-ui` (integration branch), not `main`. The follow-up issue #134 (operator kill/cancel) will build on this on its own sub-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)