### PR TITLE
docs(adr): ADR-009 — LIFEOS_LLM_BACKEND toggle for synthesis and orchestration

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,384 @@
+# Documentation Strategy
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+
+**This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
+
+## Purpose
+
+This strategy defines how we organize and maintain documentation in LifeOS. These are **rules, not guidelines** — following this strategy faithfully is critical to maintaining documentation quality across a collaborative human + AI agent project.
+
+Documentation in LifeOS serves two readers equally:
+- **Human contributors** who need to onboard, debug, and design changes.
+- **AI agents** (Claude Code, Cursor, Copilot, etc.) that load docs as context when working on the codebase.
+
+Both readers benefit from the same things: short, focused documents; explicit decisions; cross-links instead of duplication; and an unambiguous answer to "where does this kind of information live?"
+
+## Core Principles
+
+1. **Living documents over proposals** — Design docs evolve during implementation rather than being written once and frozen. Update when thinking changes, not when tasks complete.
+2. **Modular over monolithic** — Split documents by concern, not by phase or role. A 1,800-line spec is a symptom, not a feature.
+3. **Cross-linked over isolated** — Documents reference related docs with a short tagline explaining the relationship, not just a link.
+4. **Concise over comprehensive** — Each document has a clear scope; prefer multiple focused docs over one sprawling one.
+5. **Consistent over creative** — Follow established patterns and structures. Consistency makes documentation predictable and navigable.
+6. **AI-readable** — Be succinct, specific, and clear. Prefer shorter, well-named documents over longer ones. Don't overexplain, but make requirements and decisions explicit.
+7. **Single source of truth** — Default to keeping each piece of information in exactly one authoritative location; other documents link to it rather than repeating it. When in doubt about where something belongs, consult the [Content Classification table](#content-classification). When you find duplication, prefer consolidating to the authoritative location and replacing duplicates with cross-references.
+
+## Document Taxonomy
+
+```
+docs/
+├── AGENTS.md          # THIS FILE (documentation strategy)
+├── CLAUDE.md          # @AGENTS.md wrapper
+├── vision/            # WHY — project vision, philosophy
+├── specs/
+│   ├── product/       # WHAT — features, API contracts, data models (consumer perspective)
+│   ├── technical/     # HOW (design) — architecture, schema, security, infrastructure
+│   └── standards/     # HOW (work) — coding conventions, testing standards, naming rules
+├── adr/               # WHY (decisions) — immutable architecture decision records
+├── guides/            # HOW (do) — step-by-step operational instructions
+├── plans/             # WHEN — active execution work, ephemeral (gitignored)
+└── archive/           # HISTORY — superseded documents (gitignored)
+```
+
+### Vision Documents
+
+**Location:** `docs/vision/`
+**Purpose:** Vision, philosophy, and strategic direction — the WHY behind LifeOS
+**Updated:** When strategy changes (rarely)
+
+Vision docs provide foundational context that frames every design decision. For LifeOS, that's primarily the privacy-first, local-first, single-user posture — see [philosophy.md](vision/philosophy.md).
+
+### Specifications
+
+**Location:** `docs/specs/`
+**Purpose:** Design documents describing WHAT the system is/should be (target state)
+**Updated:** When the design evolves
+
+**Key principle:** Specs are the **vision** — the authoritative design for the system. Not implementation plans, not progress tracking, not task lists. They describe the intended architecture and behavior.
+
+"Living" means the spec updates when *the design* changes, not when *tasks* complete.
+
+- `product/` — What the system does from a consumer perspective. Feature behavior, API contracts, data model semantics. Answers: "What does this entity mean? What can you do with this endpoint?"
+- `technical/` — How the system is built from an engineering perspective. Architecture, schema, security implementation, query optimization. Answers: "How is this implemented? What constraints did we hit?"
+- `standards/` — Rules and conventions for how we work. Coding standards, naming conventions, testing patterns. Answers: "What conventions must we follow?"
+
+### Architecture Decision Records (ADRs)
+
+**Location:** `docs/adr/`
+**Purpose:** Immutable records of significant architectural decisions with context and rationale
+**Updated:** Never. ADRs are append-only — create a new ADR to supersede an old one. The only acceptable in-place edit is adding an `Amended by: ADR-NNN` or `Superseded By: ADR-NNN` pointer to the frontmatter.
+
+**Naming:** `NNN-short-title.md` (e.g., `008-managed-agents-cloud-routing.md`). Sequential numbering. Never reuse numbers.
+
+ADRs live at the top level (not under `specs/`) because they span product and technical concerns. A decision about data model semantics is as load-bearing as one about database engines.
+
+### Operational Guides
+
+**Location:** `docs/guides/`
+**Purpose:** Step-by-step instructions for specific operator and contributor tasks
+**Updated:** When procedures change
+
+Guides are instructional — they tell you how to do something, not why it's designed that way. If a guide starts explaining design rationale, that content belongs in a spec or ADR.
+
+### Plans
+
+**Location:** `docs/plans/` (gitignored — personal/active planning notes)
+**Purpose:** Active execution work — phases, tasks, roadmaps, backlogs
+
+Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. For trackable work, prefer GitHub issues; for personal planning, use the local `docs/plans/` directory.
+
+### Archive
+
+**Location:** `docs/archive/` (gitignored)
+**Purpose:** Superseded documents, audit notes, and historical investigation working notes retained for local context.
+
+Archive content is **not** part of the public repo. When a durable insight from an archived doc is still load-bearing, promote it: link to the relevant live spec, or extract the durable conclusion into an ADR.
+
+## Content Classification
+
+| Content Type | Belongs In | Anti-Pattern |
+|---|---|---|
+| Project vision, philosophy, strategy | `vision/` | Not in specs (too stable, too abstract) |
+| User-facing feature behavior, API contracts, data model semantics | `specs/product/` | No implementation details, no task lists |
+| Architecture, system design, schema, query design, security implementation | `specs/technical/` | No roadmaps, no "Next Steps" |
+| Coding conventions, naming rules, testing patterns | `specs/standards/` | Not in guides (standards prescribe, guides instruct) |
+| Architectural decisions with rationale and alternatives | `adr/` | Never modify after acceptance — create a new ADR to supersede |
+| Setup procedures, troubleshooting, operator how-to | `guides/` | Not design rationale |
+| Phases, tasks, roadmaps, checklists | `plans/` (or GitHub issues) | Don't put in specs |
+| Audit notes, investigation working files, superseded docs | `archive/` | Don't link from live specs unless promoting a specific insight |
+
+**Rule of thumb:** "Why do we build this?" → vision. "What should it be?" → product spec. "How is it built?" → technical spec. "Why did we decide?" → ADR. "How do I do X?" → guide. "When/how do we get there?" → plan.
+
+**LifeOS-specific classification:**
+- Data model semantics (what entities mean, relationships between them) → `specs/product/data-model.md`
+- Data model implementation (SQLite schema, ChromaDB collections, indexes) → `specs/technical/`
+- API contracts (consumer perspective, request/response shapes) → `specs/product/api-reference.md`
+- API internals (route-handler structure, middleware, error handling) → `specs/technical/`
+- Privacy/security design decisions → `specs/technical/security-privacy.md`, with corresponding ADRs for the underlying decisions
+
+## Frontmatter Standards
+
+Every document must have frontmatter:
+
+```markdown
+**Status:** Draft | Partial | Complete
+**Last Updated:** YYYY-MM-DD
+```
+
+**Additional fields by document type:**
+
+| Type | Additional Fields |
+|---|---|
+| ADR | `**Decision:** Accepted \| Superseded \| Deprecated` and (if applicable) `**Superseded By:** ADR-NNN` or `**Amended by:** ADR-NNN` |
+| Product Spec | `**Owner:** name-or-area` |
+| Technical Spec | `**Owner:** name-or-area` |
+| Guide | `**Audience:** Operator \| Contributor \| New users` |
+| Plan | `**Target Date:** YYYY-MM-DD` (or `Ongoing`); `**Completed:** YYYY-MM-DD` when archived |
+
+`Status` values:
+- **Draft** — Initial draft, not yet reviewed; may have gaps or open questions.
+- **Partial** — Some sections complete, others marked TODO; safe to read for the parts that exist.
+- **Complete** — Reviewed, accurate as of `Last Updated`, no known gaps.
+
+For ADRs, `Status` reflects document completeness; `Decision` reflects whether the decision is still in force.
+
+## ADR Template
+
+ADRs use the following structure. The retrofit issue (#182) brought existing ADRs into this shape; all new ADRs must follow it.
+
+```markdown
+# ADR-NNN: Short Title
+
+**Status:** Complete
+**Last Updated:** YYYY-MM-DD
+**Decision:** Accepted
+**Superseded By:** ADR-NNN  (only if applicable)
+**Amended by:** ADR-NNN     (only if applicable)
+
+## Context
+
+The situation, constraints, and forces at the time of the decision. Why this needed to be decided now.
+
+## Decision
+
+One unambiguous statement of what was chosen. No hedging.
+
+## Rationale
+
+Why this choice over the alternatives. Tie back to the constraints in Context.
+
+## Alternatives Considered
+
+Each alternative as its own subsection with a one-paragraph description and an explicit "Rejected because..." line. Recover alternatives from PR descriptions, commit messages, or memory. Where you genuinely don't remember, write "to be filled in by the original decider" rather than fabricating.
+
+### Alternative A
+
+Description.
+
+**Rejected because:** specific reason.
+
+## Consequences
+
+### Positive
+
+- Specific benefits this decision enables.
+
+### Negative
+
+- Specific costs, ongoing maintenance burden, or constraints this decision imposes.
+
+## Related Documents
+
+(Use the 4-bucket Related Documents structure described below.)
+```
+
+## Length Guidelines
+
+Not rigid rules, but signals for document health. When a doc passes the "max" column it should be split by concern.
+
+| Document Type | Target Lines | Max Lines |
+|---|---|---|
+| ADR | 200–500 | 800 |
+| Product Spec | 300–700 | 800 |
+| Technical Spec | 400–800 | 1,000 |
+| Standards | 200–500 | 700 |
+| Vision | 300–600 | 800 |
+| Guide | 200–500 | 800 |
+| Plan | Variable | — |
+
+**Split when:**
+- Document exceeds the Max in its column.
+- It covers multiple distinct concerns (e.g., one CRM spec covering people, interactions, graph, analytics).
+- Different readers need different sections.
+- Table of contents has more than ~8 top-level sections.
+
+When splitting, keep a thin **index document** at the original path with pointers to each split and a short overview. Update all inbound links to point at the right split.
+
+## Cross-Linking Standards
+
+Every document must include a "Related Documents" section at the bottom.
+
+**Requirements:**
+1. **Bidirectional** — if A links to B, B must link to A. When you add a link in one direction, add the reciprocal link in the same PR.
+2. **Contextual** — every link has a "— short tagline" explaining the relationship.
+3. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
+4. **Use the 4-bucket structure** below for consistency.
+
+**Standard Related Documents template:**
+
+```markdown
+## Related Documents
+
+### Design Context
+- [ADR-NNN: Decision Name](../adr/NNN-title.md) — Why this approach was chosen
+- [Vision: Philosophy](../vision/philosophy.md) — The principle behind this
+
+### Specifications
+- [Product Spec](../specs/product/feature.md) — Consumer-facing requirements
+- [Technical Spec](../specs/technical/component.md) — Implementation design
+
+### Operational
+- [Setup Guide](../guides/feature-setup.md) — How to configure this
+- [Configuration](../guides/configuration.md) — Env var reference
+
+### Code References
+- [Implementation](../../api/services/foo.py:45-120) — Production code
+- [Tests](../../tests/test_foo.py) — Coverage
+```
+
+Use only the buckets that apply — omit empty buckets rather than including them as `(none)`.
+
+## Lifecycle Rules
+
+**Specs are living:**
+- Update when the design changes, not when tasks complete.
+- If a spec describes a target that's not yet built, the `Status: Partial` value is appropriate.
+- Specs are not changelogs. Don't add "Added X in PR #N" notes; that's what `git log` and `git blame` are for.
+
+**Plans are ephemeral:**
+- A plan ends as either "completed" (move to `archive/` with `Completed: YYYY-MM-DD`) or "superseded" (note the successor and move to `archive/`).
+- Do not leave stale plans in `docs/plans/`.
+
+**ADRs are immutable:**
+- Never modify the Context / Decision / Rationale / Alternatives sections of an accepted ADR.
+- To change a decision, create a new ADR. The old ADR gets `Superseded By: ADR-NNN` added to its frontmatter — that's the only acceptable in-place edit.
+- For a smaller change (clarification, scoping refinement that doesn't reverse the decision), the new ADR is an *amendment* and the old ADR gets `Amended by: ADR-NNN`.
+
+**Guides decay:**
+- Test commands you document before shipping. Stale guides are worse than missing guides.
+
+## Writing for AI Readability
+
+Documentation is frequently consumed by AI agents during development. Optimize for:
+
+**Clarity:**
+- State requirements explicitly. Avoid "should consider" — say "do" or "don't" or "defer because X".
+- Use precise technical terminology (route handler, span, collection) rather than vague nouns.
+- Avoid ambiguous pronouns; prefer specific nouns even at the cost of repetition.
+
+**Structure:**
+- Well-named sections that match their content. A section labeled "Notes" is a smell.
+- Frontmatter with status and metadata at the top.
+- Tables when they sharpen a comparison; prose otherwise.
+
+**Brevity:**
+- Shorter, focused documents over long comprehensive ones.
+- Link to details rather than repeating them.
+- Keep documents focused on one concern so agents don't waste context loading irrelevant content.
+
+**Anti-patterns:**
+- Long narrative explanations when a bulleted list suffices.
+- Repeating context already in linked documents.
+- Vague statements like "we should consider" (instead: decided yes/no, or defer with reason).
+- Burying key decisions in prose.
+
+## LifeOS-Specific Rules
+
+### Privacy-First Documentation
+
+LifeOS handles deeply personal data — emails, messages, photos, finances. Documentation must not become a leak vector.
+
+- **Use obviously synthetic data in all examples and test fixtures.** Names like "Alex Chen", domains like `example.com`, phone numbers like `555-0123`, dollar amounts like `$1,234.56`. No real names, emails, phone numbers, or financial values, even in commit-message screenshots.
+- **Security-sensitive implementation details belong in code, not docs.** Reference the code (with line numbers) rather than restating encryption keys, auth tokens, or exact connection strings.
+- **Technical specs involving data storage or access** should include a "Privacy Considerations" subsection or link to one in `specs/technical/security-privacy.md`.
+- **Don't paste real terminal output** containing real personal data into docs. Sanitize first.
+
+### Open-Source Posture
+
+LifeOS is open-source and single-user / self-hosted. That implies two doc rules beyond the privacy ones:
+
+- **No hardcoded personal values** in examples, configs, or fixtures (paths under `/home/<personal-username>`, machine names, IP addresses). Use placeholders (`<your-username>`, `<your-machine>`).
+- **No "broken by default for a fresh downloader" assumptions.** Setup guides should walk through what a fresh clone actually needs, not what's already true on the maintainer's machine.
+
+### Sub-Directory Instruction Files
+
+Every doc subdirectory has an `AGENTS.md` + `CLAUDE.md` pair so any reader (human or agent) can orient inside the subdirectory without re-reading this strategy file.
+
+Existing pairs:
+- `docs/adr/AGENTS.md` + `CLAUDE.md`
+- `docs/guides/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/standards/AGENTS.md` + `CLAUDE.md`
+- `docs/vision/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/product/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/specs/technical/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/plans/AGENTS.md` + `CLAUDE.md` (added in #181 — note: gitignored)
+
+**AGENTS.md** is the primary instruction file (universal, works with all AI tools). **CLAUDE.md** is a one-line wrapper: `@AGENTS.md`. The `@` import is relative to the file containing it; since CLAUDE.md and AGENTS.md are always co-located, the import is always literally `@AGENTS.md`.
+
+**AGENTS.md structure (per subdirectory):**
+
+```markdown
+[One-line description of directory purpose]
+
+## Contents
+- `file.md` — one-line description
+...
+
+## Key Principles
+- Critical rules that apply to this directory's content
+
+## Related Documents
+- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
+- [Other relevant doc] — Why it matters here
+```
+
+Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended commentary — keep them tight.
+
+## Maintenance Rules
+
+**When code changes:**
+1. Update the relevant design doc in the same PR if the design changed (not the implementation — only when the *intent* changed).
+2. Update `Last Updated` in the frontmatter.
+3. Check if cross-references need updates.
+4. Verify bidirectional links still resolve.
+
+**When documents get long (over the Max in [Length Guidelines](#length-guidelines)):**
+1. Identify distinct concerns within the document.
+2. Create focused docs for each concern.
+3. Keep the original path as a thin index pointing at the splits.
+4. Update inbound references to the right split.
+
+**Common violations to avoid:**
+- Adding "Next Steps" or task lists to specs or ADRs.
+- Mixing planning (roadmaps, tasks) into design documents.
+- Creating documents without "Related Documents" sections.
+- Failing to update cross-references when moving or splitting documents.
+- Modifying an accepted ADR in place (instead of superseding).
+- Using real personal data in examples.
+
+---
+
+## Related Documents
+
+### Project Context
+- [Root AGENTS.md](../AGENTS.md) — Project-level agent reference, development principles, key files
+- [Root CLAUDE.md](../CLAUDE.md) — Claude Code-specific configuration
+
+### Specifications
+- [vision/philosophy.md](vision/philosophy.md) — The privacy-first, local-first principles that frame doc decisions
+- [specs/standards/](specs/standards/) — Coding and testing conventions referenced by docs
+
+### Operational
+- [guides/](guides/) — Operator-facing setup and troubleshooting

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/adr/007-linux-migration.md
+++ b/docs/adr/007-linux-migration.md
@@ -3,8 +3,9 @@
 > **Decision:** Migrate the LifeOS server from Mac Mini (macOS) to a Linux workstation, and replace the Claude API orchestrator with a local LLM.
 > **Date:** 2026-03-04
 > **Status:** Accepted
-> **Last Updated:** 2026-03-04
+> **Last Updated:** 2026-05-27
 > **Supersedes:** [ADR-005](005-external-venv-macos-tcc.md) (external venv rationale — TCC no longer applies, but the practice is retained by convention)
+> **Amended by:** [ADR-009](009-llm-backend-toggle.md) (the local-first orchestrator default became an operator-configurable toggle)
 
 ## Context
 

--- a/docs/adr/009-llm-backend-toggle.md
+++ b/docs/adr/009-llm-backend-toggle.md
@@ -1,0 +1,122 @@
+# ADR-009: LIFEOS_LLM_BACKEND Toggle for Synthesis and Orchestration
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+**Decision:** Accepted
+
+## Context
+
+[ADR-007](007-linux-migration.md) established **local LLM orchestration** as LifeOS's default — chat synthesis, intent orchestration, and agentic tool-calling all run against a local `llama-server` on the operator's GPU, with Claude API used only for specialized calls (relationship insights, fact extraction, web search). This was the right default for the LifeOS maintainer's hardware tier.
+
+In practice, operators have meaningfully different deployments:
+
+- Some operators don't have a high-VRAM GPU and want Anthropic by default — for them, requiring a local model is a hard blocker.
+- Some operators (including the maintainer) prefer local by default for privacy and zero marginal cost.
+- A single operator may want to switch backends mid-debug to compare local vs cloud behavior on the same query.
+
+ADR-007 mentioned `LIFEOS_LLM_BACKEND` as part of its design but treated it as an implementation detail. In hindsight the toggle is a **load-bearing architectural choice**: it determines what model handles every chat turn, where personal data flows on each query, what cost surface the operator is exposed to, and what calibration is required when prompts evolve.
+
+A unified wrapper (`api/services/llm_client.py`) was also built as part of this work. It hides the Anthropic/OpenAI shape differences — tool definitions, tool-call response shapes, system-message handling, streaming format — so tool definitions and prompts are written once and translated at call time. The wrapper's existence is what makes the toggle viable; without it, switching backends would require forking the orchestrator. This wrapper deserves its own architectural record alongside the toggle.
+
+## Decision
+
+`LIFEOS_LLM_BACKEND` is a first-class operator-facing knob with two values:
+
+- `local` — Route synthesis and orchestration to a local OpenAI-compatible `llama-server`. Model determined by which server is running on `http://localhost:8080`.
+- `anthropic` — Route synthesis and orchestration to Anthropic's API. Model determined by `LIFEOS_ANTHROPIC_MODEL` (default `claude-haiku-4-5`).
+
+The toggle controls **only synthesis + orchestration + intent classification**. Specialized calls retained on Anthropic regardless of toggle:
+
+- Relationship insights (Opus-class reasoning)
+- Fact extraction (Sonnet-class reliability for structured output)
+- Tone analysis
+- Web search (Anthropic's built-in `web_search_20250305` tool has no local equivalent)
+
+A unified wrapper at `api/services/llm_client.py` translates between Anthropic and OpenAI tool formats at call time. Tool definitions and prompts are backend-agnostic; the wrapper handles:
+
+- **Tool schema translation** — Anthropic `tool_use` blocks ↔ OpenAI `tool_calls`. Wrapper functions like `openai_tool_calls_to_anthropic` and the assistant-message converter normalize both sides.
+- **System message handling** — Anthropic separates `system` from `messages`; OpenAI inlines as a `role: "system"` message.
+- **Response-shape normalization** — `stop_reason` field is mapped (e.g., `tool_use` → `tool_calls`) so callers see one shape.
+- **Streaming events** — both backends' streaming chunks are mapped to a single event vocabulary.
+
+This is an **amendment** to [ADR-007](007-linux-migration.md), not a supersession. ADR-007's other decisions (Linux primary platform, systemd, agent-worker as a separate process, retaining the external venv convention) all remain.
+
+## Rationale
+
+- **Separation of concerns.** Orchestrator logic shouldn't fork by backend. With the wrapper, tools and prompts are write-once; only the wrapper knows the backend-specific shapes.
+- **Operator flexibility without code changes.** Switching backends requires only an `.env` change and a service restart. The same codebase ships to operators on either backend.
+- **Auditable choice.** The toggle's value (`local` vs `anthropic`) appears in perf traces and conversation logs, so it's obvious which backend handled a given turn when debugging.
+- **Aligns with ADR-007's hybrid posture.** ADR-007 already established that specialized calls remain on Anthropic. The toggle is the synthesis/orchestration analogue of that pattern — operator chooses the default, specialists still go where they're best.
+- **Cache strategy is backend-specific.** Anthropic prompt caching is automatic and significant for orchestration; local llama-server uses its own kv-cache. The wrapper exposes the right cache hints to each backend.
+
+## Alternatives Considered
+
+### Fork the codebase per backend
+
+Maintain a local-backend branch and an anthropic-backend branch (or two top-level orchestrators).
+
+**Rejected because:** Maintenance nightmare. Every prompt change, every tool addition, every bug fix has to be synced. The orchestrator logic is the same for both backends — only the API shape differs.
+
+### Local-only (drop Anthropic from synthesis)
+
+Make local the only synthesis backend.
+
+**Rejected because:** Excludes operators without a high-VRAM GPU. LifeOS is open-source; the default has to work for someone on a moderate workstation. It also means the maintainer can't temporarily compare local vs Anthropic behavior without code changes.
+
+### Anthropic-only (drop local from synthesis)
+
+Make Anthropic the only synthesis backend.
+
+**Rejected because:** Violates the privacy and zero-cost guarantees that ADR-007 was designed around. Operators who do have the hardware should be able to keep their chat context off-cloud.
+
+### Per-request runtime selection (model parameter on each call)
+
+Accept a backend parameter on each chat call, with no default.
+
+**Rejected because:** Pushes the choice onto the caller, which is the wrong layer. Almost every caller wants the same backend across the conversation, and per-call selection adds noise to every call site. A process-level `.env` knob is the right granularity.
+
+### Wrap each backend's SDK directly, no translation layer
+
+Use the Anthropic SDK and OpenAI SDK at call sites, without a unified wrapper.
+
+**Rejected because:** Tools, prompts, message construction, streaming would all fork by backend. Adding a new tool would require updating both code paths and keeping them in sync. The wrapper exists specifically so the orchestrator and tool catalog don't know which backend is in use.
+
+## Consequences
+
+### Positive
+
+- Operators with different hardware tiers can run the same LifeOS codebase by changing one `.env` value.
+- Tool definitions and prompts are write-once (in the wrapper's canonical shape) and translated at call time.
+- Single test surface for the orchestrator — behavioral differences narrow to the wrapper layer.
+- Debug ergonomics: the operator can switch backends mid-debug and re-run the same query.
+- Cache strategies are wrapped: callers don't need to know about Anthropic prompt caching vs local kv-cache.
+
+### Negative
+
+- Tool-format translation surface to maintain. When either API evolves (new tool-block types, new message-role conventions, new streaming events), the wrapper has to be updated. Anthropic and OpenAI both ship API changes regularly.
+- Default backend choice is consequential and worth periodic re-evaluation. Today (`claude-haiku-4-5`) the Anthropic default trades cost for latency; the right default may change as model pricing and local hardware evolve.
+- Subtle behavior differences between backends: Anthropic prompt caching makes long-context turns much cheaper than local equivalents; local model tool-calling reliability lags Claude on ambiguous calls. Operators switching backends should expect calibration drift.
+- An additional layer of indirection at every chat call. Stack traces include the wrapper layer; debugging requires understanding the translation step.
+- New backends (e.g., adding a third option) would require extending the wrapper's translation matrix — currently 2x2 (Anthropic↔canonical, OpenAI↔canonical); adding a third doubles edge cases.
+
+### Relationship to ADR-007
+
+ADR-007 said "replace Claude API orchestrator with local llama-server". ADR-009 reframes that as "make the orchestrator backend operator-configurable, defaulting to local where local is viable". The Linux migration, the systemd unit set, the local-LLM-first hardware target, the agent-worker as a separate process, the external venv convention — all of ADR-007's other decisions stand. ADR-007 gets `**Amended by:** ADR-009` in its frontmatter as the only acceptable in-place edit.
+
+## Related Documents
+
+### Design Context
+- [ADR-007: Linux Migration and Local LLM Orchestration](007-linux-migration.md) — Original decision establishing local-first orchestration; this ADR amends
+- [ADR-008: Managed Agents Cloud Routing](008-managed-agents-cloud-routing.md) — The parallel local/cloud split for the agent worker (different layer, same hybrid-model philosophy)
+
+### Specifications
+- [Architecture](../specs/technical/architecture.md) — Where the LLM client sits in the request flow
+- [Chat UI](../specs/product/chat-ui.md) — Consumer-facing chat that hits the wrapper
+- [Observability](../specs/technical/observability.md) — Perf traces include backend identifier per turn
+
+### Operational
+- [Configuration](../guides/configuration.md) — `LIFEOS_LLM_BACKEND` / `LIFEOS_ANTHROPIC_MODEL` env var reference (canonical home after #188 consolidation)
+
+### Code References
+- [`api/services/llm_client.py`](../../api/services/llm_client.py) — Unified wrapper; tool-format translation logic in `openai_tool_calls_to_anthropic` and surrounding helpers (lines ~60–200)
+- [`config/settings.py`](../../config/settings.py) — `LIFEOS_LLM_BACKEND`, `LIFEOS_ANTHROPIC_MODEL` definitions


### PR DESCRIPTION
## Summary

Backfills the architectural record for the `LIFEOS_LLM_BACKEND={local|anthropic}` toggle that controls chat synthesis, intent classification, and orchestration. ADR-007 mentioned it in passing but treated it as an implementation detail; this elevates it to a load-bearing choice with its own context, alternatives, and consequences.

Also captures the unified LLM client wrapper (`api/services/llm_client.py`) — Anthropic↔OpenAI tool schema translation, system-message handling, response-shape normalization, streaming event mapping — which is what makes the toggle viable without forking the orchestrator.

## Amendment, not supersession

ADR-009 **amends** ADR-007. ADR-007's other decisions (Linux primary platform, systemd, agent-worker as separate process, external venv convention) all remain. The only edit to ADR-007 is adding `> **Amended by:** [ADR-009](009-llm-backend-toggle.md)` to the frontmatter — the only acceptable in-place edit per the immutability rule (and explicitly called out in `docs/AGENTS.md § ADR Template`).

## Acceptance criteria

- [x] ADR-009 exists with all template sections
- [x] Relationship to ADR-007 explicit (amends, not supersedes) — both in ADR-009 body and ADR-007 frontmatter
- [x] `llm_client.py` referenced with line range for the tool-format translation logic (~60-200)
- [x] Default backend choice + current Anthropic model documented (`claude-haiku-4-5`)
- [x] No functional code changes

## Alternatives considered

- Fork the codebase per backend
- Local-only
- Anthropic-only
- Per-request runtime selection (model param on each call)
- Use both SDKs directly without a wrapper

Each with explicit `Rejected because:` paragraph.

## Test plan

- [x] Code refs verified: `api/services/llm_client.py`, `config/settings.py`
- [x] Bidirectional cross-link: ADR-009 → ADR-007 (Design Context); ADR-007 → ADR-009 (frontmatter Amended by)
- [ ] Reviewer: confirm "amendment, not supersession" is the right framing (vs. promoting the toggle into a full supersession)

## Targeting

Based on `docs/180-strategy-foundation`; targeted at `docs/overhaul`.

Closes #184.