### PR TITLE
feat(agents): wezterm-backed Resume + new Focus button on /agents

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -559,12 +559,25 @@ async def resume_claude_code_session(
     if target is None or not target.decoded_cwd:
         raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
 
-    # Template substitutions:
+    # Render the inner command first so the outer template can substitute
+    # `{inner_command}` (wezterm path) AND so we can copy it to the clipboard
+    # as a backup if the spawn doesn't actually run it (legacy launcher path).
+    inner_template = (settings.cc_resume_inner_cmd or "").strip()
+    inner_rendered = (
+        inner_template
+        .replace("{session_id}", bare)
+        .replace("{cwd}", target.decoded_cwd)
+    )
+
+    # Template substitutions on the launcher:
     #   {session_id}     — bare uuid (no cc: prefix)
     #   {cwd}            — decoded project working directory
     #   {session_id_url} — URL-encoded session_id for use inside `warp://`,
     #                      `vscode://` etc. query strings
     #   {cwd_url}        — URL-encoded cwd for the same
+    #   {inner_command}  — the rendered inner_command, inserted unquoted so
+    #                      shlex.split sees its individual argv tokens (used
+    #                      by the default `wezterm cli spawn ... -- {inner_command}`)
     import urllib.parse
     rendered = (
         template
@@ -572,6 +585,7 @@ async def resume_claude_code_session(
         .replace("{cwd_url}", urllib.parse.quote(target.decoded_cwd, safe=""))
         .replace("{session_id}", bare)
         .replace("{cwd}", target.decoded_cwd)
+        .replace("{inner_command}", inner_rendered)
     )
     try:
         argv = shlex.split(rendered)
@@ -598,56 +612,163 @@ async def resume_claude_code_session(
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"resume spawn failed: {exc}") from exc
 
-    # Render the inner command (the actual `claude --resume` invocation)
-    # so the operator can paste it once the terminal opens — Warp Linux
-    # ignores the `&command=` URI param.
-    inner_template = (settings.cc_resume_inner_cmd or "").strip()
-    inner_rendered = (
-        inner_template
-        .replace("{session_id}", bare)
-        .replace("{cwd}", target.decoded_cwd)
-    )
-    # Push the rendered inner command directly to the system clipboard
-    # via wl-copy / xclip. The browser-side Clipboard API silently fails
-    # when the page loses focus (which happens the instant Warp opens),
-    # so doing the copy from the server while it still has env access is
-    # far more reliable. Failure here is non-fatal — the frontend gets
-    # the command in the response and can offer manual copy.
+    # Push the rendered inner command directly to the system clipboard.
+    # For the wezterm path (default) this is redundant since wezterm runs
+    # `{inner_command}` directly, but it's cheap and serves as a backup if
+    # the operator overrides cc_resume_cmd to a launcher that opens an
+    # empty terminal (e.g., the legacy `warp-terminal warp://…` flow).
     clipboard_copied = False
     if inner_rendered:
         clipboard_copied = _copy_to_clipboard(inner_rendered, env)
 
-    # Give the spawn a beat. Two flavors of launcher are both valid:
-    #   (a) the launcher BECOMES the terminal (long-running) — wait() times
-    #       out, we return the running pid.
-    #   (b) the launcher is a URL dispatcher that delegates to a running
-    #       desktop app and exits cleanly (rc=0). `warp-terminal warp://…`
-    #       does exactly this — Warp opens but the launcher process is gone.
-    # rc=0 is success regardless of timing; only a non-zero exit is failure.
-    response_body = {
+    # Two launcher flavors coexist:
+    #   (a) `wezterm cli spawn` exits cleanly with a pane id on stdout — we
+    #       want to wait for it, parse the id, store it, and return.
+    #   (b) The launcher BECOMES the terminal (rare; not the default) —
+    #       communicate() times out, no pane id available, return spawned=True.
+    # A 1.5s timeout is plenty for (a) and short enough that the API stays
+    # snappy for (b).
+    pane_id: int | None = None
+    stdout_bytes = b""
+    stderr_bytes = b""
+    try:
+        stdout_bytes, stderr_bytes = proc.communicate(timeout=1.5)
+    except subprocess.TimeoutExpired:
+        # Long-running launcher — no pane id this turn, but the spawn is
+        # in progress; surface what we have.
+        response_body = {
+            "spawned": True,
+            "pid": proc.pid,
+            "pane_id": None,
+            "command": argv,
+            "cwd": target.decoded_cwd,
+            "inner_command": inner_rendered,
+            "clipboard_copied": clipboard_copied,
+        }
+        return response_body
+
+    if proc.returncode != 0:
+        detail = (stderr_bytes.decode("utf-8", errors="replace").strip()
+                  or f"resume process exited rc={proc.returncode}")
+        raise HTTPException(status_code=500, detail=detail)
+
+    # `wezterm cli spawn` prints a single integer (the pane id) on stdout.
+    # If the operator overrode cc_resume_cmd to a launcher that doesn't
+    # print one, we just skip the focus mapping for this session.
+    stdout_text = stdout_bytes.decode("utf-8", errors="replace").strip()
+    if stdout_text:
+        first_token = stdout_text.split()[0]
+        try:
+            pane_id = int(first_token)
+        except ValueError:
+            pane_id = None
+
+    if pane_id is not None:
+        try:
+            from api.services.cc_wezterm_store import get_default_store
+            get_default_store().upsert(session_id, pane_id, target.decoded_cwd)
+        except Exception as exc:  # noqa: BLE001 — store failure is non-fatal
+            logger.warning("cc_wezterm_store upsert failed for %s: %s", session_id, exc)
+
+    return {
         "spawned": True,
         "pid": proc.pid,
+        "pane_id": pane_id,
         "command": argv,
         "cwd": target.decoded_cwd,
         "inner_command": inner_rendered,
         "clipboard_copied": clipboard_copied,
     }
+
+
+@router.post("/sessions/{session_id}/focus")
+async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
+    """Activate the WezTerm pane that was opened for this session by a prior
+    Resume click. Returns 404 if there's no stored pane mapping (use
+    Resume to create one) and 410 if the pane no longer exists (mapping
+    cleared).
+
+    Caveat: on GNOME Wayland the compositor disallows cross-client window
+    raise, so this reliably switches the tab within wezterm but cannot
+    bring a hidden wezterm window to the foreground. A `notify-send`
+    follows the activate-pane call to flash the dock icon as a hint.
+    """
+    import shlex
+    import shutil
+    import subprocess
+
+    if not session_id.startswith("cc:"):
+        raise HTTPException(status_code=400, detail="focus is only available for Claude Code sessions")
+
     try:
-        proc.wait(timeout=0.5)
-    except subprocess.TimeoutExpired:
-        return response_body
-    if proc.returncode == 0:
-        return response_body
-    # Non-zero exit within 0.5s — surface stderr.
-    stderr_preview = b""
+        from config.settings import settings
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=f"settings unavailable: {exc}") from exc
+
+    if not getattr(settings, "cc_resume_enabled", False):
+        raise HTTPException(status_code=400, detail="cc resume disabled — set LIFEOS_CC_RESUME_ENABLED=true")
+
+    from api.services.cc_wezterm_store import get_default_store
+    store = get_default_store()
+    mapping = store.get(session_id)
+    if mapping is None:
+        raise HTTPException(
+            status_code=404,
+            detail="no tracked wezterm tab for this session — use Resume to create one",
+        )
+
+    wezterm_bin = shutil.which("wezterm") or "wezterm"
+    argv = [wezterm_bin, "cli", "activate-pane", "--pane-id", str(mapping.pane_id)]
+    env = _resume_env()
     try:
-        if proc.stderr is not None:
-            stderr_preview = proc.stderr.read(1024)
-    except Exception:  # noqa: BLE001
-        pass
-    detail = (stderr_preview.decode("utf-8", errors="replace").strip()
-              or f"resume process exited rc={proc.returncode}")
-    raise HTTPException(status_code=500, detail=detail)
+        proc = subprocess.run(  # noqa: S603 — fixed argv, no shell=True
+            argv,
+            env=env,
+            capture_output=True,
+            timeout=3.0,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=500, detail=f"wezterm not found: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(status_code=504, detail=f"wezterm activate-pane timed out: {exc}") from exc
+
+    if proc.returncode != 0:
+        # Most common cause: the user closed the tab. Clear the stale
+        # mapping so a subsequent Resume can write a fresh one.
+        store.delete(session_id)
+        detail = (proc.stderr.decode("utf-8", errors="replace").strip()
+                  or f"wezterm activate-pane exited rc={proc.returncode}")
+        raise HTTPException(status_code=410, detail=detail)
+
+    # Best-effort dock flash so a hidden wezterm window gets attention —
+    # the compositor won't raise it programmatically (see docstring), but
+    # the urgency hint on the .desktop entry will pulse the icon.
+    notify_bin = shutil.which("notify-send")
+    if notify_bin:
+        try:
+            subprocess.run(  # noqa: S603 — fixed argv
+                [
+                    notify_bin,
+                    "--urgency=critical",
+                    "--app-name=LifeOS",
+                    "--icon=utilities-terminal",
+                    "Agent session focused",
+                    f"Switched wezterm to pane {mapping.pane_id} ({shlex.quote(mapping.cwd)})",
+                ],
+                env=env,
+                capture_output=True,
+                timeout=2.0,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+    return {
+        "focused": True,
+        "pane_id": mapping.pane_id,
+        "cwd": mapping.cwd,
+    }
 
 
 async def _stream_claude_code_session(session_id: str, backfill: int):

--- a/api/services/cc_wezterm_store.py
+++ b/api/services/cc_wezterm_store.py
@@ -1,0 +1,100 @@
+"""SQLite-backed mapping from Claude Code session id → WezTerm pane id.
+
+When the /agents `Resume` action spawns a WezTerm tab via
+`wezterm cli spawn`, the resulting pane id is recorded here so the new
+`Focus` action can later call `wezterm cli activate-pane --pane-id <id>`
+and bring the user back to the existing tab instead of spawning a fresh
+one.
+
+Storage: `data/cc_wezterm.db`, one row per session_id. Pane ids may
+become stale (user closed the tab, restarted wezterm); the focus
+endpoint deletes stale rows on activate-pane failure.
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_DB_PATH = Path("data/cc_wezterm.db")
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS panes (
+    session_id   TEXT PRIMARY KEY,
+    pane_id      INTEGER NOT NULL,
+    cwd          TEXT NOT NULL,
+    created_at   INTEGER NOT NULL
+);
+"""
+
+
+@dataclass
+class PaneMapping:
+    session_id: str
+    pane_id: int
+    cwd: str
+    created_at: int
+
+
+class CCWezTermStore:
+    def __init__(self, db_path: Path | str = DEFAULT_DB_PATH) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def get(self, session_id: str) -> Optional[PaneMapping]:
+        cur = self._conn.execute(
+            "SELECT session_id, pane_id, cwd, created_at FROM panes WHERE session_id = ?",
+            (session_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return PaneMapping(
+            session_id=row["session_id"],
+            pane_id=int(row["pane_id"]),
+            cwd=row["cwd"],
+            created_at=int(row["created_at"]),
+        )
+
+    def upsert(self, session_id: str, pane_id: int, cwd: str) -> PaneMapping:
+        now = int(time.time())
+        self._conn.execute(
+            """
+            INSERT INTO panes(session_id, pane_id, cwd, created_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                pane_id    = excluded.pane_id,
+                cwd        = excluded.cwd,
+                created_at = excluded.created_at
+            """,
+            (session_id, int(pane_id), cwd, now),
+        )
+        self._conn.commit()
+        return PaneMapping(session_id=session_id, pane_id=int(pane_id), cwd=cwd, created_at=now)
+
+    def delete(self, session_id: str) -> bool:
+        cur = self._conn.execute("DELETE FROM panes WHERE session_id = ?", (session_id,))
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+_default_store: CCWezTermStore | None = None
+
+
+def get_default_store() -> CCWezTermStore:
+    """Process-wide singleton — the FastAPI workers all share one handle."""
+    global _default_store
+    if _default_store is None:
+        _default_store = CCWezTermStore()
+    return _default_store

--- a/config/settings.py
+++ b/config/settings.py
@@ -210,25 +210,29 @@ class Settings(BaseSettings):
                     "depends on the operator's desktop environment."
     )
     cc_resume_cmd: str = Field(
-        default="warp-terminal warp://action/new_tab?path={cwd_url}",
+        default="wezterm cli spawn --cwd {cwd} -- {inner_command}",
         alias="LIFEOS_CC_RESUME_CMD",
         description="Launcher command for resuming a Claude Code session. "
-                    "Default opens a new Warp tab at the project directory. "
-                    "Linux Warp ignores `&command=` in its URI scheme, so the "
-                    "actual `claude --resume` command is paired with "
-                    "LIFEOS_CC_RESUME_INNER_CMD and copied to the operator's "
-                    "clipboard on click. Substitutions: `{session_id}`, "
-                    "`{cwd}`, and URL-encoded `{session_id_url}` / `{cwd_url}`. "
-                    "Parsed with shlex.split — no shell metacharacters."
+                    "Default uses `wezterm cli spawn` which opens a new tab "
+                    "AND runs the resume command in one shot, no clipboard "
+                    "paste needed. Wezterm prints the new pane id on stdout, "
+                    "which the /agents page stores so the new `Focus` action "
+                    "can call `wezterm cli activate-pane` to revisit the tab. "
+                    "Substitutions: `{session_id}`, `{cwd}`, `{inner_command}` "
+                    "(rendered LIFEOS_CC_RESUME_INNER_CMD), and URL-encoded "
+                    "`{session_id_url}` / `{cwd_url}`. Parsed with shlex.split "
+                    "— no shell metacharacters."
     )
     cc_resume_inner_cmd: str = Field(
-        default="vt claude --dangerously-skip-permissions --resume {session_id}",
+        default="claude --dangerously-skip-permissions --resume {session_id}",
         alias="LIFEOS_CC_RESUME_INNER_CMD",
-        description="Command intended to run *inside* the spawned terminal. "
-                    "Returned in the resume response and copied to the "
-                    "operator's clipboard so they can paste it once the "
-                    "terminal opens. Set to empty to disable clipboard "
-                    "copy. Substitutions: `{session_id}`, `{cwd}`."
+        description="Command run *inside* the spawned terminal — the actual "
+                    "`claude --resume` invocation. The default template for "
+                    "LIFEOS_CC_RESUME_CMD substitutes this in via "
+                    "`{inner_command}` so wezterm launches the tab with the "
+                    "resume already running. Substitutions: `{session_id}`, "
+                    "`{cwd}`. Set to empty to skip the inner command (spawn "
+                    "an empty terminal)."
     )
     cc_resume_env_file: str = Field(
         default="",

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -157,16 +157,17 @@ Claude Code sessions do not get a Kill button — the page has no safe primitive
 
 ---
 
-## Operator controls — resume
+## Operator controls — resume and focus
 
-Claude Code sessions in `inactive` or terminal states get a green **Resume** button. The flow:
+Claude Code sessions in `inactive` or terminal states get two buttons:
 
-1. Click Resume.
-2. The server spawns a configured launcher command (`LIFEOS_CC_RESUME_CMD`). The default opens a new tab in Warp Terminal at the project's working directory.
-3. The actual `claude --resume <session_id>` command (configured via `LIFEOS_CC_RESUME_INNER_CMD`) is copied to your system clipboard server-side via `wl-copy` (Wayland) or `xclip` (X11) — done from the server because the browser Clipboard API silently fails the moment the page loses focus.
-4. A toast confirms "Warp opened. Resume command copied to clipboard — paste it." Paste the command in the new terminal and Claude Code reopens the session.
+**Resume** opens a new WezTerm tab at the session's working directory and launches `claude --resume <session_id>` in it. WezTerm prints the new pane id; LifeOS stores it in a sidecar SQLite mapping (`data/cc_wezterm.db`) keyed by session id.
 
-Resume is **off by default** because spawning GUI terminals from a systemd service depends on the operator's desktop environment. Enable with `LIFEOS_CC_RESUME_ENABLED=true`. Customize the launcher (`LIFEOS_CC_RESUME_CMD`) if you don't use Warp — substitutions `{cwd}`, `{cwd_url}`, `{session_id}`, `{session_id_url}` are available.
+**Focus** activates the existing tab for that session — calls `wezterm cli activate-pane --pane-id <id>` against the stored mapping. If WezTerm is the focused window the tab switches immediately; if it's hidden, the pane is selected in the background and a `notify-send` urgency hint pulses the dock icon. The OS-level window-raise across applications is restricted by Wayland compositors (no programmatic foreground steal); WezTerm under XWayland can be raised via `wmctrl`/`xdotool` if the operator needs it.
+
+Focus returns 404 if no Resume has been clicked yet for that session, and 410 if the stored pane no longer exists (e.g. user closed the tab); in both cases the toast prompts the operator to click Resume.
+
+Resume is **off by default** because spawning GUI terminals from a systemd service depends on the operator's desktop environment. Enable with `LIFEOS_CC_RESUME_ENABLED=true` (the same flag also enables Focus). Customize the launcher (`LIFEOS_CC_RESUME_CMD`) if you don't use WezTerm — substitutions `{cwd}`, `{cwd_url}`, `{session_id}`, `{session_id_url}`, and `{inner_command}` are available. The pane-tracking + Focus button assume the launcher prints a pane id on stdout, so non-WezTerm launchers leave Focus inert for those sessions.
 
 ---
 
@@ -188,9 +189,9 @@ All in `.env`. None are required — the defaults work for the standard LifeOS i
 | `LIFEOS_CLAUDE_CODE_VIZ_ENABLED` | Surface Claude Code CLI sessions alongside agent worker sessions. Set false to scope the viz to LifeOS sessions only. | `true` |
 | `LIFEOS_CLAUDE_CODE_PROJECTS_DIR` | Where to find Claude Code transcripts. | `~/.claude/projects` |
 | `LIFEOS_CLAUDE_CODE_LOOKBACK_DAYS` | Discovery window — older jsonl files are excluded from the snapshot (they can still be loaded by direct session id). | `7` |
-| `LIFEOS_CC_RESUME_ENABLED` | Enable the Resume button. | `false` |
-| `LIFEOS_CC_RESUME_CMD` | Launcher command. Substitutions: `{session_id}`, `{cwd}`, `{session_id_url}`, `{cwd_url}`. | `warp-terminal warp://action/new_tab?path={cwd_url}` |
-| `LIFEOS_CC_RESUME_INNER_CMD` | The command copied to the clipboard (intended for the new terminal). Set empty to disable clipboard copy. | `vt claude --dangerously-skip-permissions --resume {session_id}` |
+| `LIFEOS_CC_RESUME_ENABLED` | Enable the Resume and Focus buttons. | `false` |
+| `LIFEOS_CC_RESUME_CMD` | Launcher command. Substitutions: `{session_id}`, `{cwd}`, `{session_id_url}`, `{cwd_url}`, `{inner_command}`. The default uses WezTerm's CLI to open a tab AND run the resume in one shot. | `wezterm cli spawn --cwd {cwd} -- {inner_command}` |
+| `LIFEOS_CC_RESUME_INNER_CMD` | The command run *inside* the spawned terminal — the actual `claude --resume` invocation. Substituted into `{inner_command}` of the launcher template. | `claude --dangerously-skip-permissions --resume {session_id}` |
 | `LIFEOS_CC_RESUME_ENV_FILE` | Optional `key=value` file pinning `DISPLAY` / `XAUTHORITY` / `WAYLAND_DISPLAY` / `DBUS_SESSION_BUS_ADDRESS` for the spawned terminal. | `` (inherit systemd env) |
 
 ---

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -69,7 +69,8 @@ All under `/api/agents`. Local-network only — the kill and resume endpoints mu
 | `GET /sessions/{id}/events?limit=N` | Last N transcript events (default 200, max 2000). Dispatches by `cc:` prefix to the Claude Code ingest path. |
 | `GET /sessions/{id}/stream?backfill=N` | Per-session SSE: backfill last N events (default 50, max 500), then live-tail. Closes cleanly when the session reaches terminal status (LifeOS) or after 5 min idle (Claude Code). |
 | `POST /sessions/{id}/kill` | Operator kill — body `{reason: ""}`. LifeOS sessions only. Cascades to descendants in the subtree. |
-| `POST /sessions/{id}/resume` | Resume a Claude Code session — body `{extra_env: {}}`. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. |
+| `POST /sessions/{id}/resume` | Resume a Claude Code session — body `{extra_env: {}}`. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Spawns a WezTerm tab via `wezterm cli spawn`, captures the pane id from stdout, and stores `session_id → pane_id` in `data/cc_wezterm.db` so Focus can target it later. |
+| `POST /sessions/{id}/focus` | Activate the WezTerm tab previously opened for this session. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. 404 if no mapping exists; 410 (and mapping cleared) if `wezterm cli activate-pane` fails because the pane no longer exists. |
 
 Heartbeats: per-session SSE emits a `:heartbeat\n\n` comment every 15s when there's no new event, so dropped connections surface quickly through the browser's `EventSource` retry.
 
@@ -272,23 +273,37 @@ The endpoint must not be exposed via Tailscale Funnel or the public MCP HTTP tra
 
 ---
 
-## Claude Code resume
+## Claude Code resume + focus
 
 ```
 POST /api/agents/sessions/{id}/resume   body: {"extra_env": {...}}
+POST /api/agents/sessions/{id}/focus    body: (none)
 ```
 
-Resume opt-in via `LIFEOS_CC_RESUME_ENABLED`. Spawns a configured launcher and pushes the actual `claude --resume` command to the system clipboard server-side.
+Both opt-in via `LIFEOS_CC_RESUME_ENABLED`. Resume spawns a new WezTerm tab and records the new pane id; Focus revisits that pane.
+
+### Resume
 
 1. Validate the session id (must start with `cc:`, must pass `validate_session_id`). Strip a `:agent:...` suffix if present — operator clicks on a subagent diamond mean "resume the parent terminal".
 2. Look up the meta via `discover_sessions(...)` with a widened 365-day lookback (resume is fine on old sessions). 404 if not found or no `decoded_cwd`.
-3. Render `LIFEOS_CC_RESUME_CMD` with the substitutions `{session_id}`, `{cwd}`, `{session_id_url}`, `{cwd_url}` (URL-encoded for embedding inside `warp://…` / `vscode://…` URIs).
+3. Render `LIFEOS_CC_RESUME_INNER_CMD` with `{session_id}` / `{cwd}` first, then render `LIFEOS_CC_RESUME_CMD` with the same substitutions plus `{session_id_url}` / `{cwd_url}` (URL-encoded for legacy URI-scheme launchers) and `{inner_command}` (which expands to the rendered inner command's argv tokens, picked apart by `shlex.split`).
 4. `shlex.split(rendered)` — no `shell=True`, ever.
 5. Build the env: inherit `os.environ`, then layer `LIFEOS_CC_RESUME_ENV_FILE` (key=value lines pinning `DISPLAY` / `XAUTHORITY` / `WAYLAND_DISPLAY` / `DBUS_SESSION_BUS_ADDRESS`), then merge `body.extra_env` last.
-6. Render `LIFEOS_CC_RESUME_INNER_CMD` and push it to the system clipboard via `wl-copy` (Wayland) or `xclip` (X11). Server-side because the browser Clipboard API silently fails the instant the page loses focus to the spawned terminal.
-7. `subprocess.Popen(argv, cwd=decoded_cwd, env=env, start_new_session=True)`. Wait up to 0.5s; rc=0 is success regardless of timing (Warp's URL dispatcher exits clean after handing off to a running desktop app).
+6. Push the rendered inner command to the system clipboard via `wl-copy` (Wayland) or `xclip` (X11) as a backup — redundant for the default WezTerm path (which runs the inner command directly) but useful if the operator has overridden `LIFEOS_CC_RESUME_CMD` to a legacy launcher that opens an empty terminal.
+7. `subprocess.Popen(argv, cwd=decoded_cwd, env=env, stdout=PIPE, stderr=PIPE, start_new_session=True)`. `proc.communicate(timeout=1.5)` to drain stdout — that's where `wezterm cli spawn` prints the new pane id. rc=0 with no integer on stdout is still success (operator may have configured a non-WezTerm launcher); rc≠0 surfaces stderr as 500. A `TimeoutExpired` keeps the launcher alive and returns `pane_id: null` — for launchers that BECOME the terminal.
+8. If stdout's first token parses as an int, persist `session_id → pane_id` via `CCWezTermStore.upsert` (SQLite at `data/cc_wezterm.db`).
 
-Response: `{spawned: true, pid, command, cwd, inner_command, clipboard_copied}`. The frontend falls back to a manual-copy toast if `clipboard_copied` is false.
+Response: `{spawned: true, pid, pane_id, command, cwd, inner_command, clipboard_copied}`. The frontend uses `pane_id` to decide whether the Focus button can target this session; if `null`, Focus will respond 404.
+
+### Focus
+
+1. Validate `cc:` prefix and the `LIFEOS_CC_RESUME_ENABLED` gate.
+2. `CCWezTermStore.get(session_id)`. 404 if missing — operator must click Resume first.
+3. `subprocess.run(["wezterm", "cli", "activate-pane", "--pane-id", str(pane_id)], capture_output=True, timeout=3.0)`.
+4. rc≠0 → delete the stored mapping and return 410 with stderr preview. The mapping is stale (typically: user closed the tab), so the next Resume click writes a fresh one.
+5. Best-effort `notify-send --urgency=critical` so a hidden WezTerm window pulses the dock icon — GNOME Wayland disallows cross-client window raise, so this is the strongest attention hint we can issue from outside the focused client.
+
+Response: `{focused: true, pane_id, cwd}`.
 
 ---
 
@@ -317,12 +332,13 @@ RestartSec=10
 
 ## Security boundaries
 
-The threat model: the LifeOS MCP HTTP transport is publicly accessible via Tailscale Funnel and is the obvious place an external agent or compromised credential could hit LifeOS endpoints. Both `/kill` and `/resume`:
+The threat model: the LifeOS MCP HTTP transport is publicly accessible via Tailscale Funnel and is the obvious place an external agent or compromised credential could hit LifeOS endpoints. `/kill`, `/resume`, and `/focus`:
 
 - Live under `/api/agents/*` — the MCP transport never proxies this prefix.
 - Are not registered as MCP tools — so they cannot be invoked through the MCP layer even if an attacker has a bearer token.
 - Kill calls into worker primitives that already have an audit trail (every kill emits a transcript event).
-- Resume runs a configured launcher via `shlex.split` only — no `shell=True`. Template substitutions are URL-encoded where they go into URI strings.
+- Resume runs a configured launcher via `shlex.split` only — no `shell=True`. Template substitutions are URL-encoded where they go into URI strings. The rendered `{inner_command}` is split into individual argv tokens before reaching the launcher, so a malicious inner command cannot smuggle shell metacharacters.
+- Focus calls `wezterm cli activate-pane` with a fixed argv (no template) using the pane id from the local SQLite mapping. The store is only writeable from the same process (no cross-machine exposure), and pane ids are integers — there is no path for an external caller to inject arbitrary argv.
 
 Per-source guarantees:
 

--- a/tests/test_agent_resume_api.py
+++ b/tests/test_agent_resume_api.py
@@ -1,10 +1,14 @@
-"""Tests for the Claude Code resume endpoint (issue #160).
+"""Tests for the Claude Code resume + focus endpoints (issues #160 + wezterm).
 
-Resume spawns a local terminal via subprocess. Every test in this file
-mocks `subprocess.Popen` so no real process is launched.
+`resume` spawns a wezterm tab via `wezterm cli spawn` and captures the
+pane id from stdout. `focus` calls `wezterm cli activate-pane` to revisit
+the same tab. Both spawn subprocesses, so every test in this file mocks
+the subprocess calls and the cc_wezterm_store; no real wezterm is
+required.
 """
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -57,6 +61,48 @@ def synthetic_session(tmp_path: Path, monkeypatch):
     return tmp_path, sid
 
 
+@pytest.fixture
+def wezterm_store(tmp_path: Path, monkeypatch):
+    """Swap the default cc_wezterm store for a tmp-path-backed one so tests
+    can introspect what got persisted without touching the real DB."""
+    from api.services import cc_wezterm_store as mod
+    store = mod.CCWezTermStore(db_path=tmp_path / "cc_wezterm.db")
+    monkeypatch.setattr(mod, "_default_store", store)
+    yield store
+    store.close()
+
+
+def _make_fake_proc(*, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0,
+                    timeout: bool = False):
+    """Build a _FakeProc class whose `communicate` matches the requested
+    outcome. Tests instantiate it indirectly via `subprocess.Popen` mock."""
+
+    captured: dict[str, object] = {}
+
+    class _FakeProc:
+        def __init__(self, argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            captured["env"] = kwargs.get("env") or {}
+            self.pid = 4242
+            self.stdout = MagicMock()
+            self.stderr = MagicMock()
+            self.returncode = None
+
+        def communicate(self, timeout=None):
+            if timeout is True or timeout == "force":
+                raise subprocess.TimeoutExpired(cmd=captured["argv"], timeout=timeout)
+            self.returncode = returncode
+            return stdout, stderr
+
+    if timeout:
+        class _TimingOut(_FakeProc):
+            def communicate(self, timeout=None):  # noqa: D401
+                raise subprocess.TimeoutExpired(cmd=captured["argv"], timeout=timeout)
+        return _TimingOut, captured
+    return _FakeProc, captured
+
+
 # ---------------------------------------------------------------------------
 # Gating: disabled / non-cc / missing template
 # ---------------------------------------------------------------------------
@@ -98,29 +144,15 @@ def test_resume_empty_template_400(client, synthetic_session, monkeypatch):
 
 @pytest.mark.unit
 def test_resume_substitutes_session_id_and_spawns_with_cwd(
-    client, synthetic_session, monkeypatch
+    client, synthetic_session, wezterm_store, monkeypatch
 ):
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd",
                         "echo claude --resume {session_id} --extra")
 
-    captured: dict[str, object] = {}
-
-    class _FakeProc:
-        def __init__(self, argv, **kwargs):
-            captured["argv"] = argv
-            captured["kwargs"] = kwargs
-            self.pid = 4242
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-            self.returncode = None
-
-        def wait(self, timeout=None):
-            # Long-running process — pretend it's still up.
-            raise __import__("subprocess").TimeoutExpired(cmd=captured["argv"], timeout=timeout)
-
-    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+    Proc, captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
     _, sid = synthetic_session
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
@@ -140,29 +172,46 @@ def test_resume_substitutes_session_id_and_spawns_with_cwd(
 
 
 @pytest.mark.unit
+def test_resume_substitutes_inner_command_token(
+    client, synthetic_session, wezterm_store, monkeypatch
+):
+    """The default wezterm template inserts the rendered inner_command via
+    `{inner_command}` — its argv tokens should land in the spawn argv."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd",
+                        "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd",
+                        "claude --resume {session_id}")
+
+    Proc, captured = _make_fake_proc(stdout=b"17\n", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    argv = captured["argv"]
+    assert argv[0] == "wezterm"
+    assert "spawn" in argv
+    assert "--" in argv
+    # Inner command's individual tokens appear after the `--`.
+    dd = argv.index("--")
+    inner_tokens = argv[dd + 1:]
+    assert inner_tokens[0] == "claude"
+    assert sid in inner_tokens
+
+
+@pytest.mark.unit
 def test_resume_subagent_id_resolves_to_parent_cwd(
-    client, synthetic_session, monkeypatch
+    client, synthetic_session, wezterm_store, monkeypatch
 ):
     """Resuming a subagent synthetic id should resume the parent terminal."""
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
 
-    captured: dict[str, object] = {}
-
-    class _FakeProc:
-        def __init__(self, argv, **kwargs):
-            captured["argv"] = argv
-            captured["kwargs"] = kwargs
-            self.pid = 5
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-            self.returncode = None
-
-        def wait(self, timeout=None):
-            raise __import__("subprocess").TimeoutExpired(cmd=captured["argv"], timeout=timeout)
-
-    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+    Proc, captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
     _, sid = synthetic_session
     sub_id = f"cc:{sid}:agent:toolu_01abc"
@@ -186,12 +235,81 @@ def test_resume_returns_404_when_session_not_discovered(client, monkeypatch, tmp
 
 
 # ---------------------------------------------------------------------------
+# Pane id capture + store integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resume_captures_pane_id_from_stdout_and_stores_it(
+    client, synthetic_session, wezterm_store, monkeypatch
+):
+    """When the launcher prints a pane id (wezterm cli spawn's contract),
+    the endpoint surfaces it AND persists session_id→pane_id."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo 42")
+
+    Proc, _captured = _make_fake_proc(stdout=b"42\n", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["pane_id"] == 42
+
+    mapping = wezterm_store.get(f"cc:{sid}")
+    assert mapping is not None
+    assert mapping.pane_id == 42
+    assert mapping.cwd == "/home/syn/Code/A"
+
+
+@pytest.mark.unit
+def test_resume_pane_id_null_when_stdout_has_no_integer(
+    client, synthetic_session, wezterm_store, monkeypatch
+):
+    """If the operator overrides the launcher to a URL dispatcher that
+    prints nothing useful, we don't fabricate a pane id."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
+
+    Proc, _captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["pane_id"] is None
+    # Nothing should be stored when there's no pane id to remember.
+    assert wezterm_store.get(f"cc:{sid}") is None
+
+
+@pytest.mark.unit
+def test_resume_pane_id_null_when_stdout_is_not_an_integer(
+    client, synthetic_session, wezterm_store, monkeypatch
+):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo hello")
+
+    Proc, _captured = _make_fake_proc(stdout=b"not-a-number\n", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200
+    assert r.json()["pane_id"] is None
+
+
+# ---------------------------------------------------------------------------
 # Failure handling
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_resume_500_when_binary_missing(client, synthetic_session, monkeypatch):
+def test_resume_500_when_binary_missing(client, synthetic_session, wezterm_store, monkeypatch):
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd", "no-such-binary {session_id}")
@@ -207,27 +325,16 @@ def test_resume_500_when_binary_missing(client, synthetic_session, monkeypatch):
 
 
 @pytest.mark.unit
-def test_resume_500_when_process_exits_nonzero_with_stderr(client, synthetic_session, monkeypatch):
-    """Process exits non-zero within the 0.5s wait → 500 with stderr preview."""
+def test_resume_500_when_process_exits_nonzero_with_stderr(
+    client, synthetic_session, wezterm_store, monkeypatch
+):
+    """Non-zero exit within the timeout → 500 with stderr preview."""
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
 
-    class _ExitedProc:
-        def __init__(self, argv, **kwargs):
-            self.pid = 7
-            self.returncode = 2
-
-            class _Stream:
-                def read(self, n):
-                    return b"stderr says: bad config\n"
-            self.stderr = _Stream()
-            self.stdout = MagicMock()
-
-        def wait(self, timeout=None):
-            return self.returncode
-
-    monkeypatch.setattr("subprocess.Popen", _ExitedProc)
+    Proc, _captured = _make_fake_proc(stdout=b"", stderr=b"stderr says: bad config\n", returncode=2)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
     _, sid = synthetic_session
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
@@ -236,39 +343,57 @@ def test_resume_500_when_process_exits_nonzero_with_stderr(client, synthetic_ses
 
 
 @pytest.mark.unit
-def test_resume_pipes_inner_command_to_system_clipboard(
-    client, synthetic_session, monkeypatch
+def test_resume_timeout_returns_spawned_without_pane_id(
+    client, synthetic_session, wezterm_store, monkeypatch
 ):
-    """`inner_command` is piped to wl-copy / xclip server-side. The
-    response's `clipboard_copied` flag reflects whether the helper
-    exited rc=0."""
+    """A launcher that BECOMES the terminal (rare; not the default) times
+    out the proc.communicate. We treat that as a successful spawn but
+    surface pane_id=None so the focus button knows there's nothing tracked."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
+
+    Proc, _captured = _make_fake_proc(timeout=True)
+    monkeypatch.setattr("subprocess.Popen", Proc)
+
+    _, sid = synthetic_session
+    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["spawned"] is True
+    assert body["pane_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Clipboard backup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resume_pipes_inner_command_to_system_clipboard(
+    client, synthetic_session, wezterm_store, monkeypatch
+):
+    """`inner_command` is piped to wl-copy / xclip server-side as a backup
+    for operators who override cc_resume_cmd to a launcher that doesn't
+    run the inner command itself (e.g. the legacy warp:// flow)."""
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
     monkeypatch.setattr(settings, "cc_resume_inner_cmd",
-                        "vt claude --resume {session_id}")
+                        "claude --resume {session_id}")
 
-    class _DispatchedProc:
-        def __init__(self, argv, **kwargs):
-            self.pid = 9
-            self.returncode = 0
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
+    Proc, _captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
-        def wait(self, timeout=None):
-            return 0
-
-    monkeypatch.setattr("subprocess.Popen", _DispatchedProc)
-
-    captured: dict[str, object] = {}
+    captured_run: dict[str, object] = {}
 
     class _CompletedProcess:
         returncode = 0
         stderr = b""
 
     def _fake_run(argv, **kwargs):
-        captured["argv"] = argv
-        captured["input"] = kwargs.get("input")
+        captured_run["argv"] = argv
+        captured_run["input"] = kwargs.get("input")
         return _CompletedProcess()
 
     monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}" if name in ("wl-copy",) else None)
@@ -279,31 +404,23 @@ def test_resume_pipes_inner_command_to_system_clipboard(
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["clipboard_copied"] is True
-    # The wl-copy invocation received the rendered inner command on stdin.
-    assert captured["argv"] == ["wl-copy"]
-    assert captured["input"].decode("utf-8") == f"vt claude --resume {sid}"
+    assert captured_run["argv"] == ["wl-copy"]
+    assert captured_run["input"].decode("utf-8") == f"claude --resume {sid}"
 
 
 @pytest.mark.unit
-def test_resume_clipboard_failure_is_non_fatal(client, synthetic_session, monkeypatch):
+def test_resume_clipboard_failure_is_non_fatal(
+    client, synthetic_session, wezterm_store, monkeypatch
+):
     """No clipboard helper available → spawn still succeeds, flag is False."""
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
     monkeypatch.setattr(settings, "cc_resume_inner_cmd",
-                        "vt claude --resume {session_id}")
+                        "claude --resume {session_id}")
 
-    class _DispatchedProc:
-        def __init__(self, argv, **kwargs):
-            self.pid = 9
-            self.returncode = 0
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-
-        def wait(self, timeout=None):
-            return 0
-
-    monkeypatch.setattr("subprocess.Popen", _DispatchedProc)
+    Proc, _captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
     monkeypatch.setattr("shutil.which", lambda name: None)  # no clipboard tools
 
     _, sid = synthetic_session
@@ -313,37 +430,6 @@ def test_resume_clipboard_failure_is_non_fatal(client, synthetic_session, monkey
     assert body["spawned"] is True
     assert body["clipboard_copied"] is False
     assert body["inner_command"]  # still returned so frontend can offer manual copy
-
-
-@pytest.mark.unit
-def test_resume_rc0_immediate_exit_is_success(client, synthetic_session, monkeypatch):
-    """URL-dispatcher launchers (`warp-terminal warp://…`) exit rc=0 right
-    after delegating to the desktop app. That MUST be treated as success —
-    the spawn worked, the terminal is now running elsewhere."""
-    from config.settings import settings
-    monkeypatch.setattr(settings, "cc_resume_enabled", True)
-    monkeypatch.setattr(settings, "cc_resume_cmd", "echo {session_id}")
-    monkeypatch.setattr(settings, "cc_resume_inner_cmd",
-                        "vt claude --resume {session_id}")
-
-    class _DispatchedProc:
-        def __init__(self, argv, **kwargs):
-            self.pid = 9
-            self.returncode = 0
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-
-        def wait(self, timeout=None):
-            return self.returncode  # immediate clean exit
-
-    monkeypatch.setattr("subprocess.Popen", _DispatchedProc)
-
-    _, sid = synthetic_session
-    r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
-    assert r.status_code == 200, r.text
-    body = r.json()
-    assert body["spawned"] is True
-    assert sid in body["inner_command"]
 
 
 @pytest.mark.unit
@@ -358,32 +444,20 @@ def test_resume_rejects_traversal_session_id(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Env file
+# Substitution coverage
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_resume_substitutes_cwd_token(client, synthetic_session, monkeypatch):
+def test_resume_substitutes_cwd_token(client, synthetic_session, wezterm_store, monkeypatch):
     """`{cwd}` is replaced with the decoded project working directory."""
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd",
                         "echo --working-dir {cwd} --resume {session_id}")
 
-    captured: dict[str, object] = {}
-
-    class _FakeProc:
-        def __init__(self, argv, **kwargs):
-            captured["argv"] = argv
-            self.pid = 1
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-            self.returncode = None
-
-        def wait(self, timeout=None):
-            raise __import__("subprocess").TimeoutExpired(cmd="x", timeout=timeout)
-
-    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+    Proc, captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
     _, sid = synthetic_session
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
@@ -394,74 +468,45 @@ def test_resume_substitutes_cwd_token(client, synthetic_session, monkeypatch):
 
 @pytest.mark.unit
 def test_resume_url_encoded_substitutions_for_uri_schemes(
-    client, synthetic_session, monkeypatch
+    client, synthetic_session, wezterm_store, monkeypatch
 ):
-    """`{cwd_url}` and `{session_id_url}` are URL-encoded — needed for
-    embedding inside `warp://action/new_tab?path=...&command=...` and other
-    URI-scheme launchers where spaces and slashes must be %-encoded."""
+    """`{cwd_url}` and `{session_id_url}` are URL-encoded — preserved for
+    operators who override the launcher to a URI-scheme dispatcher."""
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(
         settings, "cc_resume_cmd",
-        "echo warp://action/new_tab?path={cwd_url}&command=vt+claude+--resume+{session_id_url}",
+        "echo warp://action/new_tab?path={cwd_url}&command=claude+--resume+{session_id_url}",
     )
 
-    captured: dict[str, object] = {}
-
-    class _FakeProc:
-        def __init__(self, argv, **kwargs):
-            captured["argv"] = argv
-            self.pid = 1
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-            self.returncode = None
-
-        def wait(self, timeout=None):
-            raise __import__("subprocess").TimeoutExpired(cmd="x", timeout=timeout)
-
-    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+    Proc, captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
     _, sid = synthetic_session
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
     assert r.status_code == 200, r.text
-    # cwd /home/syn/Code/A should be encoded to %2Fhome%2Fsyn%2FCode%2FA
     full = " ".join(captured["argv"])
     assert "%2Fhome%2Fsyn%2FCode%2FA" in full
-    # The bare session_id has no special chars so URL-encoding is a no-op,
-    # but the {session_id_url} token must have been substituted (no literal token).
     assert "{session_id_url}" not in full
     assert "{cwd_url}" not in full
-    # The non-URL substitutions are NOT applied inside the URL-encoded params
-    # (they would break the URL); only the *_url variants land there.
-    assert "/home/syn/Code/A" not in full or "%2Fhome%2Fsyn%2FCode%2FA" in full
 
 
 @pytest.mark.unit
 def test_resume_returns_inner_command_for_clipboard(
-    client, synthetic_session, monkeypatch
+    client, synthetic_session, wezterm_store, monkeypatch
 ):
     """The inner-command setting is rendered with substitutions and surfaced
-    in the response as `inner_command` so the frontend can copy it to the
-    clipboard (Warp Linux ignores its URI-scheme `&command=`)."""
+    in the response as `inner_command`."""
     from config.settings import settings
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
     monkeypatch.setattr(
         settings, "cc_resume_inner_cmd",
-        "vt claude --resume {session_id} --workdir {cwd}",
+        "claude --resume {session_id} --workdir {cwd}",
     )
 
-    class _FakeProc:
-        def __init__(self, argv, **kwargs):
-            self.pid = 1
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-            self.returncode = None
-
-        def wait(self, timeout=None):
-            raise __import__("subprocess").TimeoutExpired(cmd="x", timeout=timeout)
-
-    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+    Proc, _captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
     _, sid = synthetic_session
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
@@ -475,7 +520,7 @@ def test_resume_returns_inner_command_for_clipboard(
 
 @pytest.mark.unit
 def test_resume_empty_inner_command_yields_empty_string(
-    client, synthetic_session, monkeypatch
+    client, synthetic_session, wezterm_store, monkeypatch
 ):
     """Operators can disable the clipboard copy by setting INNER_CMD empty."""
     from config.settings import settings
@@ -483,17 +528,8 @@ def test_resume_empty_inner_command_yields_empty_string(
     monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
     monkeypatch.setattr(settings, "cc_resume_inner_cmd", "")
 
-    class _FakeProc:
-        def __init__(self, argv, **kwargs):
-            self.pid = 1
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-            self.returncode = None
-
-        def wait(self, timeout=None):
-            raise __import__("subprocess").TimeoutExpired(cmd="x", timeout=timeout)
-
-    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+    Proc, _captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
     _, sid = synthetic_session
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
@@ -503,7 +539,7 @@ def test_resume_empty_inner_command_yields_empty_string(
 
 @pytest.mark.unit
 def test_resume_env_file_overrides_systemd_env(
-    client, synthetic_session, monkeypatch, tmp_path
+    client, synthetic_session, wezterm_store, monkeypatch, tmp_path
 ):
     """LIFEOS_CC_RESUME_ENV_FILE values appear in the Popen env kwarg."""
     from config.settings import settings
@@ -513,23 +549,104 @@ def test_resume_env_file_overrides_systemd_env(
     env_path.write_text("DISPLAY=:0\nXAUTHORITY=/run/user/1000/x\n# comment\n\n", encoding="utf-8")
     monkeypatch.setattr(settings, "cc_resume_env_file", str(env_path))
 
-    captured: dict[str, object] = {}
-
-    class _FakeProc:
-        def __init__(self, argv, **kwargs):
-            captured["env"] = kwargs.get("env") or {}
-            self.pid = 1
-            self.stdout = MagicMock()
-            self.stderr = MagicMock()
-            self.returncode = None
-
-        def wait(self, timeout=None):
-            raise __import__("subprocess").TimeoutExpired(cmd="x", timeout=timeout)
-
-    monkeypatch.setattr("subprocess.Popen", _FakeProc)
+    Proc, captured = _make_fake_proc(stdout=b"", returncode=0)
+    monkeypatch.setattr("subprocess.Popen", Proc)
 
     _, sid = synthetic_session
     r = client.post(f"/api/agents/sessions/cc:{sid}/resume", json={})
     assert r.status_code == 200, r.text
     assert captured["env"]["DISPLAY"] == ":0"
     assert captured["env"]["XAUTHORITY"] == "/run/user/1000/x"
+
+
+# ---------------------------------------------------------------------------
+# /focus endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_focus_rejects_non_cc_session(client):
+    r = client.post("/api/agents/sessions/some-lifeos-uuid/focus")
+    assert r.status_code == 400
+
+
+@pytest.mark.unit
+def test_focus_disabled_by_default(client, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", False)
+    r = client.post("/api/agents/sessions/cc:any-id/focus")
+    assert r.status_code == 400
+    assert "disabled" in r.json()["detail"].lower()
+
+
+@pytest.mark.unit
+def test_focus_returns_404_when_no_mapping(client, wezterm_store, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    r = client.post("/api/agents/sessions/cc:no-mapping/focus")
+    assert r.status_code == 404
+    assert "resume" in r.json()["detail"].lower()
+
+
+@pytest.mark.unit
+def test_focus_calls_activate_pane_when_mapping_exists(
+    client, wezterm_store, monkeypatch
+):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    wezterm_store.upsert("cc:session-x", pane_id=17, cwd="/tmp/proj")
+
+    captured: dict[str, object] = {}
+
+    class _Completed:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+    def _fake_run(argv, **kwargs):
+        captured.setdefault("calls", []).append(argv)
+        return _Completed()
+
+    # `wezterm` must be locatable for the focus code to assemble the argv;
+    # notify-send is optional (covered by a separate test).
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}" if name == "wezterm" else None)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    r = client.post("/api/agents/sessions/cc:session-x/focus")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["focused"] is True
+    assert body["pane_id"] == 17
+    assert body["cwd"] == "/tmp/proj"
+
+    # Activate-pane was called with the stored pane id.
+    calls = captured["calls"]
+    assert any(
+        argv[0].endswith("wezterm") and argv[1:] == ["cli", "activate-pane", "--pane-id", "17"]
+        for argv in calls
+    )
+
+
+@pytest.mark.unit
+def test_focus_returns_410_and_clears_mapping_when_activate_fails(
+    client, wezterm_store, monkeypatch
+):
+    """Most common failure: user closed the tab. Server clears the stale
+    mapping and returns 410 so the UI can prompt for Resume."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    wezterm_store.upsert("cc:session-x", pane_id=17, cwd="/tmp/proj")
+
+    class _Failed:
+        returncode = 1
+        stdout = b""
+        stderr = b"no such pane: 17\n"
+
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}" if name == "wezterm" else None)
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: _Failed())
+
+    r = client.post("/api/agents/sessions/cc:session-x/focus")
+    assert r.status_code == 410
+    assert "no such pane" in r.json()["detail"]
+    # Stale mapping is cleared so the next Resume can write a fresh one.
+    assert wezterm_store.get("cc:session-x") is None

--- a/tests/test_cc_wezterm_store.py
+++ b/tests/test_cc_wezterm_store.py
@@ -1,0 +1,73 @@
+"""Unit tests for the cc_wezterm_store SQLite mapping module."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from api.services.cc_wezterm_store import CCWezTermStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CCWezTermStore:
+    return CCWezTermStore(db_path=tmp_path / "cc_wezterm.db")
+
+
+@pytest.mark.unit
+def test_get_returns_none_when_missing(store):
+    assert store.get("cc:nonexistent") is None
+
+
+@pytest.mark.unit
+def test_upsert_then_get_returns_mapping(store):
+    m = store.upsert("cc:abc-123", pane_id=7, cwd="/tmp/proj")
+    assert m.session_id == "cc:abc-123"
+    assert m.pane_id == 7
+    assert m.cwd == "/tmp/proj"
+
+    fetched = store.get("cc:abc-123")
+    assert fetched is not None
+    assert fetched.pane_id == 7
+    assert fetched.cwd == "/tmp/proj"
+    assert fetched.created_at > 0
+
+
+@pytest.mark.unit
+def test_upsert_overwrites_existing_pane_id(store):
+    store.upsert("cc:abc-123", pane_id=7, cwd="/tmp/proj")
+    store.upsert("cc:abc-123", pane_id=42, cwd="/tmp/proj-renamed")
+    m = store.get("cc:abc-123")
+    assert m.pane_id == 42
+    assert m.cwd == "/tmp/proj-renamed"
+
+
+@pytest.mark.unit
+def test_delete_removes_mapping(store):
+    store.upsert("cc:abc-123", pane_id=7, cwd="/tmp/proj")
+    assert store.delete("cc:abc-123") is True
+    assert store.get("cc:abc-123") is None
+    # Deleting again is a no-op.
+    assert store.delete("cc:abc-123") is False
+
+
+@pytest.mark.unit
+def test_db_persists_across_instances(tmp_path):
+    db = tmp_path / "cc_wezterm.db"
+    s1 = CCWezTermStore(db_path=db)
+    s1.upsert("cc:x", pane_id=9, cwd="/a")
+    s1.close()
+
+    s2 = CCWezTermStore(db_path=db)
+    m = s2.get("cc:x")
+    assert m is not None
+    assert m.pane_id == 9
+    s2.close()
+
+
+@pytest.mark.unit
+def test_db_path_parent_is_created(tmp_path):
+    nested = tmp_path / "nested" / "deeper" / "cc_wezterm.db"
+    assert not nested.parent.exists()
+    s = CCWezTermStore(db_path=nested)
+    assert nested.parent.exists()
+    s.close()

--- a/web/agents.html
+++ b/web/agents.html
@@ -510,6 +510,22 @@
   }
   .panel-resume:hover { background: var(--accent); color: var(--bg-primary); }
   .panel-resume:disabled { opacity: 0.6; cursor: progress; }
+  .panel-focus {
+    background: var(--bg-card);
+    border: 1px solid var(--text-dim);
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 0.75rem;
+    line-height: 1;
+    padding: 0.3rem 0.55rem;
+    border-radius: 4px;
+    float: right;
+    margin-right: 0.5rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .panel-focus:hover { background: var(--text-dim); color: var(--bg-primary); }
+  .panel-focus:disabled { opacity: 0.6; cursor: progress; }
   .modal-backdrop {
     position: fixed; inset: 0;
     background: rgba(0,0,0,0.55);
@@ -1200,7 +1216,8 @@
       <div class="panel-header">
         <button class="panel-close" aria-label="Close" id="panel-close">×</button>
         ${showKill ? '<button class="panel-kill" id="panel-kill">Kill</button>' : ''}
-        ${showResume ? '<button class="panel-resume" id="panel-resume" title="Open a terminal and resume this session">Resume</button>' : ''}
+        ${showResume ? '<button class="panel-resume" id="panel-resume" title="Open a new wezterm tab and run claude --resume">Resume</button>' : ''}
+        ${showResume ? '<button class="panel-focus" id="panel-focus" title="Switch wezterm to the existing tab for this session (if Resume was clicked before)">Focus</button>' : ''}
         <div class="label" data-field="label">${escapeHtml(s.label || s.session_id)}</div>
         <div class="cwd-hint" data-field="cwd-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-all">${s.decoded_cwd ? escapeHtml(s.decoded_cwd) : ''}</div>
         <div class="meta" data-field="meta">
@@ -1221,6 +1238,47 @@
     }
     if (showResume) {
       document.getElementById('panel-resume').onclick = () => resumeCcSession(s);
+      document.getElementById('panel-focus').onclick = () => focusCcSession(s);
+    }
+  }
+
+  async function focusCcSession(s) {
+    const btn = document.getElementById('panel-focus');
+    if (btn) {
+      btn.disabled = true;
+      btn.textContent = 'Focusing…';
+    }
+    try {
+      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/focus`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!r.ok) {
+        const text = await r.text();
+        let msg = text;
+        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+        // 404 = no mapping yet (use Resume first). 410 = pane was closed
+        // (mapping cleared on server, click Resume to recreate).
+        if (r.status === 404) {
+          showToast(`No tracked tab — click Resume first.`, true);
+        } else if (r.status === 410) {
+          showToast(`Tab no longer exists. Click Resume to open a new one.`, true);
+        } else {
+          showToast(`Focus failed: ${msg}`, true);
+        }
+        return;
+      }
+      const result = await r.json();
+      showToast(`Switched wezterm to pane ${result.pane_id}.`, false);
+    } catch (err) {
+      showToast(`Focus failed: ${err.message}`, true);
+    } finally {
+      setTimeout(() => {
+        if (btn) {
+          btn.disabled = false;
+          btn.textContent = 'Focus';
+        }
+      }, 1500);
     }
   }
 
@@ -1244,12 +1302,11 @@
         throw new Error(`HTTP ${r.status}: ${msg}`);
       }
       const result = await r.json();
-      // The server tries to push `inner_command` to the system clipboard
-      // via wl-copy / xclip — that's far more reliable than the browser
-      // Clipboard API, which silently fails when the page loses focus
-      // (which happens the instant Warp opens). If the server copy
-      // didn't land, try one more time from the browser before showing
-      // the command inline so the operator can copy it manually.
+      // With the default wezterm launcher the inner command is already
+      // running inside the new tab — no paste needed. The server still
+      // copies it to the clipboard as a backup in case the operator has
+      // overridden cc_resume_cmd to a launcher that opens an empty
+      // terminal (e.g. legacy `warp://` flow).
       let copied = !!result.clipboard_copied;
       if (!copied && result.inner_command && navigator.clipboard && navigator.clipboard.writeText) {
         try {
@@ -1259,10 +1316,12 @@
           // ignore — toast will show the command for manual copy
         }
       }
-      if (copied) {
-        showToast(`Warp opened. Resume command copied to clipboard — paste it.`, false);
+      if (result.pane_id != null) {
+        showToast(`Wezterm tab opened (pane ${result.pane_id}). Focus button will return here.`, false);
+      } else if (copied) {
+        showToast(`Tab opened. Resume command copied to clipboard — paste it.`, false);
       } else if (result.inner_command) {
-        showToast(`Warp opened. Run: ${result.inner_command}`, false);
+        showToast(`Tab opened. Run: ${result.inner_command}`, false);
       } else {
         showToast(`Spawned (pid ${result.pid}) in ${result.cwd}`, false);
       }

--- a/web/agents.html
+++ b/web/agents.html
@@ -1217,7 +1217,7 @@
         <button class="panel-close" aria-label="Close" id="panel-close">×</button>
         ${showKill ? '<button class="panel-kill" id="panel-kill">Kill</button>' : ''}
         ${showResume ? '<button class="panel-resume" id="panel-resume" title="Open a new wezterm tab and run claude --resume">Resume</button>' : ''}
-        ${showResume ? '<button class="panel-focus" id="panel-focus" title="Switch wezterm to the existing tab for this session (if Resume was clicked before)">Focus</button>' : ''}
+        ${showResume ? '<button class="panel-focus" id="panel-focus" title="Select the existing wezterm tab for this session. Wayland disallows cross-app window raise — click the wezterm dock icon to bring it forward; it will already be on the right tab.">Focus</button>' : ''}
         <div class="label" data-field="label">${escapeHtml(s.label || s.session_id)}</div>
         <div class="cwd-hint" data-field="cwd-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-all">${s.decoded_cwd ? escapeHtml(s.decoded_cwd) : ''}</div>
         <div class="meta" data-field="meta">
@@ -1269,7 +1269,10 @@
         return;
       }
       const result = await r.json();
-      showToast(`Switched wezterm to pane ${result.pane_id}.`, false);
+      // Wayland disallows cross-client window raise, so the tab is selected
+      // inside wezterm but the window doesn't pop forward — set the
+      // expectation in the toast.
+      showToast(`Tab selected in wezterm. Click the wezterm dock icon to bring it forward.`, false);
     } catch (err) {
       showToast(`Focus failed: ${err.message}`, true);
     } finally {


### PR DESCRIPTION
## Summary

- Switches `/agents` Resume from Warp URI dispatch + clipboard-paste to `wezterm cli spawn`, which opens a tab AND runs `claude --resume` in one shot.
- Captures the new pane id from stdout, persists `session_id → pane_id` in a small SQLite sidecar (`data/cc_wezterm.db`).
- Adds a new **Focus** button next to Resume — calls `wezterm cli activate-pane --pane-id <id>` to revisit the existing tab. 404 if no Resume has been clicked yet, 410 (and mapping cleared) if the pane was closed.

## Defaults flipped

| Setting | Old default | New default |
|---|---|---|
| `LIFEOS_CC_RESUME_CMD` | `warp-terminal warp://action/new_tab?path={cwd_url}` | `wezterm cli spawn --cwd {cwd} -- {inner_command}` |
| `LIFEOS_CC_RESUME_INNER_CMD` | `vt claude --dangerously-skip-permissions --resume {session_id}` | `claude --dangerously-skip-permissions --resume {session_id}` |

`vt` removed from the open-source default — operators who use it can re-add via `.env`. The legacy Warp-style launcher still works for any operator who overrides the setting (substitutions, shlex parsing, env file, clipboard backup all preserved).

## Honest Wayland caveat

GNOME Wayland disallows cross-client window raise — Focus reliably switches the tab _within_ wezterm but cannot bring a hidden wezterm window to the foreground from another client (browser, Warp). A `notify-send --urgency=critical` pulses the dock icon as the strongest attention hint we can issue. If full window-raise matters, switching wezterm to XWayland mode (`enable_wayland = false`) makes xdotool-based focus possible — out of scope for this PR.

## Test plan

- [x] New unit tests: `tests/test_cc_wezterm_store.py` (6 tests) + extended `tests/test_agent_resume_api.py` (26 tests) covering pane-id capture, store persistence, focus 404/410, gating, and existing resume behaviour preserved
- [x] Full suite: 1566 passed, 8 skipped (pre-push hook)
- [x] Empirically verified `wezterm cli spawn` returns pane_id on stdout and `activate-pane` works against captured IDs (see worktree investigation notes)
- [ ] **Manual end-to-end (post-merge):** Set `LIFEOS_CC_RESUME_ENABLED=true`, restart `lifeos-api`, open `/agents`, find a cc: session, click **Resume** → verify a wezterm tab opens with `claude --resume` running. From another window, click **Focus** → verify wezterm switches to that tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)