### PR TITLE
docs: backfill Claude Code orchestration product + technical specs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,384 @@
+# Documentation Strategy
+
+**Status:** Complete
+**Last Updated:** 2026-05-27
+
+**This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
+
+## Purpose
+
+This strategy defines how we organize and maintain documentation in LifeOS. These are **rules, not guidelines** — following this strategy faithfully is critical to maintaining documentation quality across a collaborative human + AI agent project.
+
+Documentation in LifeOS serves two readers equally:
+- **Human contributors** who need to onboard, debug, and design changes.
+- **AI agents** (Claude Code, Cursor, Copilot, etc.) that load docs as context when working on the codebase.
+
+Both readers benefit from the same things: short, focused documents; explicit decisions; cross-links instead of duplication; and an unambiguous answer to "where does this kind of information live?"
+
+## Core Principles
+
+1. **Living documents over proposals** — Design docs evolve during implementation rather than being written once and frozen. Update when thinking changes, not when tasks complete.
+2. **Modular over monolithic** — Split documents by concern, not by phase or role. A 1,800-line spec is a symptom, not a feature.
+3. **Cross-linked over isolated** — Documents reference related docs with a short tagline explaining the relationship, not just a link.
+4. **Concise over comprehensive** — Each document has a clear scope; prefer multiple focused docs over one sprawling one.
+5. **Consistent over creative** — Follow established patterns and structures. Consistency makes documentation predictable and navigable.
+6. **AI-readable** — Be succinct, specific, and clear. Prefer shorter, well-named documents over longer ones. Don't overexplain, but make requirements and decisions explicit.
+7. **Single source of truth** — Default to keeping each piece of information in exactly one authoritative location; other documents link to it rather than repeating it. When in doubt about where something belongs, consult the [Content Classification table](#content-classification). When you find duplication, prefer consolidating to the authoritative location and replacing duplicates with cross-references.
+
+## Document Taxonomy
+
+```
+docs/
+├── AGENTS.md          # THIS FILE (documentation strategy)
+├── CLAUDE.md          # @AGENTS.md wrapper
+├── vision/            # WHY — project vision, philosophy
+├── specs/
+│   ├── product/       # WHAT — features, API contracts, data models (consumer perspective)
+│   ├── technical/     # HOW (design) — architecture, schema, security, infrastructure
+│   └── standards/     # HOW (work) — coding conventions, testing standards, naming rules
+├── adr/               # WHY (decisions) — immutable architecture decision records
+├── guides/            # HOW (do) — step-by-step operational instructions
+├── plans/             # WHEN — active execution work, ephemeral (gitignored)
+└── archive/           # HISTORY — superseded documents (gitignored)
+```
+
+### Vision Documents
+
+**Location:** `docs/vision/`
+**Purpose:** Vision, philosophy, and strategic direction — the WHY behind LifeOS
+**Updated:** When strategy changes (rarely)
+
+Vision docs provide foundational context that frames every design decision. For LifeOS, that's primarily the privacy-first, local-first, single-user posture — see [philosophy.md](vision/philosophy.md).
+
+### Specifications
+
+**Location:** `docs/specs/`
+**Purpose:** Design documents describing WHAT the system is/should be (target state)
+**Updated:** When the design evolves
+
+**Key principle:** Specs are the **vision** — the authoritative design for the system. Not implementation plans, not progress tracking, not task lists. They describe the intended architecture and behavior.
+
+"Living" means the spec updates when *the design* changes, not when *tasks* complete.
+
+- `product/` — What the system does from a consumer perspective. Feature behavior, API contracts, data model semantics. Answers: "What does this entity mean? What can you do with this endpoint?"
+- `technical/` — How the system is built from an engineering perspective. Architecture, schema, security implementation, query optimization. Answers: "How is this implemented? What constraints did we hit?"
+- `standards/` — Rules and conventions for how we work. Coding standards, naming conventions, testing patterns. Answers: "What conventions must we follow?"
+
+### Architecture Decision Records (ADRs)
+
+**Location:** `docs/adr/`
+**Purpose:** Immutable records of significant architectural decisions with context and rationale
+**Updated:** Never. ADRs are append-only — create a new ADR to supersede an old one. The only acceptable in-place edit is adding an `Amended by: ADR-NNN` or `Superseded By: ADR-NNN` pointer to the frontmatter.
+
+**Naming:** `NNN-short-title.md` (e.g., `008-managed-agents-cloud-routing.md`). Sequential numbering. Never reuse numbers.
+
+ADRs live at the top level (not under `specs/`) because they span product and technical concerns. A decision about data model semantics is as load-bearing as one about database engines.
+
+### Operational Guides
+
+**Location:** `docs/guides/`
+**Purpose:** Step-by-step instructions for specific operator and contributor tasks
+**Updated:** When procedures change
+
+Guides are instructional — they tell you how to do something, not why it's designed that way. If a guide starts explaining design rationale, that content belongs in a spec or ADR.
+
+### Plans
+
+**Location:** `docs/plans/` (gitignored — personal/active planning notes)
+**Purpose:** Active execution work — phases, tasks, roadmaps, backlogs
+
+Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. For trackable work, prefer GitHub issues; for personal planning, use the local `docs/plans/` directory.
+
+### Archive
+
+**Location:** `docs/archive/` (gitignored)
+**Purpose:** Superseded documents, audit notes, and historical investigation working notes retained for local context.
+
+Archive content is **not** part of the public repo. When a durable insight from an archived doc is still load-bearing, promote it: link to the relevant live spec, or extract the durable conclusion into an ADR.
+
+## Content Classification
+
+| Content Type | Belongs In | Anti-Pattern |
+|---|---|---|
+| Project vision, philosophy, strategy | `vision/` | Not in specs (too stable, too abstract) |
+| User-facing feature behavior, API contracts, data model semantics | `specs/product/` | No implementation details, no task lists |
+| Architecture, system design, schema, query design, security implementation | `specs/technical/` | No roadmaps, no "Next Steps" |
+| Coding conventions, naming rules, testing patterns | `specs/standards/` | Not in guides (standards prescribe, guides instruct) |
+| Architectural decisions with rationale and alternatives | `adr/` | Never modify after acceptance — create a new ADR to supersede |
+| Setup procedures, troubleshooting, operator how-to | `guides/` | Not design rationale |
+| Phases, tasks, roadmaps, checklists | `plans/` (or GitHub issues) | Don't put in specs |
+| Audit notes, investigation working files, superseded docs | `archive/` | Don't link from live specs unless promoting a specific insight |
+
+**Rule of thumb:** "Why do we build this?" → vision. "What should it be?" → product spec. "How is it built?" → technical spec. "Why did we decide?" → ADR. "How do I do X?" → guide. "When/how do we get there?" → plan.
+
+**LifeOS-specific classification:**
+- Data model semantics (what entities mean, relationships between them) → `specs/product/data-model.md`
+- Data model implementation (SQLite schema, ChromaDB collections, indexes) → `specs/technical/`
+- API contracts (consumer perspective, request/response shapes) → `specs/product/api-reference.md`
+- API internals (route-handler structure, middleware, error handling) → `specs/technical/`
+- Privacy/security design decisions → `specs/technical/security-privacy.md`, with corresponding ADRs for the underlying decisions
+
+## Frontmatter Standards
+
+Every document must have frontmatter:
+
+```markdown
+**Status:** Draft | Partial | Complete
+**Last Updated:** YYYY-MM-DD
+```
+
+**Additional fields by document type:**
+
+| Type | Additional Fields |
+|---|---|
+| ADR | `**Decision:** Accepted \| Superseded \| Deprecated` and (if applicable) `**Superseded By:** ADR-NNN` or `**Amended by:** ADR-NNN` |
+| Product Spec | `**Owner:** name-or-area` |
+| Technical Spec | `**Owner:** name-or-area` |
+| Guide | `**Audience:** Operator \| Contributor \| New users` |
+| Plan | `**Target Date:** YYYY-MM-DD` (or `Ongoing`); `**Completed:** YYYY-MM-DD` when archived |
+
+`Status` values:
+- **Draft** — Initial draft, not yet reviewed; may have gaps or open questions.
+- **Partial** — Some sections complete, others marked TODO; safe to read for the parts that exist.
+- **Complete** — Reviewed, accurate as of `Last Updated`, no known gaps.
+
+For ADRs, `Status` reflects document completeness; `Decision` reflects whether the decision is still in force.
+
+## ADR Template
+
+ADRs use the following structure. The retrofit issue (#182) brought existing ADRs into this shape; all new ADRs must follow it.
+
+```markdown
+# ADR-NNN: Short Title
+
+**Status:** Complete
+**Last Updated:** YYYY-MM-DD
+**Decision:** Accepted
+**Superseded By:** ADR-NNN  (only if applicable)
+**Amended by:** ADR-NNN     (only if applicable)
+
+## Context
+
+The situation, constraints, and forces at the time of the decision. Why this needed to be decided now.
+
+## Decision
+
+One unambiguous statement of what was chosen. No hedging.
+
+## Rationale
+
+Why this choice over the alternatives. Tie back to the constraints in Context.
+
+## Alternatives Considered
+
+Each alternative as its own subsection with a one-paragraph description and an explicit "Rejected because..." line. Recover alternatives from PR descriptions, commit messages, or memory. Where you genuinely don't remember, write "to be filled in by the original decider" rather than fabricating.
+
+### Alternative A
+
+Description.
+
+**Rejected because:** specific reason.
+
+## Consequences
+
+### Positive
+
+- Specific benefits this decision enables.
+
+### Negative
+
+- Specific costs, ongoing maintenance burden, or constraints this decision imposes.
+
+## Related Documents
+
+(Use the 4-bucket Related Documents structure described below.)
+```
+
+## Length Guidelines
+
+Not rigid rules, but signals for document health. When a doc passes the "max" column it should be split by concern.
+
+| Document Type | Target Lines | Max Lines |
+|---|---|---|
+| ADR | 200–500 | 800 |
+| Product Spec | 300–700 | 800 |
+| Technical Spec | 400–800 | 1,000 |
+| Standards | 200–500 | 700 |
+| Vision | 300–600 | 800 |
+| Guide | 200–500 | 800 |
+| Plan | Variable | — |
+
+**Split when:**
+- Document exceeds the Max in its column.
+- It covers multiple distinct concerns (e.g., one CRM spec covering people, interactions, graph, analytics).
+- Different readers need different sections.
+- Table of contents has more than ~8 top-level sections.
+
+When splitting, keep a thin **index document** at the original path with pointers to each split and a short overview. Update all inbound links to point at the right split.
+
+## Cross-Linking Standards
+
+Every document must include a "Related Documents" section at the bottom.
+
+**Requirements:**
+1. **Bidirectional** — if A links to B, B must link to A. When you add a link in one direction, add the reciprocal link in the same PR.
+2. **Contextual** — every link has a "— short tagline" explaining the relationship.
+3. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
+4. **Use the 4-bucket structure** below for consistency.
+
+**Standard Related Documents template:**
+
+```markdown
+## Related Documents
+
+### Design Context
+- [ADR-NNN: Decision Name](../adr/NNN-title.md) — Why this approach was chosen
+- [Vision: Philosophy](../vision/philosophy.md) — The principle behind this
+
+### Specifications
+- [Product Spec](../specs/product/feature.md) — Consumer-facing requirements
+- [Technical Spec](../specs/technical/component.md) — Implementation design
+
+### Operational
+- [Setup Guide](../guides/feature-setup.md) — How to configure this
+- [Configuration](../guides/configuration.md) — Env var reference
+
+### Code References
+- [Implementation](../../api/services/foo.py:45-120) — Production code
+- [Tests](../../tests/test_foo.py) — Coverage
+```
+
+Use only the buckets that apply — omit empty buckets rather than including them as `(none)`.
+
+## Lifecycle Rules
+
+**Specs are living:**
+- Update when the design changes, not when tasks complete.
+- If a spec describes a target that's not yet built, the `Status: Partial` value is appropriate.
+- Specs are not changelogs. Don't add "Added X in PR #N" notes; that's what `git log` and `git blame` are for.
+
+**Plans are ephemeral:**
+- A plan ends as either "completed" (move to `archive/` with `Completed: YYYY-MM-DD`) or "superseded" (note the successor and move to `archive/`).
+- Do not leave stale plans in `docs/plans/`.
+
+**ADRs are immutable:**
+- Never modify the Context / Decision / Rationale / Alternatives sections of an accepted ADR.
+- To change a decision, create a new ADR. The old ADR gets `Superseded By: ADR-NNN` added to its frontmatter — that's the only acceptable in-place edit.
+- For a smaller change (clarification, scoping refinement that doesn't reverse the decision), the new ADR is an *amendment* and the old ADR gets `Amended by: ADR-NNN`.
+
+**Guides decay:**
+- Test commands you document before shipping. Stale guides are worse than missing guides.
+
+## Writing for AI Readability
+
+Documentation is frequently consumed by AI agents during development. Optimize for:
+
+**Clarity:**
+- State requirements explicitly. Avoid "should consider" — say "do" or "don't" or "defer because X".
+- Use precise technical terminology (route handler, span, collection) rather than vague nouns.
+- Avoid ambiguous pronouns; prefer specific nouns even at the cost of repetition.
+
+**Structure:**
+- Well-named sections that match their content. A section labeled "Notes" is a smell.
+- Frontmatter with status and metadata at the top.
+- Tables when they sharpen a comparison; prose otherwise.
+
+**Brevity:**
+- Shorter, focused documents over long comprehensive ones.
+- Link to details rather than repeating them.
+- Keep documents focused on one concern so agents don't waste context loading irrelevant content.
+
+**Anti-patterns:**
+- Long narrative explanations when a bulleted list suffices.
+- Repeating context already in linked documents.
+- Vague statements like "we should consider" (instead: decided yes/no, or defer with reason).
+- Burying key decisions in prose.
+
+## LifeOS-Specific Rules
+
+### Privacy-First Documentation
+
+LifeOS handles deeply personal data — emails, messages, photos, finances. Documentation must not become a leak vector.
+
+- **Use obviously synthetic data in all examples and test fixtures.** Names like "Alex Chen", domains like `example.com`, phone numbers like `555-0123`, dollar amounts like `$1,234.56`. No real names, emails, phone numbers, or financial values, even in commit-message screenshots.
+- **Security-sensitive implementation details belong in code, not docs.** Reference the code (with line numbers) rather than restating encryption keys, auth tokens, or exact connection strings.
+- **Technical specs involving data storage or access** should include a "Privacy Considerations" subsection or link to one in `specs/technical/security-privacy.md`.
+- **Don't paste real terminal output** containing real personal data into docs. Sanitize first.
+
+### Open-Source Posture
+
+LifeOS is open-source and single-user / self-hosted. That implies two doc rules beyond the privacy ones:
+
+- **No hardcoded personal values** in examples, configs, or fixtures (paths under `/home/<personal-username>`, machine names, IP addresses). Use placeholders (`<your-username>`, `<your-machine>`).
+- **No "broken by default for a fresh downloader" assumptions.** Setup guides should walk through what a fresh clone actually needs, not what's already true on the maintainer's machine.
+
+### Sub-Directory Instruction Files
+
+Every doc subdirectory has an `AGENTS.md` + `CLAUDE.md` pair so any reader (human or agent) can orient inside the subdirectory without re-reading this strategy file.
+
+Existing pairs:
+- `docs/adr/AGENTS.md` + `CLAUDE.md`
+- `docs/guides/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/standards/AGENTS.md` + `CLAUDE.md`
+- `docs/vision/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/product/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/specs/technical/AGENTS.md` + `CLAUDE.md` (added in #181)
+- `docs/plans/AGENTS.md` + `CLAUDE.md` (added in #181 — note: gitignored)
+
+**AGENTS.md** is the primary instruction file (universal, works with all AI tools). **CLAUDE.md** is a one-line wrapper: `@AGENTS.md`. The `@` import is relative to the file containing it; since CLAUDE.md and AGENTS.md are always co-located, the import is always literally `@AGENTS.md`.
+
+**AGENTS.md structure (per subdirectory):**
+
+```markdown
+[One-line description of directory purpose]
+
+## Contents
+- `file.md` — one-line description
+...
+
+## Key Principles
+- Critical rules that apply to this directory's content
+
+## Related Documents
+- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
+- [Other relevant doc] — Why it matters here
+```
+
+Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended commentary — keep them tight.
+
+## Maintenance Rules
+
+**When code changes:**
+1. Update the relevant design doc in the same PR if the design changed (not the implementation — only when the *intent* changed).
+2. Update `Last Updated` in the frontmatter.
+3. Check if cross-references need updates.
+4. Verify bidirectional links still resolve.
+
+**When documents get long (over the Max in [Length Guidelines](#length-guidelines)):**
+1. Identify distinct concerns within the document.
+2. Create focused docs for each concern.
+3. Keep the original path as a thin index pointing at the splits.
+4. Update inbound references to the right split.
+
+**Common violations to avoid:**
+- Adding "Next Steps" or task lists to specs or ADRs.
+- Mixing planning (roadmaps, tasks) into design documents.
+- Creating documents without "Related Documents" sections.
+- Failing to update cross-references when moving or splitting documents.
+- Modifying an accepted ADR in place (instead of superseding).
+- Using real personal data in examples.
+
+---
+
+## Related Documents
+
+### Project Context
+- [Root AGENTS.md](../AGENTS.md) — Project-level agent reference, development principles, key files
+- [Root CLAUDE.md](../CLAUDE.md) — Claude Code-specific configuration
+
+### Specifications
+- [vision/philosophy.md](vision/philosophy.md) — The privacy-first, local-first principles that frame doc decisions
+- [specs/standards/](specs/standards/) — Coding and testing conventions referenced by docs
+
+### Operational
+- [guides/](guides/) — Operator-facing setup and troubleshooting

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/guides/claude-code-orchestration.md
+++ b/docs/guides/claude-code-orchestration.md
@@ -6,9 +6,11 @@
 
 Run Claude Code tasks remotely from Telegram. Send `/code <task>` and get results back as messages.
 
+> **For what `/code` does and how the operator interaction works**, see [Claude Code Orchestration — product spec](../specs/product/claude-code-orchestration.md). **For implementation** (subprocess spawning, stream parsing, plan/clarification flow), see [Claude Code Orchestration — technical spec](../specs/technical/claude-code-orchestration.md). This file is the operator how-to.
+
 ## Prerequisites
 
-1. **Telegram configured** — `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` set in `.env`. See [Configuration](../getting-started/CONFIGURATION.md#telegram).
+1. **Telegram configured** — `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` set in `.env`. See [configuration.md § Telegram](configuration.md#telegram).
 
 2. **Claude Code installed on the server** — the CLI binary must exist at the configured path.
 
@@ -147,33 +149,7 @@ Only one session runs at a time. If you send `/code` while a session is active, 
 
 ## How It Works
 
-1. **Subprocess spawning**: `/code` spawns `claude -p <task>` as a subprocess on the server with `--output-format stream-json` for structured output parsing.
-
-2. **Stream parsing**: A background thread reads the subprocess stdout line-by-line, parsing JSON events (init, assistant, result).
-
-3. **[NOTIFY] extraction**: Assistant events are scanned for lines matching `[NOTIFY] <message>`. These are relayed to Telegram via the sync `send_message()` function.
-
-4. **Completion**: The result event triggers a final notification to Telegram with the task outcome.
-
-5. **Timeout**: A watchdog timer kills the subprocess after 10 minutes (configurable). You'll get a timeout notification in Telegram.
-
-6. **MCP tools**: Claude Code sessions have access to LifeOS data via MCP tools (`lifeos_ask`, `lifeos_search`, `lifeos_calendar_*`, etc.). This lets Claude reference personal data while performing code tasks. See [API & MCP Reference](../architecture/API-MCP-REFERENCE.md#mcp-tools) for the full tool list.
-
-7. **Server shutdown**: Active sessions are gracefully terminated during server restart.
-
-### System Prompt
-
-Claude Code receives a system prompt instructing it to:
-- **Interpret tasks creatively** — think about what you actually want, not just the literal words. Requests from Telegram are brief and informal; Claude will explore the directory, understand conventions, and do the full job (e.g., "write a cron job" means create the script AND install the cron entry)
-- **Be persistent and resourceful** — try alternative approaches before giving up, debug errors independently, and only ask the user for help after exhausting options
-- **Know the environment** — vault location, project directories, available tools (git, cron, Python venv)
-- Always include a completion summary via `[NOTIFY]`
-
-Only `[NOTIFY]` lines are relayed — all other output (tool calls, file reads, intermediate steps) stays in the subprocess.
-
-### Heartbeat Updates
-
-Every 5 minutes, if the session is still running, you'll receive an automatic progress ping ("Still working... (5m elapsed)") via Telegram. This happens regardless of whether Claude has sent any `[NOTIFY]` messages, so you always know the session is alive.
+Implementation moved to the [technical spec](../specs/technical/claude-code-orchestration.md) — that covers subprocess spawning, stream parsing, `[NOTIFY]`/`[CLARIFY]` extraction, the system prompt, the heartbeat timer, and budget enforcement. Operator-facing summary: it's a one-shot `claude` subprocess with `--output-format stream-json --dangerously-skip-permissions`, parsed in real time, with `[NOTIFY]` checkpoints relayed to Telegram and a 5-minute heartbeat so you always know it's alive.
 
 ---
 
@@ -235,5 +211,8 @@ If Claude is working in the wrong directory, make your task description more exp
 
 ## Related Documents
 
+- [Claude Code Orchestration — Product](../specs/product/claude-code-orchestration.md) -- What `/code` does (consumer view); plan mode; clarifications; budgets
+- [Claude Code Orchestration — Technical](../specs/technical/claude-code-orchestration.md) -- Implementation: subprocess, stream parsing, system prompt, cancellation
+- [Configuration](configuration.md) -- `LIFEOS_CLAUDE_*` env vars
+- [MCP Tools](../specs/product/mcp-tools.md) -- MCP tools available to Claude Code sessions
 - [Scripts Reference](scripts.md) -- All LifeOS scripts with usage examples
-- [API Reference](../specs/product/api-reference.md) -- MCP tools used by Claude Code sessions

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -185,5 +185,6 @@ All in `.env`. None are required — the defaults work for the standard LifeOS i
 
 - [Agent Viz — Technical](../technical/agent-viz.md) — Endpoint shapes, D3 force config, status inference rules, security boundaries
 - [Agent Worker](agent-worker.md) — The other half of the picture: how `#agent` tasks get claimed and run
+- [Claude Code Orchestration (product)](claude-code-orchestration.md) — The orchestrator that spawns the Claude Code sessions surfaced here
 - [Agent Worker — Technical](../technical/agent-worker.md) — Sessions, transcripts, kill primitives
 - [Architecture](../technical/architecture.md) — Where the viz fits in the broader code structure

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -178,6 +178,7 @@ All in `.env` — see [`agent-worker-setup.md`](../../guides/agent-worker-setup.
 
 - [Agent Worker — Technical](../technical/agent-worker.md) — Architecture, executors, prompts, state machine, restart resumability
 - [Agent Worker — Setup](../../guides/agent-worker-setup.md) — Operator setup (Gemma swap, MCP HTTP transport, Vault provisioning, agent preset)
+- [Claude Code Orchestration (product)](claude-code-orchestration.md) — The other autonomous-work system in LifeOS; triggered from Telegram `/code` rather than `#agent` tags
 - [Agent Viz](agent-viz.md) — Live `/agents` page showing in-flight and recently-finished worker sessions
 - [Task Management](task-management.md) — How `#agent` tasks live alongside regular tasks in the Obsidian Tasks plugin
 - [MCP Tools](mcp-tools.md) — The `lifeos_agent_*` family for inter-agent coordination

--- a/docs/specs/product/claude-code-orchestration.md
+++ b/docs/specs/product/claude-code-orchestration.md
@@ -1,0 +1,211 @@
+# Claude Code Orchestration
+
+**Status:** Complete
+**Owner:** Orchestrator
+**Last Updated:** 2026-05-27
+
+LifeOS spawns a **Claude Code** subprocess from Telegram when the operator sends `/code <task>` (or when a natural-language message is classified as requiring terminal / filesystem / browser access). The subprocess runs the task on the server, streams progress back as Telegram messages, and terminates. The operator can monitor (`/code_status`) and cancel (`/code_cancel`) the active session.
+
+This spec covers the consumer view — what the operator sees and controls. For implementation see [technical/claude-code-orchestration.md](../technical/claude-code-orchestration.md). For operator setup (binary install, `setup-token`, troubleshooting) see [guides/claude-code-orchestration.md](../../guides/claude-code-orchestration.md).
+
+---
+
+## Table of Contents
+
+1. [How it differs from the agent worker](#how-it-differs-from-the-agent-worker)
+2. [Trigger paths](#trigger-paths)
+3. [Lifecycle](#lifecycle)
+4. [Plan mode](#plan-mode)
+5. [Clarification questions](#clarification-questions)
+6. [Telegram notifications](#telegram-notifications)
+7. [Operator commands](#operator-commands)
+8. [Budget model](#budget-model)
+9. [Directory resolution](#directory-resolution)
+10. [Capability boundaries](#capability-boundaries)
+11. [Resume from the `/agents` page](#resume-from-the-agents-page)
+
+---
+
+## How it differs from the agent worker
+
+LifeOS has two related-but-distinct ways to run autonomous work on the operator's behalf. Don't conflate them:
+
+| | Claude Code orchestrator (this spec) | Agent worker ([agent-worker.md](agent-worker.md)) |
+|---|---|---|
+| **Trigger** | Telegram `/code <task>` (or auto-detect) | `#agent`-tagged Obsidian task |
+| **Runtime** | Local `claude` CLI subprocess on the server | Stand-alone Python worker hitting llama-server or Anthropic Managed Agents |
+| **State** | In-process; no persistent SessionStore | SQLite SessionStore + JSONL transcript per session |
+| **Concurrency** | One session at a time | Many concurrent sessions, bounded by config caps |
+| **Pickup** | Operator-driven (one-shot) | Worker-driven (poll loop) |
+| **Resume** | Operator can re-launch from `/agents` (see [agent-viz.md](agent-viz.md)) | Operator can swap the task tag and re-queue |
+
+Both surface on the `/agents` page side-by-side. They share the visualization layer ([agent-viz.md](agent-viz.md)) but not the execution layer.
+
+---
+
+## Trigger paths
+
+The operator gets a Claude Code session through one of two paths:
+
+1. **Explicit `/code` command in Telegram.** The Telegram bot dispatches the body of the message to the orchestrator. Examples:
+   ```
+   /code create a file called test.txt with "hello world" on the Desktop
+   /code write a backup script for the LifeOS data directory
+   /code add "integrate weather alerts" to the backlog
+   /code create a cron job that runs backup.sh daily at 2am
+   ```
+
+2. **Auto-detected via the chat intent classifier.** If the operator sends a natural-language message that the classifier tags as "code intent" (terminal, filesystem, or browser work), the chat pipeline yields a `code_intent` event and Telegram handles it identically to `/code`. The plan mode, clarification, and notification flow are the same.
+
+---
+
+## Lifecycle
+
+Each session moves through:
+
+```
+ACCEPTED  (Telegram ack message back to operator, with resolved cwd)
+   ↓
+RUNNING   (Claude Code subprocess emits stdout JSONL events; orchestrator parses)
+   ↓
+[optional] PLAN_PENDING   (plan-mode tasks: Claude proposes a plan, waits for approve/reject)
+   ↓
+[optional] CLARIFY_PENDING   (Claude asked a question; operator must answer)
+   ↓
+COMPLETED  (subprocess exited; final summary sent to Telegram)
+   or
+FAILED / TIMEOUT / CANCELLED   (operator-visible terminal state with reason)
+```
+
+Only one session runs at a time. Sending `/code` while a session is active returns an error message naming the current task plus a hint to use `/code_cancel`.
+
+---
+
+## Plan mode
+
+Tasks containing words like `refactor`, `implement`, `rewrite`, `overhaul`, `build a`, `set up a`, `add a new`, `create a new`, `remove all`, `delete all`, `migrate`, `replace`, `restructure`, or `integrate` trigger plan mode. Claude presents the plan via Telegram and waits for approval.
+
+**Flow:**
+
+1. Operator: `/code implement a new health check endpoint`
+2. Claude presents a plan via Telegram.
+3. Claude asks: "Reply 'approve' to proceed or 'reject' to cancel."
+4. Operator replies: `approve` (or `yes`, `go`, `ok`, `proceed`)
+5. Claude implements and reports completion via `[NOTIFY]`.
+
+To reject: reply `reject` (or `no`, `cancel`, `stop`).
+
+While a plan is pending, normal Telegram messages still reach the chat pipeline — only short approval/rejection keywords are intercepted.
+
+---
+
+## Clarification questions
+
+If a task is vague or ambiguous, Claude asks a clarifying question instead of guessing. The question is relayed via Telegram and the session pauses until the operator answers.
+
+**Flow:**
+
+1. Operator: `/code add this to the backlog`
+2. Claude: "The backlog has two sections (Work and Personal). Which one?"
+3. Operator: `Work`
+4. Claude resumes with the answer and completes the task.
+
+While a clarification is pending, all non-command Telegram messages route as the answer. The operator uses `/code_cancel` if they want to chat normally instead.
+
+**Note:** `no` is treated as an answer to yes/no questions, not as a cancellation. Use `/code_cancel` to actually cancel.
+
+---
+
+## Telegram notifications
+
+Claude sends three kinds of messages via Telegram:
+
+| Marker | When | Example |
+|--------|------|---------|
+| `[NOTIFY] ...` | Progress checkpoint or completion summary | `[NOTIFY] Created backup script at ~/scripts/backup.sh and added daily cron job at 2am.` |
+| `[CLARIFY] ...` | Claude needs an answer | `[CLARIFY] Which backlog section — Work or Personal?` |
+| heartbeat | Every 5 minutes while running | `Still working... (5m elapsed)` |
+
+Only `[NOTIFY]` and `[CLARIFY]` lines are relayed. All other output (tool calls, file reads, intermediate steps) stays in the subprocess. The heartbeat is sent by the orchestrator (not Claude) so the operator always knows the session is alive even when Claude is busy without notifying.
+
+---
+
+## Operator commands
+
+| Command | Behavior |
+|---------|----------|
+| `/code <task>` | Spawn a new Claude Code session with the given task. Returns an ack with resolved cwd. |
+| `/code_status` | Shows task description, working directory, current status, elapsed duration, cost-so-far. |
+| `/code_cancel` | Terminate the active session immediately. Sends a cancellation notification. |
+
+`/code_status` and `/code_cancel` operate on the single active session (if any). If no session is active, they return a message saying so.
+
+---
+
+## Budget model
+
+The orchestrator enforces three caps from `.env` (see [configuration.md § Claude Code Orchestration](../../guides/configuration.md#claude-code-orchestration-code-telegram-command)):
+
+| Cap | Default | What happens at the limit |
+|-----|---------|---------------------------|
+| `LIFEOS_CLAUDE_TIMEOUT` | 3600 seconds | Watchdog kills the subprocess; operator gets a timeout notification. |
+| `LIFEOS_CLAUDE_MAX_TURNS` | 50 turns | Session terminated; operator gets a "max turns reached" notification. |
+| `LIFEOS_CLAUDE_MAX_COST` | $2.00 USD | Session terminated; operator gets a "cost cap reached" notification. |
+
+The wall-time cap is the backstop — the 5-minute heartbeat plus `[NOTIFY]` checkpoints mean the operator usually has earlier signals to react to.
+
+---
+
+## Directory resolution
+
+The orchestrator picks the working directory from keywords in the task description:
+
+| Task description matches… | Working directory |
+|---------------------------|-------------------|
+| "edit the backlog", "update my journal" | Operator's Obsidian vault (`LIFEOS_VAULT_PATH`) |
+| "fix the lifeos server", "update sync" | `LIFEOS_CODE_DIR/LifeOS` |
+| "update the <project> readme" | `LIFEOS_CODE_DIR/<project>` |
+| "write a script", "create a cron job" | `LIFEOS_CODE_DIR` |
+| anything else | `~` (home) |
+
+If the resolution is wrong, the operator makes the task more explicit (e.g., "edit the LifeOS readme" instead of "edit the readme").
+
+---
+
+## Capability boundaries
+
+### What the orchestrator can do
+
+- Spawn a single `claude` subprocess at a time on the server.
+- Pass it the operator's task as a one-shot prompt.
+- Run with `--dangerously-skip-permissions` (no approval prompts) — Claude operates with the same filesystem and shell access as the operator.
+- Use any MCP server configured for Claude Code on the server, including the LifeOS MCP catalog (see [mcp-tools.md](mcp-tools.md)).
+- Send Telegram messages on the operator's behalf.
+
+### What the orchestrator can't do
+
+- Run two sessions in parallel — operator must `/code_cancel` first.
+- Stream every line of output to Telegram — operator gets `[NOTIFY]` checkpoints, not real-time stdout.
+- Persist conversation state across runs — each session is one-shot. (Resume via `/agents` is a separate UI; see below.)
+- Exceed the configured budgets — wall, turns, and cost caps are enforced externally.
+
+---
+
+## Resume from the `/agents` page
+
+Every Claude Code session writes a JSONL transcript to `~/.claude/projects/<encoded-cwd>/<session>.jsonl`. The `/agents` page reads those transcripts and shows finished sessions as nodes (inferred status: `inactive` after the most-recent-touch threshold elapses — see [agent-viz.md](agent-viz.md)).
+
+The operator can click "Resume" on an inactive Claude Code session and the LifeOS server runs an operator-configured terminal launcher (`LIFEOS_CC_RESUME_CMD`) that re-opens a Claude session resumed from that transcript id. Gated by `LIFEOS_CC_RESUME_ENABLED`. Configuration in [configuration.md § Claude Code Resume](../../guides/configuration.md#claude-code-resume-agents-operator-controlled-re-launch).
+
+This is operator-driven (you click it) and runs through the operator's terminal — the orchestrator itself doesn't resume sessions automatically.
+
+---
+
+## Related Documents
+
+- [Claude Code Orchestration — Technical](../technical/claude-code-orchestration.md) — Implementation: subprocess management, stream parsing, system prompt, plan-mode detection, transcript handling
+- [Claude Code Orchestration — Guide](../../guides/claude-code-orchestration.md) — Operator setup (binary install, `setup-token`, troubleshooting, examples)
+- [Agent Worker (product)](agent-worker.md) — The parallel system for `#agent`-tagged tasks
+- [Agent Viz (product)](agent-viz.md) — `/agents` page that shows both orchestrator and worker sessions
+- [MCP Tools](mcp-tools.md) — LifeOS tools available to Claude Code sessions
+- [Configuration](../../guides/configuration.md) — `LIFEOS_CLAUDE_*` env vars

--- a/docs/specs/technical/claude-code-orchestration.md
+++ b/docs/specs/technical/claude-code-orchestration.md
@@ -1,0 +1,253 @@
+# Claude Code Orchestration — Technical
+
+**Status:** Complete
+**Owner:** Orchestrator
+**Last Updated:** 2026-05-27
+
+Implementation view of `api/services/claude_orchestrator.py` — how the Telegram `/code` command spawns and supervises a `claude` CLI subprocess. For the consumer view (`/code` command, plan mode, clarifications, budgets) see [product/claude-code-orchestration.md](../product/claude-code-orchestration.md). For operator setup see [guides/claude-code-orchestration.md](../../guides/claude-code-orchestration.md).
+
+---
+
+## Table of Contents
+
+1. [Module layout](#module-layout)
+2. [Subprocess spawning](#subprocess-spawning)
+3. [Stream parsing](#stream-parsing)
+4. [`[NOTIFY]` and `[CLARIFY]` extraction](#notify-and-clarify-extraction)
+5. [Session state](#session-state)
+6. [Plan mode detection](#plan-mode-detection)
+7. [Clarification flow](#clarification-flow)
+8. [Heartbeat timer](#heartbeat-timer)
+9. [Cancellation](#cancellation)
+10. [Budget enforcement](#budget-enforcement)
+11. [System prompt](#system-prompt)
+12. [Directory resolution](#directory-resolution)
+13. [Transcript handling and the `/agents` read path](#transcript-handling-and-the-agents-read-path)
+14. [System boundaries](#system-boundaries)
+
+---
+
+## Module layout
+
+All code lives in [`api/services/claude_orchestrator.py`](../../../api/services/claude_orchestrator.py) (~700 lines). Key classes:
+
+| Symbol | Responsibility |
+|--------|----------------|
+| `ClaudeOrchestrator` | Singleton owning the active subprocess, session state, and lifecycle methods (`run_task`, `approve_plan`, `reject_plan`, `respond_to_clarification`, `cancel`, `followup`). |
+| `ClaudeSession` | Dataclass with task description, cwd, status, started_at, cost/tokens, `notifications_sent`. |
+| `_NOTIFY_RE`, `_CLARIFY_RE` | Module-level regexes that extract `[NOTIFY] ...` and `[CLARIFY] ...` blocks from Claude's streamed text. |
+| `_resolve_claude_binary` | Locates the `claude` CLI binary (`LIFEOS_CLAUDE_BINARY` override or `~/.local/bin/claude` default). |
+| `_summarize_tool_call` | One-line human-readable summary of a `tool_use` JSONL event (for transcript display, not Telegram). |
+
+The orchestrator runs **in-process** with the FastAPI server — it does not have a separate daemon. Concurrency is single-session (one `subprocess.Popen` at a time).
+
+---
+
+## Subprocess spawning
+
+`ClaudeOrchestrator.run_task(task, cwd)` does:
+
+1. Reject if `_process` is not None (single-session invariant).
+2. Resolve the working directory (see [Directory resolution](#directory-resolution)).
+3. Build the command:
+   ```
+   claude -p "<task with system prompt prepended>" \
+     --output-format stream-json \
+     --verbose \
+     --dangerously-skip-permissions
+   ```
+   Built with `shlex.split` (no `shell=True`) to avoid shell-injection paths even though `task` comes from a trusted operator.
+4. `subprocess.Popen(..., stdout=PIPE, stderr=STDOUT, text=True, bufsize=1, cwd=resolved_cwd)`.
+5. Spin up a daemon thread that calls `_read_stream(self._process.stdout, session)` to parse the JSONL line-by-line.
+6. Start the heartbeat timer (5-minute interval).
+7. Send the Telegram ack message including the resolved cwd.
+
+The `--dangerously-skip-permissions` flag means Claude doesn't pause for tool approvals. This is intentional — the operator already authorized the session by sending the `/code` command, and pausing for per-tool approvals would defeat the point of an autonomous helper.
+
+---
+
+## Stream parsing
+
+Claude Code emits one JSON object per line on stdout (`--output-format stream-json`). The reader thread classifies events:
+
+| Event `type` | Handling |
+|--------------|----------|
+| `system` (init) | Capture session id; ignore. |
+| `assistant` | Extract `content[*].text`; pipe through `[NOTIFY]`/`[CLARIFY]` extractors. |
+| `tool_use` | Summarize via `_summarize_tool_call` for transcript display. Never relayed to Telegram. |
+| `tool_result` | Track for cost/turn counting. Not relayed. |
+| `result` (terminal) | Record final cost/tokens; transition session to `COMPLETED`; send final Telegram summary. |
+
+Errors during parse log to `logs/lifeos-api-error.log` and do not crash the reader thread.
+
+---
+
+## `[NOTIFY]` and `[CLARIFY]` extraction
+
+The orchestrator scans assistant-message text for two markers using compiled regexes:
+
+```python
+_NOTIFY_RE  = re.compile(r"\[NOTIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY)\]|\Z)", re.DOTALL)
+_CLARIFY_RE = re.compile(r"\[CLARIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY)\]|\Z)", re.DOTALL)
+```
+
+The non-greedy `.*?` with a lookahead for the next marker (or end of string) means multiple `[NOTIFY]` messages within one assistant turn each get their own Telegram delivery. The session row tracks `notifications_sent` so the orchestrator can include the count in the completion summary.
+
+When a `[CLARIFY]` block is detected:
+- The orchestrator pauses the session (state → `CLARIFY_PENDING`).
+- The question is sent to Telegram.
+- The next non-command Telegram message is routed to `respond_to_clarification(answer)` instead of the chat pipeline.
+- The orchestrator then sends the answer to the still-running `claude` subprocess via stdin.
+
+---
+
+## Session state
+
+`ClaudeSession` is a single dataclass (no SQLite — orchestrator state is process-local):
+
+```python
+@dataclass
+class ClaudeSession:
+    task: str
+    cwd: Path
+    status: str   # ACCEPTED | RUNNING | PLAN_PENDING | CLARIFY_PENDING | COMPLETED | FAILED | TIMEOUT | CANCELLED
+    started_at: datetime
+    cost_usd: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    notifications_sent: int = 0
+    session_id: str | None = None   # Claude Code's own id from the `system` init event
+```
+
+On terminal status, the orchestrator clears `self._process` so the next `run_task` can proceed.
+
+---
+
+## Plan mode detection
+
+Plan mode is keyword-triggered before the subprocess starts. The orchestrator scans the task text for one of the trigger words (`refactor`, `implement`, `rewrite`, `overhaul`, `build a`, `set up a`, `add a new`, `create a new`, `remove all`, `delete all`, `migrate`, `replace`, `restructure`, `integrate`).
+
+If matched, the system prompt prepended to the task instructs Claude to present a plan first via `[NOTIFY]` and explicitly ask "Reply 'approve' to proceed or 'reject' to cancel." The state goes to `PLAN_PENDING` after the plan is delivered; `approve_plan()` / `reject_plan()` resume or cancel.
+
+Plan-mode detection is intentionally permissive — false positives (plan asked for a small change) are mildly annoying; false negatives (no plan for a big change) can damage state. The list of trigger words is conservative on the safe side.
+
+---
+
+## Clarification flow
+
+If Claude emits `[CLARIFY] <question>` mid-session, the orchestrator:
+
+1. Sends `<question>` to Telegram.
+2. Sets state to `CLARIFY_PENDING`.
+3. Stops relaying chat-pipeline messages — the next Telegram message is captured as the answer.
+4. On `respond_to_clarification(answer)`, the answer is fed to the subprocess via stdin (the `claude` CLI supports answering interactively via stdin while a session is running).
+5. State returns to `RUNNING`.
+
+If the operator wants to cancel during a clarification, they send `/code_cancel`. The orchestrator distinguishes commands from clarification answers by the leading slash.
+
+---
+
+## Heartbeat timer
+
+A `threading.Timer` runs every 5 minutes while the session is active. Each tick:
+
+- If `status == RUNNING`, send a Telegram heartbeat: `Still working... (Nm elapsed)`.
+- Reschedule.
+
+The heartbeat is the orchestrator's signal, not Claude's. It guarantees the operator hears from the session even if Claude is busy doing work without sending `[NOTIFY]` checkpoints.
+
+The timer is cancelled on any terminal status transition.
+
+---
+
+## Cancellation
+
+`ClaudeOrchestrator.cancel()`:
+
+1. If `_process` is None, return (no-op).
+2. Send `SIGTERM` to the process group; wait up to 5 seconds.
+3. If still alive, send `SIGKILL`.
+4. Mark session `CANCELLED`.
+5. Send Telegram cancellation notification.
+6. Clear `_process` and stop the heartbeat timer.
+
+This is the path `/code_cancel` triggers. It's also called by the watchdog timer when wall-time / turns / cost caps are exceeded — see [Budget enforcement](#budget-enforcement).
+
+---
+
+## Budget enforcement
+
+Three caps from `.env`:
+
+| Env var | Enforced by |
+|---------|-------------|
+| `LIFEOS_CLAUDE_TIMEOUT` (seconds, default 3600) | Wall-time watchdog `threading.Timer` started at spawn. On fire, calls `cancel()` and sets status to `TIMEOUT`. |
+| `LIFEOS_CLAUDE_MAX_TURNS` (default 50) | Counted from `tool_use` events in the stream. When the count exceeds the cap, `cancel()` is called and status is `FAILED` with reason `max_turns`. |
+| `LIFEOS_CLAUDE_MAX_COST` (USD, default 2.0) | Updated from each `result`/`assistant` event's accumulated cost; same cancel-on-breach pattern as above. |
+
+All three caps are enforced **outside** the Claude subprocess so the model can't override them. The operator gets a distinct Telegram notification per cap-breach reason.
+
+---
+
+## System prompt
+
+A fixed system prompt is prepended to every task (see `claude_orchestrator.py` lines ~50–180 for the canonical text). It instructs Claude to:
+
+- **Interpret tasks creatively** — Telegram tasks are short and informal; explore the directory, understand conventions, do the full job.
+- **Be persistent and resourceful** — try alternatives, debug, ask only after exhausting options.
+- **Know the environment** — vault location, project directories, git, cron, Python venv at `~/.venvs/lifeos`.
+- **Use `[NOTIFY]` for progress and completion summaries** — concise, 1–3 sentences. Do not use `[NOTIFY]` for routine tool calls.
+- **Use `[CLARIFY]` for genuine ambiguity** — present a single targeted question.
+- For plan-mode tasks: present the complete plan in a single `[NOTIFY]`, then ask for approval.
+
+The system prompt also tells Claude not to fix unrelated issues it notices — mention them in the completion summary instead. This keeps blast radius bounded.
+
+---
+
+## Directory resolution
+
+`api/services/directory_resolver.py` (called by `claude_orchestrator.py`) picks the cwd by keyword match against the task text:
+
+| Keyword pattern | Resolved cwd |
+|-----------------|--------------|
+| `backlog`, `journal`, `vault`, `note(s)` (without project prefix) | `LIFEOS_VAULT_PATH` |
+| `lifeos`, `lifeos server`, `sync` (LifeOS-internal terms) | `LIFEOS_CODE_DIR/LifeOS` |
+| `<project> readme/script/...` where `<project>` matches a known dir | `LIFEOS_CODE_DIR/<project>` |
+| `cron job`, `script`, `tool` (general dev terms) | `LIFEOS_CODE_DIR` |
+| anything else | `Path.home()` |
+
+The resolver is a simple match-by-precedence function. If it picks wrong, the operator gets a more-explicit task description and re-runs.
+
+---
+
+## Transcript handling and the `/agents` read path
+
+The orchestrator itself does not write a transcript file. **Claude Code writes its own** to `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` — that's where the per-session id from the `system` init event matters.
+
+The `/agents` page's Claude Code ingest path reads those JSONL files independently of this orchestrator (read-only, see [agent-viz technical spec](agent-viz.md) and [ADR-011](../../adr/011-external-agent-ingest.md)). The orchestrator and the viz are loosely coupled — neither imports the other; the JSONL file format is the contract.
+
+The "Resume from `/agents`" UX (see [product/claude-code-orchestration.md § Resume](../product/claude-code-orchestration.md#resume-from-the-agents-page)) runs a separate operator-configured terminal command (`LIFEOS_CC_RESUME_CMD`); it does not go through this orchestrator.
+
+---
+
+## System boundaries
+
+- **Local network only.** All `/code*` Telegram routes are unauthenticated beyond Telegram's own bot-token-based auth.
+- **MCP HTTP transport must not expose the orchestrator.** The bearer-gated `/mcp` HTTP endpoint serves the MCP tool catalog only; the `/code` Telegram command path is not exposed externally and the orchestrator is **not** an MCP tool. (Distinct from agent-worker Managed Agents, which is bearer-gated but external by design — see [ADR-008](../../adr/008-managed-agents-cloud-routing.md).)
+- **Operator trusts Claude with operator-level access.** `--dangerously-skip-permissions` + no sandboxing means a Claude Code session can do anything the operator's user can. This is the same trust model as the agent worker's local executor (see [agent-worker technical spec § Local executor](agent-worker.md#local-executor-gemma-path)).
+- **Single-session is a soft hardening.** Parallelism could be added but would require state migration (session map keyed by id) and isn't needed for personal-assistant usage.
+
+---
+
+## Related Documents
+
+- [Claude Code Orchestration — Product](../product/claude-code-orchestration.md) — Operator-facing behavior
+- [Claude Code Orchestration — Guide](../../guides/claude-code-orchestration.md) — Operator setup (binary install, `setup-token`, troubleshooting)
+- [Agent Worker — Technical](agent-worker.md) — Sibling autonomous-work system; different trust model and concurrency story
+- [Agent Viz — Technical](agent-viz.md) — How Claude Code transcripts surface in `/agents` (read-only)
+- [ADR-008: Managed Agents Cloud Routing](../../adr/008-managed-agents-cloud-routing.md) — Worker-side cloud path (contrast with this orchestrator's local-only model)
+- [ADR-011: External Agent Ingest](../../adr/011-external-agent-ingest.md) — Read-only adapter pattern the `/agents` page uses for these transcripts
+- [`api/services/claude_orchestrator.py`](../../../api/services/claude_orchestrator.py) — Implementation
+- [`api/services/directory_resolver.py`](../../../api/services/directory_resolver.py) — Cwd resolution


### PR DESCRIPTION
## Summary

Backfills the missing live-spec coverage for `api/services/claude_orchestrator.py` (the Telegram `/code` orchestrator). Behavior was previously documented inside the operator guide and the frozen archive/audit docs — never in a live spec.

## New files

| File | Lines | Purpose |
|------|------:|---------|
| `docs/specs/product/claude-code-orchestration.md` | 211 | Consumer view: trigger paths, lifecycle, plan mode, clarifications, budgets, capability boundaries, resume-from-`/agents` |
| `docs/specs/technical/claude-code-orchestration.md` | 253 | Implementation: subprocess management, stream parsing, system prompt, plan-mode keyword detection, clarification flow, heartbeat, cancellation, three budget caps |

Both specs explicitly disambiguate from the agent worker: the orchestrator is one-shot / single-session / operator-triggered; the worker is poll-loop / concurrent / tag-triggered. The two systems share the `/agents` visualization layer but **not** the execution layer.

## Guide rewrite (the existing `docs/guides/claude-code-orchestration.md`)

- Header pointer added so operators landing on the guide can find the new product + technical specs.
- "How It Works" implementation list (which was duplicating + drifting from the code) replaced with a one-paragraph operator summary that points at the technical spec for details.
- Fixed three broken links: `../getting-started/CONFIGURATION.md` → `configuration.md`; `../architecture/API-MCP-REFERENCE.md#mcp-tools` → removed (covered by the spec pointer); broken API ref → `mcp-tools.md`.
- Related Documents updated: new product + technical specs at top; added configuration.md and mcp-tools.md.

## Bidirectional cross-links

- `agent-worker.md` Related Documents now points at `claude-code-orchestration.md` (product) as the "other autonomous-work system in LifeOS".
- `agent-viz.md` Related Documents now points at `claude-code-orchestration.md` (product) as "the orchestrator that spawns the Claude Code sessions surfaced here".

## Acceptance criteria

- [x] Product + technical spec pair exists for Claude Code orchestration
- [x] The existing guide is a true operator how-to (Authentication Setup, Configuration pointer, Usage examples, Troubleshooting, Limitations); spec-y content moved to the technical spec
- [x] Bidirectional links with agent-viz specs and agent-worker spec
- [x] No functional code changes

## Test plan

- [x] All cross-links resolve (specs → guide; guide → both specs + config + mcp-tools)
- [x] agent-worker / agent-viz back-links point at the new product spec
- [x] Code refs in technical spec point at real files: `api/services/claude_orchestrator.py`, `api/services/directory_resolver.py`
- [ ] Reviewer: confirm the orchestrator-vs-worker comparison table accurately reflects the distinction you want users to internalize

## Targeting

Based on `docs/180-strategy-foundation`; targeted at `docs/overhaul`.

Closes #191.