### PR TITLE
fix(cc-resume): treat rc=0 immediate exit as success

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -572,19 +572,27 @@ async def resume_claude_code_session(
         .replace("{cwd}", target.decoded_cwd)
     )
 
-    # Give the spawn a beat — if it crashed immediately, surface stderr.
+    # Give the spawn a beat. Two flavors of launcher are both valid:
+    #   (a) the launcher BECOMES the terminal (long-running) — wait() times
+    #       out, we return the running pid.
+    #   (b) the launcher is a URL dispatcher that delegates to a running
+    #       desktop app and exits cleanly (rc=0). `warp-terminal warp://…`
+    #       does exactly this — Warp opens but the launcher process is gone.
+    # rc=0 is success regardless of timing; only a non-zero exit is failure.
+    response_body = {
+        "spawned": True,
+        "pid": proc.pid,
+        "command": argv,
+        "cwd": target.decoded_cwd,
+        "inner_command": inner_rendered,
+    }
     try:
         proc.wait(timeout=0.5)
     except subprocess.TimeoutExpired:
-        # Still running — that's the happy path. Detach from any unread output.
-        return {
-            "spawned": True,
-            "pid": proc.pid,
-            "command": argv,
-            "cwd": target.decoded_cwd,
-            "inner_command": inner_rendered,
-        }
-    # If we got here, the process exited within 0.5s — likely an error.
+        return response_body
+    if proc.returncode == 0:
+        return response_body
+    # Non-zero exit within 0.5s — surface stderr.
     stderr_preview = b""
     try:
         if proc.stderr is not None:

--- a/tests/test_agent_resume_api.py
+++ b/tests/test_agent_resume_api.py
@@ -202,8 +202,8 @@ def test_resume_500_when_binary_missing(client, synthetic_session, monkeypatch):
 
 
 @pytest.mark.unit
-def test_resume_500_when_process_exits_immediately(client, synthetic_session, monkeypatch):
-    """Process exits within the 0.5s wait → 500 with stderr preview."""
+def test_resume_500_when_process_exits_nonzero_with_stderr(client, synthetic_session, monkeypatch):
+    """Process exits non-zero within the 0.5s wait → 500 with stderr preview."""
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
@@ -228,6 +228,37 @@ def test_resume_500_when_process_exits_immediately(client, synthetic_session, mo
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
     assert r.status_code == 500
     assert "stderr says" in r.json()["detail"]
+
+
+@pytest.mark.unit
+def test_resume_rc0_immediate_exit_is_success(client, synthetic_session, monkeypatch):
+    """URL-dispatcher launchers (`warp-terminal warp://…`) exit rc=0 right
+    after delegating to the desktop app. That MUST be treated as success —
+    the spawn worked, the terminal is now running elsewhere."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd",
+                        "vt claude --resume {session_id}")
+
+    class _DispatchedProc:
+        def __init__(self, argv, **kwargs):
+            self.pid = 9
+            self.returncode = 0
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+
+        def wait(self, timeout=None):
+            return self.returncode  # immediate clean exit
+
+    monkeypatch.setattr("subprocess.Popen", _DispatchedProc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["spawned"] is True
+    assert sid in body["inner_command"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

\`warp-terminal warp://...\` is a URL dispatcher — it hands the URL to the running Warp instance and exits cleanly (rc=0) almost immediately. The previous resume logic treated any exit within 0.5s as a failure and returned 500 — even when the spawn actually worked. The visible symptom was 'Resume failed: HTTP 500: resume process exited rc=0' in the UI, and the frontend never got the response so the clipboard never received the inner command.

Fix: rc=0 is success regardless of timing. Only non-zero exit → 500 with stderr.

## Closes

Follow-up to #164.

## Test evidence

\`pytest tests/test_agent_resume_api.py\` → 15 passed (1 new test \`test_resume_rc0_immediate_exit_is_success\` locks in the dispatcher pattern; the old test was renamed for clarity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)