### PR TITLE
feat(ui): cross-page nav pills (Chat / CRM / Agents)

### DIFF
--- a/web/agents.html
+++ b/web/agents.html
@@ -56,6 +56,32 @@
     font-weight: 400;
     margin: 0 0.5rem;
   }
+  .header-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: 1rem;
+  }
+  .nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.75rem;
+    border-radius: 6px;
+    text-decoration: none;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    transition: all 0.2s;
+  }
+  .nav-link:hover {
+    background: var(--bg-card);
+    color: var(--text-primary);
+  }
+  .nav-link.active {
+    background: var(--accent);
+    color: var(--bg-primary);
+  }
   .chips {
     display: flex;
     gap: 0.5rem;
@@ -393,7 +419,12 @@
 </head>
 <body>
 <header>
-  <h1><a href="/">LifeOS</a><span class="crumb">›</span>Agents</h1>
+  <h1><a href="/">LifeOS</a></h1>
+  <nav class="header-nav">
+    <a href="/chat" class="nav-link">💬 Chat</a>
+    <a href="/crm" class="nav-link">👥 CRM</a>
+    <a href="/agents" class="nav-link active">🛠️ Agents</a>
+  </nav>
   <div class="chips" id="chips">
     <span class="chip running">running <strong id="chip-running">0</strong></span>
     <span class="chip blocked">blocked <strong id="chip-blocked">0</strong></span>

--- a/web/crm.html
+++ b/web/crm.html
@@ -7636,6 +7636,7 @@
             <nav class="header-nav">
                 <a href="/chat" class="nav-link">💬 Chat</a>
                 <a href="/crm" class="nav-link active">👥 CRM</a>
+                <a href="/agents" class="nav-link">🛠️ Agents</a>
             </nav>
         </div>
         <div class="header-right">

--- a/web/index.html
+++ b/web/index.html
@@ -2509,6 +2509,7 @@
                 <nav class="header-nav">
                     <a href="/chat" class="nav-link active">💬 Chat</a>
                     <a href="/crm" class="nav-link">👥 CRM</a>
+                    <a href="/agents" class="nav-link">🛠️ Agents</a>
                 </nav>
             </div>
             <div class="header-right">


### PR DESCRIPTION
## Summary

Adds an 'Agents' pill button to /chat and /crm next to the existing Chat/CRM pills, and adds the full three-pill set to /agents (which previously only had a 'LifeOS › Agents' breadcrumb).

All three pages now have parity: you can jump between Chat / CRM / Agents from any of them.

/agents picks up matching CSS rules (\`nav-link\`, \`header-nav\`) — pill-shaped, accent-colored when active, same hover behavior as the other two pages.

## Test plan

- [ ] Open /chat — pills row shows Chat (active), CRM, Agents. Click Agents → lands on /agents.
- [ ] Open /crm — pills row shows Chat, CRM (active), Agents. Click Agents → lands on /agents.
- [ ] Open /agents — pills row shows Chat, CRM, Agents (active). Click Chat → lands on /chat. Click CRM → lands on /crm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)