### PR TITLE
fix: track cache_creation + cache_read tokens in managed-session cost

### DIFF
--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -66,6 +66,12 @@ class ManagedSessionState:
     new_events: list[dict] = field(default_factory=list)
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    # Anthropic charges two extra token buckets beyond plain input/output —
+    # cache_creation (1.25× input rate) and cache_read (0.10× input rate).
+    # On cache-heavy presets, cache_creation on the first turn can dominate
+    # session cost, so we mirror both buckets from the usage payload.
+    total_cache_creation_tokens: int = 0
+    total_cache_read_tokens: int = 0
     final_text: str | None = None
     error_reason: str | None = None
     # MCP servers that failed to initialize during this session — informational,
@@ -259,6 +265,8 @@ class ManagedAgentsDriver:
             new_events=events,
             total_input_tokens=int(usage.get("input_tokens", 0)),
             total_output_tokens=int(usage.get("output_tokens", 0)),
+            total_cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0)),
+            total_cache_read_tokens=int(usage.get("cache_read_input_tokens", 0)),
             final_text=final_text,
             error_reason=error_reason,
             init_failed_mcps=init_failed_mcps,
@@ -509,8 +517,21 @@ def managed_session_cost(
     tokens_in: int,
     tokens_out: int,
     wall_seconds: float,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
 ) -> float:
-    """Total $ for a managed session: token cost + session-hour overhead."""
-    tokens = cost_for(model, tokens_in, tokens_out)
+    """Total $ for a managed session: token cost + session-hour overhead.
+
+    Cache buckets default to zero so callers that only care about plain
+    token cost (e.g., the local executor's wall-time accounting) don't
+    need to update. Managed sessions should always pass all four buckets.
+    """
+    tokens = cost_for(
+        model,
+        tokens_in,
+        tokens_out,
+        cache_creation_tokens=cache_creation_tokens,
+        cache_read_tokens=cache_read_tokens,
+    )
     overhead = (wall_seconds / 3600.0) * MANAGED_SESSION_HOUR_OVERHEAD
     return tokens + overhead

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -208,13 +208,35 @@ class ManagedExecutor:
         for event in state.new_events:
             self.transcript_store.append(sid, f"managed_event_{event.get('type', 'unknown')}", event)
 
-        # 1. Token spend delta — compare absolute remote totals to our row.
+        # 1. Token spend delta — compare absolute remote totals to our row,
+        # across all four buckets (uncached input, output, cache_creation,
+        # cache_read). Anthropic bills cache_creation at 1.25× input and
+        # cache_read at 0.10× input; pricing.cost_for applies the multipliers.
         delta_in = max(0, state.total_input_tokens - (session.total_input_tokens or 0))
         delta_out = max(0, state.total_output_tokens - (session.total_output_tokens or 0))
-        token_delta_dollars = cost_for(self.model, delta_in, delta_out)
-        if delta_in or delta_out:
+        delta_cache_creation = max(
+            0,
+            state.total_cache_creation_tokens - (session.total_cache_creation_tokens or 0),
+        )
+        delta_cache_read = max(
+            0,
+            state.total_cache_read_tokens - (session.total_cache_read_tokens or 0),
+        )
+        token_delta_dollars = cost_for(
+            self.model,
+            delta_in,
+            delta_out,
+            cache_creation_tokens=delta_cache_creation,
+            cache_read_tokens=delta_cache_read,
+        )
+        if delta_in or delta_out or delta_cache_creation or delta_cache_read:
             self.session_store.record_spend(
-                session.task_id, delta_in, delta_out, token_delta_dollars,
+                session.task_id,
+                delta_in,
+                delta_out,
+                token_delta_dollars,
+                cache_creation_tokens=delta_cache_creation,
+                cache_read_tokens=delta_cache_read,
             )
 
         # 2. Session-hour overhead delta — we only want to add what's accrued
@@ -267,16 +289,23 @@ class ManagedExecutor:
 
     @staticmethod
     def _budget_breach(refreshed_session, budget: dict) -> str | None:
-        """Return the budget kind that was exceeded, or None."""
+        """Return the budget kind that was exceeded, or None.
+
+        Dollars-first: with cache_creation and cache_read now in the dollar
+        total, `total_dollars` is the authoritative spend signal. `max_tokens`
+        remains a soft secondary gate — it only counts uncached input +
+        output, which understates cache-heavy cost, but is preserved so
+        existing token-only callers keep working.
+        """
         if not budget:
             return None
+        if budget.get("max_dollars") is not None:
+            if (refreshed_session.total_dollars or 0) >= budget["max_dollars"]:
+                return "max_dollars"
         if budget.get("max_tokens"):
             used = (refreshed_session.total_input_tokens or 0) + (refreshed_session.total_output_tokens or 0)
             if used >= budget["max_tokens"]:
                 return "max_tokens"
-        if budget.get("max_dollars") is not None:
-            if (refreshed_session.total_dollars or 0) >= budget["max_dollars"]:
-                return "max_dollars"
         return None
 
     # ------------------------------------------------------------------

--- a/api/services/agent_worker/pricing.py
+++ b/api/services/agent_worker/pricing.py
@@ -31,14 +31,43 @@ PRICING: dict[str, dict[str, float]] = {
 }
 
 
-def cost_for(model: str, tokens_in: int, tokens_out: int) -> float:
+# Anthropic prompt-cache rate multipliers, relative to the model's base input
+# rate (see https://www.anthropic.com/pricing). cache_creation writes are
+# 1.25× input — slightly more expensive than a normal input token because of
+# the indexing work. cache_read hits are 0.10× input — a 10× discount on
+# tokens that come from the cache instead of being processed fresh.
+CACHE_CREATION_RATE_MULTIPLIER: float = 1.25
+CACHE_READ_RATE_MULTIPLIER: float = 0.10
+
+
+def cost_for(
+    model: str,
+    tokens_in: int,
+    tokens_out: int,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
+) -> float:
     """Return the dollar cost of a single LLM call.
 
-    Unknown models fall through to a conservative Opus-rate estimate so a
-    typo can't accidentally suppress budget enforcement. Logging is the
-    caller's responsibility.
+    Anthropic charges four token buckets:
+    - `tokens_in` — uncached input tokens, at the model's input rate.
+    - `tokens_out` — output tokens, at the model's output rate.
+    - `cache_creation_tokens` — tokens written into the prompt cache on a
+      cache-cold turn, at 1.25× the input rate.
+    - `cache_read_tokens` — tokens served from the prompt cache on a cache-
+      warm turn, at 0.10× the input rate.
+
+    Cache buckets default to zero so existing two-arg call sites keep
+    working. Unknown models fall through to a conservative Opus-rate
+    estimate so a typo can't accidentally suppress budget enforcement.
     """
     rates = PRICING.get(model)
     if rates is None:
         rates = PRICING["claude-opus-4-7"]
-    return tokens_in * rates["input"] + tokens_out * rates["output"]
+    input_rate = rates["input"]
+    return (
+        tokens_in * input_rate
+        + tokens_out * rates["output"]
+        + cache_creation_tokens * input_rate * CACHE_CREATION_RATE_MULTIPLIER
+        + cache_read_tokens * input_rate * CACHE_READ_RATE_MULTIPLIER
+    )

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -55,6 +55,12 @@ class Session:
     managed_agent_session_id: str | None = None
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    # Prompt-cache buckets — kept separate from total_input_tokens because
+    # they're billed at different rates (cache_creation = 1.25× input,
+    # cache_read = 0.10× input). On cache-heavy presets cache_creation on the
+    # first turn often dwarfs uncached input.
+    total_cache_creation_tokens: int = 0
+    total_cache_read_tokens: int = 0
     total_dollars: float = 0.0
     total_active_seconds: float = 0.0
     root_session_id: str | None = None
@@ -73,6 +79,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     last_activity_at          INTEGER NOT NULL,
     total_input_tokens        INTEGER NOT NULL DEFAULT 0,
     total_output_tokens       INTEGER NOT NULL DEFAULT 0,
+    total_cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    total_cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
     total_dollars             REAL    NOT NULL DEFAULT 0.0,
     total_active_seconds      REAL    NOT NULL DEFAULT 0.0,
     expected_output           TEXT,
@@ -223,6 +231,21 @@ class SessionStore:
                     "ALTER TABLE pending_questions ADD COLUMN kind TEXT "
                     "NOT NULL DEFAULT 'clarification'"
                 )
+            # Idempotent migration for the prompt-cache token buckets on
+            # `sessions`. Old rows stay at zero — we don't backfill historical
+            # sessions, the raw event payloads in transcripts still have the
+            # data if anyone ever wants to recompute.
+            sess_cols = {row["name"] for row in conn.execute("PRAGMA table_info(sessions)")}
+            if "total_cache_creation_tokens" not in sess_cols:
+                conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN total_cache_creation_tokens "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
+            if "total_cache_read_tokens" not in sess_cols:
+                conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN total_cache_read_tokens "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
 
     # ------------------------------------------------------------------
     # Session CRUD
@@ -367,19 +390,36 @@ class SessionStore:
         tokens_in: int,
         tokens_out: int,
         dollars: float,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
     ) -> None:
-        """Add to a session's cumulative token + dollar counters."""
+        """Add to a session's cumulative token + dollar counters.
+
+        Cache buckets default to zero so the local executor (which only
+        sees plain input/output) doesn't need to update; managed sessions
+        always pass all four buckets.
+        """
         with self._connect() as conn:
             conn.execute(
                 """
                 UPDATE sessions
-                SET total_input_tokens  = total_input_tokens  + ?,
-                    total_output_tokens = total_output_tokens + ?,
-                    total_dollars       = total_dollars       + ?,
-                    last_activity_at    = ?
+                SET total_input_tokens          = total_input_tokens          + ?,
+                    total_output_tokens         = total_output_tokens         + ?,
+                    total_cache_creation_tokens = total_cache_creation_tokens + ?,
+                    total_cache_read_tokens     = total_cache_read_tokens     + ?,
+                    total_dollars               = total_dollars               + ?,
+                    last_activity_at            = ?
                 WHERE task_id = ?
                 """,
-                (tokens_in, tokens_out, dollars, _now(), task_id),
+                (
+                    tokens_in,
+                    tokens_out,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    dollars,
+                    _now(),
+                    task_id,
+                ),
             )
 
     def set_managed_session_id(self, task_id: str, managed_id: str) -> None:
@@ -838,6 +878,16 @@ class SessionStore:
             last_activity_at=row["last_activity_at"],
             total_input_tokens=row["total_input_tokens"],
             total_output_tokens=row["total_output_tokens"],
+            total_cache_creation_tokens=(
+                row["total_cache_creation_tokens"]
+                if "total_cache_creation_tokens" in row.keys()
+                else 0
+            ),
+            total_cache_read_tokens=(
+                row["total_cache_read_tokens"]
+                if "total_cache_read_tokens" in row.keys()
+                else 0
+            ),
             total_dollars=row["total_dollars"],
             total_active_seconds=(
                 row["total_active_seconds"]

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -70,6 +70,28 @@ def _worker_label(routing: str | None) -> str:
     return "Agent worker"
 
 
+def _format_token_buckets(
+    tokens_in: int,
+    cache_creation: int,
+    cache_read: int,
+    tokens_out: int,
+) -> str:
+    """Render the four token buckets for the completion message.
+
+    Cache buckets are only included when non-zero so local-path completions
+    (which never write or read the prompt cache) collapse to the original
+    "N tokens" form. Managed cloud sessions always have at least
+    cache_creation populated on first turn.
+    """
+    parts: list[str] = [f"{tokens_in:,} input"]
+    if cache_creation:
+        parts.append(f"{cache_creation:,} cached-write")
+    if cache_read:
+        parts.append(f"{cache_read:,} cached-read")
+    parts.append(f"{tokens_out:,} output")
+    return " + ".join(parts)
+
+
 def _is_readable_tool_result(text: str) -> bool:
     """Heuristic: is this tool result useful to dump inline as the
     operator-facing completion body? Skip raw JSON dumps (list_threads,
@@ -1179,13 +1201,21 @@ class Worker:
 
     def _completion_summary(self, session: Session, task: dict[str, Any], outcome) -> str:
         refreshed = self.session_store.get(session.task_id) or session
-        tokens = (refreshed.total_input_tokens or 0) + (refreshed.total_output_tokens or 0)
         # Use active seconds (excludes sleeps) so the figure reflects real
         # work, not wall time since the session was first created.
         active_s = int(refreshed.total_active_seconds or 0)
         expected = refreshed.expected_output or "text"
         title = task.get("description", session.task_id)
         label = _worker_label(refreshed.routing or session.routing)
+        # Four-bucket token breakdown so the operator can see what drove cost.
+        # For local sessions cache buckets are always zero and collapse out of
+        # the rendered string.
+        tokens_summary = _format_token_buckets(
+            refreshed.total_input_tokens or 0,
+            refreshed.total_cache_creation_tokens or 0,
+            refreshed.total_cache_read_tokens or 0,
+            refreshed.total_output_tokens or 0,
+        )
 
         # Body: prefer the agent's final text. When it's empty (the agent
         # used a tool and idled without summarizing — sometimes happens with
@@ -1250,7 +1280,7 @@ class Worker:
 
         return (
             f"✅ {label}: completed '{title}' "
-            f"({expected}) — {tokens:,} tokens, ${refreshed.total_dollars:.2f}, "
+            f"({expected}) — {tokens_summary}, ${refreshed.total_dollars:.2f}, "
             f"{active_s}s active.\n\n{result_blurb}{footer}"
         )
 
@@ -1375,7 +1405,12 @@ class Worker:
         parts.append("")
         parts.append("Children:")
         for c in child_sessions:
-            tokens = (c.total_input_tokens or 0) + (c.total_output_tokens or 0)
+            tokens = (
+                (c.total_input_tokens or 0)
+                + (c.total_output_tokens or 0)
+                + (c.total_cache_creation_tokens or 0)
+                + (c.total_cache_read_tokens or 0)
+            )
             header = f"- [{c.status}] {c.session_id} — {tokens} tokens, ${c.total_dollars:.4f}"
             parts.append(header)
             body = self._child_final_text(c)

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -471,6 +471,48 @@ def test_pricing_unknown_model_falls_through_to_opus_rate():
     assert unknown == pytest.approx(opus)
 
 
+@pytest.mark.unit
+def test_pricing_cache_creation_charged_at_125pct_of_input():
+    """cache_creation tokens cost 1.25× the model's input rate."""
+    # Sonnet input rate is $3/M, so 1k cache_creation = $0.003 × 1.25 = $0.00375.
+    cost = cost_for("claude-sonnet-4-6", 0, 0, cache_creation_tokens=1000)
+    assert cost == pytest.approx(0.003 * 1.25)
+
+
+@pytest.mark.unit
+def test_pricing_cache_read_charged_at_10pct_of_input():
+    """cache_read tokens cost 0.10× the model's input rate (12.5× cheaper
+    than cache_creation, 10× cheaper than uncached input)."""
+    cost = cost_for("claude-sonnet-4-6", 0, 0, cache_read_tokens=1000)
+    assert cost == pytest.approx(0.003 * 0.10)
+
+
+@pytest.mark.unit
+def test_pricing_all_four_buckets_compose():
+    """Mixed payload: input + output + cache_creation + cache_read all sum."""
+    # Sonnet: input $3/M, output $15/M.
+    # 1k input = $0.003, 1k output = $0.015,
+    # 1k cache_creation = $0.00375, 1k cache_read = $0.0003.
+    cost = cost_for(
+        "claude-sonnet-4-6",
+        tokens_in=1000,
+        tokens_out=1000,
+        cache_creation_tokens=1000,
+        cache_read_tokens=1000,
+    )
+    assert cost == pytest.approx(0.003 + 0.015 + 0.00375 + 0.0003)
+
+
+@pytest.mark.unit
+def test_pricing_cache_buckets_default_to_zero():
+    """Two-arg call sites (the local executor) keep working unchanged."""
+    cost = cost_for("claude-haiku-4-5", 1000, 500)
+    expected_two_arg = cost_for(
+        "claude-haiku-4-5", 1000, 500, cache_creation_tokens=0, cache_read_tokens=0,
+    )
+    assert cost == pytest.approx(expected_two_arg)
+
+
 # ---------------------------------------------------------------------------
 # System-prompt structure (issue #119 — Anthropic 4.6/4.7 best practices)
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -439,6 +439,61 @@ def test_completion_summary_uses_transcript_pointer_when_final_text_empty(tmp_pa
 
 
 @pytest.mark.unit
+def test_format_token_buckets_collapses_when_cache_is_zero():
+    """Local-path sessions never hit the prompt cache — the rendered string
+    should collapse to the original `N input + M output` shape."""
+    from api.services.agent_worker.worker import _format_token_buckets
+    assert _format_token_buckets(100, 0, 0, 50) == "100 input + 50 output"
+
+
+@pytest.mark.unit
+def test_format_token_buckets_includes_cache_creation_and_read_when_nonzero():
+    """Cloud sessions surface all four buckets so the operator can see what
+    drove cost (cache_creation typically dominates first-turn spend)."""
+    from api.services.agent_worker.worker import _format_token_buckets
+    rendered = _format_token_buckets(3, 109_075, 2_000, 81)
+    assert "3 input" in rendered
+    assert "109,075 cached-write" in rendered
+    assert "2,000 cached-read" in rendered
+    assert "81 output" in rendered
+
+
+@pytest.mark.unit
+def test_completion_summary_renders_four_bucket_breakdown(tmp_path: Path):
+    """When a managed session populated all four token buckets, the operator-
+    facing Telegram message must surface them — that's the visible signal
+    that #137 actually landed."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "draft email", "status": "todo",
+         "tags": ["agent", "cloud"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="Drafted.",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude"),
+                     local_executor=executor)
+    w.tick()
+    # Inject realistic four-bucket token totals via record_spend, then
+    # re-render the summary directly using the refreshed row.
+    w.session_store.record_spend(
+        "t1",
+        tokens_in=3,
+        tokens_out=81,
+        dollars=0.42,
+        cache_creation_tokens=109_075,
+        cache_read_tokens=2_000,
+    )
+    refreshed = w.session_store.get("t1")
+    msg = w._completion_summary(refreshed, {"id": "t1", "description": "draft email"},
+                                executor.outcome)
+    assert "3 input" in msg
+    assert "109,075 cached-write" in msg
+    assert "2,000 cached-read" in msg
+    assert "81 output" in msg
+
+
+@pytest.mark.unit
 def test_completion_summary_includes_init_failed_mcps_footer(tmp_path: Path):
     """When the managed executor reports MCPs that failed to initialize,
     the completion summary appends a "Note: N MCP server(s) unavailable"

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -617,3 +617,61 @@ def test_managed_session_cost_partial_hour():
     # 30 minutes of session-hour overhead.
     cost = managed_session_cost("local", 0, 0, wall_seconds=1800)
     assert cost == pytest.approx(0.5 * MANAGED_SESSION_HOUR_OVERHEAD)
+
+
+# ---------------------------------------------------------------------------
+# Prompt-cache token buckets (#137)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_session_state_parses_cache_creation_and_cache_read_tokens():
+    """The four-bucket usage payload from the live API must flow through
+    `get_session_state` into the materialized `ManagedSessionState`."""
+    handler = _make_session_handler(
+        status_body={
+            "status": "running",
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 81,
+                "cache_creation_input_tokens": 109_075,
+                "cache_read_input_tokens": 2_000,
+            },
+        },
+        events=[],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.total_input_tokens == 3
+    assert state.total_output_tokens == 81
+    assert state.total_cache_creation_tokens == 109_075
+    assert state.total_cache_read_tokens == 2_000
+
+
+@pytest.mark.unit
+def test_session_state_defaults_cache_buckets_to_zero_when_absent():
+    """Older API responses omit the cache buckets — should default to zero."""
+    handler = _make_session_handler(
+        status_body={"status": "running", "usage": {"input_tokens": 5, "output_tokens": 7}},
+        events=[],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.total_cache_creation_tokens == 0
+    assert state.total_cache_read_tokens == 0
+
+
+@pytest.mark.unit
+def test_managed_session_cost_includes_cache_buckets():
+    """cache_creation tokens are 1.25× input rate; cache_read is 0.10× input."""
+    # 100k cache_creation at Sonnet ($3/M input × 1.25) = $0.375
+    # 50k cache_read at Sonnet ($3/M input × 0.10) = $0.015
+    # 1000 input + 1000 output = $0.003 + $0.015 = $0.018
+    # No wall time → no overhead.
+    cost = managed_session_cost(
+        "claude-sonnet-4-6",
+        tokens_in=1000,
+        tokens_out=1000,
+        wall_seconds=0,
+        cache_creation_tokens=100_000,
+        cache_read_tokens=50_000,
+    )
+    expected = 0.018 + 0.375 + 0.015
+    assert cost == pytest.approx(expected)

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -435,6 +435,82 @@ def test_poll_kills_remote_session_on_token_budget_breach(stores):
 
 
 @pytest.mark.unit
+def test_poll_persists_cache_creation_and_cache_read_deltas(stores):
+    """All four token buckets (uncached input, output, cache_creation,
+    cache_read) must flow from driver state through record_spend into the
+    sessions row. Confirms the dollar total reflects cache costs."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[{"id": "evt_1", "type": "x"}],
+            total_input_tokens=10,
+            total_output_tokens=5,
+            total_cache_creation_tokens=100_000,
+            total_cache_read_tokens=2_000,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver, model="claude-sonnet-4-6")
+    executor.poll(session)
+    refreshed = store.get("t1")
+    assert refreshed.total_input_tokens == 10
+    assert refreshed.total_output_tokens == 5
+    assert refreshed.total_cache_creation_tokens == 100_000
+    assert refreshed.total_cache_read_tokens == 2_000
+    # Sonnet input $3/M:
+    # 10 input = $0.00003, 5 output ($15/M) = $0.000075,
+    # 100k cache_creation (×1.25) = $0.375, 2k cache_read (×0.10) = $0.0006.
+    # The dollar total also accrues session-hour overhead from test wall time
+    # ($0.08/hr) so we tolerate a small positive delta above the token cost.
+    expected_token_dollars = (
+        10 * 3.0e-6
+        + 5 * 15.0e-6
+        + 100_000 * 3.0e-6 * 1.25
+        + 2_000 * 3.0e-6 * 0.10
+    )
+    overhead_upper_bound = 60.0 / 3600.0 * 0.08  # 60s wall = generous
+    assert expected_token_dollars <= refreshed.total_dollars <= expected_token_dollars + overhead_upper_bound
+
+
+@pytest.mark.unit
+def test_poll_computes_cache_token_deltas_against_prior_state(stores):
+    """Token totals are absolute remote counts; record_spend gets deltas only."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[{"id": "evt_1", "type": "x"}],
+            total_input_tokens=5,
+            total_output_tokens=3,
+            total_cache_creation_tokens=50_000,
+            total_cache_read_tokens=1_000,
+        ),
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_2",
+            new_events=[{"id": "evt_2", "type": "y"}],
+            total_input_tokens=12,
+            total_output_tokens=8,
+            total_cache_creation_tokens=50_000,  # no new cache_creation
+            total_cache_read_tokens=4_500,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    executor.poll(session)
+    session = store.get("t1")
+    executor.poll(session)
+    refreshed = store.get("t1")
+    # Cumulative absolute totals — not double-counted.
+    assert refreshed.total_input_tokens == 12
+    assert refreshed.total_output_tokens == 8
+    assert refreshed.total_cache_creation_tokens == 50_000
+    assert refreshed.total_cache_read_tokens == 4_500
+
+
+@pytest.mark.unit
 def test_poll_kills_remote_session_on_dollar_budget_breach(stores):
     store, session, transcript = stores
     store.set_routing_and_budget(
@@ -458,6 +534,66 @@ def test_poll_kills_remote_session_on_dollar_budget_breach(stores):
     assert outcome.status == STATUS_BUDGET_EXCEEDED
     assert "max_dollars" in outcome.reason
     assert driver.kills
+
+
+@pytest.mark.unit
+def test_poll_dollar_breach_fires_from_cache_creation_cost_alone(stores):
+    """The whole point of #137: cache_creation-heavy sessions must trip
+    max_dollars even when uncached input + output are negligible. Previously
+    the dollar count missed cache cost entirely, so this didn't fire."""
+    store, session, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 1_000_000, "max_dollars": 0.10},
+        expected_output="text",
+    )
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 100k cache_creation at Sonnet ($3/M × 1.25) = $0.375 — over the $0.10 cap.
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_x",
+            new_events=[],
+            total_input_tokens=3,
+            total_output_tokens=81,
+            total_cache_creation_tokens=100_000,
+            total_cache_read_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver, model="claude-sonnet-4-6")
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "max_dollars" in outcome.reason
+
+
+@pytest.mark.unit
+def test_poll_dollar_breach_takes_precedence_over_token_breach(stores):
+    """When both budgets would breach, max_dollars wins. Dollars-first
+    enforcement means runaway cache_creation cost can't be masked by a
+    generous token cap."""
+    store, session, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        # Both caps fail: 200 tokens > 100-cap AND $0.003 > $0.001-cap.
+        budget={"wall_seconds": 3600, "max_tokens": 100, "max_dollars": 0.001},
+        expected_output="text",
+    )
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_x",
+            new_events=[],
+            total_input_tokens=200, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver, model="claude-opus-4-7")
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "max_dollars" in outcome.reason
+    assert "max_tokens" not in outcome.reason
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`ManagedSessionState.total_dollars` previously read only `input_tokens` from Anthropic's usage payload, ignoring `cache_creation_input_tokens` (1.25× input rate) and `cache_read_input_tokens` (0.10× input rate). On a 100k-token cached preset this underreported real spend by 10–20× — confirmed in production where platform.claude.com showed \$24/day vs our DB's \$1.15.

Now: all four token buckets flow through pricing, the schema, the executor, and the operator-facing completion summary. Budget enforcement is dollars-first so cache-heavy runaway cost can't be masked by a generous token cap.

Closes #137

## Test evidence

```
~/.venvs/lifeos/bin/python -m pytest tests/ -q -m "unit and not slow"
================ 1430 passed, 517 warnings in 154.48s ================
```

14 new tests added across `test_agent_worker_pricing` (in `test_agent_worker_local_executor.py`), `test_agent_worker_managed_driver.py`, `test_agent_worker_managed_executor.py`, and `test_agent_worker_loop.py` covering:
- cache_creation × 1.25 and cache_read × 0.10 multipliers
- four-bucket usage parsing in `get_session_state`
- delta-only token recording across polls (no double-count)
- dollar-first budget gate (cache_creation alone trips `max_dollars`)
- four-bucket rendering in the completion summary

## Review focus

- `pricing.cost_for` signature — added two kwargs with sensible defaults so existing two-arg callers (local executor) keep working unchanged.
- Idempotent schema migration on `sessions` — adds two INTEGER columns, no backfill of historical rows (transcripts still hold raw event payloads).
- Budget breach precedence flip in `managed_executor._budget_breach` — `max_dollars` is now the primary gate; `max_tokens` is preserved as a soft secondary gate.
- The `_completion_summary` change renders bucket names ("cached-write" / "cached-read") which is a one-time operator-UX shift; happy to bikeshed wording.