### PR TITLE
feat: managed executor splits create/update/post for per-class filter

### DIFF
--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -190,7 +190,16 @@ class ManagedExecutor:
     # ------------------------------------------------------------------
 
     def start(self, session, task: dict) -> ExecutorOutcome:
-        """Create the remote session and post the initial user message.
+        """Create the remote session, apply the per-class tool filter (if any),
+        and post the initial user message.
+
+        Flow (#139 §3):
+          1. POST /v1/sessions — container provisioned, no LLM cost yet.
+          2. POST /v1/sessions/{id} with the per-class tool filter (full
+             agent.tools replacement). Skipped for `preset_class=fullstack`
+             or unset (no filter, use preset as-is). LLM cost still zero.
+          3. POST /v1/sessions/{id}/events with user.message — cache_creation
+             fires now, scoped to the filtered tool set.
 
         On success: STATUS_RUNNING with `managed_agent_session_id` populated.
         On failure (network, API rejection, etc.): STATUS_FAILED.
@@ -206,14 +215,18 @@ class ManagedExecutor:
         self.transcript_store.append(sid, "managed_start",
                                      {"agent_id": self.agent_id, "environment_id": self.environment_id})
 
+        initial_message = _user_message_for(
+            task, sid, session.expected_output or "text", budget,
+        )
+        preset_class = getattr(session, "preset_class", None)
+
         try:
+            # Step 1: create the session WITHOUT initial_message. Provisions
+            # the container; no agent loop runs and no LLM cost is incurred.
             remote_id = self.driver.create_session(
                 agent_id=self.agent_id,
                 environment_id=self.environment_id,
                 vault_ids=self.vault_ids,
-                initial_message=_user_message_for(
-                    task, sid, session.expected_output or "text", budget,
-                ),
                 metadata={"lifeos_session_id": sid, "task_id": session.task_id},
                 title=_sanitize_title(task.get("description") or ""),
             )
@@ -227,9 +240,46 @@ class ManagedExecutor:
 
         self.session_store.set_managed_session_id(session.task_id, remote_id)
         self.transcript_store.append(sid, "managed_created", {"remote_id": remote_id})
-        # Mark as STATUS_RUNNING but with a remote handle attached. The
-        # worker's tick loop will pick it up via _poll_managed_sessions on
-        # subsequent ticks.
+
+        # Step 2: apply per-class tool filter if one was selected. Skipped for
+        # fullstack / unset / unknown classes. Best-effort — a filter failure
+        # falls back to the full preset rather than aborting the session.
+        from api.services.agent_worker.tool_filter import class_to_tool_filter
+        agent_payload = class_to_tool_filter(preset_class) if preset_class else None
+        if agent_payload is not None:
+            try:
+                self.driver.update_session(remote_id, agent_payload)
+                self.transcript_store.append(
+                    sid, "managed_filter_applied",
+                    {"preset_class": preset_class, "tool_count": len(agent_payload.get("tools", []))},
+                )
+            except Exception as exc:
+                logger.warning(
+                    "managed update_session failed for %s (class=%s): %s — falling back to full preset",
+                    sid, preset_class, type(exc).__name__,
+                )
+                self.transcript_store.append(
+                    sid, "managed_filter_failed",
+                    {"preset_class": preset_class, "error_type": type(exc).__name__},
+                )
+
+        # Step 3: post the initial user message. cache_creation fires here on
+        # the (possibly filtered) tool set.
+        try:
+            self.driver.post_user_message(remote_id, initial_message)
+        except Exception as exc:
+            logger.error("managed post_user_message failed for %s: %s", sid, type(exc).__name__)
+            self.session_store.update_status(session.task_id, STATUS_FAILED)
+            self.transcript_store.append(
+                sid, "managed_post_failed", {"error_type": type(exc).__name__},
+            )
+            return ExecutorOutcome(
+                status=STATUS_FAILED,
+                reason=f"post_user_message failed: {type(exc).__name__}",
+            )
+
+        # The worker's tick loop will pick this up via _poll_managed_sessions
+        # on subsequent ticks.
         return ExecutorOutcome(status=STATUS_RUNNING)
 
     def poll(self, session) -> ExecutorOutcome:

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -53,6 +53,11 @@ class Session:
     expected_output: str | None = None
     parent_session_id: str | None = None
     managed_agent_session_id: str | None = None
+    # Preset class for per-session tool filtering (#139 §3). When set,
+    # ManagedExecutor.start() calls driver.update_session() with the
+    # class's filtered tool list between create and the first user
+    # message — scoping cache_creation to the smaller tool set.
+    preset_class: str | None = None
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     # Prompt-cache buckets — kept separate from total_input_tokens because
@@ -88,7 +93,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     root_session_id           TEXT,
     spawn_depth               INTEGER NOT NULL DEFAULT 0,
     yield_waiting_for         TEXT,  -- JSON array of session_ids the agent is waiting on
-    managed_agent_session_id  TEXT
+    managed_agent_session_id  TEXT,
+    preset_class              TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -256,6 +262,12 @@ class SessionStore:
                     "ALTER TABLE sessions ADD COLUMN total_cache_read_tokens "
                     "INTEGER NOT NULL DEFAULT 0"
                 )
+            # Idempotent migration for the per-session preset_class column
+            # (#139 §3 worker wiring). Old rows stay NULL → fullstack.
+            if "preset_class" not in sess_cols:
+                conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN preset_class TEXT"
+                )
             # Idempotent migrations for the runaway detection counters on
             # managed_cursor (#139 Section 5).
             mc_cols = {row["name"] for row in conn.execute("PRAGMA table_info(managed_cursor)")}
@@ -391,19 +403,22 @@ class SessionStore:
         routing: str | None,
         budget: dict | None,
         expected_output: str | None = None,
+        preset_class: str | None = None,
     ) -> None:
-        """Update routing decision and budget after the preflight call."""
+        """Update routing, budget, expected_output, and preset_class after preflight."""
         with self._connect() as conn:
             conn.execute(
                 """
                 UPDATE sessions
-                SET routing = ?, budget_json = ?, expected_output = ?, last_activity_at = ?
+                SET routing = ?, budget_json = ?, expected_output = ?,
+                    preset_class = ?, last_activity_at = ?
                 WHERE task_id = ?
                 """,
                 (
                     routing,
                     json.dumps(budget) if budget else None,
                     expected_output,
+                    preset_class,
                     _now(),
                     task_id,
                 ),
@@ -977,6 +992,11 @@ class SessionStore:
             expected_output=row["expected_output"],
             parent_session_id=row["parent_session_id"],
             managed_agent_session_id=row["managed_agent_session_id"],
+            preset_class=(
+                row["preset_class"]
+                if "preset_class" in row.keys()
+                else None
+            ),
             root_session_id=(
                 row["root_session_id"] if "root_session_id" in row.keys() else None
             ),

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1043,6 +1043,7 @@ class Worker:
             routing=pre.routing,
             budget=budget_json,
             expected_output=pre.expected_output,
+            preset_class=pre.preset_class,
         )
         session = self.session_store.get(task_id)  # refresh
 

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -30,12 +30,17 @@ VAULT_IDS = ["vlt_test"]
 class _FakeDriver:
     """Records calls and returns scripted state objects."""
 
-    def __init__(self, *, create_returns="sess_remote", state_responses=None, create_raises=None):
+    def __init__(self, *, create_returns="sess_remote", state_responses=None,
+                 create_raises=None, post_raises=None, update_raises=None):
         self.create_returns = create_returns
         self.state_responses = list(state_responses or [])
         self.create_raises = create_raises
+        self.post_raises = post_raises
+        self.update_raises = update_raises
         self.kills: list[tuple[str, str]] = []
         self.created_with: dict | None = None
+        self.posted_messages: list[tuple[str, str]] = []
+        self.updates: list[tuple[str, dict]] = []
         self.poll_calls: list[tuple[str, str | None]] = []
 
     def create_session(self, **kwargs):
@@ -43,6 +48,16 @@ class _FakeDriver:
         if self.create_raises:
             raise self.create_raises
         return self.create_returns
+
+    def post_user_message(self, session_id, content):
+        self.posted_messages.append((session_id, content))
+        if self.post_raises:
+            raise self.post_raises
+
+    def update_session(self, session_id, agent_payload):
+        self.updates.append((session_id, agent_payload))
+        if self.update_raises:
+            raise self.update_raises
 
     def get_session_state(self, session_id, since_event_id=None):
         self.poll_calls.append((session_id, since_event_id))
@@ -102,31 +117,32 @@ def test_start_creates_remote_session_with_agent_and_environment_ids(stores):
     assert cw["vault_ids"] == VAULT_IDS
     assert cw["metadata"]["lifeos_session_id"] == session.session_id
     assert cw["metadata"]["task_id"] == "t1"
-    # Initial message carries task description + soft budget. Budget is
+    # Per #139 §3 the initial message is NOT in the create_session kwargs —
+    # it's posted as a separate user.message AFTER an optional update_session.
+    assert "initial_message" not in cw
+    # The initial user message landed via post_user_message.
+    assert len(driver.posted_messages) == 1
+    posted_sid, posted_msg = driver.posted_messages[0]
+    assert posted_sid == "sess_remote_42"
+    # Posted message carries task description + soft budget. Budget is
     # framed as "soft" because Anthropic doesn't enforce it server-side;
     # the worker kills the session externally on breach.
-    assert "say hi" in cw["initial_message"]
-    assert "expected_output=text" in cw["initial_message"]
-    assert "soft budget" in cw["initial_message"]
-    assert "~$5.0" in cw["initial_message"]
-    # Today's date is injected for day-relative reasoning. Anthropic does
-    # not inject "today" into managed sessions, and the model has a fixed
-    # training cutoff — without this, calendar/due-date interpretation
-    # picks an arbitrary date inside the cutoff window.
+    assert "say hi" in posted_msg
+    assert "expected_output=text" in posted_msg
+    assert "soft budget" in posted_msg
+    assert "~$5.0" in posted_msg
+    # Today's date is injected for day-relative reasoning.
     import re
-    assert re.search(r"today=\d{4}-\d{2}-\d{2} \([A-Z][a-z]+day\)", cw["initial_message"]), \
-        cw["initial_message"][-300:]
-    # Ambiguity policy NOT duplicated here — it lives in the agent preset's
-    # system prompt (Anthropic console). User message stays task-specific.
-    assert "ambiguous" not in cw["initial_message"]
-    # session_id IS injected as `lifeos_session_id=…` so the cloud agent
-    # can pass it as `caller_session_id` on inter-agent tool calls. The
-    # MCP HTTP layer can't infer the caller server-side (cross-process),
-    # so the agent must supply it explicitly.
-    assert f"lifeos_session_id={session.session_id}" in cw["initial_message"]
-    # NO inline system_prompt / model / mcp_servers / connectors
+    assert re.search(r"today=\d{4}-\d{2}-\d{2} \([A-Z][a-z]+day\)", posted_msg), \
+        posted_msg[-300:]
+    # Ambiguity policy NOT duplicated here — it lives in the agent preset.
+    assert "ambiguous" not in posted_msg
+    assert f"lifeos_session_id={session.session_id}" in posted_msg
+    # NO inline system_prompt / model / mcp_servers / connectors / update call
+    # (no preset_class set on the session → no filter applied).
     assert "system_prompt" not in cw
     assert "model" not in cw
+    assert driver.updates == [], "no preset_class set → no update_session call"
     assert "mcp_servers" not in cw
     assert "connectors" not in cw
 
@@ -149,6 +165,99 @@ def test_start_omits_title_when_description_empty(stores):
     executor = _make_executor(store, transcript, driver)
     executor.start(session, {"id": "t1", "description": ""})
     assert driver.created_with["title"] is None
+
+
+@pytest.mark.unit
+def test_start_applies_tool_filter_when_preset_class_set(stores):
+    """When session.preset_class is set, the executor calls update_session
+    between create and the first user message — scoping cache_creation
+    to the class's filtered tool list (#139 §3)."""
+    store, _, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+        expected_output="text",
+        preset_class="research",
+    )
+    session = store.get("t1")
+    driver = _FakeDriver(create_returns="sess_remote")
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.start(session, {"id": "t1", "description": "look it up"})
+    assert outcome.status == STATUS_RUNNING
+    # update_session called once with the research-class filter.
+    assert len(driver.updates) == 1
+    upd_sid, upd_payload = driver.updates[0]
+    assert upd_sid == "sess_remote"
+    assert "tools" in upd_payload
+    assert "lifeos_drive_search" in upd_payload["tools"]  # research-class specialty
+    assert "lifeos_search" in upd_payload["tools"]        # cross-cutting
+    # The order matters: update_session must happen BEFORE the user message
+    # or cache_creation locks in on the unfiltered preset.
+    assert driver.posted_messages, "user message should still be posted"
+
+
+@pytest.mark.unit
+def test_start_skips_filter_for_fullstack_preset_class(stores):
+    """preset_class=fullstack means no filter — update_session is skipped."""
+    store, _, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+        expected_output="text",
+        preset_class="fullstack",
+    )
+    session = store.get("t1")
+    driver = _FakeDriver(create_returns="sess_remote")
+    executor = _make_executor(store, transcript, driver)
+    executor.start(session, {"id": "t1", "description": "anything"})
+    assert driver.updates == []
+
+
+@pytest.mark.unit
+def test_start_falls_back_to_full_preset_on_update_failure(stores):
+    """If update_session fails (4xx, schema mismatch), the session still
+    proceeds with the full preset — we don't want to abort a billable
+    session over a non-fatal filter issue."""
+    import httpx
+    store, _, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+        expected_output="text",
+        preset_class="research",
+    )
+    session = store.get("t1")
+    driver = _FakeDriver(
+        create_returns="sess_remote",
+        update_raises=httpx.HTTPStatusError(
+            "400", request=httpx.Request("POST", "http://x"),
+            response=httpx.Response(400),
+        ),
+    )
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.start(session, {"id": "t1", "description": "research X"})
+    # Session continues despite the filter failure.
+    assert outcome.status == STATUS_RUNNING
+    assert driver.posted_messages, "initial message still posted after filter failure"
+
+
+@pytest.mark.unit
+def test_start_marks_failed_when_post_user_message_fails(stores):
+    """If posting the initial user message fails, the session is marked
+    failed — we can't proceed without it."""
+    store, _, transcript = stores
+    driver = _FakeDriver(
+        create_returns="sess_remote",
+        post_raises=RuntimeError("network blip"),
+    )
+    session = store.get("t1")
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.start(session, {"id": "t1", "description": "x"})
+    assert outcome.status == STATUS_FAILED
+    assert "post_user_message failed" in outcome.reason
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Worker wiring for #139 §3. Restructures `ManagedExecutor.start()` into the three-step flow so per-class tool filtering scopes cache_creation:

1. `create_session` (no initial_message) — container only, no LLM cost.
2. `update_session` with the filtered tool list (if `preset_class` is set and not `fullstack`).
3. `post_user_message` — cache_creation fires here on the filtered preset.

Composes with #149/#150/#152/#153 to deliver per-class filtering end-to-end. The live verification experiment (filtered cache_creation < 60% of full-preset baseline) is operational and remains a follow-up.

## Test evidence
1495 unit tests pass. Four new tests cover: filter applied for the `research` class, skipped for `fullstack`, fallback on filter failure, failed status on post-message failure.

## Review focus
- The migrated test (`test_start_creates_remote_session_with_agent_and_environment_ids`) now asserts against `driver.posted_messages` instead of `create_session` kwargs, reflecting the new flow.
- Filter failure is non-fatal (logged + transcript-tagged `managed_filter_failed`) — the session continues with the full preset. Post-message failure IS fatal — we can't run a session without the user turn.
- `SessionStore` gets an idempotent `preset_class` column; old rows default to NULL (= fullstack).