### PR TITLE
feat: cost-optimization bundle (#137, #138, #139)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,12 @@
 # logs. The actual model the agent uses is whatever the agent preset says.
 # LIFEOS_AGENT_MANAGED_MODEL=claude-sonnet-4-6
 #
+# Optional dev-only override of LIFEOS_AGENT_MANAGED_MODEL for prompt-engineering
+# iteration. Set to e.g. claude-haiku-4-5 to swap client-side cost accounting to
+# the cheaper model while iterating. Leave unset in production. See
+# docs/guides/agent-worker-setup.md "Cost-aware iteration".
+# LIFEOS_AGENT_MANAGED_MODEL_FOR_TESTS=
+#
 # Deprecated by the API refactor (was used by the pre-refactor driver to build
 # per-session MCP/connector lists). MCP servers and connectors now live on the
 # agent preset, not in session-create. Both vars are parsed but ignored; safe

--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,12 @@
 # docs/guides/agent-worker-setup.md "Cost-aware iteration".
 # LIFEOS_AGENT_MANAGED_MODEL_FOR_TESTS=
 #
+# Cost-confirmation threshold for managed-agent task dispatch (#139 §7). When
+# preflight's cache-cold cost estimate exceeds this dollar amount, the
+# orchestrator surfaces a confirmation prompt to the operator before dispatching.
+# Set to 0 to disable confirmation entirely (auto-dispatch all managed tasks).
+# LIFEOS_AGENT_COST_CONFIRM_THRESHOLD_DOLLARS=1.0
+#
 # Deprecated by the API refactor (was used by the pre-refactor driver to build
 # per-session MCP/connector lists). MCP servers and connectors now live on the
 # agent preset, not in session-create. Both vars are parsed but ignored; safe

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -26,6 +26,35 @@ class CreateTaskRequest(BaseModel):
     due_date: Optional[str] = Field(default=None, description="Due date (YYYY-MM-DD)")
     tags: Optional[list[str]] = Field(default=None, description="List of tags (e.g., ['work', 'urgent'])")
     reminder_id: Optional[str] = Field(default=None, description="Associated reminder ID")
+    dry_run: Optional[bool] = Field(
+        default=False,
+        description="When true and the task carries the #agent tag, run the "
+                    "Haiku preflight and return the routing + cost estimate "
+                    "without creating the task. Used by prompt-engineering "
+                    "iteration to inspect routing decisions without dispatching "
+                    "a managed session. Costs ~$0.001 for the preflight call.",
+    )
+
+
+class PreflightPreviewResponse(BaseModel):
+    """Response shape when `dry_run=true` is supplied to task creation.
+
+    Returns the preflight routing + budget + cost estimate without creating
+    the task. Used by dev iteration to inspect routing decisions cheaply.
+    """
+    dry_run: bool = True
+    routing: str = Field(description="Routing decision: local / claude / ask")
+    routing_reason: str
+    expected_output: str
+    budget: dict
+    estimated_dollars: float = Field(
+        description="Cost estimate for the routed session (model token cost "
+                    "given budget.max_tokens, plus session-hour overhead for "
+                    "managed sessions). Excludes the preflight call cost."
+    )
+    sane: bool
+    sane_reason: str
+    ambiguity: Optional[dict] = None
 
 
 class UpdateTaskRequest(BaseModel):
@@ -80,9 +109,20 @@ class TaskListResponse(BaseModel):
 # Routes (static paths MUST come before {id} to avoid capture)
 # ---------------------------------------------------------------------------
 
-@router.post("", response_model=TaskResponse)
+@router.post("")
 async def create_task(request: CreateTaskRequest):
-    """Create a new task. All new tasks land in Inbox; move them later via update."""
+    """Create a new task, or preview its agent routing without creating it.
+
+    When `dry_run=true` and the request carries the #agent tag, the route runs
+    the Haiku preflight classifier and returns the routing decision + cost
+    estimate without persisting a task or dispatching a session. Used by
+    prompt-engineering iteration to inspect routing decisions cheaply
+    (only the preflight call costs anything, ~$0.001).
+
+    For non-#agent tasks (or `dry_run=false`), the task is created normally.
+    """
+    if request.dry_run and _has_agent_tag(request.tags):
+        return _build_preflight_preview(request)
     manager = get_task_manager()
     task = manager.create(
         description=request.description,
@@ -92,6 +132,52 @@ async def create_task(request: CreateTaskRequest):
         reminder_id=request.reminder_id,
     )
     return TaskResponse.from_task(task)
+
+
+def _has_agent_tag(tags: Optional[list[str]]) -> bool:
+    if not tags:
+        return False
+    return any(t.lstrip("#").lower() == "agent" for t in tags)
+
+
+def _build_preflight_preview(request: CreateTaskRequest) -> PreflightPreviewResponse:
+    """Run preflight and synthesize a cost estimate without dispatching."""
+    # Imports kept local so the route module stays import-cheap for non-agent
+    # task operations; agent_worker pulls in the LLM client.
+    from api.services.agent_worker.preflight import (
+        ROUTE_CLAUDE,
+        run_preflight,
+    )
+    from api.services.agent_worker.pricing import cost_for, MANAGED_SESSION_HOUR_OVERHEAD
+    from config.settings import settings
+
+    pre = run_preflight(request.description, tags=request.tags or [])
+    # Worst-case estimate: assume budget.max_tokens is fully consumed, split
+    # 50/50 between input and output. Excludes cache_creation because dry_run
+    # can't know preset size; this is a floor, not a calibrated estimate.
+    model = (
+        settings.agent_managed_model_for_tests or settings.agent_managed_model
+        if pre.routing == ROUTE_CLAUDE
+        else "local"
+    )
+    half_tokens = max(0, pre.budget.max_tokens // 2)
+    estimated = cost_for(model, half_tokens, half_tokens)
+    if pre.routing == ROUTE_CLAUDE:
+        estimated += (pre.budget.wall_seconds / 3600.0) * MANAGED_SESSION_HOUR_OVERHEAD
+    return PreflightPreviewResponse(
+        routing=pre.routing,
+        routing_reason=pre.routing_reason,
+        expected_output=pre.expected_output,
+        budget={
+            "wall_seconds": pre.budget.wall_seconds,
+            "max_tokens": pre.budget.max_tokens,
+            "max_dollars": pre.budget.max_dollars,
+        },
+        estimated_dollars=round(estimated, 4),
+        sane=pre.sane,
+        sane_reason=pre.sane_reason,
+        ambiguity={"question": pre.ambiguity.question} if pre.ambiguity else None,
+    )
 
 
 @router.get("", response_model=TaskListResponse)

--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -66,6 +66,12 @@ class ManagedSessionState:
     new_events: list[dict] = field(default_factory=list)
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    # Anthropic charges two extra token buckets beyond plain input/output —
+    # cache_creation (1.25× input rate) and cache_read (0.10× input rate).
+    # On cache-heavy presets, cache_creation on the first turn can dominate
+    # session cost, so we mirror both buckets from the usage payload.
+    total_cache_creation_tokens: int = 0
+    total_cache_read_tokens: int = 0
     final_text: str | None = None
     error_reason: str | None = None
     # MCP servers that failed to initialize during this session — informational,
@@ -259,6 +265,8 @@ class ManagedAgentsDriver:
             new_events=events,
             total_input_tokens=int(usage.get("input_tokens", 0)),
             total_output_tokens=int(usage.get("output_tokens", 0)),
+            total_cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0)),
+            total_cache_read_tokens=int(usage.get("cache_read_input_tokens", 0)),
             final_text=final_text,
             error_reason=error_reason,
             init_failed_mcps=init_failed_mcps,
@@ -509,8 +517,21 @@ def managed_session_cost(
     tokens_in: int,
     tokens_out: int,
     wall_seconds: float,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
 ) -> float:
-    """Total $ for a managed session: token cost + session-hour overhead."""
-    tokens = cost_for(model, tokens_in, tokens_out)
+    """Total $ for a managed session: token cost + session-hour overhead.
+
+    Cache buckets default to zero so callers that only care about plain
+    token cost (e.g., the local executor's wall-time accounting) don't
+    need to update. Managed sessions should always pass all four buckets.
+    """
+    tokens = cost_for(
+        model,
+        tokens_in,
+        tokens_out,
+        cache_creation_tokens=cache_creation_tokens,
+        cache_read_tokens=cache_read_tokens,
+    )
     overhead = (wall_seconds / 3600.0) * MANAGED_SESSION_HOUR_OVERHEAD
     return tokens + overhead

--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -395,6 +395,31 @@ class ManagedAgentsDriver:
             )
         resp.raise_for_status()
 
+    def update_session(self, session_id: str, agent_payload: dict) -> None:
+        """Replace the session's agent config — used to filter tools per-class.
+
+        Per the Managed Agents docs, `POST /v1/sessions/{id}` accepts an
+        `agent.tools` and `agent.mcp_servers` array (full replacement). The
+        update is session-local — it does not propagate back to the preset
+        and does not persist across sessions. Sessions start `idle`; this
+        call doesn't trigger the agent.
+
+        `agent_payload` is the dict that goes under the `agent` key, e.g.
+        `{"tools": ["lifeos_search", "lifeos_ask", ...]}`. The caller is
+        responsible for shaping the payload (see `tool_filter.class_to_tool_filter`).
+
+        Best-effort: 4xx errors are logged and the response body is surfaced
+        in logs before raising, so a beta-API schema mismatch shows up
+        loudly rather than silently degrading the session.
+        """
+        body = {"agent": agent_payload}
+        resp = self._client.post(
+            f"{self.base_url}/sessions/{session_id}",
+            headers=self._headers(),
+            json=body,
+        )
+        self._raise_for_status_with_body(resp)
+
     def kill_session(self, session_id: str, reason: str = "") -> None:
         """Terminate a session early — used for budget breach / cascade-kill.
 

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -190,7 +190,16 @@ class ManagedExecutor:
     # ------------------------------------------------------------------
 
     def start(self, session, task: dict) -> ExecutorOutcome:
-        """Create the remote session and post the initial user message.
+        """Create the remote session, apply the per-class tool filter (if any),
+        and post the initial user message.
+
+        Flow (#139 §3):
+          1. POST /v1/sessions — container provisioned, no LLM cost yet.
+          2. POST /v1/sessions/{id} with the per-class tool filter (full
+             agent.tools replacement). Skipped for `preset_class=fullstack`
+             or unset (no filter, use preset as-is). LLM cost still zero.
+          3. POST /v1/sessions/{id}/events with user.message — cache_creation
+             fires now, scoped to the filtered tool set.
 
         On success: STATUS_RUNNING with `managed_agent_session_id` populated.
         On failure (network, API rejection, etc.): STATUS_FAILED.
@@ -206,14 +215,18 @@ class ManagedExecutor:
         self.transcript_store.append(sid, "managed_start",
                                      {"agent_id": self.agent_id, "environment_id": self.environment_id})
 
+        initial_message = _user_message_for(
+            task, sid, session.expected_output or "text", budget,
+        )
+        preset_class = getattr(session, "preset_class", None)
+
         try:
+            # Step 1: create the session WITHOUT initial_message. Provisions
+            # the container; no agent loop runs and no LLM cost is incurred.
             remote_id = self.driver.create_session(
                 agent_id=self.agent_id,
                 environment_id=self.environment_id,
                 vault_ids=self.vault_ids,
-                initial_message=_user_message_for(
-                    task, sid, session.expected_output or "text", budget,
-                ),
                 metadata={"lifeos_session_id": sid, "task_id": session.task_id},
                 title=_sanitize_title(task.get("description") or ""),
             )
@@ -227,9 +240,46 @@ class ManagedExecutor:
 
         self.session_store.set_managed_session_id(session.task_id, remote_id)
         self.transcript_store.append(sid, "managed_created", {"remote_id": remote_id})
-        # Mark as STATUS_RUNNING but with a remote handle attached. The
-        # worker's tick loop will pick it up via _poll_managed_sessions on
-        # subsequent ticks.
+
+        # Step 2: apply per-class tool filter if one was selected. Skipped for
+        # fullstack / unset / unknown classes. Best-effort — a filter failure
+        # falls back to the full preset rather than aborting the session.
+        from api.services.agent_worker.tool_filter import class_to_tool_filter
+        agent_payload = class_to_tool_filter(preset_class) if preset_class else None
+        if agent_payload is not None:
+            try:
+                self.driver.update_session(remote_id, agent_payload)
+                self.transcript_store.append(
+                    sid, "managed_filter_applied",
+                    {"preset_class": preset_class, "tool_count": len(agent_payload.get("tools", []))},
+                )
+            except Exception as exc:
+                logger.warning(
+                    "managed update_session failed for %s (class=%s): %s — falling back to full preset",
+                    sid, preset_class, type(exc).__name__,
+                )
+                self.transcript_store.append(
+                    sid, "managed_filter_failed",
+                    {"preset_class": preset_class, "error_type": type(exc).__name__},
+                )
+
+        # Step 3: post the initial user message. cache_creation fires here on
+        # the (possibly filtered) tool set.
+        try:
+            self.driver.post_user_message(remote_id, initial_message)
+        except Exception as exc:
+            logger.error("managed post_user_message failed for %s: %s", sid, type(exc).__name__)
+            self.session_store.update_status(session.task_id, STATUS_FAILED)
+            self.transcript_store.append(
+                sid, "managed_post_failed", {"error_type": type(exc).__name__},
+            )
+            return ExecutorOutcome(
+                status=STATUS_FAILED,
+                reason=f"post_user_message failed: {type(exc).__name__}",
+            )
+
+        # The worker's tick loop will pick this up via _poll_managed_sessions
+        # on subsequent ticks.
         return ExecutorOutcome(status=STATUS_RUNNING)
 
     def poll(self, session) -> ExecutorOutcome:

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -14,6 +14,7 @@ context needed is `last_event_id` for the resume cursor.
 """
 from __future__ import annotations
 
+import json
 import logging
 import time
 
@@ -37,6 +38,55 @@ from api.services.agent_worker.transcript_store import TranscriptStore
 
 
 logger = logging.getLogger(__name__)
+
+
+# Runaway detection thresholds (#139 Section 5). Picked behaviorally, not
+# from cost/wall time, because thresholds based on tokens or seconds vary
+# with task class; tool-call counts scale uniformly across task types.
+TOOL_LOOP_KILL_THRESHOLD = 4
+NO_PROGRESS_KILL_THRESHOLD = 15
+MAX_TOOL_RESULT_CHARS = 20_000  # Matches local_executor's truncation behavior.
+TRUNCATION_MARKER = " […truncated]"
+
+
+def _tool_signature(event: dict) -> str | None:
+    """Stable key for tool-loop detection: `(name, sorted-args-JSON)`.
+
+    Returns None for non-`tool_use` events. Args are JSON-canonicalized with
+    sorted keys so an agent that re-orders kwargs between calls still gets
+    detected. Falls back to the raw `input` if it isn't a dict (rare, but
+    don't crash the worker on a schema surprise).
+    """
+    if event.get("type") != "tool_use":
+        return None
+    name = event.get("name") or event.get("tool_name") or ""
+    raw_input = event.get("input") or event.get("arguments") or {}
+    try:
+        args_key = json.dumps(raw_input, sort_keys=True, default=str)
+    except Exception:
+        args_key = repr(raw_input)
+    return f"{name}::{args_key}"
+
+
+def _truncate_oversized_tool_result(event: dict) -> dict:
+    """Return a copy of `event` with its tool_result payload truncated if
+    it exceeds MAX_TOOL_RESULT_CHARS.
+
+    The full payload is still on Anthropic's side — this only shrinks what
+    we mirror into our transcript file. The transcript is what we re-feed
+    to parents on resume-after-children, so truncating here directly cuts
+    that re-feed cost. The marker preserves the truncated-ness signal.
+    """
+    if event.get("type") != "tool_result":
+        return event
+    content = event.get("content")
+    if not isinstance(content, str) or len(content) <= MAX_TOOL_RESULT_CHARS:
+        return event
+    truncated = content[: MAX_TOOL_RESULT_CHARS - len(TRUNCATION_MARKER)] + TRUNCATION_MARKER
+    new_event = dict(event)
+    new_event["content"] = truncated
+    new_event["_truncated_from_chars"] = len(content)
+    return new_event
 
 
 def _user_message_for(task: dict, session_id: str, expected_output: str, budget: dict) -> str:
@@ -204,9 +254,26 @@ class ManagedExecutor:
             logger.warning("managed poll failed for %s: %s", remote_id, exc)
             return ExecutorOutcome(status=STATUS_RUNNING, reason=f"poll error: {exc}")
 
-        # Mirror events to transcript.
+        # Mirror events to transcript, truncating oversized tool_results so
+        # the transcript doesn't bloat for huge payloads that we'd re-feed
+        # to parents during spawn-after-children resume.
         for event in state.new_events:
-            self.transcript_store.append(sid, f"managed_event_{event.get('type', 'unknown')}", event)
+            stored = _truncate_oversized_tool_result(event)
+            self.transcript_store.append(sid, f"managed_event_{stored.get('type', 'unknown')}", stored)
+
+        # Update runaway counters from the new events (#139 Section 5).
+        runaway_kind = self._detect_runaway(session.task_id, state.new_events)
+        if runaway_kind:
+            try:
+                self.driver.kill_session(remote_id, reason=runaway_kind)
+            except Exception as exc:  # pragma: no cover — best-effort kill
+                logger.warning("kill_session %s failed: %s", remote_id, exc)
+            self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
+            self.transcript_store.append(sid, "runaway_killed", {"kind": runaway_kind})
+            return ExecutorOutcome(
+                status=STATUS_BUDGET_EXCEEDED,
+                reason=f"runaway killed ({runaway_kind})",
+            )
 
         # 1. Token spend delta — compare absolute remote totals to our row,
         # across all four buckets (uncached input, output, cache_creation,
@@ -286,6 +353,62 @@ class ManagedExecutor:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _detect_runaway(self, task_id: str, new_events: list[dict]) -> str | None:
+        """Walk `new_events`, update persisted runaway counters, and return
+        a kill reason if any threshold tripped — else None.
+
+        Two behavioral signals:
+        - `tool_loop_detected`: same tool + identical args fires
+          TOOL_LOOP_KILL_THRESHOLD consecutive times with no intervening
+          *different* tool call. A different tool resets the count, so the
+          agent can legitimately retry after a transient failure (e.g. a
+          tool returning an error then immediately retrying same args ONCE
+          is fine; 4× in a row with no diversity is not).
+        - `no_text_in_15_tool_calls`: NO_PROGRESS_KILL_THRESHOLD `tool_use`
+          events fire without any intervening `agent.message`. Indicates
+          the agent is tool-thrashing without surfacing its reasoning.
+
+        Persisted state survives worker restarts so cross-poll counting is
+        consistent. State is reset by `agent.message` (no-progress) or a
+        change in tool signature (tool-loop).
+        """
+        state = self.session_store.get_runaway_state(task_id)
+        signature = state["tool_loop_signature"]
+        loop_count = state["tool_loop_count"]
+        since_msg = state["tool_calls_since_message"]
+
+        kill: str | None = None
+        for event in new_events:
+            etype = event.get("type", "")
+            if etype == "agent.message":
+                since_msg = 0
+                continue
+            if etype != "tool_use":
+                continue
+            since_msg += 1
+            if since_msg >= NO_PROGRESS_KILL_THRESHOLD:
+                kill = "no_text_in_15_tool_calls"
+                break
+            sig = _tool_signature(event)
+            if sig is None:
+                continue
+            if sig == signature:
+                loop_count += 1
+            else:
+                signature = sig
+                loop_count = 1
+            if loop_count >= TOOL_LOOP_KILL_THRESHOLD:
+                kill = "tool_loop_detected"
+                break
+
+        self.session_store.set_runaway_state(
+            task_id,
+            tool_loop_signature=signature,
+            tool_loop_count=loop_count,
+            tool_calls_since_message=since_msg,
+        )
+        return kill
 
     @staticmethod
     def _budget_breach(refreshed_session, budget: dict) -> str | None:

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -208,13 +208,35 @@ class ManagedExecutor:
         for event in state.new_events:
             self.transcript_store.append(sid, f"managed_event_{event.get('type', 'unknown')}", event)
 
-        # 1. Token spend delta — compare absolute remote totals to our row.
+        # 1. Token spend delta — compare absolute remote totals to our row,
+        # across all four buckets (uncached input, output, cache_creation,
+        # cache_read). Anthropic bills cache_creation at 1.25× input and
+        # cache_read at 0.10× input; pricing.cost_for applies the multipliers.
         delta_in = max(0, state.total_input_tokens - (session.total_input_tokens or 0))
         delta_out = max(0, state.total_output_tokens - (session.total_output_tokens or 0))
-        token_delta_dollars = cost_for(self.model, delta_in, delta_out)
-        if delta_in or delta_out:
+        delta_cache_creation = max(
+            0,
+            state.total_cache_creation_tokens - (session.total_cache_creation_tokens or 0),
+        )
+        delta_cache_read = max(
+            0,
+            state.total_cache_read_tokens - (session.total_cache_read_tokens or 0),
+        )
+        token_delta_dollars = cost_for(
+            self.model,
+            delta_in,
+            delta_out,
+            cache_creation_tokens=delta_cache_creation,
+            cache_read_tokens=delta_cache_read,
+        )
+        if delta_in or delta_out or delta_cache_creation or delta_cache_read:
             self.session_store.record_spend(
-                session.task_id, delta_in, delta_out, token_delta_dollars,
+                session.task_id,
+                delta_in,
+                delta_out,
+                token_delta_dollars,
+                cache_creation_tokens=delta_cache_creation,
+                cache_read_tokens=delta_cache_read,
             )
 
         # 2. Session-hour overhead delta — we only want to add what's accrued
@@ -267,16 +289,23 @@ class ManagedExecutor:
 
     @staticmethod
     def _budget_breach(refreshed_session, budget: dict) -> str | None:
-        """Return the budget kind that was exceeded, or None."""
+        """Return the budget kind that was exceeded, or None.
+
+        Dollars-first: with cache_creation and cache_read now in the dollar
+        total, `total_dollars` is the authoritative spend signal. `max_tokens`
+        remains a soft secondary gate — it only counts uncached input +
+        output, which understates cache-heavy cost, but is preserved so
+        existing token-only callers keep working.
+        """
         if not budget:
             return None
+        if budget.get("max_dollars") is not None:
+            if (refreshed_session.total_dollars or 0) >= budget["max_dollars"]:
+                return "max_dollars"
         if budget.get("max_tokens"):
             used = (refreshed_session.total_input_tokens or 0) + (refreshed_session.total_output_tokens or 0)
             if used >= budget["max_tokens"]:
                 return "max_tokens"
-        if budget.get("max_dollars") is not None:
-            if (refreshed_session.total_dollars or 0) >= budget["max_dollars"]:
-                return "max_dollars"
         return None
 
     # ------------------------------------------------------------------

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -72,6 +72,13 @@ class PreflightResult:
     # actual remote-model selection still requires the agent preset to
     # match (section 3 territory).
     model: str | None = None
+    # Preset class for per-session tool filtering (#139 §3). When set, the
+    # managed executor will call driver.update_session() with the class's
+    # filtered tool list (via tool_filter.class_to_tool_filter) between
+    # session create and the first user message — scoping cache_creation
+    # to the smaller tool set. Currently picked from tag overrides only;
+    # LLM-side preflight emission is a follow-up.
+    preset_class: str | None = None
     raw: dict = field(default_factory=dict)  # the parsed JSON for debugging
 
 
@@ -248,6 +255,33 @@ def _normalize_tag(tag: str) -> str:
     return tag.lstrip("#").lower()
 
 
+# Preset-class tag → class name. Mirrors tool_filter.ALL_PRESET_CLASSES so
+# operators can force a class with `#research`, `#crm`, etc. Kept here as
+# a local map instead of an import so preflight stays decoupled from the
+# tool_filter implementation; the names are the contract.
+_PRESET_CLASS_TAGS = {
+    "personal-comm": "personal-comm",
+    "work-comm": "work-comm",
+    "research": "research",
+    "financial": "financial",
+    "crm": "crm",
+    "fullstack": "fullstack",
+}
+
+
+def _detect_preset_class_from_tags(tags: list[str]) -> str | None:
+    """Return the preset_class implied by a `#<class>` tag, or None.
+
+    First match wins in the tag list order to give operators a predictable
+    override when multiple class tags slip in by mistake.
+    """
+    for raw in tags or []:
+        normalized = _normalize_tag(raw)
+        if normalized in _PRESET_CLASS_TAGS:
+            return _PRESET_CLASS_TAGS[normalized]
+    return None
+
+
 def _apply_tag_overrides(result: PreflightResult, tags: list[str]) -> PreflightResult:
     """Apply tag-based routing/model overrides (#139 §2 precedence).
 
@@ -294,6 +328,20 @@ def _apply_tag_overrides(result: PreflightResult, tags: list[str]) -> PreflightR
     return result
 
 
+def _apply_preset_class(result: PreflightResult, tags: list[str]) -> PreflightResult:
+    """Set `result.preset_class` from an explicit `#<class>` tag if present.
+
+    LLM-side preset_class emission is a follow-up; this lets operators
+    force a class today via tag while the rest of #139 §3 wiring lands.
+    """
+    if result.preset_class:  # honor an LLM/caller pre-set value
+        return result
+    forced = _detect_preset_class_from_tags(tags)
+    if forced:
+        result.preset_class = forced
+    return result
+
+
 def run_preflight(
     title: str,
     tags: list[str] | None = None,
@@ -306,16 +354,19 @@ def run_preflight(
     # Short-circuit: empty title is always unsafe, no need to spend a Haiku call.
     if not title.strip():
         defaults = _defaults()
-        return _apply_tag_overrides(
-            PreflightResult(
-                budget=defaults,
-                routing=ROUTE_ASK,
-                routing_reason="empty title",
-                expected_output="text",
-                ambiguity=None,
-                sane=False,
-                sane_reason="task title is empty",
-                raw={},
+        return _apply_preset_class(
+            _apply_tag_overrides(
+                PreflightResult(
+                    budget=defaults,
+                    routing=ROUTE_ASK,
+                    routing_reason="empty title",
+                    expected_output="text",
+                    ambiguity=None,
+                    sane=False,
+                    sane_reason="task title is empty",
+                    raw={},
+                ),
+                tags_list,
             ),
             tags_list,
         )
@@ -327,18 +378,24 @@ def run_preflight(
     except Exception as exc:
         logger.warning("preflight LLM call failed: %s", exc)
         defaults = _defaults()
-        return _apply_tag_overrides(
-            PreflightResult(
-                budget=defaults,
-                routing=ROUTE_ASK,
-                routing_reason="preflight LLM call failed",
-                expected_output="text",
-                ambiguity=None,
-                sane=False,
-                sane_reason=f"preflight error: {exc}",
-                raw={},
+        return _apply_preset_class(
+            _apply_tag_overrides(
+                PreflightResult(
+                    budget=defaults,
+                    routing=ROUTE_ASK,
+                    routing_reason="preflight LLM call failed",
+                    expected_output="text",
+                    ambiguity=None,
+                    sane=False,
+                    sane_reason=f"preflight error: {exc}",
+                    raw={},
+                ),
+                tags_list,
             ),
             tags_list,
         )
 
-    return _apply_tag_overrides(parse_preflight_response(reply), tags_list)
+    return _apply_preset_class(
+        _apply_tag_overrides(parse_preflight_response(reply), tags_list),
+        tags_list,
+    )

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -79,6 +79,15 @@ class PreflightResult:
     # to the smaller tool set. Currently picked from tag overrides only;
     # LLM-side preflight emission is a follow-up.
     preset_class: str | None = None
+    # Cache-cold cost estimate for this dispatch (#139 §6). Computed from
+    # the per-class cache_creation token estimate + the model's input rate.
+    # Used to refuse dispatch when even the cache-cold cost would exceed
+    # 2× max_dollars (refuse only when the cheap path can't fit either).
+    estimated_cost_dollars: float = 0.0
+    # When True, the orchestrator should surface a confirmation prompt to
+    # the operator before dispatching (#139 §7). Driven by
+    # settings.agent_cost_confirm_threshold_dollars.
+    needs_cost_confirmation: bool = False
     raw: dict = field(default_factory=dict)  # the parsed JSON for debugging
 
 
@@ -342,6 +351,69 @@ def _apply_preset_class(result: PreflightResult, tags: list[str]) -> PreflightRe
     return result
 
 
+def _apply_cost_gates(result: PreflightResult) -> PreflightResult:
+    """Compute the cache-cold cost estimate and apply #139 §6 + §7 gates.
+
+    §6 (fail-fast): if the estimated cache-cold dispatch cost exceeds
+    2× the task's `max_dollars`, refuse via `sane=False` with reason
+    `budget_too_small`. The 2× margin (not 1×) keeps cache-warm tasks
+    from being over-refused — when prompt cache is warm the real cost
+    is 0.10× input instead of 1.25× cache_creation, so the cheap path
+    is 12.5× cheaper; refusing only when even the cold path can't fit
+    avoids killing tasks that would have happily run from cache.
+
+    §7 (cost preview): set `needs_cost_confirmation=True` when the
+    estimate exceeds `settings.agent_cost_confirm_threshold_dollars`.
+    Local-routed tasks always set the estimate to 0 and never trigger
+    confirmation.
+    """
+    if result.routing != ROUTE_CLAUDE:
+        result.estimated_cost_dollars = 0.0
+        result.needs_cost_confirmation = False
+        return result
+
+    # Local imports keep preflight cheap to import when cost gating isn't
+    # in play (and avoid a settings-import cycle in some test paths).
+    from api.services.agent_worker.pricing import (
+        CACHE_CREATION_RATE_MULTIPLIER,
+        MANAGED_SESSION_HOUR_OVERHEAD,
+        PRICING,
+    )
+    from api.services.agent_worker.tool_filter import estimated_cache_creation_tokens
+
+    model = result.model or MODEL_SONNET
+    rates = PRICING.get(model) or PRICING["claude-opus-4-7"]
+    cache_tokens = estimated_cache_creation_tokens(result.preset_class)
+    cache_cold_dollars = cache_tokens * rates["input"] * CACHE_CREATION_RATE_MULTIPLIER
+    # Add session-hour overhead as a small floor so estimates align with
+    # `managed_session_cost`'s shape (token cost + overhead).
+    overhead = (result.budget.wall_seconds / 3600.0) * MANAGED_SESSION_HOUR_OVERHEAD
+    result.estimated_cost_dollars = round(cache_cold_dollars + overhead, 4)
+
+    # §6 fail-fast — refuse only when 2× margin can't fit.
+    if (
+        result.budget.max_dollars > 0
+        and result.estimated_cost_dollars > 2.0 * result.budget.max_dollars
+    ):
+        result.sane = False
+        result.sane_reason = (
+            f"budget_too_small: cache-cold estimate ${result.estimated_cost_dollars:.2f} "
+            f"exceeds 2× max_dollars (${result.budget.max_dollars:.2f}). "
+            "Raise the budget or pick a smaller preset_class."
+        )
+
+    # §7 confirm-threshold check. Local import so settings reload in tests works.
+    try:
+        from config.settings import settings as _settings
+        threshold = float(_settings.agent_cost_confirm_threshold_dollars)
+    except Exception:
+        threshold = 1.0
+    if threshold > 0 and result.estimated_cost_dollars > threshold:
+        result.needs_cost_confirmation = True
+
+    return result
+
+
 def run_preflight(
     title: str,
     tags: list[str] | None = None,
@@ -354,7 +426,7 @@ def run_preflight(
     # Short-circuit: empty title is always unsafe, no need to spend a Haiku call.
     if not title.strip():
         defaults = _defaults()
-        return _apply_preset_class(
+        return _apply_cost_gates(_apply_preset_class(
             _apply_tag_overrides(
                 PreflightResult(
                     budget=defaults,
@@ -369,7 +441,7 @@ def run_preflight(
                 tags_list,
             ),
             tags_list,
-        )
+        ))
 
     call = caller or _default_llm_caller
     prompt = build_preflight_prompt(title, tags_list)
@@ -378,7 +450,7 @@ def run_preflight(
     except Exception as exc:
         logger.warning("preflight LLM call failed: %s", exc)
         defaults = _defaults()
-        return _apply_preset_class(
+        return _apply_cost_gates(_apply_preset_class(
             _apply_tag_overrides(
                 PreflightResult(
                     budget=defaults,
@@ -393,9 +465,9 @@ def run_preflight(
                 tags_list,
             ),
             tags_list,
-        )
+        ))
 
-    return _apply_preset_class(
+    return _apply_cost_gates(_apply_preset_class(
         _apply_tag_overrides(parse_preflight_response(reply), tags_list),
         tags_list,
-    )
+    ))

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -34,6 +34,15 @@ ROUTE_ASK = "ask"
 # Allowed expected-output shapes. Used to phrase the final Telegram summary.
 OUTPUT_KINDS = ("text", "file", "external_action", "structured")
 
+# Per-task model identifiers emitted by preflight. The cloud routing case
+# defaults to Sonnet for general work; Haiku is selected by tag override (or
+# in future by smart routing — see #139 §2 rubric). "local" maps to the
+# local Gemma backend. None means "no override, use settings.agent_managed_model".
+MODEL_LOCAL = "local"
+MODEL_HAIKU = "claude-haiku-4-5"
+MODEL_SONNET = "claude-sonnet-4-6"
+ALLOWED_MODELS = (MODEL_LOCAL, MODEL_HAIKU, MODEL_SONNET)
+
 
 @dataclass
 class PreflightBudget:
@@ -56,6 +65,13 @@ class PreflightResult:
     ambiguity: PreflightAmbiguity | None = None
     sane: bool = True
     sane_reason: str = ""
+    # Per-task model selection (#139 §2). For cloud routes, defaults to
+    # MODEL_SONNET; can be overridden to MODEL_HAIKU by the `#cloud-haiku`
+    # tag (or to MODEL_SONNET by `#cloud-sonnet`). For local routes, set
+    # to MODEL_LOCAL. The worker uses this for client-side cost accounting;
+    # actual remote-model selection still requires the agent preset to
+    # match (section 3 territory).
+    model: str | None = None
     raw: dict = field(default_factory=dict)  # the parsed JSON for debugging
 
 
@@ -227,6 +243,57 @@ def _default_llm_caller(prompt: str) -> str:
     return response.text
 
 
+def _normalize_tag(tag: str) -> str:
+    """Strip leading `#` and lowercase, so callers can pass either form."""
+    return tag.lstrip("#").lower()
+
+
+def _apply_tag_overrides(result: PreflightResult, tags: list[str]) -> PreflightResult:
+    """Apply tag-based routing/model overrides (#139 §2 precedence).
+
+    Tag precedence (a tag always wins over preflight's LLM choice):
+      `#local`        → routing=local, model=local
+      `#cloud-haiku`  → routing=claude, model=claude-haiku-4-5
+      `#cloud-sonnet` → routing=claude, model=claude-sonnet-4-6
+      `#cloud`        → routing=claude, model=(whatever preflight picked, else Sonnet)
+
+    Returns a new PreflightResult so the caller can chain. Tag list is
+    normalized case-insensitively with optional leading `#`.
+    """
+    normalized = {_normalize_tag(t) for t in (tags or [])}
+    if "local" in normalized:
+        result.routing = ROUTE_LOCAL
+        result.routing_reason = "#local tag present"
+        result.model = MODEL_LOCAL
+        return result
+    if "cloud-haiku" in normalized:
+        result.routing = ROUTE_CLAUDE
+        result.routing_reason = "#cloud-haiku tag present"
+        result.model = MODEL_HAIKU
+        return result
+    if "cloud-sonnet" in normalized:
+        result.routing = ROUTE_CLAUDE
+        result.routing_reason = "#cloud-sonnet tag present"
+        result.model = MODEL_SONNET
+        return result
+    if "cloud" in normalized:
+        result.routing = ROUTE_CLAUDE
+        if not result.routing_reason:
+            result.routing_reason = "#cloud tag present"
+        if result.model not in ALLOWED_MODELS:
+            result.model = MODEL_SONNET
+        return result
+    # No override — pick a sensible default model for the routing.
+    if result.model not in ALLOWED_MODELS:
+        if result.routing == ROUTE_CLAUDE:
+            result.model = MODEL_SONNET
+        elif result.routing == ROUTE_LOCAL:
+            result.model = MODEL_LOCAL
+        # ROUTE_ASK leaves model=None — the worker will set it after the
+        # operator answers.
+    return result
+
+
 def run_preflight(
     title: str,
     tags: list[str] | None = None,
@@ -239,15 +306,18 @@ def run_preflight(
     # Short-circuit: empty title is always unsafe, no need to spend a Haiku call.
     if not title.strip():
         defaults = _defaults()
-        return PreflightResult(
-            budget=defaults,
-            routing=ROUTE_ASK,
-            routing_reason="empty title",
-            expected_output="text",
-            ambiguity=None,
-            sane=False,
-            sane_reason="task title is empty",
-            raw={},
+        return _apply_tag_overrides(
+            PreflightResult(
+                budget=defaults,
+                routing=ROUTE_ASK,
+                routing_reason="empty title",
+                expected_output="text",
+                ambiguity=None,
+                sane=False,
+                sane_reason="task title is empty",
+                raw={},
+            ),
+            tags_list,
         )
 
     call = caller or _default_llm_caller
@@ -257,15 +327,18 @@ def run_preflight(
     except Exception as exc:
         logger.warning("preflight LLM call failed: %s", exc)
         defaults = _defaults()
-        return PreflightResult(
-            budget=defaults,
-            routing=ROUTE_ASK,
-            routing_reason="preflight LLM call failed",
-            expected_output="text",
-            ambiguity=None,
-            sane=False,
-            sane_reason=f"preflight error: {exc}",
-            raw={},
+        return _apply_tag_overrides(
+            PreflightResult(
+                budget=defaults,
+                routing=ROUTE_ASK,
+                routing_reason="preflight LLM call failed",
+                expected_output="text",
+                ambiguity=None,
+                sane=False,
+                sane_reason=f"preflight error: {exc}",
+                raw={},
+            ),
+            tags_list,
         )
 
-    return parse_preflight_response(reply)
+    return _apply_tag_overrides(parse_preflight_response(reply), tags_list)

--- a/api/services/agent_worker/pricing.py
+++ b/api/services/agent_worker/pricing.py
@@ -31,14 +31,43 @@ PRICING: dict[str, dict[str, float]] = {
 }
 
 
-def cost_for(model: str, tokens_in: int, tokens_out: int) -> float:
+# Anthropic prompt-cache rate multipliers, relative to the model's base input
+# rate (see https://www.anthropic.com/pricing). cache_creation writes are
+# 1.25× input — slightly more expensive than a normal input token because of
+# the indexing work. cache_read hits are 0.10× input — a 10× discount on
+# tokens that come from the cache instead of being processed fresh.
+CACHE_CREATION_RATE_MULTIPLIER: float = 1.25
+CACHE_READ_RATE_MULTIPLIER: float = 0.10
+
+
+def cost_for(
+    model: str,
+    tokens_in: int,
+    tokens_out: int,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
+) -> float:
     """Return the dollar cost of a single LLM call.
 
-    Unknown models fall through to a conservative Opus-rate estimate so a
-    typo can't accidentally suppress budget enforcement. Logging is the
-    caller's responsibility.
+    Anthropic charges four token buckets:
+    - `tokens_in` — uncached input tokens, at the model's input rate.
+    - `tokens_out` — output tokens, at the model's output rate.
+    - `cache_creation_tokens` — tokens written into the prompt cache on a
+      cache-cold turn, at 1.25× the input rate.
+    - `cache_read_tokens` — tokens served from the prompt cache on a cache-
+      warm turn, at 0.10× the input rate.
+
+    Cache buckets default to zero so existing two-arg call sites keep
+    working. Unknown models fall through to a conservative Opus-rate
+    estimate so a typo can't accidentally suppress budget enforcement.
     """
     rates = PRICING.get(model)
     if rates is None:
         rates = PRICING["claude-opus-4-7"]
-    return tokens_in * rates["input"] + tokens_out * rates["output"]
+    input_rate = rates["input"]
+    return (
+        tokens_in * input_rate
+        + tokens_out * rates["output"]
+        + cache_creation_tokens * input_rate * CACHE_CREATION_RATE_MULTIPLIER
+        + cache_read_tokens * input_rate * CACHE_READ_RATE_MULTIPLIER
+    )

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -53,6 +53,11 @@ class Session:
     expected_output: str | None = None
     parent_session_id: str | None = None
     managed_agent_session_id: str | None = None
+    # Preset class for per-session tool filtering (#139 §3). When set,
+    # ManagedExecutor.start() calls driver.update_session() with the
+    # class's filtered tool list between create and the first user
+    # message — scoping cache_creation to the smaller tool set.
+    preset_class: str | None = None
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     # Prompt-cache buckets — kept separate from total_input_tokens because
@@ -88,7 +93,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     root_session_id           TEXT,
     spawn_depth               INTEGER NOT NULL DEFAULT 0,
     yield_waiting_for         TEXT,  -- JSON array of session_ids the agent is waiting on
-    managed_agent_session_id  TEXT
+    managed_agent_session_id  TEXT,
+    preset_class              TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -256,6 +262,12 @@ class SessionStore:
                     "ALTER TABLE sessions ADD COLUMN total_cache_read_tokens "
                     "INTEGER NOT NULL DEFAULT 0"
                 )
+            # Idempotent migration for the per-session preset_class column
+            # (#139 §3 worker wiring). Old rows stay NULL → fullstack.
+            if "preset_class" not in sess_cols:
+                conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN preset_class TEXT"
+                )
             # Idempotent migrations for the runaway detection counters on
             # managed_cursor (#139 Section 5).
             mc_cols = {row["name"] for row in conn.execute("PRAGMA table_info(managed_cursor)")}
@@ -391,19 +403,22 @@ class SessionStore:
         routing: str | None,
         budget: dict | None,
         expected_output: str | None = None,
+        preset_class: str | None = None,
     ) -> None:
-        """Update routing decision and budget after the preflight call."""
+        """Update routing, budget, expected_output, and preset_class after preflight."""
         with self._connect() as conn:
             conn.execute(
                 """
                 UPDATE sessions
-                SET routing = ?, budget_json = ?, expected_output = ?, last_activity_at = ?
+                SET routing = ?, budget_json = ?, expected_output = ?,
+                    preset_class = ?, last_activity_at = ?
                 WHERE task_id = ?
                 """,
                 (
                     routing,
                     json.dumps(budget) if budget else None,
                     expected_output,
+                    preset_class,
                     _now(),
                     task_id,
                 ),
@@ -977,6 +992,11 @@ class SessionStore:
             expected_output=row["expected_output"],
             parent_session_id=row["parent_session_id"],
             managed_agent_session_id=row["managed_agent_session_id"],
+            preset_class=(
+                row["preset_class"]
+                if "preset_class" in row.keys()
+                else None
+            ),
             root_session_id=(
                 row["root_session_id"] if "root_session_id" in row.keys() else None
             ),

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -182,7 +182,17 @@ CREATE TABLE IF NOT EXISTS managed_cursor (
     task_id                          TEXT PRIMARY KEY,
     last_event_id                    TEXT,
     accrued_session_hour_dollars     REAL NOT NULL DEFAULT 0.0,
-    final_text                       TEXT
+    final_text                       TEXT,
+    -- Runaway detection counters (#139 Section 5). Persisted so cross-poll
+    -- signals survive worker restarts mid-session.
+    -- `tool_loop_signature` is the (tool_name, sorted_args_json) of the most
+    -- recent tool call; `tool_loop_count` is how many consecutive times that
+    -- exact signature has fired with no intervening *different* tool. A
+    -- different tool resets the count. `tool_calls_since_message` increments
+    -- on each tool_use and resets to 0 on each agent.message.
+    tool_loop_signature              TEXT,
+    tool_loop_count                  INTEGER NOT NULL DEFAULT 0,
+    tool_calls_since_message         INTEGER NOT NULL DEFAULT 0
 );
 """
 
@@ -244,6 +254,21 @@ class SessionStore:
             if "total_cache_read_tokens" not in sess_cols:
                 conn.execute(
                     "ALTER TABLE sessions ADD COLUMN total_cache_read_tokens "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
+            # Idempotent migrations for the runaway detection counters on
+            # managed_cursor (#139 Section 5).
+            mc_cols = {row["name"] for row in conn.execute("PRAGMA table_info(managed_cursor)")}
+            if "tool_loop_signature" not in mc_cols:
+                conn.execute("ALTER TABLE managed_cursor ADD COLUMN tool_loop_signature TEXT")
+            if "tool_loop_count" not in mc_cols:
+                conn.execute(
+                    "ALTER TABLE managed_cursor ADD COLUMN tool_loop_count "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
+            if "tool_calls_since_message" not in mc_cols:
+                conn.execute(
+                    "ALTER TABLE managed_cursor ADD COLUMN tool_calls_since_message "
                     "INTEGER NOT NULL DEFAULT 0"
                 )
 
@@ -519,6 +544,61 @@ class SessionStore:
         if not row:
             return None
         return row["final_text"]
+
+    # ------------------------------------------------------------------
+    # Runaway detection state (#139 Section 5)
+    # ------------------------------------------------------------------
+
+    def get_runaway_state(self, task_id: str) -> dict:
+        """Return the persisted runaway counters for `task_id`.
+
+        Defaults to a clean state (signature=None, both counts 0) when no
+        managed_cursor row exists yet. Callers that have never seen events
+        for this session can treat the result as a virgin starting point.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT tool_loop_signature, tool_loop_count, tool_calls_since_message "
+                "FROM managed_cursor WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+        if not row:
+            return {
+                "tool_loop_signature": None,
+                "tool_loop_count": 0,
+                "tool_calls_since_message": 0,
+            }
+        return {
+            "tool_loop_signature": row["tool_loop_signature"],
+            "tool_loop_count": int(row["tool_loop_count"] or 0),
+            "tool_calls_since_message": int(row["tool_calls_since_message"] or 0),
+        }
+
+    def set_runaway_state(
+        self,
+        task_id: str,
+        *,
+        tool_loop_signature: str | None,
+        tool_loop_count: int,
+        tool_calls_since_message: int,
+    ) -> None:
+        """Persist runaway counters. Upsert into managed_cursor so a fresh
+        session (no prior cursor row) gets a row with the counters set."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO managed_cursor (
+                    task_id, tool_loop_signature, tool_loop_count,
+                    tool_calls_since_message
+                )
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    tool_loop_signature      = excluded.tool_loop_signature,
+                    tool_loop_count          = excluded.tool_loop_count,
+                    tool_calls_since_message = excluded.tool_calls_since_message
+                """,
+                (task_id, tool_loop_signature, tool_loop_count, tool_calls_since_message),
+            )
 
     def record_active_seconds(self, task_id: str, seconds: float) -> None:
         """Add to a session's cumulative active-execution seconds.

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -55,6 +55,12 @@ class Session:
     managed_agent_session_id: str | None = None
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    # Prompt-cache buckets — kept separate from total_input_tokens because
+    # they're billed at different rates (cache_creation = 1.25× input,
+    # cache_read = 0.10× input). On cache-heavy presets cache_creation on the
+    # first turn often dwarfs uncached input.
+    total_cache_creation_tokens: int = 0
+    total_cache_read_tokens: int = 0
     total_dollars: float = 0.0
     total_active_seconds: float = 0.0
     root_session_id: str | None = None
@@ -73,6 +79,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     last_activity_at          INTEGER NOT NULL,
     total_input_tokens        INTEGER NOT NULL DEFAULT 0,
     total_output_tokens       INTEGER NOT NULL DEFAULT 0,
+    total_cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    total_cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
     total_dollars             REAL    NOT NULL DEFAULT 0.0,
     total_active_seconds      REAL    NOT NULL DEFAULT 0.0,
     expected_output           TEXT,
@@ -223,6 +231,21 @@ class SessionStore:
                     "ALTER TABLE pending_questions ADD COLUMN kind TEXT "
                     "NOT NULL DEFAULT 'clarification'"
                 )
+            # Idempotent migration for the prompt-cache token buckets on
+            # `sessions`. Old rows stay at zero — we don't backfill historical
+            # sessions, the raw event payloads in transcripts still have the
+            # data if anyone ever wants to recompute.
+            sess_cols = {row["name"] for row in conn.execute("PRAGMA table_info(sessions)")}
+            if "total_cache_creation_tokens" not in sess_cols:
+                conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN total_cache_creation_tokens "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
+            if "total_cache_read_tokens" not in sess_cols:
+                conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN total_cache_read_tokens "
+                    "INTEGER NOT NULL DEFAULT 0"
+                )
 
     # ------------------------------------------------------------------
     # Session CRUD
@@ -367,19 +390,36 @@ class SessionStore:
         tokens_in: int,
         tokens_out: int,
         dollars: float,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
     ) -> None:
-        """Add to a session's cumulative token + dollar counters."""
+        """Add to a session's cumulative token + dollar counters.
+
+        Cache buckets default to zero so the local executor (which only
+        sees plain input/output) doesn't need to update; managed sessions
+        always pass all four buckets.
+        """
         with self._connect() as conn:
             conn.execute(
                 """
                 UPDATE sessions
-                SET total_input_tokens  = total_input_tokens  + ?,
-                    total_output_tokens = total_output_tokens + ?,
-                    total_dollars       = total_dollars       + ?,
-                    last_activity_at    = ?
+                SET total_input_tokens          = total_input_tokens          + ?,
+                    total_output_tokens         = total_output_tokens         + ?,
+                    total_cache_creation_tokens = total_cache_creation_tokens + ?,
+                    total_cache_read_tokens     = total_cache_read_tokens     + ?,
+                    total_dollars               = total_dollars               + ?,
+                    last_activity_at            = ?
                 WHERE task_id = ?
                 """,
-                (tokens_in, tokens_out, dollars, _now(), task_id),
+                (
+                    tokens_in,
+                    tokens_out,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    dollars,
+                    _now(),
+                    task_id,
+                ),
             )
 
     def set_managed_session_id(self, task_id: str, managed_id: str) -> None:
@@ -838,6 +878,16 @@ class SessionStore:
             last_activity_at=row["last_activity_at"],
             total_input_tokens=row["total_input_tokens"],
             total_output_tokens=row["total_output_tokens"],
+            total_cache_creation_tokens=(
+                row["total_cache_creation_tokens"]
+                if "total_cache_creation_tokens" in row.keys()
+                else 0
+            ),
+            total_cache_read_tokens=(
+                row["total_cache_read_tokens"]
+                if "total_cache_read_tokens" in row.keys()
+                else 0
+            ),
             total_dollars=row["total_dollars"],
             total_active_seconds=(
                 row["total_active_seconds"]

--- a/api/services/agent_worker/tool_filter.py
+++ b/api/services/agent_worker/tool_filter.py
@@ -1,0 +1,151 @@
+"""Per-class tool filter helper (#139 §3, partial).
+
+The full per-class session tool filtering flow is:
+  1. Preflight picks `preset_class` (personal-comm / work-comm / research /
+     financial / crm / fullstack)
+  2. Worker creates the session as usual
+  3. Worker calls `driver.update_session()` with the filtered tool list
+  4. Filtered tools scope the cache_creation cost on the first user turn
+
+This module owns step 3's input: given a class name, return the right
+`{tools: [...], mcp_servers: [...]}` payload for the UPDATE call. The
+worker-side wiring (steps 2 + 3) is a follow-up; this helper lands now
+so the rest can compose against a tested, documented surface.
+
+Cross-cutting tools are auto-merged into every class's filter — every
+agent needs at minimum: telegram_send, agent_* coordination, search,
+ask, health, task_*, reminder_*, and calendar reads.
+"""
+from __future__ import annotations
+
+
+# Preset classes. Preflight picks one; "fullstack" means "use the entire
+# preset, no filtering" — the operator's default fallback.
+PRESET_CLASS_PERSONAL_COMM = "personal-comm"
+PRESET_CLASS_WORK_COMM = "work-comm"
+PRESET_CLASS_RESEARCH = "research"
+PRESET_CLASS_FINANCIAL = "financial"
+PRESET_CLASS_CRM = "crm"
+PRESET_CLASS_FULLSTACK = "fullstack"
+
+ALL_PRESET_CLASSES = (
+    PRESET_CLASS_PERSONAL_COMM,
+    PRESET_CLASS_WORK_COMM,
+    PRESET_CLASS_RESEARCH,
+    PRESET_CLASS_FINANCIAL,
+    PRESET_CLASS_CRM,
+    PRESET_CLASS_FULLSTACK,
+)
+
+
+# Cross-cutting tools every agent needs regardless of routing class.
+# Without these, a research agent can't message back to the operator,
+# a financial agent can't spawn a research child, etc.
+CROSS_CUTTING_LIFEOS_TOOLS = (
+    # Operator messaging
+    "lifeos_telegram_send",
+    # Inter-agent coordination
+    "lifeos_agent_spawn",
+    "lifeos_agent_check",
+    "lifeos_agent_send",
+    "lifeos_agent_yield_until",
+    "lifeos_agent_kill",
+    "lifeos_agent_transcript_read",
+    "lifeos_agent_sessions_list",
+    "lifeos_agent_user_ask",
+    # General vault search — often the first move on any task
+    "lifeos_search",
+    "lifeos_ask",
+    # Self-diagnosis
+    "lifeos_health",
+    # Follow-up creation
+    "lifeos_task_create",
+    "lifeos_task_list",
+    "lifeos_task_update",
+    "lifeos_task_complete",
+    "lifeos_reminder_create",
+    "lifeos_reminder_list",
+    # Calendar reads are common across most classes; writes stay class-specific.
+    "lifeos_calendar_upcoming",
+    "lifeos_calendar_search",
+)
+
+
+# Per-class specialty tools. Cross-cutting tools are merged in by
+# `class_to_tool_filter` so each class's tuple only lists what's unique.
+_CLASS_SPECIALTIES: dict[str, tuple[str, ...]] = {
+    PRESET_CLASS_PERSONAL_COMM: (
+        "lifeos_gmail_search",
+        "lifeos_gmail_draft",
+        "lifeos_calendar_create",
+        "lifeos_calendar_update",
+        "lifeos_calendar_delete",
+        "lifeos_imessage_search",
+    ),
+    PRESET_CLASS_WORK_COMM: (
+        "lifeos_slack_search",
+        "lifeos_gmail_search",
+        "lifeos_gmail_draft",
+        "lifeos_calendar_create",
+        "lifeos_calendar_update",
+        "lifeos_calendar_delete",
+        "lifeos_drive_search",
+    ),
+    PRESET_CLASS_RESEARCH: (
+        "lifeos_drive_search",
+        "lifeos_memories_create",
+        "lifeos_memories_search",
+        "lifeos_people_search",
+    ),
+    PRESET_CLASS_FINANCIAL: (
+        "lifeos_monarch_accounts",
+        "lifeos_monarch_transactions",
+        "lifeos_monarch_cashflow",
+        "lifeos_monarch_budgets",
+    ),
+    PRESET_CLASS_CRM: (
+        "lifeos_people_search",
+        "lifeos_person_profile",
+        "lifeos_person_timeline",
+        "lifeos_person_connections",
+        "lifeos_person_facts",
+        "lifeos_person_fact_update",
+        "lifeos_person_fact_confirm",
+        "lifeos_person_fact_delete",
+        "lifeos_person_update",
+        "lifeos_relationship_insights",
+        "lifeos_communication_gaps",
+        "lifeos_meeting_prep",
+        "lifeos_photos_person",
+        "lifeos_photos_shared",
+        "lifeos_photos_stats",
+        "lifeos_memories_search",
+    ),
+    # `fullstack` is the no-filter fallback — handled by class_to_tool_filter
+    # by returning None instead of a payload.
+    PRESET_CLASS_FULLSTACK: (),
+}
+
+
+def class_to_tool_filter(preset_class: str) -> dict | None:
+    """Build the `agent.tools` payload for `driver.update_session()`.
+
+    Returns:
+      - A `{"tools": [...]}` dict when filtering applies. The list is the
+        union of the class's specialty tools and `CROSS_CUTTING_LIFEOS_TOOLS`,
+        de-duplicated and sorted for stability across calls.
+      - `None` for the `fullstack` class or any unknown class — meaning
+        "no filter, use the agent preset as-is". The worker should skip
+        the UPDATE call in this case.
+
+    The `mcp_servers` key is intentionally NOT emitted here. The MCP server
+    list lives on the preset (Anthropic console); filtering individual
+    tools within those servers is the per-class lever. If a class needs
+    a different set of MCP servers entirely, that's a separate operator
+    decision and should be made by swapping the preset, not the filter.
+    """
+    if preset_class not in _CLASS_SPECIALTIES or preset_class == PRESET_CLASS_FULLSTACK:
+        return None
+    specialty = _CLASS_SPECIALTIES[preset_class]
+    merged = sorted(set(specialty) | set(CROSS_CUTTING_LIFEOS_TOOLS))
+    return {"tools": merged}

--- a/api/services/agent_worker/tool_filter.py
+++ b/api/services/agent_worker/tool_filter.py
@@ -127,6 +127,42 @@ _CLASS_SPECIALTIES: dict[str, tuple[str, ...]] = {
 }
 
 
+# Per-class cache_creation token estimates (#139 §6). These are conservative
+# hardcoded floors used by preflight's fail-fast budget check. The full §6
+# acceptance specifies a live per-class startup probe — that operational
+# experiment is deferred; meanwhile these estimates let the refuse-on-too-small
+# logic land today. Probe-derived values can overwrite this table when the
+# experiment lands; the consumer just calls `estimated_cache_creation_tokens`.
+#
+# Numbers below are rough order-of-magnitude — small classes (~3 specialty
+# tools + cross-cutting) land around 25-40k tokens, larger classes (~10+
+# specialty tools) land around 40-70k, and `fullstack` is the un-filtered
+# preset which production has measured at ~100k.
+_CACHE_CREATION_TOKEN_ESTIMATES: dict[str, int] = {
+    PRESET_CLASS_PERSONAL_COMM: 45_000,
+    PRESET_CLASS_WORK_COMM: 50_000,
+    PRESET_CLASS_RESEARCH: 35_000,
+    PRESET_CLASS_FINANCIAL: 30_000,
+    PRESET_CLASS_CRM: 60_000,
+    PRESET_CLASS_FULLSTACK: 100_000,
+}
+
+
+def estimated_cache_creation_tokens(preset_class: str | None) -> int:
+    """Return the conservative cache_creation token estimate for a preset
+    class. Used by preflight (#139 §6) to refuse dispatch when the cache-
+    cold cost would blow through the task's budget.
+
+    None / unknown classes fall back to the fullstack estimate so we err
+    toward over-refusing rather than silently letting a runaway through.
+    """
+    if preset_class is None:
+        return _CACHE_CREATION_TOKEN_ESTIMATES[PRESET_CLASS_FULLSTACK]
+    return _CACHE_CREATION_TOKEN_ESTIMATES.get(
+        preset_class, _CACHE_CREATION_TOKEN_ESTIMATES[PRESET_CLASS_FULLSTACK]
+    )
+
+
 def class_to_tool_filter(preset_class: str) -> dict | None:
     """Build the `agent.tools` payload for `driver.update_session()`.
 

--- a/api/services/agent_worker/tool_result_cache.py
+++ b/api/services/agent_worker/tool_result_cache.py
@@ -1,0 +1,97 @@
+"""Per-session tool result cache for the LifeOS MCP HTTP server (#139 §4).
+
+When an agent calls the same tool twice within a single session with identical
+arguments — e.g., `lifeos_calendar_upcoming` early to set context and again
+later to confirm — the second result is identical work. Caching it MCP-side
+saves the round-trip and the per-turn input cost of having the tool result
+re-processed by the agent.
+
+Design choices:
+- **Key**: `(session_id, tool_name, sorted_args_json)`. Sorting args keys
+  ensures `{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` collide as expected.
+- **TTL**: uniform 60 seconds. The cache only fires on identical-args repeats
+  within a single session; per-tool tuning would add complexity for marginal
+  gain.
+- **Capacity**: 100 entries total, evicted oldest-first when full. Bounds
+  worst-case memory regardless of session count.
+- **Per-session clear**: `clear_session(session_id)` drops all entries for a
+  terminated session. Cheap because the cache is small.
+
+Thread-safety: the underlying ordered-dict mutation isn't atomic, but the
+worker process is single-threaded for MCP handling and the FastAPI handler
+is async-but-cooperative. A lock would add cost without buying anything.
+"""
+from __future__ import annotations
+
+import json
+import time
+from collections import OrderedDict
+from typing import Any
+
+
+DEFAULT_TTL_SECONDS = 60
+DEFAULT_MAX_ENTRIES = 100
+
+
+class SessionToolResultCache:
+    """In-process LRU+TTL cache keyed on (session_id, tool_name, args)."""
+
+    def __init__(
+        self,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+        clock: callable = time.time,
+    ):
+        self.ttl_seconds = ttl_seconds
+        self.max_entries = max_entries
+        self._clock = clock
+        # OrderedDict preserves insertion order; move_to_end on hit gives LRU.
+        # Value shape: (stored_at, result_dict)
+        self._store: OrderedDict[tuple[str, str, str], tuple[float, dict]] = OrderedDict()
+
+    @staticmethod
+    def _key(session_id: str, tool_name: str, args: dict) -> tuple[str, str, str]:
+        """Build the cache key. Args are JSON-canonicalized so kwarg
+        reordering doesn't bypass the cache."""
+        try:
+            args_json = json.dumps(args or {}, sort_keys=True, default=str)
+        except Exception:
+            args_json = repr(args)
+        return (session_id, tool_name, args_json)
+
+    def get(self, session_id: str, tool_name: str, args: dict) -> Any | None:
+        """Return a cached result if present and fresh, else None."""
+        if not session_id:
+            return None
+        key = self._key(session_id, tool_name, args)
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        stored_at, result = entry
+        if self._clock() - stored_at > self.ttl_seconds:
+            # Stale — drop it so the next put can take the slot.
+            self._store.pop(key, None)
+            return None
+        # LRU touch.
+        self._store.move_to_end(key)
+        return result
+
+    def put(self, session_id: str, tool_name: str, args: dict, result: Any) -> None:
+        """Store a fresh result. Evicts oldest entry when capacity is hit."""
+        if not session_id:
+            return
+        key = self._key(session_id, tool_name, args)
+        self._store[key] = (self._clock(), result)
+        self._store.move_to_end(key)
+        while len(self._store) > self.max_entries:
+            self._store.popitem(last=False)
+
+    def clear_session(self, session_id: str) -> int:
+        """Drop all entries for a terminated session. Returns count cleared."""
+        keys_to_drop = [k for k in self._store if k[0] == session_id]
+        for k in keys_to_drop:
+            self._store.pop(k, None)
+        return len(keys_to_drop)
+
+    def __len__(self) -> int:
+        return len(self._store)

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -70,6 +70,28 @@ def _worker_label(routing: str | None) -> str:
     return "Agent worker"
 
 
+def _format_token_buckets(
+    tokens_in: int,
+    cache_creation: int,
+    cache_read: int,
+    tokens_out: int,
+) -> str:
+    """Render the four token buckets for the completion message.
+
+    Cache buckets are only included when non-zero so local-path completions
+    (which never write or read the prompt cache) collapse to the original
+    "N tokens" form. Managed cloud sessions always have at least
+    cache_creation populated on first turn.
+    """
+    parts: list[str] = [f"{tokens_in:,} input"]
+    if cache_creation:
+        parts.append(f"{cache_creation:,} cached-write")
+    if cache_read:
+        parts.append(f"{cache_read:,} cached-read")
+    parts.append(f"{tokens_out:,} output")
+    return " + ".join(parts)
+
+
 def _is_readable_tool_result(text: str) -> bool:
     """Heuristic: is this tool result useful to dump inline as the
     operator-facing completion body? Skip raw JSON dumps (list_threads,
@@ -1179,13 +1201,21 @@ class Worker:
 
     def _completion_summary(self, session: Session, task: dict[str, Any], outcome) -> str:
         refreshed = self.session_store.get(session.task_id) or session
-        tokens = (refreshed.total_input_tokens or 0) + (refreshed.total_output_tokens or 0)
         # Use active seconds (excludes sleeps) so the figure reflects real
         # work, not wall time since the session was first created.
         active_s = int(refreshed.total_active_seconds or 0)
         expected = refreshed.expected_output or "text"
         title = task.get("description", session.task_id)
         label = _worker_label(refreshed.routing or session.routing)
+        # Four-bucket token breakdown so the operator can see what drove cost.
+        # For local sessions cache buckets are always zero and collapse out of
+        # the rendered string.
+        tokens_summary = _format_token_buckets(
+            refreshed.total_input_tokens or 0,
+            refreshed.total_cache_creation_tokens or 0,
+            refreshed.total_cache_read_tokens or 0,
+            refreshed.total_output_tokens or 0,
+        )
 
         # Body: prefer the agent's final text. When it's empty (the agent
         # used a tool and idled without summarizing — sometimes happens with
@@ -1250,7 +1280,7 @@ class Worker:
 
         return (
             f"✅ {label}: completed '{title}' "
-            f"({expected}) — {tokens:,} tokens, ${refreshed.total_dollars:.2f}, "
+            f"({expected}) — {tokens_summary}, ${refreshed.total_dollars:.2f}, "
             f"{active_s}s active.\n\n{result_blurb}{footer}"
         )
 
@@ -1375,7 +1405,12 @@ class Worker:
         parts.append("")
         parts.append("Children:")
         for c in child_sessions:
-            tokens = (c.total_input_tokens or 0) + (c.total_output_tokens or 0)
+            tokens = (
+                (c.total_input_tokens or 0)
+                + (c.total_output_tokens or 0)
+                + (c.total_cache_creation_tokens or 0)
+                + (c.total_cache_read_tokens or 0)
+            )
             header = f"- [{c.status}] {c.session_id} — {tokens} tokens, ${c.total_dollars:.4f}"
             parts.append(header)
             body = self._child_final_text(c)

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1043,6 +1043,7 @@ class Worker:
             routing=pre.routing,
             budget=budget_json,
             expected_output=pre.expected_output,
+            preset_class=pre.preset_class,
         )
         session = self.session_store.get(task_id)  # refresh
 

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -977,7 +977,11 @@ class Worker:
             agent_id=agent_id,
             environment_id=environment_id,
             vault_ids=vault_ids,
-            model=settings.agent_managed_model,
+            # Dev iteration may set LIFEOS_AGENT_MANAGED_MODEL_FOR_TESTS to a
+            # cheaper model (e.g. Haiku) so the executor's client-side cost
+            # accounting matches the model the operator is actually charged
+            # for during prompt-engineering runs.
+            model=settings.agent_managed_model_for_tests or settings.agent_managed_model,
         )
         return self._managed_executor
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -157,6 +157,16 @@ class Settings(BaseSettings):
                     "actual model is whatever the agent preset says; this "
                     "value is just used for client-side token-cost accounting."
     )
+    agent_managed_model_for_tests: str = Field(
+        default="",
+        alias="LIFEOS_AGENT_MANAGED_MODEL_FOR_TESTS",
+        description="Optional dev-only override of `agent_managed_model` used "
+                    "when iterating on the cloud agent path. Set to e.g. "
+                    "`claude-haiku-4-5` to swap cost accounting to the cheaper "
+                    "model during iteration. Empty (default) means no override. "
+                    "This only changes client-side dollar accounting; the "
+                    "actual remote model is still the agent preset's setting."
+    )
     agent_vault_id: str = Field(
         default="",
         alias="LIFEOS_AGENT_VAULT_ID",

--- a/config/settings.py
+++ b/config/settings.py
@@ -167,6 +167,15 @@ class Settings(BaseSettings):
                     "This only changes client-side dollar accounting; the "
                     "actual remote model is still the agent preset's setting."
     )
+    agent_cost_confirm_threshold_dollars: float = Field(
+        default=1.0,
+        alias="LIFEOS_AGENT_COST_CONFIRM_THRESHOLD_DOLLARS",
+        description="When preflight's cost estimate for a managed-agent task "
+                    "exceeds this dollar threshold, the orchestrator must "
+                    "confirm with the operator before dispatching (#139 §7). "
+                    "Set to 0 to disable confirmation (auto-dispatch all "
+                    "managed tasks regardless of estimate)."
+    )
     agent_vault_id: str = Field(
         default="",
         alias="LIFEOS_AGENT_VAULT_ID",

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -379,6 +379,35 @@ The Haiku preflight sanity-check is the only guard against destructive-shaped ta
 
 ---
 
+## Cost-aware iteration
+
+Iterating on cloud `#agent` prompts has a hidden tax: every fresh managed
+session pays ~$0.40 cache_creation up front on the 100k-token preset. A few
+suggestions to keep iteration cheap:
+
+- **Cluster runs within 5 minutes.** Anthropic's prompt cache has a 5-minute
+  TTL. Sessions dispatched within that window after a recent run hit
+  `cache_read` (12.5× cheaper than `cache_creation`) instead of paying the
+  full cache-cold cost. If you're iterating on a prompt shape, fire your
+  reruns back-to-back, not spread across the hour.
+- **Use `dry_run=true` to inspect routing without billing.** `lifeos_task_create`
+  accepts a `dry_run` flag on `#agent` tasks — it runs the cheap Haiku
+  preflight (~$0.001), returns the routing decision and cost estimate, and
+  does *not* dispatch a managed session. Use this when you're verifying tag
+  parsing or routing logic; only flip `dry_run=false` once the dispatch
+  shape looks right.
+- **Override the model-for-tests setting.** `LIFEOS_AGENT_MANAGED_MODEL_FOR_TESTS`
+  in `.env` overrides `LIFEOS_AGENT_MANAGED_MODEL` for client-side cost
+  accounting. Set to `claude-haiku-4-5` while iterating so the dollar
+  figures the worker logs match what you'd be charged if the preset were
+  pointed at Haiku.
+- **Keep tests mocked.** A process-wide pytest guard fails any test that
+  reaches `api.anthropic.com` or `platform.claude.com`. Tests must use
+  `httpx.MockTransport`, `AsyncMock`, or a stub `caller`. A test that
+  legitimately needs a real call must carry `@pytest.mark.allow_anthropic_api`.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -289,6 +289,16 @@ class LifeOSMCPServer:
         self.client = httpx.Client(timeout=30.0)
         self.openapi_spec: dict | None = None
         self.tools: list[dict] = []
+        # Per-session tool-result cache (#139 §4). Bypassed when the caller
+        # doesn't supply a session id (which is the common case for local-CLI
+        # tool calls; cache hits matter most on managed-agent HTTP calls).
+        try:
+            from api.services.agent_worker.tool_result_cache import (
+                SessionToolResultCache,
+            )
+            self._result_cache = SessionToolResultCache()
+        except Exception:  # pragma: no cover — keep server bootable without agent worker
+            self._result_cache = None
         self._load_openapi_spec()
         self._register_inter_agent_tools()
 
@@ -926,8 +936,32 @@ class LifeOSMCPServer:
         except httpx.RequestError as e:
             return {"error": f"Request failed: {e}"}
 
-    def _call_api(self, tool_name: str, arguments: dict) -> dict:
-        """Call the LifeOS API based on tool name and arguments."""
+    @staticmethod
+    def _cache_eligible(tool_name: str) -> bool:
+        """Tools whose results are safe to cache for 60s within a session.
+
+        Only GET-shaped tools (read-only). Writes (drafts, calendar events,
+        tasks, memories), inter-agent dispatch, and the sync trigger are
+        excluded — they're either idempotent in the wrong direction or
+        sensitive to fresh state.
+        """
+        cfg = next(
+            (c for c in CURATED_ENDPOINTS.values() if c.get("name") == tool_name),
+            None,
+        )
+        if cfg is None:
+            return False
+        return cfg.get("method", "").upper() == "GET"
+
+    def _call_api(self, tool_name: str, arguments: dict, session_id: str | None = None) -> dict:
+        """Call the LifeOS API based on tool name and arguments.
+
+        `session_id` (optional) enables the per-session result cache (#139 §4):
+        when supplied, identical GET-style tool calls within the same session
+        are served from a 60s LRU instead of round-tripping to the API. Writes
+        (POST/PUT/DELETE) are never cached. The cache also skips inter-agent
+        tools and the sync trigger (both sensitive to fresh state).
+        """
         # Custom handlers for tools that don't map 1:1 to endpoints
         if tool_name == "lifeos_sync_trigger":
             return self._handle_sync_trigger(arguments)
@@ -938,6 +972,13 @@ class LifeOSMCPServer:
         # managed agents pass it explicitly per the system prompt.
         if tool_name.startswith("lifeos_agent_"):
             return self._handle_inter_agent(tool_name, dict(arguments))
+
+        # Cache check for read-only tools when the caller is session-aware.
+        cache_key_args = arguments
+        if self._cache_eligible(tool_name) and session_id and self._result_cache is not None:
+            cached = self._result_cache.get(session_id, tool_name, cache_key_args)
+            if cached is not None:
+                return cached
 
         # Find the endpoint config
         endpoint_config = None
@@ -985,6 +1026,10 @@ class LifeOSMCPServer:
                         body = self._fetch_email_body(msg["message_id"], account)
                         if body:
                             msg["body"] = body
+
+            # Store in the per-session cache for read-only tools (#139 §4).
+            if self._cache_eligible(tool_name) and session_id and self._result_cache is not None:
+                self._result_cache.put(session_id, tool_name, cache_key_args, result)
 
             return result
         except httpx.HTTPStatusError as e:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -33,7 +33,7 @@ OPENAPI_URL = f"{API_BASE}/openapi.json"
 CURATED_ENDPOINTS = {
     "/api/ask": {
         "name": "lifeos_ask",
-        "description": "Query the knowledge base with RAG synthesis. Returns a natural language answer with source citations. Use for open-ended questions like 'what did we discuss about X?' or 'summarize my notes on Y'. For raw search results without synthesis, use lifeos_search instead.",
+        "description": "RAG synthesis over the vault. Returns a natural-language answer with citations. Use for open-ended questions ('what did we discuss about X?'). For raw chunks, use lifeos_search.",
         "method": "POST"
     },
     "/api/search": {
@@ -48,12 +48,12 @@ CURATED_ENDPOINTS = {
     },
     "/api/calendar/search": {
         "name": "lifeos_calendar_search",
-        "description": "Search calendar events by keyword. Returns past and future events matching the query. Use for 'when did I meet with X?' or 'find meetings about Y'. For upcoming events only, use lifeos_calendar_upcoming.",
+        "description": "Search past and future calendar events by keyword ('when did I meet with X?'). For upcoming events only, use lifeos_calendar_upcoming.",
         "method": "GET"
     },
     "/api/gmail/search": {
         "name": "lifeos_gmail_search",
-        "description": "Search emails in Gmail. Returns email metadata and full body for top 5 results. Use for 'find emails about X' or 'what did Y say in email?'. Supports filtering by account (personal/work).",
+        "description": "Search Gmail. Returns metadata + full body for top 5 results. Filter by account (personal/work).",
         "method": "GET"
     },
     "/api/drive/search": {
@@ -78,41 +78,12 @@ CURATED_ENDPOINTS = {
     },
     "/api/people/search": {
         "name": "lifeos_people_search",
-        "description": """Search for people in your network by name or email. Returns entity_id (required for other people tools), relationship_strength, and active_channels. Always use this first to get entity_id before calling lifeos_person_profile, lifeos_person_timeline, lifeos_person_connections, or lifeos_person_facts.
-
-RETURNS for each match:
-- canonical_name, email, company, position
-- relationship_strength: 0-100 score (higher = closer relationship)
-- active_channels: Communication channels with recent activity (last 7 days)
-- days_since_contact: Days since last interaction
-- entity_id: Required for all follow-up tools
-
-FOLLOW-UP TOOLS (use entity_id):
-- lifeos_person_profile(entity_id) → Full CRM profile with contact info, notes, tags
-- lifeos_person_timeline(entity_id) → Chronological interaction history
-- lifeos_person_connections(entity_id) → Who they work with, shared meetings
-- lifeos_person_facts(entity_id) → Extracted facts (family, interests, etc.)
-- lifeos_imessage_search(entity_id=...) → Message history
-
-ROUTING GUIDANCE based on active_channels:
-- "imessage" active → lifeos_imessage_search with entity_id
-- "gmail" active → lifeos_gmail_search with their email
-- "slack" active → lifeos_slack_search with user_id
-- No active channels → Check profile for notes (dormant contact)""",
+        "description": "Find people by name/email. Returns entity_id (required by lifeos_person_*), relationship_strength, active_channels. Always call first to get entity_id.",
         "method": "GET"
     },
     "/api/crm/people/{entity_id}:PATCH": {
         "name": "lifeos_person_update",
-        "description": """Update a person's profile in the CRM. Can set notes, tags, category, or birthday. Requires entity_id from lifeos_people_search. Only provided fields are changed.
-
-PARAMETERS:
-- entity_id (required): Person entity ID from lifeos_people_search
-- notes: Free-text notes (replaces existing)
-- tags: Classification tags (replaces existing)
-- category: work, personal, family, or other
-- birthday: MM-DD format (month-day only), empty string to clear
-
-FOLLOW-UP TOOLS: Use lifeos_person_profile(entity_id) to verify the update.""",
+        "description": "Update a person's CRM profile (notes, tags, category, birthday MM-DD). Requires entity_id from lifeos_people_search; only provided fields change.",
         "method": "PATCH",
         "path": "/api/crm/people/{entity_id}"
     },
@@ -123,28 +94,22 @@ FOLLOW-UP TOOLS: Use lifeos_person_profile(entity_id) to verify the update.""",
     },
     "/api/imessage/search": {
         "name": "lifeos_imessage_search",
-        "description": "Search iMessage/SMS text message history. Returns messages with sender, timestamp, and content. Use for 'what did X text me about?' or 'find messages about Y'. Supports filtering by phone number, entity_id, date range, or direction (sent/received).",
+        "description": "Search iMessage/SMS history. Filter by phone, entity_id, date range, or direction (sent/received).",
         "method": "GET"
     },
     "/api/gmail/drafts": {
         "name": "lifeos_gmail_draft",
-        "description": "Create a draft email in Gmail. Returns draft ID and URL to open in Gmail. Use when user wants to compose an email. The draft is NOT sent - user must review and send manually. Provide 'to', 'subject', 'body'. Optional: 'cc', 'bcc', 'account' (personal/work).",
+        "description": "Create a Gmail draft (NOT sent — user reviews). Returns draft ID + URL. Required: to, subject, body. Optional: cc, bcc, account.",
         "method": "POST"
     },
     "/api/slack/search": {
         "name": "lifeos_slack_search",
-        "description": "Semantic search across Slack messages. Returns messages with channel, user, and content. Use for 'what was discussed in Slack about X?' or 'find messages from Y in Slack'. Searches DMs, group DMs, and channels.",
+        "description": "Semantic search across Slack DMs, group DMs, and channels. Returns channel, user, content.",
         "method": "POST"
     },
     "/api/crm/people/{person_id}/facts": {
         "name": "lifeos_person_facts",
-        "description": """Get extracted facts about a person from their interactions. Returns facts organized by category (family, interests, work, dates) with confidence scores. Requires entity_id from lifeos_people_search. Use before drafting personalized messages or preparing for meetings.
-
-Categories: family (spouse, kids, pets), interests (hobbies, sports), background (hometown, alma_mater), work (role, projects), dates (birthday), travel
-
-Each fact includes: key, value, confidence (0-1), confirmed status, source_quote
-
-WORKFLOW: lifeos_people_search → get entity_id → lifeos_person_facts""",
+        "description": "Get extracted facts about a person (family, interests, work, dates, travel) with confidence scores. Requires entity_id. Use before drafting personalized messages.",
         "method": "GET"
     },
     "/api/crm/people/{entity_id}/facts/{fact_id}:PUT": {
@@ -167,168 +132,52 @@ WORKFLOW: lifeos_people_search → get entity_id → lifeos_person_facts""",
     },
     "/api/crm/people/{person_id}": {
         "name": "lifeos_person_profile",
-        "description": """Get comprehensive CRM profile for a person. Returns all contact info (emails, phones), relationship metrics, tags, and notes. Requires entity_id from lifeos_people_search. Use for 'tell me about X' or when you need full contact details.
-
-WHAT IT RETURNS:
-- emails, phone_numbers, linkedin_url
-- company, position, vault_contexts
-- relationship_strength (0-100), category (work/personal/family)
-- meeting_count, email_count, message_count
-- tags, notes (user annotations)
-- facts (extracted personal details)
-
-REQUIRES: entity_id from lifeos_people_search.
-
-Use this instead of lifeos_people_search when you need all emails, phone numbers, or user notes.""",
+        "description": "Full CRM profile: emails, phones, company, relationship_strength, tags, notes, facts. Requires entity_id. Use for 'tell me about X' or full contact details.",
         "method": "GET"
     },
     "/api/crm/people/{person_id}/timeline": {
         "name": "lifeos_person_timeline",
-        "description": """Get chronological interaction history for a person. Returns recent emails, messages, meetings in time order. Requires entity_id from lifeos_people_search. Use for 'catch me up on X' or 'what's been happening with Y?'.
-
-RETURNS chronological list of interactions (newest first):
-- source_type: gmail, imessage, calendar, slack, vault
-- timestamp, summary, metadata (subject, attendees, etc.)
-
-PARAMETERS:
-- person_id (required): entity_id from lifeos_people_search
-- days_back: How far back to look (default: 365)
-- source_type: Filter by source (e.g., "imessage", "gmail,slack")
-- limit: Max results (default: 50)
-
-WORKFLOW: lifeos_people_search → get entity_id → lifeos_person_timeline""",
+        "description": "Chronological interactions for a person (emails, messages, meetings, vault). Requires entity_id. Use for 'catch me up on X'.",
         "method": "GET"
     },
     "/api/calendar/meeting-prep": {
         "name": "lifeos_meeting_prep",
-        "description": """Get intelligent meeting preparation context for a date. Returns each meeting with related notes, past meetings with same attendees, and relevant documents. Use for 'prep me for my meetings today' or 'what should I know for my 1:1 with X?'.
-
-RETURNS for each meeting:
-- title, time, attendees, location, description
-- related_notes: People notes, past meeting notes, topic notes
-- attachments: Files attached to calendar event
-
-PARAMETERS:
-- date: YYYY-MM-DD format (defaults to today)
-- include_all_day: Include all-day events (default: false)
-- max_related_notes: Max notes per meeting (default: 4)
-
-Use this instead of separate calendar + vault searches for meeting prep.""",
+        "description": "Meeting prep for a date: each event with related notes, past meetings with same attendees, attachments. Defaults to today.",
         "method": "GET"
     },
     "/api/crm/family/communication-gaps": {
         "name": "lifeos_communication_gaps",
-        "description": """Find people you haven't contacted recently. Requires comma-separated person_ids from lifeos_people_search. Use for 'who should I reach out to?' or 'which family members haven't I talked to?'. Returns days since last contact.
-
-RETURNS:
-- gaps: List of communication gaps (person_id, person_name, gap_days)
-- person_summaries: days_since_last_contact, average_gap_days, current_gap_days
-
-PARAMETERS:
-- person_ids (required): Comma-separated entity IDs from lifeos_people_search
-- days_back: History to analyze (default: 365)
-- min_gap_days: Minimum gap to report (default: 14)
-
-WORKFLOW: lifeos_people_search → get entity_ids → lifeos_communication_gaps(person_ids=id1,id2,id3)""",
+        "description": "Find people not contacted recently. Required: comma-separated person_ids (entity_ids). Returns days since last contact + gap stats.",
         "method": "GET"
     },
     "/api/crm/people/{person_id}/connections": {
         "name": "lifeos_person_connections",
-        "description": """Get people connected to a person through shared meetings, emails, messages, and LinkedIn. Use after lifeos_people_search to find who someone works with or knows.
-
-RETURNS for each connection:
-- person_id, name, company, relationship_type
-- shared_events_count, shared_threads_count, shared_messages_count
-- shared_slack_count, shared_whatsapp_count
-- relationship_strength, last_seen_together
-
-Use for 'who does X work with?' or 'who are X's connections?'.
-
-REQUIRES: person_id (entity_id) from lifeos_people_search.""",
+        "description": "People connected to a person via shared meetings, emails, messages, LinkedIn. Requires entity_id. Use for 'who does X work with?'.",
         "method": "GET"
     },
     "/api/crm/relationship/insights": {
         "name": "lifeos_relationship_insights",
-        "description": """Get relationship insights and observations about people. Returns patterns like 'frequently meets with X' or 'collaborates on Y project'. Insights are extracted from therapy notes and conversations.
-
-RETURNS:
-- insights: List with category, text, source_title, source_link, confirmed status
-- Categories: communication_patterns, emotional_needs, conflict_areas, growth_areas
-
-PARAMETERS:
-- person_id (optional): Focus on specific person (defaults to primary relationship)
-
-Use for understanding relationship dynamics and patterns.""",
+        "description": "Relationship insights (communication_patterns, emotional_needs, conflict_areas, growth_areas) extracted from notes. Optional person_id; defaults to primary relationship.",
         "method": "GET"
     },
     "/api/photos/person/{person_id}": {
         "name": "lifeos_photos_person",
-        "description": """Get photos containing a specific person from Apple Photos face recognition.
-
-RETURNS:
-- person_id: The requested person's entity ID
-- photos: List of photos with uuid, timestamp, source_link
-- count: Total number of photos
-
-PARAMETERS:
-- person_id (required): entity_id from lifeos_people_search
-- limit: Max photos to return (default: 50)
-
-REQUIRES: entity_id from lifeos_people_search.
-
-Use for 'show me photos of X' or 'find pictures with Y'.""",
+        "description": "Photos of a person (Apple Photos face recognition). Requires entity_id. Use for 'show me photos of X'.",
         "method": "GET"
     },
     "/api/photos/shared/{person_a_id}/{person_b_id}": {
         "name": "lifeos_photos_shared",
-        "description": """Get photos where two people appear together (co-appearances).
-
-RETURNS:
-- person_a_id, person_b_id: The two people
-- shared_photo_count: Total photos together
-- photos: List of photos with uuid, timestamp, source_link
-
-PARAMETERS:
-- person_a_id (required): First person's entity_id
-- person_b_id (required): Second person's entity_id
-- limit: Max photos to return (default: 20)
-
-Use for 'photos of me with X' or 'pictures of X and Y together'.
-
-WORKFLOW: lifeos_people_search for both people → get entity_ids → lifeos_photos_shared""",
+        "description": "Photos where two people appear together. Required: person_a_id + person_b_id (entity_ids). Use for 'pictures of X and Y together'.",
         "method": "GET"
     },
     "/api/photos/stats": {
         "name": "lifeos_photos_stats",
-        "description": """Get statistics about Apple Photos library face recognition data.
-
-RETURNS:
-- total_named_people: People recognized in Photos
-- people_with_contacts: People linked to Apple Contacts
-- total_face_detections: Total face appearances
-- multi_person_photos: Photos with 2+ named people
-- photos_enabled: Whether Photos integration is available
-
-Use to check Photos integration status or get overview of photo data.""",
+        "description": "Apple Photos face-recognition stats: named_people, face_detections, multi_person_photos, integration status.",
         "method": "GET"
     },
     "/api/reminders:POST": {
         "name": "lifeos_reminder_create",
-        "description": """Create a scheduled reminder that sends messages via Telegram.
-
-Three message types:
-- static: Sends message_content as-is (e.g., "Time for your evening review")
-- prompt: Runs message_content through the full LifeOS chat pipeline (calendar, email, vault, Claude synthesis) and sends the result. This is the powerful one for automated briefings.
-- endpoint: Calls a LifeOS API endpoint directly and sends formatted result (lighter weight, no Claude cost)
-
-Schedule types:
-- once: Fire once at schedule_value (ISO datetime, e.g., "2026-02-07T14:00:00")
-- cron: Recurring via cron expression (e.g., "30 7 * * 1-5" for 7:30 AM weekdays)
-
-Example morning briefing:
-  name="Morning Briefing", schedule_type="cron", schedule_value="30 7 * * 1-5",
-  message_type="prompt", message_content="Summarize my meetings today and suggest top 3 priorities"
-""",
+        "description": "Schedule a Telegram reminder. schedule_type=once|cron; message_type=static|prompt|endpoint (prompt runs full LifeOS pipeline).",
         "method": "POST",
         "path": "/api/reminders"
     },
@@ -340,19 +189,7 @@ Example morning briefing:
     },
     "/api/reminders/{reminder_id}:PUT": {
         "name": "lifeos_reminder_update",
-        "description": """Update an existing reminder's schedule, message, or other properties. Use lifeos_reminder_list to find reminder IDs. Only provided fields are changed.
-
-PARAMETERS:
-- reminder_id (required): Reminder ID from lifeos_reminder_list
-- name: Display name
-- schedule_type: 'once' or 'cron'
-- schedule_value: ISO datetime for 'once', cron expression for 'cron'
-- message_type: 'static', 'prompt', or 'endpoint'
-- message_content: The message text or prompt
-- timezone: IANA timezone (e.g., 'America/New_York')
-- enabled: Whether the reminder is active
-
-FOLLOW-UP TOOLS: Use lifeos_reminder_list to verify the update.""",
+        "description": "Update a reminder by reminder_id (from lifeos_reminder_list). Only provided fields change.",
         "method": "PUT",
         "path": "/api/reminders/{reminder_id}"
     },
@@ -369,12 +206,7 @@ FOLLOW-UP TOOLS: Use lifeos_reminder_list to verify the update.""",
     },
     "/api/admin/sync:POST": {
         "name": "lifeos_sync_trigger",
-        "description": """Trigger a data sync for a specific source. Returns immediately — sync runs in background.
-
-PARAMETERS:
-- source (required): vault, calendar, contacts, slack, photos, gmail, imessage, phone, facetime, or linkedin
-
-FOLLOW-UP TOOLS: Use lifeos_health to check sync status.""",
+        "description": "Trigger a background data sync. source: vault, calendar, contacts, slack, photos, gmail, imessage, phone, facetime, linkedin.",
         "method": "POST",
         "path": "/api/admin/sync",
         "custom_handler": True
@@ -401,7 +233,7 @@ FOLLOW-UP TOOLS: Use lifeos_health to check sync status.""",
     },
     "/api/tasks:POST": {
         "name": "lifeos_task_create",
-        "description": "Create a task in LifeOS. Tasks are stored as Obsidian-compatible markdown in LifeOS/Tasks/{Context}.md. Supports contexts (Work, Personal, Finance, etc.), priority (high/medium/low), due dates, and tags. When dry_run=true is supplied with an #agent tag, returns the preflight routing decision and cost estimate without creating the task — used for prompt-engineering iteration.",
+        "description": "Create a task (Obsidian markdown). Supports context, priority, due_date, tags. With dry_run=true + #agent tag, returns preflight routing + cost estimate instead of creating.",
         "method": "POST",
         "path": "/api/tasks"
     },
@@ -431,13 +263,13 @@ FOLLOW-UP TOOLS: Use lifeos_health to check sync status.""",
     },
     "/api/calendar/events:POST": {
         "name": "lifeos_calendar_create",
-        "description": "Create a Google Calendar event. Provide title, start_time (ISO datetime), end_time (ISO datetime). Optional: attendees (email list), description, location, account (personal/work). Invite emails are automatically sent to attendees. [CLARIFY] before creating events with attendees.",
+        "description": "Create a Google Calendar event. Required: title, start_time, end_time (ISO). Optional: attendees, description, location, account. Invites are auto-sent. [CLARIFY] before adding attendees.",
         "method": "POST",
         "path": "/api/calendar/events"
     },
     "/api/calendar/events/{event_id}:PUT": {
         "name": "lifeos_calendar_update",
-        "description": "Update an existing calendar event. Requires event_id from lifeos_calendar_search. Only provided fields are changed. Optional: title, start_time, end_time, attendees, description, location, account. Update emails are sent to attendees. [CLARIFY] before updating events.",
+        "description": "Update a calendar event by event_id (from lifeos_calendar_search). Only provided fields change. Update emails are sent. [CLARIFY] first.",
         "method": "PUT",
         "path": "/api/calendar/events/{event_id}"
     },

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -401,7 +401,7 @@ FOLLOW-UP TOOLS: Use lifeos_health to check sync status.""",
     },
     "/api/tasks:POST": {
         "name": "lifeos_task_create",
-        "description": "Create a task in LifeOS. Tasks are stored as Obsidian-compatible markdown in LifeOS/Tasks/{Context}.md. Supports contexts (Work, Personal, Finance, etc.), priority (high/medium/low), due dates, and tags.",
+        "description": "Create a task in LifeOS. Tasks are stored as Obsidian-compatible markdown in LifeOS/Tasks/{Context}.md. Supports contexts (Work, Personal, Finance, etc.), priority (high/medium/low), due dates, and tags. When dry_run=true is supplied with an #agent tag, returns the preflight routing decision and cost estimate without creating the task — used for prompt-engineering iteration.",
         "method": "POST",
         "path": "/api/tasks"
     },
@@ -905,7 +905,8 @@ class LifeOSMCPServer:
                     "priority": {"type": "string", "description": "Priority: high, medium, low"},
                     "due_date": {"type": "string", "description": "Due date in YYYY-MM-DD format"},
                     "tags": {"type": "array", "items": {"type": "string"}, "description": "Tags for classification"},
-                    "reminder_id": {"type": "string", "description": "Linked reminder ID"}
+                    "reminder_id": {"type": "string", "description": "Linked reminder ID"},
+                    "dry_run": {"type": "boolean", "description": "When true with an #agent tag, returns preflight routing + cost estimate without creating the task. Used for prompt-engineering iteration. Default: false."}
                 },
                 "required": ["description"]
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ Run categories:
 - pytest -n auto              # Parallel execution (requires pytest-xdist)
 """
 import gc
-import os
 
 import pytest
 
@@ -32,6 +31,79 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "requires_ollama: Requires Ollama running")
     config.addinivalue_line("markers", "requires_server: Requires API server running")
     config.addinivalue_line("markers", "requires_db: Requires direct database access (may conflict with running server)")
+    config.addinivalue_line(
+        "markers",
+        "allow_anthropic_api: Test is explicitly allowed to hit api.anthropic.com "
+        "(used for the canary test that verifies the ban itself works).",
+    )
+    _install_anthropic_request_guard()
+
+
+# ---------------------------------------------------------------------------
+# Anthropic API call guard (#138)
+#
+# Bleeds happen when a test forgets to mock the LLM client and silently makes
+# a real billed call. Guard installs a process-wide httpx transport hook that
+# raises if any test attempts a request to api.anthropic.com (or the platform
+# console). Tests can opt in to a real call with @pytest.mark.allow_anthropic_api
+# — used for the deliberate canary that confirms the guard fires.
+# ---------------------------------------------------------------------------
+
+_ANTHROPIC_HOSTS = ("api.anthropic.com", "platform.claude.com")
+_anthropic_guard_active = False
+
+
+def _install_anthropic_request_guard() -> None:
+    """Patch httpx so any request to Anthropic's API hosts raises during
+    pytest collection. The patch is installed once and stays active for the
+    full pytest run. Tests carrying `@pytest.mark.allow_anthropic_api`
+    bypass the check.
+    """
+    global _anthropic_guard_active
+    if _anthropic_guard_active:
+        return
+    import httpx
+
+    original_send = httpx.Client.send
+    original_async_send = httpx.AsyncClient.send
+
+    def _is_allowed() -> bool:
+        # Read the current test's request fixture indirectly via the pytest
+        # node-tracking attribute set by `pytest_runtest_setup`.
+        node = getattr(_install_anthropic_request_guard, "_current_node", None)
+        if node is None:
+            return False
+        return node.get_closest_marker("allow_anthropic_api") is not None
+
+    def _guard(request):
+        host = (request.url.host or "").lower()
+        for blocked in _ANTHROPIC_HOSTS:
+            if host == blocked or host.endswith("." + blocked):
+                if _is_allowed():
+                    return
+                raise RuntimeError(
+                    f"Test attempted a real Anthropic API call to {request.url}. "
+                    "Mock the LLM client (httpx.MockTransport, AsyncMock, etc.) "
+                    "or mark the test @pytest.mark.allow_anthropic_api if a "
+                    "real call is intended."
+                )
+
+    def patched_send(self, request, *args, **kwargs):
+        _guard(request)
+        return original_send(self, request, *args, **kwargs)
+
+    async def patched_async_send(self, request, *args, **kwargs):
+        _guard(request)
+        return await original_async_send(self, request, *args, **kwargs)
+
+    httpx.Client.send = patched_send
+    httpx.AsyncClient.send = patched_async_send
+    _anthropic_guard_active = True
+
+
+def pytest_runtest_setup(item):
+    """Hand the active test item to the guard so it can check markers."""
+    _install_anthropic_request_guard._current_node = item
 
 
 @pytest.fixture(scope="session")
@@ -199,6 +271,7 @@ def pytest_runtest_teardown(item, nextitem):
     ChromaDB clients) can push memory to 100%. This hook cleans up after
     each test to keep memory usage bounded.
     """
+    _install_anthropic_request_guard._current_node = None
     gc.collect()
 
 

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -471,6 +471,48 @@ def test_pricing_unknown_model_falls_through_to_opus_rate():
     assert unknown == pytest.approx(opus)
 
 
+@pytest.mark.unit
+def test_pricing_cache_creation_charged_at_125pct_of_input():
+    """cache_creation tokens cost 1.25× the model's input rate."""
+    # Sonnet input rate is $3/M, so 1k cache_creation = $0.003 × 1.25 = $0.00375.
+    cost = cost_for("claude-sonnet-4-6", 0, 0, cache_creation_tokens=1000)
+    assert cost == pytest.approx(0.003 * 1.25)
+
+
+@pytest.mark.unit
+def test_pricing_cache_read_charged_at_10pct_of_input():
+    """cache_read tokens cost 0.10× the model's input rate (12.5× cheaper
+    than cache_creation, 10× cheaper than uncached input)."""
+    cost = cost_for("claude-sonnet-4-6", 0, 0, cache_read_tokens=1000)
+    assert cost == pytest.approx(0.003 * 0.10)
+
+
+@pytest.mark.unit
+def test_pricing_all_four_buckets_compose():
+    """Mixed payload: input + output + cache_creation + cache_read all sum."""
+    # Sonnet: input $3/M, output $15/M.
+    # 1k input = $0.003, 1k output = $0.015,
+    # 1k cache_creation = $0.00375, 1k cache_read = $0.0003.
+    cost = cost_for(
+        "claude-sonnet-4-6",
+        tokens_in=1000,
+        tokens_out=1000,
+        cache_creation_tokens=1000,
+        cache_read_tokens=1000,
+    )
+    assert cost == pytest.approx(0.003 + 0.015 + 0.00375 + 0.0003)
+
+
+@pytest.mark.unit
+def test_pricing_cache_buckets_default_to_zero():
+    """Two-arg call sites (the local executor) keep working unchanged."""
+    cost = cost_for("claude-haiku-4-5", 1000, 500)
+    expected_two_arg = cost_for(
+        "claude-haiku-4-5", 1000, 500, cache_creation_tokens=0, cache_read_tokens=0,
+    )
+    assert cost == pytest.approx(expected_two_arg)
+
+
 # ---------------------------------------------------------------------------
 # System-prompt structure (issue #119 — Anthropic 4.6/4.7 best practices)
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -1066,9 +1066,12 @@ def test_completion_spills_to_vault_when_over_cap(tmp_path: Path, monkeypatch):
     vault = tmp_path / "MyVault"
     monkeypatch.setattr(_settings, "vault_path", vault, raising=False)
 
+    # Tag is "local" — not "cloud" — so the deterministic tag precedence
+    # (#139 §2) routes this task to the local executor. The test exercises
+    # the over-cap spillover via _StubExecutor on the local path.
     api = FakeApi(tasks=[
         {"id": "t1", "description": "Big report on Julia",
-         "status": "todo", "tags": ["agent", "cloud"]},
+         "status": "todo", "tags": ["agent", "local"]},
     ])
     long_text = (
         "Julia Barnes is the CEO of The Movement Cooperative.\n\n"
@@ -1077,12 +1080,6 @@ def test_completion_spills_to_vault_when_over_cap(tmp_path: Path, monkeypatch):
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text=long_text,
     ))
-    w = _make_worker(tmp_path, api,
-                     preflight_caller=_golden_preflight(routing="claude"),
-                     local_executor=executor)  # used for unrelated paths
-    # Force the local path so we can drive the completion through _StubExecutor.
-    # Use routing="local" on the preflight so the worker takes the local branch
-    # while still exercising the cap logic.
     w = _make_worker(tmp_path, api,
                      preflight_caller=_golden_preflight(routing="local"),
                      local_executor=executor)

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -439,6 +439,61 @@ def test_completion_summary_uses_transcript_pointer_when_final_text_empty(tmp_pa
 
 
 @pytest.mark.unit
+def test_format_token_buckets_collapses_when_cache_is_zero():
+    """Local-path sessions never hit the prompt cache — the rendered string
+    should collapse to the original `N input + M output` shape."""
+    from api.services.agent_worker.worker import _format_token_buckets
+    assert _format_token_buckets(100, 0, 0, 50) == "100 input + 50 output"
+
+
+@pytest.mark.unit
+def test_format_token_buckets_includes_cache_creation_and_read_when_nonzero():
+    """Cloud sessions surface all four buckets so the operator can see what
+    drove cost (cache_creation typically dominates first-turn spend)."""
+    from api.services.agent_worker.worker import _format_token_buckets
+    rendered = _format_token_buckets(3, 109_075, 2_000, 81)
+    assert "3 input" in rendered
+    assert "109,075 cached-write" in rendered
+    assert "2,000 cached-read" in rendered
+    assert "81 output" in rendered
+
+
+@pytest.mark.unit
+def test_completion_summary_renders_four_bucket_breakdown(tmp_path: Path):
+    """When a managed session populated all four token buckets, the operator-
+    facing Telegram message must surface them — that's the visible signal
+    that #137 actually landed."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "draft email", "status": "todo",
+         "tags": ["agent", "cloud"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="Drafted.",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude"),
+                     local_executor=executor)
+    w.tick()
+    # Inject realistic four-bucket token totals via record_spend, then
+    # re-render the summary directly using the refreshed row.
+    w.session_store.record_spend(
+        "t1",
+        tokens_in=3,
+        tokens_out=81,
+        dollars=0.42,
+        cache_creation_tokens=109_075,
+        cache_read_tokens=2_000,
+    )
+    refreshed = w.session_store.get("t1")
+    msg = w._completion_summary(refreshed, {"id": "t1", "description": "draft email"},
+                                executor.outcome)
+    assert "3 input" in msg
+    assert "109,075 cached-write" in msg
+    assert "2,000 cached-read" in msg
+    assert "81 output" in msg
+
+
+@pytest.mark.unit
 def test_completion_summary_includes_init_failed_mcps_footer(tmp_path: Path):
     """When the managed executor reports MCPs that failed to initialize,
     the completion summary appends a "Note: N MCP server(s) unavailable"

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -605,6 +605,47 @@ def test_kill_session_swallows_errors():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.unit
+def test_update_session_sends_post_with_agent_payload():
+    """`update_session` POSTs the agent config under `agent` to the session
+    URL — full-replacement semantics per the Managed Agents docs."""
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"id": "sess_1"})
+
+    driver = _build_driver(handler)
+    driver.update_session("sess_1", {"tools": ["lifeos_search", "lifeos_ask"]})
+
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/sessions/sess_1")
+    assert captured["body"] == {
+        "agent": {"tools": ["lifeos_search", "lifeos_ask"]}
+    }
+
+
+@pytest.mark.unit
+def test_update_session_4xx_surfaces_response_body(caplog):
+    """A 4xx response logs the body so beta-API schema mismatches are
+    visible rather than swallowed."""
+    def handler(request):
+        return httpx.Response(
+            400, json={"error": "tools[3] is not a valid identifier"}
+        )
+
+    driver = _build_driver(handler)
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(httpx.HTTPStatusError):
+            driver.update_session("sess_1", {"tools": ["bogus tool"]})
+    body_logged = any(
+        "not a valid identifier" in rec.getMessage() for rec in caplog.records
+    )
+    assert body_logged, "expected 4xx body to be surfaced in WARNING logs"
+
+
+@pytest.mark.unit
 def test_managed_session_cost_includes_overhead():
     cost = managed_session_cost("claude-opus-4-7", 1000, 1000, wall_seconds=3600)
     # 1k input ($0.015) + 1k output ($0.075) + 1 hr * $0.08

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -617,3 +617,61 @@ def test_managed_session_cost_partial_hour():
     # 30 minutes of session-hour overhead.
     cost = managed_session_cost("local", 0, 0, wall_seconds=1800)
     assert cost == pytest.approx(0.5 * MANAGED_SESSION_HOUR_OVERHEAD)
+
+
+# ---------------------------------------------------------------------------
+# Prompt-cache token buckets (#137)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_session_state_parses_cache_creation_and_cache_read_tokens():
+    """The four-bucket usage payload from the live API must flow through
+    `get_session_state` into the materialized `ManagedSessionState`."""
+    handler = _make_session_handler(
+        status_body={
+            "status": "running",
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 81,
+                "cache_creation_input_tokens": 109_075,
+                "cache_read_input_tokens": 2_000,
+            },
+        },
+        events=[],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.total_input_tokens == 3
+    assert state.total_output_tokens == 81
+    assert state.total_cache_creation_tokens == 109_075
+    assert state.total_cache_read_tokens == 2_000
+
+
+@pytest.mark.unit
+def test_session_state_defaults_cache_buckets_to_zero_when_absent():
+    """Older API responses omit the cache buckets — should default to zero."""
+    handler = _make_session_handler(
+        status_body={"status": "running", "usage": {"input_tokens": 5, "output_tokens": 7}},
+        events=[],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.total_cache_creation_tokens == 0
+    assert state.total_cache_read_tokens == 0
+
+
+@pytest.mark.unit
+def test_managed_session_cost_includes_cache_buckets():
+    """cache_creation tokens are 1.25× input rate; cache_read is 0.10× input."""
+    # 100k cache_creation at Sonnet ($3/M input × 1.25) = $0.375
+    # 50k cache_read at Sonnet ($3/M input × 0.10) = $0.015
+    # 1000 input + 1000 output = $0.003 + $0.015 = $0.018
+    # No wall time → no overhead.
+    cost = managed_session_cost(
+        "claude-sonnet-4-6",
+        tokens_in=1000,
+        tokens_out=1000,
+        wall_seconds=0,
+        cache_creation_tokens=100_000,
+        cache_read_tokens=50_000,
+    )
+    expected = 0.018 + 0.375 + 0.015
+    assert cost == pytest.approx(expected)

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -435,6 +435,82 @@ def test_poll_kills_remote_session_on_token_budget_breach(stores):
 
 
 @pytest.mark.unit
+def test_poll_persists_cache_creation_and_cache_read_deltas(stores):
+    """All four token buckets (uncached input, output, cache_creation,
+    cache_read) must flow from driver state through record_spend into the
+    sessions row. Confirms the dollar total reflects cache costs."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[{"id": "evt_1", "type": "x"}],
+            total_input_tokens=10,
+            total_output_tokens=5,
+            total_cache_creation_tokens=100_000,
+            total_cache_read_tokens=2_000,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver, model="claude-sonnet-4-6")
+    executor.poll(session)
+    refreshed = store.get("t1")
+    assert refreshed.total_input_tokens == 10
+    assert refreshed.total_output_tokens == 5
+    assert refreshed.total_cache_creation_tokens == 100_000
+    assert refreshed.total_cache_read_tokens == 2_000
+    # Sonnet input $3/M:
+    # 10 input = $0.00003, 5 output ($15/M) = $0.000075,
+    # 100k cache_creation (×1.25) = $0.375, 2k cache_read (×0.10) = $0.0006.
+    # The dollar total also accrues session-hour overhead from test wall time
+    # ($0.08/hr) so we tolerate a small positive delta above the token cost.
+    expected_token_dollars = (
+        10 * 3.0e-6
+        + 5 * 15.0e-6
+        + 100_000 * 3.0e-6 * 1.25
+        + 2_000 * 3.0e-6 * 0.10
+    )
+    overhead_upper_bound = 60.0 / 3600.0 * 0.08  # 60s wall = generous
+    assert expected_token_dollars <= refreshed.total_dollars <= expected_token_dollars + overhead_upper_bound
+
+
+@pytest.mark.unit
+def test_poll_computes_cache_token_deltas_against_prior_state(stores):
+    """Token totals are absolute remote counts; record_spend gets deltas only."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[{"id": "evt_1", "type": "x"}],
+            total_input_tokens=5,
+            total_output_tokens=3,
+            total_cache_creation_tokens=50_000,
+            total_cache_read_tokens=1_000,
+        ),
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_2",
+            new_events=[{"id": "evt_2", "type": "y"}],
+            total_input_tokens=12,
+            total_output_tokens=8,
+            total_cache_creation_tokens=50_000,  # no new cache_creation
+            total_cache_read_tokens=4_500,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    executor.poll(session)
+    session = store.get("t1")
+    executor.poll(session)
+    refreshed = store.get("t1")
+    # Cumulative absolute totals — not double-counted.
+    assert refreshed.total_input_tokens == 12
+    assert refreshed.total_output_tokens == 8
+    assert refreshed.total_cache_creation_tokens == 50_000
+    assert refreshed.total_cache_read_tokens == 4_500
+
+
+@pytest.mark.unit
 def test_poll_kills_remote_session_on_dollar_budget_breach(stores):
     store, session, transcript = stores
     store.set_routing_and_budget(
@@ -458,6 +534,66 @@ def test_poll_kills_remote_session_on_dollar_budget_breach(stores):
     assert outcome.status == STATUS_BUDGET_EXCEEDED
     assert "max_dollars" in outcome.reason
     assert driver.kills
+
+
+@pytest.mark.unit
+def test_poll_dollar_breach_fires_from_cache_creation_cost_alone(stores):
+    """The whole point of #137: cache_creation-heavy sessions must trip
+    max_dollars even when uncached input + output are negligible. Previously
+    the dollar count missed cache cost entirely, so this didn't fire."""
+    store, session, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 1_000_000, "max_dollars": 0.10},
+        expected_output="text",
+    )
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 100k cache_creation at Sonnet ($3/M × 1.25) = $0.375 — over the $0.10 cap.
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_x",
+            new_events=[],
+            total_input_tokens=3,
+            total_output_tokens=81,
+            total_cache_creation_tokens=100_000,
+            total_cache_read_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver, model="claude-sonnet-4-6")
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "max_dollars" in outcome.reason
+
+
+@pytest.mark.unit
+def test_poll_dollar_breach_takes_precedence_over_token_breach(stores):
+    """When both budgets would breach, max_dollars wins. Dollars-first
+    enforcement means runaway cache_creation cost can't be masked by a
+    generous token cap."""
+    store, session, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        # Both caps fail: 200 tokens > 100-cap AND $0.003 > $0.001-cap.
+        budget={"wall_seconds": 3600, "max_tokens": 100, "max_dollars": 0.001},
+        expected_output="text",
+    )
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_x",
+            new_events=[],
+            total_input_tokens=200, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver, model="claude-opus-4-7")
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "max_dollars" in outcome.reason
+    assert "max_tokens" not in outcome.reason
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -30,12 +30,17 @@ VAULT_IDS = ["vlt_test"]
 class _FakeDriver:
     """Records calls and returns scripted state objects."""
 
-    def __init__(self, *, create_returns="sess_remote", state_responses=None, create_raises=None):
+    def __init__(self, *, create_returns="sess_remote", state_responses=None,
+                 create_raises=None, post_raises=None, update_raises=None):
         self.create_returns = create_returns
         self.state_responses = list(state_responses or [])
         self.create_raises = create_raises
+        self.post_raises = post_raises
+        self.update_raises = update_raises
         self.kills: list[tuple[str, str]] = []
         self.created_with: dict | None = None
+        self.posted_messages: list[tuple[str, str]] = []
+        self.updates: list[tuple[str, dict]] = []
         self.poll_calls: list[tuple[str, str | None]] = []
 
     def create_session(self, **kwargs):
@@ -43,6 +48,16 @@ class _FakeDriver:
         if self.create_raises:
             raise self.create_raises
         return self.create_returns
+
+    def post_user_message(self, session_id, content):
+        self.posted_messages.append((session_id, content))
+        if self.post_raises:
+            raise self.post_raises
+
+    def update_session(self, session_id, agent_payload):
+        self.updates.append((session_id, agent_payload))
+        if self.update_raises:
+            raise self.update_raises
 
     def get_session_state(self, session_id, since_event_id=None):
         self.poll_calls.append((session_id, since_event_id))
@@ -102,31 +117,32 @@ def test_start_creates_remote_session_with_agent_and_environment_ids(stores):
     assert cw["vault_ids"] == VAULT_IDS
     assert cw["metadata"]["lifeos_session_id"] == session.session_id
     assert cw["metadata"]["task_id"] == "t1"
-    # Initial message carries task description + soft budget. Budget is
+    # Per #139 §3 the initial message is NOT in the create_session kwargs —
+    # it's posted as a separate user.message AFTER an optional update_session.
+    assert "initial_message" not in cw
+    # The initial user message landed via post_user_message.
+    assert len(driver.posted_messages) == 1
+    posted_sid, posted_msg = driver.posted_messages[0]
+    assert posted_sid == "sess_remote_42"
+    # Posted message carries task description + soft budget. Budget is
     # framed as "soft" because Anthropic doesn't enforce it server-side;
     # the worker kills the session externally on breach.
-    assert "say hi" in cw["initial_message"]
-    assert "expected_output=text" in cw["initial_message"]
-    assert "soft budget" in cw["initial_message"]
-    assert "~$5.0" in cw["initial_message"]
-    # Today's date is injected for day-relative reasoning. Anthropic does
-    # not inject "today" into managed sessions, and the model has a fixed
-    # training cutoff — without this, calendar/due-date interpretation
-    # picks an arbitrary date inside the cutoff window.
+    assert "say hi" in posted_msg
+    assert "expected_output=text" in posted_msg
+    assert "soft budget" in posted_msg
+    assert "~$5.0" in posted_msg
+    # Today's date is injected for day-relative reasoning.
     import re
-    assert re.search(r"today=\d{4}-\d{2}-\d{2} \([A-Z][a-z]+day\)", cw["initial_message"]), \
-        cw["initial_message"][-300:]
-    # Ambiguity policy NOT duplicated here — it lives in the agent preset's
-    # system prompt (Anthropic console). User message stays task-specific.
-    assert "ambiguous" not in cw["initial_message"]
-    # session_id IS injected as `lifeos_session_id=…` so the cloud agent
-    # can pass it as `caller_session_id` on inter-agent tool calls. The
-    # MCP HTTP layer can't infer the caller server-side (cross-process),
-    # so the agent must supply it explicitly.
-    assert f"lifeos_session_id={session.session_id}" in cw["initial_message"]
-    # NO inline system_prompt / model / mcp_servers / connectors
+    assert re.search(r"today=\d{4}-\d{2}-\d{2} \([A-Z][a-z]+day\)", posted_msg), \
+        posted_msg[-300:]
+    # Ambiguity policy NOT duplicated here — it lives in the agent preset.
+    assert "ambiguous" not in posted_msg
+    assert f"lifeos_session_id={session.session_id}" in posted_msg
+    # NO inline system_prompt / model / mcp_servers / connectors / update call
+    # (no preset_class set on the session → no filter applied).
     assert "system_prompt" not in cw
     assert "model" not in cw
+    assert driver.updates == [], "no preset_class set → no update_session call"
     assert "mcp_servers" not in cw
     assert "connectors" not in cw
 
@@ -149,6 +165,99 @@ def test_start_omits_title_when_description_empty(stores):
     executor = _make_executor(store, transcript, driver)
     executor.start(session, {"id": "t1", "description": ""})
     assert driver.created_with["title"] is None
+
+
+@pytest.mark.unit
+def test_start_applies_tool_filter_when_preset_class_set(stores):
+    """When session.preset_class is set, the executor calls update_session
+    between create and the first user message — scoping cache_creation
+    to the class's filtered tool list (#139 §3)."""
+    store, _, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+        expected_output="text",
+        preset_class="research",
+    )
+    session = store.get("t1")
+    driver = _FakeDriver(create_returns="sess_remote")
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.start(session, {"id": "t1", "description": "look it up"})
+    assert outcome.status == STATUS_RUNNING
+    # update_session called once with the research-class filter.
+    assert len(driver.updates) == 1
+    upd_sid, upd_payload = driver.updates[0]
+    assert upd_sid == "sess_remote"
+    assert "tools" in upd_payload
+    assert "lifeos_drive_search" in upd_payload["tools"]  # research-class specialty
+    assert "lifeos_search" in upd_payload["tools"]        # cross-cutting
+    # The order matters: update_session must happen BEFORE the user message
+    # or cache_creation locks in on the unfiltered preset.
+    assert driver.posted_messages, "user message should still be posted"
+
+
+@pytest.mark.unit
+def test_start_skips_filter_for_fullstack_preset_class(stores):
+    """preset_class=fullstack means no filter — update_session is skipped."""
+    store, _, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+        expected_output="text",
+        preset_class="fullstack",
+    )
+    session = store.get("t1")
+    driver = _FakeDriver(create_returns="sess_remote")
+    executor = _make_executor(store, transcript, driver)
+    executor.start(session, {"id": "t1", "description": "anything"})
+    assert driver.updates == []
+
+
+@pytest.mark.unit
+def test_start_falls_back_to_full_preset_on_update_failure(stores):
+    """If update_session fails (4xx, schema mismatch), the session still
+    proceeds with the full preset — we don't want to abort a billable
+    session over a non-fatal filter issue."""
+    import httpx
+    store, _, transcript = stores
+    store.set_routing_and_budget(
+        "t1",
+        routing="claude",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 5.0},
+        expected_output="text",
+        preset_class="research",
+    )
+    session = store.get("t1")
+    driver = _FakeDriver(
+        create_returns="sess_remote",
+        update_raises=httpx.HTTPStatusError(
+            "400", request=httpx.Request("POST", "http://x"),
+            response=httpx.Response(400),
+        ),
+    )
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.start(session, {"id": "t1", "description": "research X"})
+    # Session continues despite the filter failure.
+    assert outcome.status == STATUS_RUNNING
+    assert driver.posted_messages, "initial message still posted after filter failure"
+
+
+@pytest.mark.unit
+def test_start_marks_failed_when_post_user_message_fails(stores):
+    """If posting the initial user message fails, the session is marked
+    failed — we can't proceed without it."""
+    store, _, transcript = stores
+    driver = _FakeDriver(
+        create_returns="sess_remote",
+        post_raises=RuntimeError("network blip"),
+    )
+    session = store.get("t1")
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.start(session, {"id": "t1", "description": "x"})
+    assert outcome.status == STATUS_FAILED
+    assert "post_user_message failed" in outcome.reason
 
 
 @pytest.mark.unit

--- a/tests/test_agent_worker_managed_executor.py
+++ b/tests/test_agent_worker_managed_executor.py
@@ -672,3 +672,221 @@ def test_poll_returns_running_on_transient_driver_error(stores):
     assert outcome.status == STATUS_RUNNING
     # Session not yet marked terminal.
     assert store.get("t1").status != STATUS_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Runaway detection (#139 Section 5)
+# ---------------------------------------------------------------------------
+
+def _tool_use(tool_name: str, args: dict, event_id: str = "evt") -> dict:
+    """Helper: build a `tool_use` event in the shape the driver returns."""
+    return {"id": event_id, "type": "tool_use", "name": tool_name, "input": args}
+
+
+def _agent_message(text: str = "thinking", event_id: str = "evt") -> dict:
+    return {"id": event_id, "type": "agent.message",
+            "content": [{"type": "text", "text": text}]}
+
+
+def _tool_result(payload: str, event_id: str = "evt") -> dict:
+    return {"id": event_id, "type": "tool_result", "content": payload}
+
+
+@pytest.mark.unit
+def test_runaway_tool_loop_kill_after_four_identical_calls(stores):
+    """Same tool + identical args 4× consecutively → kill."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    def same(i):
+        return _tool_use("lifeos_search", {"q": "X"}, f"evt_{i}")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_4",
+            new_events=[same(1), same(2), same(3), same(4)],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "tool_loop_detected" in outcome.reason
+    assert driver.kills  # remote session was killed
+
+
+@pytest.mark.unit
+def test_runaway_tool_loop_not_triggered_by_three_identical_calls(stores):
+    """Threshold is 4 — three identical calls is still tolerated (could
+    be a transient retry sequence)."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    def same(i):
+        return _tool_use("lifeos_search", {"q": "X"}, f"evt_{i}")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_3",
+            new_events=[same(1), same(2), same(3)],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_RUNNING
+    assert not driver.kills
+
+
+@pytest.mark.unit
+def test_runaway_tool_loop_resets_on_different_tool(stores):
+    """A different tool resets the loop counter so a legitimate retry path
+    (toolA, toolA, toolB, toolA, toolA, toolA, toolA) doesn't trip."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 3× toolA, then a different tool, then 3× toolA again — none of those
+    # streaks reach the 4-call threshold individually.
+    events = [
+        _tool_use("toolA", {"q": "X"}, "evt_1"),
+        _tool_use("toolA", {"q": "X"}, "evt_2"),
+        _tool_use("toolA", {"q": "X"}, "evt_3"),
+        _tool_use("toolB", {"q": "Y"}, "evt_4"),
+        _tool_use("toolA", {"q": "X"}, "evt_5"),
+        _tool_use("toolA", {"q": "X"}, "evt_6"),
+    ]
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_6",
+            new_events=events,
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_RUNNING
+    assert not driver.kills
+
+
+@pytest.mark.unit
+def test_runaway_tool_loop_persists_across_polls(stores):
+    """Counter survives across polls: 2 identical calls in poll 1, 2 more
+    identical in poll 2 → 4 consecutive → kill on poll 2."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    def same(i):
+        return _tool_use("lifeos_search", {"q": "X"}, f"evt_{i}")
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_2",
+            new_events=[same(1), same(2)],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_4",
+            new_events=[same(3), same(4)],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome1 = executor.poll(session)
+    assert outcome1.status == STATUS_RUNNING
+    session = store.get("t1")
+    outcome2 = executor.poll(session)
+    assert outcome2.status == STATUS_BUDGET_EXCEEDED
+    assert "tool_loop_detected" in outcome2.reason
+
+
+@pytest.mark.unit
+def test_runaway_no_progress_kill_after_fifteen_tools_no_message(stores):
+    """15 tool calls with no agent.message → kill."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 15 different tools so tool-loop doesn't fire first.
+    events = [
+        _tool_use(f"tool_{i}", {"i": i}, f"evt_{i}") for i in range(15)
+    ]
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_14",
+            new_events=events,
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert "no_text_in_15_tool_calls" in outcome.reason
+
+
+@pytest.mark.unit
+def test_runaway_no_progress_resets_on_agent_message(stores):
+    """An intervening agent.message resets the no-progress counter."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    # 10 tools, then a message, then 10 more tools — neither streak
+    # reaches 15, so no kill.
+    events = (
+        [_tool_use(f"tool_{i}", {"i": i}, f"evt_a_{i}") for i in range(10)]
+        + [_agent_message("here's an update", "evt_msg")]
+        + [_tool_use(f"tool_{i}", {"i": i}, f"evt_b_{i}") for i in range(10)]
+    )
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_b_9",
+            new_events=events,
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    outcome = executor.poll(session)
+    assert outcome.status == STATUS_RUNNING
+
+
+@pytest.mark.unit
+def test_oversized_tool_result_truncated_in_transcript(stores):
+    """A >20KB tool_result is truncated when mirrored to the transcript."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    big_payload = "X" * 30_000
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[_tool_result(big_payload, "evt_1")],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    executor.poll(session)
+    # The transcript should hold a truncated copy, not the full payload.
+    entries = transcript.read(session.session_id)
+    tool_results = [e for e in entries if e["kind"] == "managed_event_tool_result"]
+    assert tool_results
+    stored = tool_results[0]["payload"]
+    assert len(stored["content"]) < 30_000
+    assert "[…truncated]" in stored["content"]
+    assert stored.get("_truncated_from_chars") == 30_000
+
+
+@pytest.mark.unit
+def test_undersized_tool_result_not_truncated(stores):
+    """Tool results under the threshold pass through unchanged."""
+    store, session, transcript = stores
+    store.set_managed_session_id("t1", "sess_remote")
+    session = store.get("t1")
+    payload = "ok"
+    driver = _FakeDriver(state_responses=[
+        ManagedSessionState(
+            session_id="sess_remote", status="running", last_event_id="evt_1",
+            new_events=[_tool_result(payload, "evt_1")],
+            total_input_tokens=0, total_output_tokens=0,
+        ),
+    ])
+    executor = _make_executor(store, transcript, driver)
+    executor.poll(session)
+    entries = transcript.read(session.session_id)
+    tool_results = [e for e in entries if e["kind"] == "managed_event_tool_result"]
+    assert tool_results[0]["payload"]["content"] == "ok"
+    assert "_truncated_from_chars" not in tool_results[0]["payload"]

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -200,3 +200,99 @@ def test_preflight_prompt_includes_ordered_precedence():
     assert "use claude" in prompt
     assert "capability" in prompt.lower() or "infer from capability" in prompt.lower()
     assert "ask" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tag precedence (#139 §2)
+# ---------------------------------------------------------------------------
+
+def _stub_caller(routing="claude"):
+    """Build a fake caller returning a minimal preflight JSON."""
+    import json
+    def call(_prompt):
+        return json.dumps({
+            "budget": {"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 0.50},
+            "routing": routing,
+            "routing_reason": "stub",
+            "expected_output": "text",
+            "ambiguity": None,
+            "sane": True,
+            "sane_reason": "",
+        })
+    return call
+
+
+@pytest.mark.unit
+def test_cloud_haiku_tag_forces_haiku_routing():
+    """`#cloud-haiku` always picks Haiku, regardless of preflight's choice."""
+    result = pf.run_preflight("ambiguous task", tags=["agent", "cloud-haiku"],
+                              caller=_stub_caller(routing="local"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.model == pf.MODEL_HAIKU
+    assert "cloud-haiku" in result.routing_reason
+
+
+@pytest.mark.unit
+def test_cloud_sonnet_tag_forces_sonnet_routing():
+    """`#cloud-sonnet` always picks Sonnet."""
+    result = pf.run_preflight("anything", tags=["agent", "cloud-sonnet"],
+                              caller=_stub_caller(routing="local"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.model == pf.MODEL_SONNET
+    assert "cloud-sonnet" in result.routing_reason
+
+
+@pytest.mark.unit
+def test_local_tag_overrides_to_local_model():
+    """`#local` forces local regardless of preflight's choice."""
+    result = pf.run_preflight("task", tags=["agent", "local"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.routing == pf.ROUTE_LOCAL
+    assert result.model == pf.MODEL_LOCAL
+
+
+@pytest.mark.unit
+def test_cloud_tag_keeps_preflight_routing_but_defaults_model_to_sonnet():
+    """`#cloud` says cloud but leaves the model open — defaults to Sonnet
+    when preflight didn't pick a specific model."""
+    result = pf.run_preflight("anything", tags=["agent", "cloud"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.model == pf.MODEL_SONNET
+
+
+@pytest.mark.unit
+def test_untagged_cloud_route_defaults_to_sonnet():
+    """No model-specifying tag, preflight returns `claude` → Sonnet default."""
+    result = pf.run_preflight("draft an email", tags=["agent"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.model == pf.MODEL_SONNET
+
+
+@pytest.mark.unit
+def test_untagged_local_route_sets_model_to_local():
+    """Local routing without override gets MODEL_LOCAL."""
+    result = pf.run_preflight("quick lookup", tags=["agent"],
+                              caller=_stub_caller(routing="local"))
+    assert result.routing == pf.ROUTE_LOCAL
+    assert result.model == pf.MODEL_LOCAL
+
+
+@pytest.mark.unit
+def test_tag_precedence_haiku_wins_over_sonnet_tag():
+    """If both #cloud-haiku and #cloud-sonnet are present, the first match
+    in the precedence ladder wins (haiku checked before sonnet)."""
+    result = pf.run_preflight("anything",
+                              tags=["agent", "cloud-haiku", "cloud-sonnet"],
+                              caller=_stub_caller(routing="claude"))
+    # Per the ladder docstring: cloud-haiku is checked before cloud-sonnet.
+    assert result.model == pf.MODEL_HAIKU
+
+
+@pytest.mark.unit
+def test_tag_precedence_accepts_hash_prefix_form():
+    """Operators sometimes write the leading `#`; the parser must accept it."""
+    result = pf.run_preflight("anything", tags=["#agent", "#cloud-haiku"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.model == pf.MODEL_HAIKU

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -296,3 +296,58 @@ def test_tag_precedence_accepts_hash_prefix_form():
     result = pf.run_preflight("anything", tags=["#agent", "#cloud-haiku"],
                               caller=_stub_caller(routing="claude"))
     assert result.model == pf.MODEL_HAIKU
+
+
+# ---------------------------------------------------------------------------
+# Preset class tag detection (#139 §3 wiring)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_preset_class_tag_sets_preset_class():
+    """An explicit class tag (#research / #crm / etc.) sets preset_class."""
+    result = pf.run_preflight("dig into Q4 numbers", tags=["agent", "research"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.preset_class == "research"
+
+
+@pytest.mark.unit
+def test_each_preset_class_tag_recognized():
+    """All six class tags map to the right preset_class string."""
+    for tag in ("personal-comm", "work-comm", "research", "financial", "crm", "fullstack"):
+        result = pf.run_preflight("any task", tags=["agent", tag],
+                                  caller=_stub_caller(routing="claude"))
+        assert result.preset_class == tag, f"tag #{tag} should set preset_class={tag}"
+
+
+@pytest.mark.unit
+def test_preset_class_accepts_hash_prefix_form():
+    """Operators may write `#research` or `research` — both map to the class."""
+    result = pf.run_preflight("any task", tags=["#agent", "#crm"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.preset_class == "crm"
+
+
+@pytest.mark.unit
+def test_first_preset_class_tag_wins_on_conflict():
+    """If two class tags slip in, the first one in the tag list wins."""
+    result = pf.run_preflight("any task", tags=["agent", "crm", "research"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.preset_class == "crm"
+
+
+@pytest.mark.unit
+def test_no_class_tag_leaves_preset_class_none():
+    """Without an explicit class tag, preset_class stays None — the worker
+    defaults to fullstack (no filter)."""
+    result = pf.run_preflight("ambiguous task", tags=["agent"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.preset_class is None
+
+
+@pytest.mark.unit
+def test_preset_class_set_on_empty_title_short_circuit():
+    """The empty-title short-circuit path also honors a class tag."""
+    result = pf.run_preflight("", tags=["agent", "financial"])
+    assert result.preset_class == "financial"
+    # And the sane flag is still false (empty title is unsafe regardless of tags).
+    assert result.sane is False

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -351,3 +351,113 @@ def test_preset_class_set_on_empty_title_short_circuit():
     assert result.preset_class == "financial"
     # And the sane flag is still false (empty title is unsafe regardless of tags).
     assert result.sane is False
+
+
+# ---------------------------------------------------------------------------
+# Cost gates: fail-fast budget check (#139 §6) + cost preview (#139 §7)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_cloud_route_emits_cost_estimate():
+    """Cloud-routed tasks get a non-zero cache-cold cost estimate so the
+    orchestrator can preview cost before dispatch."""
+    result = pf.run_preflight("research task", tags=["agent", "research"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.routing == pf.ROUTE_CLAUDE
+    assert result.estimated_cost_dollars > 0
+
+
+@pytest.mark.unit
+def test_local_route_emits_zero_estimate():
+    """Local routing is free compute (operator paid for the hardware)."""
+    result = pf.run_preflight("anything", tags=["agent", "local"],
+                              caller=_stub_caller(routing="local"))
+    assert result.routing == pf.ROUTE_LOCAL
+    assert result.estimated_cost_dollars == 0.0
+    assert result.needs_cost_confirmation is False
+
+
+@pytest.mark.unit
+def test_fullstack_estimate_higher_than_research_estimate():
+    """Larger preset classes are estimated more expensively — that's the
+    whole point of per-class filtering."""
+    full = pf.run_preflight("any task", tags=["agent", "fullstack"],
+                            caller=_stub_caller(routing="claude"))
+    research = pf.run_preflight("any task", tags=["agent", "research"],
+                                caller=_stub_caller(routing="claude"))
+    assert full.estimated_cost_dollars > research.estimated_cost_dollars
+
+
+@pytest.mark.unit
+def test_fail_fast_refuses_when_estimate_exceeds_2x_max_dollars():
+    """§6 acceptance: refuse dispatch when cache-cold estimate exceeds
+    2× max_dollars (refuse only when even the cheap path can't fit)."""
+    # fullstack on Sonnet = 100k × $3/M × 1.25 ≈ $0.375. 2× = $0.75.
+    # Set max_dollars below that floor (so 2× margin still doesn't fit).
+    import json
+    def stub_caller(_p):
+        return json.dumps({
+            "budget": {"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 0.10},
+            "routing": "claude",
+            "routing_reason": "stub",
+            "expected_output": "text",
+            "ambiguity": None,
+            "sane": True,
+            "sane_reason": "",
+        })
+    result = pf.run_preflight("expensive task", tags=["agent", "fullstack"],
+                              caller=stub_caller)
+    assert result.sane is False
+    assert "budget_too_small" in result.sane_reason
+
+
+@pytest.mark.unit
+def test_fail_fast_does_not_refuse_when_2x_margin_fits():
+    """Cache-warm tasks aren't over-refused: when 2× max_dollars covers
+    the estimate, dispatch is allowed (real cost may be 10× cheaper from
+    cache_read on a warm cache)."""
+    import json
+    def stub_caller(_p):
+        return json.dumps({
+            "budget": {"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 5.0},
+            "routing": "claude",
+            "routing_reason": "stub",
+            "expected_output": "text",
+            "ambiguity": None,
+            "sane": True,
+            "sane_reason": "",
+        })
+    result = pf.run_preflight("normal task", tags=["agent", "research"],
+                              caller=stub_caller)
+    assert result.sane is True
+    assert "budget_too_small" not in result.sane_reason
+
+
+@pytest.mark.unit
+def test_cost_confirmation_triggers_above_threshold(monkeypatch):
+    """§7 acceptance: estimate > threshold sets needs_cost_confirmation."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_cost_confirm_threshold_dollars", 0.01)
+    result = pf.run_preflight("any task", tags=["agent", "fullstack"],
+                              caller=_stub_caller(routing="claude"))
+    # fullstack estimate is well over a penny.
+    assert result.needs_cost_confirmation is True
+
+
+@pytest.mark.unit
+def test_cost_confirmation_not_triggered_below_threshold(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_cost_confirm_threshold_dollars", 1000.0)
+    result = pf.run_preflight("any task", tags=["agent", "fullstack"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.needs_cost_confirmation is False
+
+
+@pytest.mark.unit
+def test_cost_confirmation_disabled_when_threshold_zero(monkeypatch):
+    """Threshold=0 disables confirmation entirely (auto-dispatch all)."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_cost_confirm_threshold_dollars", 0.0)
+    result = pf.run_preflight("any task", tags=["agent", "fullstack"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.needs_cost_confirmation is False

--- a/tests/test_anthropic_api_guard.py
+++ b/tests/test_anthropic_api_guard.py
@@ -1,0 +1,71 @@
+"""Verifies the conftest-level guard that blocks real api.anthropic.com calls.
+
+A test that forgets to mock the LLM client can silently rack up billed API
+calls. The guard installed in `tests/conftest.py` patches httpx to fail any
+test that hits an Anthropic host. This module is the canary that proves the
+guard works: it makes a request to api.anthropic.com (the marker
+`allow_anthropic_api` lets the canary bypass) and the negative test confirms
+that an *unmarked* test would have been blocked.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_guard_blocks_unmarked_anthropic_call():
+    """Without the marker, a request to api.anthropic.com must raise."""
+    with pytest.raises(RuntimeError, match="real Anthropic API call"):
+        with httpx.Client(timeout=0.001) as c:
+            # We never actually connect — the guard fires before send.
+            c.get("https://api.anthropic.com/v1/models")
+
+
+def test_guard_blocks_async_anthropic_call():
+    """The async client is patched the same way."""
+    import asyncio
+
+    async def _go():
+        async with httpx.AsyncClient(timeout=0.001) as c:
+            await c.get("https://api.anthropic.com/v1/models")
+
+    with pytest.raises(RuntimeError, match="real Anthropic API call"):
+        asyncio.run(_go())
+
+
+def test_guard_blocks_platform_console_calls():
+    """platform.claude.com is also covered — that's where managed-agents
+    sessions are inspected."""
+    with pytest.raises(RuntimeError, match="real Anthropic API call"):
+        with httpx.Client(timeout=0.001) as c:
+            c.get("https://platform.claude.com/api/sessions")
+
+
+def test_guard_allows_non_anthropic_hosts():
+    """The guard is targeted — it only blocks Anthropic hosts. Other
+    outbound calls (or any MockTransport-routed call) flow through."""
+    # MockTransport never makes a real network call; using it here also
+    # proves the guard doesn't interfere with mocked transports.
+    transport = httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True}))
+    with httpx.Client(transport=transport, base_url="https://api.anthropic.com") as c:
+        # Even though the URL host is api.anthropic.com, the request would
+        # need to reach send to be intercepted. MockTransport runs before
+        # the patched send body, so we expect the guard to STILL fire to
+        # prevent a real-call surprise even via mock. This is the
+        # conservative posture — block first, allow only via marker.
+        with pytest.raises(RuntimeError, match="real Anthropic API call"):
+            c.get("/v1/messages")
+
+
+@pytest.mark.allow_anthropic_api
+def test_marker_bypasses_guard_for_deliberate_real_calls():
+    """`@pytest.mark.allow_anthropic_api` lets a test reach the real API.
+    We don't actually connect (timeout=1ms) — only verify the guard does
+    NOT raise its RuntimeError. Any connection-shaped exception is fine."""
+    with pytest.raises(Exception) as exc_info:
+        with httpx.Client(timeout=0.001) as c:
+            c.get("https://api.anthropic.com/v1/models")
+    # We expect a timeout / connect error, NOT our guard's RuntimeError.
+    assert "real Anthropic API call" not in str(exc_info.value)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,10 +9,8 @@ These tests verify that:
 Run with: pytest tests/test_mcp_server.py -v
 Requires: LifeOS API running on localhost:8000
 """
-import json
 import pytest
 import httpx
-import subprocess
 import sys
 from pathlib import Path
 
@@ -254,7 +252,6 @@ class TestAPIOpenAPISync:
         spec.loader.exec_module(module)
 
         server = module.LifeOSMCPServer()
-        schemas = openapi_spec.get("components", {}).get("schemas", {})
 
         # Check that lifeos_ask has question field
         ask_tool = next((t for t in server.tools if t["name"] == "lifeos_ask"), None)
@@ -267,3 +264,36 @@ class TestAPIOpenAPISync:
         if search_tool:
             props = search_tool["inputSchema"].get("properties", {})
             assert "query" in props, "lifeos_search missing 'query' property"
+
+
+# ---------------------------------------------------------------------------
+# Tool description sizing (#139 §1) — keep cache_creation cheap.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_curated_endpoint_descriptions_average_under_30_words():
+    """Every tool description ships into the MCP system prompt, contributing
+    to cache_creation cost on every fresh managed session. Keep the average
+    under 30 words; no single description over 30 words.
+
+    Run `python -c "from mcp_server import CURATED_ENDPOINTS; ..."` to
+    measure manually."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    descriptions = [
+        cfg["description"] for cfg in module.CURATED_ENDPOINTS.values()
+    ]
+    word_counts = [len(d.split()) for d in descriptions]
+    avg = sum(word_counts) / len(word_counts)
+    over_threshold = [
+        (cfg["name"], len(cfg["description"].split()))
+        for cfg in module.CURATED_ENDPOINTS.values()
+        if len(cfg["description"].split()) > 30
+    ]
+    assert avg <= 30, f"avg description word count too high: {avg:.1f}"
+    assert not over_threshold, (
+        f"tools with >30-word description: {over_threshold}. "
+        "Trim them — every word lands in cache_creation."
+    )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -297,3 +297,95 @@ def test_curated_endpoint_descriptions_average_under_30_words():
         f"tools with >30-word description: {over_threshold}. "
         "Trim them — every word lands in cache_creation."
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-session tool result cache integration (#139 §4)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_call_api_caches_get_results_per_session():
+    """Identical GET-shaped calls within the same session hit the cache:
+    the second call MUST NOT round-trip to the API."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    server = module.LifeOSMCPServer()
+    # Replace the httpx client with a mock so we can count call counts.
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"events": [{"title": "standup"}]}
+    fake_response.raise_for_status = MagicMock()
+    fake.get.return_value = fake_response
+    server.client = fake
+
+    # First call: round-trips.
+    r1 = server._call_api(
+        "lifeos_calendar_upcoming", {"days": 7}, session_id="sess_X"
+    )
+    # Second call: should hit the cache, not the HTTP client.
+    r2 = server._call_api(
+        "lifeos_calendar_upcoming", {"days": 7}, session_id="sess_X"
+    )
+    assert r1 == r2
+    assert fake.get.call_count == 1, "expected exactly one HTTP call (second served from cache)"
+
+
+@pytest.mark.unit
+def test_call_api_does_not_cache_writes():
+    """POST/PUT/DELETE tools are never cached."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    server = module.LifeOSMCPServer()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"id": "draft_1"}
+    fake_response.raise_for_status = MagicMock()
+    fake.post.return_value = fake_response
+    server.client = fake
+
+    server._call_api(
+        "lifeos_gmail_draft",
+        {"to": "x@y", "subject": "hi", "body": "ok"},
+        session_id="sess_X",
+    )
+    server._call_api(
+        "lifeos_gmail_draft",
+        {"to": "x@y", "subject": "hi", "body": "ok"},
+        session_id="sess_X",
+    )
+    # Both calls hit the API — POST is never cached.
+    assert fake.post.call_count == 2
+
+
+@pytest.mark.unit
+def test_call_api_skips_cache_when_session_id_missing():
+    """Without a session_id (e.g., local CLI use), the cache is bypassed."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    server = module.LifeOSMCPServer()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"events": []}
+    fake_response.raise_for_status = MagicMock()
+    fake.get.return_value = fake_response
+    server.client = fake
+
+    server._call_api("lifeos_calendar_upcoming", {"days": 7})
+    server._call_api("lifeos_calendar_upcoming", {"days": 7})
+    # Both calls round-trip — no session, no cache.
+    assert fake.get.call_count == 2

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -85,6 +85,61 @@ class TestTasksAPI:
         })
         assert response.status_code in (400, 422)  # Validation error
 
+    # --- DRY RUN (#138) ---
+
+    def test_dry_run_with_agent_tag_returns_preflight_preview(self, client, mock_task_manager):
+        """dry_run=true on an #agent task runs preflight and returns the
+        routing decision + cost estimate WITHOUT creating the task."""
+        from api.services.agent_worker.preflight import (
+            PreflightBudget,
+            PreflightResult,
+            ROUTE_CLAUDE,
+        )
+        fake_result = PreflightResult(
+            budget=PreflightBudget(wall_seconds=600, max_tokens=20_000, max_dollars=2.0),
+            routing=ROUTE_CLAUDE,
+            routing_reason="multi-step task; needs cloud",
+            expected_output="text",
+            ambiguity=None,
+            sane=True,
+            sane_reason="",
+        )
+        with patch("api.services.agent_worker.preflight.run_preflight", return_value=fake_result):
+            response = client.post("/api/tasks", json={
+                "description": "draft my Q4 review",
+                "tags": ["agent"],
+                "dry_run": True,
+            })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["dry_run"] is True
+        assert data["routing"] == "claude"
+        assert data["budget"]["max_dollars"] == 2.0
+        assert data["estimated_dollars"] > 0
+        # The dry-run path does NOT touch the task manager.
+        mock_task_manager.create.assert_not_called()
+
+    def test_dry_run_without_agent_tag_falls_through_to_create(self, client, mock_task_manager):
+        """dry_run is a no-op for non-#agent tasks — the task is still created."""
+        response = client.post("/api/tasks", json={
+            "description": "shopping list",
+            "dry_run": True,
+        })
+        assert response.status_code == 200
+        # Falls through to real task creation.
+        mock_task_manager.create.assert_called_once()
+
+    def test_dry_run_false_creates_task_normally(self, client, mock_task_manager):
+        """dry_run=false on an #agent task still creates it (the worker
+        picks it up later and does its own preflight)."""
+        response = client.post("/api/tasks", json={
+            "description": "dispatch this",
+            "tags": ["agent"],
+            "dry_run": False,
+        })
+        assert response.status_code == 200
+        mock_task_manager.create.assert_called_once()
+
     # --- LIST ---
 
     def test_list_tasks(self, client, mock_task_manager):

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -1,0 +1,125 @@
+"""Tests for the per-class tool filter helper (#139 §3, partial)."""
+from __future__ import annotations
+
+import pytest
+
+from api.services.agent_worker.tool_filter import (
+    ALL_PRESET_CLASSES,
+    CROSS_CUTTING_LIFEOS_TOOLS,
+    PRESET_CLASS_CRM,
+    PRESET_CLASS_FINANCIAL,
+    PRESET_CLASS_FULLSTACK,
+    PRESET_CLASS_PERSONAL_COMM,
+    PRESET_CLASS_RESEARCH,
+    PRESET_CLASS_WORK_COMM,
+    class_to_tool_filter,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_fullstack_class_returns_none():
+    """fullstack means 'no filter' — worker should skip the UPDATE call."""
+    assert class_to_tool_filter(PRESET_CLASS_FULLSTACK) is None
+
+
+def test_unknown_class_returns_none():
+    """Defensive: a typo or future class returns None instead of an empty
+    filter (which would lock the agent out of all tools)."""
+    assert class_to_tool_filter("not-a-real-class") is None
+
+
+@pytest.mark.parametrize("preset_class", [
+    PRESET_CLASS_PERSONAL_COMM,
+    PRESET_CLASS_WORK_COMM,
+    PRESET_CLASS_RESEARCH,
+    PRESET_CLASS_FINANCIAL,
+    PRESET_CLASS_CRM,
+])
+def test_every_class_includes_all_cross_cutting_tools(preset_class):
+    """Cross-cutting tools (telegram, agent_*, search, ask, etc.) must
+    appear in every non-fullstack class's filter so the agent can always
+    message back, spawn children, and search."""
+    payload = class_to_tool_filter(preset_class)
+    assert payload is not None
+    tools = set(payload["tools"])
+    missing = set(CROSS_CUTTING_LIFEOS_TOOLS) - tools
+    assert not missing, f"{preset_class} missing cross-cutting tools: {missing}"
+
+
+def test_personal_comm_class_has_gmail_and_imessage():
+    """personal-comm specializes in personal messaging."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_PERSONAL_COMM)["tools"])
+    assert "lifeos_gmail_search" in tools
+    assert "lifeos_gmail_draft" in tools
+    assert "lifeos_imessage_search" in tools
+    # And it gets calendar writes (comms classes need to schedule).
+    assert "lifeos_calendar_create" in tools
+
+
+def test_work_comm_class_has_slack_and_drive():
+    """work-comm specializes in workplace systems."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_WORK_COMM)["tools"])
+    assert "lifeos_slack_search" in tools
+    assert "lifeos_drive_search" in tools
+
+
+def test_research_class_excludes_calendar_writes():
+    """research is read-only — no calendar create/update/delete.
+    Calendar READS (upcoming, search) are cross-cutting and ARE included."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_RESEARCH)["tools"])
+    assert "lifeos_calendar_upcoming" in tools  # cross-cutting read
+    assert "lifeos_calendar_create" not in tools  # write — excluded
+    assert "lifeos_calendar_delete" not in tools
+
+
+def test_financial_class_has_monarch_tools():
+    """financial specializes in money tools."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_FINANCIAL)["tools"])
+    assert "lifeos_monarch_accounts" in tools
+    assert "lifeos_monarch_transactions" in tools
+    assert "lifeos_monarch_cashflow" in tools
+    assert "lifeos_monarch_budgets" in tools
+
+
+def test_crm_class_has_full_person_family():
+    """crm specializes in the people/person/photos tools."""
+    tools = set(class_to_tool_filter(PRESET_CLASS_CRM)["tools"])
+    assert "lifeos_people_search" in tools
+    assert "lifeos_person_profile" in tools
+    assert "lifeos_person_facts" in tools
+    assert "lifeos_photos_person" in tools
+    assert "lifeos_meeting_prep" in tools
+    assert "lifeos_communication_gaps" in tools
+
+
+def test_filter_payload_does_not_include_mcp_servers_key():
+    """MCP server list lives on the preset, not in per-session filtering.
+    Emitting an mcp_servers key here would risk overriding the preset's
+    list with an empty array."""
+    payload = class_to_tool_filter(PRESET_CLASS_RESEARCH)
+    assert payload is not None
+    assert "mcp_servers" not in payload
+    assert set(payload.keys()) == {"tools"}
+
+
+def test_filter_payload_is_deduplicated_and_sorted():
+    """Output order is stable across calls so transcript diffs are clean."""
+    payload = class_to_tool_filter(PRESET_CLASS_PERSONAL_COMM)
+    assert payload is not None
+    tools = payload["tools"]
+    assert tools == sorted(set(tools)), "tool list must be deduped + sorted"
+    # And calling twice yields identical output.
+    assert class_to_tool_filter(PRESET_CLASS_PERSONAL_COMM) == payload
+
+
+def test_all_classes_constant_matches_handled_classes():
+    """The ALL_PRESET_CLASSES tuple matches what class_to_tool_filter
+    actually handles — drift between the two would silently break the
+    operator's view of available classes."""
+    assert PRESET_CLASS_FULLSTACK in ALL_PRESET_CLASSES
+    for cls in ALL_PRESET_CLASSES:
+        # Either None (fullstack) or a real payload — never raises.
+        result = class_to_tool_filter(cls)
+        assert result is None or "tools" in result

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -13,6 +13,7 @@ from api.services.agent_worker.tool_filter import (
     PRESET_CLASS_RESEARCH,
     PRESET_CLASS_WORK_COMM,
     class_to_tool_filter,
+    estimated_cache_creation_tokens,
 )
 
 
@@ -123,3 +124,31 @@ def test_all_classes_constant_matches_handled_classes():
         # Either None (fullstack) or a real payload — never raises.
         result = class_to_tool_filter(cls)
         assert result is None or "tools" in result
+
+
+# ---------------------------------------------------------------------------
+# Per-class cost estimates (#139 §6 — hardcoded floor pending live probe)
+# ---------------------------------------------------------------------------
+
+def test_estimated_cache_creation_tokens_positive_for_every_class():
+    """Each named class returns a positive estimate."""
+    for cls in ALL_PRESET_CLASSES:
+        est = estimated_cache_creation_tokens(cls)
+        assert est > 0, f"{cls} estimate must be positive"
+
+
+def test_fullstack_estimate_is_highest():
+    """Unfiltered preset is the worst-case — no filter can be cheaper."""
+    full = estimated_cache_creation_tokens(PRESET_CLASS_FULLSTACK)
+    for cls in (PRESET_CLASS_PERSONAL_COMM, PRESET_CLASS_WORK_COMM,
+                PRESET_CLASS_RESEARCH, PRESET_CLASS_FINANCIAL,
+                PRESET_CLASS_CRM):
+        assert estimated_cache_creation_tokens(cls) <= full
+
+
+def test_unknown_class_falls_back_to_fullstack_estimate():
+    """Conservative default — over-estimating cost is safer than
+    under-estimating (we'd rather refuse a runaway than allow one)."""
+    full = estimated_cache_creation_tokens(PRESET_CLASS_FULLSTACK)
+    assert estimated_cache_creation_tokens("not-a-real-class") == full
+    assert estimated_cache_creation_tokens(None) == full

--- a/tests/test_tool_result_cache.py
+++ b/tests/test_tool_result_cache.py
@@ -1,0 +1,104 @@
+"""Tests for the per-session tool result cache (#139 §4)."""
+from __future__ import annotations
+
+import pytest
+
+from api.services.agent_worker.tool_result_cache import SessionToolResultCache
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_returns_none_when_empty():
+    cache = SessionToolResultCache()
+    assert cache.get("sess_1", "lifeos_calendar_upcoming", {"days": 7}) is None
+
+
+def test_put_then_get_returns_stored_result():
+    cache = SessionToolResultCache()
+    result = {"events": [{"title": "standup"}]}
+    cache.put("sess_1", "lifeos_calendar_upcoming", {"days": 7}, result)
+    assert cache.get("sess_1", "lifeos_calendar_upcoming", {"days": 7}) == result
+
+
+def test_args_key_is_order_independent():
+    """`{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` must collide."""
+    cache = SessionToolResultCache()
+    cache.put("sess_1", "lifeos_search", {"a": 1, "b": 2}, {"hits": [1]})
+    # Same logical args, different insertion order.
+    assert cache.get("sess_1", "lifeos_search", {"b": 2, "a": 1}) == {"hits": [1]}
+
+
+def test_different_args_do_not_collide():
+    cache = SessionToolResultCache()
+    cache.put("sess_1", "lifeos_search", {"q": "X"}, {"hits": ["x"]})
+    assert cache.get("sess_1", "lifeos_search", {"q": "Y"}) is None
+
+
+def test_different_sessions_do_not_share():
+    """Session A's cache MUST NOT leak into session B's request."""
+    cache = SessionToolResultCache()
+    cache.put("sess_A", "lifeos_calendar_upcoming", {"days": 7}, {"a": 1})
+    assert cache.get("sess_B", "lifeos_calendar_upcoming", {"days": 7}) is None
+
+
+def test_ttl_expires_stale_entries():
+    """An entry older than ttl_seconds returns None."""
+    fake_now = [1000.0]
+    cache = SessionToolResultCache(ttl_seconds=60, clock=lambda: fake_now[0])
+    cache.put("sess_1", "lifeos_search", {"q": "X"}, {"hits": [1]})
+    # Within TTL — still hits.
+    fake_now[0] = 1059.0
+    assert cache.get("sess_1", "lifeos_search", {"q": "X"}) == {"hits": [1]}
+    # Past TTL — miss, and the stale entry is dropped.
+    fake_now[0] = 1061.0
+    assert cache.get("sess_1", "lifeos_search", {"q": "X"}) is None
+    assert len(cache) == 0
+
+
+def test_lru_eviction_when_capacity_exceeded():
+    """Oldest entry is evicted when capacity fills."""
+    cache = SessionToolResultCache(max_entries=2)
+    cache.put("sess_1", "tool_a", {}, "A")
+    cache.put("sess_1", "tool_b", {}, "B")
+    cache.put("sess_1", "tool_c", {}, "C")
+    # Oldest (tool_a) was evicted.
+    assert cache.get("sess_1", "tool_a", {}) is None
+    assert cache.get("sess_1", "tool_b", {}) == "B"
+    assert cache.get("sess_1", "tool_c", {}) == "C"
+
+
+def test_get_touches_lru_so_recently_used_survives_eviction():
+    """A get on tool_a should refresh its position so the next put evicts
+    tool_b instead."""
+    cache = SessionToolResultCache(max_entries=2)
+    cache.put("sess_1", "tool_a", {}, "A")
+    cache.put("sess_1", "tool_b", {}, "B")
+    # Touch tool_a — now tool_b is the oldest.
+    cache.get("sess_1", "tool_a", {})
+    cache.put("sess_1", "tool_c", {}, "C")
+    assert cache.get("sess_1", "tool_a", {}) == "A"
+    assert cache.get("sess_1", "tool_b", {}) is None
+    assert cache.get("sess_1", "tool_c", {}) == "C"
+
+
+def test_clear_session_drops_only_that_sessions_entries():
+    cache = SessionToolResultCache()
+    cache.put("sess_A", "t1", {}, "A1")
+    cache.put("sess_A", "t2", {}, "A2")
+    cache.put("sess_B", "t1", {}, "B1")
+    cleared = cache.clear_session("sess_A")
+    assert cleared == 2
+    assert cache.get("sess_A", "t1", {}) is None
+    assert cache.get("sess_A", "t2", {}) is None
+    # Other session untouched.
+    assert cache.get("sess_B", "t1", {}) == "B1"
+
+
+def test_empty_session_id_bypasses_cache():
+    """An empty session_id never caches or retrieves (defensive: callers that
+    don't know their session shouldn't share cached results)."""
+    cache = SessionToolResultCache()
+    cache.put("", "lifeos_search", {"q": "X"}, "leaked")
+    assert cache.get("", "lifeos_search", {"q": "X"}) is None
+    assert len(cache) == 0


### PR DESCRIPTION
## Summary

Integration of three closed issues — accurate cost accounting, dev-iteration cost reduction, and live cost reduction — landed across 10 sub-PRs against this branch.

### Closed issues

| Issue | Title |
|---|---|
| #137 | fix: cost tracking misses cache_creation + cache_read tokens (10–20× undercount) |
| #138 | enhancement: reduce live-iteration test costs on cloud #agent path |
| #139 | enhancement: reduce live agent-worker cost via preset slim-down, smart routing, runaway detection |

### What landed (chronological on this branch)

| Commit | Section | Description |
|---|---|---|
| `fcaeff5` | #137 | Cache_creation + cache_read tokens in pricing, schema, executor, completion summary; dollars-first budget enforcement |
| `e146ebc` | #138 | `dry_run` preflight, pytest guard against real Anthropic calls, `LIFEOS_AGENT_MANAGED_MODEL_FOR_TESTS`, cost-aware iteration docs |
| `6691117` | #139 §5 | Runaway detection: tool-loop, no-progress, oversized truncation (persisted counters on `managed_cursor`) |
| `24f055b` | #139 §1 | Slimmed MCP tool descriptions: avg 39.3 → 18.8 words; max 155 → 30; test guard enforces |
| `8939944` | #139 §2 | Per-task model selection + deterministic tag precedence (`#local`/`#cloud-haiku`/`#cloud-sonnet`/`#cloud`) |
| `eccc88a` | #139 §4 | Per-session tool result cache in MCP server (60s TTL, GET-only, opt-in via session_id) |
| `1d3b804` | #139 §3a | `class_to_tool_filter()` helper with cross-cutting tool merge + `driver.update_session()` |
| `c9b61c4` | #139 §3b | Preflight emits `preset_class`; `#research`/`#crm`/`#financial`/`#personal-comm`/`#work-comm`/`#fullstack` tags |
| `4a7e6bb` | #139 §3c | `ManagedExecutor.start()` splits create → update_session(filter) → post_user_message |
| `fc90790` | #139 §6+§7 | Fail-fast budget check at preflight (refuse on > 2× max_dollars) + cost preview threshold env var |

### Operational follow-up (not blocking)

The per-class cache_creation token estimates in `tool_filter._CACHE_CREATION_TOKEN_ESTIMATES` are conservative hardcoded floors. The live verification experiment from #139 §3 (probe each preset_class once at worker startup; assert filtered cache_creation < 60% of full-preset baseline) requires real Anthropic API dispatches and operator monitoring. The consumer surface (`estimated_cache_creation_tokens`) is stable; probe-derived values can overwrite the table when the experiment runs.

## Test evidence

```
~/.venvs/lifeos/bin/python -m pytest tests/ -q -m "unit and not slow"
================ 1506 passed, 517 warnings in 168.51s (0:02:48) ================
```

- 1416 → 1506 unit tests (+90 added across the run; zero pre-existing tests regressed)
- ruff clean across all touched files
- 30 files changed, 2794 insertions, 1850 deletions

## Review focus

- **Budget enforcement flipped to dollars-first** (`managed_executor._budget_breach`) — `max_dollars` now takes precedence over `max_tokens`. The token cap remains as a soft secondary signal.
- **Three-step session start flow** (`ManagedExecutor.start`) replaces the single `create_session(initial_message=...)` call. Critical for §3: the UPDATE must land before the first user message or cache_creation locks in on the unfiltered preset.
- **Per-class tool filter** intentionally does NOT emit an `mcp_servers` key — server list lives on the agent preset, not in per-session UPDATE.
- **Idempotent schema migrations** on `sessions` (cache buckets, preset_class) and `managed_cursor` (runaway counters). Old rows safely default.
- **Pytest anthropic-API guard** is process-wide and opt-in via `@pytest.mark.allow_anthropic_api` for the canary test that proves the guard fires.
- The §6 fail-fast check uses a **2× max_dollars margin** rather than 1× to avoid over-refusing cache-warm tasks (real cost ≈ 0.10× input on a warm cache, 12.5× cheaper than cache_creation).