### PR TITLE
docs(adr): retrofit ADRs 001-007 to upgraded template + ADR-005 superseded by ADR-007

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,384 @@
+# Documentation Strategy
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+
+**This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
+
+## Purpose
+
+This strategy defines how we organize and maintain documentation in LifeOS. These are **rules, not guidelines** — following this strategy faithfully is critical to maintaining documentation quality across a collaborative human + AI agent project.
+
+Documentation in LifeOS serves two readers equally:
+- **Human contributors** who need to onboard, debug, and design changes.
+- **AI agents** (Claude Code, Cursor, Copilot, etc.) that load docs as context when working on the codebase.
+
+Both readers benefit from the same things: short, focused documents; explicit decisions; cross-links instead of duplication; and an unambiguous answer to "where does this kind of information live?"
+
+## Core Principles
+
+1. **Living documents over proposals** — Design docs evolve during implementation rather than being written once and frozen. Update when thinking changes, not when tasks complete.
+2. **Modular over monolithic** — Split documents by concern, not by phase or role. A 1,800-line spec is a symptom, not a feature.
+3. **Cross-linked over isolated** — Documents reference related docs with a short tagline explaining the relationship, not just a link.
+4. **Concise over comprehensive** — Each document has a clear scope; prefer multiple focused docs over one sprawling one.
+5. **Consistent over creative** — Follow established patterns and structures. Consistency makes documentation predictable and navigable.
+6. **AI-readable** — Be succinct, specific, and clear. Prefer shorter, well-named documents over longer ones. Don't overexplain, but make requirements and decisions explicit.
+7. **Single source of truth** — Default to keeping each piece of information in exactly one authoritative location; other documents link to it rather than repeating it. When in doubt about where something belongs, consult the [Content Classification table](#content-classification). When you find duplication, prefer consolidating to the authoritative location and replacing duplicates with cross-references.
+
+## Document Taxonomy
+
+```
+docs/
+├── AGENTS.md          # THIS FILE (documentation strategy)
+├── CLAUDE.md          # @AGENTS.md wrapper
+├── vision/            # WHY — project vision, philosophy
+├── specs/
+│   ├── product/       # WHAT — features, API contracts, data models (consumer perspective)
+│   ├── technical/     # HOW (design) — architecture, schema, security, infrastructure
+│   └── standards/     # HOW (work) — coding conventions, testing standards, naming rules
+├── adr/               # WHY (decisions) — immutable architecture decision records
+├── guides/            # HOW (do) — step-by-step operational instructions
+├── plans/             # WHEN — active execution work, ephemeral (gitignored)
+└── archive/           # HISTORY — superseded documents (gitignored)
+```
+
+### Vision Documents
+
+**Location:** `docs/vision/`
+**Purpose:** Vision, philosophy, and strategic direction — the WHY behind LifeOS
+**Updated:** When strategy changes (rarely)
+
+Vision docs provide foundational context that frames every design decision. For LifeOS, that's primarily the privacy-first, local-first, single-user posture — see [philosophy.md](vision/philosophy.md).
+
+### Specifications
+
+**Location:** `docs/specs/`
+**Purpose:** Design documents describing WHAT the system is/should be (target state)
+**Updated:** When the design evolves
+
+**Key principle:** Specs are the **vision** — the authoritative design for the system. Not implementation plans, not progress tracking, not task lists. They describe the intended architecture and behavior.
+
+"Living" means the spec updates when *the design* changes, not when *tasks* complete.
+
+- `product/` — What the system does from a consumer perspective. Feature behavior, API contracts, data model semantics. Answers: "What does this entity mean? What can you do with this endpoint?"
+- `technical/` — How the system is built from an engineering perspective. Architecture, schema, security implementation, query optimization. Answers: "How is this implemented? What constraints did we hit?"
+- `standards/` — Rules and conventions for how we work. Coding standards, naming conventions, testing patterns. Answers: "What conventions must we follow?"
+
+### Architecture Decision Records (ADRs)
+
+**Location:** `docs/adr/`
+**Purpose:** Immutable records of significant architectural decisions with context and rationale
+**Updated:** Never. ADRs are append-only — create a new ADR to supersede an old one. The only acceptable in-place edit is adding an `Amended by: ADR-NNN` or `Superseded By: ADR-NNN` pointer to the frontmatter.
+
+**Naming:** `NNN-short-title.md` (e.g., `008-managed-agents-cloud-routing.md`). Sequential numbering. Never reuse numbers.
+
+ADRs live at the top level (not under `specs/`) because they span product and technical concerns. A decision about data model semantics is as load-bearing as one about database engines.
+
+### Operational Guides
+
+**Location:** `docs/guides/`
+**Purpose:** Step-by-step instructions for specific operator and contributor tasks
+**Updated:** When procedures change
+
+Guides are instructional — they tell you how to do something, not why it's designed that way. If a guide starts explaining design rationale, that content belongs in a spec or ADR.
+
+### Plans
+
+**Location:** `docs/plans/` (gitignored — personal/active planning notes)
+**Purpose:** Active execution work — phases, tasks, roadmaps, backlogs
+
+Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. For trackable work, prefer GitHub issues; for personal planning, use the local `docs/plans/` directory.
+
+### Archive
+
+**Location:** `docs/archive/` (gitignored)
+**Purpose:** Superseded documents, audit notes, and historical investigation working notes retained for local context.
+
+Archive content is **not** part of the public repo. When a durable insight from an archived doc is still load-bearing, promote it: link to the relevant live spec, or extract the durable conclusion into an ADR.
+
+## Content Classification
+
+| Content Type | Belongs In | Anti-Pattern |
+|---|---|---|
+| Project vision, philosophy, strategy | `vision/` | Not in specs (too stable, too abstract) |
+| User-facing feature behavior, API contracts, data model semantics | `specs/product/` | No implementation details, no task lists |
+| Architecture, system design, schema, query design, security implementation | `specs/technical/` | No roadmaps, no "Next Steps" |
+| Coding conventions, naming rules, testing patterns | `specs/standards/` | Not in guides (standards prescribe, guides instruct) |
+| Architectural decisions with rationale and alternatives | `adr/` | Never modify after acceptance — create a new ADR to supersede |
+| Setup procedures, troubleshooting, operator how-to | `guides/` | Not design rationale |
+| Phases, tasks, roadmaps, checklists | `plans/` (or GitHub issues) | Don't put in specs |
+| Audit notes, investigation working files, superseded docs | `archive/` | Don't link from live specs unless promoting a specific insight |
+
+**Rule of thumb:** "Why do we build this?" → vision. "What should it be?" → product spec. "How is it built?" → technical spec. "Why did we decide?" → ADR. "How do I do X?" → guide. "When/how do we get there?" → plan.
+
+**LifeOS-specific classification:**
+- Data model semantics (what entities mean, relationships between them) → `specs/product/data-model.md`
+- Data model implementation (SQLite schema, ChromaDB collections, indexes) → `specs/technical/`
+- API contracts (consumer perspective, request/response shapes) → `specs/product/api-reference.md`
+- API internals (route-handler structure, middleware, error handling) → `specs/technical/`
+- Privacy/security design decisions → `specs/technical/security-privacy.md`, with corresponding ADRs for the underlying decisions
+
+## Frontmatter Standards
+
+Every document must have frontmatter:
+
+```markdown
+**Status:** Draft | Partial | Complete
+**Last Updated:** YYYY-MM-DD
+```
+
+**Additional fields by document type:**
+
+| Type | Additional Fields |
+|---|---|
+| ADR | `**Decision:** Accepted \| Superseded \| Deprecated` and (if applicable) `**Superseded By:** ADR-NNN` or `**Amended by:** ADR-NNN` |
+| Product Spec | `**Owner:** name-or-area` |
+| Technical Spec | `**Owner:** name-or-area` |
+| Guide | `**Audience:** Operator \| Contributor \| New users` |
+| Plan | `**Target Date:** YYYY-MM-DD` (or `Ongoing`); `**Completed:** YYYY-MM-DD` when archived |
+
+`Status` values:
+- **Draft** — Initial draft, not yet reviewed; may have gaps or open questions.
+- **Partial** — Some sections complete, others marked TODO; safe to read for the parts that exist.
+- **Complete** — Reviewed, accurate as of `Last Updated`, no known gaps.
+
+For ADRs, `Status` reflects document completeness; `Decision` reflects whether the decision is still in force.
+
+## ADR Template
+
+ADRs use the following structure. The retrofit issue (#182) brought existing ADRs into this shape; all new ADRs must follow it.
+
+```markdown
+# ADR-NNN: Short Title
+
+**Status:** Complete
+**Last Updated:** YYYY-MM-DD
+**Decision:** Accepted
+**Superseded By:** ADR-NNN  (only if applicable)
+**Amended by:** ADR-NNN     (only if applicable)
+
+## Context
+
+The situation, constraints, and forces at the time of the decision. Why this needed to be decided now.
+
+## Decision
+
+One unambiguous statement of what was chosen. No hedging.
+
+## Rationale
+
+Why this choice over the alternatives. Tie back to the constraints in Context.
+
+## Alternatives Considered
+
+Each alternative as its own subsection with a one-paragraph description and an explicit "Rejected because..." line. Recover alternatives from PR descriptions, commit messages, or memory. Where you genuinely don't remember, write "to be filled in by the original decider" rather than fabricating.
+
+### Alternative A
+
+Description.
+
+**Rejected because:** specific reason.
+
+## Consequences
+
+### Positive
+
+- Specific benefits this decision enables.
+
+### Negative
+
+- Specific costs, ongoing maintenance burden, or constraints this decision imposes.
+
+## Related Documents
+
+(Use the 4-bucket Related Documents structure described below.)
+```
+
+## Length Guidelines
+
+Not rigid rules, but signals for document health. When a doc passes the "max" column it should be split by concern.
+
+| Document Type | Target Lines | Max Lines |
+|---|---|---|
+| ADR | 200–500 | 800 |
+| Product Spec | 300–700 | 800 |
+| Technical Spec | 400–800 | 1,000 |
+| Standards | 200–500 | 700 |
+| Vision | 300–600 | 800 |
+| Guide | 200–500 | 800 |
+| Plan | Variable | — |
+
+**Split when:**
+- Document exceeds the Max in its column.
+- It covers multiple distinct concerns (e.g., one CRM spec covering people, interactions, graph, analytics).
+- Different readers need different sections.
+- Table of contents has more than ~8 top-level sections.
+
+When splitting, keep a thin **index document** at the original path with pointers to each split and a short overview. Update all inbound links to point at the right split.
+
+## Cross-Linking Standards
+
+Every document must include a "Related Documents" section at the bottom.
+
+**Requirements:**
+1. **Bidirectional** — if A links to B, B must link to A. When you add a link in one direction, add the reciprocal link in the same PR.
+2. **Contextual** — every link has a "— short tagline" explaining the relationship.
+3. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
+4. **Use the 4-bucket structure** below for consistency.
+
+**Standard Related Documents template:**
+
+```markdown
+## Related Documents
+
+### Design Context
+- [ADR-NNN: Decision Name](../adr/NNN-title.md) — Why this approach was chosen
+- [Vision: Philosophy](../vision/philosophy.md) — The principle behind this
+
+### Specifications
+- [Product Spec](../specs/product/feature.md) — Consumer-facing requirements
+- [Technical Spec](../specs/technical/component.md) — Implementation design
+
+### Operational
+- [Setup Guide](../guides/feature-setup.md) — How to configure this
+- [Configuration](../guides/configuration.md) — Env var reference
+
+### Code References
+- [Implementation](../../api/services/foo.py:45-120) — Production code
+- [Tests](../../tests/test_foo.py) — Coverage
+```
+
+Use only the buckets that apply — omit empty buckets rather than including them as `(none)`.
+
+## Lifecycle Rules
+
+**Specs are living:**
+- Update when the design changes, not when tasks complete.
+- If a spec describes a target that's not yet built, the `Status: Partial` value is appropriate.
+- Specs are not changelogs. Don't add "Added X in PR #N" notes; that's what `git log` and `git blame` are for.
+
+**Plans are ephemeral:**
+- A plan ends as either "completed" (move to `archive/` with `Completed: YYYY-MM-DD`) or "superseded" (note the successor and move to `archive/`).
+- Do not leave stale plans in `docs/plans/`.
+
+**ADRs are immutable:**
+- Never modify the Context / Decision / Rationale / Alternatives sections of an accepted ADR.
+- To change a decision, create a new ADR. The old ADR gets `Superseded By: ADR-NNN` added to its frontmatter — that's the only acceptable in-place edit.
+- For a smaller change (clarification, scoping refinement that doesn't reverse the decision), the new ADR is an *amendment* and the old ADR gets `Amended by: ADR-NNN`.
+
+**Guides decay:**
+- Test commands you document before shipping. Stale guides are worse than missing guides.
+
+## Writing for AI Readability
+
+Documentation is frequently consumed by AI agents during development. Optimize for:
+
+**Clarity:**
+- State requirements explicitly. Avoid "should consider" — say "do" or "don't" or "defer because X".
+- Use precise technical terminology (route handler, span, collection) rather than vague nouns.
+- Avoid ambiguous pronouns; prefer specific nouns even at the cost of repetition.
+
+**Structure:**
+- Well-named sections that match their content. A section labeled "Notes" is a smell.
+- Frontmatter with status and metadata at the top.
+- Tables when they sharpen a comparison; prose otherwise.
+
+**Brevity:**
+- Shorter, focused documents over long comprehensive ones.
+- Link to details rather than repeating them.
+- Keep documents focused on one concern so agents don't waste context loading irrelevant content.
+
+**Anti-patterns:**
+- Long narrative explanations when a bulleted list suffices.
+- Repeating context already in linked documents.
+- Vague statements like "we should consider" (instead: decided yes/no, or defer with reason).
+- Burying key decisions in prose.
+
+## LifeOS-Specific Rules
+
+### Privacy-First Documentation
+
+LifeOS handles deeply personal data — emails, messages, photos, finances. Documentation must not become a leak vector.
+
+- **Use obviously synthetic data in all examples and test fixtures.** Names like "Alex Chen", domains like `example.com`, phone numbers like `555-0123`, dollar amounts like `$1,234.56`. No real names, emails, phone numbers, or financial values, even in commit-message screenshots.
+- **Security-sensitive implementation details belong in code, not docs.** Reference the code (with line numbers) rather than restating encryption keys, auth tokens, or exact connection strings.
+- **Technical specs involving data storage or access** should include a "Privacy Considerations" subsection or link to one in `specs/technical/security-privacy.md`.
+- **Don't paste real terminal output** containing real personal data into docs. Sanitize first.
+
+### Open-Source Posture
+
+LifeOS is open-source and single-user / self-hosted. That implies two doc rules beyond the privacy ones:
+
+- **No hardcoded personal values** in examples, configs, or fixtures (paths under `/home/<personal-username>`, machine names, IP addresses). Use placeholders (`<your-username>`, `<your-machine>`).
+- **No "broken by default for a fresh downloader" assumptions.** Setup guides should walk through what a fresh clone actually needs, not what's already true on the maintainer's machine.
+
+### Sub-Directory Instruction Files
+
+Every doc subdirectory has an `AGENTS.md` + `CLAUDE.md` pair so any reader (human or agent) can orient inside the subdirectory without re-reading this strategy file.
+
+Existing pairs:
+- `docs/adr/AGENTS.md` + `CLAUDE.md`
+- `docs/guides/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/standards/AGENTS.md` + `CLAUDE.md`
+- `docs/vision/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/product/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/specs/technical/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/plans/AGENTS.md` + `CLAUDE.md` (added in #181 — note: gitignored)
+
+**AGENTS.md** is the primary instruction file (universal, works with all AI tools). **CLAUDE.md** is a one-line wrapper: `@AGENTS.md`. The `@` import is relative to the file containing it; since CLAUDE.md and AGENTS.md are always co-located, the import is always literally `@AGENTS.md`.
+
+**AGENTS.md structure (per subdirectory):**
+
+```markdown
+[One-line description of directory purpose]
+
+## Contents
+- `file.md` — one-line description
+...
+
+## Key Principles
+- Critical rules that apply to this directory's content
+
+## Related Documents
+- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
+- [Other relevant doc] — Why it matters here
+```
+
+Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended commentary — keep them tight.
+
+## Maintenance Rules
+
+**When code changes:**
+1. Update the relevant design doc in the same PR if the design changed (not the implementation — only when the *intent* changed).
+2. Update `Last Updated` in the frontmatter.
+3. Check if cross-references need updates.
+4. Verify bidirectional links still resolve.
+
+**When documents get long (over the Max in [Length Guidelines](#length-guidelines)):**
+1. Identify distinct concerns within the document.
+2. Create focused docs for each concern.
+3. Keep the original path as a thin index pointing at the splits.
+4. Update inbound references to the right split.
+
+**Common violations to avoid:**
+- Adding "Next Steps" or task lists to specs or ADRs.
+- Mixing planning (roadmaps, tasks) into design documents.
+- Creating documents without "Related Documents" sections.
+- Failing to update cross-references when moving or splitting documents.
+- Modifying an accepted ADR in place (instead of superseding).
+- Using real personal data in examples.
+
+---
+
+## Related Documents
+
+### Project Context
+- [Root AGENTS.md](../AGENTS.md) — Project-level agent reference, development principles, key files
+- [Root CLAUDE.md](../CLAUDE.md) — Claude Code-specific configuration
+
+### Specifications
+- [vision/philosophy.md](vision/philosophy.md) — The privacy-first, local-first principles that frame doc decisions
+- [specs/standards/](specs/standards/) — Coding and testing conventions referenced by docs
+
+### Operational
+- [guides/](guides/) — Operator-facing setup and troubleshooting

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/adr/001-python-fastapi.md
+++ b/docs/adr/001-python-fastapi.md
@@ -1,9 +1,8 @@
 # ADR-001: Python/FastAPI as Primary Stack
 
-> **Decision:** Use Python 3.11+ with FastAPI as the backend framework for LifeOS.
-> **Date:** 2026-02-19
-> **Status:** Accepted
-> **Last Updated:** 2026-02-19
+**Status:** Complete
+**Last Updated:** 2026-02-19
+**Decision:** Accepted
 
 ## Context
 
@@ -11,64 +10,77 @@ LifeOS is a self-hosted AI assistant that indexes personal data (notes, emails, 
 
 The backend needs to integrate tightly with ML/NLP libraries (embedding models, vector stores, LLM clients), support async I/O for concurrent API requests, SSE streaming, and external service calls, and enable rapid prototyping for a single-developer project where iteration speed matters more than raw throughput. It must also generate an OpenAPI schema automatically for MCP tool integration, which enables Claude to discover and call LifeOS tools programmatically.
 
-The project is solo-developed and self-hosted on a Mac Mini. Enterprise-scale concerns (horizontal scaling, microservices, container orchestration) are not relevant. The right choice optimizes for developer productivity, library ecosystem breadth, and ML/AI integration depth.
+The project is solo-developed and self-hosted. Enterprise-scale concerns (horizontal scaling, microservices, container orchestration) are not relevant. The right choice optimizes for developer productivity, library ecosystem breadth, and ML/AI integration depth.
 
 ## Decision
 
-Python 3.11+ with the FastAPI framework, using Pydantic for request/response validation and uvicorn as the ASGI server.
+Use Python 3.11+ with the FastAPI framework, Pydantic for request/response validation, and uvicorn as the ASGI server.
 
 ## Rationale
 
 - **ML ecosystem**: Python has first-class support for sentence-transformers, ChromaDB, the Anthropic SDK, and Ollama bindings. No other language comes close for ML tooling breadth or library maturity.
-- **FastAPI strengths**: Native async/await, automatic OpenAPI spec generation (critical for MCP tool discovery), Pydantic validation, and dependency injection.
-- **Development velocity**: Single-developer project benefits from Python's rapid prototyping cycle. Type hints + Pydantic catch errors early without Java-level ceremony.
+- **FastAPI strengths**: Native async/await, automatic OpenAPI spec generation (critical for MCP tool discovery), Pydantic validation, dependency injection.
+- **Development velocity**: A single-developer project benefits from Python's rapid prototyping cycle. Type hints + Pydantic catch errors early without Java-level ceremony.
 - **Community**: Large ecosystem of middleware, auth libraries, and deployment guides. Problems are well-documented and solutions are readily available.
 
 ## Alternatives Considered
 
 ### Go
 
-Go offers excellent performance, low memory usage, and easy deployment via static binaries. For a networked service handling concurrent requests, Go's goroutine model is compelling. However, the ML/NLP ecosystem in Go is immature — there are no native equivalents to sentence-transformers, ChromaDB's Python client, or the Anthropic SDK. Using Go would require either CGo bindings (which negate many of Go's deployment advantages) or running Python as a sidecar service for all ML operations, effectively maintaining two runtimes. For a project where ML integration is central, not peripheral, this tradeoff is unfavorable.
+Go offers excellent performance, low memory usage, and easy deployment via static binaries. The goroutine model is compelling for a networked service handling concurrent requests.
+
+**Rejected because:** The ML/NLP ecosystem in Go is immature — no native equivalents to sentence-transformers, ChromaDB's Python client, or the Anthropic SDK. Using Go would require either CGo bindings (which negate many of Go's deployment advantages) or running Python as a sidecar service for all ML operations, effectively maintaining two runtimes. For a project where ML integration is central, not peripheral, the tradeoff is unfavorable.
 
 ### Node.js / TypeScript
 
-Node.js has strong async capabilities and TypeScript provides good type safety. However, the ML library ecosystem in JavaScript is significantly weaker than Python's. Critical dependencies — sentence-transformers for embeddings, ChromaDB's native client, Ollama's Python bindings — either don't exist in JS or are community-maintained wrappers around Python. Using Node would require a Python sidecar for embedding generation and vector operations anyway, adding operational complexity without meaningful benefit. The JavaScript ecosystem excels at frontend and real-time applications, but LifeOS's core workload is ML-heavy backend processing.
+Node.js has strong async capabilities and TypeScript provides good type safety.
+
+**Rejected because:** The ML library ecosystem in JavaScript is significantly weaker than Python's. Critical dependencies — sentence-transformers, ChromaDB's native client, Ollama bindings — either don't exist in JS or are community-maintained wrappers around Python. Using Node would require a Python sidecar for embedding generation and vector operations anyway, adding operational complexity without meaningful benefit.
 
 ### Django
 
-Django is a mature, full-featured Python framework with ORM, admin interface, template engine, and authentication built in. However, this "batteries included" approach adds weight that LifeOS doesn't need — there's no relational ORM (data lives in SQLite with raw queries and ChromaDB), no need for Django's template engine (frontend is static HTML/JS), and the admin interface adds complexity without value for a single-user system. Django's async support via Django Channels requires additional setup and is less native than FastAPI's built-in async. FastAPI's lighter footprint and OpenAPI generation are better fits.
+Django is a mature, full-featured Python framework with ORM, admin, template engine, and authentication built in.
+
+**Rejected because:** Its "batteries included" approach adds weight LifeOS doesn't need — no relational ORM (data lives in SQLite with raw queries and ChromaDB), no template engine (frontend is static HTML/JS), no admin interface for a single-user system. Django's async support via Channels requires additional setup and is less native than FastAPI's built-in async. FastAPI's lighter footprint and built-in OpenAPI generation are a better fit.
 
 ### Flask
 
-Flask is lightweight and flexible but lacks native async support — a significant limitation for a server that must handle concurrent API requests, SSE streaming, and external service calls simultaneously. Flask also has no built-in request validation (requiring marshmallow or similar) and no automatic OpenAPI generation. Reaching feature parity with FastAPI would require assembling multiple extensions (Flask-RESTful, Flask-Marshmallow, Flask-SocketIO), resulting in more code and more maintenance surface than using FastAPI directly.
+Flask is lightweight and flexible.
+
+**Rejected because:** It lacks native async support — a significant limitation for a server that must handle concurrent API requests, SSE streaming, and external service calls simultaneously. Flask has no built-in request validation and no automatic OpenAPI generation. Reaching FastAPI parity requires assembling multiple extensions (Flask-RESTful, Flask-Marshmallow, Flask-SocketIO), resulting in more code and more maintenance than using FastAPI directly.
 
 ## Consequences
 
-**Positive:**
+### Positive
+
 - Rapid development with excellent library support across ML, API, and data processing.
 - Automatic OpenAPI generation enables seamless MCP tool integration.
 - Async I/O handles concurrent requests, SSE streaming, and external API calls well.
 - Easy to onboard contributors familiar with Python.
 
-**Negative:**
-- Slower than Go/Rust for CPU-bound tasks (mitigated: CPU-heavy work is in C extensions like numpy/torch, not pure Python).
-- GIL limits true parallelism for CPU-bound threads (mitigated: workload is I/O-bound, and async handles concurrency).
-- Deployment requires managing a Python virtual environment and dependencies.
+### Negative
 
-**Risks:**
-- Python's packaging ecosystem remains fragile — dependency conflicts and version pinning require ongoing vigilance. The external venv (see ADR-005) adds a layer of operational complexity.
-- If LifeOS ever needs to handle significantly higher throughput (e.g., serving multiple users or real-time indexing), Python's per-request overhead may become a bottleneck. This would require profiling and potentially offloading hot paths to compiled extensions.
-- FastAPI's rapid release cycle occasionally introduces breaking changes in minor versions. Pinning uvicorn and FastAPI versions in requirements.txt is essential.
+- Slower than Go/Rust for CPU-bound tasks (mitigated: CPU-heavy work is in C extensions like numpy/torch, not pure Python).
+- GIL limits true parallelism for CPU-bound threads (mitigated: workload is I/O-bound, async handles concurrency).
+- Deployment requires managing a Python virtual environment and pinned dependencies.
+- Python's packaging ecosystem remains fragile — dependency conflicts and version pinning require ongoing vigilance. The external venv (see [ADR-005](005-external-venv-macos-tcc.md)) adds a layer of operational complexity.
+- FastAPI's release cycle occasionally introduces breaking changes in minor versions. Pinning `uvicorn` and `fastapi` versions in `requirements.txt` is essential.
+- If LifeOS ever needs to serve significantly higher throughput (multiple users, real-time indexing), Python's per-request overhead may become a bottleneck — would require profiling and offloading hot paths to compiled extensions.
 
 ## Related Documents
 
-**Design Context:**
-- [ADR-005: External Venv](005-external-venv-macos-tcc.md) — Why the virtual environment lives outside the project directory
+### Design Context
+- [ADR-005: External Venv](005-external-venv-macos-tcc.md) — Why the virtual environment lives outside the project directory (TCC-driven; superseded by ADR-007)
+- [ADR-007: Linux Migration](007-linux-migration.md) — Stack carried forward to Linux; venv convention retained
 
-**Specifications:**
+### Specifications
 - [Architecture](../specs/technical/architecture.md) — Code structure and module layout built on this stack
 - [Python Conventions](../specs/standards/python-conventions.md) — Coding standards for this Python/FastAPI codebase
 
-**Operational:**
+### Operational
 - [Installation Guide](../guides/installation.md) — How to set up the Python environment
 - [Scripts Reference](../guides/scripts.md) — Server management scripts that wrap uvicorn
+
+### Code References
+- [`api/main.py`](../../api/main.py) — FastAPI application entry point
+- [`requirements.txt`](../../requirements.txt) — Pinned dependency set

--- a/docs/adr/002-chromadb-vector-store.md
+++ b/docs/adr/002-chromadb-vector-store.md
@@ -1,81 +1,99 @@
 # ADR-002: ChromaDB for Vector Storage
 
-> **Decision:** Use ChromaDB in client-server mode as the vector database for semantic search.
-> **Date:** 2026-02-19
-> **Status:** Accepted
-> **Last Updated:** 2026-02-19
+**Status:** Complete
+**Last Updated:** 2026-02-19
+**Decision:** Accepted
 
 ## Context
 
-LifeOS needs a vector database for semantic search over personal documents including Obsidian notes, emails, calendar events, messages, and more. The vector store is a core infrastructure component — it stores embeddings for every indexed document and handles similarity queries that power the search pipeline.
+LifeOS needs a vector database for semantic search over personal documents — Obsidian notes, emails, calendar events, messages, and more. The vector store is core infrastructure: it stores embeddings for every indexed document and handles similarity queries that power the search pipeline.
 
-Requirements are shaped by LifeOS's design principles. **Local-first**: all data must stay on the user's machine — no cloud vector databases. **Server mode**: the vector store should run as a separate process so the API server can restart independently without losing index state or triggering expensive re-indexing. **Scale**: must handle ~100K+ documents with acceptable query latency (<500ms). **Python-native**: first-class Python client to minimize integration friction with the FastAPI backend.
+Requirements are shaped by LifeOS's design principles:
+- **Local-first**: all data must stay on the user's machine — no cloud vector databases.
+- **Server mode**: the vector store should run as a separate process so the API server can restart independently without losing index state.
+- **Scale**: must handle ~100K+ documents with acceptable query latency (<500ms).
+- **Python-native**: first-class Python client to minimize integration friction with the FastAPI backend.
 
-The choice of vector database also affects operational complexity. LifeOS runs on a Mac Mini as a background service managed by launchd. Any vector store must be reliable enough to run unattended, with minimal configuration and reasonable recovery from crashes or ungraceful shutdowns.
+The choice also affects operational complexity. LifeOS runs as a background service (originally launchd on a Mac Mini; now systemd on Linux per [ADR-007](007-linux-migration.md)). Any vector store must be reliable enough to run unattended, with minimal configuration and reasonable recovery from crashes or ungraceful shutdowns.
 
 ## Decision
 
-ChromaDB running in client-server mode on port 8001. The embedding model (all-MiniLM-L6-v2) runs in-process within the FastAPI server. ChromaDB stores pre-computed embeddings and handles similarity search.
+ChromaDB running in client-server mode on port 8001. The embedding model runs in-process within the FastAPI server. ChromaDB stores pre-computed embeddings and handles similarity search.
 
 ## Rationale
 
-- **Local-first**: ChromaDB runs entirely on the local machine with no cloud dependency, satisfying the core privacy requirement.
+- **Local-first**: ChromaDB runs entirely on the local machine with no cloud dependency, satisfying the privacy requirement.
 - **Simple Python API**: Native Python client with a clean collection-based interface. Adding, querying, and deleting documents is straightforward.
 - **Server mode**: Client-server separation means the API can restart without rebuilding the vector index. ChromaDB persists data to disk independently.
-- **Adequate performance**: For the target scale (~100K documents, single user), ChromaDB provides sub-200ms query latency, which is well within requirements.
+- **Adequate performance**: For ~100K documents and a single user, ChromaDB provides sub-200ms query latency, well within requirements.
 - **Low operational overhead**: Single binary, minimal configuration, SQLite-backed metadata storage.
 
 ## Alternatives Considered
 
 ### Pinecone
 
-Pinecone is a fully managed cloud vector database with excellent query performance and scaling capabilities. However, it fundamentally violates LifeOS's local-first privacy requirement — all vectors and metadata would be stored on Pinecone's servers. Beyond privacy, it introduces an external dependency and recurring cost ($70+/month for production usage) for a single-user system that runs on local hardware. Pinecone is the right choice for multi-tenant SaaS applications, not for a self-hosted personal assistant.
+Pinecone is a fully managed cloud vector database with excellent performance and scaling.
+
+**Rejected because:** It violates LifeOS's local-first requirement — all vectors and metadata would live on Pinecone's servers. It also introduces an external dependency and recurring cost ($70+/month) for a single-user system running on local hardware. Pinecone is the right choice for multi-tenant SaaS, not for a self-hosted personal assistant.
 
 ### Weaviate
 
-Weaviate is a capable open-source vector database with a rich feature set including hybrid search, multi-tenancy, and GraphQL APIs. It can run self-hosted and satisfies the local-first requirement. However, its operational footprint is significantly heavier than ChromaDB — it requires more memory, has more complex configuration (schema definitions, module configuration), and its Docker-based deployment model adds friction for a launchd-managed macOS service. For a single-user system indexing ~100K documents, Weaviate's enterprise features (multi-tenancy, horizontal scaling) add complexity without corresponding benefit.
+Weaviate is a capable open-source vector database with hybrid search, multi-tenancy, and GraphQL APIs. It can run self-hosted.
+
+**Rejected because:** Its operational footprint is significantly heavier than ChromaDB — more memory, more complex configuration (schema definitions, module configuration), Docker-based deployment that adds friction for a systemd/launchd-managed personal service. The enterprise features (multi-tenancy, horizontal scaling) add complexity without corresponding benefit at single-user scale.
 
 ### Qdrant
 
-Qdrant is a strong open-source alternative with excellent performance characteristics and a Rust-based engine. At the time of evaluation, its Python client was less mature than ChromaDB's, with fewer examples and less community support for the specific integration patterns LifeOS uses (collection-per-source, metadata filtering). Qdrant would be a viable migration target if ChromaDB's stability issues worsen — its Rust core offers better reliability guarantees than ChromaDB's Python/SQLite backend.
+Qdrant is a strong open-source alternative with excellent performance characteristics and a Rust-based engine.
+
+**Rejected because:** At evaluation time its Python client was less mature than ChromaDB's, with fewer examples and less community support for the integration patterns LifeOS uses (collection-per-source, metadata filtering). Qdrant remains a viable migration target if ChromaDB stability degrades — its Rust core offers better reliability guarantees than ChromaDB's Python/SQLite backend.
 
 ### pgvector (PostgreSQL extension)
 
-pgvector adds vector similarity search to PostgreSQL. While this would consolidate the data layer (vectors + metadata in one database), it requires adding PostgreSQL as a dependency. LifeOS currently uses only SQLite for relational data, and adding a full PostgreSQL server for vector search alone is disproportionate to the need. PostgreSQL also requires more memory, more configuration, and more operational attention than ChromaDB's self-contained deployment.
+pgvector adds vector similarity search to PostgreSQL, which would consolidate the data layer (vectors + metadata in one database).
+
+**Rejected because:** It requires adding PostgreSQL as a dependency. LifeOS currently uses only SQLite for relational data, and adding a full PostgreSQL server for vector search alone is disproportionate. PostgreSQL also requires more memory, more configuration, and more operational attention than ChromaDB's self-contained deployment.
 
 ### FAISS (Facebook AI Similarity Search)
 
-FAISS provides excellent vector search performance and is widely used in research. However, it operates as an in-process library with no built-in server mode or persistence management. Every API server restart would require reloading the entire index from disk, adding seconds to startup time. FAISS also lacks built-in metadata storage and filtering — these would need to be implemented separately. For a service that restarts frequently during development and must persist state across process lifecycles, FAISS's in-process model is a poor fit.
+FAISS provides excellent vector search performance and is widely used in research.
+
+**Rejected because:** It operates as an in-process library with no built-in server mode or persistence management. Every API server restart would require reloading the entire index from disk, adding seconds to startup time. FAISS also lacks built-in metadata storage and filtering — these would need to be implemented separately. For a service that restarts frequently during development, FAISS's in-process model is a poor fit.
 
 ## Consequences
 
-**Positive:**
+### Positive
+
 - All personal data stays on the local machine — no cloud vector database dependency.
 - Simple API reduces integration and maintenance effort.
 - Server mode provides process isolation and independent persistence.
-- Lightweight enough to run alongside the API server on a Mac Mini.
+- Lightweight enough to run alongside the API server on modest hardware.
 
-**Negative:**
-- Less battle-tested at scale than Pinecone or Weaviate. Occasional stability issues under heavy write loads required adding a watchdog process (`LifeOS watchdog`).
+### Negative
+
+- Less battle-tested at scale than Pinecone or Weaviate. Occasional stability issues under heavy write loads required adding a watchdog process.
 - Smaller community means fewer resources for troubleshooting edge cases.
-- Migration to another vector store would require re-embedding all documents.
-
-**Risks:**
-- ChromaDB's stability under heavy write loads (bulk sync operations) has required a watchdog process. If stability degrades further, migration to Qdrant or another store may be necessary, which would require re-embedding the entire corpus.
-- ChromaDB's development pace means API changes between versions can require code updates. Pinning the ChromaDB version and testing upgrades before deploying is essential.
-- The SQLite-backed metadata store has a theoretical size limit, though this is unlikely to be reached at the current scale (~100K documents).
+- Migration to another vector store would require re-embedding all documents — a significant operation for a large corpus.
+- ChromaDB's stability under heavy write loads (bulk sync operations) has required a watchdog. If stability degrades further, migration to Qdrant or another store may be necessary.
+- API changes between ChromaDB versions can require code updates. Pinning the ChromaDB version and testing upgrades before deploying is essential.
+- The SQLite-backed metadata store has a theoretical size limit, though this is unlikely to be reached at the current scale.
 
 ## Related Documents
 
-**Design Context:**
+### Design Context
 - [ADR-004: Hybrid Search](004-hybrid-search.md) — How ChromaDB is used alongside BM25 for search
 - [ADR-001: Python/FastAPI](001-python-fastapi.md) — The Python stack that ChromaDB integrates with
+- [ADR-007: Linux Migration](007-linux-migration.md) — ChromaDB now runs under `lifeos-chromadb.service` (systemd) rather than launchd
 
-**Specifications:**
+### Specifications
 - [Data and Sync](../specs/technical/data-and-sync.md) — Sync pipeline that populates ChromaDB
 - [Search Indexing](../specs/technical/search-indexing.md) — How vector search fits into the hybrid search pipeline
 - [Architecture](../specs/technical/architecture.md) — System architecture including ChromaDB's role
 
-**Operational:**
+### Operational
 - [Troubleshooting](../guides/troubleshooting.md) — ChromaDB debugging and watchdog management
-- [AGENTS.md](../../AGENTS.md) — Watchdog cron entry and health check commands
+- [Scripts Reference](../guides/scripts.md) — Watchdog and health check commands
+
+### Code References
+- [`api/services/vectorstore.py`](../../api/services/vectorstore.py) — ChromaDB client wrapper
+- [`config/systemd/lifeos-chromadb.service`](../../config/systemd/lifeos-chromadb.service) — Service unit

--- a/docs/adr/003-two-tier-data-model.md
+++ b/docs/adr/003-two-tier-data-model.md
@@ -1,17 +1,16 @@
 # ADR-003: Two-Tier Data Model (SourceEntity / PersonEntity)
 
-> **Decision:** Adopt a two-tier data model separating raw observations (SourceEntity) from canonical records (PersonEntity).
-> **Date:** 2026-02-19
-> **Status:** Accepted
-> **Last Updated:** 2026-02-19
+**Status:** Complete
+**Last Updated:** 2026-02-19
+**Decision:** Accepted
 
 ## Context
 
-LifeOS ingests data from 12+ sources: Gmail, Google Calendar, iMessage, WhatsApp, Slack, Apple Contacts, Apple Photos, phone/FaceTime call history, Obsidian vault, and more. The system's core value proposition — being a personal AI assistant with full context — depends on unifying this data into a coherent model.
+LifeOS ingests data from 12+ sources: Gmail, Google Calendar, iMessage, WhatsApp, Slack, Apple Contacts, Apple Photos, phone/FaceTime call history, Obsidian vault, and more. The system's core value — being a personal AI assistant with full context — depends on unifying this data into a coherent model.
 
-The same person appears across these sources with different identifiers: an email address in Gmail, a phone number in iMessage and call history, a Slack user ID in Slack messages, a display name in Obsidian notes. A single contact might appear as "john@acme.com" in email, "+1-555-0100" in iMessage, "U04ABCD" in Slack, and "John Smith" in Obsidian. The system must recognize these as the same person while preserving the raw data for debugging, re-processing, and audit purposes.
+The same person appears across these sources with different identifiers: an email in Gmail, a phone number in iMessage and call history, a Slack user ID in Slack, a display name in Obsidian notes. A single contact might appear as `alex@example.com`, `+1-555-0100`, `U04ABCD`, and "Alex Chen" — the system must recognize these as the same person while preserving the raw data for debugging, re-processing, and audit.
 
-Entity resolution — the process of determining which observations refer to the same real-world person — is inherently imperfect. Heuristics will incorrectly merge distinct people who share a name, or fail to merge the same person across sources with no overlapping identifiers. The data model must support correcting these errors without re-ingesting data from original sources, which may be slow, rate-limited, or unavailable.
+Entity resolution — determining which observations refer to the same real-world person — is inherently imperfect. Heuristics will incorrectly merge distinct people who share a name, or fail to merge the same person across sources with no overlapping identifiers. The data model must support correcting these errors without re-ingesting from original sources, which may be slow, rate-limited, or unavailable.
 
 ## Decision
 
@@ -25,53 +24,64 @@ Entity resolution runs as a batch process that maps SourceEntities to PersonEnti
 
 ## Rationale
 
-- **Lossless data**: Raw observations are never modified. If entity resolution makes a mistake (merges two different people, or fails to merge the same person), the original data is intact for correction.
-- **Re-runnable resolution**: Entity resolution can be re-executed with improved heuristics without re-ingesting data from sources. This proved critical during development when the resolution algorithm was refined multiple times.
+- **Lossless data**: Raw observations are never modified. If resolution makes a mistake, the original data is intact for correction.
+- **Re-runnable resolution**: Entity resolution can be re-executed with improved heuristics without re-ingesting from sources. This proved critical during development when the algorithm was refined multiple times.
 - **Provenance tracking**: Every fact about a person traces back to a specific source observation with a timestamp, enabling "where did we learn this?" queries.
-- **Merge/split support**: When entity resolution incorrectly merges two people, the PersonEntity can be split and the SourceEntities reassigned without data loss.
+- **Merge/split support**: When resolution incorrectly merges two people, the PersonEntity can be split and the SourceEntities reassigned without data loss.
 
 ## Alternatives Considered
 
 ### Single-Entity Model
 
-A single-entity model merges data in-place as it arrives: when a new email is ingested, it's immediately added to the matching person record, overwriting or appending fields. This is simpler to implement and query — there's only one table to search, and every person record is immediately complete. However, merging in-place is destructive. If entity resolution incorrectly links two people, untangling their merged data requires re-ingesting from original sources. Provenance is lost — there's no record of which source provided which fact. And re-running resolution with improved heuristics requires a full re-ingest, not just a re-computation. For a system that iterated through multiple resolution algorithms during development, this would have been prohibitively expensive.
+Merge data in-place as it arrives: when a new email is ingested, immediately add it to the matching person record, overwriting or appending fields.
+
+**Rejected because:** Merging in-place is destructive. If resolution incorrectly links two people, untangling their merged data requires re-ingesting from original sources. Provenance is lost — there's no record of which source provided which fact. And re-running resolution with improved heuristics requires a full re-ingest, not just a re-computation. For a system that iterated through multiple resolution algorithms during development, this would have been prohibitively expensive.
 
 ### Graph-Only Model
 
-A graph database (e.g., Neo4j) naturally represents people as nodes and relationships as edges, making it flexible for modeling complex social networks. Queries like "who is connected to whom through what?" are elegant in graph query languages. However, basic operations that LifeOS performs constantly — list all contacts sorted by recency, search by name, count interactions — are more complex in graph queries than in relational SQL. A graph model is powerful for relationship analysis but adds query complexity for the primary use case (CRM-style contact management). The two-tier model provides a simpler foundation, with graph-like queries possible through joins when needed.
+A graph database (e.g., Neo4j) naturally represents people as nodes and relationships as edges, making complex social-network queries elegant.
+
+**Rejected because:** Basic operations LifeOS performs constantly — list all contacts sorted by recency, search by name, count interactions — are more complex in graph queries than in relational SQL. A graph model is powerful for relationship analysis but adds query complexity for the primary use case (CRM-style contact management). The two-tier relational model is simpler, with graph-like queries possible through joins when needed.
 
 ### Per-Source Tables
 
-Per-source tables (one table for Gmail contacts, another for iMessage contacts, etc.) preserve source-specific schemas and avoid the abstraction overhead of a unified SourceEntity. However, this approach duplicates schema definitions across tables and makes cross-source queries require complex unions. Entity resolution becomes table-specific rather than operating on a unified data model. As LifeOS adds new data sources, each new source requires a new table, new ingestion code, and new resolution logic — a maintenance burden that scales linearly with source count. The unified SourceEntity model absorbs new sources with minimal schema changes.
+One table per source (Gmail contacts, iMessage contacts, etc.) preserves source-specific schemas and avoids the abstraction overhead of a unified SourceEntity.
+
+**Rejected because:** It duplicates schema definitions across tables and makes cross-source queries require complex unions. Entity resolution becomes table-specific rather than operating on a unified data model. Each new data source requires a new table, new ingestion code, and new resolution logic — a maintenance burden that scales linearly with source count. The unified SourceEntity model absorbs new sources with minimal schema changes.
 
 ## Consequences
 
-**Positive:**
+### Positive
+
 - Lossless data preservation — original observations are never modified.
 - Entity resolution can be improved and re-run without re-ingesting source data.
 - Clean separation between "what we observed" and "what we believe to be true."
 - Supports merge/split corrections when resolution makes mistakes.
 - Provenance for every piece of information about a person.
 
-**Negative:**
+### Negative
+
 - More complex queries — displaying a person's full profile requires joining across SourceEntity and PersonEntity tables.
 - Entity resolution is a non-trivial subsystem that requires ongoing maintenance.
 - Storage overhead from keeping both tiers (acceptable at current scale).
-
-**Risks:**
-- Entity resolution quality directly affects user experience. Poor resolution (too many false merges or missed merges) creates confusion in the CRM. Ongoing heuristic refinement will be necessary as new data sources are added.
+- Resolution quality directly affects user experience. Poor resolution (too many false merges or missed merges) creates confusion in the CRM. Ongoing heuristic refinement is necessary as new data sources are added.
 - The two-tier model adds query complexity that could become a performance concern at scale. If PersonEntity profiles require joining across thousands of SourceEntities, query optimization or materialized views may be needed.
 - New data sources may not fit cleanly into the SourceEntity schema, requiring schema extensions. The generic model trades source-specific richness for uniformity.
 
 ## Related Documents
 
-**Design Context:**
+### Design Context
 - [ADR-004: Hybrid Search](004-hybrid-search.md) — How both tiers are indexed for search
 
-**Specifications:**
+### Specifications
 - [Data Model](../specs/product/data-model.md) — Consumer-facing semantics of SourceEntity and PersonEntity
 - [Entity Resolution](../specs/product/entity-resolution.md) — How people are matched and merged across sources
 - [Data and Sync](../specs/technical/data-and-sync.md) — Sync pipeline that creates SourceEntities and triggers resolution
 
-**Operational:**
-- [AGENTS.md](../../AGENTS.md) — CRM API commands for searching and managing people
+### Operational
+- [Root AGENTS.md](../../AGENTS.md) — CRM API commands for searching and managing people
+
+### Code References
+- [`api/services/entity_resolver.py`](../../api/services/entity_resolver.py) — Resolution heuristics, scoring, merge logic
+- [`api/services/people_aggregator.py`](../../api/services/people_aggregator.py) — SourceEntity → PersonEntity aggregation
+- [`config/people_dictionary.example.json`](../../config/people_dictionary.example.json) — Template for the local-only `people_dictionary.json` used during resolution

--- a/docs/adr/004-hybrid-search.md
+++ b/docs/adr/004-hybrid-search.md
@@ -1,23 +1,22 @@
 # ADR-004: Hybrid Search (Vector + BM25 with RRF Fusion)
 
-> **Decision:** Combine ChromaDB vector search with SQLite FTS5 BM25 keyword search, fused via Reciprocal Rank Fusion.
-> **Date:** 2026-02-19
-> **Status:** Accepted
-> **Last Updated:** 2026-02-19
+**Status:** Complete
+**Last Updated:** 2026-02-19
+**Decision:** Accepted
 
 ## Context
 
-LifeOS serves personal data queries that span a wide spectrum of intent and specificity. Users ask semantic questions ("meetings about the product roadmap"), exact-match questions ("email from john@acme.com on January 15th"), and hybrid questions that require both ("what did Sarah say about the budget?"). A single search technology cannot serve all three well.
+LifeOS serves personal data queries that span a wide spectrum of intent and specificity. Users ask semantic questions ("meetings about the product roadmap"), exact-match questions ("email from alex@example.com on January 15th"), and hybrid questions that require both ("what did Sarah say about the budget?"). A single search technology cannot serve all three well.
 
-Vector search using embedding models excels at understanding intent and meaning — it knows that "strategy" and "roadmap" are conceptually related. But it struggles with exact matches: querying "john@acme.com" relies on the embedding model recognizing email address patterns, which is unreliable. Keyword search (BM25) excels at exact and partial term matching but misses conceptual similarity entirely — "meetings about strategy" would not match documents using "planning" or "roadmap."
+Vector search using embedding models excels at understanding intent and meaning — it knows "strategy" and "roadmap" are conceptually related. But it struggles with exact matches: querying `alex@example.com` relies on the embedding model recognizing email-address patterns, which is unreliable. Keyword search (BM25) excels at exact and partial term matching but misses conceptual similarity entirely — "meetings about strategy" wouldn't match documents using "planning" or "roadmap."
 
-Personal data queries are particularly demanding because they frequently combine proper nouns (names, email addresses, dates) with semantic intent. The search system must handle both dimensions simultaneously, which requires retrieving candidates from multiple sources and combining them intelligently.
+Personal data queries are particularly demanding because they frequently combine proper nouns (names, emails, dates) with semantic intent. The search system must handle both dimensions simultaneously, which requires retrieving candidates from multiple sources and combining them intelligently.
 
 ## Decision
 
 Dual-index search with fusion:
 
-1. **Vector search**: ChromaDB with all-MiniLM-L6-v2 embeddings for semantic similarity.
+1. **Vector search**: ChromaDB with embeddings (current default `gte-Qwen2-1.5B-instruct`, 1536-dim) for semantic similarity.
 2. **Keyword search**: SQLite FTS5 with BM25 scoring for exact and partial term matching.
 3. **Fusion**: Reciprocal Rank Fusion (RRF) combines ranked results from both sources into a single ranking, with optional query-type-aware boosting.
 4. **Reranking**: A final reranking pass scores fused results against the original query.
@@ -27,7 +26,7 @@ Both indexes are populated during the same ingestion pipeline. The BM25 index li
 ## Rationale
 
 - **Complementary strengths**: Vector search excels at "what is this about?" while BM25 excels at "does this contain this exact term?" Together they cover the full query spectrum.
-- **RRF is simple and effective**: Reciprocal Rank Fusion (`score = 1 / (k + rank)` with k=60) is parameter-free beyond the constant k, well-studied in IR literature, and produces strong results without complex learned fusion models. It does not require training data or per-query weight tuning.
+- **RRF is simple and effective**: `score = 1 / (k + rank)` with `k=60` is parameter-free beyond the constant, well-studied in IR literature, and produces strong results without complex learned fusion. No training data or per-query weight tuning required.
 - **SQLite FTS5 is lightweight**: No additional service dependency. FTS5 is built into SQLite, which is already used for metadata. The BM25 index adds disk usage but no operational complexity.
 - **Name expansion**: The search pipeline expands person names using the known-people dictionary before querying, improving recall for queries like "messages from Mike" when the contact is stored as "Michael."
 
@@ -35,48 +34,60 @@ Both indexes are populated during the same ingestion pipeline. The BM25 index li
 
 ### Vector-Only Search
 
-Using only ChromaDB for all queries would simplify the architecture to a single search path. Semantic queries would work well, and the system would be easier to maintain with one index. However, vector search fundamentally struggles with exact-match queries. Querying "john@acme.com" produces unpredictable results because embedding models were not trained to treat email addresses as atomic identifiers. Similarly, date queries ("January 15th") depend on the embedding model's incidental handling of date formats. For LifeOS, where users frequently search for specific people by name or email, this recall gap is unacceptable.
+Using only ChromaDB for all queries would simplify the architecture to a single search path. Semantic queries would work well, and the system would be easier to maintain with one index.
+
+**Rejected because:** Vector search fundamentally struggles with exact-match queries. Querying `alex@example.com` produces unpredictable results because embedding models were not trained to treat email addresses as atomic identifiers. Similarly, date queries depend on incidental handling of date formats. For LifeOS, where users frequently search for specific people by name or email, this recall gap is unacceptable.
 
 ### Keyword-Only Search (BM25)
 
-BM25 keyword search is well-understood, fast, and excellent for exact-match queries. It would handle "email from john@acme.com" perfectly. However, it completely misses semantic similarity — "meetings about strategy" would not match documents containing "planning session" or "roadmap discussion." For a personal AI assistant where users often ask conceptual questions about their data, keyword-only search would produce frustrating gaps. The value of semantic understanding for personal data queries outweighs BM25's simplicity advantage.
+BM25 keyword search is well-understood, fast, and excellent for exact-match queries.
+
+**Rejected because:** It completely misses semantic similarity — "meetings about strategy" wouldn't match documents containing "planning session" or "roadmap discussion." For a personal AI assistant where users often ask conceptual questions, keyword-only search would produce frustrating gaps. The value of semantic understanding for personal data queries outweighs BM25's simplicity advantage.
 
 ### Elasticsearch
 
-Elasticsearch provides both keyword and vector search in a single system, with sophisticated query DSL, analyzers, and built-in hybrid search capabilities. It would eliminate the need for a separate ChromaDB instance and SQLite FTS5 index. However, Elasticsearch requires a JVM, consumes significant memory (1-2GB minimum), and adds substantial operational complexity for a single-user system. The benefit of consolidation does not justify adding a heavyweight Java dependency to a Python/SQLite stack. For LifeOS's scale (~100K documents, single user), the lighter combination of ChromaDB + FTS5 is proportionate.
+Elasticsearch provides both keyword and vector search in a single system, with sophisticated query DSL, analyzers, and built-in hybrid search capabilities.
+
+**Rejected because:** It requires a JVM, consumes significant memory (1-2GB minimum), and adds substantial operational complexity for a single-user system. Consolidation does not justify adding a heavyweight Java dependency to a Python/SQLite stack. At LifeOS's scale (~100K documents, single user), the lighter combination of ChromaDB + FTS5 is proportionate.
 
 ### Reranking-Only (Single Source + Reranker)
 
-A reranking approach would retrieve candidates from a single source (e.g., vector search) and then rerank them using a cross-encoder model. This can improve precision significantly but cannot fix recall — if the initial retrieval misses a relevant document because it's an exact-match query, no reranker can recover it. LifeOS uses reranking as a final stage after fusion, not as a substitute for dual-source retrieval. The combination of broad recall (from two retrieval sources) plus precision (from reranking) produces better results than either approach alone.
+Retrieve candidates from one source (e.g., vector search) and rerank using a cross-encoder model. This can improve precision significantly.
+
+**Rejected because:** It cannot fix recall — if the initial retrieval misses a relevant document because it's an exact-match query, no reranker can recover it. LifeOS uses reranking as a final stage after fusion, not as a substitute for dual-source retrieval. Broad recall (from two retrieval sources) plus precision (from reranking) beats either approach alone.
 
 ## Consequences
 
-**Positive:**
+### Positive
+
 - Excellent recall across both semantic and exact-match queries.
 - Lightweight — no additional services beyond SQLite (already present) and ChromaDB (already required).
 - RRF fusion is simple to implement and maintain.
 - Name expansion via the people dictionary improves people-related query recall.
 
-**Negative:**
-- Two indexes to maintain — ingestion and reindexing take roughly twice as long.
-- RRF weights may need per-query-type tuning for edge cases (currently uses fixed k=60).
-- Debugging search results requires inspecting both vector and BM25 contributions.
+### Negative
 
-**Risks:**
-- As the corpus grows, maintaining two indexes doubles the indexing time and storage requirements. If sync operations become slow, the dual-index approach may need optimization (incremental indexing, batch updates).
-- The fixed RRF constant (k=60) was chosen empirically. Different query types may benefit from different fusion weights, which would require a more sophisticated query-aware fusion strategy.
-- FTS5's default tokenizer may not handle all data formats well (e.g., CamelCase identifiers, hyphenated names, international characters). Custom tokenizer configuration may be needed as the data diversity increases.
+- Two indexes to maintain — ingestion and reindexing take roughly twice as long.
+- RRF weights may need per-query-type tuning for edge cases (currently uses fixed `k=60`).
+- Debugging search results requires inspecting both vector and BM25 contributions.
+- As the corpus grows, maintaining two indexes doubles indexing time and storage. If sync operations become slow, the dual-index approach may need optimization (incremental indexing, batch updates).
+- The fixed RRF constant was chosen empirically. Different query types may benefit from different fusion weights, which would require a more sophisticated query-aware fusion strategy.
+- FTS5's default tokenizer may not handle all data formats well (CamelCase, hyphenated names, international characters). Custom tokenizer configuration may be needed as data diversity increases.
 
 ## Related Documents
 
-**Design Context:**
+### Design Context
 - [ADR-002: ChromaDB](002-chromadb-vector-store.md) — The vector database powering semantic search
 - [ADR-006: Ollama Query Routing](006-ollama-query-routing.md) — How queries are classified before reaching the search pipeline
 
-**Specifications:**
+### Specifications
 - [Search Indexing](../specs/technical/search-indexing.md) — Detailed hybrid search implementation
 - [Architecture](../specs/technical/architecture.md) — How search fits into the overall system
 - [Data Model](../specs/product/data-model.md) — What gets indexed (SourceEntity and PersonEntity data)
 
-**Operational:**
-- [AGENTS.md](../../AGENTS.md) — Search API commands and vault reindex trigger
+### Operational
+- [Root AGENTS.md](../../AGENTS.md) — Search API commands and vault reindex trigger
+
+### Code References
+- [`api/services/hybrid_search.py`](../../api/services/hybrid_search.py) — Hybrid search pipeline, RRF fusion, reranking
+- [`api/services/bm25_index.py`](../../api/services/bm25_index.py) — SQLite FTS5 wrapper

--- a/docs/adr/005-external-venv-macos-tcc.md
+++ b/docs/adr/005-external-venv-macos-tcc.md
@@ -1,17 +1,19 @@
 # ADR-005: External Virtual Environment for macOS TCC
 
-> **Decision:** Place the Python virtual environment at `~/.venvs/lifeos`, outside the project directory.
-> **Date:** 2026-02-19
-> **Status:** Accepted
-> **Last Updated:** 2026-02-19
+**Status:** Complete
+**Last Updated:** 2026-03-04
+**Decision:** Superseded
+**Superseded By:** ADR-007
+
+> The original TCC-driven rationale no longer applies after the Linux migration (see [ADR-007](007-linux-migration.md)). The practice — venv at `~/.venvs/lifeos`, outside the project directory — is retained by convention on both Linux and macOS, but for different reasons (keeping the venv out of file-sync tools and out of the project tree). This ADR is preserved as the original record.
 
 ## Context
 
-LifeOS runs as a launchd service on macOS. The project source code lives in `~/Documents/Code/LifeOS/`, which is synced via iCloud between the Mac Mini (server) and MacBook Pro (development machine). This syncing is valuable — code edits on the MacBook are immediately visible on the Mac Mini without manual file transfer.
+LifeOS originally ran as a launchd service on macOS. The project source lived in `~/Documents/Code/LifeOS/`, synced via iCloud between the Mac Mini (server) and MacBook Pro (development machine). Code edits on the MacBook were immediately visible on the Mac Mini without manual file transfer.
 
-macOS TCC (Transparency, Consent, and Control) performs security scanning on files within protected directories like `~/Documents/`. When launchd loads a Python process whose virtual environment is inside `~/Documents/`, TCC scans every `.pyc` and `.so` file in the venv — hundreds of files across dozens of packages. This caused server startup times of **30+ seconds**, unacceptable for a service that needs to restart quickly after code changes during development.
+macOS TCC (Transparency, Consent, and Control) performs security scanning on files within protected directories like `~/Documents/`. When launchd loaded a Python process whose virtual environment was inside `~/Documents/`, TCC scanned every `.pyc` and `.so` file in the venv — hundreds of files across dozens of packages. This caused server startup times of **30+ seconds**, unacceptable for a service that needed to restart quickly after code changes.
 
-The issue is specific to launchd-triggered processes. Running the same venv from an interactive terminal session does not trigger the same scanning delay, which made this problem difficult to diagnose initially. The root cause was identified by profiling server startup and observing that file I/O to venv directories dominated the startup trace under launchd but not under interactive shells.
+The issue was specific to launchd-triggered processes. Running the same venv from an interactive terminal session did not trigger the same scanning delay, which made the problem difficult to diagnose initially. The root cause was identified by profiling server startup and observing that file I/O to venv directories dominated the startup trace under launchd but not under interactive shells.
 
 ## Decision
 
@@ -28,51 +30,60 @@ Place the virtual environment at `~/.venvs/lifeos` (outside `~/Documents/`). All
 
 ### Disable TCC Scanning
 
-macOS provides some mechanisms to exclude directories from TCC scanning, but these require modifying system security settings. Disabling or reducing TCC protection system-wide is a disproportionate response to a venv performance issue. TCC exists to protect user data from unauthorized access, and weakening it to solve a deployment convenience problem sets a poor precedent. The external venv approach achieves the same performance benefit without touching security settings.
+macOS provides some mechanisms to exclude directories from TCC scanning.
 
-### Move Entire Project Out of ~/Documents/
+**Rejected because:** Doing so requires modifying system security settings. Disabling or reducing TCC protection system-wide is a disproportionate response to a venv performance issue — TCC exists to protect user data from unauthorized access, and weakening it to solve a deployment convenience problem sets a poor precedent. The external venv achieves the same performance benefit without touching security settings.
 
-Moving the project to a non-TCC directory (e.g., `~/Code/` or `/opt/lifeos/`) would solve the TCC scanning issue for both source code and venv. However, this breaks iCloud sync between the Mac Mini and MacBook, which is fundamental to the development workflow — edits on the MacBook appear on the Mac Mini without SSH, git push, or rsync. Replacing iCloud sync with a manual mechanism (git-based workflow, rsync scripts, or Syncthing) adds friction to every development cycle. Moving only the venv out preserves the sync workflow while solving the performance problem.
+### Move Entire Project Out of `~/Documents/`
+
+Move the project to a non-TCC directory (e.g., `~/Code/` or `/opt/lifeos/`).
+
+**Rejected because:** This breaks iCloud sync between the Mac Mini and MacBook, which is fundamental to the development workflow — edits on the MacBook appear on the Mac Mini without SSH, git push, or rsync. Replacing iCloud sync with a manual mechanism (git-based workflow, rsync scripts, Syncthing) adds friction to every development cycle. Moving only the venv out preserves the sync workflow while solving the performance problem.
 
 ### Use System Python
 
-Using the macOS system Python (or Homebrew Python) without a virtual environment would avoid the venv scanning issue entirely. However, this eliminates dependency isolation. LifeOS has 50+ pinned dependencies, several of which conflict with versions required by other Python projects. Without a venv, installing LifeOS dependencies could break other tools on the system. Version pinning becomes fragile without the isolation boundary that a venv provides.
+Use the macOS system Python (or Homebrew Python) without a virtual environment.
+
+**Rejected because:** This eliminates dependency isolation. LifeOS has 50+ pinned dependencies, several of which conflict with versions required by other Python projects. Without a venv, installing LifeOS dependencies could break other tools on the system. Version pinning becomes fragile without the isolation boundary a venv provides.
 
 ### Docker Container
 
-Running LifeOS in a Docker container would isolate the entire runtime from TCC scanning. However, Docker Desktop on macOS introduces its own performance issues — filesystem I/O via VirtioFS adds measurable latency to every file operation, which is problematic for a system that reads and writes thousands of files during sync operations. Docker also adds significant operational complexity (container management, volume mounts, networking) for a single-user system where the simpler fix is moving a directory. The Docker overhead is not justified for this use case.
+Run LifeOS in a Docker container to isolate the entire runtime from TCC scanning.
+
+**Rejected because:** Docker Desktop on macOS introduces its own performance issues — filesystem I/O via VirtioFS adds measurable latency to every file operation, problematic for a system that reads and writes thousands of files during sync operations. Docker also adds significant operational complexity (container management, volume mounts, networking) for a single-user system where the simpler fix is moving a directory.
 
 ### Homebrew Python Without Venv
 
-Similar to system Python, using Homebrew's Python without a venv removes the scanning target. But it shares the same isolation problems — no way to pin LifeOS-specific dependency versions without risking conflicts with other Python tools installed via Homebrew. The Homebrew Python installation is also a moving target that updates independently, which can break pinned dependencies.
+Similar to system Python: use Homebrew's Python directly.
+
+**Rejected because:** It shares the same isolation problems — no way to pin LifeOS-specific dependency versions without risking conflicts with other Python tools installed via Homebrew. The Homebrew Python installation is also a moving target that updates independently, which can break pinned dependencies.
 
 ## Consequences
 
-**Positive:**
+### Positive
+
 - Server startup drops from 30+ seconds to under 2 seconds.
 - iCloud sync continues working for source code.
 - No security compromise — only third-party packages move outside TCC scope.
 
-**Negative:**
+### Negative
+
 - Virtual environment is not co-located with the project, which is confusing for initial setup. Requires explicit documentation.
 - All scripts must use absolute paths to the venv (`~/.venvs/lifeos/bin/python`).
-- The venv exists only on the Mac Mini. The MacBook development machine does not have one — tests and server commands must be run remotely via SSH.
-- `pip install` must be run on the Mac Mini, not the MacBook.
-
-**Risks:**
+- (Original era) The venv exists only on the Mac Mini; the MacBook development machine does not have one — tests and server commands must be run remotely via SSH.
 - The separated venv path is a constant source of confusion for new agents and tools that expect `./venv/` or `.venv/` in the project root. Documentation must be explicit and scripts must use absolute paths consistently.
-- If iCloud sync is replaced with a different mechanism in the future, the motivation for keeping source code in `~/Documents/` weakens, and the project layout should be re-evaluated.
 - macOS TCC behavior may change in future versions, potentially making this workaround unnecessary — or introducing new scanning patterns that affect `~/.venvs/`.
 
 ## Related Documents
 
-**Design Context:**
+### Design Context
 - [ADR-001: Python/FastAPI](001-python-fastapi.md) — The Python stack that requires a venv
+- [ADR-007: Linux Migration](007-linux-migration.md) — Supersedes this ADR; venv convention retained on Linux for different reasons
 
-**Specifications:**
+### Specifications
 - [Architecture](../specs/technical/architecture.md) — System architecture including deployment model
 
-**Operational:**
+### Operational
 - [Installation Guide](../guides/installation.md) — Setup instructions including venv creation
-- [launchd Setup](../guides/launchd-setup.md) — Service configuration that's affected by TCC
+- [launchd Setup](../guides/launchd-setup.md) — Service configuration that's affected by TCC (now Apple-Data-Agent-only after Linux migration)
 - [Scripts Reference](../guides/scripts.md) — Scripts that reference the external venv path

--- a/docs/adr/006-ollama-query-routing.md
+++ b/docs/adr/006-ollama-query-routing.md
@@ -1,79 +1,91 @@
 # ADR-006: Ollama for Local Query Routing
 
-> **Decision:** Use Ollama with a local LLM for query routing and intent classification, with a multi-level fallback chain.
-> **Date:** 2026-02-19
-> **Status:** Accepted
-> **Last Updated:** 2026-02-19
+**Status:** Complete
+**Last Updated:** 2026-02-19
+**Decision:** Accepted
 
 ## Context
 
-Every chat query in LifeOS must be classified before processing to determine the correct pipeline: general knowledge (Claude answers directly, no data fetched), web search (external information retrieved), personal data (routed to the hybrid search pipeline), or compound (multiple steps). This classification happens before the main Claude API call.
+Every chat query in LifeOS must be classified before processing to determine the correct pipeline: general knowledge (LLM answers directly, no data fetched), web search (external information retrieved), personal data (routed to the hybrid search pipeline), or compound (multiple steps). This classification happens before the main synthesis call.
 
-Using Claude for routing would add approximately 1 second of latency and API cost to every single query, including trivial ones like "what time is it?" or "tell me a joke." At hundreds of queries per week, this adds up in both time and money. The classification task itself is straightforward — a four-category intent classification — and does not require frontier model capability. A smaller, local model can achieve high accuracy on this task at a fraction of the cost and latency.
+Using the main LLM for routing would add approximately 1 second of latency and API/inference cost to every single query, including trivial ones. At hundreds of queries per week, this adds up. The classification task itself is straightforward — a four-category intent classification — and does not require frontier-model capability. A smaller, local model can achieve high accuracy on this task at a fraction of the cost and latency.
 
-The routing system must also be resilient. If the primary routing model is unavailable (e.g., after a macOS restart before Ollama auto-starts), queries should still be processed rather than failing. This requires a fallback chain that degrades gracefully from high-quality local inference to simpler heuristics.
+The routing system must also be resilient. If the primary routing model is unavailable (e.g., after a system restart before the service auto-starts), queries should still be processed rather than failing. This requires a fallback chain that degrades gracefully from high-quality local inference to simpler heuristics.
 
 ## Decision
 
-Use Ollama running locally with a small language model (Qwen 2.5 7B Instruct) for query routing and intent classification. Implement a three-level fallback chain:
+Use Ollama running locally with a small language model (Qwen 2.5 7B Instruct at decision time) for query routing and intent classification. Implement a three-level fallback chain:
 
 1. **Ollama** (primary): Local inference, ~200ms latency, zero API cost.
-2. **Anthropic Haiku** (fallback): Cloud-based, ~500ms latency, minimal cost. Used when Ollama is unavailable (e.g., after a macOS restart before Ollama auto-starts).
+2. **Anthropic Haiku** (fallback): Cloud-based, ~500ms latency, minimal cost. Used when Ollama is unavailable.
 3. **Pattern matching** (last resort): Regex-based heuristics, <1ms, zero cost. Handles basic routing when both LLM services are unavailable.
 
 ## Rationale
 
-- **Cost**: Local inference has zero marginal cost. Over hundreds of daily queries, this avoids meaningful API spend on a task that does not require frontier model capability. At ~$0.001 per Haiku call, routing all queries through Haiku would cost roughly $3-5/month — not prohibitive, but unnecessary when a local model performs comparably.
-- **Latency**: Local Ollama responds in ~200ms vs ~500ms-1s for a cloud API call. For a classification task that gates every query, this 300-800ms saving is noticeable in the user experience. Over a conversation with 10+ turns, the cumulative time savings are significant.
-- **Sufficient accuracy**: Intent classification is a straightforward task. A 7B parameter model achieves high accuracy on the four-category classification. Edge cases (compound queries like "look up X and create a task for Y") are the main failure mode, and these degrade gracefully — the query is still processed, just potentially with a suboptimal pipeline.
-- **Graceful degradation**: The fallback chain ensures the system never hard-fails on routing. If Ollama is down, Haiku handles it. If Haiku is unreachable, pattern matching provides basic coverage. Degradation events are tracked and reported via the alerting system.
+- **Cost**: Local inference has zero marginal cost. Over hundreds of daily queries this avoids meaningful API spend on a task that does not require frontier capability.
+- **Latency**: Local Ollama responds in ~200ms vs ~500ms–1s for a cloud API call. For a classification task that gates every query, the 300–800ms saving is noticeable. Over a conversation with 10+ turns the cumulative time savings are significant.
+- **Sufficient accuracy**: A 7B-parameter model achieves high accuracy on four-category classification. Edge cases (compound queries like "look up X and create a task for Y") degrade gracefully — the query is still processed, just potentially with a suboptimal pipeline.
+- **Graceful degradation**: The fallback chain ensures routing never hard-fails. If Ollama is down, Haiku handles it. If Haiku is unreachable, pattern matching provides basic coverage. Degradation events are tracked and reported via the alerting system.
 
 ## Alternatives Considered
 
-### Always Use Claude for Routing
+### Always Use the Main LLM for Routing
 
-Using Claude (Sonnet or Opus) for every routing decision would provide the highest classification accuracy, especially for ambiguous and compound queries. However, it adds ~1 second of latency and ~$0.01 per query in API cost. Over hundreds of queries per week, this adds noticeable lag to every interaction and meaningful cost. More importantly, the accuracy improvement over a 7B local model is marginal for a four-category classification task — Claude's strengths (reasoning, nuance, long-context understanding) are wasted on "is this a personal data query or a general knowledge question?"
+Use the same Claude model (Sonnet or Opus) for every routing decision — highest accuracy, especially for ambiguous and compound queries.
+
+**Rejected because:** It adds ~1 second of latency and ~$0.01 per query in API cost. Over hundreds of queries per week this adds noticeable lag and meaningful cost. The accuracy improvement over a 7B local model is marginal for four-category classification — frontier-model strengths (reasoning, nuance, long-context understanding) are wasted on "is this a personal data query or a general knowledge question?"
 
 ### Rules-Based Only (No LLM)
 
-A purely regex-based router would be the fastest and cheapest option — no model loading, no API calls, sub-millisecond classification. Simple patterns work well for obvious cases ("create a task" → compound, "what's the weather" → web search). However, natural language is inherently ambiguous. "Tell me about the meeting with Sarah" could be personal data or general knowledge depending on context. "What did we discuss at dinner?" requires understanding that "we" implies personal data. A rules-only approach cannot handle this ambiguity, leading to frequent misrouting and degraded search results. It works as a last-resort fallback but is too rigid as the primary router.
+A purely regex-based router would be the fastest and cheapest option — no model loading, no API calls, sub-millisecond classification.
+
+**Rejected because:** Natural language is inherently ambiguous. "Tell me about the meeting with Sarah" could be personal data or general knowledge depending on context. "What did we discuss at dinner?" requires understanding that "we" implies personal data. A rules-only approach can't handle this ambiguity, leading to frequent misrouting and degraded search results. It works as a last-resort fallback but is too rigid as the primary router.
 
 ### Fine-Tuned Classifier
 
-A purpose-built classifier (e.g., fine-tuned BERT or a small transformer trained on labeled routing data) would be fast and potentially very accurate for the specific four-category classification. However, this requires creating a training dataset, building an evaluation pipeline, and retraining when categories evolve (e.g., adding a new routing category). For a four-class problem that a general-purpose 7B model handles well, the engineering overhead of a custom classifier is unjustified. The maintenance burden of keeping training data current and retraining on changes outweighs the marginal accuracy improvement.
+A purpose-built classifier (e.g., fine-tuned BERT or a small transformer trained on labeled routing data) would be fast and potentially very accurate.
+
+**Rejected because:** It requires creating a training dataset, building an evaluation pipeline, and retraining when categories evolve. For a four-class problem that a general-purpose 7B model handles well, the engineering overhead is unjustified. Maintenance burden of keeping training data current and retraining on changes outweighs the marginal accuracy improvement.
 
 ### No Routing (Uniform Pipeline)
 
-Sending every query through the same pipeline — always searching the vault, always checking web, always querying Claude — would eliminate the routing step entirely. However, this wastes resources on irrelevant searches (general knowledge queries don't need vault search), adds latency (every query pays the cost of the full pipeline), and produces noisy results (vault search results appearing alongside Claude's direct answer for "what is the capital of France?"). Routing exists to match queries to the appropriate pipeline, reducing both latency and noise.
+Send every query through the same pipeline — always search the vault, always check web, always query the LLM.
+
+**Rejected because:** It wastes resources on irrelevant searches (general knowledge queries don't need vault search), adds latency (every query pays the cost of the full pipeline), and produces noisy results (vault search results appearing alongside the LLM's direct answer for "what is the capital of France?"). Routing exists to match queries to the appropriate pipeline.
 
 ## Consequences
 
-**Positive:**
+### Positive
+
 - Fast classification (~200ms) with zero marginal API cost.
 - Graceful degradation through three fallback levels — the system never hard-fails on routing.
 - Ollama is useful beyond routing (can serve other local inference tasks in the future).
 
-**Negative:**
-- Requires Ollama service running on the Mac Mini (managed via launchd).
+### Negative
+
+- Requires Ollama service running on the host (managed via systemd on Linux, launchd on macOS).
 - Model updates must be pulled manually (`ollama pull qwen2.5:7b-instruct`).
 - Local model is less accurate than Claude for ambiguous or compound queries — these occasionally route incorrectly and produce suboptimal responses.
 - Additional service to monitor (tracked via the health/alerting system as a WARNING-level dependency).
-
-**Risks:**
-- Ollama's macOS integration depends on launchd auto-start working reliably. After macOS updates or power events, Ollama may not restart automatically, causing the system to fall back to Haiku for extended periods. Monitoring the fallback rate helps detect this.
-- The Qwen 2.5 7B model may be superseded by better options. Periodic evaluation of newer small models (Phi, Gemma, Llama) is worthwhile to maintain or improve routing accuracy.
-- If LifeOS adds more routing categories (beyond the current four), the 7B model's classification accuracy may degrade, potentially requiring a larger model or a different approach.
+- Ollama auto-start reliability after system updates or power events is imperfect — monitoring the fallback rate helps detect when the system has been on Haiku for an extended period.
+- The Qwen 2.5 7B model may be superseded by better options. Periodic evaluation of newer small models (Phi, Gemma, Llama) is worthwhile.
+- If LifeOS adds more routing categories beyond the current four, the 7B model's classification accuracy may degrade, potentially requiring a larger model or a different approach.
 
 ## Related Documents
 
-**Design Context:**
+### Design Context
 - [ADR-004: Hybrid Search](004-hybrid-search.md) — The search pipeline that routing feeds into
 - [ADR-001: Python/FastAPI](001-python-fastapi.md) — The backend that integrates Ollama
 
-**Specifications:**
+### Specifications
 - [Architecture](../specs/technical/architecture.md) — System architecture including query flow
 - [Observability](../specs/technical/observability.md) — How routing fallbacks are monitored
 
-**Operational:**
+### Operational
 - [Troubleshooting](../guides/troubleshooting.md) — Ollama debugging and restart procedures
-- [AGENTS.md](../../AGENTS.md) — Health check commands and observability overview
+- [Root AGENTS.md](../../AGENTS.md) — Health check commands and observability overview
+
+### Code References
+- [`api/services/query_classifier.py`](../../api/services/query_classifier.py) — Intent classifier
+- [`api/services/query_router.py`](../../api/services/query_router.py) — Pipeline routing built on the classifier
+- [`api/services/ollama_client.py`](../../api/services/ollama_client.py) — Ollama client wrapper used by the classifier

--- a/docs/adr/007-linux-migration.md
+++ b/docs/adr/007-linux-migration.md
@@ -1,14 +1,13 @@
 # ADR-007: Linux Migration and Local LLM Orchestration
 
-> **Decision:** Migrate the LifeOS server from Mac Mini (macOS) to a Linux workstation, and replace the Claude API orchestrator with a local LLM.
-> **Date:** 2026-03-04
-> **Status:** Accepted
-> **Last Updated:** 2026-03-04
-> **Supersedes:** [ADR-005](005-external-venv-macos-tcc.md) (external venv rationale — TCC no longer applies, but the practice is retained by convention)
+**Status:** Complete
+**Last Updated:** 2026-03-04
+**Decision:** Accepted
+**Supersedes:** [ADR-005](005-external-venv-macos-tcc.md) — TCC rationale no longer applies; external venv practice retained by convention.
 
 ## Context
 
-LifeOS was running on a Mac Mini (macOS) as its primary server, with all AI orchestration (agentic chat loop, RAG synthesis) handled by the Claude API (Anthropic). This architecture worked but had growing limitations:
+LifeOS was running on a Mac Mini (macOS) as its primary server, with all AI orchestration (agentic chat loop, RAG synthesis) handled by the Claude API. This architecture worked but had growing limitations:
 
 1. **Compute ceiling**: The Mac Mini lacked GPU resources for running large local models. Growing interest in local LLM orchestration (for privacy, cost, and latency) required hardware with significant VRAM — at least 96GB to run a 120B-parameter model.
 
@@ -16,7 +15,7 @@ LifeOS was running on a Mac Mini (macOS) as its primary server, with all AI orch
 
 3. **Privacy posture**: Although Claude API calls are discrete and LifeOS stores no data remotely, the orchestrator — which sees the full context of every query including personal notes, emails, and messages — was running through a third-party API. Running orchestration locally eliminates this data transit entirely.
 
-4. **Platform constraints**: macOS-specific requirements (launchd, FDA wrappers, TCC scanning workarounds) added operational complexity. The `LifeOS.app` FDA wrapper, launchd plists, and TCC-driven venv placement (ADR-005) were all workarounds for macOS restrictions that don't exist on Linux.
+4. **Platform constraints**: macOS-specific requirements (launchd, FDA wrappers, TCC scanning workarounds) added operational complexity. The `LifeOS.app` FDA wrapper, launchd plists, and TCC-driven venv placement ([ADR-005](005-external-venv-macos-tcc.md)) were all workarounds for macOS restrictions that don't exist on Linux.
 
 5. **ROCm and GPU ecosystem**: The target workstation ships with an AMD GPU requiring ROCm, which has mature Linux support but no macOS support.
 
@@ -34,15 +33,11 @@ Migrate the LifeOS server from the Mac Mini (macOS) to a Linux workstation with 
 
 ### Local LLM for orchestration
 
-Replace the Claude API as the orchestrator with a local LLM (GPT-OSS-120B) served via `llama-server` on the local GPU. The agentic chat loop and RAG synthesis — the highest-volume LLM calls — now run entirely locally.
+Replace the Claude API as the orchestrator with a local LLM served via `llama-server` on the local GPU. The agentic chat loop and RAG synthesis — the highest-volume LLM calls — now run entirely locally by default.
 
-Create a unified LLM client (`api/services/llm_client.py`) that abstracts over both local (OpenAI-compatible) and Anthropic backends. This client handles:
-- Bidirectional tool schema translation between Anthropic format (`input_schema`) and OpenAI format (`parameters`)
-- Streaming format differences
-- Stop reason normalization (`tool_use` vs `tool_calls`)
-- System prompt format conversion (content blocks vs single string)
+Create a unified LLM client (`api/services/llm_client.py`) that abstracts over both local (OpenAI-compatible) and Anthropic backends. The client handles bidirectional tool-schema translation, streaming format differences, stop-reason normalization, and system-prompt format conversion.
 
-Add `LIFEOS_LLM_BACKEND` setting to `config/settings.py` to switch between `local` and `anthropic` backends without code changes. Specialized Claude API calls (relationship insights, fact extraction, tone analysis, web search) are retained on Anthropic where frontier model quality provides clear value.
+Add `LIFEOS_LLM_BACKEND` setting to `config/settings.py` to switch between `local` and `anthropic` backends without code changes. Specialized Claude API calls (relationship insights, fact extraction, tone analysis, web search) are retained on Anthropic where frontier-model quality provides clear value.
 
 ### Mac Mini role change
 
@@ -58,79 +53,91 @@ Replace macOS launchd and FDA wrappers with systemd on Linux:
 - `lifeos-sync.timer` — Nightly sync pipeline
 - `lifeos-watchdog.timer` — ChromaDB health monitoring
 
-The `LifeOS.app` FDA wrapper is no longer needed. Linux has no TCC-equivalent file access restrictions.
+The `LifeOS.app` FDA wrapper is no longer needed on the LifeOS server. Linux has no TCC-equivalent file-access restrictions. The wrapper is still used on the Mac for the Apple Data Agent role.
 
 ### Codebase compatibility
 
 Keep the codebase dual-compatible (Linux and macOS) via OS-detection wrappers:
-- Shell scripts use `uname` checks for BSD vs GNU tool differences (e.g., `stat -f%z` vs `stat -c%s`)
-- Python code uses `sys.platform` guards for macOS-specific imports (e.g., `pyobjc`)
-- Scripts synced between the MacBook (macOS, editor) and Linux (server) must work on both platforms
+- Shell scripts use `uname` checks for BSD vs GNU tool differences (e.g., `stat -f%z` vs `stat -c%s`).
+- Python code uses `sys.platform` guards for macOS-specific imports (e.g., `pyobjc`).
+- Scripts synced between the MacBook (macOS editor) and Linux (server) must work on both platforms.
 
 ### External venv convention
 
-The external venv pattern from ADR-005 (`~/.venvs/lifeos`) is retained by convention, even though the original TCC motivation no longer applies on Linux. The practice has proven useful regardless of platform: it keeps the venv out of file sync tools (previously iCloud, now Syncthing) and avoids bloating the project directory with machine-specific binary artifacts.
+The external venv pattern from [ADR-005](005-external-venv-macos-tcc.md) (`~/.venvs/lifeos`) is retained by convention, even though the original TCC motivation no longer applies on Linux. The practice has proven useful regardless of platform: it keeps the venv out of file-sync tools (previously iCloud, now whatever the operator uses) and avoids bloating the project directory with machine-specific binary artifacts.
 
 ## Rationale
 
-- **Privacy**: The orchestrator — which processes the full context of every query — now runs locally. No personal data transits to any external API for the primary chat flow.
-- **Cost**: Orchestration and synthesis (the highest-volume API calls) become zero marginal cost. Only specialized calls (relationship insights, fact extraction, web search) still use paid API tiers.
+- **Privacy**: The orchestrator now runs locally by default. No personal data transits to any external API for the primary chat flow.
+- **Cost**: Orchestration and synthesis (the highest-volume API calls) become zero marginal cost when on the local backend. Only specialized calls (relationship insights, fact extraction, web search) still use paid API tiers.
 - **Latency**: Local LLM inference on a high-VRAM GPU eliminates network round-trips for the agentic loop, reducing per-turn latency.
 - **Hardware utilization**: A 96GB VRAM GPU can run a 120B-parameter model with overhead for prefix caching and concurrent requests — capability that was impossible on the Mac Mini.
-- **Operational simplicity**: systemd is more transparent and debuggable than launchd + FDA wrappers. No more TCC scanning delays, no more `.app` bundles for file access permissions.
+- **Operational simplicity**: systemd is more transparent and debuggable than launchd + FDA wrappers. No more TCC scanning delays, no more `.app` bundles for file access on the server side.
 - **Retained flexibility**: The `LIFEOS_LLM_BACKEND` toggle and unified LLM client mean the system can fall back to the Claude API for orchestration if local model quality degrades for a specific use case. Specialist calls remain on Anthropic regardless.
 
 ## Alternatives Considered
 
-### Keep everything on Claude API (no local LLM)
+### Keep Everything on Claude API (no local LLM)
 
-Running LifeOS on Linux with all LLM calls still going to the Claude API was the simplest option and was used as a stabilization milestone (Phases 1-2 of the migration). However, this leaves the cost and privacy motivations unaddressed. The local LLM was the primary driver for acquiring high-VRAM hardware in the first place. Keeping Claude API as the sole orchestrator would make the GPU investment largely wasted.
+Run LifeOS on Linux with all LLM calls still going to the Claude API. This was used as a stabilization milestone (Phases 1–2 of the migration).
 
-### Full local (no Claude API at all)
+**Rejected because:** It leaves the cost and privacy motivations unaddressed. The local LLM was the primary driver for acquiring high-VRAM hardware in the first place. Keeping the Claude API as the sole orchestrator would make the GPU investment largely wasted.
 
-Replacing all Claude API calls — including relationship insights (Opus), fact extraction (Sonnet/Haiku), tone analysis (Sonnet), and web search (Sonnet with built-in web search tool) — with local models. This was rejected because frontier model quality provides measurable value for these specialized tasks. Relationship analysis over sensitive personal data benefits from Opus-level reasoning. Web search requires Anthropic's built-in search tool, which has no local equivalent. The hybrid approach (local orchestrator + cloud specialists) captures the majority of cost and privacy benefits while preserving quality where it matters most.
+### Full Local (no Claude API at all)
 
-### vLLM instead of llama-server
+Replace all Claude API calls — including relationship insights, fact extraction, tone analysis, and web search — with local models.
 
-vLLM was initially planned as the local inference server. However, llama-server (from llama.cpp) provided better ROCm compatibility with the target GPU and simpler deployment for a single-user system. vLLM's strengths (high-throughput batching, PagedAttention for concurrent users) are less relevant for a system serving one user. llama-server's lower operational overhead was a better fit.
+**Rejected because:** Frontier-model quality provides measurable value for these specialized tasks. Relationship analysis over sensitive personal data benefits from Opus-level reasoning. Web search requires Anthropic's built-in search tool, which has no local equivalent. The hybrid approach (local orchestrator + cloud specialists) captures the majority of cost and privacy benefits while preserving quality where it matters most.
+
+### vLLM Instead of llama-server
+
+vLLM was initially planned as the local inference server.
+
+**Rejected because:** llama-server (from llama.cpp) provided better ROCm compatibility with the target GPU and simpler deployment for a single-user system. vLLM's strengths (high-throughput batching, PagedAttention for concurrent users) are less relevant for a system serving one user. llama-server's lower operational overhead was a better fit.
 
 ### Cloud VM with GPU
 
-Running LifeOS on a cloud VM with an attached GPU (e.g., AWS p4d, Lambda Labs) would avoid hardware procurement. However, this contradicts LifeOS's core principle that all data stays local. Hosting personal emails, messages, therapy notes, and financial data on a cloud VM — even one you control — introduces attack surface and ongoing cost that self-hosted hardware avoids. The workstation is a one-time capital expense with no recurring cloud bills.
+Run LifeOS on a cloud VM with an attached GPU (e.g., AWS p4d, Lambda Labs) to avoid hardware procurement.
+
+**Rejected because:** This contradicts LifeOS's core principle that all data stays local. Hosting personal emails, messages, therapy notes, and financial data on a cloud VM — even one you control — introduces attack surface and ongoing cost that self-hosted hardware avoids. The workstation is a one-time capital expense with no recurring cloud bills.
 
 ## Consequences
 
-**Positive:**
-- Orchestration runs locally — no personal data sent to external APIs for the primary chat flow.
-- Zero marginal cost for orchestration and synthesis (previously the largest API expense).
+### Positive
+
+- Orchestration runs locally by default — no personal data sent to external APIs for the primary chat flow.
+- Zero marginal cost for orchestration and synthesis when on local backend (previously the largest API expense).
 - Lower latency for agentic chat interactions (no network round-trips per tool-calling round).
 - systemd provides cleaner service management than launchd + FDA wrappers.
 - Hardware overhead allows future model upgrades without architecture changes.
 - Dual-compatible codebase means development workflow (edit on MacBook, run on server) is preserved.
 
-**Negative:**
+### Negative
+
 - Hardware dependency: LifeOS now requires specific GPU hardware. If the workstation fails, there is no automatic fallback (though `LIFEOS_LLM_BACKEND=anthropic` can restore Claude API orchestration manually).
-- Model quality variance: The local 120B model may underperform Claude for certain query types, particularly complex multi-step reasoning or nuanced tool selection. Ongoing prompt tuning may be required.
-- Operational complexity: Two machines (Linux server + Mac for Apple data) instead of one Mac Mini. The Apple Data Agent adds a nightly rsync dependency.
+- Model quality variance: a local 120B-class model may underperform Claude for certain query types, particularly complex multi-step reasoning or nuanced tool selection. Ongoing prompt tuning may be required.
+- Operational complexity: two machines (Linux server + Mac for Apple data) instead of one Mac Mini. The Apple Data Agent adds a nightly rsync dependency.
 - ROCm ecosystem: AMD GPU tooling (ROCm, PyTorch ROCm builds) is less mature than NVIDIA CUDA. Occasional compatibility issues with new PyTorch versions are expected.
 - Dual-platform maintenance: OS-detection wrappers in shell scripts and Python add conditional complexity that must be tested on both platforms.
-
-**Risks:**
 - Local model tool-calling reliability may be lower than Claude's, causing agent loop failures or degraded responses. Mitigation: the backend toggle allows falling back to Claude API per-session or globally.
 - Apple Data Agent timing: if the Mac fails to export before the nightly sync runs on Linux, Apple data sources will be stale. Mitigation: staleness checks and alerting before sync.
-- ROCm version drift: PyTorch ROCm builds may lag behind CUDA builds, limiting access to the latest model optimizations. Currently mitigated with `HSA_OVERRIDE_GFX_VERSION` for GPU compatibility.
 
 ## Related Documents
 
-**Design Context:**
-- [ADR-005: External Venv](005-external-venv-macos-tcc.md) — Superseded; TCC rationale no longer applies, but external venv practice retained
+### Design Context
+- [ADR-005: External Venv](005-external-venv-macos-tcc.md) — Superseded by this ADR; TCC rationale no longer applies, external venv practice retained
 - [ADR-001: Python/FastAPI](001-python-fastapi.md) — The backend stack, unchanged by this migration
+- [ADR-006: Ollama Query Routing](006-ollama-query-routing.md) — The routing layer now runs under systemd
 
-**Specifications:**
+### Specifications
 - [Architecture](../specs/technical/architecture.md) — System architecture (updated for Linux deployment)
 - [Data & Sync](../specs/technical/data-and-sync.md) — Sync pipeline details (Apple Data Agent added)
 - [Observability](../specs/technical/observability.md) — Monitoring and alerting (systemd integration)
 
-**Plans (Archived):**
-- [Linux Migration Plan](../plans/archive/2026-03-linux-migration.md) — Full migration plan (Phases 1-6)
-- [Remaining Steps](../plans/archive/linux-migration-remaining-steps.md) — Post-migration operational checklist
+### Operational
+- [Installation Guide](../guides/installation.md) — Linux setup steps
+- [Scripts Reference](../guides/scripts.md) — `setup-systemd.sh` and related operator scripts
+
+### Code References
+- [`api/services/llm_client.py`](../../api/services/llm_client.py) — Unified LLM wrapper with Anthropic↔OpenAI tool-format translation
+- [`config/systemd/`](../../config/systemd/) — All systemd unit files installed by `setup-systemd.sh`

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -6,16 +6,18 @@ This directory contains Architecture Decision Records (ADRs) — immutable recor
 - `002-chromadb-vector-store.md` — ChromaDB in client-server mode for semantic search
 - `003-two-tier-data-model.md` — SourceEntity (raw) + PersonEntity (canonical) separation
 - `004-hybrid-search.md` — Vector (ChromaDB) + keyword (BM25/FTS5) with RRF fusion
-- `005-external-venv-macos-tcc.md` — Virtual environment at ~/.venvs to avoid TCC scanning
+- `005-external-venv-macos-tcc.md` — Virtual environment at ~/.venvs to avoid TCC scanning **(Superseded by 007)**
 - `006-ollama-query-routing.md` — Local Ollama + Qwen 2.5 for query classification
 - `007-linux-migration.md` — Linux migration and local LLM orchestration (supersedes 005)
 
 ## Key Principles
 
-- ADRs are **append-only**. Never modify an accepted ADR; create a new one to supersede it.
+- ADRs are **append-only**. Never modify an accepted ADR. The only acceptable in-place edit is adding a `**Superseded By:** ADR-NNN` or `**Amended by:** ADR-NNN` pointer in the frontmatter.
 - Naming: `NNN-kebab-case.md`. Sequential numbering, never reuse numbers.
-- Every ADR must include frontmatter: Decision, Date, Status, Last Updated.
-- Target length: 200–600 lines (max 800).
+- Every ADR must include frontmatter: `**Status:** Complete | Partial | Draft`, `**Last Updated:** YYYY-MM-DD`, `**Decision:** Accepted | Superseded | Deprecated`, and (if applicable) `**Superseded By:** ADR-NNN` / `**Amended by:** ADR-NNN`.
+- Required sections: Context, Decision, Rationale, **Alternatives Considered** (each alternative + explicit "Rejected because"), **Consequences** split into **Positive** and **Negative**, Related Documents (4-bucket structure: Design Context / Specifications / Operational / Code References).
+- Target length: 200–500 lines (max 800). Split into multiple ADRs if a single decision is too sprawling.
+- See [docs/AGENTS.md § ADR Template](../AGENTS.md#adr-template) for the full template.
 
 ## Related Documents
 


### PR DESCRIPTION
## Summary

- Retrofits all 7 existing ADRs to the upgraded template encoded in `docs/AGENTS.md` (PR #193 / issue #180).
- Adds `**Superseded By:** ADR-007` to ADR-005 (its TCC rationale doesn't apply on Linux; the venv practice carries over by convention).
- Adds `**Supersedes:** ADR-005` to ADR-007 for the reciprocal forward pointer.
- Updates `docs/adr/AGENTS.md` to enumerate the new template requirements.

## Frontmatter conversion (all 7)

| Before | After |
|--------|-------|
| `> **Decision:** Use Python 3.11+ with FastAPI...` (prose + status conflated in one blockquote) | `**Status:** Complete`<br>`**Last Updated:** YYYY-MM-DD`<br>`**Decision:** Accepted` (or Superseded for 005) |

The "what was decided" sentence moved into the Decision *section* (not the frontmatter), per the template. `Status` (doc completeness) is now distinct from `Decision` (whether the decision is still in force) — matters for ADR-005 (`Status: Complete`, `Decision: Superseded`).

## Structural changes (all 7)

- **Alternatives Considered**: each alternative gets its own `###` subsection ending with an explicit `**Rejected because:**` paragraph. Existing ADRs already had this content as prose; the retrofit just standardizes the format.
- **Consequences**: previously `**Positive:** / **Negative:** / **Risks:**` mix-of-bold-text-and-bullets. Now `### Positive` and `### Negative` subsection headers per the template. `Risks` content folded into `Negative` (risks are negatives that happen to be probabilistic — a separate bucket bred ambiguity).
- **Related Documents**: previously 3-bucket (`**Design Context:** / **Specifications:** / **Operational:**`). Now 4-bucket per template (`### Design Context / ### Specifications / ### Operational / ### Code References`). Empty buckets are omitted.

## Code-ref accuracy

All Code References hand-verified to point at files that exist in the current repo:

| ADR | Refs |
|-----|------|
| 001 | `api/main.py`, `requirements.txt` |
| 002 | `api/services/vectorstore.py` (NOT `chroma_client.py` — wrong name in my first draft, corrected), `config/systemd/lifeos-chromadb.service` |
| 003 | `api/services/entity_resolver.py`, `api/services/people_aggregator.py`, `config/people_dictionary.example.json` (the canonical `.json` is gitignored — see #181) |
| 004 | `api/services/hybrid_search.py`, `api/services/bm25_index.py` |
| 006 | `api/services/query_classifier.py`, `api/services/query_router.py`, `api/services/ollama_client.py` |
| 007 | `api/services/llm_client.py`, `config/systemd/` |

## Length

| ADR | Lines |
|-----|-------|
| 001 | 86 |
| 002 | 99 |
| 003 | 87 |
| 004 | 93 |
| 005 | 89 |
| 006 | 91 |
| 007 | 143 |

All well within the 200–500 target / 800 max.

## Acceptance criteria

- [x] Template documented in `docs/AGENTS.md` (landed in PR #193 / issue #180)
- [x] All 7 ADRs match the new template (every section present)
- [x] ADR-005 has `**Superseded By:** ADR-007` in frontmatter
- [x] All ADR Related Documents sections use the 4-bucket structure
- [x] No functional code changes

## Test plan

- [x] `wc -l` on each ADR confirms length within target
- [x] `/bin/ls` verified every Code References path resolves in the current repo
- [x] ADR-005 ↔ ADR-007 bidirectional cross-link verified
- [ ] Reviewer: confirm folding `Risks` into `Negative` is the right call (vs. keeping `Risks` as a third subsection)
- [ ] Reviewer: spot-check one ADR (e.g., #004) and confirm the Alternatives Considered shape reads cleanly

## Targeting

Based on `docs/180-strategy-foundation`; targeted at `docs/overhaul`.

Closes #182.