### PR TITLE
docs: backlog-in-issues policy + vision refresh for two-half framing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,12 @@
 > **Status:** Complete
 > **Last Updated:** 2026-03-04
 
-LifeOS is a self-hosted AI assistant that indexes personal data (notes, emails, messages, photos, financial data) for semantic search, synthesis, and proactive intelligence. Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMessage, phone calls, and contacts.
+LifeOS is a self-hosted personal AI assistant with two halves:
+
+1. **A context layer** — indexes personal data (notes, emails, messages, photos, calendar, contacts, financial data) into a unified semantically-searchable corpus with cross-source entity resolution.
+2. **An agentic layer** — an agent worker plus chat/Telegram/MCP surfaces that autonomously complete multi-step tasks against that context (drafting, scheduling, researching, prepping) and report progress as they work.
+
+Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMessage, phone calls, and contacts.
 
 ---
 
@@ -14,7 +19,8 @@ LifeOS is a self-hosted AI assistant that indexes personal data (notes, emails, 
 - **Hybrid search**: Vector similarity (ChromaDB) + keyword matching (BM25/FTS5), fused via Reciprocal Rank Fusion. See [ADR-004](docs/adr/004-hybrid-search.md).
 - **Entity resolution**: Links emails, phones, and names across sources to canonical people using fuzzy matching with scoring.
 - **Sync phases**: Seven-phase nightly pipeline — Collection → Entity Processing → Relationship Building → Indexing → Content Sync → Entity Cleanup → Consistency Verification.
-- **Agentic chat**: Local LLM autonomously calls 15 tools (search, calendar, email, tasks, etc.) across multiple rounds to answer queries.
+- **Agentic chat**: Orchestrator LLM autonomously calls 15+ tools (search, calendar, email, tasks, etc.) across multiple rounds to answer queries.
+- **Agent worker**: Autonomous executor for `#agent`-tagged tasks (or work delegated from chat/Telegram). Runs long, multi-step sessions with the full MCP tool catalog, reports progress through the originating channel, and can route to local Gemma or cloud Claude via Managed Agents. See [specs/product/agent-worker.md](docs/specs/product/agent-worker.md).
 
 ## Tech Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,13 @@ curl http://localhost:8000/health/full | jq   # Health check
 ## Common Mistakes
 
 1. **Putting implementation details in product specs** → Product specs describe WHAT (consumer view). Implementation goes in `specs/technical/`.
-2. **Adding "Next Steps" or task lists to specs** → Specs describe target state. Tasks go in `plans/` or GitHub issues.
+2. **Adding "Next Steps" or task lists to specs** → Specs describe target state. Backlog items go in **GitHub issues**; time-bounded execution notes go in `plans/`.
 3. **Modifying an ADR** → ADRs are immutable. Create a new one that supersedes.
 4. **Missing Related Documents section** → Every doc must have one, with bidirectional links.
 5. **Using real personal data in examples** → Always use obviously synthetic data.
 6. **Creating monolithic docs** → Split by concern. Target line counts are in `docs/AGENTS.md`.
 7. **Leaving stale plans in `docs/plans/`** → Completed or superseded plans must be moved to `docs/plans/archive/`.
-8. **Over-documenting routine changes** → Not every change needs a docs update. Write what helps the next reader understand current state.
-9. **Deleting or modifying a failing test to unblock a commit** → See AGENTS.md § "Tests Are Sacred" for the full decision framework.
-10. **Committing without running the test suite** → Run `./scripts/test.sh` before every commit. No exceptions.
+8. **Creating a `backlog.md` (or `todo.md`, `ideas.md`)** → Backlog lives in GitHub issues. Plan files are only for time-bounded execution notes for a specific in-flight effort.
+9. **Over-documenting routine changes** → Not every change needs a docs update. Write what helps the next reader understand current state.
+10. **Deleting or modifying a failing test to unblock a commit** → See AGENTS.md § "Tests Are Sacred" for the full decision framework.
+11. **Committing without running the test suite** → Run `./scripts/test.sh` before every commit. No exceptions.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -3,6 +3,8 @@
 **Status:** Complete
 **Last Updated:** 2026-05-27
 
+> **Backlog lives in GitHub issues.** Future work, deferred features, bugs, and enhancements are tracked as GitHub issues — never as `backlog.md` files in this directory. Plan files are reserved for time-bounded execution notes (migration plans, gap analyses, point-in-time issue-drafting context).
+
 **This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
 
 ## Purpose
@@ -85,9 +87,11 @@ Guides are instructional — they tell you how to do something, not why it's des
 ### Plans
 
 **Location:** `docs/plans/` (gitignored — personal/active planning notes)
-**Purpose:** Active execution work — phases, tasks, roadmaps, backlogs
+**Purpose:** Time-bounded execution notes for a specific effort — migration plans, dated gap analyses, point-in-time issue-drafting context.
 
-Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. For trackable work, prefer GitHub issues; for personal planning, use the local `docs/plans/` directory.
+**Backlog and trackable cross-contributor work belong in GitHub issues, not in `docs/plans/`.** Never create a running `backlog.md`, `todo.md`, or `ideas.md` — file an issue. Plan files exist only for the slice of work that's actively being executed and would clutter the issue tracker (e.g., "phase 2 of the linux migration"), and they're moved to `archive/` the moment that work is done.
+
+Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete.
 
 ### Archive
 
@@ -106,7 +110,8 @@ Archive content is **not** part of the public repo. When a durable insight from 
 | Coding conventions, naming rules, testing patterns | `specs/standards/` | Not in guides (standards prescribe, guides instruct) |
 | Architectural decisions with rationale and alternatives | `adr/` | Never modify after acceptance — create a new ADR to supersede |
 | Setup procedures, troubleshooting, operator how-to | `guides/` | Not design rationale |
-| Phases, tasks, roadmaps, checklists | `plans/` (or GitHub issues) | Don't put in specs |
+| Backlog, deferred features, bugs, enhancements | **GitHub issues** | Never in `backlog.md` or any plan file |
+| Time-bounded execution notes (migration plans, dated gap analyses) | `plans/` | Don't put in specs; not a substitute for GitHub issues |
 | Audit notes, investigation working files, superseded docs | `archive/` | Don't link from live specs unless promoting a specific insight |
 
 **Rule of thumb:** "Why do we build this?" → vision. "What should it be?" → product spec. "How is it built?" → technical spec. "Why did we decide?" → ADR. "How do I do X?" → guide. "When/how do we get there?" → plan.
@@ -319,11 +324,12 @@ Every doc subdirectory has an `AGENTS.md` + `CLAUDE.md` pair so any reader (huma
 Existing pairs:
 - `docs/adr/AGENTS.md` + `CLAUDE.md`
 - `docs/guides/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/product/AGENTS.md` + `CLAUDE.md`
+- `docs/specs/technical/AGENTS.md` + `CLAUDE.md`
 - `docs/specs/standards/AGENTS.md` + `CLAUDE.md`
 - `docs/vision/AGENTS.md` + `CLAUDE.md`
-- `docs/specs/product/AGENTS.md` + `CLAUDE.md` (added in #181)
-- `docs/specs/technical/AGENTS.md` + `CLAUDE.md` (added in #181)
-- `docs/plans/AGENTS.md` + `CLAUDE.md` (added in #181 — note: gitignored)
+- `docs/plans/AGENTS.md` + `CLAUDE.md` (gitignored directory; only the AGENTS pair is tracked)
 
 **AGENTS.md** is the primary instruction file (universal, works with all AI tools). **CLAUDE.md** is a one-line wrapper: `@AGENTS.md`. The `@` import is relative to the file containing it; since CLAUDE.md and AGENTS.md are always co-located, the import is always literally `@AGENTS.md`.
 
@@ -363,6 +369,7 @@ Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended c
 **Common violations to avoid:**
 - Adding "Next Steps" or task lists to specs or ADRs.
 - Mixing planning (roadmaps, tasks) into design documents.
+- Creating a running backlog file (`backlog.md`, `todo.md`, `ideas.md`) instead of filing GitHub issues.
 - Creating documents without "Related Documents" sections.
 - Failing to update cross-references when moving or splitting documents.
 - Modifying an accepted ADR in place (instead of superseding).

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -9,6 +9,11 @@ This directory contains Architecture Decision Records (ADRs) — immutable recor
 - `005-external-venv-macos-tcc.md` — Virtual environment at ~/.venvs to avoid TCC scanning **(Superseded by 007)**
 - `006-ollama-query-routing.md` — Local Ollama + Qwen 2.5 for query classification
 - `007-linux-migration.md` — Linux migration and local LLM orchestration (supersedes 005)
+- `008-managed-agents-cloud-routing.md` — Routing agent-worker sessions to cloud Claude via Managed Agents
+- `009-llm-backend-toggle.md` — `LIFEOS_LLM_BACKEND` switch between Anthropic and local llama-server
+- `010-apple-data-agent.md` — Mac as nightly source for iMessage, calls, and contacts
+- `011-external-agent-ingest.md` — Read-only direct-access ingest path for external agents
+- `012-embedding-pipeline.md` — GPU embedding pipeline with CPU fallback
 
 ## Key Principles
 

--- a/docs/plans/AGENTS.md
+++ b/docs/plans/AGENTS.md
@@ -1,19 +1,21 @@
-This directory contains active execution plans — ephemeral working notes describing how and when to build what specs describe.
+This directory contains time-bounded execution notes — working files for a specific in-flight effort.
 
 > **Gitignored content:** the actual plan files in this directory are personal and gitignored. Only this `AGENTS.md` and `CLAUDE.md` are tracked, so any agent or contributor landing here knows the conventions even when the personal content isn't visible.
+
+> **Backlog lives in GitHub issues — never in `docs/plans/`.** Do not create `backlog.md`, `todo.md`, `ideas.md`, or any running list of deferred work. File a GitHub issue instead. Plan files exist only for the slice of work that's actively being executed and needs scratch space outside the issue tracker.
 
 ## Contents
 
 The directory typically holds:
 
-- `backlog.md` — running operator backlog of small tasks, bugs, and improvements (personal, gitignored).
 - `archive/` — completed or superseded plans (also gitignored; preserved locally for reference).
-- Dated planning notes — point-in-time snapshots, gap analyses, issue-drafting context. Date-prefixed in the filename.
+- Dated planning notes — point-in-time snapshots, gap analyses, issue-drafting context for a specific effort. Date-prefixed in the filename (e.g., `2026-05-11-mvp-gap-analysis.md`).
 
-For trackable cross-contributor work, prefer **GitHub issues** over plan files. Plan files are for personal/local planning that doesn't need to be in the repo history.
+The directory does **not** hold: running backlogs, idea lists, todo files, or anything that should live as a GitHub issue.
 
 ## Key Principles
 
+- **Backlog → GitHub issues, never plan files.** If you're tempted to write a list of "things to do later", that's an issue, not a plan.
 - Plans are **ephemeral**. They become git history (or, in this repo, never enter the public repo) when complete. Move finished plans to `archive/` with a `**Completed:** YYYY-MM-DD` line in the frontmatter; supersede stale plans with a pointer to the successor.
 - Plans answer "how do we get from current state to the spec?" They are **not** specs themselves — keep target-state design out of plan files; that belongs in [`../specs/`](../specs/).
 - Every plan file should include frontmatter: `Status` (`Draft` | `Active` | `Completed` | `Superseded`), `Last Updated`, and `Target Date` (or `Ongoing`).

--- a/docs/specs/product/AGENTS.md
+++ b/docs/specs/product/AGENTS.md
@@ -4,9 +4,15 @@ This directory contains product specifications — what the system does from a c
 
 - `agent-viz.md` — The `/agents` page (D3 graph + side panel) that visualizes agent worker and Claude Code sessions
 - `agent-worker.md` — The `#agent`-tagged task workflow (Telegram-triggered autonomous worker)
+- `api-crm.md` — CRM-specific HTTP endpoints (people, interactions, graph data)
 - `api-reference.md` — HTTP endpoint catalog (request/response shapes, query parameters)
 - `chat-ui.md` — The web chat interface
-- `crm-ui.md` — The `/crm` page (people, interactions, graph, analytics)
+- `claude-code-orchestration.md` — How LifeOS exposes itself to Claude Code (skills, MCP, orchestration patterns)
+- `crm-analytics.md` — CRM dashboards (Family / Me / Birthdays / Relationship)
+- `crm-graph.md` — CRM graph view (pan/zoom/drag, edge semantics)
+- `crm-interactions.md` — CRM interaction timeline
+- `crm-people.md` — CRM people list and person detail views
+- `crm-ui.md` — `/crm` page index (links out to the per-view specs above)
 - `data-model.md` — Canonical entities (SourceEntity, PersonEntity) and relationships
 - `entity-resolution.md` — How emails, phones, and names link to canonical people
 - `mcp-tools.md` — The MCP tool catalog exposed to Claude Code and other agents

--- a/docs/specs/technical/AGENTS.md
+++ b/docs/specs/technical/AGENTS.md
@@ -5,6 +5,7 @@ This directory contains technical specifications — how the system is built fro
 - `agent-viz.md` — Implementation of the `/agents` page (SSE feed, JSONL ingest, D3 graph, status inference)
 - `agent-worker.md` — Agent worker internals (session lifecycle, executor split, MCP transport, budget enforcement)
 - `architecture.md` — Top-level code structure, module boundaries, request flow
+- `claude-code-orchestration.md` — Implementation of the Claude Code orchestration surface (skill discovery, MCP server wiring)
 - `data-and-sync.md` — Seven-phase nightly sync pipeline; per-phase responsibilities and failure modes
 - `frontend.md` — Vanilla HTML/JS architecture (no build step), shared components, page conventions
 - `observability.md` — Performance tracing (spans, SQLite), health checks, alerting tiers

--- a/docs/vision/philosophy.md
+++ b/docs/vision/philosophy.md
@@ -1,36 +1,42 @@
 # LifeOS: Project Vision
 
 > **Status:** Complete
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-05-27
 
 ## The Problem
 
 Personal data is fragmented across dozens of silos. Emails live in Gmail, messages in iMessage and WhatsApp, notes in Obsidian, tasks in various apps, contacts scattered across platforms, photos in Apple Photos, financial data in banking apps. No single tool has the full picture of a person's life.
 
-This fragmentation means every question requires manual detective work. "When did I last talk to Sarah?" requires checking email, messages, call history, and calendar. "What did we decide about the project?" requires searching email threads, meeting notes, and Slack channels. "Who introduced me to my dentist?" requires memory or digging through years of messages.
+This fragmentation means every question requires manual detective work, and every action requires switching apps. "When did I last talk to Sarah?" means checking email, messages, call history, and calendar. "Draft a reply to that thread using what we discussed at lunch" means stitching context together by hand. "Who introduced me to my dentist?" means memory or digging through years of messages.
 
-The information exists. It's just inaccessible — locked in separate apps with separate search systems, none of which understand context across boundaries.
+The information exists. It's just inaccessible — locked in separate apps with separate search systems, none of which understand context across boundaries, and none of which can act on your behalf with that context in mind.
 
 ## The Thesis
 
-The missing piece is an AI assistant with full personal context. Not another app to organize data into — a layer that sits above all existing apps and unifies their data for search, synthesis, and proactive intelligence.
+A personal AI assistant needs two halves working together:
 
-LifeOS indexes personal data from every source, resolves entities across platforms (recognizing that john@acme.com in Gmail and "+1-555-0100" in iMessage are the same person), and makes the unified corpus searchable through natural language. Claude provides synthesis — answering questions that span multiple sources, generating briefings, and proactively surfacing relevant context.
+1. **A context layer** that ingests every silo of personal data and resolves entities across them — so any question or action can be grounded in the full picture of your life. This is the *aggregator/maintainer* half: indexes, entity resolution, nightly syncs, semantic + keyword search.
+2. **An agentic layer** that uses that context to *do things* on your behalf — drafting, scheduling, researching, prepping, following up — communicating progress as it works rather than only replying when prompted. This is the *autonomous assistant* half: an agent worker that owns multi-step tasks, reports back through Telegram or chat, and surfaces what you need before you ask.
+
+Most personal assistants pick one half. LifeOS does both because they're inseparable — context without action is a search engine; action without context is a generic LLM. The combination is what makes a system useful as a *personal* assistant rather than a generic one.
+
+Both halves run on your own machine. LLM inference is the only thing that ever leaves the box, and only as discrete query payloads — never wholesale data uploads.
 
 ## What LifeOS Is
 
-- **Self-hosted AI assistant** for personal data indexing, search, and synthesis.
-- **Unifier** across 12+ data sources: notes, emails, messages, calendar, contacts, photos, financial data, call history.
-- **Semantic search engine** combining vector similarity and keyword matching for natural language queries over personal data.
-- **Personal CRM** tracking relationships, interactions, and facts about people across all communication channels.
-- **Proactive intelligence** layer with reminders, briefings, and relationship tracking.
+- **A unified personal context layer.** 12+ data sources (notes, email, messages, calendar, contacts, photos, financial data, call history) indexed into a single semantically searchable corpus, with cross-source entity resolution so `john@acme.com`, `+1-555-0100`, and "John from the conference" all resolve to the same person.
+- **An agentic assistant that completes tasks autonomously.** An agent worker takes on `#agent`-tagged tasks (or work delegated from chat / Telegram), runs multi-round tool-using sessions backed by the full LifeOS context, and reports progress and results as it goes. Long-running work happens without you having to babysit it.
+- **A proactive intelligence layer.** Reminders, briefings before meetings, surfacing of relevant context, nudges about people you haven't talked to in a while — things the assistant decides to tell you rather than waiting to be asked.
+- **A personal CRM.** Canonical people, interactions, facts, and relationships, kept in sync with every communication channel.
+- **A natural-language interface to all of it.** Chat UI, Telegram, MCP for Claude Code — same context, same tools, same agent capabilities everywhere.
 
 ## What LifeOS Is Not
 
-- **Not a cloud service.** Everything runs locally on a Linux workstation. Privacy is the foundation, not a feature.
+- **Not a cloud service.** Everything runs locally on the user's own machine. Privacy is the foundation, not a feature. LLM inference is the only external call, and it's per-query, payload-scoped, and toggleable to fully local.
 - **Not a data platform or infrastructure.** LifeOS is an application — it consumes data from existing sources and makes it useful. It does not replace or abstract storage systems.
-- **Not a replacement for individual apps.** Users continue using Gmail, iMessage, Obsidian, etc. LifeOS sits above them, indexing and unifying without interfering.
-- **Not multi-user.** LifeOS is designed for a single user's personal data. There is no multi-tenant architecture, no user management, no access control beyond macOS permissions.
+- **Not a replacement for individual apps.** Users continue using Gmail, iMessage, Obsidian, etc. LifeOS sits above them, indexing and acting without interfering.
+- **Not multi-user.** LifeOS is designed for a single user's personal data. There is no multi-tenant architecture, no user management, no access control beyond the host OS's permissions.
+- **Not a chatbot wrapper.** The agentic half does real work — drafting, scheduling, researching across hours and tool calls — not just question-answering.
 
 ## Principles
 
@@ -50,11 +56,21 @@ LifeOS does not ask users to organize their data better. It meets data where it 
 
 The most valuable personal assistant anticipates needs rather than waiting for questions. Reminders about people not contacted recently, briefings before meetings with relevant context, surfacing connections between unrelated-seeming information — these proactive capabilities differentiate LifeOS from a search engine.
 
+### Action, Not Just Answers
+
+A query-response loop is the floor, not the ceiling. The agent worker takes on multi-step tasks — drafting an email and waiting for the user's edits, researching a topic across sources before producing a summary, prepping a meeting and posting the brief to the right channel — and reports back as it works. The system should be able to *finish* things, not just describe what should be done.
+
+### Same Context Everywhere
+
+The same indexed corpus, the same canonical people, and the same tool catalog back every interface: the web chat, Telegram, the agent worker, and MCP for Claude Code. Switching channel never means losing context or capability.
+
 ## Scope
 
 ### Current
 
-Communication (email, messages, calls), notes (Obsidian vault), calendar (Google Calendar), tasks (Obsidian Tasks), contacts (Apple Contacts, CRM), financial data (Monarch Money).
+**Context sources:** Communication (email, messages, calls), notes (Obsidian vault), calendar (Google Calendar), tasks (Obsidian Tasks), contacts (Apple Contacts, CRM), financial data (Monarch Money), photos.
+
+**Agentic surfaces:** Web chat UI, Telegram bot, agent worker (autonomous `#agent`-tagged task execution with progress reporting), MCP server (Claude Code and other agent clients).
 
 ### Future
 
@@ -62,8 +78,19 @@ Deeper photo intelligence (face recognition, scene understanding), health data i
 
 ## Related Documents
 
-- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
-- [ADR-001: Python/FastAPI](../adr/001-python-fastapi.md) — Backend framework choice
-- [ADR-003: Two-Tier Data Model](../adr/003-two-tier-data-model.md) — Core data architecture
-- [Data Model](../specs/product/data-model.md) — Entity semantics
+### Design Context
+- [ADR-003: Two-Tier Data Model](../adr/003-two-tier-data-model.md) — Core data architecture enabling the context layer
+- [ADR-004: Hybrid Search](../adr/004-hybrid-search.md) — Vector + BM25 retrieval that powers grounded answers
+- [ADR-007: Linux Migration & Local LLM](../adr/007-linux-migration.md) — Foundation for the agentic half running locally
+- [ADR-008: Managed Agents Cloud Routing](../adr/008-managed-agents-cloud-routing.md) — How the agent worker delegates to cloud Claude
+- [ADR-011: External Agent Ingest](../adr/011-external-agent-ingest.md) — Read-only direct-access path for external agents
+
+### Specifications
+- [Data Model](../specs/product/data-model.md) — Entity semantics for the context layer
+- [Agent Worker](../specs/product/agent-worker.md) — The autonomous task surface
+- [MCP Tools](../specs/product/mcp-tools.md) — Tool catalog shared across all surfaces
 - [Security & Privacy](../specs/technical/security-privacy.md) — How privacy principles are implemented
+
+### Operational
+- [Documentation Strategy](../AGENTS.md) — Rules governing all documentation
+- [Installation](../guides/installation.md) — How to stand up both halves locally


### PR DESCRIPTION
## Summary

- **Backlog policy:** Restate in 4 places that backlog and trackable work belong in GitHub issues, not in `backlog.md` / `todo.md` / `ideas.md` plan files. `docs/plans/` is now reserved for time-bounded execution notes (migration plans, dated gap analyses). Updates: `docs/AGENTS.md` (Plans section, Content Classification table, Common Violations), `docs/plans/AGENTS.md` (Contents + Key Principles), root `CLAUDE.md` (Common Mistakes #8).
- **Vision refresh:** `docs/vision/philosophy.md` rewritten to lead with the two-half framing — context aggregator + autonomous agentic assistant — rather than just "indexing, search, and synthesis." Adds principles *Action, Not Just Answers* and *Same Context Everywhere*. Scope splits into Context sources + Agentic surfaces.
- **Root `AGENTS.md`:** Intro and Key Concepts updated to lead with both halves and explicitly call out the agent worker.
- **Subdirectory AGENTS.md sweep:** Refreshes stale Contents lists in `docs/adr/AGENTS.md` (ADRs 008–012 added), `docs/specs/product/AGENTS.md` (added `api-crm.md`, `claude-code-orchestration.md`, 4 CRM split specs), `docs/specs/technical/AGENTS.md` (added `claude-code-orchestration.md`). Refreshes the "Existing pairs" list in `docs/AGENTS.md` to include `docs/specs/`.

Migrated the one still-relevant deferred-feature from the old `docs/plans/backlog.md` to a GitHub issue (#212 — emotion wheel visualization) and deleted the now-orphaned backlog file (was gitignored).

## Test plan

- [x] Docs-only PR — no tests required
- [x] Reviewer: confirm vision rewrite captures the intent (LifeOS as context + agentic, not just search/synthesis)
- [x] Reviewer: confirm the backlog rule is unambiguous across all 4 places it's stated
- [x] Reviewer: spot-check subdirectory AGENTS.md Contents lists against actual files on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)