### PR TITLE
fix(agents): align Claude Code cost calc with cache-aware pricing (post #157)

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -172,6 +172,8 @@ def _session_to_dict(s: Session, transcript: TranscriptStore) -> dict[str, Any]:
         "last_activity_at": s.last_activity_at,
         "total_input_tokens": s.total_input_tokens,
         "total_output_tokens": s.total_output_tokens,
+        "total_cache_creation_tokens": getattr(s, "total_cache_creation_tokens", 0),
+        "total_cache_read_tokens": getattr(s, "total_cache_read_tokens", 0),
         "total_dollars": round(s.total_dollars, 6),
         "total_active_seconds": round(s.total_active_seconds, 3),
         "expected_output": s.expected_output,

--- a/api/services/claude_code/session_ingest.py
+++ b/api/services/claude_code/session_ingest.py
@@ -382,20 +382,27 @@ def _truncate(s: str, cap: int = _PAYLOAD_PREVIEW_MAX) -> str:
 def _cost_from_usage(usage: dict[str, Any], model: str) -> float:
     """Apply pricing.py to a single message's `usage` block.
 
-    Sums input + output tokens only — matches the agent worker (which
-    only reads `input_tokens` / `output_tokens` from the Anthropic API
-    response; see `managed_executor.py` and `local_executor.py`). Cache
-    tokens are tracked separately in the `SessionMeta` for visibility
-    but are NOT added into the cost so the two sources are
-    apples-to-apples until cache-aware pricing lands (#137). When #137
-    ships, both sides should be updated together.
+    Sums all four Anthropic token buckets — uncached input, output,
+    cache_creation (1.25× input), cache_read (0.10× input) — matching
+    the agent worker's cost accounting after #145 / #157 landed
+    cache-aware pricing in `pricing.cost_for`. This keeps API spend
+    numbers apples-to-apples across LifeOS agent and Claude Code
+    sources.
     """
     from api.services.agent_worker.pricing import cost_for
 
     in_tok = int(usage.get(_USAGE_INPUT, 0) or 0)
     out_tok = int(usage.get(_USAGE_OUTPUT, 0) or 0)
+    cache_creation = int(usage.get(_USAGE_CACHE_CREATION, 0) or 0)
+    cache_read = int(usage.get(_USAGE_CACHE_READ, 0) or 0)
     use_model = model or "claude-sonnet-4-6"  # safer default than the Opus fallback
-    return cost_for(use_model, in_tok, out_tok)
+    return cost_for(
+        use_model,
+        in_tok,
+        out_tok,
+        cache_creation_tokens=cache_creation,
+        cache_read_tokens=cache_read,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_claude_code_ingest.py
+++ b/tests/test_claude_code_ingest.py
@@ -260,13 +260,15 @@ def test_parse_session_sums_tokens_and_cost(tmp_path: Path):
     assert meta.total_output_tokens == 75
     assert meta.total_cache_creation_tokens == 200
     assert meta.total_cache_read_tokens == 1500
-    # Cost matches the agent worker: input + output tokens only, no cache
-    # tokens (see #137 for the eventual cache-aware pricing). Sonnet rates
-    # are $3/M input, $15/M output.
-    # Msg 1: 100*3e-6 + 50*15e-6 = 0.0003 + 0.00075 = 0.00105
-    # Msg 2: 50*3e-6  + 25*15e-6 = 0.00015 + 0.000375 = 0.000525
-    # Total: 0.001575
-    assert meta.total_dollars == pytest.approx(0.001575, rel=1e-3)
+    # Cost matches the agent worker after cache-aware pricing landed
+    # (#145 / #157). Sonnet rates: $3/M input, $15/M output. cache_creation
+    # is 1.25× input ($3.75/M); cache_read is 0.10× input ($0.30/M).
+    # Msg 1: 100*3e-6 + 50*15e-6 + 200*3.75e-6 + 1000*0.30e-6
+    #      = 0.0003 + 0.00075 + 0.00075 + 0.0003 = 0.00210
+    # Msg 2: 50*3e-6 + 25*15e-6 + 0 + 500*0.30e-6
+    #      = 0.00015 + 0.000375 + 0.00015 = 0.000675
+    # Total: 0.002775
+    assert meta.total_dollars == pytest.approx(0.002775, rel=1e-3)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When #145 / #157 landed cache-aware pricing in \`pricing.cost_for\`, the managed executor was updated to pass \`cache_creation_tokens\` and \`cache_read_tokens\`. The Claude Code ingest path (\`api/services/claude_code/session_ingest.py\`) was not — it still summed only input + output, so CC node tooltips under-counted by ~25% on cache-heavy sessions (which is most of them).

This restores the apples-to-apples parity the original CC ingest set out to keep:

- \`_cost_from_usage\` now reads \`cache_creation_input_tokens\` + \`cache_read_input_tokens\` from each assistant message's \`usage\` and passes them to \`cost_for\` (1.25× input for creation, 0.10× input for reads).
- \`_session_to_dict\` in \`api/routes/agents.py\` surfaces \`total_cache_creation_tokens\` / \`total_cache_read_tokens\` on LifeOS-agent sessions too, matching the shape CC already exposed.
- The cost test gets the new expected value ($0.001575 → $0.002775 for the same usage inputs).

## API spend chip remains correct

The \`API spend\` chip on the agents UI continues to filter \`s.source !== 'claude_code'\`. With cache-aware pricing now flowing through both sources, the chip sums **only** LifeOS agent worker dollars and that number is accurate across all four Anthropic billing buckets. CC stays excluded — the user's stated 'CLI is paid via subscription, not metered API' rule is preserved.

## Test evidence

\`pytest tests/test_claude_code_ingest.py tests/test_agent_viz_api.py tests/test_agent_kill_api.py tests/test_agent_resume_api.py\` → **71 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)