### PR TITLE
feat: cc resume + airier graph physics (#160)

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -436,6 +436,141 @@ async def operator_kill_session(session_id: str, body: KillRequest | None = None
                 pass
 
 
+class CCResumeRequest(BaseModel):
+    """Body for POST /api/agents/sessions/{id}/resume — accepts overrides
+    for the spawn env when the systemd-inherited env isn't enough."""
+    extra_env: dict[str, str] = {}
+
+
+def _resume_env() -> dict[str, str]:
+    """Build the environment dict for the resume subprocess.
+
+    Inherits from the FastAPI process env (typical systemd-imported env),
+    then layers in key=value lines from LIFEOS_CC_RESUME_ENV_FILE if set.
+    The file lets operators pin DISPLAY / XAUTHORITY / WAYLAND_DISPLAY /
+    DBUS_SESSION_BUS_ADDRESS explicitly — systemd usually omits them.
+    """
+    import os
+    env: dict[str, str] = dict(os.environ)
+    try:
+        from config.settings import settings
+        path = (settings.cc_resume_env_file or "").strip()
+    except Exception:  # noqa: BLE001
+        path = ""
+    if path:
+        try:
+            with open(os.path.expanduser(path), "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if "=" not in line:
+                        continue
+                    k, _, v = line.partition("=")
+                    env[k.strip()] = v.strip()
+        except OSError as exc:
+            logger.warning("cc_resume_env_file unreadable (%s): %s", path, exc)
+    return env
+
+
+@router.post("/sessions/{session_id}/resume")
+async def resume_claude_code_session(
+    session_id: str,
+    body: CCResumeRequest | None = None,
+) -> dict[str, Any]:
+    """Spawn a local terminal that re-opens a Claude Code session.
+
+    Only valid for `cc:`-prefixed sessions. Opt-in via
+    `LIFEOS_CC_RESUME_ENABLED`. Local-network only — do not expose via
+    Tailscale Funnel or the public MCP HTTP transport.
+    """
+    import shlex
+    import subprocess
+
+    if not session_id.startswith("cc:"):
+        raise HTTPException(status_code=400, detail="resume is only available for Claude Code sessions")
+
+    try:
+        from config.settings import settings
+    except Exception as exc:  # noqa: BLE001 — settings should always load
+        raise HTTPException(status_code=500, detail=f"settings unavailable: {exc}") from exc
+
+    if not getattr(settings, "cc_resume_enabled", False):
+        raise HTTPException(status_code=400, detail="cc resume disabled — set LIFEOS_CC_RESUME_ENABLED=true")
+    template = (settings.cc_resume_cmd or "").strip()
+    if not template:
+        raise HTTPException(status_code=400, detail="LIFEOS_CC_RESUME_CMD is empty")
+
+    from api.services.claude_code import session_ingest as cc
+
+    try:
+        bare = cc.validate_session_id(session_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    # Subagent synthetic ids point at the parent's bare uuid; the operator
+    # really wants to resume the parent terminal session, not a sub-slice.
+    if ":agent:" in bare:
+        bare = bare.split(":agent:", 1)[0]
+
+    # Find the matching jsonl to recover the working directory.
+    metas = cc.discover_sessions(
+        projects_dir=settings.claude_code_projects_dir,
+        lookback_days=max(int(settings.claude_code_lookback_days), 365),  # widen lookback for resume
+    )
+    target = next((m for m in metas if m.raw_session_id == bare), None)
+    if target is None or not target.decoded_cwd:
+        raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
+
+    # Render the template — {session_id} is the only supported substitution.
+    rendered = template.replace("{session_id}", bare)
+    try:
+        argv = shlex.split(rendered)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"resume_cmd parse failed: {exc}") from exc
+    if not argv:
+        raise HTTPException(status_code=400, detail="resume_cmd resolved to an empty argv")
+
+    env = _resume_env()
+    if body and body.extra_env:
+        env.update(body.extra_env)
+
+    try:
+        proc = subprocess.Popen(  # noqa: S603 — argv only, no shell=True (explicit shlex.split above)
+            argv,
+            cwd=target.decoded_cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=500, detail=f"resume binary not found: {exc}") from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"resume spawn failed: {exc}") from exc
+
+    # Give the spawn a beat — if it crashed immediately, surface stderr.
+    try:
+        proc.wait(timeout=0.5)
+    except subprocess.TimeoutExpired:
+        # Still running — that's the happy path. Detach from any unread output.
+        return {
+            "spawned": True,
+            "pid": proc.pid,
+            "command": argv,
+            "cwd": target.decoded_cwd,
+        }
+    # If we got here, the process exited within 0.5s — likely an error.
+    stderr_preview = b""
+    try:
+        if proc.stderr is not None:
+            stderr_preview = proc.stderr.read(1024)
+    except Exception:  # noqa: BLE001
+        pass
+    detail = (stderr_preview.decode("utf-8", errors="replace").strip()
+              or f"resume process exited rc={proc.returncode}")
+    raise HTTPException(status_code=500, detail=detail)
+
+
 async def _stream_claude_code_session(session_id: str, backfill: int):
     """Per-session SSE generator for Claude Code (cc:-prefixed) sessions."""
     from config.settings import settings

--- a/config/settings.py
+++ b/config/settings.py
@@ -200,6 +200,31 @@ class Settings(BaseSettings):
                     "within this many days. Keeps the snapshot lean — older "
                     "transcripts can still be opened on demand by direct id."
     )
+    cc_resume_enabled: bool = Field(
+        default=False,
+        alias="LIFEOS_CC_RESUME_ENABLED",
+        description="When true, the /agents UI exposes a 'Resume' button on "
+                    "terminal-state Claude Code sessions that spawns a local "
+                    "terminal running the configured resume command. Opt-in "
+                    "because spawning GUI terminals from a systemd service "
+                    "depends on the operator's desktop environment."
+    )
+    cc_resume_cmd: str = Field(
+        default="vt claude --dangerously-skip-permissions --chrome --resume {session_id}",
+        alias="LIFEOS_CC_RESUME_CMD",
+        description="Template command for resuming a Claude Code session. "
+                    "The single supported substitution token is `{session_id}`, "
+                    "replaced with the bare session uuid (no `cc:` prefix). "
+                    "Parsed with shlex.split — no shell metacharacters."
+    )
+    cc_resume_env_file: str = Field(
+        default="",
+        alias="LIFEOS_CC_RESUME_ENV_FILE",
+        description="Optional path to a `key=value` file pinning DISPLAY / "
+                    "XAUTHORITY / WAYLAND_DISPLAY / DBUS_SESSION_BUS_ADDRESS "
+                    "for the spawned terminal. Leave empty to inherit the "
+                    "systemd service's env (which usually has none of these)."
+    )
     agent_vault_id: str = Field(
         default="",
         alias="LIFEOS_AGENT_VAULT_ID",

--- a/tests/test_agent_resume_api.py
+++ b/tests/test_agent_resume_api.py
@@ -1,0 +1,280 @@
+"""Tests for the Claude Code resume endpoint (issue #160).
+
+Resume spawns a local terminal via subprocess. Every test in this file
+mocks `subprocess.Popen` so no real process is launched.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+def _write_jsonl(path: Path, line: dict):
+    """Write a single synthetic Claude Code jsonl line — enough to surface
+    in discovery + recover a decoded_cwd for the resume target."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    import json
+    with path.open("w", encoding="utf-8") as f:
+        f.write(json.dumps(line) + "\n")
+
+
+@pytest.fixture
+def synthetic_session(tmp_path: Path, monkeypatch):
+    """Build a synthetic ~/.claude/projects/-tmp-x/<uuid>.jsonl and point
+    settings + discovery at it. Returns (projects_dir, session_id)."""
+    from config.settings import settings
+
+    proj = tmp_path / "-home-syn-Code-A"
+    sid = "resume-target-uuid"
+    _write_jsonl(proj / f"{sid}.jsonl", {
+        "type": "assistant",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "message": {"role": "assistant", "model": "claude-sonnet-4-6",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "usage": {"input_tokens": 1, "output_tokens": 1}},
+    })
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "claude_code_lookback_days", 365)
+    # Reset both ingest caches so the new fixture data is visible.
+    from api.services.claude_code import session_ingest as cc
+    cc.invalidate_cache()
+    cc.invalidate_process_cache()
+    return tmp_path, sid
+
+
+# ---------------------------------------------------------------------------
+# Gating: disabled / non-cc / missing template
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resume_rejects_non_cc_session(client):
+    r = client.post("/api/agents/sessions/some-lifeos-uuid/resume", json={})
+    assert r.status_code == 400
+    assert "claude code" in r.json()["detail"].lower()
+
+
+@pytest.mark.unit
+def test_resume_disabled_by_default(client, synthetic_session, monkeypatch):
+    """LIFEOS_CC_RESUME_ENABLED defaults to False — endpoint refuses."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", False)
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 400
+    assert "disabled" in r.json()["detail"].lower()
+
+
+@pytest.mark.unit
+def test_resume_empty_template_400(client, synthetic_session, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "")
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 400
+    assert "empty" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Template substitution + spawn invocation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resume_substitutes_session_id_and_spawns_with_cwd(
+    client, synthetic_session, monkeypatch
+):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd",
+                        "echo claude --resume {session_id} --extra")
+
+    captured: dict[str, object] = {}
+
+    class _FakeProc:
+        def __init__(self, argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            self.pid = 4242
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+            self.returncode = None
+
+        def wait(self, timeout=None):
+            # Long-running process — pretend it's still up.
+            raise __import__("subprocess").TimeoutExpired(cmd=captured["argv"], timeout=timeout)
+
+    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["spawned"] is True
+    assert body["pid"] == 4242
+    # The bare uuid (no cc: prefix) appears in argv.
+    assert sid in body["command"]
+    assert "{session_id}" not in body["command"]
+    # cwd is the decoded project path, not the encoded one.
+    assert body["cwd"] == "/home/syn/Code/A"
+    # No shell=True anywhere — verify by inspecting the spawn kwargs.
+    assert captured["kwargs"].get("shell", False) is False
+    # cwd reaches Popen.
+    assert captured["kwargs"]["cwd"] == "/home/syn/Code/A"
+
+
+@pytest.mark.unit
+def test_resume_subagent_id_resolves_to_parent_cwd(
+    client, synthetic_session, monkeypatch
+):
+    """Resuming a subagent synthetic id should resume the parent terminal."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
+
+    captured: dict[str, object] = {}
+
+    class _FakeProc:
+        def __init__(self, argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            self.pid = 5
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+            self.returncode = None
+
+        def wait(self, timeout=None):
+            raise __import__("subprocess").TimeoutExpired(cmd=captured["argv"], timeout=timeout)
+
+    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+
+    _, sid = synthetic_session
+    sub_id = f"cc:{sid}:agent:toolu_01abc"
+    r = client.post(f"/api/agents/sessions/{sub_id}/resume", json={})
+    assert r.status_code == 200, r.text
+    # argv has the parent uuid, not the synthetic subagent suffix.
+    assert sid in captured["argv"]
+    assert "agent:" not in " ".join(captured["argv"])
+
+
+@pytest.mark.unit
+def test_resume_returns_404_when_session_not_discovered(client, monkeypatch, tmp_path):
+    """Empty projects dir → 404."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(tmp_path))
+    from api.services.claude_code import session_ingest as cc
+    cc.invalidate_cache()
+    r = client.post("/api/agents/sessions/cc:nonexistent-id/resume", json={})
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resume_500_when_binary_missing(client, synthetic_session, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "no-such-binary {session_id}")
+
+    def _raise(*args, **kwargs):
+        raise FileNotFoundError("no-such-binary")
+    monkeypatch.setattr("subprocess.Popen", _raise)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 500
+    assert "not found" in r.json()["detail"].lower()
+
+
+@pytest.mark.unit
+def test_resume_500_when_process_exits_immediately(client, synthetic_session, monkeypatch):
+    """Process exits within the 0.5s wait → 500 with stderr preview."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
+
+    class _ExitedProc:
+        def __init__(self, argv, **kwargs):
+            self.pid = 7
+            self.returncode = 2
+
+            class _Stream:
+                def read(self, n):
+                    return b"stderr says: bad config\n"
+            self.stderr = _Stream()
+            self.stdout = MagicMock()
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+    monkeypatch.setattr("subprocess.Popen", _ExitedProc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 500
+    assert "stderr says" in r.json()["detail"]
+
+
+@pytest.mark.unit
+def test_resume_rejects_traversal_session_id(client, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    r = client.post("/api/agents/sessions/cc:..%2Fetc/resume", json={})
+    # Either rejected by the path-traversal check (400) or normalized away by
+    # FastAPI's path matching (404). Both are acceptable so long as nothing
+    # outside the projects dir is touched.
+    assert r.status_code in (400, 404)
+
+
+# ---------------------------------------------------------------------------
+# Env file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resume_env_file_overrides_systemd_env(
+    client, synthetic_session, monkeypatch, tmp_path
+):
+    """LIFEOS_CC_RESUME_ENV_FILE values appear in the Popen env kwarg."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
+    env_path = tmp_path / "env.txt"
+    env_path.write_text("DISPLAY=:0\nXAUTHORITY=/run/user/1000/x\n# comment\n\n", encoding="utf-8")
+    monkeypatch.setattr(settings, "cc_resume_env_file", str(env_path))
+
+    captured: dict[str, object] = {}
+
+    class _FakeProc:
+        def __init__(self, argv, **kwargs):
+            captured["env"] = kwargs.get("env") or {}
+            self.pid = 1
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+            self.returncode = None
+
+        def wait(self, timeout=None):
+            raise __import__("subprocess").TimeoutExpired(cmd="x", timeout=timeout)
+
+    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    assert captured["env"]["DISPLAY"] == ":0"
+    assert captured["env"]["XAUTHORITY"] == "/run/user/1000/x"

--- a/tests/test_agent_viz_api.py
+++ b/tests/test_agent_viz_api.py
@@ -31,6 +31,10 @@ def stores(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
     # Clear the label cache so labels are recomputed against the test fixtures.
     agents_route._label_cache.clear()
+    # Disable the Claude Code union so these tests only exercise the LifeOS
+    # agent path — otherwise the snapshot would mix in real CC sessions from
+    # ~/.claude/projects/ on the test machine.
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", lambda: ([], []))
     yield session_store, transcript_store
     agents_route._label_cache.clear()
 

--- a/web/agents.html
+++ b/web/agents.html
@@ -247,6 +247,22 @@
     opacity: 0.6;
     cursor: progress;
   }
+  .panel-resume {
+    background: var(--bg-card);
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    cursor: pointer;
+    font-size: 0.75rem;
+    line-height: 1;
+    padding: 0.3rem 0.55rem;
+    border-radius: 4px;
+    float: right;
+    margin-right: 0.5rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .panel-resume:hover { background: var(--accent); color: var(--bg-primary); }
+  .panel-resume:disabled { opacity: 0.6; cursor: progress; }
   .modal-backdrop {
     position: fixed; inset: 0;
     background: rgba(0,0,0,0.55);
@@ -445,12 +461,24 @@
   const edges = new vis.DataSet([]);
   const network = new vis.Network(graphEl, { nodes, edges }, {
     physics: {
-      // Stabilize once on load; subsequent snapshot ticks update node attrs
-      // in place via DataSet.update so positions stay put.
+      // forceAtlas2Based gives the same airy, repulsion-dominant layout the
+      // /crm graph has — clusters form from charge, not link length. Strong
+      // gravitationalConstant + avoidOverlap keep nodes from stacking even
+      // when token-based sizing makes some of them big.
       enabled: true,
-      stabilization: { iterations: 120, fit: true },
-      barnesHut: { gravitationalConstant: -2400, springLength: 130, damping: 0.6 },
-      timestep: 0.45,
+      stabilization: { iterations: 250, fit: true },
+      solver: 'forceAtlas2Based',
+      forceAtlas2Based: {
+        gravitationalConstant: -180,
+        centralGravity: 0.005,
+        springLength: 180,
+        springConstant: 0.04,
+        damping: 0.55,
+        avoidOverlap: 0.9,
+      },
+      maxVelocity: 50,
+      minVelocity: 0.5,
+      timestep: 0.4,
     },
     interaction: { hover: true, tooltipDelay: 200, dragNodes: true },
     edges: {
@@ -643,15 +671,21 @@
     const live = !TERMINAL.has(s.status);
     const safeStatus = escapeAttr(s.status);
     const isClaudeCode = (s.source === 'claude_code');
+    const isSubagent = !!s.is_subagent;
     // No kill button for Claude Code sessions — we don't have a safe primitive
     // to terminate them from outside the terminal.
     const showKill = live && !isClaudeCode;
+    // Resume button: only for terminal-state Claude Code sessions (not subagents).
+    // Whether the backend will actually accept the click depends on
+    // LIFEOS_CC_RESUME_ENABLED on the server; if disabled, click → toast error.
+    const showResume = isClaudeCode && !isSubagent && (TERMINAL.has(s.status) || s.status === 'yielded');
     const sourceLabel = isClaudeCode ? 'Claude Code' : 'LifeOS agent';
     const inferredHint = s.status_inferred ? ' (inferred)' : '';
     panelEl.innerHTML = `
       <div class="panel-header">
         <button class="panel-close" aria-label="Close" id="panel-close">×</button>
         ${showKill ? '<button class="panel-kill" id="panel-kill">Kill</button>' : ''}
+        ${showResume ? '<button class="panel-resume" id="panel-resume" title="Open a terminal and resume this session">Resume</button>' : ''}
         <div class="label" data-field="label">${escapeHtml(s.label || s.session_id)}</div>
         <div class="cwd-hint" data-field="cwd-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-all">${s.decoded_cwd ? escapeHtml(s.decoded_cwd) : ''}</div>
         <div class="meta" data-field="meta">
@@ -669,6 +703,43 @@
     document.getElementById('panel-close').onclick = closePanel;
     if (showKill) {
       document.getElementById('panel-kill').onclick = () => openKillModal(s);
+    }
+    if (showResume) {
+      document.getElementById('panel-resume').onclick = () => resumeCcSession(s);
+    }
+  }
+
+  async function resumeCcSession(s) {
+    const btn = document.getElementById('panel-resume');
+    if (btn) {
+      btn.disabled = true;
+      btn.textContent = 'Resuming…';
+    }
+    try {
+      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/resume`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      if (!r.ok) {
+        const text = await r.text();
+        // FastAPI returns {"detail": "..."} on HTTPException — surface that.
+        let msg = text;
+        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+        throw new Error(`HTTP ${r.status}: ${msg}`);
+      }
+      const result = await r.json();
+      showToast(`Spawned (pid ${result.pid}) in ${result.cwd}`, false);
+    } catch (err) {
+      showToast(`Resume failed: ${err.message}`, true);
+    } finally {
+      // Re-enable after a beat so accidental double-click is harmless.
+      setTimeout(() => {
+        if (btn) {
+          btn.disabled = false;
+          btn.textContent = 'Resume';
+        }
+      }, 4000);
     }
   }
 


### PR DESCRIPTION
## Summary

Two-in-one PR addressing live-page feedback after #159 landed.

Closes #160.

### 1. Resume button for Claude Code sessions (#160)

- New `POST /api/agents/sessions/{id}/resume` — cc-prefixed sessions only, opt-in via `LIFEOS_CC_RESUME_ENABLED` (default false).
- Spawns a local terminal via `subprocess.Popen` with explicit argv (`shlex.split`, no `shell=True`). Template configurable via `LIFEOS_CC_RESUME_CMD`; default:
  ```
  vt claude --dangerously-skip-permissions --chrome --resume {session_id}
  ```
- Working directory comes from the discovered jsonl's decoded cwd. Subagent synthetic ids (`cc:<parent>:agent:<tool_use_id>`) resolve to the parent's terminal.
- `LIFEOS_CC_RESUME_ENV_FILE` optionally pins `DISPLAY` / `XAUTHORITY` / `WAYLAND_DISPLAY` / `DBUS_SESSION_BUS_ADDRESS` for the spawn — systemd-imported env usually omits these.
- 0.5s wait after spawn: if the process exited that fast, return 500 with captured stderr; if still running, return `{spawned, pid, command, cwd}`.
- Frontend: 'Resume' button on the side panel for terminal-state or yielded Claude Code sessions (hidden for running, subagents, and LifeOS agent sessions). Toast feedback on result.

### 2. Airier graph physics

- Swapped from `barnesHut` to `forceAtlas2Based` with stronger repulsion (`gravitationalConstant: -180`), lower central gravity (`0.005`), and `avoidOverlap: 0.9` — matches the /crm graph's repulsion-dominant feel. Token-sized boxes don't stack anymore. Nodes still freeze after first stabilization so subsequent snapshot ticks don't jitter them.

### 3. Test isolation fix

- `test_agent_viz_api.py`'s `stores` fixture stubs out the claude_code source so its assertions aren't polluted by real `~/.claude/projects/` entries on the test machine.

## Test evidence

`pytest tests/test_agent_resume_api.py tests/test_agent_viz_api.py tests/test_agent_kill_api.py tests/test_claude_code_ingest.py` → **64 passed** (10 new resume tests).

10 new test cases cover: non-cc rejection, disabled-by-default refusal, empty template, `{session_id}` substitution + cwd in Popen call, subagent → parent resolution, missing-session 404, missing-binary 500, immediate-exit 500 with stderr preview, traversal rejection, env file overlay.

## Review focus

- `subprocess.Popen` is invoked **without** `shell=True` and with `shlex.split` — verify by inspecting the test that asserts `kwargs.get('shell', False) is False`.
- The env-file parser is line-oriented `key=value` with `#` comments — no expansion, no shell-eval.
- `cc_resume_enabled` defaults to `false` so this PR ships behaviorally inert on existing installs.
- The endpoint must not be exposed via the public MCP HTTP transport — operator-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)