### PR TITLE
feat: operator kill/cancel for agent sessions

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 from api.services.agent_worker.session_store import (
     TERMINAL_STATUSES,
@@ -239,6 +240,129 @@ async def stream_snapshots() -> StreamingResponse:
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
     )
+
+
+class KillRequest(BaseModel):
+    reason: str = ""
+
+
+def _collect_subtree(session_store: SessionStore, target: Session) -> list[Session]:
+    """Return `target` followed by every non-self descendant in its subtree.
+
+    Walks via `parent_session_id` so non-root targets only take down their
+    own children — not unrelated peers under the same root.
+    """
+    root_id = target.root_session_id or target.session_id
+    all_in_root: list[Session] = list(session_store.list_descendants(root_id))
+    if target.session_id != root_id:
+        # `list_descendants` excludes the root itself; ensure we have the
+        # root in the pool too in case the target's parent chain runs back
+        # up through it.
+        root_session = session_store.get_by_session_id(root_id)
+        if root_session is not None:
+            all_in_root.append(root_session)
+
+    children_of: dict[str, list[Session]] = {}
+    for s in all_in_root:
+        if s.session_id == target.session_id:
+            continue
+        children_of.setdefault(s.parent_session_id or "", []).append(s)
+
+    subtree: list[Session] = [target]
+    queue: list[str] = [target.session_id]
+    seen: set[str] = {target.session_id}
+    while queue:
+        sid = queue.pop(0)
+        for child in children_of.get(sid, []):
+            if child.session_id in seen:
+                continue
+            seen.add(child.session_id)
+            subtree.append(child)
+            queue.append(child.session_id)
+    return subtree
+
+
+def _maybe_managed_driver():
+    """Lazy-instantiate a ManagedAgentsDriver when credentials are available.
+
+    Returning `None` is fine — `teardown_session` then degrades to a
+    local-only kill, and the worker's next managed poll reconciles the
+    remote side. We don't reuse the worker's driver because the worker
+    runs in a separate process.
+    """
+    try:
+        from config.settings import settings
+        api_key = settings.anthropic_api_key
+        if not api_key:
+            return None
+        from api.services.agent_worker.managed_driver import ManagedAgentsDriver
+        return ManagedAgentsDriver(api_key=api_key)
+    except Exception as exc:  # noqa: BLE001 — never block the kill on driver setup
+        logger.warning("operator kill: managed driver unavailable: %s", exc)
+        return None
+
+
+@router.post("/sessions/{session_id}/kill")
+async def operator_kill_session(session_id: str, body: KillRequest | None = None) -> dict[str, Any]:
+    """Operator-initiated kill: stop the target session and all descendants
+    in its subtree. Target gets an `operator_killed` transcript event;
+    descendants get `cascade_killed`.
+
+    Local-network only — must NOT be exposed via Tailscale Funnel or the
+    public MCP HTTP transport.
+    """
+    session_store = _get_session_store()
+    transcript_store = _get_transcript_store()
+    reason = (body.reason if body else "").strip() if body else ""
+
+    target = session_store.get_by_session_id(session_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail=f"session {session_id} not found")
+    if target.status in TERMINAL_STATUSES:
+        return {"killed": [], "failures": [], "reason": f"already {target.status}"}
+
+    subtree = _collect_subtree(session_store, target)
+    driver = _maybe_managed_driver()
+    try:
+        from api.services.agent_worker.inter_agent import teardown_session as _teardown
+
+        killed: list[str] = []
+        failures: list[dict[str, str]] = []
+        for idx, s in enumerate(subtree):
+            if s.status in TERMINAL_STATUSES:
+                continue
+            if idx == 0:
+                kind = "operator_killed"
+                payload = {
+                    "reason": reason,
+                    "managed_remote": s.managed_agent_session_id,
+                }
+            else:
+                kind = "cascade_killed"
+                payload = {
+                    "root": target.session_id,
+                    "reason": reason,
+                    "managed_remote": s.managed_agent_session_id,
+                }
+            result = _teardown(
+                session_store, transcript_store, s,
+                transcript_kind=kind,
+                transcript_payload=payload,
+                managed_driver=driver,
+            )
+            killed.append(s.session_id)
+            if result.get("managed_failure"):
+                failures.append({
+                    "session_id": s.session_id,
+                    "reason": result["managed_failure"],
+                })
+        return {"killed": killed, "failures": failures}
+    finally:
+        if driver is not None:
+            try:
+                driver.close()
+            except Exception:  # noqa: BLE001
+                pass
 
 
 @router.get("/sessions/{session_id}/stream")

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -37,6 +37,7 @@ from api.services.agent_worker.session_store import (
     STATUS_FAILED,
     STATUS_YIELDED,
     TERMINAL_STATUSES,
+    Session,
     SessionStore,
     new_session_id,
 )
@@ -439,6 +440,42 @@ def yield_until(ctx: InterAgentContext, args: dict) -> dict:
     return _ok({"yielded": True, "waiting_on": children})
 
 
+def teardown_session(
+    session_store: SessionStore,
+    transcript_store: TranscriptStore,
+    target: Session,
+    transcript_kind: str,
+    transcript_payload: dict,
+    managed_driver: Any | None = None,
+) -> dict[str, Any]:
+    """Tear down a single session: kill the managed remote (best-effort),
+    flip the local DB status to FAILED, and append a transcript event.
+
+    Shared between agent-initiated `kill()` (this module) and the operator
+    HTTP kill endpoint (`api/routes/agents.py`). Authorization is the
+    caller's responsibility — this helper just runs the mechanics.
+
+    Returns `{"managed_failure": <reason or None>}` so the caller can
+    surface partial-success in its response.
+    """
+    managed_failure: str | None = None
+    if target.managed_agent_session_id and managed_driver is not None:
+        try:
+            managed_driver.kill_session(
+                target.managed_agent_session_id,
+                reason=transcript_payload.get("reason", ""),
+            )
+        except Exception as exc:  # noqa: BLE001 — degrade to local-only on remote failure
+            managed_failure = str(exc)
+            logger.warning(
+                "kill_session %s failed: %s",
+                target.managed_agent_session_id, exc,
+            )
+    session_store.update_status(target.task_id, STATUS_FAILED)
+    transcript_store.append(target.session_id, transcript_kind, transcript_payload)
+    return {"managed_failure": managed_failure}
+
+
 def kill(ctx: InterAgentContext, args: dict) -> dict:
     target_id = args.get("session_id", "").strip()
     if not target_id:
@@ -456,26 +493,18 @@ def kill(ctx: InterAgentContext, args: dict) -> dict:
     if target.status in TERMINAL_STATUSES:
         return _ok({"killed": False, "reason": f"already {target.status}"})
 
-    # Managed children: kill the remote session too so it stops accruing
-    # tokens / session-hour overhead. Without a driver we can only flip the
-    # local DB status; the worker's next managed poll will then see the
-    # local FAILED status and treat the session as terminal even if the
-    # remote still reports running.
-    if target.managed_agent_session_id and ctx.managed_driver is not None:
-        try:
-            ctx.managed_driver.kill_session(
-                target.managed_agent_session_id,
-                reason=args.get("reason", ""),
-            )
-        except Exception as exc:
-            logger.warning("kill_session %s failed: %s",
-                           target.managed_agent_session_id, exc)
-
-    ctx.session_store.update_status(target.task_id, STATUS_FAILED)
-    ctx.transcript_store.append(target_id, "killed", {
-        "by": caller.session_id, "reason": args.get("reason", ""),
-        "managed_remote": target.managed_agent_session_id,
-    })
+    teardown_session(
+        ctx.session_store,
+        ctx.transcript_store,
+        target,
+        transcript_kind="killed",
+        transcript_payload={
+            "by": caller.session_id,
+            "reason": args.get("reason", ""),
+            "managed_remote": target.managed_agent_session_id,
+        },
+        managed_driver=ctx.managed_driver,
+    )
     return _ok({"killed": True})
 
 

--- a/tests/test_agent_kill_api.py
+++ b/tests/test_agent_kill_api.py
@@ -1,0 +1,242 @@
+"""API + helper tests for operator kill (issue #134).
+
+Covers the new POST /api/agents/sessions/{sid}/kill endpoint and the
+shared `teardown_session` helper that agent-initiated kill and operator
+kill both call into.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services.agent_worker import inter_agent
+from api.services.agent_worker.inter_agent import InterAgentContext, Caps, teardown_session
+from api.services.agent_worker.session_store import (
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    agents_route._label_cache.clear()
+    # Disable managed-driver instantiation so the endpoint runs purely against
+    # the local DB — `teardown_session` then degrades to a local-only kill.
+    monkeypatch.setattr(agents_route, "_maybe_managed_driver", lambda: None)
+    yield session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+def _make_subtree(session_store: SessionStore):
+    """Build a synthetic root + two children + one grandchild."""
+    root = session_store.create(task_id="root-task", status=STATUS_RUNNING, routing="claude")
+    child_a = session_store.create(
+        task_id="child-a",
+        status=STATUS_RUNNING,
+        routing="local",
+        parent_session_id=root.session_id,
+        root_session_id=root.session_id,
+        spawn_depth=1,
+    )
+    child_b = session_store.create(
+        task_id="child-b",
+        status=STATUS_RUNNING,
+        routing="local",
+        parent_session_id=root.session_id,
+        root_session_id=root.session_id,
+        spawn_depth=1,
+    )
+    grandchild = session_store.create(
+        task_id="grand",
+        status=STATUS_RUNNING,
+        routing="local",
+        parent_session_id=child_a.session_id,
+        root_session_id=root.session_id,
+        spawn_depth=2,
+    )
+    return root, child_a, child_b, grandchild
+
+
+@pytest.mark.unit
+def test_kill_root_cascades_to_all_descendants(client, stores):
+    session_store, transcript_store = stores
+    root, child_a, child_b, grandchild = _make_subtree(session_store)
+
+    r = client.post(f"/api/agents/sessions/{root.session_id}/kill", json={"reason": "operator stop"})
+    assert r.status_code == 200
+    body = r.json()
+    killed = set(body["killed"])
+    assert killed == {root.session_id, child_a.session_id, child_b.session_id, grandchild.session_id}
+    assert body["failures"] == []
+
+    for s in (root, child_a, child_b, grandchild):
+        assert session_store.get_by_session_id(s.session_id).status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_kill_non_root_only_kills_target_subtree(client, stores):
+    """Killing a non-root target must NOT take down unrelated peers."""
+    session_store, transcript_store = stores
+    root, child_a, child_b, grandchild = _make_subtree(session_store)
+
+    r = client.post(f"/api/agents/sessions/{child_a.session_id}/kill", json={})
+    assert r.status_code == 200
+    killed = set(r.json()["killed"])
+    # Only child_a + its grandchild should be killed; root and child_b stay running.
+    assert killed == {child_a.session_id, grandchild.session_id}
+    assert session_store.get_by_session_id(root.session_id).status == STATUS_RUNNING
+    assert session_store.get_by_session_id(child_b.session_id).status == STATUS_RUNNING
+    assert session_store.get_by_session_id(child_a.session_id).status == STATUS_FAILED
+    assert session_store.get_by_session_id(grandchild.session_id).status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_kill_transcript_kinds(client, stores):
+    session_store, transcript_store = stores
+    root, child_a, _, grandchild = _make_subtree(session_store)
+
+    client.post(f"/api/agents/sessions/{root.session_id}/kill", json={"reason": "test"})
+
+    # Target gets operator_killed; descendants get cascade_killed.
+    root_events = transcript_store.read(root.session_id)
+    assert any(e["kind"] == "operator_killed" for e in root_events)
+    assert root_events[-1]["payload"].get("reason") == "test"
+
+    child_events = transcript_store.read(child_a.session_id)
+    assert any(e["kind"] == "cascade_killed" for e in child_events)
+    cascade_ev = next(e for e in child_events if e["kind"] == "cascade_killed")
+    assert cascade_ev["payload"].get("root") == root.session_id
+
+    grand_events = transcript_store.read(grandchild.session_id)
+    assert any(e["kind"] == "cascade_killed" for e in grand_events)
+
+
+@pytest.mark.unit
+def test_kill_already_terminal_session_is_noop(client, stores):
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t-done", status=STATUS_COMPLETED, routing="local")
+
+    r = client.post(f"/api/agents/sessions/{s.session_id}/kill", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["killed"] == []
+    assert body.get("reason", "").startswith("already")
+    # Status untouched.
+    assert session_store.get_by_session_id(s.session_id).status == STATUS_COMPLETED
+    # No new transcript events.
+    assert transcript_store.read(s.session_id) == []
+
+
+@pytest.mark.unit
+def test_kill_unknown_session_returns_404(client, stores):
+    r = client.post("/api/agents/sessions/does-not-exist/kill", json={})
+    assert r.status_code == 404
+
+
+@pytest.mark.unit
+def test_kill_calls_managed_driver_when_present(client, stores, monkeypatch):
+    """When a managed driver is available, kill_session() is invoked for each
+    managed remote in the subtree. Failures are reported in the response but
+    do not stop the local cascade."""
+    session_store, transcript_store = stores
+    # Synthetic subtree where one node has a managed remote.
+    parent = session_store.create(task_id="p", status=STATUS_RUNNING, routing="claude")
+    session_store.set_managed_session_id(parent.task_id, "managed-parent")
+    child = session_store.create(
+        task_id="c", status=STATUS_RUNNING, routing="claude",
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    session_store.set_managed_session_id(child.task_id, "managed-child")
+    # Re-fetch so the in-memory Session objects reflect the managed IDs.
+    parent = session_store.get_by_session_id(parent.session_id)
+    child = session_store.get_by_session_id(child.session_id)
+
+    driver = MagicMock()
+    driver.kill_session.side_effect = [None, RuntimeError("network error")]
+    monkeypatch.setattr(agents_route, "_maybe_managed_driver", lambda: driver)
+
+    r = client.post(f"/api/agents/sessions/{parent.session_id}/kill", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body["killed"]) == {parent.session_id, child.session_id}
+    assert len(body["failures"]) == 1
+    assert body["failures"][0]["session_id"] == child.session_id
+
+    # Both managed remotes called.
+    assert driver.kill_session.call_count == 2
+    called_remote_ids = {call.args[0] for call in driver.kill_session.call_args_list}
+    assert called_remote_ids == {"managed-parent", "managed-child"}
+
+
+# ---------------------------------------------------------------------------
+# Shared helper — used by both inter_agent.kill (agent-to-agent) and the
+# operator kill HTTP endpoint. Confirms the agent path still works.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_teardown_session_helper_flips_status_and_writes_transcript(tmp_path):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    s = session_store.create(task_id="t1", status=STATUS_RUNNING)
+
+    result = teardown_session(
+        session_store, transcript_store, s,
+        transcript_kind="killed",
+        transcript_payload={"by": "test", "reason": "synthetic"},
+        managed_driver=None,
+    )
+    assert result["managed_failure"] is None
+    assert session_store.get_by_session_id(s.session_id).status == STATUS_FAILED
+    events = transcript_store.read(s.session_id)
+    assert events[-1]["kind"] == "killed"
+    assert events[-1]["payload"]["by"] == "test"
+
+
+@pytest.mark.unit
+def test_inter_agent_kill_still_works_via_shared_helper(tmp_path):
+    """Verifies the agent-to-agent kill path (inter_agent.kill) still produces
+    the same observable effect after the refactor to share `teardown_session`."""
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+
+    caller = session_store.create(task_id="caller", status=STATUS_RUNNING)
+    target = session_store.create(
+        task_id="target",
+        status=STATUS_RUNNING,
+        parent_session_id=caller.session_id,
+        root_session_id=caller.session_id,
+        spawn_depth=1,
+    )
+
+    ctx = InterAgentContext(
+        session_store=session_store,
+        transcript_store=transcript_store,
+        caller_session_id=caller.session_id,
+        caps=Caps(),
+        managed_driver=None,
+    )
+    result = inter_agent.kill(ctx, {"session_id": target.session_id, "reason": "test"})
+    assert result["ok"] is True
+    assert session_store.get_by_session_id(target.session_id).status == STATUS_FAILED
+    events = transcript_store.read(target.session_id)
+    assert events[-1]["kind"] == "killed"
+    assert events[-1]["payload"]["by"] == caller.session_id

--- a/web/agents.html
+++ b/web/agents.html
@@ -228,6 +228,112 @@
     float: right;
   }
   .panel-close:hover { background: var(--bg-card); color: var(--text-primary); }
+  .panel-kill {
+    background: var(--bg-card);
+    border: 1px solid var(--failed);
+    color: var(--failed);
+    cursor: pointer;
+    font-size: 0.75rem;
+    line-height: 1;
+    padding: 0.3rem 0.55rem;
+    border-radius: 4px;
+    float: right;
+    margin-right: 0.5rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .panel-kill:hover { background: var(--failed); color: var(--bg-primary); }
+  .panel-kill:disabled {
+    opacity: 0.6;
+    cursor: progress;
+  }
+  .modal-backdrop {
+    position: fixed; inset: 0;
+    background: rgba(0,0,0,0.55);
+    z-index: 100;
+    display: flex; align-items: center; justify-content: center;
+    animation: fadeIn 0.15s ease;
+  }
+  .modal {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.25rem;
+    width: min(420px, 90vw);
+    box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+  }
+  .modal h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.6rem;
+  }
+  .modal .target {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    margin-bottom: 0.5rem;
+    word-break: break-word;
+  }
+  .modal .descendants {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin: 0.5rem 0;
+    max-height: 6rem;
+    overflow-y: auto;
+  }
+  .modal textarea {
+    width: 100%;
+    background: var(--bg-elev);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.4rem 0.6rem;
+    font-family: inherit;
+    font-size: 0.8rem;
+    resize: vertical;
+    min-height: 3rem;
+    margin: 0.5rem 0;
+  }
+  .modal .actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 0.75rem;
+  }
+  .modal button {
+    background: var(--bg-elev);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.4rem 0.85rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+  .modal button.danger {
+    background: var(--failed);
+    color: var(--bg-primary);
+    border-color: var(--failed);
+    font-weight: 600;
+  }
+  .modal button:hover { filter: brightness(1.15); }
+  .toast {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.6rem 1rem;
+    font-size: 0.85rem;
+    box-shadow: 0 6px 24px rgba(0,0,0,0.4);
+    z-index: 110;
+    animation: fadeIn 0.2s ease;
+  }
+  .toast.error { border-color: var(--failed); color: var(--failed); }
   .live-dot {
     display: inline-block;
     width: 8px;
@@ -442,9 +548,11 @@
   function renderPanelHeader(s) {
     const live = !TERMINAL.has(s.status);
     const safeStatus = escapeAttr(s.status);
+    const showKill = live;
     panelEl.innerHTML = `
       <div class="panel-header">
         <button class="panel-close" aria-label="Close" id="panel-close">×</button>
+        ${showKill ? '<button class="panel-kill" id="panel-kill">Kill</button>' : ''}
         <div class="label">${escapeHtml(s.label || s.session_id)}</div>
         <div class="meta">
           ${live ? '<span class="live-dot" title="live"></span>' : ''}
@@ -458,6 +566,84 @@
       <div class="events" id="events"></div>
     `;
     document.getElementById('panel-close').onclick = closePanel;
+    if (showKill) {
+      document.getElementById('panel-kill').onclick = () => openKillModal(s);
+    }
+  }
+
+  function openKillModal(session) {
+    const descendants = allSessions.filter(x =>
+      x.root_session_id === session.session_id &&
+      x.session_id !== session.session_id &&
+      !TERMINAL.has(x.status)
+    );
+    const backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+    backdrop.innerHTML = `
+      <div class="modal" role="dialog" aria-labelledby="kill-title">
+        <h2 id="kill-title">Kill agent session?</h2>
+        <div class="target">${escapeHtml(session.label || session.session_id)}</div>
+        ${descendants.length > 0 ? `
+          <div class="descendants">
+            Will also kill ${descendants.length} descendant${descendants.length === 1 ? '' : 's'}:
+            ${descendants.slice(0, 5).map(d =>
+              `<div>• ${escapeHtml(d.label || d.session_id)}</div>`
+            ).join('')}
+            ${descendants.length > 5 ? `<div>…and ${descendants.length - 5} more</div>` : ''}
+          </div>
+        ` : ''}
+        <label style="font-size:0.75rem;color:var(--text-secondary)">Reason (optional)</label>
+        <textarea id="kill-reason" placeholder="Why are you killing this?"></textarea>
+        <div class="actions">
+          <button id="kill-cancel">Cancel</button>
+          <button class="danger" id="kill-confirm">Kill</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(backdrop);
+    const cleanup = () => { if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop); };
+    backdrop.addEventListener('click', e => { if (e.target === backdrop) cleanup(); });
+    document.getElementById('kill-cancel').onclick = cleanup;
+    document.getElementById('kill-confirm').onclick = async () => {
+      const reason = document.getElementById('kill-reason').value || '';
+      const confirmBtn = document.getElementById('kill-confirm');
+      confirmBtn.disabled = true;
+      confirmBtn.textContent = 'Killing…';
+      try {
+        const r = await fetch(`/api/agents/sessions/${encodeURIComponent(session.session_id)}/kill`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason }),
+        });
+        if (!r.ok) {
+          const text = await r.text();
+          throw new Error(`HTTP ${r.status}: ${text}`);
+        }
+        const result = await r.json();
+        const failures = result.failures || [];
+        const killed = result.killed || [];
+        if (killed.length === 0 && result.reason) {
+          showToast(`Already ${result.reason}`, false);
+        } else if (failures.length === 0) {
+          showToast(`Killed ${killed.length} session${killed.length === 1 ? '' : 's'}`, false);
+        } else {
+          showToast(`Killed ${killed.length}; ${failures.length} remote failure(s)`, true);
+        }
+        cleanup();
+      } catch (err) {
+        showToast(`Kill failed: ${err.message}`, true);
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = 'Kill';
+      }
+    };
+  }
+
+  function showToast(message, isError) {
+    const t = document.createElement('div');
+    t.className = 'toast' + (isError ? ' error' : '');
+    t.textContent = message;
+    document.body.appendChild(t);
+    setTimeout(() => { if (t.parentNode) t.parentNode.removeChild(t); }, 3500);
   }
 
   function closePanel() {

--- a/web/agents.html
+++ b/web/agents.html
@@ -572,11 +572,27 @@
   }
 
   function openKillModal(session) {
-    const descendants = allSessions.filter(x =>
-      x.root_session_id === session.session_id &&
-      x.session_id !== session.session_id &&
-      !TERMINAL.has(x.status)
-    );
+    // BFS down parent_session_id so non-root targets only show *their* subtree,
+    // matching the backend cascade scope. (Filtering by root_session_id would
+    // wrongly include unrelated peers under the same root.)
+    const childrenOf = new Map();
+    for (const x of allSessions) {
+      if (!x.parent_session_id) continue;
+      if (!childrenOf.has(x.parent_session_id)) childrenOf.set(x.parent_session_id, []);
+      childrenOf.get(x.parent_session_id).push(x);
+    }
+    const descendants = [];
+    const queue = [session.session_id];
+    const seen = new Set([session.session_id]);
+    while (queue.length) {
+      const sid = queue.shift();
+      for (const child of (childrenOf.get(sid) || [])) {
+        if (seen.has(child.session_id)) continue;
+        seen.add(child.session_id);
+        if (!TERMINAL.has(child.status)) descendants.push(child);
+        queue.push(child.session_id);
+      }
+    }
     const backdrop = document.createElement('div');
     backdrop.className = 'modal-backdrop';
     backdrop.innerHTML = `


### PR DESCRIPTION
## Summary

Adds operator-initiated kill from the `/agents` UI with cascade across the target's subtree and best-effort managed-remote teardown.

Closes #134. Builds on #133 (merged into `feat/agent-ui` as 7636c66).

- **Backend**: `POST /api/agents/sessions/{sid}/kill` walks the target's subtree via `parent_session_id`, calls `managed_driver.kill_session` for each managed remote, flips DB statuses to `STATUS_FAILED`, and writes `operator_killed` (target) / `cascade_killed` (descendants) transcript events. Returns `{killed: [...], failures: [...]}`.
- **Shared helper**: `inter_agent.teardown_session()` factors out the single-session teardown mechanics. The existing agent-to-agent `inter_agent.kill()` now uses it too — same observable behavior, single source of truth.
- **Frontend**: Kill button on the side panel for non-terminal sessions, confirmation modal listing the descendants that will also be killed, optional reason textarea, optimistic spinner, success/partial-failure toast feedback.
- **Tests** (`tests/test_agent_kill_api.py`): 8 new tests — root cascade, non-root subtree (peers untouched), transcript kinds, already-terminal no-op, 404 on missing, managed-driver invocation + partial failure handling, helper unit test, agent-to-agent kill regression test.

## Test evidence

- `~/.venvs/lifeos/bin/python -m pytest tests/test_agent_kill_api.py tests/test_agent_viz_api.py tests/test_agent_worker_inter_agent.py` → 49 passed
- Includes the existing inter_agent test suite to confirm the agent-kill refactor didn't regress.

## Review focus

- Subtree walk in `_collect_subtree` — BFS via `parent_session_id`, not `root_session_id`. Killing a non-root must not take down peers.
- `_maybe_managed_driver()` instantiates a fresh driver per request and closes it in `finally`. Worker's driver instance is process-isolated.
- `teardown_session` is the only mutation path — both call sites share it.
- Endpoint MUST stay local-network only. No new MCP exposure.