### PR TITLE
feat: per-session tool result cache in MCP server

### DIFF
--- a/api/services/agent_worker/tool_result_cache.py
+++ b/api/services/agent_worker/tool_result_cache.py
@@ -1,0 +1,97 @@
+"""Per-session tool result cache for the LifeOS MCP HTTP server (#139 §4).
+
+When an agent calls the same tool twice within a single session with identical
+arguments — e.g., `lifeos_calendar_upcoming` early to set context and again
+later to confirm — the second result is identical work. Caching it MCP-side
+saves the round-trip and the per-turn input cost of having the tool result
+re-processed by the agent.
+
+Design choices:
+- **Key**: `(session_id, tool_name, sorted_args_json)`. Sorting args keys
+  ensures `{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` collide as expected.
+- **TTL**: uniform 60 seconds. The cache only fires on identical-args repeats
+  within a single session; per-tool tuning would add complexity for marginal
+  gain.
+- **Capacity**: 100 entries total, evicted oldest-first when full. Bounds
+  worst-case memory regardless of session count.
+- **Per-session clear**: `clear_session(session_id)` drops all entries for a
+  terminated session. Cheap because the cache is small.
+
+Thread-safety: the underlying ordered-dict mutation isn't atomic, but the
+worker process is single-threaded for MCP handling and the FastAPI handler
+is async-but-cooperative. A lock would add cost without buying anything.
+"""
+from __future__ import annotations
+
+import json
+import time
+from collections import OrderedDict
+from typing import Any
+
+
+DEFAULT_TTL_SECONDS = 60
+DEFAULT_MAX_ENTRIES = 100
+
+
+class SessionToolResultCache:
+    """In-process LRU+TTL cache keyed on (session_id, tool_name, args)."""
+
+    def __init__(
+        self,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+        clock: callable = time.time,
+    ):
+        self.ttl_seconds = ttl_seconds
+        self.max_entries = max_entries
+        self._clock = clock
+        # OrderedDict preserves insertion order; move_to_end on hit gives LRU.
+        # Value shape: (stored_at, result_dict)
+        self._store: OrderedDict[tuple[str, str, str], tuple[float, dict]] = OrderedDict()
+
+    @staticmethod
+    def _key(session_id: str, tool_name: str, args: dict) -> tuple[str, str, str]:
+        """Build the cache key. Args are JSON-canonicalized so kwarg
+        reordering doesn't bypass the cache."""
+        try:
+            args_json = json.dumps(args or {}, sort_keys=True, default=str)
+        except Exception:
+            args_json = repr(args)
+        return (session_id, tool_name, args_json)
+
+    def get(self, session_id: str, tool_name: str, args: dict) -> Any | None:
+        """Return a cached result if present and fresh, else None."""
+        if not session_id:
+            return None
+        key = self._key(session_id, tool_name, args)
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        stored_at, result = entry
+        if self._clock() - stored_at > self.ttl_seconds:
+            # Stale — drop it so the next put can take the slot.
+            self._store.pop(key, None)
+            return None
+        # LRU touch.
+        self._store.move_to_end(key)
+        return result
+
+    def put(self, session_id: str, tool_name: str, args: dict, result: Any) -> None:
+        """Store a fresh result. Evicts oldest entry when capacity is hit."""
+        if not session_id:
+            return
+        key = self._key(session_id, tool_name, args)
+        self._store[key] = (self._clock(), result)
+        self._store.move_to_end(key)
+        while len(self._store) > self.max_entries:
+            self._store.popitem(last=False)
+
+    def clear_session(self, session_id: str) -> int:
+        """Drop all entries for a terminated session. Returns count cleared."""
+        keys_to_drop = [k for k in self._store if k[0] == session_id]
+        for k in keys_to_drop:
+            self._store.pop(k, None)
+        return len(keys_to_drop)
+
+    def __len__(self) -> int:
+        return len(self._store)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -289,6 +289,16 @@ class LifeOSMCPServer:
         self.client = httpx.Client(timeout=30.0)
         self.openapi_spec: dict | None = None
         self.tools: list[dict] = []
+        # Per-session tool-result cache (#139 §4). Bypassed when the caller
+        # doesn't supply a session id (which is the common case for local-CLI
+        # tool calls; cache hits matter most on managed-agent HTTP calls).
+        try:
+            from api.services.agent_worker.tool_result_cache import (
+                SessionToolResultCache,
+            )
+            self._result_cache = SessionToolResultCache()
+        except Exception:  # pragma: no cover — keep server bootable without agent worker
+            self._result_cache = None
         self._load_openapi_spec()
         self._register_inter_agent_tools()
 
@@ -926,8 +936,32 @@ class LifeOSMCPServer:
         except httpx.RequestError as e:
             return {"error": f"Request failed: {e}"}
 
-    def _call_api(self, tool_name: str, arguments: dict) -> dict:
-        """Call the LifeOS API based on tool name and arguments."""
+    @staticmethod
+    def _cache_eligible(tool_name: str) -> bool:
+        """Tools whose results are safe to cache for 60s within a session.
+
+        Only GET-shaped tools (read-only). Writes (drafts, calendar events,
+        tasks, memories), inter-agent dispatch, and the sync trigger are
+        excluded — they're either idempotent in the wrong direction or
+        sensitive to fresh state.
+        """
+        cfg = next(
+            (c for c in CURATED_ENDPOINTS.values() if c.get("name") == tool_name),
+            None,
+        )
+        if cfg is None:
+            return False
+        return cfg.get("method", "").upper() == "GET"
+
+    def _call_api(self, tool_name: str, arguments: dict, session_id: str | None = None) -> dict:
+        """Call the LifeOS API based on tool name and arguments.
+
+        `session_id` (optional) enables the per-session result cache (#139 §4):
+        when supplied, identical GET-style tool calls within the same session
+        are served from a 60s LRU instead of round-tripping to the API. Writes
+        (POST/PUT/DELETE) are never cached. The cache also skips inter-agent
+        tools and the sync trigger (both sensitive to fresh state).
+        """
         # Custom handlers for tools that don't map 1:1 to endpoints
         if tool_name == "lifeos_sync_trigger":
             return self._handle_sync_trigger(arguments)
@@ -938,6 +972,13 @@ class LifeOSMCPServer:
         # managed agents pass it explicitly per the system prompt.
         if tool_name.startswith("lifeos_agent_"):
             return self._handle_inter_agent(tool_name, dict(arguments))
+
+        # Cache check for read-only tools when the caller is session-aware.
+        cache_key_args = arguments
+        if self._cache_eligible(tool_name) and session_id and self._result_cache is not None:
+            cached = self._result_cache.get(session_id, tool_name, cache_key_args)
+            if cached is not None:
+                return cached
 
         # Find the endpoint config
         endpoint_config = None
@@ -985,6 +1026,10 @@ class LifeOSMCPServer:
                         body = self._fetch_email_body(msg["message_id"], account)
                         if body:
                             msg["body"] = body
+
+            # Store in the per-session cache for read-only tools (#139 §4).
+            if self._cache_eligible(tool_name) and session_id and self._result_cache is not None:
+                self._result_cache.put(session_id, tool_name, cache_key_args, result)
 
             return result
         except httpx.HTTPStatusError as e:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -297,3 +297,95 @@ def test_curated_endpoint_descriptions_average_under_30_words():
         f"tools with >30-word description: {over_threshold}. "
         "Trim them — every word lands in cache_creation."
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-session tool result cache integration (#139 §4)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_call_api_caches_get_results_per_session():
+    """Identical GET-shaped calls within the same session hit the cache:
+    the second call MUST NOT round-trip to the API."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    server = module.LifeOSMCPServer()
+    # Replace the httpx client with a mock so we can count call counts.
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"events": [{"title": "standup"}]}
+    fake_response.raise_for_status = MagicMock()
+    fake.get.return_value = fake_response
+    server.client = fake
+
+    # First call: round-trips.
+    r1 = server._call_api(
+        "lifeos_calendar_upcoming", {"days": 7}, session_id="sess_X"
+    )
+    # Second call: should hit the cache, not the HTTP client.
+    r2 = server._call_api(
+        "lifeos_calendar_upcoming", {"days": 7}, session_id="sess_X"
+    )
+    assert r1 == r2
+    assert fake.get.call_count == 1, "expected exactly one HTTP call (second served from cache)"
+
+
+@pytest.mark.unit
+def test_call_api_does_not_cache_writes():
+    """POST/PUT/DELETE tools are never cached."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    server = module.LifeOSMCPServer()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"id": "draft_1"}
+    fake_response.raise_for_status = MagicMock()
+    fake.post.return_value = fake_response
+    server.client = fake
+
+    server._call_api(
+        "lifeos_gmail_draft",
+        {"to": "x@y", "subject": "hi", "body": "ok"},
+        session_id="sess_X",
+    )
+    server._call_api(
+        "lifeos_gmail_draft",
+        {"to": "x@y", "subject": "hi", "body": "ok"},
+        session_id="sess_X",
+    )
+    # Both calls hit the API — POST is never cached.
+    assert fake.post.call_count == 2
+
+
+@pytest.mark.unit
+def test_call_api_skips_cache_when_session_id_missing():
+    """Without a session_id (e.g., local CLI use), the cache is bypassed."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    server = module.LifeOSMCPServer()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"events": []}
+    fake_response.raise_for_status = MagicMock()
+    fake.get.return_value = fake_response
+    server.client = fake
+
+    server._call_api("lifeos_calendar_upcoming", {"days": 7})
+    server._call_api("lifeos_calendar_upcoming", {"days": 7})
+    # Both calls round-trip — no session, no cache.
+    assert fake.get.call_count == 2

--- a/tests/test_tool_result_cache.py
+++ b/tests/test_tool_result_cache.py
@@ -1,0 +1,104 @@
+"""Tests for the per-session tool result cache (#139 §4)."""
+from __future__ import annotations
+
+import pytest
+
+from api.services.agent_worker.tool_result_cache import SessionToolResultCache
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_returns_none_when_empty():
+    cache = SessionToolResultCache()
+    assert cache.get("sess_1", "lifeos_calendar_upcoming", {"days": 7}) is None
+
+
+def test_put_then_get_returns_stored_result():
+    cache = SessionToolResultCache()
+    result = {"events": [{"title": "standup"}]}
+    cache.put("sess_1", "lifeos_calendar_upcoming", {"days": 7}, result)
+    assert cache.get("sess_1", "lifeos_calendar_upcoming", {"days": 7}) == result
+
+
+def test_args_key_is_order_independent():
+    """`{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` must collide."""
+    cache = SessionToolResultCache()
+    cache.put("sess_1", "lifeos_search", {"a": 1, "b": 2}, {"hits": [1]})
+    # Same logical args, different insertion order.
+    assert cache.get("sess_1", "lifeos_search", {"b": 2, "a": 1}) == {"hits": [1]}
+
+
+def test_different_args_do_not_collide():
+    cache = SessionToolResultCache()
+    cache.put("sess_1", "lifeos_search", {"q": "X"}, {"hits": ["x"]})
+    assert cache.get("sess_1", "lifeos_search", {"q": "Y"}) is None
+
+
+def test_different_sessions_do_not_share():
+    """Session A's cache MUST NOT leak into session B's request."""
+    cache = SessionToolResultCache()
+    cache.put("sess_A", "lifeos_calendar_upcoming", {"days": 7}, {"a": 1})
+    assert cache.get("sess_B", "lifeos_calendar_upcoming", {"days": 7}) is None
+
+
+def test_ttl_expires_stale_entries():
+    """An entry older than ttl_seconds returns None."""
+    fake_now = [1000.0]
+    cache = SessionToolResultCache(ttl_seconds=60, clock=lambda: fake_now[0])
+    cache.put("sess_1", "lifeos_search", {"q": "X"}, {"hits": [1]})
+    # Within TTL — still hits.
+    fake_now[0] = 1059.0
+    assert cache.get("sess_1", "lifeos_search", {"q": "X"}) == {"hits": [1]}
+    # Past TTL — miss, and the stale entry is dropped.
+    fake_now[0] = 1061.0
+    assert cache.get("sess_1", "lifeos_search", {"q": "X"}) is None
+    assert len(cache) == 0
+
+
+def test_lru_eviction_when_capacity_exceeded():
+    """Oldest entry is evicted when capacity fills."""
+    cache = SessionToolResultCache(max_entries=2)
+    cache.put("sess_1", "tool_a", {}, "A")
+    cache.put("sess_1", "tool_b", {}, "B")
+    cache.put("sess_1", "tool_c", {}, "C")
+    # Oldest (tool_a) was evicted.
+    assert cache.get("sess_1", "tool_a", {}) is None
+    assert cache.get("sess_1", "tool_b", {}) == "B"
+    assert cache.get("sess_1", "tool_c", {}) == "C"
+
+
+def test_get_touches_lru_so_recently_used_survives_eviction():
+    """A get on tool_a should refresh its position so the next put evicts
+    tool_b instead."""
+    cache = SessionToolResultCache(max_entries=2)
+    cache.put("sess_1", "tool_a", {}, "A")
+    cache.put("sess_1", "tool_b", {}, "B")
+    # Touch tool_a — now tool_b is the oldest.
+    cache.get("sess_1", "tool_a", {})
+    cache.put("sess_1", "tool_c", {}, "C")
+    assert cache.get("sess_1", "tool_a", {}) == "A"
+    assert cache.get("sess_1", "tool_b", {}) is None
+    assert cache.get("sess_1", "tool_c", {}) == "C"
+
+
+def test_clear_session_drops_only_that_sessions_entries():
+    cache = SessionToolResultCache()
+    cache.put("sess_A", "t1", {}, "A1")
+    cache.put("sess_A", "t2", {}, "A2")
+    cache.put("sess_B", "t1", {}, "B1")
+    cleared = cache.clear_session("sess_A")
+    assert cleared == 2
+    assert cache.get("sess_A", "t1", {}) is None
+    assert cache.get("sess_A", "t2", {}) is None
+    # Other session untouched.
+    assert cache.get("sess_B", "t1", {}) == "B1"
+
+
+def test_empty_session_id_bypasses_cache():
+    """An empty session_id never caches or retrieves (defensive: callers that
+    don't know their session shouldn't share cached results)."""
+    cache = SessionToolResultCache()
+    cache.put("", "lifeos_search", {"q": "X"}, "leaked")
+    assert cache.get("", "lifeos_search", {"q": "X"}) is None
+    assert len(cache) == 0


### PR DESCRIPTION
## Summary

Per-session LRU+TTL cache for read-only tool results in the MCP server (#139 §4). When an agent calls the same GET-style tool twice within a session with identical args, the second call returns the cached result instead of round-tripping to the API.

- New \`SessionToolResultCache\` (60s uniform TTL, 100-entry cap, args-canonicalized so kwarg order doesn't matter).
- Wired into \`LifeOSMCPServer._call_api\` via optional \`session_id\` param. GET tools cached, writes (POST/PUT/DELETE) skipped, inter-agent + sync_trigger skipped.
- 10 unit tests on the cache + 3 integration tests on \`_call_api\` cache-hit/cache-skip behavior.

Wiring the HTTP transport to extract the caller's session id from \`mcp-session-id\` header or inter-agent \`caller_session_id\` is a follow-up.

Relates to #139 (partial — Section 4 only)

## Test evidence

\`\`\`
tests/test_tool_result_cache.py .......... (10 passed)
tests/test_mcp_server.py .................. (18 passed; 3 new for cache)
\`\`\`

## Review focus

- One bug caught during testing: \`SessionToolResultCache.__len__\` returning 0 made the empty cache evaluate as falsy. The guard \`if self._cache_eligible(...) and session_id and self._result_cache:\` was therefore short-circuiting on the very first call. Switched to \`self._result_cache is not None\`.
- Cache key uses sorted-JSON canonicalization (\`{"a":1,"b":2}\` matches \`{"b":2,"a":1}\`).
- Conservative eligibility: only tools whose \`CURATED_ENDPOINTS\` \`method\` is GET are cached.