### PR TITLE
feat(agents): graph pan/zoom/drag, pretty transcripts, fix managed-cost parser

### DIFF
--- a/api/services/agent_worker/managed_driver.py
+++ b/api/services/agent_worker/managed_driver.py
@@ -265,7 +265,7 @@ class ManagedAgentsDriver:
             new_events=events,
             total_input_tokens=int(usage.get("input_tokens", 0)),
             total_output_tokens=int(usage.get("output_tokens", 0)),
-            total_cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0)),
+            total_cache_creation_tokens=_extract_cache_creation_tokens(usage),
             total_cache_read_tokens=int(usage.get("cache_read_input_tokens", 0)),
             final_text=final_text,
             error_reason=error_reason,
@@ -439,8 +439,42 @@ class ManagedAgentsDriver:
 
 
 # ---------------------------------------------------------------------------
-# Event-stream parsing helpers
+# Usage / event-stream parsing helpers
 # ---------------------------------------------------------------------------
+
+def _extract_cache_creation_tokens(usage: dict) -> int:
+    """Sum cache_creation tokens, handling both the flat and nested shapes
+    Anthropic's API has emitted.
+
+    Live Managed-Agents responses (confirmed 2026-05-27) return cache_creation
+    as a nested object split into ephemeral_5m / ephemeral_1h buckets:
+        {"cache_creation": {"ephemeral_5m_input_tokens": N,
+                            "ephemeral_1h_input_tokens": M}}
+    Older API doc snippets reference a flat `cache_creation_input_tokens`
+    key. We accept either so the parser survives both shapes.
+
+    Both ephemeral buckets are billed by Anthropic, so we sum them. The
+    1h-cache write is technically 2× input vs. 1.25× for 5m, but
+    `pricing.CACHE_CREATION_RATE_MULTIPLIER` only encodes the 5m multiplier
+    today — refining the split is a follow-up if 1h-cache usage becomes
+    non-trivial (currently 0 in observed responses).
+    """
+    flat = usage.get("cache_creation_input_tokens")
+    if flat is not None:
+        try:
+            return int(flat)
+        except (TypeError, ValueError):
+            return 0
+    nested = usage.get("cache_creation")
+    if isinstance(nested, dict):
+        ephem_5m = nested.get("ephemeral_5m_input_tokens", 0) or 0
+        ephem_1h = nested.get("ephemeral_1h_input_tokens", 0) or 0
+        try:
+            return int(ephem_5m) + int(ephem_1h)
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
 
 def _synthesize_status_from_events(events: list[dict]) -> str | None:
     """Map event-stream signals to a terminal status string, or None.

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -52,7 +52,9 @@ The graph mirrors `/crm/graph`'s pointer model:
 - **Scroll-wheel / pinch** — zooms in and out (0.2× – 5×).
 - **Click a node** — opens its transcript in the side panel and highlights its parent/child relationships (selected node gets a thick white border, 1-hop neighbors get a thinner white border, everything else dims).
 - **Click the same node again, or click empty background** — deselects and closes the panel.
-- **Filter change** — releases any drag-pinned positions so the new visible set lays out from scratch.
+- **Filter change** — releases any drag-pinned positions and resets the pan/zoom transform so the new visible set lays out from scratch at the natural scale.
+
+Between filter operations the simulation **freezes after settling** (~6s). Snapshot ticks every 2s only re-energize the layout if the visible-id set actually changed — new session appeared or one dropped out. Same-set snapshots leave settled nodes alone, so the graph no longer jitters every couple seconds at rest.
 
 ---
 

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -38,9 +38,21 @@ The page is a force-directed graph of sessions, laid out left-to-right by recenc
 | **Size** | Log-scaled by total tokens (input + output + cache). A 100k-token session is roughly 2× a 1k-token session, not 100×. Capped so one fat node can't dominate the canvas. |
 | **White pulsing border** | Session is `running` AND has written to its transcript in the last 60 seconds (i.e. *actively producing output right now*) |
 | **Edge** | Spawn relationship — parent → subagent |
-| **X position** | Last-activity recency. Most recent sessions to the right, ≥24h old pinned to the left. Same-age sessions spread vertically via repulsion. |
+| **X position** | Last-activity recency. Most recent sessions to the right, ≥24h old pinned to the left. The recency rail compresses around center when few nodes are visible — one filtered-down node ends up centered, two sit on a narrow band — and stretches to the full width as more nodes appear. |
+| **Edge styling** | Plain curved paths (no arrowheads) between parents and subagents. When a node is selected, edges adjacent to it brighten to white. |
 
 The simulation converges in ~8 seconds and then stops, so the graph stops jittering once it settles. New snapshots arrive every 2 seconds and only nudge nodes whose positions are now misleading.
+
+### Canvas controls
+
+The graph mirrors `/crm/graph`'s pointer model:
+
+- **Drag a node** — pins it where you drop it. Useful when you want to inspect a busy cluster without the simulation nudging things around.
+- **Drag the empty background** — pans the whole graph.
+- **Scroll-wheel / pinch** — zooms in and out (0.2× – 5×).
+- **Click a node** — opens its transcript in the side panel and highlights its parent/child relationships (selected node gets a thick white border, 1-hop neighbors get a thinner white border, everything else dims).
+- **Click the same node again, or click empty background** — deselects and closes the panel.
+- **Filter change** — releases any drag-pinned positions so the new visible set lays out from scratch.
 
 ---
 
@@ -120,11 +132,11 @@ The event feed is newest-on-top. Backfill arrives first (the last 50 events by d
 
 - A **kind label** — click to filter the feed to just that kind (e.g. `tool_call`, `user_message`, `failed`). Click again to clear. When a session first opens with any `user_message` events present, the filter auto-defaults to `user_message` to focus the view on the operator-visible turns.
 - A **timestamp** in your local timezone.
-- A **payload preview** — truncated to 240 chars. Click anywhere on the event to expand to the full payload (rendered in white for legibility); click again to collapse.
+- A **payload preview** — rendered as structured fields (model badge, routing decision, tool-call pills `Name(arg, arg)`, compact budget `90s · $0.30 · 500k tok`, usage summary `↓ in · ↑ out · cache read/create`, free-text fields like `ambiguity` / `question` / `reason`). Noisy fields (`iterations`, nested `ephemeral_*`, etc.) are suppressed. Click anywhere on the event to expand — the raw JSON appears beneath the structured view for diagnostics; click again to collapse.
 
 The panel is **resizable**: drag the left edge to widen or narrow it. The chosen width is remembered across sessions via `localStorage`.
 
-Clicking the same node again, or hitting the `×` button, closes the panel. The graph stays selected; you can click another node directly without re-opening.
+Clicking the same node again, the `×` button, or empty background area closes the panel and clears the graph selection. You can click another node directly to switch focus.
 
 ---
 

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -216,7 +216,7 @@ setTimeout(() => simulation.alpha(0).stop(), 8000);  // 8s convergence backstop
 |---|---|
 | `link.strength(0.04)` | Spawn edges are *informational*, not load-bearing — weak so they don't yank parent + child off the recency-x rail. |
 | `charge -220, distanceMax(600)` | Strong-ish repulsion within 600 vbox units. Caps the influence radius so far-apart clusters don't push each other. |
-| `forceX(recencyTargetX) strength 0.18` | Soft pull toward `0.92*W` for now-recent and `0.08*W` for ≥24h-old. Strength balanced against repulsion so same-recency nodes spread vertically without escaping the x-band. |
+| `forceX(recencyTargetX) strength 0.18` | Soft pull along the recency rail, newer to the right. Rail *width* scales with the visible-node count via `recencyRailSpan()` — `0` (centered) for one visible node, `~0.30·W` for two, growing logarithmically to `0.84·W` at 32+. This way filtered-down sets re-center instead of getting pinned to their absolute time-position. |
 | `forceY(VIEW_H/2) strength 0.12` | Mild vertical centering — without it, nodes drift off-canvas; too strong and the collide force can't separate them. |
 | `forceCollide radius = nodeRadius + 14, strength 0.9` | Hard guarantee that token-based-sized nodes never overlap. |
 | `velocityDecay 0.45`, `alphaDecay 0.025` | Settles in ~6s; the 8s `alpha(0).stop()` is a backstop in case extreme node counts prevent natural convergence. |
@@ -224,6 +224,18 @@ setTimeout(() => simulation.alpha(0).stop(), 8000);  // 8s convergence backstop
 Node shape varies by source — `circle` (LifeOS), `rect` (Claude Code, `rx`/`ry` rounded), `polygon` (subagent diamond). The simulation tick re-positions whichever element is bound to each datum; size and color are re-applied on every snapshot tick via `applyShapeAttrs`. The actively-writing pulse (white border, 1.4s ease-in-out) is a CSS keyframe applied via the `.pulsing` class — far simpler than the previous vis-network `DataSet.update` polling.
 
 The `viewBox` is `1600 × 1100` with `preserveAspectRatio="xMidYMid meet"` and `overflow: visible` so collision-pushed nodes don't get clipped at the edges.
+
+### Interaction model
+
+Both link and node layers live inside a single `<g class="viewport">` whose `transform` is mutated by `d3.zoom` (scaleExtent 0.2–5). Because `d3.pointer` returns viewBox-space coordinates when the target carries a `viewBox`, pan tracks the cursor 1:1 without explicit screen↔viewBox compensation.
+
+Per-node `d3.drag` sets `fx`/`fy` on the bound datum so positions persist after drop. The drag handler's `mousedown` stops propagation, so node-drags don't also pan the canvas. Drag pins persist across snapshot ticks but are cleared on filter change (`releasePins()`) so the new visible set reflows.
+
+Selection state is tracked in `selectedSessionId` and re-applied on every render plus on `openPanel`/`closePanel` via `applySelectionStyles()`. The helper computes the 1-hop neighbor set from the link layer's bound data and toggles `.selected` (5px white border, overrides `.pulsing`), `.related` (3px translucent white), and `.dimmed` (0.28 opacity) classes on nodes / labels / edges. Clicking the SVG background (target === svg root) calls `closePanel()`; clicking an already-selected node toggles it off.
+
+### Transcript event rendering
+
+`prettyPayload(payload)` is a field-aware formatter shared by backfill + live tail. It recognizes routing decisions (`routing` + `routing_reason`), assistant text (with a `(no text — called tools)` placeholder when `text === ""` alongside non-empty `tool_uses`), tool-call pills (`Name(input_keys)`), labeled text fields (`question`, `answer`, `prompt`, `reason`, `ambiguity`, `sane_reason`, `description`, `label`), compact `budget` and `usage` lines, scalar badges (`model`, `task_id`, `expected_output`, `speed`, `service_tier`, `source`, parent/child ids), and a `pp-extra` tail for unrecognized scalars. Noisy fields (`iterations`, `inference_geo`, `server_tool_use`, the nested `cache_creation` ephemeral buckets, zero `thinking_chars`) are suppressed. Click-to-expand reveals the raw JSON in a sibling `<pre class="payload-raw">` for diagnostic inspection.
 
 ---
 

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -231,6 +231,8 @@ Both link and node layers live inside a single `<g class="viewport">` whose `tra
 
 Per-node `d3.drag` sets `fx`/`fy` on the bound datum so positions persist after drop. The drag handler's `mousedown` stops propagation, so node-drags don't also pan the canvas. Drag pins persist across snapshot ticks but are cleared on filter change (`releasePins()`) so the new visible set reflows.
 
+`renderGraph` keeps `_lastVisibleIdsKey` (the sorted-and-joined session-id set of the previous tick) and only fires `simulation.alpha(0.3).restart()` when that key changes. Same-set snapshot ticks therefore leave settled nodes alone — the periodic jitter that previously fell out of the every-2s SSE refresh is gone. Filter changes additionally reset the pan/zoom transform via `svg.transition().duration(300).call(zoom.transform, d3.zoomIdentity)` so the operator's prior zoom doesn't strand the freshly-filtered set in empty space.
+
 Selection state is tracked in `selectedSessionId` and re-applied on every render plus on `openPanel`/`closePanel` via `applySelectionStyles()`. The helper computes the 1-hop neighbor set from the link layer's bound data and toggles `.selected` (5px white border, overrides `.pulsing`), `.related` (3px translucent white), and `.dimmed` (0.28 opacity) classes on nodes / labels / edges. Clicking the SVG background (target === svg root) calls `closePanel()`; clicking an already-selected node toggles it off.
 
 ### Transcript event rendering

--- a/scripts/backfill_managed_session_costs.py
+++ b/scripts/backfill_managed_session_costs.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Re-poll Anthropic for every managed session and rewrite stored token totals
++ total_dollars from the authoritative live usage.
+
+Why this exists
+---------------
+Two compounding bugs left historical `total_dollars` numbers ~20× too low:
+
+1. The cache-token-tracking commit (fcaeff5) landed 2026-05-27 02:17; the
+   worker ran old code (which never recorded cache_creation / cache_read)
+   until restarting at 18:42. Every session that ran in that window
+   silently dropped its cache-token usage.
+2. Live API responses use a nested `cache_creation` object
+   (`{ephemeral_5m_input_tokens, ephemeral_1h_input_tokens}`), not the flat
+   `cache_creation_input_tokens` field the parser looked for. So even
+   sessions that ran on the post-fcaeff5 code still booked $0 of
+   cache_creation cost. The parser fix in this same change handles both
+   shapes going forward.
+
+This script re-polls Anthropic for every session with a
+`managed_agent_session_id` and overwrites the four token counters +
+`total_dollars` with the recomputed values. Wall-time overhead is
+included.
+
+Usage
+-----
+    # Preview (default — no writes)
+    python scripts/backfill_managed_session_costs.py
+
+    # Apply
+    python scripts/backfill_managed_session_costs.py --execute
+
+Reads ANTHROPIC_API_KEY from .env or env. Skips sessions whose remote
+returns 404 (deleted), leaving their existing numbers untouched.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# .env load — match the pattern other backfill scripts use.
+try:
+    from dotenv import load_dotenv
+    load_dotenv(REPO_ROOT / ".env")
+except ImportError:
+    pass
+
+from api.services.agent_worker.managed_driver import ManagedAgentsDriver, managed_session_cost  # noqa: E402
+from config.settings import settings  # noqa: E402
+
+
+DB_PATH = REPO_ROOT / "data" / "agent_sessions.db"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--execute", action="store_true", help="Apply changes (default: dry-run)")
+    ap.add_argument("--model", default=None,
+                    help="Pricing model to use for recompute (default: settings.agent_managed_model)")
+    args = ap.parse_args()
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY not set")
+        return 1
+    model = args.model or settings.agent_managed_model
+
+    if not DB_PATH.exists():
+        print(f"ERROR: DB not found at {DB_PATH}")
+        return 1
+
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """SELECT task_id, session_id, managed_agent_session_id,
+                  started_at, last_activity_at,
+                  total_input_tokens, total_output_tokens,
+                  total_cache_creation_tokens, total_cache_read_tokens,
+                  total_dollars
+           FROM sessions
+           WHERE routing = 'claude' AND managed_agent_session_id IS NOT NULL
+           ORDER BY started_at"""
+    ).fetchall()
+
+    print(f"{'DRY-RUN' if not args.execute else 'EXECUTE'}: {len(rows)} managed sessions, model={model}\n")
+    print(f"{'sess':24}  {'in':>6} {'out':>7} {'cache_cr':>9} {'cache_rd':>10} {'$ before':>10} {'$ after':>10}  status")
+
+    driver = ManagedAgentsDriver(api_key=api_key)
+    try:
+        sum_before = 0.0
+        sum_after = 0.0
+        updated = 0
+        skipped = 0
+        for row in rows:
+            sum_before += float(row["total_dollars"] or 0)
+            remote_id = row["managed_agent_session_id"]
+            try:
+                state = driver.get_session_state(remote_id)
+            except Exception as exc:
+                print(f"{remote_id:24}  {'?':>6} {'?':>7} {'?':>9} {'?':>10} {row['total_dollars']:>10.4f} {'?':>10}  poll-error: {exc}")
+                sum_after += float(row["total_dollars"] or 0)
+                skipped += 1
+                continue
+
+            if state.status == "cancelled" and not state.total_input_tokens:
+                # 404 or deleted-remote — preserve existing row.
+                print(f"{remote_id:24}  {'-':>6} {'-':>7} {'-':>9} {'-':>10} {row['total_dollars']:>10.4f} {'-':>10}  deleted-remote (kept)")
+                sum_after += float(row["total_dollars"] or 0)
+                skipped += 1
+                continue
+
+            wall_seconds = max(0.0, float(row["last_activity_at"] or 0) - float(row["started_at"] or 0))
+            new_dollars = managed_session_cost(
+                model,
+                state.total_input_tokens,
+                state.total_output_tokens,
+                wall_seconds,
+                cache_creation_tokens=state.total_cache_creation_tokens,
+                cache_read_tokens=state.total_cache_read_tokens,
+            )
+            sum_after += new_dollars
+            print(
+                f"{remote_id:24}  "
+                f"{state.total_input_tokens:>6} {state.total_output_tokens:>7} "
+                f"{state.total_cache_creation_tokens:>9} {state.total_cache_read_tokens:>10} "
+                f"{(row['total_dollars'] or 0):>10.4f} {new_dollars:>10.4f}  ok"
+            )
+            if args.execute:
+                conn.execute(
+                    """UPDATE sessions SET
+                          total_input_tokens          = ?,
+                          total_output_tokens         = ?,
+                          total_cache_creation_tokens = ?,
+                          total_cache_read_tokens     = ?,
+                          total_dollars               = ?
+                       WHERE task_id = ?""",
+                    (
+                        state.total_input_tokens,
+                        state.total_output_tokens,
+                        state.total_cache_creation_tokens,
+                        state.total_cache_read_tokens,
+                        new_dollars,
+                        row["task_id"],
+                    ),
+                )
+                updated += 1
+
+        if args.execute:
+            conn.commit()
+
+        print(f"\nTotals: ${sum_before:.4f} → ${sum_after:.4f}  (delta +${sum_after - sum_before:.4f})")
+        print(f"Sessions updated: {updated},  skipped: {skipped}")
+        if not args.execute:
+            print("\nRe-run with --execute to apply.")
+    finally:
+        driver.close()
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agent_worker_managed_driver.py
+++ b/tests/test_agent_worker_managed_driver.py
@@ -700,6 +700,32 @@ def test_session_state_defaults_cache_buckets_to_zero_when_absent():
 
 
 @pytest.mark.unit
+def test_session_state_parses_nested_cache_creation_object():
+    """Managed-Agents API returns cache_creation as a nested object split into
+    ephemeral_5m + ephemeral_1h buckets — both must be summed and surfaced as
+    `total_cache_creation_tokens`. (Live response confirmed 2026-05-27 returned
+    this nested shape, not the flat `cache_creation_input_tokens` key.)"""
+    handler = _make_session_handler(
+        status_body={
+            "status": "running",
+            "usage": {
+                "input_tokens": 14,
+                "output_tokens": 23034,
+                "cache_read_input_tokens": 1_706_547,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 137_571,
+                    "ephemeral_1h_input_tokens": 1_000,
+                },
+            },
+        },
+        events=[],
+    )
+    state = _build_driver(handler).get_session_state("sess")
+    assert state.total_cache_creation_tokens == 138_571  # 137_571 + 1_000
+    assert state.total_cache_read_tokens == 1_706_547
+
+
+@pytest.mark.unit
 def test_managed_session_cost_includes_cache_buckets():
     """cache_creation tokens are 1.25× input rate; cache_read is 0.10× input."""
     # 100k cache_creation at Sonnet ($3/M input × 1.25) = $0.375

--- a/web/agents.html
+++ b/web/agents.html
@@ -781,6 +781,12 @@
   // visible-node count: 1 node centers, 2 nodes sit on a narrow band, many
   // nodes spread across most of the canvas.
   let visibleCount = 0;
+  // Sorted-and-joined visible session_id set from the previous render. Used
+  // to detect structural changes (filter operations, new sessions arriving,
+  // sessions terminating out of view) so the simulation only re-energizes
+  // when there's an actual reason to move nodes — never on a same-set
+  // snapshot tick, which would otherwise jitter every 2 seconds.
+  let _lastVisibleIdsKey = '';
   function recencyRailSpan() {
     if (visibleCount <= 1) return 0;
     return Math.min(0.84, 0.15 + 0.15 * Math.log2(visibleCount));
@@ -1070,15 +1076,20 @@
 
     sel.exit().remove();
 
-    // Feed the merged node array + links into the simulation. `alpha(0.3)`
-    // is enough to spread new nodes without throwing the whole layout
-    // around; existing nodes already have stable (x, y). visibleCount
-    // feeds `recencyRailSpan()` so the rail compresses to center when few
-    // nodes are visible.
+    // Feed the merged node array + links into the simulation. Only re-energize
+    // alpha when the visible *set* actually changed (new ids appeared or old
+    // ones disappeared) — otherwise the 2s snapshot tick would keep nudging
+    // settled nodes for no structural reason, manifesting as periodic jitter.
+    // visibleCount feeds `recencyRailSpan()` so the rail compresses to center
+    // when few nodes are visible.
     visibleCount = merged.length;
     simulation.nodes(merged);
     simulation.force('link').links(visibleLinks);
-    simulation.alpha(0.3).restart();
+    const visibleIdsKey = visible.map(s => s.session_id).sort().join('|');
+    if (visibleIdsKey !== _lastVisibleIdsKey) {
+      _lastVisibleIdsKey = visibleIdsKey;
+      simulation.alpha(0.3).restart();
+    }
 
     emptyStateEl.style.display = visible.length === 0 ? '' : 'none';
     updateChips(visible);
@@ -1731,6 +1742,12 @@
   }
   function onFilterChange() {
     releasePins();
+    // Reset the pan/zoom transform so the new visible set lays out at the
+    // natural scale + position. Without this, an operator who had zoomed
+    // into a corner would see the freshly-filtered set still anchored
+    // there — usually empty space — even though the simulation correctly
+    // re-centered around the recency rail + center-y forces.
+    svg.transition().duration(300).call(zoom.transform, d3.zoomIdentity);
     renderGraph(allSessions, allEdges);
   }
   filterTerminalEl.addEventListener('change', () => {

--- a/web/agents.html
+++ b/web/agents.html
@@ -168,8 +168,11 @@
     pointer-events: none;
   }
   #graph-svg .node-shape {
-    cursor: pointer;
+    cursor: grab;
     transition: stroke-width 0.2s ease, filter 0.2s ease;
+  }
+  #graph-svg .node-shape:active {
+    cursor: grabbing;
   }
   #graph-svg .node-shape:hover {
     stroke: #e8e8ed;
@@ -191,6 +194,32 @@
   }
   #graph-svg .node-shape.pulsing {
     animation: node-pulse 1.4s ease-in-out infinite;
+  }
+  /* Selection emphasis — `!important` on stroke beats the pulsing keyframe
+     when both apply (selected actively-writing node prefers selection cue). */
+  #graph-svg .node-shape.selected {
+    stroke: #ffffff !important;
+    stroke-width: 5 !important;
+    animation: none !important;
+  }
+  #graph-svg .node-shape.related {
+    stroke: rgba(255, 255, 255, 0.78) !important;
+    stroke-width: 3 !important;
+    animation: none !important;
+  }
+  #graph-svg .node-shape.dimmed {
+    opacity: 0.28;
+  }
+  #graph-svg .node-label.dimmed {
+    opacity: 0.35;
+  }
+  #graph-svg .link.highlighted {
+    stroke: #ffffff;
+    stroke-width: 2.4;
+    opacity: 1;
+  }
+  #graph-svg .link.dimmed {
+    opacity: 0.18;
   }
   #graph .empty-state {
     position: absolute;
@@ -330,6 +359,110 @@
     overflow: visible;
     text-overflow: clip;
   }
+  /* Pretty payload — replaces raw JSON in the collapsed view. The raw JSON
+     is still emitted in a sibling .payload-raw <pre> revealed on expand,
+     so power users can still inspect the full shape. */
+  .event .payload {
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    max-height: 14rem;
+  }
+  .event .payload-raw {
+    display: none;
+    margin-top: 0.35rem;
+    padding-top: 0.35rem;
+    border-top: 1px dashed var(--border);
+    color: var(--text-secondary);
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.7rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 20rem;
+    overflow-y: auto;
+  }
+  .event.expanded .payload-raw { display: block; }
+  .pp-text {
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .pp-text.muted { color: var(--text-dim); font-style: italic; }
+  .pp-routing {
+    color: var(--text-primary);
+    margin-top: 0.15rem;
+  }
+  .pp-routing .pp-target {
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .pp-routing .pp-reason { color: var(--text-secondary); }
+  .pp-field {
+    margin-top: 0.25rem;
+    color: var(--text-secondary);
+  }
+  .pp-field .pp-label,
+  .pp-budget .pp-label,
+  .pp-usage  .pp-label,
+  .pp-kv     .pp-label,
+  .pp-badge  .pp-label {
+    text-transform: uppercase;
+    font-size: 0.62rem;
+    letter-spacing: 0.04em;
+    color: var(--text-dim);
+    margin-right: 0.3rem;
+  }
+  .pp-field .pp-value {
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .pp-tools {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-top: 0.3rem;
+  }
+  .pp-tool {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+  }
+  .pp-tool .pp-tool-name { color: var(--accent); font-weight: 600; }
+  .pp-tool .pp-tool-args { color: var(--text-dim); }
+  .pp-budget, .pp-usage {
+    margin-top: 0.25rem;
+    color: var(--text-secondary);
+  }
+  .pp-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-top: 0.3rem;
+  }
+  .pp-badge {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.05rem 0.4rem;
+    font-size: 0.7rem;
+    color: var(--text-primary);
+  }
+  .pp-badge.pp-warn { color: var(--blocked); border-color: var(--blocked); }
+  .pp-extra {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.9rem;
+    margin-top: 0.3rem;
+    color: var(--text-secondary);
+  }
+  .pp-empty { color: var(--text-dim); font-style: italic; }
   .panel-close {
     background: none;
     border: none;
@@ -506,7 +639,7 @@
     <span class="chip blocked">blocked <strong id="chip-blocked">0</strong></span>
     <span class="chip">recent <strong id="chip-recent">0</strong></span>
     <span class="chip" title="Claude Code CLI sessions (shown as boxes)">cc <strong id="chip-cc">0</strong></span>
-    <span class="chip spend" title="API-billed spend: only LifeOS agent worker sessions (Claude Code CLI uses your subscription, not the API)">API spend <strong id="chip-spend">$0.00</strong></span>
+    <span class="chip spend" title="API-billed spend: only LifeOS agent worker sessions (Claude Code CLI uses your subscription, not the API).">API spend <strong id="chip-spend">$0.00</strong></span>
     <span class="chip legend" title="Node shapes: circle = LifeOS agent worker · square = Claude Code CLI · diamond = Task-tool subagent">
       <span style="opacity:0.6">●</span> agent &nbsp;
       <span style="opacity:0.6">■</span> cli &nbsp;
@@ -617,25 +750,51 @@
   // nodes don't get clipped at the edges. The viewBox is the *intended*
   // window; physics may briefly nudge nodes beyond it.
   svg.style('overflow', 'visible');
-  // Arrow marker for spawn edges (parent → subagent).
-  svg.append('defs').append('marker')
-    .attr('id', 'arrow-head')
-    .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 16).attr('refY', 0)
-    .attr('markerWidth', 7).attr('markerHeight', 7)
-    .attr('orient', 'auto')
-    .append('path').attr('d', 'M0,-5L10,0L0,5').attr('fill', '#3a3a4a');
-  const linkLayer = svg.append('g').attr('class', 'links');
-  const nodeLayer = svg.append('g').attr('class', 'nodes');
+  // Single zoomable viewport that wraps both layers — the d3.zoom behavior
+  // mutates this group's transform, mirroring /crm/graph (crm.html:17528).
+  const viewport = svg.append('g').attr('class', 'viewport');
+  const linkLayer = viewport.append('g').attr('class', 'links');
+  const nodeLayer = viewport.append('g').attr('class', 'nodes');
+
+  // Pan (drag background) + zoom (wheel / pinch). d3.drag on nodes stops
+  // propagation, so node-drags don't also pan the canvas.
+  const zoom = d3.zoom()
+    .scaleExtent([0.2, 5])
+    .on('zoom', (event) => {
+      viewport.attr('transform', event.transform);
+    });
+  svg.call(zoom);
+  // Match crm.html: cursor hint on the background so the operator knows it's
+  // pannable. Node cursors override this when hovering a draggable node.
+  svg.style('cursor', 'grab');
+  svg.on('mousedown.cursor', () => svg.style('cursor', 'grabbing'));
+  svg.on('mouseup.cursor',   () => svg.style('cursor', 'grab'));
+
+  // Click on empty SVG background → deselect (mirrors /crm/graph's
+  // close-panels-on-empty-click pattern at crm.html:17522). Node clicks bubble
+  // up too, but we only act when the target is the svg itself.
+  svg.on('click', (event) => {
+    if (event.target === svg.node() && selectedSessionId) closePanel();
+  });
+
+  // Width fraction of the viewBox used by the recency rail. Scales with the
+  // visible-node count: 1 node centers, 2 nodes sit on a narrow band, many
+  // nodes spread across most of the canvas.
+  let visibleCount = 0;
+  function recencyRailSpan() {
+    if (visibleCount <= 1) return 0;
+    return Math.min(0.84, 0.15 + 0.15 * Math.log2(visibleCount));
+  }
 
   // Map session.last_activity_at → x in viewBox coords. Newer to the right,
-  // older to the left, clamped at 24h. Used as a soft `forceX` target —
-  // repulsion can still spread same-recency nodes.
+  // older to the left, clamped at 24h. Width of the rail shrinks as
+  // visibleCount shrinks so single-node filters end up centered.
   function recencyTargetX(s) {
+    const span = recencyRailSpan();
     const nowSec = Date.now() / 1000;
     const ageSec = Math.max(0, nowSec - (s.last_activity_at || nowSec));
     const ageNorm = Math.min(ageSec, 86400) / 86400;
-    return VIEW_W * (0.92 - ageNorm * 0.84);  // newer → ~0.92*W, old → ~0.08*W
+    return VIEW_W * (0.5 + span / 2 - ageNorm * span);
   }
 
   // Force simulation. Constants chosen to mirror /crm/graph's settled feel:
@@ -850,7 +1009,7 @@
     linkLayer.selectAll('path.link')
       .data(visibleLinks, d => d.id)
       .join(
-        enter => enter.append('path').attr('class', 'link').attr('marker-end', 'url(#arrow-head)'),
+        enter => enter.append('path').attr('class', 'link'),
         update => update,
         exit => exit.remove()
       );
@@ -877,8 +1036,25 @@
 
     const entered = sel.enter().append('g')
       .attr('class', 'node')
-      .style('cursor', 'pointer')
-      .on('click', (event, d) => openPanel(d.session_id));
+      .style('cursor', 'grab')
+      .call(d3.drag()
+        .on('start', (event, d) => {
+          if (!event.active) simulation.alphaTarget(0.1).restart();
+          d.fx = d.x;
+          d.fy = d.y;
+        })
+        .on('drag', (event, d) => {
+          d.fx = event.x;
+          d.fy = event.y;
+        })
+        .on('end', (event, d) => {
+          if (!event.active) simulation.alphaTarget(0);
+          // Leave fx/fy set so the node stays where dropped (mirrors /crm/graph).
+        }))
+      .on('click', (event, d) => {
+        if (d.session_id === selectedSessionId) closePanel();
+        else openPanel(d.session_id);
+      });
     // One shape element per node, type chosen by source.
     entered.append(d => document.createElementNS('http://www.w3.org/2000/svg', nodeShapeTag(d)))
       .attr('class', 'node-shape');
@@ -896,7 +1072,10 @@
 
     // Feed the merged node array + links into the simulation. `alpha(0.3)`
     // is enough to spread new nodes without throwing the whole layout
-    // around; existing nodes already have stable (x, y).
+    // around; existing nodes already have stable (x, y). visibleCount
+    // feeds `recencyRailSpan()` so the rail compresses to center when few
+    // nodes are visible.
+    visibleCount = merged.length;
     simulation.nodes(merged);
     simulation.force('link').links(visibleLinks);
     simulation.alpha(0.3).restart();
@@ -904,6 +1083,55 @@
     emptyStateEl.style.display = visible.length === 0 ? '' : 'none';
     updateChips(visible);
     updateCwdOptions(allSessions);
+    applySelectionStyles();
+  }
+
+  // Pull session_id off a link endpoint regardless of whether the force-link
+  // pass has converted it from a string id into a node object yet.
+  function linkEndpoints(e) {
+    const s = (typeof e.source === 'object') ? e.source.session_id : e.source;
+    const t = (typeof e.target === 'object') ? e.target.session_id : e.target;
+    return [s, t];
+  }
+
+  // 1-hop parent/child set for the currently selected session.
+  function relatedTo(sessionId) {
+    const out = new Set();
+    if (!sessionId) return out;
+    linkLayer.selectAll('path.link').each(function(e) {
+      const [s, t] = linkEndpoints(e);
+      if (s === sessionId) out.add(t);
+      if (t === sessionId) out.add(s);
+    });
+    return out;
+  }
+
+  // Toggle .selected / .related / .dimmed across the visible nodes + edges
+  // based on `selectedSessionId`. Cheap to re-run on every render and panel
+  // open/close — no allocations per node beyond the related set.
+  function applySelectionStyles() {
+    const hasSelection = !!selectedSessionId;
+    const related = relatedTo(selectedSessionId);
+
+    nodeLayer.selectAll('.node-shape')
+      .classed('selected', d => hasSelection && d.session_id === selectedSessionId)
+      .classed('related',  d => hasSelection && related.has(d.session_id))
+      .classed('dimmed',   d => hasSelection && d.session_id !== selectedSessionId && !related.has(d.session_id));
+
+    nodeLayer.selectAll('text.node-label')
+      .classed('dimmed', d => hasSelection && d.session_id !== selectedSessionId && !related.has(d.session_id));
+
+    linkLayer.selectAll('path.link')
+      .classed('highlighted', e => {
+        if (!hasSelection) return false;
+        const [s, t] = linkEndpoints(e);
+        return s === selectedSessionId || t === selectedSessionId;
+      })
+      .classed('dimmed', e => {
+        if (!hasSelection) return false;
+        const [s, t] = linkEndpoints(e);
+        return s !== selectedSessionId && t !== selectedSessionId;
+      });
   }
 
   function updateChips(sessions) {
@@ -1189,6 +1417,7 @@
     eventKindFilter = null;
     if (transcriptES) { transcriptES.close(); transcriptES = null; }
     panelEl.innerHTML = '<div class="panel-empty" id="panel-empty">Click a node to inspect its transcript.</div>';
+    applySelectionStyles();
   }
 
   function openPanel(sessionId) {
@@ -1196,6 +1425,7 @@
     // Reset filter when switching sessions — kinds are session-scoped.
     eventKindFilter = null;
     selectedSessionId = sessionId;
+    applySelectionStyles();
     const s = allSessions.find(x => x.session_id === sessionId);
     if (!s) return;
     renderPanelHeader(s);
@@ -1254,6 +1484,149 @@
     return `${date} ${time} ET`;
   }
 
+  // Compact 1.3k / 500k / 1.2M for token counts and similar.
+  function formatNumCompact(n) {
+    const x = Number(n);
+    if (!isFinite(x)) return String(n);
+    if (Math.abs(x) >= 1_000_000) return (x / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+    if (Math.abs(x) >= 1_000)     return (x / 1_000).toFixed(1).replace(/\.0$/, '') + 'k';
+    return String(x);
+  }
+
+  // Field-aware payload renderer. Maps the most common transcript-event
+  // shapes (model responses, routing decisions, tool calls, errors, etc.)
+  // to compact human-readable HTML. Anything unrecognized falls through to
+  // a generic key/value tail, and the full raw JSON is always available
+  // via click-to-expand for diagnostics.
+  const NOISE_FIELDS = new Set([
+    'iterations', 'inference_geo', 'server_tool_use', 'cache_creation',
+    'ephemeral_1h_input_tokens', 'ephemeral_5m_input_tokens',
+    'thinking_chars',  // surfaced separately when nonzero
+  ]);
+  const SECONDARY_BADGES = ['model', 'task_id', 'expected_output', 'speed', 'service_tier', 'source', 'parent_session_id', 'child_session_id'];
+
+  function prettyPayload(payload) {
+    if (payload == null) return '';
+    if (typeof payload !== 'object') {
+      return `<div class="pp-text">${escapeHtml(String(payload))}</div>`;
+    }
+    const parts = [];
+
+    // Routing decision (routing_resolved et al.)
+    if (payload.routing) {
+      let s = `<div class="pp-routing">→ <span class="pp-target">${escapeHtml(String(payload.routing))}</span>`;
+      if (payload.routing_reason) s += ` <span class="pp-reason">· ${escapeHtml(payload.routing_reason)}</span>`;
+      s += `</div>`;
+      parts.push(s);
+    }
+
+    // Primary text body. `text` empty + `tool_uses` present is the common
+    // assistant-called-tools case — surface that explicitly.
+    if (typeof payload.text === 'string' && payload.text.trim()) {
+      parts.push(`<div class="pp-text">${escapeHtml(payload.text)}</div>`);
+    } else if (payload.text === '' && Array.isArray(payload.tool_uses) && payload.tool_uses.length) {
+      parts.push(`<div class="pp-text muted">(no text — called tools)</div>`);
+    }
+
+    // Tool uses → pills with name + arg keys.
+    if (Array.isArray(payload.tool_uses) && payload.tool_uses.length) {
+      const tools = payload.tool_uses.map(t => {
+        const name = t && t.name ? String(t.name) : 'tool';
+        const argKeys = Array.isArray(t && t.input_keys)
+          ? t.input_keys
+          : (t && t.input && typeof t.input === 'object' ? Object.keys(t.input) : []);
+        const argStr = argKeys.length ? `<span class="pp-tool-args">(${escapeHtml(argKeys.join(', '))})</span>` : '';
+        return `<span class="pp-tool"><span class="pp-tool-name">${escapeHtml(name)}</span>${argStr}</span>`;
+      }).join('');
+      parts.push(`<div class="pp-tools">${tools}</div>`);
+    }
+
+    // Labeled freeform fields — render in this order so the reader sees the
+    // semantically most useful info first.
+    const TEXT_FIELDS = [
+      ['question', 'question'],
+      ['answer', 'answer'],
+      ['prompt', 'prompt'],
+      ['reason', 'reason'],
+      ['ambiguity', 'ambiguity'],
+      ['sane_reason', 'sane reason'],
+      ['description', 'description'],
+      ['label', 'label'],
+    ];
+    for (const [field, label] of TEXT_FIELDS) {
+      const v = payload[field];
+      if (typeof v === 'string' && v.trim()) {
+        parts.push(`<div class="pp-field"><span class="pp-label">${escapeHtml(label)}</span><span class="pp-value">${escapeHtml(v)}</span></div>`);
+      }
+    }
+
+    // Budget — compact "90s · $0.30 · 500k tok"
+    if (payload.budget && typeof payload.budget === 'object') {
+      const b = payload.budget;
+      const bits = [];
+      if (b.wall_seconds != null)  bits.push(`${b.wall_seconds}s`);
+      if (b.max_dollars != null)   bits.push(`$${Number(b.max_dollars).toFixed(2)}`);
+      if (b.max_tokens != null)    bits.push(`${formatNumCompact(b.max_tokens)} tok`);
+      if (bits.length) parts.push(`<div class="pp-budget"><span class="pp-label">budget</span>${escapeHtml(bits.join(' · '))}</div>`);
+    }
+
+    // Usage — compact "↓ 1 in · ↑ 1.3k out · cache 400k read / 199 create"
+    if (payload.usage && typeof payload.usage === 'object') {
+      const u = payload.usage;
+      const bits = [];
+      if (u.input_tokens != null)  bits.push(`↓ ${formatNumCompact(u.input_tokens)} in`);
+      if (u.output_tokens != null) bits.push(`↑ ${formatNumCompact(u.output_tokens)} out`);
+      const cacheR = u.cache_read_input_tokens;
+      const cacheC = u.cache_creation_input_tokens;
+      if (cacheR || cacheC) {
+        const cb = [];
+        if (cacheR) cb.push(`${formatNumCompact(cacheR)} read`);
+        if (cacheC) cb.push(`${formatNumCompact(cacheC)} create`);
+        bits.push(`cache ${cb.join(' / ')}`);
+      }
+      if (bits.length) parts.push(`<div class="pp-usage"><span class="pp-label">usage</span>${escapeHtml(bits.join(' · '))}</div>`);
+    }
+
+    // Thinking chars (only if nonzero — when zero it's pure noise).
+    if (typeof payload.thinking_chars === 'number' && payload.thinking_chars > 0) {
+      parts.push(`<div class="pp-field"><span class="pp-label">thinking</span><span class="pp-value">${formatNumCompact(payload.thinking_chars)} chars</span></div>`);
+    }
+
+    // Scalar badges (model, task_id, etc.)
+    const badges = [];
+    for (const f of SECONDARY_BADGES) {
+      const v = payload[f];
+      if (v != null && typeof v !== 'object') {
+        badges.push(`<span class="pp-badge"><span class="pp-label">${escapeHtml(f.replace(/_/g, ' '))}</span>${escapeHtml(String(v))}</span>`);
+      }
+    }
+    if (payload.sane === false) {
+      badges.push(`<span class="pp-badge pp-warn">not sane</span>`);
+    }
+    if (badges.length) parts.push(`<div class="pp-badges">${badges.join('')}</div>`);
+
+    // Anything else (scalar tail) — fields we didn't explicitly handle.
+    const handled = new Set([
+      'routing', 'routing_reason', 'text', 'tool_uses',
+      ...TEXT_FIELDS.map(t => t[0]),
+      'budget', 'usage', 'thinking_chars',
+      ...SECONDARY_BADGES, 'sane',
+      ...NOISE_FIELDS,
+    ]);
+    const remainder = Object.entries(payload).filter(([k, v]) =>
+      !handled.has(k) && v != null
+      && (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
+    );
+    if (remainder.length) {
+      const items = remainder.map(([k, v]) =>
+        `<span class="pp-kv"><span class="pp-label">${escapeHtml(k.replace(/_/g, ' '))}</span>${escapeHtml(String(v))}</span>`
+      ).join('');
+      parts.push(`<div class="pp-extra">${items}</div>`);
+    }
+
+    return parts.length ? parts.join('') : `<div class="pp-empty">(no fields)</div>`;
+  }
+
   // appendEvent always renders newest-on-top so backfill and live additions
   // share the same visual order. Backfill is delivered oldest-first, so we
   // prepend each one as it arrives, leaving the chronologically-newest event
@@ -1263,8 +1636,9 @@
     if (!container) return;
     const kind = String(ev.kind || '');
     const ts = formatTs(ev.ts);
-    const payload = ev.payload ? JSON.stringify(ev.payload, null, 0) : '';
-    const truncated = payload.length > 240 ? payload.slice(0, 240) + '…' : payload;
+    const payload = ev.payload || null;
+    const prettyHtml = payload ? prettyPayload(payload) : '';
+    const rawJson = payload ? JSON.stringify(payload, null, 2) : '';
     const div = document.createElement('div');
     // classList.add validates token shape — defense-in-depth even though
     // `kind` is server-controlled today.
@@ -1276,7 +1650,8 @@
     }
     div.innerHTML = `
       <div><span class="kind" role="button" tabindex="0" title="Click to filter to this event type">${escapeHtml(kind)}</span><span class="ts">${escapeHtml(ts)}</span></div>
-      ${payload ? `<div class="payload" data-full="${escapeHtml(payload)}" title="Click to expand">${escapeHtml(truncated)}</div>` : ''}
+      ${prettyHtml ? `<div class="payload" title="Click to expand">${prettyHtml}</div>` : ''}
+      ${rawJson ? `<pre class="payload-raw">${escapeHtml(rawJson)}</pre>` : ''}
     `;
     // Hide the event up front if a filter is active and doesn't match.
     if (eventKindFilter && kind !== eventKindFilter) {
@@ -1296,20 +1671,12 @@
         }
       });
     }
-    // Click anywhere else on the event → toggle expanded (full text + white).
+    // Click anywhere else on the event → toggle expanded (reveals raw JSON).
     div.addEventListener('click', e => {
-      if (e.target.closest('.kind')) return;  // kind label owns its click
-      toggleEventExpanded(div, payload, truncated);
+      if (e.target.closest('.kind')) return;
+      div.classList.toggle('expanded');
     });
     container.prepend(div);
-  }
-
-  function toggleEventExpanded(eventEl, fullText, truncatedText) {
-    const payloadEl = eventEl.querySelector('.payload');
-    const expanded = eventEl.classList.toggle('expanded');
-    if (payloadEl) {
-      payloadEl.textContent = expanded ? fullText : truncatedText;
-    }
   }
 
   function toggleKindFilter(kind) {
@@ -1357,18 +1724,27 @@
   }
 
   // --- Filters ---
+  // Release any drag-pinned positions so the new visible set lays out from
+  // the recency rail / center forces instead of frozen drop points.
+  function releasePins() {
+    nodeLayer.selectAll('.node').each(function(d) { d.fx = null; d.fy = null; });
+  }
+  function onFilterChange() {
+    releasePins();
+    renderGraph(allSessions, allEdges);
+  }
   filterTerminalEl.addEventListener('change', () => {
     applyRecencyDefault();
-    renderGraph(allSessions, allEdges);
+    onFilterChange();
   });
   if (filterRecencyEl) {
     filterRecencyEl.addEventListener('change', () => {
       recencyManuallySet = true;
-      renderGraph(allSessions, allEdges);
+      onFilterChange();
     });
   }
   [filterRouteEl, filterStatusEl, filterCwdEl].filter(Boolean).forEach(el =>
-    el.addEventListener('change', () => renderGraph(allSessions, allEdges))
+    el.addEventListener('change', onFilterChange)
   );
 
   // --- Side panel resize ---


### PR DESCRIPTION
## Summary

Two intertwined improvements to the `/agents` page:

- **Graph UX**: node dragging, canvas pan/zoom, selection styling, edges without arrowheads, structured (non-JSON) transcript event rendering, click-to-deselect, recency rail that re-centers for small visible sets.
- **Cost fix**: Anthropic's Managed Agents `/v1/sessions/{id}` endpoint returns `cache_creation` as a **nested** object (`{ephemeral_5m_input_tokens, ephemeral_1h_input_tokens}`), not the flat `cache_creation_input_tokens` key the parser looked for. Result: cache_creation cost was silently booked as $0 on every managed session. After today's parser fix + the new backfill script, this repo's `API spend` chip jumped from **$1.15 → $26.63**, matching the Claude platform's reported spend within rounding.

## What changed

### `web/agents.html`
- Per-node `d3.drag` with `fx`/`fy` pinning; drop position survives snapshot ticks, cleared on filter change so the new visible set reflows.
- `d3.zoom` (0.2×–5×) on a new `viewport` `<g>` wrapping link/node layers; empty-background click closes the panel.
- Selection styling: selected node = 5px white border (overrides `.pulsing`), 1-hop parent/child neighbors = 3px translucent white, everything else = 0.28 opacity. Edges adjacent to the selection brighten to white.
- Edge arrowheads removed (and bright/dark marker swap with them).
- Click an already-selected node, the `×`, or empty background → deselect + close.
- Recency rail width scales with visible-node count via `recencyRailSpan()` (1 → 0, 2 → ~0.30·W, log-growth to 0.84·W at 32+).
- New `prettyPayload()` formatter for transcript events: routing decision (`→ claude · ...`), assistant text + tool-call pills (`Name(arg, arg)`), labeled text fields (`question`, `answer`, `prompt`, `reason`, `ambiguity`, `sane_reason`), compact `budget` (`90s · $0.30 · 500k tok`) and `usage` (`↓ in · ↑ out · cache read/create`) lines, scalar badges (`model`, `task_id`, `expected_output`, `speed`, `service_tier`, `source`, parent/child ids), `not sane` warning badge, scalar tail for the long-tail of unrecognized fields. Noisy fields suppressed (`iterations`, nested ephemeral cache buckets, `inference_geo`, `server_tool_use`, zero `thinking_chars`). Click-to-expand reveals raw JSON beneath for diagnostics.

### `api/services/agent_worker/managed_driver.py`
- New `_extract_cache_creation_tokens(usage)` handles both the live nested shape and the legacy flat key. Wired into `get_session_state`. Both ephemeral_5m and ephemeral_1h are summed (1h was 0 in observed responses; pricing.py only encodes the 1.25× multiplier today — refining the split is a follow-up if 1h-cache usage becomes non-trivial).
- New test asserts the nested shape parses correctly (`ephemeral_5m + ephemeral_1h` summed into `total_cache_creation_tokens`).

### `scripts/backfill_managed_session_costs.py` (new)
- One-shot script. Re-polls Anthropic for every session with a `managed_agent_session_id` and overwrites the four token counters + `total_dollars`. Includes wall-time session-hour overhead via `managed_session_cost()`. Dry-run by default; `--execute` to apply. Skips sessions whose remote returns 404 (Anthropic-side deletion) without clobbering their stored numbers.
- Already applied on this machine: 18 sessions updated, 2 deleted-remote skipped, $1.15 → $26.63.

### Docs
- `docs/specs/product/agent-viz.md`: added "Canvas controls" subsection (drag, pan, zoom, click-to-deselect), updated side-panel description for structured payloads, noted edges no longer carry arrowheads and that the recency rail compresses for small visible sets.
- `docs/specs/technical/agent-viz.md`: added "Interaction model" + "Transcript event rendering" subsections covering d3.zoom/viewport, d3.drag pinning + filter-change pin release, `applySelectionStyles()`, and `prettyPayload()`. Updated the `recency-x` row in the force-tuning table.

## Test plan

- [x] `tests/test_agent_worker_managed_driver.py` — 38 tests pass, new nested-cache test asserts the bug is fixed.
- [x] Full unit suite — 1559 passed (pre-push hook). The 4 pre-existing failures on full `./scripts/test.sh` (`test_p91_data_integrity` ×2, `test_settings.test_local_llm_*`) are unrelated to this change.
- [x] Backfill dry-run + execute against the live Anthropic API — totals match platform spend.
- [ ] Manual: drag a node, drag the background to pan, scroll to zoom, click a node to see selection styling + connected highlighting, click the same node again to deselect, click background to deselect, change filters and confirm pins reset, expand a transcript event to see raw JSON beneath the pretty view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)