### PR TITLE
docs(adr): ADR-008 — Managed Agents cloud routing for agent worker

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,384 @@
+# Documentation Strategy
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+
+**This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
+
+## Purpose
+
+This strategy defines how we organize and maintain documentation in LifeOS. These are **rules, not guidelines** — following this strategy faithfully is critical to maintaining documentation quality across a collaborative human + AI agent project.
+
+Documentation in LifeOS serves two readers equally:
+- **Human contributors** who need to onboard, debug, and design changes.
+- **AI agents** (Claude Code, Cursor, Copilot, etc.) that load docs as context when working on the codebase.
+
+Both readers benefit from the same things: short, focused documents; explicit decisions; cross-links instead of duplication; and an unambiguous answer to "where does this kind of information live?"
+
+## Core Principles
+
+1. **Living documents over proposals** — Design docs evolve during implementation rather than being written once and frozen. Update when thinking changes, not when tasks complete.
+2. **Modular over monolithic** — Split documents by concern, not by phase or role. A 1,800-line spec is a symptom, not a feature.
+3. **Cross-linked over isolated** — Documents reference related docs with a short tagline explaining the relationship, not just a link.
+4. **Concise over comprehensive** — Each document has a clear scope; prefer multiple focused docs over one sprawling one.
+5. **Consistent over creative** — Follow established patterns and structures. Consistency makes documentation predictable and navigable.
+6. **AI-readable** — Be succinct, specific, and clear. Prefer shorter, well-named documents over longer ones. Don't overexplain, but make requirements and decisions explicit.
+7. **Single source of truth** — Default to keeping each piece of information in exactly one authoritative location; other documents link to it rather than repeating it. When in doubt about where something belongs, consult the [Content Classification table](#content-classification). When you find duplication, prefer consolidating to the authoritative location and replacing duplicates with cross-references.
+
+## Document Taxonomy
+
+```
+docs/
+├── AGENTS.md          # THIS FILE (documentation strategy)
+├── CLAUDE.md          # @AGENTS.md wrapper
+├── vision/            # WHY — project vision, philosophy
+├── specs/
+│   ├── product/       # WHAT — features, API contracts, data models (consumer perspective)
+│   ├── technical/     # HOW (design) — architecture, schema, security, infrastructure
+│   └── standards/     # HOW (work) — coding conventions, testing standards, naming rules
+├── adr/               # WHY (decisions) — immutable architecture decision records
+├── guides/            # HOW (do) — step-by-step operational instructions
+├── plans/             # WHEN — active execution work, ephemeral (gitignored)
+└── archive/           # HISTORY — superseded documents (gitignored)
+```
+
+### Vision Documents
+
+**Location:** `docs/vision/`
+**Purpose:** Vision, philosophy, and strategic direction — the WHY behind LifeOS
+**Updated:** When strategy changes (rarely)
+
+Vision docs provide foundational context that frames every design decision. For LifeOS, that's primarily the privacy-first, local-first, single-user posture — see [philosophy.md](vision/philosophy.md).
+
+### Specifications
+
+**Location:** `docs/specs/`
+**Purpose:** Design documents describing WHAT the system is/should be (target state)
+**Updated:** When the design evolves
+
+**Key principle:** Specs are the **vision** — the authoritative design for the system. Not implementation plans, not progress tracking, not task lists. They describe the intended architecture and behavior.
+
+"Living" means the spec updates when *the design* changes, not when *tasks* complete.
+
+- `product/` — What the system does from a consumer perspective. Feature behavior, API contracts, data model semantics. Answers: "What does this entity mean? What can you do with this endpoint?"
+- `technical/` — How the system is built from an engineering perspective. Architecture, schema, security implementation, query optimization. Answers: "How is this implemented? What constraints did we hit?"
+- `standards/` — Rules and conventions for how we work. Coding standards, naming conventions, testing patterns. Answers: "What conventions must we follow?"
+
+### Architecture Decision Records (ADRs)
+
+**Location:** `docs/adr/`
+**Purpose:** Immutable records of significant architectural decisions with context and rationale
+**Updated:** Never. ADRs are append-only — create a new ADR to supersede an old one. The only acceptable in-place edit is adding an `Amended by: ADR-NNN` or `Superseded By: ADR-NNN` pointer to the frontmatter.
+
+**Naming:** `NNN-short-title.md` (e.g., `008-managed-agents-cloud-routing.md`). Sequential numbering. Never reuse numbers.
+
+ADRs live at the top level (not under `specs/`) because they span product and technical concerns. A decision about data model semantics is as load-bearing as one about database engines.
+
+### Operational Guides
+
+**Location:** `docs/guides/`
+**Purpose:** Step-by-step instructions for specific operator and contributor tasks
+**Updated:** When procedures change
+
+Guides are instructional — they tell you how to do something, not why it's designed that way. If a guide starts explaining design rationale, that content belongs in a spec or ADR.
+
+### Plans
+
+**Location:** `docs/plans/` (gitignored — personal/active planning notes)
+**Purpose:** Active execution work — phases, tasks, roadmaps, backlogs
+
+Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. For trackable work, prefer GitHub issues; for personal planning, use the local `docs/plans/` directory.
+
+### Archive
+
+**Location:** `docs/archive/` (gitignored)
+**Purpose:** Superseded documents, audit notes, and historical investigation working notes retained for local context.
+
+Archive content is **not** part of the public repo. When a durable insight from an archived doc is still load-bearing, promote it: link to the relevant live spec, or extract the durable conclusion into an ADR.
+
+## Content Classification
+
+| Content Type | Belongs In | Anti-Pattern |
+|---|---|---|
+| Project vision, philosophy, strategy | `vision/` | Not in specs (too stable, too abstract) |
+| User-facing feature behavior, API contracts, data model semantics | `specs/product/` | No implementation details, no task lists |
+| Architecture, system design, schema, query design, security implementation | `specs/technical/` | No roadmaps, no "Next Steps" |
+| Coding conventions, naming rules, testing patterns | `specs/standards/` | Not in guides (standards prescribe, guides instruct) |
+| Architectural decisions with rationale and alternatives | `adr/` | Never modify after acceptance — create a new ADR to supersede |
+| Setup procedures, troubleshooting, operator how-to | `guides/` | Not design rationale |
+| Phases, tasks, roadmaps, checklists | `plans/` (or GitHub issues) | Don't put in specs |
+| Audit notes, investigation working files, superseded docs | `archive/` | Don't link from live specs unless promoting a specific insight |
+
+**Rule of thumb:** "Why do we build this?" → vision. "What should it be?" → product spec. "How is it built?" → technical spec. "Why did we decide?" → ADR. "How do I do X?" → guide. "When/how do we get there?" → plan.
+
+**LifeOS-specific classification:**
+- Data model semantics (what entities mean, relationships between them) → `specs/product/data-model.md`
+- Data model implementation (SQLite schema, ChromaDB collections, indexes) → `specs/technical/`
+- API contracts (consumer perspective, request/response shapes) → `specs/product/api-reference.md`
+- API internals (route-handler structure, middleware, error handling) → `specs/technical/`
+- Privacy/security design decisions → `specs/technical/security-privacy.md`, with corresponding ADRs for the underlying decisions
+
+## Frontmatter Standards
+
+Every document must have frontmatter:
+
+```markdown
+**Status:** Draft | Partial | Complete
+**Last Updated:** YYYY-MM-DD
+```
+
+**Additional fields by document type:**
+
+| Type | Additional Fields |
+|---|---|
+| ADR | `**Decision:** Accepted \| Superseded \| Deprecated` and (if applicable) `**Superseded By:** ADR-NNN` or `**Amended by:** ADR-NNN` |
+| Product Spec | `**Owner:** name-or-area` |
+| Technical Spec | `**Owner:** name-or-area` |
+| Guide | `**Audience:** Operator \| Contributor \| New users` |
+| Plan | `**Target Date:** YYYY-MM-DD` (or `Ongoing`); `**Completed:** YYYY-MM-DD` when archived |
+
+`Status` values:
+- **Draft** — Initial draft, not yet reviewed; may have gaps or open questions.
+- **Partial** — Some sections complete, others marked TODO; safe to read for the parts that exist.
+- **Complete** — Reviewed, accurate as of `Last Updated`, no known gaps.
+
+For ADRs, `Status` reflects document completeness; `Decision` reflects whether the decision is still in force.
+
+## ADR Template
+
+ADRs use the following structure. The retrofit issue (#182) brought existing ADRs into this shape; all new ADRs must follow it.
+
+```markdown
+# ADR-NNN: Short Title
+
+**Status:** Complete
+**Last Updated:** YYYY-MM-DD
+**Decision:** Accepted
+**Superseded By:** ADR-NNN  (only if applicable)
+**Amended by:** ADR-NNN     (only if applicable)
+
+## Context
+
+The situation, constraints, and forces at the time of the decision. Why this needed to be decided now.
+
+## Decision
+
+One unambiguous statement of what was chosen. No hedging.
+
+## Rationale
+
+Why this choice over the alternatives. Tie back to the constraints in Context.
+
+## Alternatives Considered
+
+Each alternative as its own subsection with a one-paragraph description and an explicit "Rejected because..." line. Recover alternatives from PR descriptions, commit messages, or memory. Where you genuinely don't remember, write "to be filled in by the original decider" rather than fabricating.
+
+### Alternative A
+
+Description.
+
+**Rejected because:** specific reason.
+
+## Consequences
+
+### Positive
+
+- Specific benefits this decision enables.
+
+### Negative
+
+- Specific costs, ongoing maintenance burden, or constraints this decision imposes.
+
+## Related Documents
+
+(Use the 4-bucket Related Documents structure described below.)
+```
+
+## Length Guidelines
+
+Not rigid rules, but signals for document health. When a doc passes the "max" column it should be split by concern.
+
+| Document Type | Target Lines | Max Lines |
+|---|---|---|
+| ADR | 200–500 | 800 |
+| Product Spec | 300–700 | 800 |
+| Technical Spec | 400–800 | 1,000 |
+| Standards | 200–500 | 700 |
+| Vision | 300–600 | 800 |
+| Guide | 200–500 | 800 |
+| Plan | Variable | — |
+
+**Split when:**
+- Document exceeds the Max in its column.
+- It covers multiple distinct concerns (e.g., one CRM spec covering people, interactions, graph, analytics).
+- Different readers need different sections.
+- Table of contents has more than ~8 top-level sections.
+
+When splitting, keep a thin **index document** at the original path with pointers to each split and a short overview. Update all inbound links to point at the right split.
+
+## Cross-Linking Standards
+
+Every document must include a "Related Documents" section at the bottom.
+
+**Requirements:**
+1. **Bidirectional** — if A links to B, B must link to A. When you add a link in one direction, add the reciprocal link in the same PR.
+2. **Contextual** — every link has a "— short tagline" explaining the relationship.
+3. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
+4. **Use the 4-bucket structure** below for consistency.
+
+**Standard Related Documents template:**
+
+```markdown
+## Related Documents
+
+### Design Context
+- [ADR-NNN: Decision Name](../adr/NNN-title.md) — Why this approach was chosen
+- [Vision: Philosophy](../vision/philosophy.md) — The principle behind this
+
+### Specifications
+- [Product Spec](../specs/product/feature.md) — Consumer-facing requirements
+- [Technical Spec](../specs/technical/component.md) — Implementation design
+
+### Operational
+- [Setup Guide](../guides/feature-setup.md) — How to configure this
+- [Configuration](../guides/configuration.md) — Env var reference
+
+### Code References
+- [Implementation](../../api/services/foo.py:45-120) — Production code
+- [Tests](../../tests/test_foo.py) — Coverage
+```
+
+Use only the buckets that apply — omit empty buckets rather than including them as `(none)`.
+
+## Lifecycle Rules
+
+**Specs are living:**
+- Update when the design changes, not when tasks complete.
+- If a spec describes a target that's not yet built, the `Status: Partial` value is appropriate.
+- Specs are not changelogs. Don't add "Added X in PR #N" notes; that's what `git log` and `git blame` are for.
+
+**Plans are ephemeral:**
+- A plan ends as either "completed" (move to `archive/` with `Completed: YYYY-MM-DD`) or "superseded" (note the successor and move to `archive/`).
+- Do not leave stale plans in `docs/plans/`.
+
+**ADRs are immutable:**
+- Never modify the Context / Decision / Rationale / Alternatives sections of an accepted ADR.
+- To change a decision, create a new ADR. The old ADR gets `Superseded By: ADR-NNN` added to its frontmatter — that's the only acceptable in-place edit.
+- For a smaller change (clarification, scoping refinement that doesn't reverse the decision), the new ADR is an *amendment* and the old ADR gets `Amended by: ADR-NNN`.
+
+**Guides decay:**
+- Test commands you document before shipping. Stale guides are worse than missing guides.
+
+## Writing for AI Readability
+
+Documentation is frequently consumed by AI agents during development. Optimize for:
+
+**Clarity:**
+- State requirements explicitly. Avoid "should consider" — say "do" or "don't" or "defer because X".
+- Use precise technical terminology (route handler, span, collection) rather than vague nouns.
+- Avoid ambiguous pronouns; prefer specific nouns even at the cost of repetition.
+
+**Structure:**
+- Well-named sections that match their content. A section labeled "Notes" is a smell.
+- Frontmatter with status and metadata at the top.
+- Tables when they sharpen a comparison; prose otherwise.
+
+**Brevity:**
+- Shorter, focused documents over long comprehensive ones.
+- Link to details rather than repeating them.
+- Keep documents focused on one concern so agents don't waste context loading irrelevant content.
+
+**Anti-patterns:**
+- Long narrative explanations when a bulleted list suffices.
+- Repeating context already in linked documents.
+- Vague statements like "we should consider" (instead: decided yes/no, or defer with reason).
+- Burying key decisions in prose.
+
+## LifeOS-Specific Rules
+
+### Privacy-First Documentation
+
+LifeOS handles deeply personal data — emails, messages, photos, finances. Documentation must not become a leak vector.
+
+- **Use obviously synthetic data in all examples and test fixtures.** Names like "Alex Chen", domains like `example.com`, phone numbers like `555-0123`, dollar amounts like `$1,234.56`. No real names, emails, phone numbers, or financial values, even in commit-message screenshots.
+- **Security-sensitive implementation details belong in code, not docs.** Reference the code (with line numbers) rather than restating encryption keys, auth tokens, or exact connection strings.
+- **Technical specs involving data storage or access** should include a "Privacy Considerations" subsection or link to one in `specs/technical/security-privacy.md`.
+- **Don't paste real terminal output** containing real personal data into docs. Sanitize first.
+
+### Open-Source Posture
+
+LifeOS is open-source and single-user / self-hosted. That implies two doc rules beyond the privacy ones:
+
+- **No hardcoded personal values** in examples, configs, or fixtures (paths under `/home/<personal-username>`, machine names, IP addresses). Use placeholders (`<your-username>`, `<your-machine>`).
+- **No "broken by default for a fresh downloader" assumptions.** Setup guides should walk through what a fresh clone actually needs, not what's already true on the maintainer's machine.
+
+### Sub-Directory Instruction Files
+
+Every doc subdirectory has an `AGENTS.md` + `CLAUDE.md` pair so any reader (human or agent) can orient inside the subdirectory without re-reading this strategy file.
+
+Existing pairs:
+- `docs/adr/AGENTS.md` + `CLAUDE.md`
+- `docs/guides/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/standards/AGENTS.md` + `CLAUDE.md`
+- `docs/vision/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/product/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/specs/technical/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/plans/AGENTS.md` + `CLAUDE.md` (added in #181 — note: gitignored)
+
+**AGENTS.md** is the primary instruction file (universal, works with all AI tools). **CLAUDE.md** is a one-line wrapper: `@AGENTS.md`. The `@` import is relative to the file containing it; since CLAUDE.md and AGENTS.md are always co-located, the import is always literally `@AGENTS.md`.
+
+**AGENTS.md structure (per subdirectory):**
+
+```markdown
+[One-line description of directory purpose]
+
+## Contents
+- `file.md` — one-line description
+...
+
+## Key Principles
+- Critical rules that apply to this directory's content
+
+## Related Documents
+- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
+- [Other relevant doc] — Why it matters here
+```
+
+Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended commentary — keep them tight.
+
+## Maintenance Rules
+
+**When code changes:**
+1. Update the relevant design doc in the same PR if the design changed (not the implementation — only when the *intent* changed).
+2. Update `Last Updated` in the frontmatter.
+3. Check if cross-references need updates.
+4. Verify bidirectional links still resolve.
+
+**When documents get long (over the Max in [Length Guidelines](#length-guidelines)):**
+1. Identify distinct concerns within the document.
+2. Create focused docs for each concern.
+3. Keep the original path as a thin index pointing at the splits.
+4. Update inbound references to the right split.
+
+**Common violations to avoid:**
+- Adding "Next Steps" or task lists to specs or ADRs.
+- Mixing planning (roadmaps, tasks) into design documents.
+- Creating documents without "Related Documents" sections.
+- Failing to update cross-references when moving or splitting documents.
+- Modifying an accepted ADR in place (instead of superseding).
+- Using real personal data in examples.
+
+---
+
+## Related Documents
+
+### Project Context
+- [Root AGENTS.md](../AGENTS.md) — Project-level agent reference, development principles, key files
+- [Root CLAUDE.md](../CLAUDE.md) — Claude Code-specific configuration
+
+### Specifications
+- [vision/philosophy.md](vision/philosophy.md) — The privacy-first, local-first principles that frame doc decisions
+- [specs/standards/](specs/standards/) — Coding and testing conventions referenced by docs
+
+### Operational
+- [guides/](guides/) — Operator-facing setup and troubleshooting

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/adr/008-managed-agents-cloud-routing.md
+++ b/docs/adr/008-managed-agents-cloud-routing.md
@@ -1,0 +1,106 @@
+# ADR-008: Managed Agents Cloud Routing for the Agent Worker
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+**Decision:** Accepted
+
+## Context
+
+[ADR-007](007-linux-migration.md) established a local-LLM-first posture for LifeOS: orchestration and synthesis default to a local `llama-server` running on the operator's GPU. The agent worker (`#agent`-tagged Obsidian tasks running autonomously — see [agent-worker product spec](../specs/product/agent-worker.md)) initially shipped local-only on the same model.
+
+Two pressures emerged that local-only couldn't satisfy:
+
+1. **Cloud connectors.** Many useful agent tasks ("draft a reply to last week's intro thread", "find every meeting that mentioned the Q3 launch", "post to the partnership Slack channel") require Gmail, Calendar, Drive, Slack, Asana, etc. Those connectors live in Anthropic's Vault as OAuth-authenticated MCP servers — they cannot be wired to a local LLM without re-implementing OAuth flows for each service and re-creating the connector inventory.
+2. **Model capability for ambiguous tasks.** The agent loop is sensitive to model quality on judgment calls (which tool to call next, when to stop, how to phrase a clarification). For tasks where the operator wants frontier-model behavior, falling back to a hosted model is the simpler path than fine-tuning a local one.
+
+The decision is **how** to route between local and cloud — what triggers the choice, how the two paths share infrastructure, what new attack surface cloud routing introduces, and how the cost model is exposed to the operator.
+
+## Decision
+
+Add a second execution path to the agent worker: **Anthropic Managed Agents** (`api.anthropic.com/v1/sessions`). Route between local and cloud at preflight time, on three signals (in order of precedence):
+
+1. **Explicit tag** — `#local` or `#cloud` on the task forces the corresponding path.
+2. **Title cue** — phrases like "draft an email", "check my calendar", "search my gmail" infer cloud (those need connectors); "with local agent" / "using gemma" force local.
+3. **Ask the operator** — if the preflight can't determine routing, the task parks at `#agent-blocked` and the worker asks via Telegram.
+
+The Managed Agents path uses:
+
+- **MCP HTTP transport** for LifeOS tool access (`config/systemd/lifeos-mcp-http.service`, bearer-token-gated, exposed via Tailscale Funnel). The cloud session needs to reach LifeOS tools from outside the operator's LAN.
+- **Anthropic Vault** for cloud-only connector OAuth credentials (Gmail, Calendar, Drive, Slack, etc.) — provisioned by the operator out-of-band in the Anthropic Console.
+- **Anthropic Console agent preset** that bundles the Vault connectors, system prompt, and model choice. The preset name is referenced from `.env`; the actual agent configuration lives in the Anthropic Console.
+
+Both paths share the same session store, transcript store, spend tracker, preflight, inter-agent coordination, and Telegram delivery. The split is at the executor level (`local_executor.py` vs `managed_executor.py`); everything above and below them is shared.
+
+## Rationale
+
+- **Connector authenticatability.** Cloud-only connectors aren't authenticatable to a local agent. Routing tasks that need them to Managed Agents is the only path that doesn't require re-implementing OAuth for every connector.
+- **Frontier model quality** for ambiguous judgment calls. Local Gemma is fine for deterministic tasks; for "decide what to do here", a hosted Claude Sonnet 4.6 has noticeably better tool selection and stopping behavior.
+- **Shared infrastructure.** The session store, transcripts, spend ledger, and inter-agent tools work identically for both paths. The operator's mental model is one worker, two executors — not two parallel systems.
+- **Operator-controlled cost surface.** Per-task `$`/wall/token budgets and the global daily $-cap apply identically to both paths. The flat `$0.08/hour` Managed-session-hour overhead (per [Anthropic pricing](https://platform.claude.com/docs/en/managed-agents/overview), announced April 2026) is baked into the cost calculation in `pricing.py:MANAGED_SESSION_HOUR_OVERHEAD`, so budget enforcement accounts for it without operator intervention.
+- **Aligned with [ADR-007](007-linux-migration.md)'s hybrid model.** ADR-007 already established that specialized Claude API calls remain on Anthropic while orchestration runs locally. Agent worker cloud routing is the same pattern at a different layer.
+
+## Alternatives Considered
+
+### Local-only with mock connectors
+
+Build local stubs that fake Gmail/Calendar/Drive responses for development, with a roadmap to re-implement the real connectors against local OAuth flows.
+
+**Rejected because:** Re-implementing N OAuth flows + connector inventories + per-service rate-limit handling + token refresh logic is a multi-quarter project. Anthropic Vault solves the connector problem today. The mock approach also blocks users from doing the actual tasks they want (drafting real emails, checking real calendars).
+
+### Third-party agent runtime (LangGraph cloud, OpenAI Assistants)
+
+Use an external agent platform instead of Anthropic's Managed Agents.
+
+**Rejected because:** Two reasons. First, the LifeOS MCP server is already authored to Anthropic's MCP conventions — running against an Anthropic-native runtime is the lowest-impedance path. Second, third-party runtimes add a vendor dependency that LifeOS hasn't otherwise taken on. The fewer external runtimes that see operator data, the smaller the privacy surface.
+
+### Cloud-only routing (drop the local path)
+
+Route every `#agent` task through Managed Agents.
+
+**Rejected because:** It gives up the privacy and zero-cost guarantees that motivated [ADR-007](007-linux-migration.md) in the first place. Many tasks (vault grepping, file authoring, local CLI work) don't need cloud connectors and shouldn't pay the Managed-session-hour fee or send their context off-machine. The local path stays the default for that class of work.
+
+### Single-executor with a connector shim layer
+
+Keep one executor but introduce a "connector adapter" layer that transparently routes Gmail/Calendar/etc. calls through Anthropic-hosted MCP while keeping the agent loop local.
+
+**Rejected because:** Routing only the tool calls externally still requires the local agent to reason about each cloud connector's response shape, latency, and failure modes — and the agent loop itself isn't where the model-quality gap lives. Splitting at the executor level (each path has its own end-to-end agent runtime) is cleaner than splitting at the tool-call level.
+
+## Consequences
+
+### Positive
+
+- Operator can complete tasks that require cloud connectors (Gmail/Calendar/Drive/Slack/etc.) without re-implementing OAuth for each service.
+- Frontier model available for ambiguous tasks where local model quality is the bottleneck.
+- Cost surface is explicit and bounded: per-task budgets and a global daily cap, with session-hour overhead included in the math.
+- Both executors share state, transcripts, and inter-agent tools — operator sees one queue, one transcript stream, one Telegram interface regardless of routing.
+- Routing is transparent: operator can override via tag, accept the preflight's inference, or be asked.
+
+### Negative
+
+- New per-session-hour billing dimension. Long-idle Managed sessions accrue `$0.08/hr` even when no model calls happen — motivated the `yield-and-resume` pattern (see [agent worker — session state machine](../specs/technical/agent-worker.md#session-state-machine)) so sessions don't sit idle paying the overhead.
+- MCP HTTP transport is now a load-bearing piece of agent-worker infrastructure. The bearer token must remain secret, the Tailscale Funnel exposure must remain narrow (only the `/mcp` endpoint), and kill/resume endpoints must **not** be exposed through it.
+- Operator must provision Anthropic Console artifacts out-of-band: a Vault with connector OAuth credentials, an agent preset, and an environment binding. This is documented in [agent-worker-setup.md](../guides/agent-worker-setup.md) but adds setup steps a local-only deployment doesn't need.
+- Cloud sessions run in an Anthropic-managed ephemeral container by default — the agent doesn't have the operator's local filesystem. For tasks that need both cloud connectors and local file access, the operator chooses one or splits the task.
+- More moving parts to monitor: Managed session creation can fail (4xx), session events polling has its own failure modes, and rate limits are now in the cost picture.
+- Routing inference can be wrong. A task title that doesn't clearly cue local or cloud may pause indefinitely until the operator answers the Telegram clarification.
+
+## Related Documents
+
+### Design Context
+- [ADR-007: Linux Migration](007-linux-migration.md) — Established the local-default posture this ADR adds the cloud path to
+- [ADR-009: LIFEOS_LLM_BACKEND toggle](009-llm-backend-toggle.md) — The parallel local/cloud toggle for chat synthesis and orchestration (separate code path; same hybrid-model philosophy)
+
+### Specifications
+- [Agent Worker (product)](../specs/product/agent-worker.md) — Consumer view: tag conventions, budgets, lifecycle, capability boundaries
+- [Agent Worker (technical)](../specs/technical/agent-worker.md) — Implementation: executor split, MCP transport, session state machine, restart resumability
+
+### Operational
+- [Agent Worker Setup](../guides/agent-worker-setup.md) — Operator setup including Anthropic Vault, preset, MCP HTTP transport, Tailscale Funnel
+
+### Code References
+- [`api/services/agent_worker/managed_executor.py`](../../api/services/agent_worker/managed_executor.py) — Managed session lifecycle (`start()` → `poll()` → `_finalize_remote()`)
+- [`api/services/agent_worker/managed_driver.py`](../../api/services/agent_worker/managed_driver.py) — HTTP wrapper for `api.anthropic.com/v1/sessions` + events
+- [`api/services/agent_worker/router.py`](../../api/services/agent_worker/router.py) — Thin local-vs-cloud dispatch helper
+- [`api/services/agent_worker/preflight.py`](../../api/services/agent_worker/preflight.py) — Haiku classifier producing the routing decision
+- [`api/services/agent_worker/pricing.py`](../../api/services/agent_worker/pricing.py) — Per-model pricing table; `MANAGED_SESSION_HOUR_OVERHEAD = 0.08`
+- [`config/systemd/lifeos-mcp-http.service`](../../config/systemd/lifeos-mcp-http.service) — Bearer-gated MCP HTTP transport used by Managed Agents

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -176,6 +176,7 @@ All in `.env` — see [`agent-worker-setup.md`](../../guides/agent-worker-setup.
 
 ## Related Documents
 
+- [ADR-008: Managed Agents Cloud Routing](../../adr/008-managed-agents-cloud-routing.md) — Why local + cloud, how routing is decided, cost model
 - [Agent Worker — Technical](../technical/agent-worker.md) — Architecture, executors, prompts, state machine, restart resumability
 - [Agent Worker — Setup](../../guides/agent-worker-setup.md) — Operator setup (Gemma swap, MCP HTTP transport, Vault provisioning, agent preset)
 - [Agent Viz](agent-viz.md) — Live `/agents` page showing in-flight and recently-finished worker sessions

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -347,6 +347,7 @@ Full reference in [`agent-worker-setup.md`](../../guides/agent-worker-setup.md).
 
 ## Related Documents
 
+- [ADR-008: Managed Agents Cloud Routing](../../adr/008-managed-agents-cloud-routing.md) — Decision record for the local-vs-cloud executor split
 - [Agent Worker — Product](../product/agent-worker.md) — What `#agent` does, consumer view
 - [Agent Worker — Setup](../../guides/agent-worker-setup.md) — Operator setup walkthrough
 - [Agent Viz — Technical](agent-viz.md) — `/agents` page that reads SessionStore + TranscriptStore here


### PR DESCRIPTION
## Summary

Backfills the architectural record for the local-vs-cloud routing decision in the agent worker. The decision shipped across PRs #105/#108/#113/#115 in spring 2026 but was never captured as an ADR.

## Acceptance criteria

- [x] ADR-008 exists with all template sections (Status / Decision / Context / Rationale / Alternatives Considered / Consequences Positive+Negative / Related Documents 4-bucket)
- [x] Bidirectional links: ADR → product spec + technical spec; both specs → ADR (added at top of their existing Related Documents lists)
- [x] Cost model explicitly captured (per-task budgets + $0.08/hr session-hour overhead, referencing `pricing.py:MANAGED_SESSION_HOUR_OVERHEAD`)
- [x] Security boundary noted (MCP HTTP transport must remain bearer-gated; only `/mcp` exposed via Tailscale Funnel; kill/resume endpoints must NOT be exposed through it)
- [x] No functional code changes

## Routing signals (in precedence order)

1. Explicit tag (`#local` / `#cloud`)
2. Title cue (Haiku preflight infers from phrasing)
3. Ask the operator (Telegram clarification, park at `#agent-blocked`)

## Alternatives considered (each with `Rejected because:`)

- Local-only with mock connectors
- Third-party agent runtime (LangGraph, OpenAI Assistants)
- Cloud-only routing (drop local path)
- Single-executor with a connector shim layer

## Code references (all verified to exist)

- `api/services/agent_worker/managed_executor.py` (538 lines)
- `api/services/agent_worker/managed_driver.py` (562 lines)
- `api/services/agent_worker/router.py`
- `api/services/agent_worker/preflight.py`
- `api/services/agent_worker/pricing.py` (line: `MANAGED_SESSION_HOUR_OVERHEAD: float = 0.08`)
- `config/systemd/lifeos-mcp-http.service`

## Length

106 lines — within ADR target.

## Test plan

- [x] All code-ref paths exist in current repo
- [x] Bidirectional links resolve: ADR-008 → both agent-worker specs; both back to ADR-008
- [ ] Reviewer: confirm the cost-model framing (session-hour overhead motivates the yield-and-resume pattern) is accurate

## Targeting

Based on `docs/180-strategy-foundation`; targeted at `docs/overhaul`.

Closes #183.