### PR TITLE
feat: runaway detection for managed agent sessions

### DIFF
--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -14,6 +14,7 @@ context needed is `last_event_id` for the resume cursor.
 """
 from __future__ import annotations
 
+import json
 import logging
 import time
 
@@ -37,6 +38,55 @@ from api.services.agent_worker.transcript_store import TranscriptStore
 
 
 logger = logging.getLogger(__name__)
+
+
+# Runaway detection thresholds (#139 Section 5). Picked behaviorally, not
+# from cost/wall time, because thresholds based on tokens or seconds vary
+# with task class; tool-call counts scale uniformly across task types.
+TOOL_LOOP_KILL_THRESHOLD = 4
+NO_PROGRESS_KILL_THRESHOLD = 15
+MAX_TOOL_RESULT_CHARS = 20_000  # Matches local_executor's truncation behavior.
+TRUNCATION_MARKER = " […truncated]"
+
+
+def _tool_signature(event: dict) -> str | None:
+    """Stable key for tool-loop detection: `(name, sorted-args-JSON)`.
+
+    Returns None for non-`tool_use` events. Args are JSON-canonicalized with
+    sorted keys so an agent that re-orders kwargs between calls still gets
+    detected. Falls back to the raw `input` if it isn't a dict (rare, but
+    don't crash the worker on a schema surprise).
+    """
+    if event.get("type") != "tool_use":
+        return None
+    name = event.get("name") or event.get("tool_name") or ""
+    raw_input = event.get("input") or event.get("arguments") or {}
+    try:
+        args_key = json.dumps(raw_input, sort_keys=True, default=str)
+    except Exception:
+        args_key = repr(raw_input)
+    return f"{name}::{args_key}"
+
+
+def _truncate_oversized_tool_result(event: dict) -> dict:
+    """Return a copy of `event` with its tool_result payload truncated if
+    it exceeds MAX_TOOL_RESULT_CHARS.
+
+    The full payload is still on Anthropic's side — this only shrinks what
+    we mirror into our transcript file. The transcript is what we re-feed
+    to parents on resume-after-children, so truncating here directly cuts
+    that re-feed cost. The marker preserves the truncated-ness signal.
+    """
+    if event.get("type") != "tool_result":
+        return event
+    content = event.get("content")
+    if not isinstance(content, str) or len(content) <= MAX_TOOL_RESULT_CHARS:
+        return event
+    truncated = content[: MAX_TOOL_RESULT_CHARS - len(TRUNCATION_MARKER)] + TRUNCATION_MARKER
+    new_event = dict(event)
+    new_event["content"] = truncated
+    new_event["_truncated_from_chars"] = len(content)
+    return new_event
 
 
 def _user_message_for(task: dict, session_id: str, expected_output: str, budget: dict) -> str:
@@ -204,9 +254,26 @@ class ManagedExecutor:
             logger.warning("managed poll failed for %s: %s", remote_id, exc)
             return ExecutorOutcome(status=STATUS_RUNNING, reason=f"poll error: {exc}")
 
-        # Mirror events to transcript.
+        # Mirror events to transcript, truncating oversized tool_results so
+        # the transcript doesn't bloat for huge payloads that we'd re-feed
+        # to parents during spawn-after-children resume.
         for event in state.new_events:
-            self.transcript_store.append(sid, f"managed_event_{event.get('type', 'unknown')}", event)
+            stored = _truncate_oversized_tool_result(event)
+            self.transcript_store.append(sid, f"managed_event_{stored.get('type', 'unknown')}", stored)
+
+        # Update runaway counters from the new events (#139 Section 5).
+        runaway_kind = self._detect_runaway(session.task_id, state.new_events)
+        if runaway_kind:
+            try:
+                self.driver.kill_session(remote_id, reason=runaway_kind)
+            except Exception as exc:  # pragma: no cover — best-effort kill
+                logger.warning("kill_session %s failed: %s", remote_id, exc)
+            self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
+            self.transcript_store.append(sid, "runaway_killed", {"kind": runaway_kind})
+            return ExecutorOutcome(
+                status=STATUS_BUDGET_EXCEEDED,
+                reason=f"runaway killed ({runaway_kind})",
+            )
 
         # 1. Token spend delta — compare absolute remote totals to our row,
         # across all four buckets (uncached input, output, cache_creation,
@@ -286,6 +353,62 @@ class ManagedExecutor:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _detect_runaway(self, task_id: str, new_events: list[dict]) -> str | None:
+        """Walk `new_events`, update persisted runaway counters, and return
+        a kill reason if any threshold tripped — else None.
+
+        Two behavioral signals:
+        - `tool_loop_detected`: same tool + identical args fires
+          TOOL_LOOP_KILL_THRESHOLD consecutive times with no intervening
+          *different* tool call. A different tool resets the count, so the
+          agent can legitimately retry after a transient failure (e.g. a
+          tool returning an error then immediately retrying same args ONCE
+          is fine; 4× in a row with no diversity is not).
+        - `no_text_in_15_tool_calls`: NO_PROGRESS_KILL_THRESHOLD `tool_use`
+          events fire without any intervening `agent.message`. Indicates
+          the agent is tool-thrashing without surfacing its reasoning.
+
+        Persisted state survives worker restarts so cross-poll counting is
+        consistent. State is reset by `agent.message` (no-progress) or a
+        change in tool signature (tool-loop).
+        """
+        state = self.session_store.get_runaway_state(task_id)
+        signature = state["tool_loop_signature"]
+        loop_count = state["tool_loop_count"]
+        since_msg = state["tool_calls_since_message"]
+
+        kill: str | None = None
+        for event in new_events:
+            etype = event.get("type", "")
+            if etype == "agent.message":
+                since_msg = 0
+                continue
+            if etype != "tool_use":
+                continue
+            since_msg += 1
+            if since_msg >= NO_PROGRESS_KILL_THRESHOLD:
+                kill = "no_text_in_15_tool_calls"
+                break
+            sig = _tool_signature(event)
+            if sig is None:
+                continue
+            if sig == signature:
+                loop_count += 1
+            else:
+                signature = sig
+                loop_count = 1
+            if loop_count >= TOOL_LOOP_KILL_THRESHOLD:
+                kill = "tool_loop_detected"
+                break
+
+        self.session_store.set_runaway_state(
+            task_id,
+            tool_loop_signature=signature,
+            tool_loop_count=loop_count,
+            tool_calls_since_message=since_msg,
+        )
+        return kill
 
     @staticmethod
     def _budget_breach(refreshed_session, budget: dict) -> str | None:

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -182,7 +182,17 @@ CREATE TABLE IF NOT EXISTS managed_cursor (
     task_id                          TEXT PRIMARY KEY,
     last_event_id                    TEXT,
     accrued_session_hour_dollars     REAL NOT NULL DEFAULT 0.0,
-    final_text                       TEXT
+    final_text                       TEXT,
+    -- Runaway detection counters (#139 Section 5). Persisted so cross-poll
+    -- signals survive worker restarts mid-session.
+    -- `tool_loop_signature` is the (tool_name, sorted_args_json) of the most
+    -- recent tool call; `tool_loop_count` is how many consecutive times that
+    -- exact signature has fired with no intervening *different* tool. A
+    -- different tool resets the count. `tool_calls_since_message` increments
+    -- on each tool_use and resets to 0 on each agent.message.
+    tool_loop_signature              TEXT,
+    tool_loop_count                  INTEGER NOT NULL DEFAULT 0,
+    tool_calls_since_message         INTEGER NOT NULL DEFAULT 0
 );
 """
 
@@ -244,6 +254,21 @@ class SessionStore:
             if "total_cache_read_tokens" not in sess_cols:
                 conn.execute(
                     "ALTER TABLE sessions ADD COLUMN total_cache_read_tokens "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
+            # Idempotent migrations for the runaway detection counters on
+            # managed_cursor (#139 Section 5).
+            mc_cols = {row["name"] for row in conn.execute("PRAGMA table_info(managed_cursor)")}
+            if "tool_loop_signature" not in mc_cols:
+                conn.execute("ALTER TABLE managed_cursor ADD COLUMN tool_loop_signature TEXT")
+            if "tool_loop_count" not in mc_cols:
+                conn.execute(
+                    "ALTER TABLE managed_cursor ADD COLUMN tool_loop_count "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
+            if "tool_calls_since_message" not in mc_cols:
+                conn.execute(
+                    "ALTER TABLE managed_cursor ADD COLUMN tool_calls_since_message "
                     "INTEGER NOT NULL DEFAULT 0"
                 )
 
@@ -519,6 +544,61 @@ class SessionStore:
         if not row:
             return None
         return row["final_text"]
+
+    # ------------------------------------------------------------------
+    # Runaway detection state (#139 Section 5)
+    # ------------------------------------------------------------------
+
+    def get_runaway_state(self, task_id: str) -> dict:
+        """Return the persisted runaway counters for `task_id`.
+
+        Defaults to a clean state (signature=None, both counts 0) when no
+        managed_cursor row exists yet. Callers that have never seen events
+        for this session can treat the result as a virgin starting point.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT tool_loop_signature, tool_loop_count, tool_calls_since_message "
+                "FROM managed_cursor WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+        if not row:
+            return {
+                "tool_loop_signature": None,
+                "tool_loop_count": 0,
+                "tool_calls_since_message": 0,
+            }
+        return {
+            "tool_loop_signature": row["tool_loop_signature"],
+            "tool_loop_count": int(row["tool_loop_count"] or 0),
+            "tool_calls_since_message": int(row["tool_calls_since_message"] or 0),
+        }
+
+    def set_runaway_state(
+        self,
+        task_id: str,
+        *,
+        tool_loop_signature: str | None,
+        tool_loop_count: int,
+        tool_calls_since_message: int,
+    ) -> None:
+        """Persist runaway counters. Upsert into managed_cursor so a fresh
+        session (no prior cursor row) gets a row with the counters set."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO managed_cursor (
+                    task_id, tool_loop_signature, tool_loop_count,
+                    tool_calls_since_message
+                )
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    tool_loop_signature      = excluded.tool_loop_signature,
+                    tool_loop_count          = excluded.tool_loop_count,
+                    tool_calls_since_message = excluded.tool_calls_since_message
+                """,
+                (task_id, tool_loop_signature, tool_loop_count, tool_calls_since_message),
+            )
 
     def record_active_seconds(self, task_id: str, seconds: float) -> None:
         """Add to a session's cumulative active-execution seconds.

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -672,3 +672,221 @@ def test_poll_returns_running_on_transient_driver_error(stores):
     assert outcome.status == STATUS_RUNNING
     # Session not yet marked terminal.
     assert store.get("t1").status != STATUS_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Runaway detection (#139 Section 5)
+# ---------------------------------------------------------------------------
+
+def _tool_use(tool_name: str, args: dict, event_id: str = "evt") -> dict:
+    """Helper: build a `tool_use` event in the shape the driver returns."""
+    return {"id": event_id, "type": "tool_use", "name": tool_name, "input": args}
+
+
+def _agent_message(text: str = "thinking", event_id: str = "evt") -> dict:
+    return {"id": event_id, "type": "agent.message",
+            "content": [{"type": "text", "text": text}]}
+
+
+def _tool_result(payload: str, event_id: str = "evt") -> dict:
+    return {"id": event_id, "type": "tool_result", "content": payload}
+
+
+@pytest.mark.unit
+def test_runaway_tool_loop_kill_after_four_identical_calls(stores):
+    """Same tool + identical args 4× consecutively → kill."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    def same(i):
+        return _tool_use("lifeos_search", {"q": "X"}, f"evt_{i}")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_4",
+            new_events=[same(1), same(2), same(3), same(4)],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "tool_loop_detected" in outcome.reason
+    assert driver.kills  # remote session was killed
+
+
+@pytest.mark.unit
+def test_runaway_tool_loop_not_triggered_by_three_identical_calls(stores):
+    """Threshold is 4 — three identical calls is still tolerated (could
+    be a transient retry sequence)."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    def same(i):
+        return _tool_use("lifeos_search", {"q": "X"}, f"evt_{i}")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_3",
+            new_events=[same(1), same(2), same(3)],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_RUNNING
+    assert not driver.kills
+
+
+@pytest.mark.unit
+def test_runaway_tool_loop_resets_on_different_tool(stores):
+    """A different tool resets the loop counter so a legitimate retry path
+    (toolA, toolA, toolB, toolA, toolA, toolA, toolA) doesn't trip."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 3× toolA, then a different tool, then 3× toolA again — none of those
+    # streaks reach the 4-call threshold individually.
+    events = [
+        _tool_use("toolA", {"q": "X"}, "evt_1"),
+        _tool_use("toolA", {"q": "X"}, "evt_2"),
+        _tool_use("toolA", {"q": "X"}, "evt_3"),
+        _tool_use("toolB", {"q": "Y"}, "evt_4"),
+        _tool_use("toolA", {"q": "X"}, "evt_5"),
+        _tool_use("toolA", {"q": "X"}, "evt_6"),
+    ]
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_6",
+            new_events=events,
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_RUNNING
+    assert not driver.kills
+
+
+@pytest.mark.unit
+def test_runaway_tool_loop_persists_across_polls(stores):
+    """Counter survives across polls: 2 identical calls in poll 1, 2 more
+    identical in poll 2 → 4 consecutive → kill on poll 2."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    def same(i):
+        return _tool_use("lifeos_search", {"q": "X"}, f"evt_{i}")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_2",
+            new_events=[same(1), same(2)],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_4",
+            new_events=[same(3), same(4)],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome1 = executor.poll(session)
+    assert outcome1.status == STATUS_RUNNING
+    session = store.get("t1")
+    outcome2 = executor.poll(session)
+    assert outcome2.status == STATUS_BUDGET_EXCEEDED
+    assert "tool_loop_detected" in outcome2.reason
+
+
+@pytest.mark.unit
+def test_runaway_no_progress_kill_after_fifteen_tools_no_message(stores):
+    """15 tool calls with no agent.message → kill."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 15 different tools so tool-loop doesn't fire first.
+    events = [
+        _tool_use(f"tool_{i}", {"i": i}, f"evt_{i}") for i in range(15)
+    ]
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_14",
+            new_events=events,
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "no_text_in_15_tool_calls" in outcome.reason
+
+
+@pytest.mark.unit
+def test_runaway_no_progress_resets_on_agent_message(stores):
+    """An intervening agent.message resets the no-progress counter."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 10 tools, then a message, then 10 more tools — neither streak
+    # reaches 15, so no kill.
+    events = (
+        [_tool_use(f"tool_{i}", {"i": i}, f"evt_a_{i}") for i in range(10)]
+        + [_agent_message("here's an update", "evt_msg")]
+        + [_tool_use(f"tool_{i}", {"i": i}, f"evt_b_{i}") for i in range(10)]
+    )
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_b_9",
+            new_events=events,
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_RUNNING
+
+
+@pytest.mark.unit
+def test_oversized_tool_result_truncated_in_transcript(stores):
+    """A >20KB tool_result is truncated when mirrored to the transcript."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    big_payload = "X" * 30_000
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[_tool_result(big_payload, "evt_1")],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    executor.poll(session)
+    # The transcript should hold a truncated copy, not the full payload.
+    entries = transcript.read(session.session_id)
+    tool_results = [e for e in entries if e["kind"] == "managed_event_tool_result"]
+    assert tool_results
+    stored = tool_results[0]["payload"]
+    assert len(stored["content"]) < 30_000
+    assert "[…truncated]" in stored["content"]
+    assert stored.get("_truncated_from_chars") == 30_000
+
+
+@pytest.mark.unit
+def test_undersized_tool_result_not_truncated(stores):
+    """Tool results under the threshold pass through unchanged."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    payload = "ok"
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[_tool_result(payload, "evt_1")],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    executor.poll(session)
+    entries = transcript.read(session.session_id)
+    tool_results = [e for e in entries if e["kind"] == "managed_event_tool_result"]
+    assert tool_results[0]["payload"]["content"] == "ok"
+    assert "_truncated_from_chars" not in tool_results[0]["payload"]


### PR DESCRIPTION
## Summary

Worker-side behavioral kills that fire on managed sessions before they burn more budget. Implements **Section 5** of #139:

- **Tool-loop detection**: same tool + identical args 4× consecutively (no intervening different tool) → kill with reason `tool_loop_detected`. A different tool resets the counter so transient retries are tolerated.
- **No-progress detection**: 15 tool calls fire with no intervening `agent.message` → kill with reason `no_text_in_15_tool_calls`.
- **Oversized tool result truncation**: any `tool_result` over 20KB is shrunk to 20KB plus a `[…truncated]` marker in the transcript file (matches the local executor's `MAX_TOOL_RESULT_CHARS`).

Counters are persisted on `managed_cursor` so cross-poll detection survives worker restarts mid-session. Idempotent ALTER migrations add three new columns; old session rows default to zero.

Kills flow through the existing `STATUS_BUDGET_EXCEEDED` handler — the operator-facing Telegram message and transcript pointer fire automatically.

Relates to #139 (partial — Section 5 only)

## Test evidence

\`\`\`
~/.venvs/lifeos/bin/python -m pytest tests/ -q -m \"unit and not slow\"
================ 1446 passed, 517 warnings in 150.93s ================
\`\`\`

8 new tests covering: 4-call tool-loop kill, 3-call doesn't fire, different-tool resets counter, counter persists across polls, 15-tool no-progress kill, agent.message resets no-progress, oversized truncation, undersized passthrough.

## Review focus

- `_tool_signature` JSON-canonicalizes args with `sort_keys=True` so kwarg reordering doesn't bypass detection.
- Persisted runaway state lives on `managed_cursor` (same row as the event cursor) — natural co-location and one fewer table.
- Truncation only affects what we store in our transcript file. The remote agent's context (which Anthropic constructs server-side) isn't affected — that's section 3's per-class filter problem, deferred to a later PR.
- Reason string format ("runaway killed (tool_loop_detected)") flows through the existing budget-exceeded Telegram handler. Slightly clunky English but functional and grep-friendly. Happy to reformat if reviewer prefers a dedicated handler.