### PR TITLE
feat(cc-resume): copy inner command to clipboard (Warp Linux limitation)

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -560,6 +560,18 @@ async def resume_claude_code_session(
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"resume spawn failed: {exc}") from exc
 
+    # Render the inner command (the actual `claude --resume` invocation)
+    # for the frontend to copy to clipboard — Warp Linux ignores the
+    # `&command=` URI param, so the operator pastes it once the terminal
+    # opens. Same substitution rules as the outer template (raw only —
+    # URL-encoded variants aren't meaningful inside a terminal).
+    inner_template = (settings.cc_resume_inner_cmd or "").strip()
+    inner_rendered = (
+        inner_template
+        .replace("{session_id}", bare)
+        .replace("{cwd}", target.decoded_cwd)
+    )
+
     # Give the spawn a beat — if it crashed immediately, surface stderr.
     try:
         proc.wait(timeout=0.5)
@@ -570,6 +582,7 @@ async def resume_claude_code_session(
             "pid": proc.pid,
             "command": argv,
             "cwd": target.decoded_cwd,
+            "inner_command": inner_rendered,
         }
     # If we got here, the process exited within 0.5s — likely an error.
     stderr_preview = b""

--- a/config/settings.py
+++ b/config/settings.py
@@ -210,21 +210,25 @@ class Settings(BaseSettings):
                     "depends on the operator's desktop environment."
     )
     cc_resume_cmd: str = Field(
-        default=(
-            "warp-terminal "
-            "warp://action/new_tab?path={cwd_url}"
-            "&command=vt+claude+--dangerously-skip-permissions+--resume+{session_id_url}"
-        ),
+        default="warp-terminal warp://action/new_tab?path={cwd_url}",
         alias="LIFEOS_CC_RESUME_CMD",
-        description="Template command for resuming a Claude Code session. "
-                    "Substitutions: `{session_id}` (bare uuid), `{cwd}` "
-                    "(decoded project dir), and URL-encoded variants "
-                    "`{session_id_url}` / `{cwd_url}` for use inside "
-                    "`warp://`, `vscode://`, or other URI-scheme launchers. "
-                    "The default opens the session in a new Warp tab and "
-                    "runs vt+claude inline; override to point at a "
-                    "different terminal app. Parsed with shlex.split — "
-                    "no shell metacharacters."
+        description="Launcher command for resuming a Claude Code session. "
+                    "Default opens a new Warp tab at the project directory. "
+                    "Linux Warp ignores `&command=` in its URI scheme, so the "
+                    "actual `claude --resume` command is paired with "
+                    "LIFEOS_CC_RESUME_INNER_CMD and copied to the operator's "
+                    "clipboard on click. Substitutions: `{session_id}`, "
+                    "`{cwd}`, and URL-encoded `{session_id_url}` / `{cwd_url}`. "
+                    "Parsed with shlex.split — no shell metacharacters."
+    )
+    cc_resume_inner_cmd: str = Field(
+        default="vt claude --dangerously-skip-permissions --resume {session_id}",
+        alias="LIFEOS_CC_RESUME_INNER_CMD",
+        description="Command intended to run *inside* the spawned terminal. "
+                    "Returned in the resume response and copied to the "
+                    "operator's clipboard so they can paste it once the "
+                    "terminal opens. Set to empty to disable clipboard "
+                    "copy. Substitutions: `{session_id}`, `{cwd}`."
     )
     cc_resume_env_file: str = Field(
         default="",

--- a/tests/test_agent_resume_api.py
+++ b/tests/test_agent_resume_api.py
@@ -321,6 +321,71 @@ def test_resume_url_encoded_substitutions_for_uri_schemes(
 
 
 @pytest.mark.unit
+def test_resume_returns_inner_command_for_clipboard(
+    client, synthetic_session, monkeypatch
+):
+    """The inner-command setting is rendered with substitutions and surfaced
+    in the response as `inner_command` so the frontend can copy it to the
+    clipboard (Warp Linux ignores its URI-scheme `&command=`)."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
+    monkeypatch.setattr(
+        settings, "cc_resume_inner_cmd",
+        "vt claude --resume {session_id} --workdir {cwd}",
+    )
+
+    class _FakeProc:
+        def __init__(self, argv, **kwargs):
+            self.pid = 1
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+            self.returncode = None
+
+        def wait(self, timeout=None):
+            raise __import__("subprocess").TimeoutExpired(cmd="x", timeout=timeout)
+
+    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert sid in body["inner_command"]
+    assert "/home/syn/Code/A" in body["inner_command"]
+    assert "{session_id}" not in body["inner_command"]
+    assert "{cwd}" not in body["inner_command"]
+
+
+@pytest.mark.unit
+def test_resume_empty_inner_command_yields_empty_string(
+    client, synthetic_session, monkeypatch
+):
+    """Operators can disable the clipboard copy by setting INNER_CMD empty."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "")
+
+    class _FakeProc:
+        def __init__(self, argv, **kwargs):
+            self.pid = 1
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+            self.returncode = None
+
+        def wait(self, timeout=None):
+            raise __import__("subprocess").TimeoutExpired(cmd="x", timeout=timeout)
+
+    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    assert r.json()["inner_command"] == ""
+
+
+@pytest.mark.unit
 def test_resume_env_file_overrides_systemd_env(
     client, synthetic_session, monkeypatch, tmp_path
 ):

--- a/web/agents.html
+++ b/web/agents.html
@@ -746,7 +746,27 @@
         throw new Error(`HTTP ${r.status}: ${msg}`);
       }
       const result = await r.json();
-      showToast(`Spawned (pid ${result.pid}) in ${result.cwd}`, false);
+      // Warp Linux ignores `&command=` in its URI scheme, so the actual
+      // `claude --resume` invocation comes back as `inner_command` and we
+      // copy it to the clipboard for the operator to paste once the
+      // terminal opens.
+      let copied = false;
+      if (result.inner_command && navigator.clipboard && navigator.clipboard.writeText) {
+        try {
+          await navigator.clipboard.writeText(result.inner_command);
+          copied = true;
+        } catch (_) {
+          // Clipboard API can fail when the page isn't focused (browser
+          // throws NotAllowedError). Fall through to a non-copy toast.
+        }
+      }
+      if (copied) {
+        showToast(`Warp opened. Resume command copied to clipboard — paste it.`, false);
+      } else if (result.inner_command) {
+        showToast(`Warp opened. Run: ${result.inner_command}`, false);
+      } else {
+        showToast(`Spawned (pid ${result.pid}) in ${result.cwd}`, false);
+      }
     } catch (err) {
       showToast(`Resume failed: ${err.message}`, true);
     } finally {


### PR DESCRIPTION
## Summary

Warp Linux's `warp://action/new_tab?path=...&command=...` URI scheme honors `path=` but **silently drops `command=`** — terminal opens in the right cwd, command never runs.

Fix: split the resume into two settings:

- `LIFEOS_CC_RESUME_CMD` (launcher) — default `warp-terminal warp://action/new_tab?path={cwd_url}`
- `LIFEOS_CC_RESUME_INNER_CMD` (the command to actually run) — default `vt claude --dangerously-skip-permissions --resume {session_id}`

The backend renders the inner command (same `{session_id}` / `{cwd}` substitutions) and returns it in the resume response as `inner_command`. Frontend copies it to clipboard via `navigator.clipboard.writeText` and shows a toast: **"Warp opened. Resume command copied to clipboard — paste it."** Falls back to plain text on Clipboard API failure (focus-loss can throw `NotAllowedError`). Empty INNER_CMD disables the copy.

## Test evidence

`pytest tests/test_agent_resume_api.py` → **14 passed** (2 new):

- `test_resume_returns_inner_command_for_clipboard` — substitutions land, no leftover `{tokens}`
- `test_resume_empty_inner_command_yields_empty_string` — opt-out path

## Closes #160 follow-up

This is the practical fix for the Warp Linux limitation noticed live — `vt claude --resume <id>` now reliably lands in the operator's clipboard on click. Paste once Warp opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)