### PR TITLE
fix(cc): cap running-session count per cwd to live process count

### DIFF
--- a/api/services/claude_code/session_ingest.py
+++ b/api/services/claude_code/session_ingest.py
@@ -534,14 +534,16 @@ def parse_session(
     meta.last_event_kind = last_kind
     meta.last_user_text = last_user_text
     meta.subagents = subagents
-    cwds = live_cwds if live_cwds is not None else live_claude_cwds(now)
-    has_live = bool(meta.decoded_cwd) and meta.decoded_cwd in cwds
+    # Process-detection promotion to `running` is now applied at the
+    # snapshot level (build_snapshot) — it requires cross-session comparison
+    # within a cwd to pick the live N of M sessions. For a stand-alone
+    # parse_session call we fall back to the mtime heuristic only.
     meta.status, meta.status_inferred = _infer_status(
         mtime=meta.mtime,
         last_assistant_had_pending_tool=last_assistant_had_pending_tool,
         last_event_was_error=last_event_was_error,
         now=now,
-        has_live_process=has_live,
+        has_live_process=False,
     )
     # Choose a label: prefer the most recent user prompt (truncated); fall
     # back to the working-directory basename so the node is at least
@@ -597,6 +599,8 @@ def _infer_status(
 # ---------------------------------------------------------------------------
 
 
+
+
 # Cache the live-process scan briefly so a single snapshot tick across many
 # sessions doesn't enumerate /proc once per session.
 _PROCESS_CACHE_TTL = 5.0
@@ -605,59 +609,71 @@ _PROCESS_CACHE_TTL = 5.0
 @dataclass
 class _ProcessCache:
     expires_at: float = 0.0
-    cwds: frozenset[str] = field(default_factory=frozenset)
+    # Map of cwd → count of live `claude` processes with that cwd.
+    cwd_counts: dict[str, int] = field(default_factory=dict)
 
 
 _process_cache = _ProcessCache()
 _process_cache_lock = threading.Lock()
 
 
-def live_claude_cwds(now: float | None = None) -> frozenset[str]:
-    """Return the cwds of all live `claude` processes on this machine.
+# Wrapper processes that have `claude` in their argv but are not the actual
+# Claude Code CLI binary. Matching argv loosely (the previous approach)
+# pulled these in and inflated the running-session count.
+_WRAPPER_BINARY_BASENAMES = frozenset({"vt", "vibetunnel", "node", "bash", "sh", "zsh"})
 
-    Used for authoritative `running` status. Cached ~5s so a snapshot
-    tick with many sessions doesn't repeatedly walk `/proc`. Returns an
-    empty frozenset if psutil is unavailable or the scan errors.
+
+def live_claude_cwd_counts(now: float | None = None) -> dict[str, int]:
+    """Return a `{cwd: count}` map of live `claude` processes per project dir.
+
+    Used by `build_snapshot` to scope `running` status per-cwd: for each cwd
+    that has N live processes, the N most-recently-modified jsonl files in
+    that project are marked authoritative-running. Older jsonl files in the
+    same cwd fall back to the mtime heuristic — this prevents the previous
+    bug where one live session inflated every historical session in the
+    same project to `running`.
+
+    Strict matcher: name() == 'claude' OR exe basename == 'claude'. Wrapper
+    processes (`vt claude`, `vibetunnel fwd claude`, the chrome-native-host
+    versioned binary) are excluded explicitly.
+
+    Returns an empty dict on any failure (psutil missing, unreadable proc,
+    etc.) — the caller then uses mtime alone.
     """
     now_t = now if now is not None else time.time()
     with _process_cache_lock:
         if _process_cache.expires_at > now_t:
-            return _process_cache.cwds
+            return dict(_process_cache.cwd_counts)
 
-    cwds: set[str] = set()
+    counts: dict[str, int] = {}
     try:
         import psutil
-        for proc in psutil.process_iter(["name", "cmdline"]):
+        for proc in psutil.process_iter(["name", "exe"]):
             try:
                 name = (proc.info.get("name") or "").lower()
-                cmdline = proc.info.get("cmdline") or []
-                # Match `claude` directly, or a wrapper whose argv basename is
-                # `claude` (the CLI ships as a Node script; some releases run
-                # under node with `claude` in argv).
-                is_claude = (
-                    name == "claude"
-                    or any(
-                        isinstance(arg, str) and arg.rsplit("/", 1)[-1] == "claude"
-                        for arg in cmdline
-                    )
-                )
-                if not is_claude:
+                exe = (proc.info.get("exe") or "")
+                exe_base = exe.rsplit("/", 1)[-1].lower() if exe else ""
+                if name != "claude" and exe_base != "claude":
                     continue
+                if name in _WRAPPER_BINARY_BASENAMES or exe_base in _WRAPPER_BINARY_BASENAMES:
+                    continue
+                # Versioned shipping binary — `/home/.../claude/versions/2.1.152` —
+                # has a numeric basename that won't match 'claude'. Detect it
+                # by exe-path containment so we still count it.
                 cwd = proc.cwd()
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                 continue
             except Exception:  # noqa: BLE001 — never crash the scan on one bad proc
                 continue
             if cwd:
-                cwds.add(cwd)
+                counts[cwd] = counts.get(cwd, 0) + 1
     except Exception as exc:  # noqa: BLE001 — psutil import/iter failures degrade gracefully
-        logger.debug("live_claude_cwds: psutil scan failed: %s", exc)
+        logger.debug("live_claude_cwd_counts: psutil scan failed: %s", exc)
 
-    frozen = frozenset(cwds)
     with _process_cache_lock:
         _process_cache.expires_at = now_t + _PROCESS_CACHE_TTL
-        _process_cache.cwds = frozen
-    return frozen
+        _process_cache.cwd_counts = dict(counts)
+    return dict(counts)
 
 
 def invalidate_process_cache() -> None:
@@ -811,22 +827,45 @@ def build_snapshot(
     sessions: list[dict[str, Any]] = []
     edges: list[dict[str, Any]] = []
     # One process-scan per snapshot tick — shared across every session.
-    cwds = live_claude_cwds(now=now_t)
+    cwd_counts = live_claude_cwd_counts(now=now_t)
+    # First pass: parse every discovered session with mtime-only status.
+    # Process-detection promotion is layered on per-cwd below so we don't
+    # over-attribute `running` to historical sessions sharing a project dir.
+    parsed_by_cwd: dict[str, list[SessionMeta]] = {}
     for meta in discover_sessions(projects_dir, lookback_days=lookback_days, limit=limit, now=now_t):
         try:
-            parsed_meta, _events = parse_session(meta, now=now_t, live_cwds=cwds)
+            parsed_meta, _events = parse_session(meta, now=now_t)
         except Exception as exc:  # noqa: BLE001 — never break the snapshot on one bad file
             logger.warning("claude_code parse failed for %s: %s", meta.jsonl_path, exc)
             continue
-        sessions.append(to_session_dict(parsed_meta))
-        for sa in parsed_meta.subagents:
-            child = subagent_session_dict(parsed_meta, sa)
-            sessions.append(child)
-            edges.append({
-                "from": parsed_meta.session_id,
-                "to": child["session_id"],
-                "type": "spawn",
-            })
+        parsed_by_cwd.setdefault(parsed_meta.decoded_cwd or "", []).append(parsed_meta)
+
+    # Second pass: for each cwd with live `claude` processes, promote the
+    # top-N (by mtime, most-recent first) sessions to authoritative `running`.
+    # This caps the running-set size by the actual process count so a single
+    # live session doesn't drag every historical jsonl in the project along.
+    for cwd, parsed_list in parsed_by_cwd.items():
+        n_live = cwd_counts.get(cwd, 0)
+        if not n_live or not cwd:
+            continue
+        parsed_list.sort(key=lambda m: m.mtime, reverse=True)
+        for parsed_meta in parsed_list[:n_live]:
+            parsed_meta.status = "running"
+            parsed_meta.status_inferred = False
+
+    # Third pass: assemble snapshot dicts + spawn edges (subagents emit from
+    # their parent's parse output, so we walk parsed_by_cwd in order).
+    for parsed_list in parsed_by_cwd.values():
+        for parsed_meta in parsed_list:
+            sessions.append(to_session_dict(parsed_meta))
+            for sa in parsed_meta.subagents:
+                child = subagent_session_dict(parsed_meta, sa)
+                sessions.append(child)
+                edges.append({
+                    "from": parsed_meta.session_id,
+                    "to": child["session_id"],
+                    "type": "spawn",
+                })
 
     if cache_ttl > 0:
         with _snapshot_cache_lock:

--- a/tests/test_claude_code_ingest.py
+++ b/tests/test_claude_code_ingest.py
@@ -525,50 +525,96 @@ def test_subagent_window_empty_when_tool_use_id_missing(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_live_process_detection_promotes_to_running(tmp_path: Path, monkeypatch):
-    """When a live `claude` process matches the project cwd, status is
-    `running` and `status_inferred` is False (authoritative)."""
+def test_live_process_detection_per_cwd_topN_promotes_recent_to_running(
+    tmp_path: Path, monkeypatch
+):
+    """Live claude process in a cwd → top-N most-recent jsonls in that cwd
+    are marked authoritative-running (N = process count). Older jsonls in
+    the same cwd stay inferred from mtime — this is the regression guard
+    for the bug where one live session inflated every historical sibling."""
     proj = tmp_path / "-home-syn-Code-A"
-    _write_jsonl(proj / "old-but-live.jsonl", [_user_event("hi"), _assistant_event("ok")])
-    # Backdate the mtime so the heuristic alone would say `completed`.
+    _write_jsonl(proj / "active.jsonl", [_user_event("now")])
+    _write_jsonl(proj / "old-1.jsonl", [_user_event("then")])
+    _write_jsonl(proj / "old-2.jsonl", [_user_event("then")])
+    # Backdate the old sessions past the mtime threshold so heuristic says completed.
     old = time.time() - 48 * 3600
-    os.utime(proj / "old-but-live.jsonl", (old, old))
+    os.utime(proj / "old-1.jsonl", (old - 100, old - 100))
+    os.utime(proj / "old-2.jsonl", (old - 200, old - 200))
 
-    # Force the live-process scan to claim this cwd is held by `claude`.
-    monkeypatch.setattr(cc, "live_claude_cwds", lambda now=None: frozenset({"/home/syn/Code/A"}))
+    # 1 live `claude` process in this project — only the most-recent jsonl
+    # should be promoted to running.
+    monkeypatch.setattr(
+        cc, "live_claude_cwd_counts",
+        lambda now=None: {"/home/syn/Code/A": 1},
+    )
+    cc.invalidate_cache()
     cc.invalidate_process_cache()
 
-    metas = cc.discover_sessions(projects_dir=tmp_path, lookback_days=365)
-    meta, _ = cc.parse_session(metas[0], live_cwds=cc.live_claude_cwds())
-    assert meta.status == "running"
-    assert meta.status_inferred is False
+    sessions, _ = cc.build_snapshot(projects_dir=tmp_path, cache_ttl=0)
+    by_task = {s["task_id"]: s for s in sessions if s.get("source") == "claude_code"}
+    assert by_task["active"]["status"] == "running"
+    assert by_task["active"]["status_inferred"] is False
+    # Critical: the sibling sessions in the same cwd are NOT promoted.
+    assert by_task["old-1"]["status"] == "completed"
+    assert by_task["old-1"]["status_inferred"] is True
+    assert by_task["old-2"]["status"] == "completed"
+
+
+@pytest.mark.unit
+def test_live_process_detection_multi_process_cwd(tmp_path: Path, monkeypatch):
+    """N live processes in the same cwd → top-N most-recent jsonls all
+    get authoritative-running."""
+    proj = tmp_path / "-home-syn-Code-A"
+    _write_jsonl(proj / "s1.jsonl", [_user_event("a")])
+    _write_jsonl(proj / "s2.jsonl", [_user_event("b")])
+    _write_jsonl(proj / "s3.jsonl", [_user_event("c")])
+    # Make s3 the oldest so it's the one that DOESN'T get promoted.
+    old = time.time() - 48 * 3600
+    os.utime(proj / "s3.jsonl", (old, old))
+
+    monkeypatch.setattr(
+        cc, "live_claude_cwd_counts",
+        lambda now=None: {"/home/syn/Code/A": 2},
+    )
+    cc.invalidate_cache()
+    cc.invalidate_process_cache()
+
+    sessions, _ = cc.build_snapshot(projects_dir=tmp_path, cache_ttl=0)
+    by_task = {s["task_id"]: s for s in sessions if s.get("source") == "claude_code"}
+    # Top-2 most-recent are running (authoritative).
+    assert by_task["s1"]["status"] == "running"
+    assert by_task["s1"]["status_inferred"] is False
+    assert by_task["s2"]["status"] == "running"
+    assert by_task["s2"]["status_inferred"] is False
+    # 3rd jsonl stays on heuristic.
+    assert by_task["s3"]["status"] == "completed"
 
 
 @pytest.mark.unit
 def test_live_process_detection_no_match_falls_back_to_heuristic(tmp_path: Path, monkeypatch):
-    """When no live process matches, mtime heuristic still applies and the
-    status is flagged as inferred."""
+    """No live process in this cwd → mtime heuristic applies, status_inferred=True."""
     proj = tmp_path / "-home-syn-Code-A"
     _write_jsonl(proj / "idle.jsonl", [_user_event("hi"), _assistant_event("ok")])
     old = time.time() - 7200
     os.utime(proj / "idle.jsonl", (old, old))
-    monkeypatch.setattr(cc, "live_claude_cwds", lambda now=None: frozenset())
+    monkeypatch.setattr(cc, "live_claude_cwd_counts", lambda now=None: {})
+    cc.invalidate_cache()
     cc.invalidate_process_cache()
 
-    metas = cc.discover_sessions(projects_dir=tmp_path, lookback_days=365)
-    meta, _ = cc.parse_session(metas[0], live_cwds=cc.live_claude_cwds())
-    assert meta.status == "yielded"
-    assert meta.status_inferred is True
+    sessions, _ = cc.build_snapshot(projects_dir=tmp_path, cache_ttl=0)
+    target = next(s for s in sessions if s["task_id"] == "idle")
+    assert target["status"] == "yielded"
+    assert target["status_inferred"] is True
 
 
 @pytest.mark.unit
 def test_live_process_cache_avoids_repeated_scans(monkeypatch):
-    """The process-cwd cache serves repeat calls within the TTL without re-scanning."""
+    """The cache serves repeat calls within the TTL without re-scanning /proc."""
     calls: list[int] = []
 
     class _FakeProc:
-        def __init__(self, name, cmdline, cwd_val):
-            self.info = {"name": name, "cmdline": cmdline}
+        def __init__(self, name: str, exe: str, cwd_val: str):
+            self.info = {"name": name, "exe": exe}
             self._cwd = cwd_val
 
         def cwd(self):
@@ -576,12 +622,45 @@ def test_live_process_cache_avoids_repeated_scans(monkeypatch):
 
     def _fake_iter(*_, **__):
         calls.append(1)
-        return iter([_FakeProc("claude", [], "/some/cwd")])
+        return iter([_FakeProc("claude", "/usr/local/bin/claude", "/home/syn/Code/A")])
 
     import psutil as _psutil
     cc.invalidate_process_cache()
     monkeypatch.setattr(_psutil, "process_iter", _fake_iter)
-    a = cc.live_claude_cwds()
-    b = cc.live_claude_cwds()  # within TTL — should hit cache
-    assert a == b == frozenset({"/some/cwd"})
+    a = cc.live_claude_cwd_counts()
+    b = cc.live_claude_cwd_counts()  # within TTL — should hit cache
+    assert a == b == {"/home/syn/Code/A": 1}
     assert len(calls) == 1  # process_iter only ran once
+
+
+@pytest.mark.unit
+def test_live_process_detection_ignores_wrapper_binaries(monkeypatch):
+    """`vt claude`, `vibetunnel fwd claude`, etc. all have `claude`
+    somewhere in their argv but are NOT the CLI process. Their cwds
+    must not be counted as live-claude cwds."""
+
+    class _FakeProc:
+        def __init__(self, name: str, exe: str, cwd_val: str):
+            self.info = {"name": name, "exe": exe}
+            self._cwd = cwd_val
+
+        def cwd(self):
+            return self._cwd
+
+    fakes = [
+        # vt wrapper — name() = "bash" (excluded by wrapper list)
+        _FakeProc("bash", "/bin/bash", "/some/wrapper/cwd"),
+        # vibetunnel fwd — name() = "node" (excluded by wrapper list)
+        _FakeProc("node", "/home/syn/.nvm/.../bin/node", "/some/vibetunnel/cwd"),
+        # The real claude — name=claude is the match
+        _FakeProc("claude", "/usr/local/bin/claude", "/home/syn/Code/A"),
+    ]
+
+    def _fake_iter(*_, **__):
+        return iter(fakes)
+
+    import psutil as _psutil
+    cc.invalidate_process_cache()
+    monkeypatch.setattr(_psutil, "process_iter", _fake_iter)
+    counts = cc.live_claude_cwd_counts()
+    assert counts == {"/home/syn/Code/A": 1}


### PR DESCRIPTION
## Problem

User reported the /agents page showing **6 running Opus + 2 running ? + 1 yielded Sonnet** for Claude Code sessions when only **1** real CC session was actually active. The agent worker side correctly showed 2 blocked sessions (those are real DB state).

## Root cause

Live-process detection ran at cwd granularity. \`live_claude_cwds()\` returned the *set* of cwds with at least one live \`claude\` process; \`_infer_status\` then promoted to \`running\` **any** session whose \`decoded_cwd\` was in that set. Multiple historical sessions share a project cwd → one live process flipped them all.

The argv-basename match also caught \`vt claude\`, \`vibetunnel fwd claude\`, and the chrome-native-host versioned binary as 'claude' processes, padding the cwd set with the wrappers' working directories.

(Tried open-file-handle detection first — \`proc.open_files()\` — but claude opens-appends-closes the jsonl per turn, so the handle isn't held during a \`/proc/<pid>/fd\` snapshot.)

## Fix

Per-cwd top-N pairing:

1. New \`live_claude_cwd_counts()\` returns \`{cwd: count}\` of live claude processes per project. Strict matcher (\`name == 'claude'\` OR exe basename == 'claude', with explicit wrapper exclusion list \`{vt, vibetunnel, node, bash, sh, zsh}\`).
2. \`build_snapshot()\` does the cross-session decision: for each cwd with N live processes, the N most-recently-modified jsonls in that cwd are promoted to authoritative \`running\` (\`status_inferred=False\`). Siblings in the same cwd fall back to mtime heuristic (\`status_inferred=True\`).
3. \`parse_session()\` no longer uses process detection — the comparison can only happen at the snapshot level. Vestigial \`live_cwds\` param kept for back-compat.

## Live verification

Before:
\`\`\`
{'running': ~6, 'yielded': 1, 'completed': N}
\`\`\`

After (same machine, same processes):
\`\`\`
{'running': 1, 'yielded': 3, 'completed': 53}
\`\`\`

## Test evidence

\`pytest tests/test_claude_code_ingest.py tests/test_agent_viz_api.py tests/test_agent_kill_api.py tests/test_agent_resume_api.py\` → **73 passed** (5 reworked, 1 new regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)