### PR TITLE
feat: per-task model selection in preflight + tag precedence

### DIFF
--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -34,6 +34,15 @@ ROUTE_ASK = "ask"
 # Allowed expected-output shapes. Used to phrase the final Telegram summary.
 OUTPUT_KINDS = ("text", "file", "external_action", "structured")
 
+# Per-task model identifiers emitted by preflight. The cloud routing case
+# defaults to Sonnet for general work; Haiku is selected by tag override (or
+# in future by smart routing — see #139 §2 rubric). "local" maps to the
+# local Gemma backend. None means "no override, use settings.agent_managed_model".
+MODEL_LOCAL = "local"
+MODEL_HAIKU = "claude-haiku-4-5"
+MODEL_SONNET = "claude-sonnet-4-6"
+ALLOWED_MODELS = (MODEL_LOCAL, MODEL_HAIKU, MODEL_SONNET)
+
 
 @dataclass
 class PreflightBudget:
@@ -56,6 +65,13 @@ class PreflightResult:
     ambiguity: PreflightAmbiguity | None = None
     sane: bool = True
     sane_reason: str = ""
+    # Per-task model selection (#139 §2). For cloud routes, defaults to
+    # MODEL_SONNET; can be overridden to MODEL_HAIKU by the `#cloud-haiku`
+    # tag (or to MODEL_SONNET by `#cloud-sonnet`). For local routes, set
+    # to MODEL_LOCAL. The worker uses this for client-side cost accounting;
+    # actual remote-model selection still requires the agent preset to
+    # match (section 3 territory).
+    model: str | None = None
     raw: dict = field(default_factory=dict)  # the parsed JSON for debugging
 
 
@@ -227,6 +243,57 @@ def _default_llm_caller(prompt: str) -> str:
     return response.text
 
 
+def _normalize_tag(tag: str) -> str:
+    """Strip leading `#` and lowercase, so callers can pass either form."""
+    return tag.lstrip("#").lower()
+
+
+def _apply_tag_overrides(result: PreflightResult, tags: list[str]) -> PreflightResult:
+    """Apply tag-based routing/model overrides (#139 §2 precedence).
+
+    Tag precedence (a tag always wins over preflight's LLM choice):
+      `#local`        → routing=local, model=local
+      `#cloud-haiku`  → routing=claude, model=claude-haiku-4-5
+      `#cloud-sonnet` → routing=claude, model=claude-sonnet-4-6
+      `#cloud`        → routing=claude, model=(whatever preflight picked, else Sonnet)
+
+    Returns a new PreflightResult so the caller can chain. Tag list is
+    normalized case-insensitively with optional leading `#`.
+    """
+    normalized = {_normalize_tag(t) for t in (tags or [])}
+    if "local" in normalized:
+        result.routing = ROUTE_LOCAL
+        result.routing_reason = "#local tag present"
+        result.model = MODEL_LOCAL
+        return result
+    if "cloud-haiku" in normalized:
+        result.routing = ROUTE_CLAUDE
+        result.routing_reason = "#cloud-haiku tag present"
+        result.model = MODEL_HAIKU
+        return result
+    if "cloud-sonnet" in normalized:
+        result.routing = ROUTE_CLAUDE
+        result.routing_reason = "#cloud-sonnet tag present"
+        result.model = MODEL_SONNET
+        return result
+    if "cloud" in normalized:
+        result.routing = ROUTE_CLAUDE
+        if not result.routing_reason:
+            result.routing_reason = "#cloud tag present"
+        if result.model not in ALLOWED_MODELS:
+            result.model = MODEL_SONNET
+        return result
+    # No override — pick a sensible default model for the routing.
+    if result.model not in ALLOWED_MODELS:
+        if result.routing == ROUTE_CLAUDE:
+            result.model = MODEL_SONNET
+        elif result.routing == ROUTE_LOCAL:
+            result.model = MODEL_LOCAL
+        # ROUTE_ASK leaves model=None — the worker will set it after the
+        # operator answers.
+    return result
+
+
 def run_preflight(
     title: str,
     tags: list[str] | None = None,
@@ -239,15 +306,18 @@ def run_preflight(
     # Short-circuit: empty title is always unsafe, no need to spend a Haiku call.
     if not title.strip():
         defaults = _defaults()
-        return PreflightResult(
-            budget=defaults,
-            routing=ROUTE_ASK,
-            routing_reason="empty title",
-            expected_output="text",
-            ambiguity=None,
-            sane=False,
-            sane_reason="task title is empty",
-            raw={},
+        return _apply_tag_overrides(
+            PreflightResult(
+                budget=defaults,
+                routing=ROUTE_ASK,
+                routing_reason="empty title",
+                expected_output="text",
+                ambiguity=None,
+                sane=False,
+                sane_reason="task title is empty",
+                raw={},
+            ),
+            tags_list,
         )
 
     call = caller or _default_llm_caller
@@ -257,15 +327,18 @@ def run_preflight(
     except Exception as exc:
         logger.warning("preflight LLM call failed: %s", exc)
         defaults = _defaults()
-        return PreflightResult(
-            budget=defaults,
-            routing=ROUTE_ASK,
-            routing_reason="preflight LLM call failed",
-            expected_output="text",
-            ambiguity=None,
-            sane=False,
-            sane_reason=f"preflight error: {exc}",
-            raw={},
+        return _apply_tag_overrides(
+            PreflightResult(
+                budget=defaults,
+                routing=ROUTE_ASK,
+                routing_reason="preflight LLM call failed",
+                expected_output="text",
+                ambiguity=None,
+                sane=False,
+                sane_reason=f"preflight error: {exc}",
+                raw={},
+            ),
+            tags_list,
         )
 
-    return parse_preflight_response(reply)
+    return _apply_tag_overrides(parse_preflight_response(reply), tags_list)

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -1066,9 +1066,12 @@ def test_completion_spills_to_vault_when_over_cap(tmp_path: Path, monkeypatch):
     vault = tmp_path / "MyVault"
     monkeypatch.setattr(_settings, "vault_path", vault, raising=False)
 
+    # Tag is "local" — not "cloud" — so the deterministic tag precedence
+    # (#139 §2) routes this task to the local executor. The test exercises
+    # the over-cap spillover via _StubExecutor on the local path.
     api = FakeApi(tasks=[
         {"id": "t1", "description": "Big report on Julia",
-         "status": "todo", "tags": ["agent", "cloud"]},
+         "status": "todo", "tags": ["agent", "local"]},
     ])
     long_text = (
         "Julia Barnes is the CEO of The Movement Cooperative.\n\n"
@@ -1077,12 +1080,6 @@ def test_completion_spills_to_vault_when_over_cap(tmp_path: Path, monkeypatch):
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text=long_text,
     ))
-    w = _make_worker(tmp_path, api,
-                     preflight_caller=_golden_preflight(routing="claude"),
-                     local_executor=executor)  # used for unrelated paths
-    # Force the local path so we can drive the completion through _StubExecutor.
-    # Use routing="local" on the preflight so the worker takes the local branch
-    # while still exercising the cap logic.
     w = _make_worker(tmp_path, api,
                      preflight_caller=_golden_preflight(routing="local"),
                      local_executor=executor)

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -200,3 +200,99 @@ def test_preflight_prompt_includes_ordered_precedence():
     assert "use claude" in prompt
     assert "capability" in prompt.lower() or "infer from capability" in prompt.lower()
     assert "ask" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tag precedence (#139 §2)
+# ---------------------------------------------------------------------------
+
+def _stub_caller(routing="claude"):
+    """Build a fake caller returning a minimal preflight JSON."""
+    import json
+    def call(_prompt):
+        return json.dumps({
+            "budget": {"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 0.50},
+            "routing": routing,
+            "routing_reason": "stub",
+            "expected_output": "text",
+            "ambiguity": None,
+            "sane": True,
+            "sane_reason": "",
+        })
+    return call
+
+
+@pytest.mark.unit
+def test_cloud_haiku_tag_forces_haiku_routing():
+    """`#cloud-haiku` always picks Haiku, regardless of preflight's choice."""
+    result = pf.run_preflight("ambiguous task", tags=["agent", "cloud-haiku"],
+                              caller=_stub_caller(routing="local"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.model == pf.MODEL_HAIKU
+    assert "cloud-haiku" in result.routing_reason
+
+
+@pytest.mark.unit
+def test_cloud_sonnet_tag_forces_sonnet_routing():
+    """`#cloud-sonnet` always picks Sonnet."""
+    result = pf.run_preflight("anything", tags=["agent", "cloud-sonnet"],
+                              caller=_stub_caller(routing="local"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.model == pf.MODEL_SONNET
+    assert "cloud-sonnet" in result.routing_reason
+
+
+@pytest.mark.unit
+def test_local_tag_overrides_to_local_model():
+    """`#local` forces local regardless of preflight's choice."""
+    result = pf.run_preflight("task", tags=["agent", "local"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.routing == pf.ROUTE_LOCAL
+    assert result.model == pf.MODEL_LOCAL
+
+
+@pytest.mark.unit
+def test_cloud_tag_keeps_preflight_routing_but_defaults_model_to_sonnet():
+    """`#cloud` says cloud but leaves the model open — defaults to Sonnet
+    when preflight didn't pick a specific model."""
+    result = pf.run_preflight("anything", tags=["agent", "cloud"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.model == pf.MODEL_SONNET
+
+
+@pytest.mark.unit
+def test_untagged_cloud_route_defaults_to_sonnet():
+    """No model-specifying tag, preflight returns `claude` → Sonnet default."""
+    result = pf.run_preflight("draft an email", tags=["agent"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.model == pf.MODEL_SONNET
+
+
+@pytest.mark.unit
+def test_untagged_local_route_sets_model_to_local():
+    """Local routing without override gets MODEL_LOCAL."""
+    result = pf.run_preflight("quick lookup", tags=["agent"],
+                              caller=_stub_caller(routing="local"))
+    assert result.routing == pf.ROUTE_LOCAL
+    assert result.model == pf.MODEL_LOCAL
+
+
+@pytest.mark.unit
+def test_tag_precedence_haiku_wins_over_sonnet_tag():
+    """If both #cloud-haiku and #cloud-sonnet are present, the first match
+    in the precedence ladder wins (haiku checked before sonnet)."""
+    result = pf.run_preflight("anything",
+                              tags=["agent", "cloud-haiku", "cloud-sonnet"],
+                              caller=_stub_caller(routing="claude"))
+    # Per the ladder docstring: cloud-haiku is checked before cloud-sonnet.
+    assert result.model == pf.MODEL_HAIKU
+
+
+@pytest.mark.unit
+def test_tag_precedence_accepts_hash_prefix_form():
+    """Operators sometimes write the leading `#`; the parser must accept it."""
+    result = pf.run_preflight("anything", tags=["#agent", "#cloud-haiku"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.model == pf.MODEL_HAIKU


### PR DESCRIPTION
## Summary

Preflight now emits a \`model\` field on \`PreflightResult\` and honors deterministic operator tag overrides for routing + model:

| Tag | Routing | Model |
|---|---|---|
| \`#local\` | local | local |
| \`#cloud-haiku\` | claude | claude-haiku-4-5 |
| \`#cloud-sonnet\` | claude | claude-sonnet-4-6 |
| \`#cloud\` | claude | sonnet (default) |
| (untagged → claude) | claude | sonnet |
| (untagged → local) | local | local |

Tag overrides are checked in precedence order (haiku before sonnet so the first match wins) and always beat the classifier's choice. Tags accept both `cloud-haiku` and `#cloud-haiku`.

Relates to #139 (partial — Section 2 only)

## Test evidence

\`\`\`
1455 passed, 517 warnings in 150.69s
\`\`\`

8 new preflight tests + 1 fixed test (\`test_completion_spills_to_vault_when_over_cap\` was incidentally relying on tag/routing precedence flexibility that no longer exists).

## Review focus

- **Behavior change**: The previous design routed tags through the Haiku preflight prompt — the LLM was *told* to honor tags. Now the tag precedence is enforced deterministically in post-processing, so even a stub caller that returns "local" gets overridden by `#cloud`. The pre-existing test `test_completion_spills_to_vault_when_over_cap` was relying on the stub bypassing tag precedence; updated to use a `#local` tag matching its routing="local" stub.
- **Scope**: This PR plumbs the \`model\` field through preflight. Wiring it into the managed executor's cost accounting and (when API supports) per-session model selection is a follow-up for Section 3.