### PR TITLE
fix(tests): unbreak 7 tests that assumed user-specific data

### DIFF
--- a/tests/test_config_structure.py
+++ b/tests/test_config_structure.py
@@ -58,8 +58,14 @@ class TestCrmMappings:
         assert isinstance(mappings, dict)
 
     def test_has_domain_mappings(self):
-        """CRM mappings should have domain_mappings section."""
+        """CRM mappings should have domain_mappings section when configured."""
+        from pathlib import Path
+
         from config.crm_config import get_mappings
+
+        if not (Path("config") / "crm_mappings.yaml").exists():
+            pytest.skip("crm_mappings.yaml not configured (expected for open-source)")
+
         mappings = get_mappings()
         assert "domain_mappings" in mappings
 

--- a/tests/test_directory_resolver.py
+++ b/tests/test_directory_resolver.py
@@ -5,9 +5,12 @@ import os
 import pytest
 from unittest.mock import patch
 
+from config.settings import settings
+
 pytestmark = pytest.mark.unit
 
 HOME = os.path.expanduser("~")
+VAULT_DIR = str(settings.vault_path)
 
 
 class TestResolveWorkingDirectory:
@@ -20,20 +23,20 @@ class TestResolveWorkingDirectory:
         return mod.resolve_working_directory(task)
 
     def test_vault_keywords(self):
-        assert self._resolve("edit my journal entry") == os.path.join(HOME, "Notes 2025")
-        assert self._resolve("add to the backlog") == os.path.join(HOME, "Notes 2025")
-        assert self._resolve("update my meeting notes") == os.path.join(HOME, "Notes 2025")
-        assert self._resolve("create a daily note") == os.path.join(HOME, "Notes 2025")
-        assert self._resolve("open the vault") == os.path.join(HOME, "Notes 2025")
-        assert self._resolve("find obsidian files") == os.path.join(HOME, "Notes 2025")
+        assert self._resolve("edit my journal entry") == VAULT_DIR
+        assert self._resolve("add to the backlog") == VAULT_DIR
+        assert self._resolve("update my meeting notes") == VAULT_DIR
+        assert self._resolve("create a daily note") == VAULT_DIR
+        assert self._resolve("open the vault") == VAULT_DIR
+        assert self._resolve("find obsidian files") == VAULT_DIR
 
     def test_vault_word_boundary(self):
         """'note' should not match 'notification' or 'denoted'."""
         result = self._resolve("send a notification to the team")
-        assert result != os.path.join(HOME, "Notes 2025")
+        assert result != VAULT_DIR
 
         result = self._resolve("this denoted something")
-        assert result != os.path.join(HOME, "Notes 2025")
+        assert result != VAULT_DIR
 
     def test_lifeos_keywords(self):
         assert self._resolve("fix the lifeos server") == os.path.join(HOME, "Code", "LifeOS")
@@ -63,7 +66,7 @@ class TestResolveWorkingDirectory:
         """Vault keywords should take priority over LifeOS keywords."""
         # "sync" is LifeOS, but "notes" is vault — vault should win since checked first
         result = self._resolve("sync my notes")
-        assert result == os.path.join(HOME, "Notes 2025")
+        assert result == VAULT_DIR
 
     @patch("api.services.directory_resolver.Path")
     def test_project_name_match(self, mock_path_cls):

--- a/tests/test_pair_strength_migration.py
+++ b/tests/test_pair_strength_migration.py
@@ -17,11 +17,13 @@ class TestPairStrengthBaseline:
     """Baseline tests capturing current edge_weight behavior."""
 
     def test_relationship_store_loads(self):
-        """Relationship store can load relationships."""
+        """Relationship store can be queried without error."""
         from api.services.relationship import get_relationship_store
         store = get_relationship_store()
         all_rels = store.get_all_relationships()
-        assert len(all_rels) > 0, "Should have relationships in store"
+        # The store must return a list-like result (open-source default: empty).
+        # Populated installs are exercised by the integration tests below.
+        assert isinstance(all_rels, list)
 
     def test_edge_weight_property_exists(self):
         """Relationship has edge_weight property."""
@@ -170,13 +172,13 @@ class TestNetworkGraphIntegration:
         # Use settings.my_person_id to get the correct owner ID
         # (get_by_name may return wrong ID if there are duplicates)
         owner = person_store.get_by_id(settings.my_person_id)
-        assert owner is not None, "Owner should exist"
+        if owner is None:
+            pytest.skip("Owner PersonEntity not populated (expected for open-source default)")
 
         rel_store = get_relationship_store()
         rels = rel_store.get_for_person(owner.id)
-
-        # At least some relationships should exist
-        assert len(rels) > 0, "Owner should have relationships"
+        if not rels:
+            pytest.skip("Owner has no relationships (expected for fresh install)")
 
         # All should have edge_weight (or pair_strength after migration)
         for rel in rels[:10]:
@@ -207,7 +209,8 @@ class TestEdgeWeightSourceLogic:
                     test_person = p
                     break
 
-        assert test_person is not None, "Should find a person with relationship to owner"
+        if test_person is None:
+            pytest.skip("No populated owner relationships (expected for fresh install)")
 
         # For owner edges, weight should match relationship_strength (not pair_strength)
         rel = rel_store.get_between(owner_id, test_person.id)
@@ -221,10 +224,8 @@ class TestEdgeWeightSourceLogic:
     def test_non_owner_edge_uses_pair_strength(self):
         """Edges not involving the owner should use pair_strength."""
         from api.services.relationship import get_relationship_store
-        from api.services.person_entity import get_person_entity_store
         from config.settings import settings
 
-        person_store = get_person_entity_store()
         rel_store = get_relationship_store()
         owner_id = settings.my_person_id
 
@@ -237,7 +238,8 @@ class TestEdgeWeightSourceLogic:
                     non_owner_rel = rel
                     break
 
-        assert non_owner_rel is not None, "Should find a non-owner relationship"
+        if non_owner_rel is None:
+            pytest.skip("No populated non-owner relationships (expected for fresh install)")
 
         # For non-owner edges, weight should be pair_strength
         expected_weight = non_owner_rel.pair_strength


### PR DESCRIPTION
## Summary
- These tests hard-coded the maintainer's personal vault path (`~/Notes 2025`) or required a populated CRM database. Both fail by default for fresh downloaders, violating LifeOS's open-source-first principle — and have been bypassed with `--no-verify` for the entire `/agents` workstream.
- 7 tests fixed (1 `test_config_structure`, 2 `test_directory_resolver`, 4 `test_pair_strength_migration`) — all skip cleanly on a fresh install and execute their assertions on a populated install.

## Changes
- `test_directory_resolver`: read `settings.vault_path` instead of hard-coding `~/Notes 2025`. Resolver and tests now agree on the same source of truth.
- `test_config_structure::test_has_domain_mappings`: skip when `config/crm_mappings.yaml` is absent (matches existing `TestPeopleDictionary::test_structure_if_exists` pattern).
- `test_pair_strength_migration`:
  - `test_relationship_store_loads`: assert the store returns a list (the actual "loads" semantic) rather than requiring data.
  - `test_network_graph_returns_edges_with_weight` / `test_owner_edge_uses_relationship_strength` / `test_non_owner_edge_uses_pair_strength`: skip when no owner / relationships exist (data-dependent integration tests).

## Test plan
- [x] `./scripts/test.sh unit` — 1550 passed, 8 skipped (clean exit) on the worktree pre-push hook
- [ ] On a populated install (i.e. the maintainer's machine), confirm the 3 newly-skipped integration tests still pass when data is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)