### PR TITLE
fix: expand ~ in claude_code projects_dir

### DIFF
--- a/api/services/claude_code/session_ingest.py
+++ b/api/services/claude_code/session_ingest.py
@@ -159,6 +159,21 @@ def _projects_dir(override: str | None = None) -> Path:
     return Path(os.path.expanduser(raw))
 
 
+def _resolve_projects_dir(projects_dir: str | Path | None) -> Path:
+    """Resolve a projects_dir value into a `Path` with `~` expanded.
+
+    Callers pass either an absolute `Path` (tests), a string that may
+    contain `~` (settings — `~/.claude/projects` is the default), or
+    `None` (fall back to env / default). Without this, the route handed
+    the literal `~/.claude/projects` string straight to `Path()`, which
+    does not expand `~` and silently returned zero sessions in
+    production.
+    """
+    if projects_dir is None:
+        return _projects_dir()
+    return Path(os.path.expanduser(str(projects_dir)))
+
+
 def discover_sessions(
     projects_dir: str | Path | None = None,
     lookback_days: int = 7,
@@ -175,7 +190,7 @@ def discover_sessions(
     Discovery is the expensive part of ingestion — callers should cache the
     result for ~30s rather than re-scanning every SSE tick.
     """
-    root = Path(projects_dir) if projects_dir else _projects_dir()
+    root = _resolve_projects_dir(projects_dir)
     if not root.exists() or not root.is_dir():
         return []
     cutoff = (now if now is not None else time.time()) - max(0, lookback_days) * 86_400
@@ -841,7 +856,7 @@ def read_normalized_events(
         bare = validate_session_id(bare)
     # Scan projects dir for the matching jsonl. Linear scan; for very large
     # projects directories consider an explicit map cache later.
-    root = Path(projects_dir) if projects_dir else _projects_dir()
+    root = _resolve_projects_dir(projects_dir)
     if not root.exists() or not root.is_dir():
         return []
     for proj in root.iterdir():


### PR DESCRIPTION
## Summary

`settings.claude_code_projects_dir` defaults to `~/.claude/projects`. The agents route passed that literal string to `discover_sessions`, which constructed `Path('~/.claude/projects')` — `Path` does **not** expand `~` — so `root.exists()` returned False and the snapshot silently produced **zero** Claude Code sessions in production despite the data being present.

Hit this checking the live page: 33 LifeOS sessions, 0 Claude Code. Direct Python call to `build_snapshot` with the same setting value also reproduced 0 sessions, then 12 after expanding the tilde manually.

## What changed

- New `_resolve_projects_dir()` helper that calls `os.path.expanduser` on string inputs before wrapping in `Path`.
- `discover_sessions` routes every `projects_dir` value through that helper.
- Tests are unchanged because they all pass absolute `tmp_path` values (which don't contain `~`) — the bug only manifests with the live settings string.

## Test evidence

`pytest tests/test_claude_code_ingest.py` → **31 passed**.

Verified directly: after the fix, `discover_sessions(projects_dir='~/.claude/projects', lookback_days=7)` returns 12 sessions on this machine instead of 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)