### PR TITLE
docs(adr): ADR-012 — embedding pipeline (GPU + CPU fallback + OOM protection)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,384 @@
+# Documentation Strategy
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+
+**This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
+
+## Purpose
+
+This strategy defines how we organize and maintain documentation in LifeOS. These are **rules, not guidelines** — following this strategy faithfully is critical to maintaining documentation quality across a collaborative human + AI agent project.
+
+Documentation in LifeOS serves two readers equally:
+- **Human contributors** who need to onboard, debug, and design changes.
+- **AI agents** (Claude Code, Cursor, Copilot, etc.) that load docs as context when working on the codebase.
+
+Both readers benefit from the same things: short, focused documents; explicit decisions; cross-links instead of duplication; and an unambiguous answer to "where does this kind of information live?"
+
+## Core Principles
+
+1. **Living documents over proposals** — Design docs evolve during implementation rather than being written once and frozen. Update when thinking changes, not when tasks complete.
+2. **Modular over monolithic** — Split documents by concern, not by phase or role. A 1,800-line spec is a symptom, not a feature.
+3. **Cross-linked over isolated** — Documents reference related docs with a short tagline explaining the relationship, not just a link.
+4. **Concise over comprehensive** — Each document has a clear scope; prefer multiple focused docs over one sprawling one.
+5. **Consistent over creative** — Follow established patterns and structures. Consistency makes documentation predictable and navigable.
+6. **AI-readable** — Be succinct, specific, and clear. Prefer shorter, well-named documents over longer ones. Don't overexplain, but make requirements and decisions explicit.
+7. **Single source of truth** — Default to keeping each piece of information in exactly one authoritative location; other documents link to it rather than repeating it. When in doubt about where something belongs, consult the [Content Classification table](#content-classification). When you find duplication, prefer consolidating to the authoritative location and replacing duplicates with cross-references.
+
+## Document Taxonomy
+
+```
+docs/
+├── AGENTS.md          # THIS FILE (documentation strategy)
+├── CLAUDE.md          # @AGENTS.md wrapper
+├── vision/            # WHY — project vision, philosophy
+├── specs/
+│   ├── product/       # WHAT — features, API contracts, data models (consumer perspective)
+│   ├── technical/     # HOW (design) — architecture, schema, security, infrastructure
+│   └── standards/     # HOW (work) — coding conventions, testing standards, naming rules
+├── adr/               # WHY (decisions) — immutable architecture decision records
+├── guides/            # HOW (do) — step-by-step operational instructions
+├── plans/             # WHEN — active execution work, ephemeral (gitignored)
+└── archive/           # HISTORY — superseded documents (gitignored)
+```
+
+### Vision Documents
+
+**Location:** `docs/vision/`
+**Purpose:** Vision, philosophy, and strategic direction — the WHY behind LifeOS
+**Updated:** When strategy changes (rarely)
+
+Vision docs provide foundational context that frames every design decision. For LifeOS, that's primarily the privacy-first, local-first, single-user posture — see [philosophy.md](vision/philosophy.md).
+
+### Specifications
+
+**Location:** `docs/specs/`
+**Purpose:** Design documents describing WHAT the system is/should be (target state)
+**Updated:** When the design evolves
+
+**Key principle:** Specs are the **vision** — the authoritative design for the system. Not implementation plans, not progress tracking, not task lists. They describe the intended architecture and behavior.
+
+"Living" means the spec updates when *the design* changes, not when *tasks* complete.
+
+- `product/` — What the system does from a consumer perspective. Feature behavior, API contracts, data model semantics. Answers: "What does this entity mean? What can you do with this endpoint?"
+- `technical/` — How the system is built from an engineering perspective. Architecture, schema, security implementation, query optimization. Answers: "How is this implemented? What constraints did we hit?"
+- `standards/` — Rules and conventions for how we work. Coding standards, naming conventions, testing patterns. Answers: "What conventions must we follow?"
+
+### Architecture Decision Records (ADRs)
+
+**Location:** `docs/adr/`
+**Purpose:** Immutable records of significant architectural decisions with context and rationale
+**Updated:** Never. ADRs are append-only — create a new ADR to supersede an old one. The only acceptable in-place edit is adding an `Amended by: ADR-NNN` or `Superseded By: ADR-NNN` pointer to the frontmatter.
+
+**Naming:** `NNN-short-title.md` (e.g., `008-managed-agents-cloud-routing.md`). Sequential numbering. Never reuse numbers.
+
+ADRs live at the top level (not under `specs/`) because they span product and technical concerns. A decision about data model semantics is as load-bearing as one about database engines.
+
+### Operational Guides
+
+**Location:** `docs/guides/`
+**Purpose:** Step-by-step instructions for specific operator and contributor tasks
+**Updated:** When procedures change
+
+Guides are instructional — they tell you how to do something, not why it's designed that way. If a guide starts explaining design rationale, that content belongs in a spec or ADR.
+
+### Plans
+
+**Location:** `docs/plans/` (gitignored — personal/active planning notes)
+**Purpose:** Active execution work — phases, tasks, roadmaps, backlogs
+
+Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. For trackable work, prefer GitHub issues; for personal planning, use the local `docs/plans/` directory.
+
+### Archive
+
+**Location:** `docs/archive/` (gitignored)
+**Purpose:** Superseded documents, audit notes, and historical investigation working notes retained for local context.
+
+Archive content is **not** part of the public repo. When a durable insight from an archived doc is still load-bearing, promote it: link to the relevant live spec, or extract the durable conclusion into an ADR.
+
+## Content Classification
+
+| Content Type | Belongs In | Anti-Pattern |
+|---|---|---|
+| Project vision, philosophy, strategy | `vision/` | Not in specs (too stable, too abstract) |
+| User-facing feature behavior, API contracts, data model semantics | `specs/product/` | No implementation details, no task lists |
+| Architecture, system design, schema, query design, security implementation | `specs/technical/` | No roadmaps, no "Next Steps" |
+| Coding conventions, naming rules, testing patterns | `specs/standards/` | Not in guides (standards prescribe, guides instruct) |
+| Architectural decisions with rationale and alternatives | `adr/` | Never modify after acceptance — create a new ADR to supersede |
+| Setup procedures, troubleshooting, operator how-to | `guides/` | Not design rationale |
+| Phases, tasks, roadmaps, checklists | `plans/` (or GitHub issues) | Don't put in specs |
+| Audit notes, investigation working files, superseded docs | `archive/` | Don't link from live specs unless promoting a specific insight |
+
+**Rule of thumb:** "Why do we build this?" → vision. "What should it be?" → product spec. "How is it built?" → technical spec. "Why did we decide?" → ADR. "How do I do X?" → guide. "When/how do we get there?" → plan.
+
+**LifeOS-specific classification:**
+- Data model semantics (what entities mean, relationships between them) → `specs/product/data-model.md`
+- Data model implementation (SQLite schema, ChromaDB collections, indexes) → `specs/technical/`
+- API contracts (consumer perspective, request/response shapes) → `specs/product/api-reference.md`
+- API internals (route-handler structure, middleware, error handling) → `specs/technical/`
+- Privacy/security design decisions → `specs/technical/security-privacy.md`, with corresponding ADRs for the underlying decisions
+
+## Frontmatter Standards
+
+Every document must have frontmatter:
+
+```markdown
+**Status:** Draft | Partial | Complete
+**Last Updated:** YYYY-MM-DD
+```
+
+**Additional fields by document type:**
+
+| Type | Additional Fields |
+|---|---|
+| ADR | `**Decision:** Accepted \| Superseded \| Deprecated` and (if applicable) `**Superseded By:** ADR-NNN` or `**Amended by:** ADR-NNN` |
+| Product Spec | `**Owner:** name-or-area` |
+| Technical Spec | `**Owner:** name-or-area` |
+| Guide | `**Audience:** Operator \| Contributor \| New users` |
+| Plan | `**Target Date:** YYYY-MM-DD` (or `Ongoing`); `**Completed:** YYYY-MM-DD` when archived |
+
+`Status` values:
+- **Draft** — Initial draft, not yet reviewed; may have gaps or open questions.
+- **Partial** — Some sections complete, others marked TODO; safe to read for the parts that exist.
+- **Complete** — Reviewed, accurate as of `Last Updated`, no known gaps.
+
+For ADRs, `Status` reflects document completeness; `Decision` reflects whether the decision is still in force.
+
+## ADR Template
+
+ADRs use the following structure. The retrofit issue (#182) brought existing ADRs into this shape; all new ADRs must follow it.
+
+```markdown
+# ADR-NNN: Short Title
+
+**Status:** Complete
+**Last Updated:** YYYY-MM-DD
+**Decision:** Accepted
+**Superseded By:** ADR-NNN  (only if applicable)
+**Amended by:** ADR-NNN     (only if applicable)
+
+## Context
+
+The situation, constraints, and forces at the time of the decision. Why this needed to be decided now.
+
+## Decision
+
+One unambiguous statement of what was chosen. No hedging.
+
+## Rationale
+
+Why this choice over the alternatives. Tie back to the constraints in Context.
+
+## Alternatives Considered
+
+Each alternative as its own subsection with a one-paragraph description and an explicit "Rejected because..." line. Recover alternatives from PR descriptions, commit messages, or memory. Where you genuinely don't remember, write "to be filled in by the original decider" rather than fabricating.
+
+### Alternative A
+
+Description.
+
+**Rejected because:** specific reason.
+
+## Consequences
+
+### Positive
+
+- Specific benefits this decision enables.
+
+### Negative
+
+- Specific costs, ongoing maintenance burden, or constraints this decision imposes.
+
+## Related Documents
+
+(Use the 4-bucket Related Documents structure described below.)
+```
+
+## Length Guidelines
+
+Not rigid rules, but signals for document health. When a doc passes the "max" column it should be split by concern.
+
+| Document Type | Target Lines | Max Lines |
+|---|---|---|
+| ADR | 200–500 | 800 |
+| Product Spec | 300–700 | 800 |
+| Technical Spec | 400–800 | 1,000 |
+| Standards | 200–500 | 700 |
+| Vision | 300–600 | 800 |
+| Guide | 200–500 | 800 |
+| Plan | Variable | — |
+
+**Split when:**
+- Document exceeds the Max in its column.
+- It covers multiple distinct concerns (e.g., one CRM spec covering people, interactions, graph, analytics).
+- Different readers need different sections.
+- Table of contents has more than ~8 top-level sections.
+
+When splitting, keep a thin **index document** at the original path with pointers to each split and a short overview. Update all inbound links to point at the right split.
+
+## Cross-Linking Standards
+
+Every document must include a "Related Documents" section at the bottom.
+
+**Requirements:**
+1. **Bidirectional** — if A links to B, B must link to A. When you add a link in one direction, add the reciprocal link in the same PR.
+2. **Contextual** — every link has a "— short tagline" explaining the relationship.
+3. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
+4. **Use the 4-bucket structure** below for consistency.
+
+**Standard Related Documents template:**
+
+```markdown
+## Related Documents
+
+### Design Context
+- [ADR-NNN: Decision Name](../adr/NNN-title.md) — Why this approach was chosen
+- [Vision: Philosophy](../vision/philosophy.md) — The principle behind this
+
+### Specifications
+- [Product Spec](../specs/product/feature.md) — Consumer-facing requirements
+- [Technical Spec](../specs/technical/component.md) — Implementation design
+
+### Operational
+- [Setup Guide](../guides/feature-setup.md) — How to configure this
+- [Configuration](../guides/configuration.md) — Env var reference
+
+### Code References
+- [Implementation](../../api/services/foo.py:45-120) — Production code
+- [Tests](../../tests/test_foo.py) — Coverage
+```
+
+Use only the buckets that apply — omit empty buckets rather than including them as `(none)`.
+
+## Lifecycle Rules
+
+**Specs are living:**
+- Update when the design changes, not when tasks complete.
+- If a spec describes a target that's not yet built, the `Status: Partial` value is appropriate.
+- Specs are not changelogs. Don't add "Added X in PR #N" notes; that's what `git log` and `git blame` are for.
+
+**Plans are ephemeral:**
+- A plan ends as either "completed" (move to `archive/` with `Completed: YYYY-MM-DD`) or "superseded" (note the successor and move to `archive/`).
+- Do not leave stale plans in `docs/plans/`.
+
+**ADRs are immutable:**
+- Never modify the Context / Decision / Rationale / Alternatives sections of an accepted ADR.
+- To change a decision, create a new ADR. The old ADR gets `Superseded By: ADR-NNN` added to its frontmatter — that's the only acceptable in-place edit.
+- For a smaller change (clarification, scoping refinement that doesn't reverse the decision), the new ADR is an *amendment* and the old ADR gets `Amended by: ADR-NNN`.
+
+**Guides decay:**
+- Test commands you document before shipping. Stale guides are worse than missing guides.
+
+## Writing for AI Readability
+
+Documentation is frequently consumed by AI agents during development. Optimize for:
+
+**Clarity:**
+- State requirements explicitly. Avoid "should consider" — say "do" or "don't" or "defer because X".
+- Use precise technical terminology (route handler, span, collection) rather than vague nouns.
+- Avoid ambiguous pronouns; prefer specific nouns even at the cost of repetition.
+
+**Structure:**
+- Well-named sections that match their content. A section labeled "Notes" is a smell.
+- Frontmatter with status and metadata at the top.
+- Tables when they sharpen a comparison; prose otherwise.
+
+**Brevity:**
+- Shorter, focused documents over long comprehensive ones.
+- Link to details rather than repeating them.
+- Keep documents focused on one concern so agents don't waste context loading irrelevant content.
+
+**Anti-patterns:**
+- Long narrative explanations when a bulleted list suffices.
+- Repeating context already in linked documents.
+- Vague statements like "we should consider" (instead: decided yes/no, or defer with reason).
+- Burying key decisions in prose.
+
+## LifeOS-Specific Rules
+
+### Privacy-First Documentation
+
+LifeOS handles deeply personal data — emails, messages, photos, finances. Documentation must not become a leak vector.
+
+- **Use obviously synthetic data in all examples and test fixtures.** Names like "Alex Chen", domains like `example.com`, phone numbers like `555-0123`, dollar amounts like `$1,234.56`. No real names, emails, phone numbers, or financial values, even in commit-message screenshots.
+- **Security-sensitive implementation details belong in code, not docs.** Reference the code (with line numbers) rather than restating encryption keys, auth tokens, or exact connection strings.
+- **Technical specs involving data storage or access** should include a "Privacy Considerations" subsection or link to one in `specs/technical/security-privacy.md`.
+- **Don't paste real terminal output** containing real personal data into docs. Sanitize first.
+
+### Open-Source Posture
+
+LifeOS is open-source and single-user / self-hosted. That implies two doc rules beyond the privacy ones:
+
+- **No hardcoded personal values** in examples, configs, or fixtures (paths under `/home/<personal-username>`, machine names, IP addresses). Use placeholders (`<your-username>`, `<your-machine>`).
+- **No "broken by default for a fresh downloader" assumptions.** Setup guides should walk through what a fresh clone actually needs, not what's already true on the maintainer's machine.
+
+### Sub-Directory Instruction Files
+
+Every doc subdirectory has an `AGENTS.md` + `CLAUDE.md` pair so any reader (human or agent) can orient inside the subdirectory without re-reading this strategy file.
+
+Existing pairs:
+- `docs/adr/AGENTS.md` + `CLAUDE.md`
+- `docs/guides/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/standards/AGENTS.md` + `CLAUDE.md`
+- `docs/vision/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/product/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/specs/technical/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/plans/AGENTS.md` + `CLAUDE.md` (added in #181 — note: gitignored)
+
+**AGENTS.md** is the primary instruction file (universal, works with all AI tools). **CLAUDE.md** is a one-line wrapper: `@AGENTS.md`. The `@` import is relative to the file containing it; since CLAUDE.md and AGENTS.md are always co-located, the import is always literally `@AGENTS.md`.
+
+**AGENTS.md structure (per subdirectory):**
+
+```markdown
+[One-line description of directory purpose]
+
+## Contents
+- `file.md` — one-line description
+...
+
+## Key Principles
+- Critical rules that apply to this directory's content
+
+## Related Documents
+- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
+- [Other relevant doc] — Why it matters here
+```
+
+Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended commentary — keep them tight.
+
+## Maintenance Rules
+
+**When code changes:**
+1. Update the relevant design doc in the same PR if the design changed (not the implementation — only when the *intent* changed).
+2. Update `Last Updated` in the frontmatter.
+3. Check if cross-references need updates.
+4. Verify bidirectional links still resolve.
+
+**When documents get long (over the Max in [Length Guidelines](#length-guidelines)):**
+1. Identify distinct concerns within the document.
+2. Create focused docs for each concern.
+3. Keep the original path as a thin index pointing at the splits.
+4. Update inbound references to the right split.
+
+**Common violations to avoid:**
+- Adding "Next Steps" or task lists to specs or ADRs.
+- Mixing planning (roadmaps, tasks) into design documents.
+- Creating documents without "Related Documents" sections.
+- Failing to update cross-references when moving or splitting documents.
+- Modifying an accepted ADR in place (instead of superseding).
+- Using real personal data in examples.
+
+---
+
+## Related Documents
+
+### Project Context
+- [Root AGENTS.md](../AGENTS.md) — Project-level agent reference, development principles, key files
+- [Root CLAUDE.md](../CLAUDE.md) — Claude Code-specific configuration
+
+### Specifications
+- [vision/philosophy.md](vision/philosophy.md) — The privacy-first, local-first principles that frame doc decisions
+- [specs/standards/](specs/standards/) — Coding and testing conventions referenced by docs
+
+### Operational
+- [guides/](guides/) — Operator-facing setup and troubleshooting

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/adr/012-embedding-pipeline.md
+++ b/docs/adr/012-embedding-pipeline.md
@@ -1,0 +1,126 @@
+# ADR-012: Embedding Pipeline (GPU Acceleration + CPU Fallback)
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+**Decision:** Accepted
+
+## Context
+
+LifeOS indexes ~100K personal documents (Obsidian notes, emails, calendar events, messages, transcripts, etc.) for semantic search. The embedding pipeline — model choice, hardware utilization, OOM behavior, library compatibility — directly determines:
+
+- Search quality (higher-dimensional embeddings on a stronger encoder produce measurably better retrieval).
+- ChromaDB collection dimension (changing the model requires a full reindex).
+- Hardware requirements (a 1.5B-parameter encoder needs meaningful VRAM; a small encoder runs anywhere).
+- Library pinning (newer encoder models require specific `transformers` versions).
+- Failure modes (running an encoder out of VRAM mid-batch has historically killed the box).
+
+LifeOS targets a wide range of operator hardware: high-VRAM Linux workstations on the maintainer's end, modest Macs and lower-VRAM systems on other operators'. The embedding pipeline must default to a quality model for the maintainer's tier while being overridable for constrained hardware, and must never crash the box when the GPU is unhappy.
+
+This decision was made incrementally — original model selection (`mxbai-embed-large-v1`, 1024-dim, [ADR-004](004-hybrid-search.md) was written against this model), the 2026-03-05 upgrade to `gte-Qwen2-1.5B-instruct` (1536-dim, included a full reindex), the GPU→CPU fallback added after a hard hang during a long embed batch, and the pre-flight RAM check added after a kernel OOM-kill on a tight-memory run. This ADR backfills the consolidated record.
+
+## Decision
+
+- **Library**: `sentence-transformers` for the encoder runtime. It's the dominant Python library and has the catalog of supported models.
+- **Default model**: `Alibaba-NLP/gte-Qwen2-1.5B-instruct` (1536-dim). Overridable via `LIFEOS_EMBEDDING_MODEL` for constrained hardware.
+- **Hardware**: GPU (ROCm on AMD, CUDA on NVIDIA) when available. Embedding is the most GPU-hungry phase of the sync pipeline.
+- **Fallback semantics**: any HIP / CUDA / GPU error during load or encode falls back to CPU automatically. The error is tracked as a degradation event in the alerting system. CPU is 10–20× slower but keeps the box up.
+- **Pre-flight RAM check**: `run_all_syncs.py` checks free system RAM before phase 4 (embedding). If free RAM is below `LIFEOS_EMBEDDING_MEMORY_THRESHOLD_MB` (default 28000), the phase is skipped with a clear log line rather than risking a kernel OOM kill.
+- **LLM coordination**: the local LLM (`lifeos-llm`) is paused before embedding phases when both can't coexist in VRAM, and restarted afterward. (Documented in [data-and-sync.md](../specs/technical/data-and-sync.md).)
+- **Library pinning**: `transformers<5` is required for native Qwen2 support without `trust_remote_code`. The 5.x branch broke Qwen2's `rope_theta` and `tokenizer_qwen2_fast` paths.
+- **Input sanitation**: `api/services/chunker.py:_strip_base64_images` removes `data:image/...;base64,...` URLs before chunking. Granola meeting notes inline base64 images; embedding the raw markdown OOMs the encoder. Replacing the payload with `[image]` keeps the chunk small.
+
+## Rationale
+
+- **`sentence-transformers` is the gravitational center** of Python embedding tooling. Choosing it inherits the model catalog, the encode-batch ergonomics, and the community's worked examples without operator overhead.
+- **`gte-Qwen2-1.5B-instruct` outperformed mxbai on internal evals.** The 1024→1536 dimension change is a one-time reindex cost; the per-query quality lift is permanent. Worth it for a system whose primary value is retrieval quality.
+- **GPU is essential at vault scale.** 100K+ docs encoded on CPU is hours; on GPU it's minutes. For routine nightly sync, the GPU path is the only one that fits the operator's expectation of "wakes up tomorrow with fresh data."
+- **Fallback semantics keep the box up.** GPU OOM, ROCm misbehavior, or a transient HIP error has historically taken down the box (kernel OOM, then the whole sync stack). Catching `HIP error: out of memory` (and friends) and silently moving to CPU is uglier on latency but vastly better on availability.
+- **Pre-flight RAM gate prevents kernel OOM.** Embedding peaks at 15–22 GB transient memory for the default model. If free RAM is below threshold *before* the encode starts, skipping the phase is the right call — we'd OOM the kernel anyway, and a kernel OOM kill is much worse than a skipped sync phase.
+- **Operator override.** `LIFEOS_EMBEDDING_MODEL` is the supported escape hatch. Smaller models (`all-MiniLM-L6-v2`, 384-dim, ~80 MB; `mxbai-embed-large-v1`, 1024-dim, ~1.3 GB) run on modest hardware. The dimension change requires a one-time reindex, and operators on different hardware shouldn't be forced into the maintainer's model choice.
+
+## Alternatives Considered
+
+### Stay on `mxbai-embed-large-v1` (1024-dim)
+
+Keep the original model; skip the reindex.
+
+**Rejected because:** Qwen2 outperformed on internal retrieval evals. The reindex cost is one-time; the quality lift is permanent. For a system whose primary value is search quality, paying the one-time cost was the right call.
+
+### ONNX or quantized inference
+
+Convert the embedding model to ONNX (or use a quantized variant) for faster CPU and lower memory.
+
+**Rejected for now:** Adds runtime complexity (ONNX runtime, quantization tooling, accuracy validation per quant level). Marginal benefit on current hardware where GPU is the primary path. The fallback case is tolerable as-is; chasing CPU performance for an edge case adds maintenance surface without commensurate value. Worth revisiting if many operators end up CPU-bound.
+
+### Cloud embedding API (OpenAI `text-embedding-3-large` or similar)
+
+Use a hosted embedding API instead of local inference.
+
+**Rejected because:** Violates LifeOS's local-first principle. Sending every chunk of every personal document through a third-party API is a hard privacy regression — and a recurring cost ($0.13/M tokens for `text-embedding-3-large` at the time of writing) that scales with corpus growth. The whole point of LifeOS is that personal data stays local.
+
+### Self-hosted Triton inference server
+
+Run a Triton Inference Server alongside `llama-server` for embedding inference.
+
+**Rejected because:** Operational overhead disproportionate to the use case. Triton wins when you're serving multiple models at high concurrency to many clients; LifeOS serves one operator with one embedding model. The complexity (Docker, Triton config, model repo layout, GPU sharing across services) doesn't earn its keep.
+
+### Train a custom embedding model
+
+Fine-tune an embedding model on the operator's vault for personal-vocab specificity.
+
+**Rejected because:** Requires labeled retrieval data the operator doesn't have, infrastructure for training, and per-operator model artifacts. Off-the-shelf models on a strong encoder generalize well enough for personal-data retrieval that the engineering cost isn't justified.
+
+## Consequences
+
+### Positive
+
+- Quality: 1536-dim Qwen2 outperforms previous 1024-dim mxbai on retrieval evals.
+- Local: no embeddings sent to a third-party API; no recurring cost; aligns with LifeOS's privacy posture.
+- Resilient: GPU→CPU fallback never crashes the box on a HIP/CUDA error.
+- Pre-flight RAM gate prevents the worst failure mode (kernel OOM mid-encode).
+- Operator-overridable: smaller models (`all-MiniLM-L6-v2`, etc.) run on constrained hardware; `LIFEOS_EMBEDDING_MODEL` is the supported knob.
+- Granola-style base64-image notes don't OOM the encoder thanks to `_strip_base64_images`.
+
+### Negative
+
+- Model change requires a full reindex (the ChromaDB collection dimension is per-collection). For a 100K-doc vault this is a non-trivial operation.
+- `transformers` must be pinned `<5` for Qwen2 native support without `trust_remote_code`. New `transformers` major releases now require a compatibility check.
+- CPU fallback is 10–20× slower than GPU. A long sync that lands on the CPU path can take hours instead of minutes.
+- Pre-flight RAM check is a heuristic — the chosen threshold (28000 MB default) is empirical and may need re-tuning on different hardware. Too low → kernel OOM; too high → embedding skipped unnecessarily.
+- The default model needs ~15-22 GB transient memory. Operators on systems with less than that *must* override `LIFEOS_EMBEDDING_MODEL` to a smaller encoder.
+- Coordination with the local LLM (`lifeos-llm` stop/start around embedding phases) is brittle — both services compete for GPU and the sync pipeline has to choreograph the handoff.
+- Granola-style sources that inline non-image binary blobs (audio? video frames? other encodings) could still OOM the encoder. The current strip is image-base64 only; broader sanitation may be needed if new sources appear.
+
+### Migration history
+
+- **2026-03-05**: Default model changed from `mixedbread-ai/mxbai-embed-large-v1` (1024-dim) to `Alibaba-NLP/gte-Qwen2-1.5B-instruct` (1536-dim). Required a full reindex; ChromaDB collection dimension changed.
+
+### Override path
+
+Set `LIFEOS_EMBEDDING_MODEL` in `.env`. Smaller models suitable for constrained hardware:
+
+- `sentence-transformers/all-MiniLM-L6-v2` — 384-dim, ~80 MB, runs on CPU comfortably.
+- `mixedbread-ai/mxbai-embed-large-v1` — 1024-dim, ~1.3 GB, the previous default.
+
+Changing the model requires reindexing the ChromaDB collection. The sync pipeline handles this automatically on the next run with a new model when the collection dimension mismatches the encoder.
+
+## Related Documents
+
+### Design Context
+- [ADR-002: ChromaDB](002-chromadb-vector-store.md) — Vector store that consumes the embeddings produced here
+- [ADR-004: Hybrid Search](004-hybrid-search.md) — Search pipeline that uses these embeddings (RRF fusion with BM25)
+- [ADR-007: Linux Migration](007-linux-migration.md) — Established the GPU posture this pipeline targets
+
+### Specifications
+- [Search Indexing](../specs/technical/search-indexing.md) — Hybrid search internals (RRF, reranking) that consume the embeddings
+- [Data & Sync](../specs/technical/data-and-sync.md) — Embedding phase position in the seven-phase pipeline; LLM stop/start choreography
+
+### Operational
+- [Configuration](../guides/configuration.md) — `LIFEOS_EMBEDDING_MODEL`, `LIFEOS_EMBEDDING_MEMORY_THRESHOLD_MB`, `PYTORCH_CUDA_ALLOC_CONF` env vars (canonical home after #188)
+- [Troubleshooting](../guides/troubleshooting.md) — OOM symptoms and recovery steps
+- [Installation](../guides/installation.md) — GPU prerequisites (ROCm version, PyTorch wheel selection)
+
+### Code References
+- [`api/services/embeddings.py`](../../api/services/embeddings.py) — `EmbeddingService` with GPU→CPU fallback (`_encode_with_fallback`), supported dimensions table
+- [`api/services/chunker.py`](../../api/services/chunker.py) — `_strip_base64_images` (line ~206) called from `_chunk_markdown` before encoding
+- [`scripts/run_all_syncs.py`](../../scripts/run_all_syncs.py) — `_EMBEDDING_MEMORY_THRESHOLD_MB` gate, `_stop_llm_for_embeddings` choreography

--- a/docs/specs/technical/data-and-sync.md
+++ b/docs/specs/technical/data-and-sync.md
@@ -515,3 +515,4 @@ The scraping system uses Claude in Chrome MCP for browser automation. It require
 - [Search & Indexing](search-indexing.md) -- Hybrid search pipeline
 - [ADR-002: ChromaDB](../../adr/002-chromadb-vector-store.md) -- Why ChromaDB was chosen
 - [ADR-003: Two-Tier Data Model](../../adr/003-two-tier-data-model.md) -- Why SourceEntity and PersonEntity are separate
+- [ADR-012: Embedding Pipeline](../../adr/012-embedding-pipeline.md) -- Embedding model, GPU/CPU fallback, pre-flight RAM gate around phase 4

--- a/docs/specs/technical/search-indexing.md
+++ b/docs/specs/technical/search-indexing.md
@@ -82,3 +82,4 @@ The query classifier (`api/services/query_classifier.py`) determines whether a q
 - [Data & Sync](data-and-sync.md) -- Data ingestion and vector store indexing
 - [Architecture](architecture.md) -- System architecture and code structure
 - [ADR-004: Hybrid Search](../../adr/004-hybrid-search.md) -- Why both vector and keyword search
+- [ADR-012: Embedding Pipeline](../../adr/012-embedding-pipeline.md) -- Encoder model choice, GPU/CPU fallback, OOM protection


### PR DESCRIPTION
## Summary

Backfills the consolidated architectural record for the embedding pipeline. Was scattered across ADR-004 (now stale on model details), `config/settings.py` docstrings, user memory (1024→1536 upgrade, `transformers<5` pin), and `chunker.py` (`_strip_base64_images`).

## Acceptance criteria

- [x] ADR-012 exists with all template sections
- [x] Migration history captured (date, from, to, required reindex)
- [x] Override path documented (`LIFEOS_EMBEDDING_MODEL` with smaller-encoder examples)
- [x] Failure mode + mitigation documented (HIP/CUDA OOM → CPU fallback; pre-flight RAM check)
- [x] No functional code changes

## Alternatives considered

- Stay on `mxbai-embed-large-v1` (1024-dim)
- ONNX or quantized inference
- Cloud embedding API (OpenAI `text-embedding-3-large` or similar)
- Self-hosted Triton inference server
- Fine-tune a custom embedding model

Each with explicit `Rejected because:` paragraph.

## Code refs (all verified)

- `api/services/embeddings.py` (`EmbeddingService._encode_with_fallback` at ~line 98)
- `api/services/chunker.py:206` (`_strip_base64_images`)
- `scripts/run_all_syncs.py` (`_EMBEDDING_MEMORY_THRESHOLD_MB` at ~line 70, `_stop_llm_for_embeddings` choreography)

## Length

121 lines — within ADR target.

## Bidirectional cross-links

- ADR-002, ADR-004, ADR-007 in Design Context
- `search-indexing.md` and `data-and-sync.md` updated to back-link ADR-012

## Test plan

- [x] All code-ref paths exist
- [x] Env var names match `config/settings.py` and `run_all_syncs.py` constants
- [x] Bidirectional cross-links verified
- [ ] Reviewer: confirm the threshold heuristic (28 GB default) and CPU-fallback slowdown (10–20×) are the right numbers

## Targeting

Based on `docs/180-strategy-foundation`; targeted at `docs/overhaul`.

Closes #187.