### PR TITLE
fix(cc-resume): server-side clipboard copy

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -442,6 +442,42 @@ class CCResumeRequest(BaseModel):
     extra_env: dict[str, str] = {}
 
 
+def _copy_to_clipboard(text: str, env: dict[str, str]) -> bool:
+    """Push `text` to the system clipboard via `wl-copy` (Wayland) or
+    `xclip` (X11). Returns True on success, False on any failure. Never
+    raises — the resume flow proceeds either way; the frontend gets the
+    rendered command in the response as a backup.
+    """
+    import shutil
+    import subprocess
+
+    # Wayland first (the user is on a Wayland session — WAYLAND_DISPLAY is
+    # set in the env overlay). xclip works on X11 / Xwayland.
+    candidates: list[list[str]] = []
+    if shutil.which("wl-copy"):
+        candidates.append(["wl-copy"])
+    if shutil.which("xclip"):
+        candidates.append(["xclip", "-selection", "clipboard"])
+    for argv in candidates:
+        try:
+            proc = subprocess.run(
+                argv,
+                input=text.encode("utf-8"),
+                env=env,
+                timeout=2.0,
+                check=False,
+                capture_output=True,
+            )
+            if proc.returncode == 0:
+                return True
+            logger.debug("clipboard helper %s exited rc=%d: %s",
+                         argv[0], proc.returncode, proc.stderr[:200])
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            logger.debug("clipboard helper %s failed: %s", argv[0], exc)
+            continue
+    return False
+
+
 def _resume_env() -> dict[str, str]:
     """Build the environment dict for the resume subprocess.
 
@@ -561,16 +597,23 @@ async def resume_claude_code_session(
         raise HTTPException(status_code=500, detail=f"resume spawn failed: {exc}") from exc
 
     # Render the inner command (the actual `claude --resume` invocation)
-    # for the frontend to copy to clipboard — Warp Linux ignores the
-    # `&command=` URI param, so the operator pastes it once the terminal
-    # opens. Same substitution rules as the outer template (raw only —
-    # URL-encoded variants aren't meaningful inside a terminal).
+    # so the operator can paste it once the terminal opens — Warp Linux
+    # ignores the `&command=` URI param.
     inner_template = (settings.cc_resume_inner_cmd or "").strip()
     inner_rendered = (
         inner_template
         .replace("{session_id}", bare)
         .replace("{cwd}", target.decoded_cwd)
     )
+    # Push the rendered inner command directly to the system clipboard
+    # via wl-copy / xclip. The browser-side Clipboard API silently fails
+    # when the page loses focus (which happens the instant Warp opens),
+    # so doing the copy from the server while it still has env access is
+    # far more reliable. Failure here is non-fatal — the frontend gets
+    # the command in the response and can offer manual copy.
+    clipboard_copied = False
+    if inner_rendered:
+        clipboard_copied = _copy_to_clipboard(inner_rendered, env)
 
     # Give the spawn a beat. Two flavors of launcher are both valid:
     #   (a) the launcher BECOMES the terminal (long-running) — wait() times
@@ -585,6 +628,7 @@ async def resume_claude_code_session(
         "command": argv,
         "cwd": target.decoded_cwd,
         "inner_command": inner_rendered,
+        "clipboard_copied": clipboard_copied,
     }
     try:
         proc.wait(timeout=0.5)

--- a/tests/test_agent_resume_api.py
+++ b/tests/test_agent_resume_api.py
@@ -49,6 +49,11 @@ def synthetic_session(tmp_path: Path, monkeypatch):
     from api.services.claude_code import session_ingest as cc
     cc.invalidate_cache()
     cc.invalidate_process_cache()
+    # Short-circuit the server-side clipboard helper for the default mock
+    # setup — tests that want to assert on it override `shutil.which`
+    # themselves. Without this, every test that mocks subprocess.Popen
+    # would also have to handle the `wl-copy`/`xclip` subprocess.run.
+    monkeypatch.setattr("shutil.which", lambda name: None)
     return tmp_path, sid
 
 
@@ -228,6 +233,86 @@ def test_resume_500_when_process_exits_nonzero_with_stderr(client, synthetic_ses
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
     assert r.status_code == 500
     assert "stderr says" in r.json()["detail"]
+
+
+@pytest.mark.unit
+def test_resume_pipes_inner_command_to_system_clipboard(
+    client, synthetic_session, monkeypatch
+):
+    """`inner_command` is piped to wl-copy / xclip server-side. The
+    response's `clipboard_copied` flag reflects whether the helper
+    exited rc=0."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd",
+                        "vt claude --resume {session_id}")
+
+    class _DispatchedProc:
+        def __init__(self, argv, **kwargs):
+            self.pid = 9
+            self.returncode = 0
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+
+        def wait(self, timeout=None):
+            return 0
+
+    monkeypatch.setattr("subprocess.Popen", _DispatchedProc)
+
+    captured: dict[str, object] = {}
+
+    class _CompletedProcess:
+        returncode = 0
+        stderr = b""
+
+    def _fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["input"] = kwargs.get("input")
+        return _CompletedProcess()
+
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}" if name in ("wl-copy",) else None)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["clipboard_copied"] is True
+    # The wl-copy invocation received the rendered inner command on stdin.
+    assert captured["argv"] == ["wl-copy"]
+    assert captured["input"].decode("utf-8") == f"vt claude --resume {sid}"
+
+
+@pytest.mark.unit
+def test_resume_clipboard_failure_is_non_fatal(client, synthetic_session, monkeypatch):
+    """No clipboard helper available → spawn still succeeds, flag is False."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd",
+                        "vt claude --resume {session_id}")
+
+    class _DispatchedProc:
+        def __init__(self, argv, **kwargs):
+            self.pid = 9
+            self.returncode = 0
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+
+        def wait(self, timeout=None):
+            return 0
+
+    monkeypatch.setattr("subprocess.Popen", _DispatchedProc)
+    monkeypatch.setattr("shutil.which", lambda name: None)  # no clipboard tools
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["spawned"] is True
+    assert body["clipboard_copied"] is False
+    assert body["inner_command"]  # still returned so frontend can offer manual copy
 
 
 @pytest.mark.unit

--- a/web/agents.html
+++ b/web/agents.html
@@ -746,18 +746,19 @@
         throw new Error(`HTTP ${r.status}: ${msg}`);
       }
       const result = await r.json();
-      // Warp Linux ignores `&command=` in its URI scheme, so the actual
-      // `claude --resume` invocation comes back as `inner_command` and we
-      // copy it to the clipboard for the operator to paste once the
-      // terminal opens.
-      let copied = false;
-      if (result.inner_command && navigator.clipboard && navigator.clipboard.writeText) {
+      // The server tries to push `inner_command` to the system clipboard
+      // via wl-copy / xclip — that's far more reliable than the browser
+      // Clipboard API, which silently fails when the page loses focus
+      // (which happens the instant Warp opens). If the server copy
+      // didn't land, try one more time from the browser before showing
+      // the command inline so the operator can copy it manually.
+      let copied = !!result.clipboard_copied;
+      if (!copied && result.inner_command && navigator.clipboard && navigator.clipboard.writeText) {
         try {
           await navigator.clipboard.writeText(result.inner_command);
           copied = true;
         } catch (_) {
-          // Clipboard API can fail when the page isn't focused (browser
-          // throws NotAllowedError). Fall through to a non-copy toast.
+          // ignore — toast will show the command for manual copy
         }
       }
       if (copied) {


### PR DESCRIPTION
## Summary

The browser's Clipboard API silently fails when the page loses focus — which happens the instant Warp opens. Server now pushes the rendered inner command to the system clipboard directly via \`wl-copy\` (Wayland) or \`xclip\` (X11), using the same DISPLAY/WAYLAND_DISPLAY env it inherits for the launcher spawn.

Response gains \`clipboard_copied: bool\`. Frontend trusts that first; falls back to its own clipboard attempt only if the server-side copy didn't land; falls back to a copy-the-text-from-the-toast UX if both fail.

## Test evidence

\`pytest tests/test_agent_resume_api.py\` → 17 passed (2 new). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)