### PR TITLE
feat(agents): rename CC 'yielded' → 'inactive', bump threshold, pulse fresh-activity border

### DIFF
--- a/api/services/claude_code/session_ingest.py
+++ b/api/services/claude_code/session_ingest.py
@@ -60,8 +60,13 @@ _USAGE_CACHE_READ = "cache_read_input_tokens"
 _SUBAGENT_TOOL_NAMES = frozenset({"Agent", "Task"})
 
 # Status-inference thresholds (seconds).
-_RUNNING_MTIME_THRESHOLD = 60
-_YIELDED_MTIME_THRESHOLD = 86_400  # 24h
+# A jsonl touched in the last 10 minutes reads as `running` even if the
+# user has stepped away — the CLI typically appends in bursts and a single
+# tight 60s threshold flipped sessions to inactive mid-pause.
+_RUNNING_MTIME_THRESHOLD = 600  # 10 min
+# Anything modified within 24h is `inactive` (resumable) — beyond that
+# we treat as truly done.
+_INACTIVE_MTIME_THRESHOLD = 86_400  # 24h
 
 # Truncation cap for tool-result payload previews (privacy + UI bandwidth).
 _PAYLOAD_PREVIEW_MAX = 240
@@ -133,7 +138,7 @@ class SessionMeta:
     mtime: float
     started_at: int = 0
     last_activity_at: int = 0
-    status: str = "yielded"
+    status: str = "inactive"
     status_inferred: bool = True
     model: str = ""
     parent_session_id: str | None = None
@@ -573,11 +578,13 @@ def _infer_status(
     Rules:
       - Live `claude` process matches the project cwd → `running`
         (authoritative — `inferred=False`).
-      - Modified in the last 60s → `running` (mtime-only — `inferred=True`).
-      - Modified within 24h → `yielded` (resumable; user closed the terminal).
+      - Modified in the last 10 minutes → `running` (mtime-only).
+      - Modified within 24h → `inactive` (resumable; user closed the
+        terminal or stepped away). Distinct from the agent worker's
+        `yielded` which specifically means 'paused waiting on children'.
       - Older, ended on an error → `failed`.
-      - Older, pending tool in flight → `yielded` (could be a long-running
-        tool; lacking process evidence we can't say it's abandoned).
+      - Older, pending tool in flight → `inactive` (could be a long-
+        running tool; lacking process evidence we can't say abandoned).
       - Otherwise → `completed`.
     """
     if has_live_process:
@@ -585,12 +592,12 @@ def _infer_status(
     age = (now if now is not None else time.time()) - mtime
     if age < _RUNNING_MTIME_THRESHOLD:
         return ("running", True)
-    if age < _YIELDED_MTIME_THRESHOLD:
-        return ("yielded", True)
+    if age < _INACTIVE_MTIME_THRESHOLD:
+        return ("inactive", True)
     if last_event_was_error:
         return ("failed", True)
     if last_assistant_had_pending_tool:
-        return ("yielded", True)
+        return ("inactive", True)
     return ("completed", True)
 
 

--- a/tests/test_claude_code_ingest.py
+++ b/tests/test_claude_code_ingest.py
@@ -288,16 +288,16 @@ def test_status_inference_running_when_mtime_fresh(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_status_inference_yielded_when_idle(tmp_path: Path):
+def test_status_inference_inactive_when_idle(tmp_path: Path):
     proj = tmp_path / "-home-syn-Code-A"
     path = proj / "idle.jsonl"
     _write_jsonl(path, [_user_event("hi"), _assistant_event("ok")])
-    # Backdate to 2h ago — past 60s threshold but before 24h.
+    # Backdate to 2h ago — past 10-min running threshold but before 24h.
     two_hours = time.time() - 7200
     os.utime(path, (two_hours, two_hours))
     metas = cc.discover_sessions(projects_dir=tmp_path)
     meta, _ = cc.parse_session(metas[0])
-    assert meta.status == "yielded"
+    assert meta.status == "inactive"
 
 
 @pytest.mark.unit
@@ -603,7 +603,7 @@ def test_live_process_detection_no_match_falls_back_to_heuristic(tmp_path: Path,
 
     sessions, _ = cc.build_snapshot(projects_dir=tmp_path, cache_ttl=0)
     target = next(s for s in sessions if s["task_id"] == "idle")
-    assert target["status"] == "yielded"
+    assert target["status"] == "inactive"
     assert target["status_inferred"] is True
 
 

--- a/web/agents.html
+++ b/web/agents.html
@@ -178,6 +178,7 @@
   .badge.status-running { color: var(--running); border-color: var(--running); }
   .badge.status-claimed { color: var(--claimed); border-color: var(--claimed); }
   .badge.status-yielded { color: var(--yielded); border-color: var(--yielded); }
+  .badge.status-inactive { color: var(--yielded); border-color: var(--yielded); }
   .badge.status-blocked { color: var(--blocked); border-color: var(--blocked); }
   .badge.status-completed { color: var(--completed); border-color: var(--completed); }
   .badge.status-failed,
@@ -454,6 +455,7 @@
       <option value="running">running</option>
       <option value="claimed">claimed</option>
       <option value="yielded">yielded</option>
+      <option value="inactive">inactive</option>
       <option value="blocked">blocked</option>
       <option value="completed">completed</option>
       <option value="failed">failed</option>
@@ -479,7 +481,8 @@
   const STATUS_COLORS = {
     running:   '#34d399',
     claimed:   '#60a5fa',
-    yielded:   '#fbbf24',
+    yielded:   '#fbbf24',  // agent worker — paused waiting on children
+    inactive:  '#fbbf24',  // claude code — paused, resumable
     blocked:   '#fb923c',
     completed: '#6b7280',
     failed:    '#f87171',
@@ -545,6 +548,22 @@
     network.setOptions({ physics: { enabled: false } });
   });
 
+  // Pulse the border of actively-writing nodes (recent activity in last 60s).
+  // Toggles borderWidth between a thin and thick value every ~700ms — pure
+  // DataSet.update on the targeted IDs so the rest of the canvas doesn't
+  // re-render.
+  let pulsePhase = 0;
+  setInterval(() => {
+    if (activelyWritingIds.size === 0) return;
+    pulsePhase = (pulsePhase + 1) % 2;
+    const next = pulsePhase === 0 ? 2 : 5;
+    const updates = [];
+    activelyWritingIds.forEach(id => updates.push({ id, borderWidth: next }));
+    if (updates.length) {
+      try { nodes.update(updates); } catch (_) {}
+    }
+  }, 700);
+
   network.on('click', (params) => {
     if (params.nodes && params.nodes.length > 0) {
       openPanel(params.nodes[0]);
@@ -591,6 +610,12 @@
     return Math.min(56, Math.max(14, 14 + grown));
   }
 
+  // Tracks the IDs of nodes currently considered 'actively writing' — fresh
+  // activity in the last 60s. We pulse their border via a setInterval to
+  // separate them visually from a session that's running-but-quiet within
+  // the broader 10-min running window.
+  const activelyWritingIds = new Set();
+
   function nodeFor(s) {
     const color = STATUS_COLORS[s.status] || '#6b7280';
     const isTerminal = TERMINAL.has(s.status);
@@ -598,6 +623,15 @@
     const isInferred = !!s.status_inferred;
     const isClaudeCode = (s.source === 'claude_code');
     const isSubagent = !!s.is_subagent;
+    // Recent-activity window: a node that was touched in the last 60s
+    // earns a pulsing border. Running-but-quiet nodes (within 10min but
+    // outside 60s) still read as `running` but don't blink.
+    const nowSec = Date.now() / 1000;
+    const isActivelyWriting = s.status === 'running'
+      && s.last_activity_at
+      && (nowSec - s.last_activity_at) < 60;
+    if (isActivelyWriting) activelyWritingIds.add(s.session_id);
+    else activelyWritingIds.delete(s.session_id);
     const totalTokens = (s.total_input_tokens || 0) + (s.total_output_tokens || 0);
     const size = sizeForTokens(totalTokens);
     const fill = isTerminal ? hexWithAlpha(color, 0.35) : hexWithAlpha(color, 0.85);
@@ -726,7 +760,7 @@
     // Resume button: only for terminal-state Claude Code sessions (not subagents).
     // Whether the backend will actually accept the click depends on
     // LIFEOS_CC_RESUME_ENABLED on the server; if disabled, click → toast error.
-    const showResume = isClaudeCode && !isSubagent && (TERMINAL.has(s.status) || s.status === 'yielded');
+    const showResume = isClaudeCode && !isSubagent && (TERMINAL.has(s.status) || s.status === 'inactive' || s.status === 'yielded');
     const sourceLabel = isClaudeCode ? 'Claude Code' : 'LifeOS agent';
     const inferredHint = s.status_inferred ? ' (inferred)' : '';
     panelEl.innerHTML = `


### PR DESCRIPTION
## Summary

Three operator-driven /agents UI tweaks:

1. **Claude Code 'yielded' → 'inactive'.** 'Yielded' is the agent-worker term of art (paused waiting on children); for a CC terminal session that's just sat idle, 'inactive' reads accurately. Frontend STATUS_COLORS, status-filter dropdown, badge CSS, and Resume-button gating all updated. Agent worker continues to emit 'yielded' for its own sessions — different meaning, distinct.
2. **'running' threshold 60s → 600s (10min).** The CLI appends in bursts; a 60s window flipped sessions to inactive mid-pause when the user was thinking.
3. **Pulsing border on fresh-activity nodes.** Running nodes whose \`last_activity_at\` is within the last 60s pulse their border between thin and thick every ~700ms — distinguishes 'actively writing right now' from 'running but quiet for a few minutes'. Pure \`DataSet.update()\` on tracked IDs, no canvas re-render.

## Test evidence

\`pytest tests/test_claude_code_ingest.py tests/test_agent_viz_api.py tests/test_agent_kill_api.py tests/test_agent_resume_api.py\` → **73 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)