### PR TITLE
feat: per-class tool filter helper + driver.update_session

### DIFF
--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -395,6 +395,31 @@ class ManagedAgentsDriver:
             )
         resp.raise_for_status()
 
+    def update_session(self, session_id: str, agent_payload: dict) -> None:
+        """Replace the session's agent config — used to filter tools per-class.
+
+        Per the Managed Agents docs, `POST /v1/sessions/{id}` accepts an
+        `agent.tools` and `agent.mcp_servers` array (full replacement). The
+        update is session-local — it does not propagate back to the preset
+        and does not persist across sessions. Sessions start `idle`; this
+        call doesn't trigger the agent.
+
+        `agent_payload` is the dict that goes under the `agent` key, e.g.
+        `{"tools": ["lifeos_search", "lifeos_ask", ...]}`. The caller is
+        responsible for shaping the payload (see `tool_filter.class_to_tool_filter`).
+
+        Best-effort: 4xx errors are logged and the response body is surfaced
+        in logs before raising, so a beta-API schema mismatch shows up
+        loudly rather than silently degrading the session.
+        """
+        body = {"agent": agent_payload}
+        resp = self._client.post(
+            f"{self.base_url}/sessions/{session_id}",
+            headers=self._headers(),
+            json=body,
+        )
+        self._raise_for_status_with_body(resp)
+
     def kill_session(self, session_id: str, reason: str = "") -> None:
         """Terminate a session early — used for budget breach / cascade-kill.
 

--- a/api/services/agent_worker/tool_filter.py
+++ b/api/services/agent_worker/tool_filter.py
@@ -1,0 +1,151 @@
+"""Per-class tool filter helper (#139 §3, partial).
+
+The full per-class session tool filtering flow is:
+  1. Preflight picks `preset_class` (personal-comm / work-comm / research /
+     financial / crm / fullstack)
+  2. Worker creates the session as usual
+  3. Worker calls `driver.update_session()` with the filtered tool list
+  4. Filtered tools scope the cache_creation cost on the first user turn
+
+This module owns step 3's input: given a class name, return the right
+`{tools: [...], mcp_servers: [...]}` payload for the UPDATE call. The
+worker-side wiring (steps 2 + 3) is a follow-up; this helper lands now
+so the rest can compose against a tested, documented surface.
+
+Cross-cutting tools are auto-merged into every class's filter — every
+agent needs at minimum: telegram_send, agent_* coordination, search,
+ask, health, task_*, reminder_*, and calendar reads.
+"""
+from __future__ import annotations
+
+
+# Preset classes. Preflight picks one; "fullstack" means "use the entire
+# preset, no filtering" — the operator's default fallback.
+PRESET_CLASS_PERSONAL_COMM = "personal-comm"
+PRESET_CLASS_WORK_COMM = "work-comm"
+PRESET_CLASS_RESEARCH = "research"
+PRESET_CLASS_FINANCIAL = "financial"
+PRESET_CLASS_CRM = "crm"
+PRESET_CLASS_FULLSTACK = "fullstack"
+
+ALL_PRESET_CLASSES = (
+    PRESET_CLASS_PERSONAL_COMM,
+    PRESET_CLASS_WORK_COMM,
+    PRESET_CLASS_RESEARCH,
+    PRESET_CLASS_FINANCIAL,
+    PRESET_CLASS_CRM,
+    PRESET_CLASS_FULLSTACK,
+)
+
+
+# Cross-cutting tools every agent needs regardless of routing class.
+# Without these, a research agent can't message back to the operator,
+# a financial agent can't spawn a research child, etc.
+CROSS_CUTTING_LIFEOS_TOOLS = (
+    # Operator messaging
+    "lifeos_telegram_send",
+    # Inter-agent coordination
+    "lifeos_agent_spawn",
+    "lifeos_agent_check",
+    "lifeos_agent_send",
+    "lifeos_agent_yield_until",
+    "lifeos_agent_kill",
+    "lifeos_agent_transcript_read",
+    "lifeos_agent_sessions_list",
+    "lifeos_agent_user_ask",
+    # General vault search — often the first move on any task
+    "lifeos_search",
+    "lifeos_ask",
+    # Self-diagnosis
+    "lifeos_health",
+    # Follow-up creation
+    "lifeos_task_create",
+    "lifeos_task_list",
+    "lifeos_task_update",
+    "lifeos_task_complete",
+    "lifeos_reminder_create",
+    "lifeos_reminder_list",
+    # Calendar reads are common across most classes; writes stay class-specific.
+    "lifeos_calendar_upcoming",
+    "lifeos_calendar_search",
+)
+
+
+# Per-class specialty tools. Cross-cutting tools are merged in by
+# `class_to_tool_filter` so each class's tuple only lists what's unique.
+_CLASS_SPECIALTIES: dict[str, tuple[str, ...]] = {
+    PRESET_CLASS_PERSONAL_COMM: (
+        "lifeos_gmail_search",
+        "lifeos_gmail_draft",
+        "lifeos_calendar_create",
+        "lifeos_calendar_update",
+        "lifeos_calendar_delete",
+        "lifeos_imessage_search",
+    ),
+    PRESET_CLASS_WORK_COMM: (
+        "lifeos_slack_search",
+        "lifeos_gmail_search",
+        "lifeos_gmail_draft",
+        "lifeos_calendar_create",
+        "lifeos_calendar_update",
+        "lifeos_calendar_delete",
+        "lifeos_drive_search",
+    ),
+    PRESET_CLASS_RESEARCH: (
+        "lifeos_drive_search",
+        "lifeos_memories_create",
+        "lifeos_memories_search",
+        "lifeos_people_search",
+    ),
+    PRESET_CLASS_FINANCIAL: (
+        "lifeos_monarch_accounts",
+        "lifeos_monarch_transactions",
+        "lifeos_monarch_cashflow",
+        "lifeos_monarch_budgets",
+    ),
+    PRESET_CLASS_CRM: (
+        "lifeos_people_search",
+        "lifeos_person_profile",
+        "lifeos_person_timeline",
+        "lifeos_person_connections",
+        "lifeos_person_facts",
+        "lifeos_person_fact_update",
+        "lifeos_person_fact_confirm",
+        "lifeos_person_fact_delete",
+        "lifeos_person_update",
+        "lifeos_relationship_insights",
+        "lifeos_communication_gaps",
+        "lifeos_meeting_prep",
+        "lifeos_photos_person",
+        "lifeos_photos_shared",
+        "lifeos_photos_stats",
+        "lifeos_memories_search",
+    ),
+    # `fullstack` is the no-filter fallback — handled by class_to_tool_filter
+    # by returning None instead of a payload.
+    PRESET_CLASS_FULLSTACK: (),
+}
+
+
+def class_to_tool_filter(preset_class: str) -> dict | None:
+    """Build the `agent.tools` payload for `driver.update_session()`.
+
+    Returns:
+      - A `{"tools": [...]}` dict when filtering applies. The list is the
+        union of the class's specialty tools and `CROSS_CUTTING_LIFEOS_TOOLS`,
+        de-duplicated and sorted for stability across calls.
+      - `None` for the `fullstack` class or any unknown class — meaning
+        "no filter, use the agent preset as-is". The worker should skip
+        the UPDATE call in this case.
+
+    The `mcp_servers` key is intentionally NOT emitted here. The MCP server
+    list lives on the preset (Anthropic console); filtering individual
+    tools within those servers is the per-class lever. If a class needs
+    a different set of MCP servers entirely, that's a separate operator
+    decision and should be made by swapping the preset, not the filter.
+    """
+    if preset_class not in _CLASS_SPECIALTIES or preset_class == PRESET_CLASS_FULLSTACK:
+        return None
+    specialty = _CLASS_SPECIALTIES[preset_class]
+    merged = sorted(set(specialty) | set(CROSS_CUTTING_LIFEOS_TOOLS))
+    return {"tools": merged}

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -605,6 +605,47 @@ def test_kill_session_swallows_errors():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.unit
+def test_update_session_sends_post_with_agent_payload():
+    """`update_session` POSTs the agent config under `agent` to the session
+    URL — full-replacement semantics per the Managed Agents docs."""
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"id": "sess_1"})
+
+    driver = _build_driver(handler)
+    driver.update_session("sess_1", {"tools": ["lifeos_search", "lifeos_ask"]})
+
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/sessions/sess_1")
+    assert captured["body"] == {
+        "agent": {"tools": ["lifeos_search", "lifeos_ask"]}
+    }
+
+
+@pytest.mark.unit
+def test_update_session_4xx_surfaces_response_body(caplog):
+    """A 4xx response logs the body so beta-API schema mismatches are
+    visible rather than swallowed."""
+    def handler(request):
+        return httpx.Response(
+            400, json={"error": "tools[3] is not a valid identifier"}
+        )
+
+    driver = _build_driver(handler)
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(httpx.HTTPStatusError):
+            driver.update_session("sess_1", {"tools": ["bogus tool"]})
+    body_logged = any(
+        "not a valid identifier" in rec.getMessage() for rec in caplog.records
+    )
+    assert body_logged, "expected 4xx body to be surfaced in WARNING logs"
+
+
+@pytest.mark.unit
 def test_managed_session_cost_includes_overhead():
     cost = managed_session_cost("claude-opus-4-7", 1000, 1000, wall_seconds=3600)
     # 1k input ($0.015) + 1k output ($0.075) + 1 hr * $0.08

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -1,0 +1,125 @@
+"""Tests for the per-class tool filter helper (#139 §3, partial)."""
+from __future__ import annotations
+
+import pytest
+
+from api.services.agent_worker.tool_filter import (
+    ALL_PRESET_CLASSES,
+    CROSS_CUTTING_LIFEOS_TOOLS,
+    PRESET_CLASS_CRM,
+    PRESET_CLASS_FINANCIAL,
+    PRESET_CLASS_FULLSTACK,
+    PRESET_CLASS_PERSONAL_COMM,
+    PRESET_CLASS_RESEARCH,
+    PRESET_CLASS_WORK_COMM,
+    class_to_tool_filter,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_fullstack_class_returns_none():
+    """fullstack means 'no filter' — worker should skip the UPDATE call."""
+    assert class_to_tool_filter(PRESET_CLASS_FULLSTACK) is None
+
+
+def test_unknown_class_returns_none():
+    """Defensive: a typo or future class returns None instead of an empty
+    filter (which would lock the agent out of all tools)."""
+    assert class_to_tool_filter("not-a-real-class") is None
+
+
+@pytest.mark.parametrize("preset_class", [
+    PRESET_CLASS_PERSONAL_COMM,
+    PRESET_CLASS_WORK_COMM,
+    PRESET_CLASS_RESEARCH,
+    PRESET_CLASS_FINANCIAL,
+    PRESET_CLASS_CRM,
+])
+def test_every_class_includes_all_cross_cutting_tools(preset_class):
+    """Cross-cutting tools (telegram, agent_*, search, ask, etc.) must
+    appear in every non-fullstack class's filter so the agent can always
+    message back, spawn children, and search."""
+    payload = class_to_tool_filter(preset_class)
+    assert payload is not None
+    tools = set(payload["tools"])
+    missing = set(CROSS_CUTTING_LIFEOS_TOOLS) - tools
+    assert not missing, f"{preset_class} missing cross-cutting tools: {missing}"
+
+
+def test_personal_comm_class_has_gmail_and_imessage():
+    """personal-comm specializes in personal messaging."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_PERSONAL_COMM)["tools"])
+    assert "lifeos_gmail_search" in tools
+    assert "lifeos_gmail_draft" in tools
+    assert "lifeos_imessage_search" in tools
+    # And it gets calendar writes (comms classes need to schedule).
+    assert "lifeos_calendar_create" in tools
+
+
+def test_work_comm_class_has_slack_and_drive():
+    """work-comm specializes in workplace systems."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_WORK_COMM)["tools"])
+    assert "lifeos_slack_search" in tools
+    assert "lifeos_drive_search" in tools
+
+
+def test_research_class_excludes_calendar_writes():
+    """research is read-only — no calendar create/update/delete.
+    Calendar READS (upcoming, search) are cross-cutting and ARE included."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_RESEARCH)["tools"])
+    assert "lifeos_calendar_upcoming" in tools  # cross-cutting read
+    assert "lifeos_calendar_create" not in tools  # write — excluded
+    assert "lifeos_calendar_delete" not in tools
+
+
+def test_financial_class_has_monarch_tools():
+    """financial specializes in money tools."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_FINANCIAL)["tools"])
+    assert "lifeos_monarch_accounts" in tools
+    assert "lifeos_monarch_transactions" in tools
+    assert "lifeos_monarch_cashflow" in tools
+    assert "lifeos_monarch_budgets" in tools
+
+
+def test_crm_class_has_full_person_family():
+    """crm specializes in the people/person/photos tools."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_CRM)["tools"])
+    assert "lifeos_people_search" in tools
+    assert "lifeos_person_profile" in tools
+    assert "lifeos_person_facts" in tools
+    assert "lifeos_photos_person" in tools
+    assert "lifeos_meeting_prep" in tools
+    assert "lifeos_communication_gaps" in tools
+
+
+def test_filter_payload_does_not_include_mcp_servers_key():
+    """MCP server list lives on the preset, not in per-session filtering.
+    Emitting an mcp_servers key here would risk overriding the preset's
+    list with an empty array."""
+    payload = class_to_tool_filter(PRESET_CLASS_RESEARCH)
+    assert payload is not None
+    assert "mcp_servers" not in payload
+    assert set(payload.keys()) == {"tools"}
+
+
+def test_filter_payload_is_deduplicated_and_sorted():
+    """Output order is stable across calls so transcript diffs are clean."""
+    payload = class_to_tool_filter(PRESET_CLASS_PERSONAL_COMM)
+    assert payload is not None
+    tools = payload["tools"]
+    assert tools == sorted(set(tools)), "tool list must be deduped + sorted"
+    # And calling twice yields identical output.
+    assert class_to_tool_filter(PRESET_CLASS_PERSONAL_COMM) == payload
+
+
+def test_all_classes_constant_matches_handled_classes():
+    """The ALL_PRESET_CLASSES tuple matches what class_to_tool_filter
+    actually handles — drift between the two would silently break the
+    operator's view of available classes."""
+    assert PRESET_CLASS_FULLSTACK in ALL_PRESET_CLASSES
+    for cls in ALL_PRESET_CLASSES:
+        # Either None (fullstack) or a real payload — never raises.
+        result = class_to_tool_filter(cls)
+        assert result is None or "tools" in result


### PR DESCRIPTION
## Summary

Foundation pieces of #139 §3 (per-class session tool filtering):

- New \`tool_filter.class_to_tool_filter(preset_class) -> dict | None\` — returns the \`{tools: [...]}\` UPDATE payload for \`personal-comm\` / \`work-comm\` / \`research\` / \`financial\` / \`crm\`. \`fullstack\` and unknown classes return None ("no filter, use preset as-is").
- Auto-merges \`CROSS_CUTTING_LIFEOS_TOOLS\` (telegram_send, agent_*, search, ask, health, task_*, reminder_*, calendar reads) into every class.
- New \`ManagedAgentsDriver.update_session(session_id, agent_payload)\` — POSTs full-replacement agent config.

**Deferred to a follow-up PR**:
- Wiring preflight to emit \`preset_class\`
- Worker calling \`update_session\` between create and first user message
- The live verification experiment (filtered cache_creation < 60% of full-preset baseline)

Relates to #139 (partial — Section 3 foundation)

## Test evidence

\`\`\`
tests/test_tool_filter.py                  ... 15 passed
tests/test_agent_worker_managed_driver.py  ... 37 passed (2 new for update_session)
\`\`\`

## Review focus

- The filter intentionally does NOT emit an \`mcp_servers\` key. MCP servers live on the preset; emitting them per-session risks overriding the operator's preset list with an empty array.
- \`fullstack\` returns None so the worker can detect "skip update call" without an extra signal.
- Tool list is sorted+deduplicated so transcripts diff cleanly across runs.