### PR TITLE
fix(systemd): move StartLimit* to [Unit] section

### DIFF
--- a/config/systemd/lifeos-agent-worker.service
+++ b/config/systemd/lifeos-agent-worker.service
@@ -9,6 +9,12 @@ After=network.target lifeos-api.service
 Requires=lifeos-api.service
 BindsTo=lifeos-api.service
 PartOf=lifeos-api.service
+# StartLimit* belongs in [Unit] in modern systemd — putting it in
+# [Service] gets silently ignored. Circuit breaker: if the worker
+# crashes more than 5 times in 5 minutes, systemd backs off and the
+# operator has to intervene.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -19,12 +25,8 @@ ExecStart=__VENV__/bin/python -m api.services.agent_worker.worker
 # Restart on any exit (crash OR clean) so the worker stays up through
 # unhandled exceptions, OOM kills, transient API outages, etc. The
 # only thing that keeps it down is an operator-issued `systemctl stop`.
-# StartLimit* caps protect against truly broken state — if it crashes
-# 5 times in 5 minutes systemd backs off until the operator intervenes.
 Restart=always
 RestartSec=10
-StartLimitIntervalSec=300
-StartLimitBurst=5
 StandardOutput=append:__LIFEOS_DIR__/logs/agent-worker.log
 StandardError=append:__LIFEOS_DIR__/logs/agent-worker.log
 


### PR DESCRIPTION
## Summary

Tiny follow-up to #168. \`StartLimitIntervalSec\` and \`StartLimitBurst\` were placed in the \`[Service]\` section but belong in \`[Unit]\` for modern systemd. Result: \`daemon-reload\` printed a warning and the circuit breaker was silently ignored. The rest of #168 (PartOf, BindsTo, Restart=always) worked — the API-restart cascade is firing correctly on the live system.

This patch relocates the two directives so the circuit breaker actually takes effect.

## Test plan

- [ ] sudo cp + daemon-reload, no 'Unknown key name' warning
- [ ] systemctl show lifeos-agent-worker -p StartLimitBurst → 5
- [ ] systemctl show lifeos-agent-worker -p StartLimitIntervalUSec → 300000000 (300s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)