### PR TITLE
docs(adr): ADR-010 — Apple Data Agent (Mac as nightly source, Linux as system of record)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,384 @@
+# Documentation Strategy
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+
+**This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
+
+## Purpose
+
+This strategy defines how we organize and maintain documentation in LifeOS. These are **rules, not guidelines** — following this strategy faithfully is critical to maintaining documentation quality across a collaborative human + AI agent project.
+
+Documentation in LifeOS serves two readers equally:
+- **Human contributors** who need to onboard, debug, and design changes.
+- **AI agents** (Claude Code, Cursor, Copilot, etc.) that load docs as context when working on the codebase.
+
+Both readers benefit from the same things: short, focused documents; explicit decisions; cross-links instead of duplication; and an unambiguous answer to "where does this kind of information live?"
+
+## Core Principles
+
+1. **Living documents over proposals** — Design docs evolve during implementation rather than being written once and frozen. Update when thinking changes, not when tasks complete.
+2. **Modular over monolithic** — Split documents by concern, not by phase or role. A 1,800-line spec is a symptom, not a feature.
+3. **Cross-linked over isolated** — Documents reference related docs with a short tagline explaining the relationship, not just a link.
+4. **Concise over comprehensive** — Each document has a clear scope; prefer multiple focused docs over one sprawling one.
+5. **Consistent over creative** — Follow established patterns and structures. Consistency makes documentation predictable and navigable.
+6. **AI-readable** — Be succinct, specific, and clear. Prefer shorter, well-named documents over longer ones. Don't overexplain, but make requirements and decisions explicit.
+7. **Single source of truth** — Default to keeping each piece of information in exactly one authoritative location; other documents link to it rather than repeating it. When in doubt about where something belongs, consult the [Content Classification table](#content-classification). When you find duplication, prefer consolidating to the authoritative location and replacing duplicates with cross-references.
+
+## Document Taxonomy
+
+```
+docs/
+├── AGENTS.md          # THIS FILE (documentation strategy)
+├── CLAUDE.md          # @AGENTS.md wrapper
+├── vision/            # WHY — project vision, philosophy
+├── specs/
+│   ├── product/       # WHAT — features, API contracts, data models (consumer perspective)
+│   ├── technical/     # HOW (design) — architecture, schema, security, infrastructure
+│   └── standards/     # HOW (work) — coding conventions, testing standards, naming rules
+├── adr/               # WHY (decisions) — immutable architecture decision records
+├── guides/            # HOW (do) — step-by-step operational instructions
+├── plans/             # WHEN — active execution work, ephemeral (gitignored)
+└── archive/           # HISTORY — superseded documents (gitignored)
+```
+
+### Vision Documents
+
+**Location:** `docs/vision/`
+**Purpose:** Vision, philosophy, and strategic direction — the WHY behind LifeOS
+**Updated:** When strategy changes (rarely)
+
+Vision docs provide foundational context that frames every design decision. For LifeOS, that's primarily the privacy-first, local-first, single-user posture — see [philosophy.md](vision/philosophy.md).
+
+### Specifications
+
+**Location:** `docs/specs/`
+**Purpose:** Design documents describing WHAT the system is/should be (target state)
+**Updated:** When the design evolves
+
+**Key principle:** Specs are the **vision** — the authoritative design for the system. Not implementation plans, not progress tracking, not task lists. They describe the intended architecture and behavior.
+
+"Living" means the spec updates when *the design* changes, not when *tasks* complete.
+
+- `product/` — What the system does from a consumer perspective. Feature behavior, API contracts, data model semantics. Answers: "What does this entity mean? What can you do with this endpoint?"
+- `technical/` — How the system is built from an engineering perspective. Architecture, schema, security implementation, query optimization. Answers: "How is this implemented? What constraints did we hit?"
+- `standards/` — Rules and conventions for how we work. Coding standards, naming conventions, testing patterns. Answers: "What conventions must we follow?"
+
+### Architecture Decision Records (ADRs)
+
+**Location:** `docs/adr/`
+**Purpose:** Immutable records of significant architectural decisions with context and rationale
+**Updated:** Never. ADRs are append-only — create a new ADR to supersede an old one. The only acceptable in-place edit is adding an `Amended by: ADR-NNN` or `Superseded By: ADR-NNN` pointer to the frontmatter.
+
+**Naming:** `NNN-short-title.md` (e.g., `008-managed-agents-cloud-routing.md`). Sequential numbering. Never reuse numbers.
+
+ADRs live at the top level (not under `specs/`) because they span product and technical concerns. A decision about data model semantics is as load-bearing as one about database engines.
+
+### Operational Guides
+
+**Location:** `docs/guides/`
+**Purpose:** Step-by-step instructions for specific operator and contributor tasks
+**Updated:** When procedures change
+
+Guides are instructional — they tell you how to do something, not why it's designed that way. If a guide starts explaining design rationale, that content belongs in a spec or ADR.
+
+### Plans
+
+**Location:** `docs/plans/` (gitignored — personal/active planning notes)
+**Purpose:** Active execution work — phases, tasks, roadmaps, backlogs
+
+Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. For trackable work, prefer GitHub issues; for personal planning, use the local `docs/plans/` directory.
+
+### Archive
+
+**Location:** `docs/archive/` (gitignored)
+**Purpose:** Superseded documents, audit notes, and historical investigation working notes retained for local context.
+
+Archive content is **not** part of the public repo. When a durable insight from an archived doc is still load-bearing, promote it: link to the relevant live spec, or extract the durable conclusion into an ADR.
+
+## Content Classification
+
+| Content Type | Belongs In | Anti-Pattern |
+|---|---|---|
+| Project vision, philosophy, strategy | `vision/` | Not in specs (too stable, too abstract) |
+| User-facing feature behavior, API contracts, data model semantics | `specs/product/` | No implementation details, no task lists |
+| Architecture, system design, schema, query design, security implementation | `specs/technical/` | No roadmaps, no "Next Steps" |
+| Coding conventions, naming rules, testing patterns | `specs/standards/` | Not in guides (standards prescribe, guides instruct) |
+| Architectural decisions with rationale and alternatives | `adr/` | Never modify after acceptance — create a new ADR to supersede |
+| Setup procedures, troubleshooting, operator how-to | `guides/` | Not design rationale |
+| Phases, tasks, roadmaps, checklists | `plans/` (or GitHub issues) | Don't put in specs |
+| Audit notes, investigation working files, superseded docs | `archive/` | Don't link from live specs unless promoting a specific insight |
+
+**Rule of thumb:** "Why do we build this?" → vision. "What should it be?" → product spec. "How is it built?" → technical spec. "Why did we decide?" → ADR. "How do I do X?" → guide. "When/how do we get there?" → plan.
+
+**LifeOS-specific classification:**
+- Data model semantics (what entities mean, relationships between them) → `specs/product/data-model.md`
+- Data model implementation (SQLite schema, ChromaDB collections, indexes) → `specs/technical/`
+- API contracts (consumer perspective, request/response shapes) → `specs/product/api-reference.md`
+- API internals (route-handler structure, middleware, error handling) → `specs/technical/`
+- Privacy/security design decisions → `specs/technical/security-privacy.md`, with corresponding ADRs for the underlying decisions
+
+## Frontmatter Standards
+
+Every document must have frontmatter:
+
+```markdown
+**Status:** Draft | Partial | Complete
+**Last Updated:** YYYY-MM-DD
+```
+
+**Additional fields by document type:**
+
+| Type | Additional Fields |
+|---|---|
+| ADR | `**Decision:** Accepted \| Superseded \| Deprecated` and (if applicable) `**Superseded By:** ADR-NNN` or `**Amended by:** ADR-NNN` |
+| Product Spec | `**Owner:** name-or-area` |
+| Technical Spec | `**Owner:** name-or-area` |
+| Guide | `**Audience:** Operator \| Contributor \| New users` |
+| Plan | `**Target Date:** YYYY-MM-DD` (or `Ongoing`); `**Completed:** YYYY-MM-DD` when archived |
+
+`Status` values:
+- **Draft** — Initial draft, not yet reviewed; may have gaps or open questions.
+- **Partial** — Some sections complete, others marked TODO; safe to read for the parts that exist.
+- **Complete** — Reviewed, accurate as of `Last Updated`, no known gaps.
+
+For ADRs, `Status` reflects document completeness; `Decision` reflects whether the decision is still in force.
+
+## ADR Template
+
+ADRs use the following structure. The retrofit issue (#182) brought existing ADRs into this shape; all new ADRs must follow it.
+
+```markdown
+# ADR-NNN: Short Title
+
+**Status:** Complete
+**Last Updated:** YYYY-MM-DD
+**Decision:** Accepted
+**Superseded By:** ADR-NNN  (only if applicable)
+**Amended by:** ADR-NNN     (only if applicable)
+
+## Context
+
+The situation, constraints, and forces at the time of the decision. Why this needed to be decided now.
+
+## Decision
+
+One unambiguous statement of what was chosen. No hedging.
+
+## Rationale
+
+Why this choice over the alternatives. Tie back to the constraints in Context.
+
+## Alternatives Considered
+
+Each alternative as its own subsection with a one-paragraph description and an explicit "Rejected because..." line. Recover alternatives from PR descriptions, commit messages, or memory. Where you genuinely don't remember, write "to be filled in by the original decider" rather than fabricating.
+
+### Alternative A
+
+Description.
+
+**Rejected because:** specific reason.
+
+## Consequences
+
+### Positive
+
+- Specific benefits this decision enables.
+
+### Negative
+
+- Specific costs, ongoing maintenance burden, or constraints this decision imposes.
+
+## Related Documents
+
+(Use the 4-bucket Related Documents structure described below.)
+```
+
+## Length Guidelines
+
+Not rigid rules, but signals for document health. When a doc passes the "max" column it should be split by concern.
+
+| Document Type | Target Lines | Max Lines |
+|---|---|---|
+| ADR | 200–500 | 800 |
+| Product Spec | 300–700 | 800 |
+| Technical Spec | 400–800 | 1,000 |
+| Standards | 200–500 | 700 |
+| Vision | 300–600 | 800 |
+| Guide | 200–500 | 800 |
+| Plan | Variable | — |
+
+**Split when:**
+- Document exceeds the Max in its column.
+- It covers multiple distinct concerns (e.g., one CRM spec covering people, interactions, graph, analytics).
+- Different readers need different sections.
+- Table of contents has more than ~8 top-level sections.
+
+When splitting, keep a thin **index document** at the original path with pointers to each split and a short overview. Update all inbound links to point at the right split.
+
+## Cross-Linking Standards
+
+Every document must include a "Related Documents" section at the bottom.
+
+**Requirements:**
+1. **Bidirectional** — if A links to B, B must link to A. When you add a link in one direction, add the reciprocal link in the same PR.
+2. **Contextual** — every link has a "— short tagline" explaining the relationship.
+3. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
+4. **Use the 4-bucket structure** below for consistency.
+
+**Standard Related Documents template:**
+
+```markdown
+## Related Documents
+
+### Design Context
+- [ADR-NNN: Decision Name](../adr/NNN-title.md) — Why this approach was chosen
+- [Vision: Philosophy](../vision/philosophy.md) — The principle behind this
+
+### Specifications
+- [Product Spec](../specs/product/feature.md) — Consumer-facing requirements
+- [Technical Spec](../specs/technical/component.md) — Implementation design
+
+### Operational
+- [Setup Guide](../guides/feature-setup.md) — How to configure this
+- [Configuration](../guides/configuration.md) — Env var reference
+
+### Code References
+- [Implementation](../../api/services/foo.py:45-120) — Production code
+- [Tests](../../tests/test_foo.py) — Coverage
+```
+
+Use only the buckets that apply — omit empty buckets rather than including them as `(none)`.
+
+## Lifecycle Rules
+
+**Specs are living:**
+- Update when the design changes, not when tasks complete.
+- If a spec describes a target that's not yet built, the `Status: Partial` value is appropriate.
+- Specs are not changelogs. Don't add "Added X in PR #N" notes; that's what `git log` and `git blame` are for.
+
+**Plans are ephemeral:**
+- A plan ends as either "completed" (move to `archive/` with `Completed: YYYY-MM-DD`) or "superseded" (note the successor and move to `archive/`).
+- Do not leave stale plans in `docs/plans/`.
+
+**ADRs are immutable:**
+- Never modify the Context / Decision / Rationale / Alternatives sections of an accepted ADR.
+- To change a decision, create a new ADR. The old ADR gets `Superseded By: ADR-NNN` added to its frontmatter — that's the only acceptable in-place edit.
+- For a smaller change (clarification, scoping refinement that doesn't reverse the decision), the new ADR is an *amendment* and the old ADR gets `Amended by: ADR-NNN`.
+
+**Guides decay:**
+- Test commands you document before shipping. Stale guides are worse than missing guides.
+
+## Writing for AI Readability
+
+Documentation is frequently consumed by AI agents during development. Optimize for:
+
+**Clarity:**
+- State requirements explicitly. Avoid "should consider" — say "do" or "don't" or "defer because X".
+- Use precise technical terminology (route handler, span, collection) rather than vague nouns.
+- Avoid ambiguous pronouns; prefer specific nouns even at the cost of repetition.
+
+**Structure:**
+- Well-named sections that match their content. A section labeled "Notes" is a smell.
+- Frontmatter with status and metadata at the top.
+- Tables when they sharpen a comparison; prose otherwise.
+
+**Brevity:**
+- Shorter, focused documents over long comprehensive ones.
+- Link to details rather than repeating them.
+- Keep documents focused on one concern so agents don't waste context loading irrelevant content.
+
+**Anti-patterns:**
+- Long narrative explanations when a bulleted list suffices.
+- Repeating context already in linked documents.
+- Vague statements like "we should consider" (instead: decided yes/no, or defer with reason).
+- Burying key decisions in prose.
+
+## LifeOS-Specific Rules
+
+### Privacy-First Documentation
+
+LifeOS handles deeply personal data — emails, messages, photos, finances. Documentation must not become a leak vector.
+
+- **Use obviously synthetic data in all examples and test fixtures.** Names like "Alex Chen", domains like `example.com`, phone numbers like `555-0123`, dollar amounts like `$1,234.56`. No real names, emails, phone numbers, or financial values, even in commit-message screenshots.
+- **Security-sensitive implementation details belong in code, not docs.** Reference the code (with line numbers) rather than restating encryption keys, auth tokens, or exact connection strings.
+- **Technical specs involving data storage or access** should include a "Privacy Considerations" subsection or link to one in `specs/technical/security-privacy.md`.
+- **Don't paste real terminal output** containing real personal data into docs. Sanitize first.
+
+### Open-Source Posture
+
+LifeOS is open-source and single-user / self-hosted. That implies two doc rules beyond the privacy ones:
+
+- **No hardcoded personal values** in examples, configs, or fixtures (paths under `/home/<personal-username>`, machine names, IP addresses). Use placeholders (`<your-username>`, `<your-machine>`).
+- **No "broken by default for a fresh downloader" assumptions.** Setup guides should walk through what a fresh clone actually needs, not what's already true on the maintainer's machine.
+
+### Sub-Directory Instruction Files
+
+Every doc subdirectory has an `AGENTS.md` + `CLAUDE.md` pair so any reader (human or agent) can orient inside the subdirectory without re-reading this strategy file.
+
+Existing pairs:
+- `docs/adr/AGENTS.md` + `CLAUDE.md`
+- `docs/guides/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/standards/AGENTS.md` + `CLAUDE.md`
+- `docs/vision/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/product/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/specs/technical/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/plans/AGENTS.md` + `CLAUDE.md` (added in #181 — note: gitignored)
+
+**AGENTS.md** is the primary instruction file (universal, works with all AI tools). **CLAUDE.md** is a one-line wrapper: `@AGENTS.md`. The `@` import is relative to the file containing it; since CLAUDE.md and AGENTS.md are always co-located, the import is always literally `@AGENTS.md`.
+
+**AGENTS.md structure (per subdirectory):**
+
+```markdown
+[One-line description of directory purpose]
+
+## Contents
+- `file.md` — one-line description
+...
+
+## Key Principles
+- Critical rules that apply to this directory's content
+
+## Related Documents
+- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
+- [Other relevant doc] — Why it matters here
+```
+
+Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended commentary — keep them tight.
+
+## Maintenance Rules
+
+**When code changes:**
+1. Update the relevant design doc in the same PR if the design changed (not the implementation — only when the *intent* changed).
+2. Update `Last Updated` in the frontmatter.
+3. Check if cross-references need updates.
+4. Verify bidirectional links still resolve.
+
+**When documents get long (over the Max in [Length Guidelines](#length-guidelines)):**
+1. Identify distinct concerns within the document.
+2. Create focused docs for each concern.
+3. Keep the original path as a thin index pointing at the splits.
+4. Update inbound references to the right split.
+
+**Common violations to avoid:**
+- Adding "Next Steps" or task lists to specs or ADRs.
+- Mixing planning (roadmaps, tasks) into design documents.
+- Creating documents without "Related Documents" sections.
+- Failing to update cross-references when moving or splitting documents.
+- Modifying an accepted ADR in place (instead of superseding).
+- Using real personal data in examples.
+
+---
+
+## Related Documents
+
+### Project Context
+- [Root AGENTS.md](../AGENTS.md) — Project-level agent reference, development principles, key files
+- [Root CLAUDE.md](../CLAUDE.md) — Claude Code-specific configuration
+
+### Specifications
+- [vision/philosophy.md](vision/philosophy.md) — The privacy-first, local-first principles that frame doc decisions
+- [specs/standards/](specs/standards/) — Coding and testing conventions referenced by docs
+
+### Operational
+- [guides/](guides/) — Operator-facing setup and troubleshooting

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/adr/007-linux-migration.md
+++ b/docs/adr/007-linux-migration.md
@@ -125,6 +125,7 @@ Running LifeOS on a cloud VM with an attached GPU (e.g., AWS p4d, Lambda Labs) w
 **Design Context:**
 - [ADR-005: External Venv](005-external-venv-macos-tcc.md) — Superseded; TCC rationale no longer applies, but external venv practice retained
 - [ADR-001: Python/FastAPI](001-python-fastapi.md) — The backend stack, unchanged by this migration
+- [ADR-010: Apple Data Agent](010-apple-data-agent.md) — Formalizes the Mac's post-migration role as a nightly Apple-data source
 
 **Specifications:**
 - [Architecture](../specs/technical/architecture.md) — System architecture (updated for Linux deployment)

--- a/docs/adr/010-apple-data-agent.md
+++ b/docs/adr/010-apple-data-agent.md
@@ -1,0 +1,128 @@
+# ADR-010: Apple Data Agent — Mac as Nightly Data Source, Linux as System of Record
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+**Decision:** Accepted
+
+## Context
+
+[ADR-007](007-linux-migration.md) moved LifeOS's primary runtime from a Mac Mini to a Linux workstation. Most data sources (Gmail, Google Calendar, Slack, Obsidian vault, Monarch Money, etc.) are platform-portable and run cleanly on Linux. **Three sources are not:**
+
+- **iMessage** — `~/Library/Messages/chat.db`, SQLite read directly off the Mac.
+- **Phone / FaceTime call history** — `~/Library/Application Support/CallHistoryDB/CallHistory.storedata`.
+- **Apple Contacts + Photos face data** — via `pyobjc` bindings to native AddressBook and Photos frameworks.
+
+These exist only on macOS. They require:
+
+1. **macOS Transparency, Consent, and Control (TCC) — Full Disk Access (FDA).** Reading the Messages SQLite, call history, and contacts databases is gated by FDA. Without it, reads silently return empty results or fail.
+2. **A binary that holds the FDA grant.** TCC grants are per-binary, not per-user — they survive across invocations of the granted binary but don't extend to children spawned through `cron` or `launchd` from another binary.
+3. **A persistent host.** Once granted, the FDA-holding binary needs to be reachable from `cron` / `launchd` so the export can run unattended.
+
+LifeOS still wants this data — iMessage history is central to "who did I talk to about X?" queries. The choice is **how** to bridge a macOS-only data source to a Linux primary runtime.
+
+## Decision
+
+A dedicated Mac runs `/Applications/LifeOS.app` — a tiny bash-script-based `.app` bundle that holds Full Disk Access. The Mac runs a nightly cron job that:
+
+1. Invokes `LifeOS exec` with the export script, so the work runs inside the FDA-granted binary.
+2. Exports Apple-only data (iMessage SQLite copy, call history, Apple Contacts dump, Photos face data) to a local staging directory.
+3. `rsync`s the staging directory over SSH (Tailscale-routed) to the Linux server.
+
+The Linux server owns everything else:
+
+- All long-lived SQLite tables (interactions, entities, person facts).
+- ChromaDB collections (embeddings, vector search).
+- The seven-phase nightly sync pipeline (Linux runs phase 5 *imports* the Mac's export, then proceeds to embed, resolve entities, etc.).
+- The agent worker, chat orchestrator, MCP server.
+
+The Mac is **stateless w.r.t. LifeOS** — losing the Mac's local cache loses nothing that matters. The Linux server is the only system of record.
+
+### LifeOS.app
+
+`/Applications/LifeOS.app/Contents/MacOS/LifeOS` is a bash script (~30 lines). It exists so the FDA grant is attached to a known, persistent path. Operators grant FDA to `/Applications/LifeOS.app` once in System Settings → Privacy & Security → Full Disk Access. After that, `LifeOS exec <script>` runs `<script>` as a child of the FDA-holding binary, inheriting the grant. The cron entry calls `LifeOS exec scripts/apple_data_agent.sh`.
+
+### Transport: rsync over SSH
+
+The export pushes via `rsync -e ssh` to the Linux server. Tailscale provides the network — both machines are on the same tailnet. SSH key auth (no passwords). rsync's `--delete` is **not** used (the Linux side may have additional data from other sources). Each export overwrites the previous staging snapshot.
+
+## Rationale
+
+- **TCC can't be bypassed.** macOS FDA exists to gate access to user data. Disabling or circumventing it would be a security regression. The `.app` bundle is the supported pattern for holding a persistent FDA grant.
+- **FDA grant persistence requires a wrapper binary.** `cron` and `launchd` jobs without FDA can't read `~/Library/Messages/`. Routing through `LifeOS exec` is the simplest way to give cron-triggered scripts FDA inheritance.
+- **rsync is the right transport.** Idempotent, well-understood, survives Mac sleep cycles (resumes on next run), no schema-on-the-wire to drift. The alternative protocols (HTTP, sync frameworks) add code without solving a problem rsync hasn't.
+- **Separating Mac (data source) from Linux (system of record) means the Mac can fail without taking down LifeOS.** Search, chat, agent worker all keep working with stale Apple data. The Mac's role is narrow — export and rsync — and its failure is a freshness problem, not an availability problem.
+- **FDA scope is minimized.** The `.app` is a bash script, not the full Python project. Only that binary holds FDA; the rest of the LifeOS codebase doesn't need it.
+
+## Alternatives Considered
+
+### Run LifeOS entirely on the Mac
+
+Skip the Linux migration and keep everything on a Mac (likely a Mac Studio with high RAM).
+
+**Rejected because:** GPU and RAM constraints. A 96GB-VRAM AMD GPU enables local LLM orchestration ([ADR-007](007-linux-migration.md)) — Apple Silicon doesn't offer the same VRAM headroom for the same budget, and the ROCm ecosystem doesn't run on macOS. Also creates an SPOF: every LifeOS component depends on one Mac.
+
+### Third-party Apple data extractor (e.g., iMazing CLI)
+
+Use a commercial Mac-data-extraction tool (iMazing, etc.) to handle the export, then rsync its output to Linux.
+
+**Rejected because:** Privacy + control. iMazing reads the same files but adds a third-party dependency for personal data. Lifecycle risk — if the tool changes formats or drops Mac-side support, LifeOS breaks. The 660-line `apple_data_export.py` is straightforward enough to maintain in-tree.
+
+### Pull from iCloud APIs
+
+Pull iMessage history, contacts, and call history from iCloud rather than off the Mac.
+
+**Rejected because:** Several problems. Apple doesn't expose iMessage history via a developer API. Contacts are available via CloudKit but require Apple Developer membership and per-app data-handling review. The data on iCloud is also incomplete (only the most recent slice of messages depending on iCloud Messages settings). And pulling via cloud APIs gives up the local-first principle that motivates LifeOS in the first place.
+
+### Push from Mac via network protocol (HTTP, sync framework)
+
+Build a small HTTP service on the Mac that pushes new rows to the Linux server.
+
+**Rejected because:** Adds two failure modes (the Mac-side server, the wire protocol) that rsync doesn't have. Rsync handles partial transfers, interrupted networks, and Mac sleep cycles automatically. A custom protocol would have to re-solve all of that. The wire schema would also become a maintenance surface — every new column in the iMessage export would need protocol-level handling. rsync just copies files.
+
+### Mount the Mac's filesystem on Linux (SSHFS, NFS, etc.)
+
+Skip the export step entirely; have Linux read the Mac's `~/Library/` over a network filesystem.
+
+**Rejected because:** TCC doesn't grant FDA across network mounts in a way that makes the Messages SQLite readable. Even if it did, holding open a SQLite database across a network mount is a recipe for corruption. The export-to-snapshot pattern decouples the read (on Mac, with FDA) from the consumption (on Linux, against a stable file).
+
+## Consequences
+
+### Positive
+
+- Clean machine separation: Mac fails → freshness degrades, but search/agent/chat all keep working.
+- Minimal moving parts on the Mac (one cron entry, one `.app`, one rsync push).
+- FDA scope is limited to one binary; the rest of LifeOS doesn't need it.
+- Stateless Mac means rebuilding the Mac side (new hardware, OS reinstall) needs only to grant FDA + drop in `apple_data_agent.sh`.
+- rsync is well-understood and easy to debug (`--dry-run`, `--itemize-changes`).
+
+### Negative
+
+- Two-machine setup complexity. Operators who don't have a Mac handy can't ingest iMessage / contacts / call history.
+- macOS TCC reset (system update, app re-signing, `tccutil reset SystemPolicyAllFiles`) silently breaks exports until FDA is re-granted. There's no programmatic way to detect "FDA was revoked" from inside the exporting script — only `chat.db` returning empty data, which looks like "no new messages."
+- rsync has no schema validation. A corrupt or partial export file reaches the Linux importer, which has to defend against it.
+- Operator owns two machines now: keeping the Mac powered on, on the tailnet, and with the LifeOS.app FDA grant intact is part of the operational burden.
+- Network coupling: if Tailscale is down or the Mac is offline at nightly-sync time, the Apple data sources are stale. The Linux sync still runs but skips imports.
+
+### Failure modes
+
+- **Mac offline at nightly sync time** → import step skips; iMessage/contacts/calls go stale; search/chat keep working with previous data. Staleness is detectable via export file mtime.
+- **FDA grant revoked** → export script reads empty databases; produces zero-row exports. Looks like "no new data" rather than an error. Mitigation: the importer logs row deltas; a sudden drop to zero is a flag.
+- **rsync partial / interrupted** → next run resumes (rsync's default behavior). Linux importer is idempotent and re-processable from any partial state.
+- **Mac sleep / power event** → cron jobs missed; data is at most one day stale by the next run. Acceptable for the freshness expectations of personal data.
+
+## Related Documents
+
+### Design Context
+- [ADR-007: Linux Migration](007-linux-migration.md) — Established the multi-machine pattern this ADR formalizes; the Mac's role change to "Apple Data Agent" was part of that decision but not given its own record
+
+### Specifications
+- [Data & Sync](../specs/technical/data-and-sync.md) — Seven-phase nightly sync pipeline; phase 5 imports the Mac's export
+
+### Operational
+- [Installation Guide](../guides/installation.md) — Apple Data Agent setup steps (FDA grant, cron entry, Tailscale)
+- [launchd Setup](../guides/launchd-setup.md) — macOS launchd configuration that's now Apple-Data-Agent-only
+
+### Code References
+- [`scripts/apple_data_export.py`](../../scripts/apple_data_export.py) — Reads iMessage SQLite, call history, contacts, photos face data; writes staging snapshot (660 lines)
+- [`scripts/apple_data_import.py`](../../scripts/apple_data_import.py) — Linux-side importer that consumes the rsynced snapshot and writes to LifeOS SQLite (665 lines)
+- [`scripts/apple_data_agent.sh`](../../scripts/apple_data_agent.sh) — Mac cron wrapper: invokes `LifeOS exec` so the export runs with FDA, then rsyncs to the Linux server (184 lines)

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -180,7 +180,7 @@ All checks should pass. If any fail, see [Troubleshooting](../reference/TROUBLES
 1. **Configure integrations**: See [Configuration](CONFIGURATION.md)
 2. **Set up Google OAuth**: See [Google OAuth Guide](../guides/GOOGLE-OAUTH.md)
 3. **Set up systemd services** (Linux): `sudo ./scripts/setup-systemd.sh`
-4. **Set up FDA wrapper** (macOS, for Apple Data Agent): `./scripts/create-lifeos-app.sh`
+4. **Set up FDA wrapper** (macOS, for Apple Data Agent): `./scripts/create-lifeos-app.sh` — see [ADR-010: Apple Data Agent](../adr/010-apple-data-agent.md) for the design context (why a `.app` bundle, why rsync, what fails when)
 5. **Configure launchd services** (macOS): See [Launchd Setup](../guides/LAUNCHD-SETUP.md)
 6. **Run your first sync**: See [First Run Guide](FIRST-RUN.md)
 


### PR DESCRIPTION
## Summary

Formalizes the architectural pattern from ADR-007: the Mac runs nightly Apple-data exports (iMessage, contacts, call history, Photos face data) and rsyncs to the Linux server, which owns all long-lived state.

ADR-007 introduced this as a sub-point. This ADR captures the full design rationale, the FDA wrapper pattern, the transport choice, and explicit failure modes — so future readers don't have to reconstruct the why from `scripts/apple_data_agent.sh`.

## Acceptance criteria

- [x] ADR-010 exists with all template sections (Status / Decision / Context / Rationale / Alternatives / Positive+Negative / Related Documents)
- [x] All three scripts referenced with one-line role description (export, import, agent.sh)
- [x] Failure modes explicitly documented (Mac offline, FDA revoked, rsync partial, sleep/power events)
- [x] Cross-linked with ADR-007 and the operator-facing installation guide
- [x] No functional code changes

## Alternatives considered

- Run LifeOS entirely on the Mac
- Third-party Apple data extractor (iMazing CLI, etc.)
- Pull from iCloud APIs
- Push from Mac via custom HTTP / sync protocol
- Mount the Mac's filesystem on Linux (SSHFS / NFS)

Each with explicit `Rejected because:` paragraph.

## Code references (all verified to exist)

- `scripts/apple_data_export.py` (660 lines)
- `scripts/apple_data_import.py` (665 lines)
- `scripts/apple_data_agent.sh` (184 lines)

## Length

128 lines — within ADR target.

## Test plan

- [x] All script paths verified to exist
- [x] ADR-007 Related Documents updated with bidirectional link
- [x] `installation.md` FDA-wrapper step now references ADR-010 for design context
- [ ] Reviewer: confirm the failure-modes section captures the actual operational pain points (the user has lived with this longer than I have)
- [ ] Reviewer: confirm the LifeOS.app design rationale (FDA grant attached to a `.app` so cron-triggered scripts inherit it) is accurately framed

## Soft dependency for #192

Issue #192 (archive audit + macOS docs) has a soft dependency on this ADR — its macOS-docs scoping references ADR-010. Land this PR before #192 if possible so #192 can link cleanly.

## Targeting

Based on `docs/180-strategy-foundation`; targeted at `docs/overhaul`.

Closes #185.