### PR TITLE
fix(systemd): keep agent worker up through API restarts + any exit

### DIFF
--- a/config/systemd/lifeos-agent-worker.service
+++ b/config/systemd/lifeos-agent-worker.service
@@ -1,7 +1,14 @@
 [Unit]
 Description=LifeOS Agent Worker
 After=network.target lifeos-api.service
+# `Requires=` cascades a stop when lifeos-api stops; `BindsTo=` plus
+# `PartOf=` add the reverse — the worker restarts when lifeos-api
+# restarts, instead of just stopping and staying down. Without these
+# the post-commit hook (which restarts lifeos-api whenever api/ or
+# config/ files change) would leave the worker stopped indefinitely.
 Requires=lifeos-api.service
+BindsTo=lifeos-api.service
+PartOf=lifeos-api.service
 
 [Service]
 Type=simple
@@ -9,8 +16,15 @@ User=__USER__
 WorkingDirectory=__LIFEOS_DIR__
 EnvironmentFile=__LIFEOS_DIR__/.env
 ExecStart=__VENV__/bin/python -m api.services.agent_worker.worker
-Restart=on-failure
+# Restart on any exit (crash OR clean) so the worker stays up through
+# unhandled exceptions, OOM kills, transient API outages, etc. The
+# only thing that keeps it down is an operator-issued `systemctl stop`.
+# StartLimit* caps protect against truly broken state — if it crashes
+# 5 times in 5 minutes systemd backs off until the operator intervenes.
+Restart=always
 RestartSec=10
+StartLimitIntervalSec=300
+StartLimitBurst=5
 StandardOutput=append:__LIFEOS_DIR__/logs/agent-worker.log
 StandardError=append:__LIFEOS_DIR__/logs/agent-worker.log
 


### PR DESCRIPTION
## Problem

The agent worker has been silently stopping every time \`./scripts/server.sh restart\` runs (which the post-commit hook triggers on every \`api/\` or \`config/\` change). The unit had \`Requires=lifeos-api.service\` which cascades a stop, but no \`PartOf=\` to cascade a restart — so the worker stays down indefinitely.

Compounding this, \`Restart=on-failure\` doesn't re-spawn after the cascade-stop because it's a clean exit, not a failure. Net result: operator notices tasks aren't getting picked up, manually runs \`systemctl start lifeos-agent-worker\`. Repeat.

## Fix

\`config/systemd/lifeos-agent-worker.service\`:

- Add \`BindsTo=lifeos-api.service\` + \`PartOf=lifeos-api.service\` next to existing \`Requires=\`. \`PartOf\` propagates restart events (not just stops), so the worker comes back when the API does.
- \`Restart=on-failure\` → \`Restart=always\`. Comes back from any exit (clean SIGTERM, crash, OOM) except an operator-issued \`systemctl stop\`.
- Add \`StartLimitIntervalSec=300\` + \`StartLimitBurst=5\` as a circuit breaker — broken state can't burn the system with infinite restart loops.

## Applying

Fresh installs pick this up via \`scripts/setup-systemd.sh\`. Existing installs need:

\`\`\`bash
sudo ./scripts/setup-systemd.sh
# OR just the worker:
sed -e 's|__USER__|YOUR_USER|g' -e 's|__LIFEOS_DIR__|/your/path|g' -e 's|__VENV__|/your/venv|g' \\
    config/systemd/lifeos-agent-worker.service | sudo tee /etc/systemd/system/lifeos-agent-worker.service && \\
  sudo systemctl daemon-reload && sudo systemctl restart lifeos-agent-worker
\`\`\`

## Test plan

- [ ] Restart the API: \`sudo systemctl restart lifeos-api\`
- [ ] Verify worker came back: \`systemctl is-active lifeos-agent-worker\` → active
- [ ] Kill the worker with SIGTERM: \`sudo systemctl kill -s SIGTERM lifeos-agent-worker\`
- [ ] Verify it auto-restarted within ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)