### PR TITLE
docs(adr): ADR-011 — read-only direct-access ingest for external agent transcripts

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,384 @@
+# Documentation Strategy
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+
+**This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
+
+## Purpose
+
+This strategy defines how we organize and maintain documentation in LifeOS. These are **rules, not guidelines** — following this strategy faithfully is critical to maintaining documentation quality across a collaborative human + AI agent project.
+
+Documentation in LifeOS serves two readers equally:
+- **Human contributors** who need to onboard, debug, and design changes.
+- **AI agents** (Claude Code, Cursor, Copilot, etc.) that load docs as context when working on the codebase.
+
+Both readers benefit from the same things: short, focused documents; explicit decisions; cross-links instead of duplication; and an unambiguous answer to "where does this kind of information live?"
+
+## Core Principles
+
+1. **Living documents over proposals** — Design docs evolve during implementation rather than being written once and frozen. Update when thinking changes, not when tasks complete.
+2. **Modular over monolithic** — Split documents by concern, not by phase or role. A 1,800-line spec is a symptom, not a feature.
+3. **Cross-linked over isolated** — Documents reference related docs with a short tagline explaining the relationship, not just a link.
+4. **Concise over comprehensive** — Each document has a clear scope; prefer multiple focused docs over one sprawling one.
+5. **Consistent over creative** — Follow established patterns and structures. Consistency makes documentation predictable and navigable.
+6. **AI-readable** — Be succinct, specific, and clear. Prefer shorter, well-named documents over longer ones. Don't overexplain, but make requirements and decisions explicit.
+7. **Single source of truth** — Default to keeping each piece of information in exactly one authoritative location; other documents link to it rather than repeating it. When in doubt about where something belongs, consult the [Content Classification table](#content-classification). When you find duplication, prefer consolidating to the authoritative location and replacing duplicates with cross-references.
+
+## Document Taxonomy
+
+```
+docs/
+├── AGENTS.md          # THIS FILE (documentation strategy)
+├── CLAUDE.md          # @AGENTS.md wrapper
+├── vision/            # WHY — project vision, philosophy
+├── specs/
+│   ├── product/       # WHAT — features, API contracts, data models (consumer perspective)
+│   ├── technical/     # HOW (design) — architecture, schema, security, infrastructure
+│   └── standards/     # HOW (work) — coding conventions, testing standards, naming rules
+├── adr/               # WHY (decisions) — immutable architecture decision records
+├── guides/            # HOW (do) — step-by-step operational instructions
+├── plans/             # WHEN — active execution work, ephemeral (gitignored)
+└── archive/           # HISTORY — superseded documents (gitignored)
+```
+
+### Vision Documents
+
+**Location:** `docs/vision/`
+**Purpose:** Vision, philosophy, and strategic direction — the WHY behind LifeOS
+**Updated:** When strategy changes (rarely)
+
+Vision docs provide foundational context that frames every design decision. For LifeOS, that's primarily the privacy-first, local-first, single-user posture — see [philosophy.md](vision/philosophy.md).
+
+### Specifications
+
+**Location:** `docs/specs/`
+**Purpose:** Design documents describing WHAT the system is/should be (target state)
+**Updated:** When the design evolves
+
+**Key principle:** Specs are the **vision** — the authoritative design for the system. Not implementation plans, not progress tracking, not task lists. They describe the intended architecture and behavior.
+
+"Living" means the spec updates when *the design* changes, not when *tasks* complete.
+
+- `product/` — What the system does from a consumer perspective. Feature behavior, API contracts, data model semantics. Answers: "What does this entity mean? What can you do with this endpoint?"
+- `technical/` — How the system is built from an engineering perspective. Architecture, schema, security implementation, query optimization. Answers: "How is this implemented? What constraints did we hit?"
+- `standards/` — Rules and conventions for how we work. Coding standards, naming conventions, testing patterns. Answers: "What conventions must we follow?"
+
+### Architecture Decision Records (ADRs)
+
+**Location:** `docs/adr/`
+**Purpose:** Immutable records of significant architectural decisions with context and rationale
+**Updated:** Never. ADRs are append-only — create a new ADR to supersede an old one. The only acceptable in-place edit is adding an `Amended by: ADR-NNN` or `Superseded By: ADR-NNN` pointer to the frontmatter.
+
+**Naming:** `NNN-short-title.md` (e.g., `008-managed-agents-cloud-routing.md`). Sequential numbering. Never reuse numbers.
+
+ADRs live at the top level (not under `specs/`) because they span product and technical concerns. A decision about data model semantics is as load-bearing as one about database engines.
+
+### Operational Guides
+
+**Location:** `docs/guides/`
+**Purpose:** Step-by-step instructions for specific operator and contributor tasks
+**Updated:** When procedures change
+
+Guides are instructional — they tell you how to do something, not why it's designed that way. If a guide starts explaining design rationale, that content belongs in a spec or ADR.
+
+### Plans
+
+**Location:** `docs/plans/` (gitignored — personal/active planning notes)
+**Purpose:** Active execution work — phases, tasks, roadmaps, backlogs
+
+Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. For trackable work, prefer GitHub issues; for personal planning, use the local `docs/plans/` directory.
+
+### Archive
+
+**Location:** `docs/archive/` (gitignored)
+**Purpose:** Superseded documents, audit notes, and historical investigation working notes retained for local context.
+
+Archive content is **not** part of the public repo. When a durable insight from an archived doc is still load-bearing, promote it: link to the relevant live spec, or extract the durable conclusion into an ADR.
+
+## Content Classification
+
+| Content Type | Belongs In | Anti-Pattern |
+|---|---|---|
+| Project vision, philosophy, strategy | `vision/` | Not in specs (too stable, too abstract) |
+| User-facing feature behavior, API contracts, data model semantics | `specs/product/` | No implementation details, no task lists |
+| Architecture, system design, schema, query design, security implementation | `specs/technical/` | No roadmaps, no "Next Steps" |
+| Coding conventions, naming rules, testing patterns | `specs/standards/` | Not in guides (standards prescribe, guides instruct) |
+| Architectural decisions with rationale and alternatives | `adr/` | Never modify after acceptance — create a new ADR to supersede |
+| Setup procedures, troubleshooting, operator how-to | `guides/` | Not design rationale |
+| Phases, tasks, roadmaps, checklists | `plans/` (or GitHub issues) | Don't put in specs |
+| Audit notes, investigation working files, superseded docs | `archive/` | Don't link from live specs unless promoting a specific insight |
+
+**Rule of thumb:** "Why do we build this?" → vision. "What should it be?" → product spec. "How is it built?" → technical spec. "Why did we decide?" → ADR. "How do I do X?" → guide. "When/how do we get there?" → plan.
+
+**LifeOS-specific classification:**
+- Data model semantics (what entities mean, relationships between them) → `specs/product/data-model.md`
+- Data model implementation (SQLite schema, ChromaDB collections, indexes) → `specs/technical/`
+- API contracts (consumer perspective, request/response shapes) → `specs/product/api-reference.md`
+- API internals (route-handler structure, middleware, error handling) → `specs/technical/`
+- Privacy/security design decisions → `specs/technical/security-privacy.md`, with corresponding ADRs for the underlying decisions
+
+## Frontmatter Standards
+
+Every document must have frontmatter:
+
+```markdown
+**Status:** Draft | Partial | Complete
+**Last Updated:** YYYY-MM-DD
+```
+
+**Additional fields by document type:**
+
+| Type | Additional Fields |
+|---|---|
+| ADR | `**Decision:** Accepted \| Superseded \| Deprecated` and (if applicable) `**Superseded By:** ADR-NNN` or `**Amended by:** ADR-NNN` |
+| Product Spec | `**Owner:** name-or-area` |
+| Technical Spec | `**Owner:** name-or-area` |
+| Guide | `**Audience:** Operator \| Contributor \| New users` |
+| Plan | `**Target Date:** YYYY-MM-DD` (or `Ongoing`); `**Completed:** YYYY-MM-DD` when archived |
+
+`Status` values:
+- **Draft** — Initial draft, not yet reviewed; may have gaps or open questions.
+- **Partial** — Some sections complete, others marked TODO; safe to read for the parts that exist.
+- **Complete** — Reviewed, accurate as of `Last Updated`, no known gaps.
+
+For ADRs, `Status` reflects document completeness; `Decision` reflects whether the decision is still in force.
+
+## ADR Template
+
+ADRs use the following structure. The retrofit issue (#182) brought existing ADRs into this shape; all new ADRs must follow it.
+
+```markdown
+# ADR-NNN: Short Title
+
+**Status:** Complete
+**Last Updated:** YYYY-MM-DD
+**Decision:** Accepted
+**Superseded By:** ADR-NNN  (only if applicable)
+**Amended by:** ADR-NNN     (only if applicable)
+
+## Context
+
+The situation, constraints, and forces at the time of the decision. Why this needed to be decided now.
+
+## Decision
+
+One unambiguous statement of what was chosen. No hedging.
+
+## Rationale
+
+Why this choice over the alternatives. Tie back to the constraints in Context.
+
+## Alternatives Considered
+
+Each alternative as its own subsection with a one-paragraph description and an explicit "Rejected because..." line. Recover alternatives from PR descriptions, commit messages, or memory. Where you genuinely don't remember, write "to be filled in by the original decider" rather than fabricating.
+
+### Alternative A
+
+Description.
+
+**Rejected because:** specific reason.
+
+## Consequences
+
+### Positive
+
+- Specific benefits this decision enables.
+
+### Negative
+
+- Specific costs, ongoing maintenance burden, or constraints this decision imposes.
+
+## Related Documents
+
+(Use the 4-bucket Related Documents structure described below.)
+```
+
+## Length Guidelines
+
+Not rigid rules, but signals for document health. When a doc passes the "max" column it should be split by concern.
+
+| Document Type | Target Lines | Max Lines |
+|---|---|---|
+| ADR | 200–500 | 800 |
+| Product Spec | 300–700 | 800 |
+| Technical Spec | 400–800 | 1,000 |
+| Standards | 200–500 | 700 |
+| Vision | 300–600 | 800 |
+| Guide | 200–500 | 800 |
+| Plan | Variable | — |
+
+**Split when:**
+- Document exceeds the Max in its column.
+- It covers multiple distinct concerns (e.g., one CRM spec covering people, interactions, graph, analytics).
+- Different readers need different sections.
+- Table of contents has more than ~8 top-level sections.
+
+When splitting, keep a thin **index document** at the original path with pointers to each split and a short overview. Update all inbound links to point at the right split.
+
+## Cross-Linking Standards
+
+Every document must include a "Related Documents" section at the bottom.
+
+**Requirements:**
+1. **Bidirectional** — if A links to B, B must link to A. When you add a link in one direction, add the reciprocal link in the same PR.
+2. **Contextual** — every link has a "— short tagline" explaining the relationship.
+3. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
+4. **Use the 4-bucket structure** below for consistency.
+
+**Standard Related Documents template:**
+
+```markdown
+## Related Documents
+
+### Design Context
+- [ADR-NNN: Decision Name](../adr/NNN-title.md) — Why this approach was chosen
+- [Vision: Philosophy](../vision/philosophy.md) — The principle behind this
+
+### Specifications
+- [Product Spec](../specs/product/feature.md) — Consumer-facing requirements
+- [Technical Spec](../specs/technical/component.md) — Implementation design
+
+### Operational
+- [Setup Guide](../guides/feature-setup.md) — How to configure this
+- [Configuration](../guides/configuration.md) — Env var reference
+
+### Code References
+- [Implementation](../../api/services/foo.py:45-120) — Production code
+- [Tests](../../tests/test_foo.py) — Coverage
+```
+
+Use only the buckets that apply — omit empty buckets rather than including them as `(none)`.
+
+## Lifecycle Rules
+
+**Specs are living:**
+- Update when the design changes, not when tasks complete.
+- If a spec describes a target that's not yet built, the `Status: Partial` value is appropriate.
+- Specs are not changelogs. Don't add "Added X in PR #N" notes; that's what `git log` and `git blame` are for.
+
+**Plans are ephemeral:**
+- A plan ends as either "completed" (move to `archive/` with `Completed: YYYY-MM-DD`) or "superseded" (note the successor and move to `archive/`).
+- Do not leave stale plans in `docs/plans/`.
+
+**ADRs are immutable:**
+- Never modify the Context / Decision / Rationale / Alternatives sections of an accepted ADR.
+- To change a decision, create a new ADR. The old ADR gets `Superseded By: ADR-NNN` added to its frontmatter — that's the only acceptable in-place edit.
+- For a smaller change (clarification, scoping refinement that doesn't reverse the decision), the new ADR is an *amendment* and the old ADR gets `Amended by: ADR-NNN`.
+
+**Guides decay:**
+- Test commands you document before shipping. Stale guides are worse than missing guides.
+
+## Writing for AI Readability
+
+Documentation is frequently consumed by AI agents during development. Optimize for:
+
+**Clarity:**
+- State requirements explicitly. Avoid "should consider" — say "do" or "don't" or "defer because X".
+- Use precise technical terminology (route handler, span, collection) rather than vague nouns.
+- Avoid ambiguous pronouns; prefer specific nouns even at the cost of repetition.
+
+**Structure:**
+- Well-named sections that match their content. A section labeled "Notes" is a smell.
+- Frontmatter with status and metadata at the top.
+- Tables when they sharpen a comparison; prose otherwise.
+
+**Brevity:**
+- Shorter, focused documents over long comprehensive ones.
+- Link to details rather than repeating them.
+- Keep documents focused on one concern so agents don't waste context loading irrelevant content.
+
+**Anti-patterns:**
+- Long narrative explanations when a bulleted list suffices.
+- Repeating context already in linked documents.
+- Vague statements like "we should consider" (instead: decided yes/no, or defer with reason).
+- Burying key decisions in prose.
+
+## LifeOS-Specific Rules
+
+### Privacy-First Documentation
+
+LifeOS handles deeply personal data — emails, messages, photos, finances. Documentation must not become a leak vector.
+
+- **Use obviously synthetic data in all examples and test fixtures.** Names like "Alex Chen", domains like `example.com`, phone numbers like `555-0123`, dollar amounts like `$1,234.56`. No real names, emails, phone numbers, or financial values, even in commit-message screenshots.
+- **Security-sensitive implementation details belong in code, not docs.** Reference the code (with line numbers) rather than restating encryption keys, auth tokens, or exact connection strings.
+- **Technical specs involving data storage or access** should include a "Privacy Considerations" subsection or link to one in `specs/technical/security-privacy.md`.
+- **Don't paste real terminal output** containing real personal data into docs. Sanitize first.
+
+### Open-Source Posture
+
+LifeOS is open-source and single-user / self-hosted. That implies two doc rules beyond the privacy ones:
+
+- **No hardcoded personal values** in examples, configs, or fixtures (paths under `/home/<personal-username>`, machine names, IP addresses). Use placeholders (`<your-username>`, `<your-machine>`).
+- **No "broken by default for a fresh downloader" assumptions.** Setup guides should walk through what a fresh clone actually needs, not what's already true on the maintainer's machine.
+
+### Sub-Directory Instruction Files
+
+Every doc subdirectory has an `AGENTS.md` + `CLAUDE.md` pair so any reader (human or agent) can orient inside the subdirectory without re-reading this strategy file.
+
+Existing pairs:
+- `docs/adr/AGENTS.md` + `CLAUDE.md`
+- `docs/guides/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/standards/AGENTS.md` + `CLAUDE.md`
+- `docs/vision/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/product/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/specs/technical/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/plans/AGENTS.md` + `CLAUDE.md` (added in #181 — note: gitignored)
+
+**AGENTS.md** is the primary instruction file (universal, works with all AI tools). **CLAUDE.md** is a one-line wrapper: `@AGENTS.md`. The `@` import is relative to the file containing it; since CLAUDE.md and AGENTS.md are always co-located, the import is always literally `@AGENTS.md`.
+
+**AGENTS.md structure (per subdirectory):**
+
+```markdown
+[One-line description of directory purpose]
+
+## Contents
+- `file.md` — one-line description
+...
+
+## Key Principles
+- Critical rules that apply to this directory's content
+
+## Related Documents
+- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
+- [Other relevant doc] — Why it matters here
+```
+
+Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended commentary — keep them tight.
+
+## Maintenance Rules
+
+**When code changes:**
+1. Update the relevant design doc in the same PR if the design changed (not the implementation — only when the *intent* changed).
+2. Update `Last Updated` in the frontmatter.
+3. Check if cross-references need updates.
+4. Verify bidirectional links still resolve.
+
+**When documents get long (over the Max in [Length Guidelines](#length-guidelines)):**
+1. Identify distinct concerns within the document.
+2. Create focused docs for each concern.
+3. Keep the original path as a thin index pointing at the splits.
+4. Update inbound references to the right split.
+
+**Common violations to avoid:**
+- Adding "Next Steps" or task lists to specs or ADRs.
+- Mixing planning (roadmaps, tasks) into design documents.
+- Creating documents without "Related Documents" sections.
+- Failing to update cross-references when moving or splitting documents.
+- Modifying an accepted ADR in place (instead of superseding).
+- Using real personal data in examples.
+
+---
+
+## Related Documents
+
+### Project Context
+- [Root AGENTS.md](../AGENTS.md) — Project-level agent reference, development principles, key files
+- [Root CLAUDE.md](../CLAUDE.md) — Claude Code-specific configuration
+
+### Specifications
+- [vision/philosophy.md](vision/philosophy.md) — The privacy-first, local-first principles that frame doc decisions
+- [specs/standards/](specs/standards/) — Coding and testing conventions referenced by docs
+
+### Operational
+- [guides/](guides/) — Operator-facing setup and troubleshooting

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/adr/011-external-agent-ingest.md
+++ b/docs/adr/011-external-agent-ingest.md
@@ -1,0 +1,124 @@
+# ADR-011: Read-Only Direct-Access Ingest for External Agent Transcripts
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+**Decision:** Accepted
+
+## Context
+
+The `/agents` page (see [agent-viz product spec](../specs/product/agent-viz.md) and [agent-viz technical spec](../specs/technical/agent-viz.md)) shows two kinds of work happening on the host:
+
+1. **LifeOS agent worker sessions** — `#agent`-tagged tasks running through `api/services/agent_worker/`. State lives in the worker's own SQLite `SessionStore`; transcripts in `data/agent_transcripts/`. LifeOS owns this data.
+
+2. **Claude Code sessions** — the operator running `claude` in any terminal on any cwd. State lives in Claude Code's per-session JSONL transcripts at `~/.claude/projects/<encoded-cwd>/*.jsonl`. **Claude Code owns this data.**
+
+The decision is how to surface Claude Code sessions in the `/agents` viz without violating Claude Code's ownership of its data, without coupling LifeOS to Claude Code's release cadence, and without losing the ability to fall back gracefully if the operator doesn't have Claude Code installed at all.
+
+This pattern also matters going forward: future external agent runtimes (Codex CLI, Cursor session logs, other operator-side AI tools) will have the same shape — they each own their transcripts and LifeOS wants to surface them.
+
+## Decision
+
+A **read-only adapter** at `api/services/claude_code/session_ingest.py` translates Claude Code's JSONL format to LifeOS's `{ts, kind, payload}` shape at read time. The adapter:
+
+- Walks `~/.claude/projects/<encoded-cwd>/*.jsonl` (path overridable via `LIFEOS_CLAUDE_CODE_PROJECTS_DIR`).
+- Validates paths against a regex + rejects `..` traversal, even though discovery is internal.
+- Reads JSONL files newest-first by mtime, capped by `LIFEOS_CLAUDE_CODE_LOOKBACK_DAYS`.
+- Filters noise (system messages, permission-mode changes) on the way in.
+- Infers session status from file `mtime` + a 10-minute "running" threshold + a `psutil` live-process check.
+- Detects spawn relationships by inspecting `Task` / Agent tool-use blocks inside parent transcripts and generates synthetic subagent nodes.
+- Caches the snapshot for 30 seconds so the 2-second SSE tick doesn't re-read JSONL every loop.
+
+**Never writes back.** The adapter has no edit, delete, append, or mutate methods. The Claude Code data store is treated as immutable from LifeOS's perspective.
+
+`/agents` API routes dispatch by `session_id` prefix: a `cc:`-prefixed id goes through this adapter; everything else goes through the LifeOS agent-worker SessionStore. The two stores are never joined; the viz layer merges at render time.
+
+The whole path is gated by `LIFEOS_CLAUDE_CODE_VIZ_ENABLED` (default `true`). Operators who don't use Claude Code, or who want to opt out for any reason, can disable the entire adapter from `.env` without any code path running.
+
+## Rationale
+
+- **Zero coupling to Claude Code's roadmap.** Claude Code can rename fields, restructure JSONL events, add or remove message types — only the adapter has to update. Nothing else in LifeOS knows about Claude Code's internal format.
+- **Read-only is auditable.** "We don't write to `~/.claude/`" is a property a reviewer can verify in one grep. There's no shared-state risk, no chance of corrupting Claude Code's own session resume.
+- **Operator can opt out.** `LIFEOS_CLAUDE_CODE_VIZ_ENABLED=false` skips the whole path. Operators who don't use Claude Code see nothing odd, and the missing `~/.claude/projects/` directory doesn't surface as an error.
+- **Pattern reusable for future external agents.** Read-only adapter + foreign-schema translation at read time + `<source>:` session_id prefix for dispatch routing + path-validated lookups + never write back. Same shape works for any future external agent runtime (Codex CLI, Cursor session logs, etc.).
+- **Path validation even for internal input.** Even though discovery is by walking a known directory, the adapter rejects `..` and non-matching filenames. Defense in depth: internal inputs become external when the directory contents are operator-controlled (operators can drop files into `~/.claude/projects/`).
+- **Snapshot caching matches the SSE tick.** The viz polls every 2 seconds; re-reading every JSONL file at that cadence is wasteful. A 30-second snapshot cache is well under the freshness expectations of the viz and well above the cost of a JSONL walk.
+
+## Alternatives Considered
+
+### Ask Claude Code to push events to LifeOS via webhook
+
+Have Claude Code emit each event as an HTTP POST to a LifeOS endpoint.
+
+**Rejected because:** Claude Code doesn't expose hooks for this and adding one is out of LifeOS's control. Even if it existed, it would create a dependency on an external tool's lifecycle — every Claude Code version bump becomes a potential ingest break.
+
+### Poll a Claude Code API
+
+Read Claude Code state through an official API.
+
+**Rejected because:** There isn't one. JSONL transcripts are the only stable interface.
+
+### Replicate transcripts into LifeOS storage
+
+Periodically copy JSONL files into LifeOS's data directory and read from the copy.
+
+**Rejected because:** Write amplification, storage duplication, ownership ambiguity (which copy is canonical?), and it breaks the read-only guarantee that makes the design auditable. The 30-second snapshot cache already solves the "don't re-read every 2 seconds" cost without copying.
+
+### Tail JSONL files via inotify
+
+Use kernel filesystem-event subscriptions to react in real time as Claude Code writes new lines.
+
+**Rejected because:** The snapshot pattern (30s cache) is simpler and sufficient for the 2-second SSE tick rate the viz actually needs. inotify adds a long-running subscription per project directory, more failure modes, and a tighter coupling to JSONL append semantics. The viz isn't real-time-critical — bounded freshness is fine.
+
+### Write a Claude Code SDK wrapper
+
+Build a higher-level abstraction over the JSONL format that other LifeOS components could also use.
+
+**Rejected because:** Speculative abstraction. The viz is the only consumer today. If a second consumer emerges, the adapter can be promoted. Premature abstraction would force the read-once-translate-once contract into a more elaborate interface that isn't earning its keep.
+
+## Consequences
+
+### Positive
+
+- Zero Claude Code coupling: format changes touch one file (`session_ingest.py`).
+- Read-only is auditable: one grep verifies no write paths exist.
+- Falls back cleanly: missing `~/.claude/projects/` → adapter returns empty list, viz renders fine.
+- Pattern is reusable: future external agent runtimes can copy the adapter shape.
+- Operator-controllable: `LIFEOS_CLAUDE_CODE_VIZ_ENABLED=false` disables the entire path.
+
+### Negative
+
+- Schema changes in Claude Code can silently break ingest. Mitigation: defensive parsing, log on unknown event types, don't crash on shape mismatches.
+- mtime-based status is a heuristic. The 10-minute "running" threshold can mislabel a finished-but-not-yet-touched session as still running for up to 10 minutes; the `psutil` live-process check tightens this but doesn't eliminate the edge case.
+- Path-traversal hardening must be maintained in the adapter even though the discovery surface is internal. Any time the adapter accepts a session_id from an HTTP route, that's an external boundary and the validation has to be checked.
+- 30-second snapshot cache means a brand-new Claude Code session takes up to 30s to appear in the viz. Acceptable trade-off; configurable via the cache TTL constant.
+- Per-session psutil scan is O(N) over running processes. At scale (hundreds of concurrent sessions) the per-tick cost grows. Not a concern at single-operator scale.
+- The adapter is the only thing that knows Claude Code's JSONL format. If the adapter is buggy, the bug looks like "the viz misrepresents Claude Code work" — and the operator may not know to look at the adapter. Mitigation: integration tests against fixture JSONL files representing known Claude Code versions.
+
+### Pattern reusability
+
+Future external agent runtimes should follow the same shape:
+
+1. **Read-only adapter** in `api/services/<source>/` that owns all knowledge of the foreign format.
+2. **Foreign-schema translation at read time** — translate to LifeOS's `{ts, kind, payload}` shape, not to some intermediate.
+3. **`<source>:` session_id prefix** for dispatch routing — viz API routes look at the prefix and dispatch to the right adapter.
+4. **Path validation** on every adapter entry point, even for paths discovered internally.
+5. **Never write back** to the foreign data store.
+6. **Operator opt-out env var** so the whole path can be disabled cleanly.
+
+## Related Documents
+
+### Design Context
+- [ADR-007: Linux Migration](007-linux-migration.md) — Established the local-execution / external-process posture this ADR builds on
+- [ADR-008: Managed Agents Cloud Routing](008-managed-agents-cloud-routing.md) — Sibling agent runtime, different ownership model (LifeOS owns Managed Agents session state)
+
+### Specifications
+- [Agent Viz (product)](../specs/product/agent-viz.md) — Consumer view of the `/agents` page that consumes this adapter
+- [Agent Viz (technical)](../specs/technical/agent-viz.md) — Implementation; the reader using this adapter, the SSE feed, the D3 graph, the status inference
+- [Agent Worker (technical)](../specs/technical/agent-worker.md) — Sibling SessionStore; how LifeOS-owned sessions differ
+
+### Operational
+- [Configuration](../guides/configuration.md) — `LIFEOS_CLAUDE_CODE_VIZ_ENABLED`, `LIFEOS_CLAUDE_CODE_PROJECTS_DIR`, `LIFEOS_CLAUDE_CODE_LOOKBACK_DAYS` env vars
+
+### Code References
+- [`api/services/claude_code/session_ingest.py`](../../api/services/claude_code/session_ingest.py) — The read-only adapter (965 lines)
+- [`api/routes/agents.py`](../../api/routes/agents.py) — Dispatcher that routes `cc:`-prefixed session_ids to the adapter; `_claude_code_enabled()` and `_claude_code_snapshot()` are the entry points

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -183,6 +183,7 @@ All in `.env`. None are required — the defaults work for the standard LifeOS i
 
 ## Related Documents
 
+- [ADR-011: External Agent Ingest](../../adr/011-external-agent-ingest.md) — Why Claude Code sessions surface read-only via a foreign-schema adapter
 - [Agent Viz — Technical](../technical/agent-viz.md) — Endpoint shapes, D3 force config, status inference rules, security boundaries
 - [Agent Worker](agent-worker.md) — The other half of the picture: how `#agent` tasks get claimed and run
 - [Agent Worker — Technical](../technical/agent-worker.md) — Sessions, transcripts, kill primitives

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -320,6 +320,7 @@ Per-source guarantees:
 
 ## Related Documents
 
+- [ADR-011: External Agent Ingest](../../adr/011-external-agent-ingest.md) — Read-only adapter pattern this spec implements
 - [Agent Viz — Product](../product/agent-viz.md) — Consumer view: filters, chips, status semantics, operator controls
 - [Agent Worker — Technical](agent-worker.md) — Sessions, transcripts, kill primitives, inter-agent coordination
 - [Agent Worker — Product](../product/agent-worker.md) — `#agent` task lifecycle, Telegram interactions


### PR DESCRIPTION
## Summary

Captures the architectural pattern that surfaces Claude Code sessions in the `/agents` viz: a read-only adapter (`api/services/claude_code/session_ingest.py`) translates Claude Code's per-session JSONL format to LifeOS's `{ts, kind, payload}` shape at read time, never writes back, and is gated by `LIFEOS_CLAUDE_CODE_VIZ_ENABLED`.

## Acceptance criteria

- [x] ADR-011 exists with all template sections
- [x] Path-validation contract explicitly called out as a maintained invariant (Decision section + Negative consequences)
- [x] "Pattern reusability" section explicit (read-only adapter, foreign-schema translation at read time, `<source>:` prefix, path validation, never write back, opt-out env var) so future external agents follow the same shape
- [x] Cross-linked with both agent-viz specs (bidirectional)
- [x] No functional code changes

## Alternatives considered

- Webhook push from Claude Code
- Polling a Claude Code API
- Replicating transcripts into LifeOS storage
- Tailing via inotify
- Building a Claude Code SDK abstraction

Each with explicit `Rejected because:` paragraph.

## Code references (all verified)

- `api/services/claude_code/session_ingest.py` (965 lines — the adapter)
- `api/routes/agents.py` (the dispatcher with `_claude_code_enabled()` / `_claude_code_snapshot()` entry points)

## Env vars referenced

- `LIFEOS_CLAUDE_CODE_VIZ_ENABLED` (default `true`)
- `LIFEOS_CLAUDE_CODE_PROJECTS_DIR` (default `~/.claude/projects`)
- `LIFEOS_CLAUDE_CODE_LOOKBACK_DAYS`

All confirmed against `config/settings.py` lines 179-198.

## Length

105 lines — within ADR target.

## Test plan

- [x] Adapter path exists, route handlers exist
- [x] Env var names match `config/settings.py`
- [x] Bidirectional cross-links: ADR-011 → both agent-viz specs; both specs → ADR-011
- [ ] Reviewer: confirm the "pattern reusability" framing captures the right invariants for future external-agent runtimes

## Targeting

Based on `docs/180-strategy-foundation`; targeted at `docs/overhaul`.

Closes #186.