### PR TITLE
fix(sync): comprehensive sync health — vault reindex, stats reporting, server stacking (closes #199)

### DIFF
--- a/api/routes/monarch.py
+++ b/api/routes/monarch.py
@@ -9,11 +9,23 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException
 
-from api.services.monarch import get_monarch_client
+from api.services.monarch import get_monarch_client, get_session_status
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/monarch", tags=["monarch"])
+
+
+@router.get("/session_status")
+async def session_status():
+    """Report Monarch session age + expiry-soon warnings.
+
+    Used by /health/services and dashboards to surface the impending re-auth
+    requirement *before* the monthly sync hits 401/525. The session is just a
+    pickle on disk — checking its age is cheap and doesn't make any network
+    calls.
+    """
+    return get_session_status()
 
 
 @router.get("/accounts")

--- a/api/services/bm25_index.py
+++ b/api/services/bm25_index.py
@@ -121,6 +121,46 @@ class BM25Index:
         finally:
             conn.close()
 
+    def delete_by_path(self, file_path: str) -> int:
+        """Delete every chunk indexed for ``file_path`` (chunks + summary).
+
+        Chunk ``doc_id`` values are ``{path}_{i}``; the summary uses
+        ``{path}::summary``. ``delete_document`` only matches an exact id, so
+        callers that wanted to drop "all chunks for this file" — like the
+        indexer's re-index path — silently leaked stale rows whenever the
+        chunk count shrank or the path changed (e.g. macOS → Linux). This
+        helper clears everything for the given path in one query.
+
+        Args:
+            file_path: Absolute file path used as the doc_id prefix.
+
+        Returns:
+            Number of rows removed (chunks + summary).
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            # FTS5 doesn't support ESCAPE on LIKE, so escape special chars
+            # by enumerating the two known suffix patterns explicitly. The
+            # summary uses '::summary' and chunks use '_<int>'.
+            cursor = conn.execute(
+                """
+                DELETE FROM chunks_fts
+                WHERE doc_id = ?
+                   OR doc_id = ?
+                   OR doc_id GLOB ?
+                """,
+                (
+                    file_path,                       # legacy: path with no suffix
+                    f"{file_path}::summary",         # summary chunk
+                    f"{file_path}_*",                # numbered chunks
+                ),
+            )
+            deleted = cursor.rowcount
+            conn.commit()
+            return deleted
+        finally:
+            conn.close()
+
     def _sanitize_query(self, query: str, use_or: bool = True) -> str:
         """
         Sanitize query for FTS5 MATCH syntax.

--- a/api/services/embeddings.py
+++ b/api/services/embeddings.py
@@ -134,6 +134,13 @@ class EmbeddingService:
         whole vault reindex — bubble up as ConnectionError / DNS failures and
         kill the load. When the model is already cached on disk, the right
         behaviour is to skip the network probe entirely.
+
+        Thread safety: mutates ``os.environ`` for the duration of the retry.
+        ``EmbeddingService`` is a process-wide singleton loaded lazily on
+        first access (typically the background sync worker), so concurrent
+        loads don't happen in practice. The try/finally restores the env
+        before any other code can observe it. If a future caller starts
+        triggering loads from multiple threads at once, wrap this in a lock.
         """
         try:
             return st_cls(**load_kwargs)

--- a/api/services/embeddings.py
+++ b/api/services/embeddings.py
@@ -8,6 +8,7 @@ NOTE: sentence_transformers is imported lazily to avoid slow startup.
 This allows tests to import this module without loading the ML library.
 """
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 from config.settings import settings
@@ -16,6 +17,34 @@ logger = logging.getLogger(__name__)
 
 # GPU error keywords — shared between load-time and encode-time fallback
 _GPU_ERROR_KEYWORDS = ("hip", "cuda", "out of memory", "invalid device", "gpu hang")
+
+# Network error keywords — model load tries to check HF for updates even when
+# the snapshot is already cached. We retry offline if any of these fire.
+_NETWORK_ERROR_KEYWORDS = (
+    "huggingface.co",
+    "max retries exceeded",
+    "name or service not known",
+    "temporary failure in name resolution",
+    "connection refused",
+    "connection timed out",
+    "connection reset",
+    "name resolution",
+    "getaddrinfo",
+    "dns",
+)
+
+
+def _looks_like_network_error(exc: BaseException) -> bool:
+    """Return True if the exception looks like a transient network failure."""
+    msg = str(exc).lower()
+    if any(kw in msg for kw in _NETWORK_ERROR_KEYWORDS):
+        return True
+    # huggingface_hub raises specific subclasses for offline / network issues;
+    # fall back to module name matching to avoid importing it at module load.
+    cls_module = type(exc).__module__ or ""
+    if cls_module.startswith("huggingface_hub") or cls_module.startswith("requests"):
+        return True
+    return False
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -63,7 +92,7 @@ class EmbeddingService:
                 if self._force_cpu:
                     load_kwargs["device"] = "cpu"
 
-                self._model = SentenceTransformer(**load_kwargs)
+                self._model = self._load_with_offline_retry(SentenceTransformer, load_kwargs)
                 from api.services.service_health import mark_service_healthy
                 mark_service_healthy("embedding_model")
             except RuntimeError as e:
@@ -72,11 +101,12 @@ class EmbeddingService:
                 if any(kw in error_msg for kw in _GPU_ERROR_KEYWORDS):
                     logger.warning(f"GPU embedding load failed ({e}), falling back to CPU")
                     try:
-                        self._model = SentenceTransformer(
-                            self.model_name,
+                        cpu_kwargs = dict(
+                            model_name_or_path=self.model_name,
                             cache_folder=self.cache_dir,
                             device="cpu",
                         )
+                        self._model = self._load_with_offline_retry(SentenceTransformer, cpu_kwargs)
                         self._force_cpu = True
                         from api.services.service_health import mark_service_healthy
                         mark_service_healthy("embedding_model")
@@ -94,6 +124,51 @@ class EmbeddingService:
                 mark_service_failed("embedding_model", str(e), Severity.CRITICAL)
                 raise
         return self._model
+
+    def _load_with_offline_retry(self, st_cls, load_kwargs: dict):
+        """Load the SentenceTransformer, retrying with HF_HUB_OFFLINE=1 on network errors.
+
+        Sentence-transformers contacts HuggingFace at startup to check for
+        updates even when the snapshot is already cached locally. Past
+        outages — including the 2026-05-23 DNS retry storm that took down the
+        whole vault reindex — bubble up as ConnectionError / DNS failures and
+        kill the load. When the model is already cached on disk, the right
+        behaviour is to skip the network probe entirely.
+        """
+        try:
+            return st_cls(**load_kwargs)
+        except Exception as exc:
+            if not _looks_like_network_error(exc):
+                raise
+            logger.warning(
+                f"Embedding model load failed with network error ({exc.__class__.__name__}: {exc}). "
+                "Retrying with HF_HUB_OFFLINE=1 to skip the upstream version check."
+            )
+            prev_offline = os.environ.get("HF_HUB_OFFLINE")
+            prev_tf_offline = os.environ.get("TRANSFORMERS_OFFLINE")
+            os.environ["HF_HUB_OFFLINE"] = "1"
+            os.environ["TRANSFORMERS_OFFLINE"] = "1"
+            try:
+                model = st_cls(**load_kwargs)
+            finally:
+                # Restore env so other components keep their previous behaviour.
+                if prev_offline is None:
+                    os.environ.pop("HF_HUB_OFFLINE", None)
+                else:
+                    os.environ["HF_HUB_OFFLINE"] = prev_offline
+                if prev_tf_offline is None:
+                    os.environ.pop("TRANSFORMERS_OFFLINE", None)
+                else:
+                    os.environ["TRANSFORMERS_OFFLINE"] = prev_tf_offline
+            try:
+                from api.services.service_health import record_degradation
+                record_degradation(
+                    "embedding_model", "load", "offline_cache",
+                    f"HF network unreachable: {exc}",
+                )
+            except Exception:
+                pass
+            return model
 
     def _encode_with_fallback(self, data, **kwargs):
         """Encode with GPU→CPU fallback on RuntimeError.

--- a/api/services/indexer.py
+++ b/api/services/indexer.py
@@ -436,8 +436,10 @@ class IndexerService:
         self.vector_store.update_document(chunks, metadata)
 
         # Update in BM25 index for keyword search
-        # First delete any existing chunks for this file
-        self.bm25_index.delete_document(str(path.resolve()))
+        # First delete all existing chunks (numbered + summary) for this file —
+        # delete_document only matches one exact id, which left stale chunks
+        # behind whenever the count shrank or the vault path changed.
+        self.bm25_index.delete_by_path(str(path.resolve()))
         # Add each chunk to BM25
         for i, chunk in enumerate(chunks):
             doc_id = f"{path.resolve()}_{i}"
@@ -499,11 +501,8 @@ class IndexerService:
         # This works even for non-existent files
         real_path = os.path.realpath(file_path)
         self.vector_store.delete_document(real_path)
-        self.bm25_index.delete_document(real_path)
-
-        # Also delete summary chunk if exists
-        summary_id = f"{real_path}::summary"
-        self.bm25_index.delete_document(summary_id)
+        # delete_by_path drops numbered chunks + the summary in one query.
+        self.bm25_index.delete_by_path(real_path)
 
         logger.debug(f"Deleted {file_path} from index (resolved: {real_path})")
 

--- a/api/services/monarch.py
+++ b/api/services/monarch.py
@@ -23,6 +23,56 @@ logger = logging.getLogger(__name__)
 
 SESSION_PATH = Path(__file__).parent.parent.parent / "data" / "monarch_session.pickle"
 
+# Empirically observed Monarch session lifetime. Re-auth before this is hit
+# so the monthly sync doesn't silently 401/525. See issue #199 §3.
+SESSION_EXPIRY_DAYS = 30
+SESSION_WARNING_DAYS = 25  # Surface in health endpoints before things break.
+
+
+def get_session_age_days() -> Optional[float]:
+    """Return the cached Monarch session's age in days, or None if not present.
+
+    Uses the file mtime of the saved pickle — monarchmoney writes the file
+    fresh on each successful authentication, so mtime is a faithful proxy
+    for "last good login". Returns ``None`` (not 0) when no session exists so
+    callers can distinguish "fresh install" from "session just rotated".
+    """
+    if not SESSION_PATH.exists():
+        return None
+    age_seconds = datetime.now().timestamp() - SESSION_PATH.stat().st_mtime
+    return age_seconds / 86400.0
+
+
+def get_session_status() -> dict:
+    """Summarise Monarch session freshness for /health and dashboards."""
+    age = get_session_age_days()
+    if age is None:
+        return {
+            "exists": False,
+            "age_days": None,
+            "status": "missing",
+            "message": (
+                "No cached Monarch session at data/monarch_session.pickle. "
+                "Run the interactive login documented in AGENTS.md to authenticate."
+            ),
+        }
+
+    if age >= SESSION_EXPIRY_DAYS:
+        status = "expired"
+        message = f"Monarch session is {age:.0f}d old — likely expired (>={SESSION_EXPIRY_DAYS}d). Re-authenticate."
+    elif age >= SESSION_WARNING_DAYS:
+        status = "expiring_soon"
+        message = f"Monarch session is {age:.0f}d old — re-auth recommended before it expires (~{SESSION_EXPIRY_DAYS}d)."
+    else:
+        status = "ok"
+        message = f"Monarch session is {age:.0f}d old."
+    return {
+        "exists": True,
+        "age_days": round(age, 1),
+        "status": status,
+        "message": message,
+    }
+
 
 class MonarchClient:
     """Thin wrapper around monarchmoney with session caching."""

--- a/api/services/monarch.py
+++ b/api/services/monarch.py
@@ -13,6 +13,7 @@ Session caching avoids repeated login/MFA. First login must be interactive
 """
 import asyncio
 import logging
+import time
 from datetime import datetime, date, timezone
 from pathlib import Path
 from typing import Optional
@@ -39,7 +40,7 @@ def get_session_age_days() -> Optional[float]:
     """
     if not SESSION_PATH.exists():
         return None
-    age_seconds = datetime.now().timestamp() - SESSION_PATH.stat().st_mtime
+    age_seconds = time.time() - SESSION_PATH.stat().st_mtime
     return age_seconds / 86400.0
 
 

--- a/api/services/service_health.py
+++ b/api/services/service_health.py
@@ -32,7 +32,7 @@ Usage:
 """
 import logging
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from enum import Enum
 from typing import Optional
@@ -417,6 +417,17 @@ class ServiceHealthRegistry:
         else:
             overall = "healthy"
 
+        # Monarch session age (issue #199 §3) — surface re-auth need before
+        # the monthly sync 401s. Cheap (just file mtime), no network.
+        monarch_session = None
+        try:
+            from api.services.monarch import get_session_status
+            monarch_session = get_session_status()
+        except Exception:
+            monarch_session = None
+        if monarch_session and monarch_session.get("status") in ("expired", "missing"):
+            overall = "degraded" if overall == "healthy" else overall
+
         return {
             "overall_status": overall,
             "services": services,
@@ -425,6 +436,7 @@ class ServiceHealthRegistry:
             "critical_issues": [
                 {"service": svc, "error": err} for svc, err in critical_issues
             ],
+            "monarch_session": monarch_session,
             "checked_at": datetime.now(timezone.utc).isoformat(),
         }
 

--- a/api/services/summarizer.py
+++ b/api/services/summarizer.py
@@ -2,7 +2,9 @@
 Document summarization service using local LLM.
 
 Generates brief summaries for document discovery and high-level search.
-Uses Ollama with qwen2.5:7b-instruct for zero-cost local summarization.
+Talks to the OpenAI-compatible local LLM server (llama-server) configured by
+``settings.local_llm_url`` — same endpoint the orchestrator uses, so there's
+no second model to keep running.
 
 ## Tiered Summarization
 
@@ -108,7 +110,7 @@ def generate_summary(
     use_retry_prompt: bool = False
 ) -> tuple[Optional[str], bool]:
     """
-    Generate a document summary using local LLM.
+    Generate a document summary using the local OpenAI-compatible LLM server.
 
     Args:
         content: Document content to summarize
@@ -139,23 +141,26 @@ def generate_summary(
         prompt_template = RETRY_PROMPT if use_retry_prompt else SUMMARY_PROMPT
         prompt = prompt_template.format(content=truncated)
 
-        # Call Ollama synchronously
-        url = f"{settings.ollama_host}/api/generate"
+        # OpenAI-compatible chat completions against the local llama-server.
+        # We pass model="local" because llama-server ignores the field but the
+        # OpenAI spec requires it to be present.
+        url = f"{settings.local_llm_url.rstrip('/')}/v1/chat/completions"
         payload = {
-            "model": settings.ollama_model,
-            "prompt": prompt,
+            "model": "local",
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.2,
+            "max_tokens": 75,
             "stream": False,
-            "options": {
-                "temperature": 0.2,  # Low temperature for factual summary
-                "num_predict": 75,   # Force very brief response
-            }
         }
 
         with httpx.Client(timeout=timeout) as client:
             response = client.post(url, json=payload)
             response.raise_for_status()
             data = response.json()
-            summary = data.get("response", "").strip()
+            choices = data.get("choices") or []
+            summary = ""
+            if choices:
+                summary = (choices[0].get("message", {}).get("content") or "").strip()
 
         # Validate summary (increased max for 7B model verbosity)
         if len(summary) < 20 or len(summary) > 1000:
@@ -166,10 +171,10 @@ def generate_summary(
         return summary, True
 
     except httpx.TimeoutException as e:
-        logger.warning(f"Ollama timeout for {file_name}: {e}")
+        logger.warning(f"LLM timeout for {file_name}: {e}")
         return None, False  # Mark as failure for retry
     except httpx.ConnectError as e:
-        logger.warning(f"Ollama connection failed for {file_name}: {e}")
+        logger.warning(f"LLM connection failed for {file_name}: {e}")
         return None, False  # Mark as failure for retry
     except Exception as e:
         logger.warning(f"Summary generation failed for {file_name}: {e}")
@@ -262,11 +267,12 @@ def _fallback_summary(content: str, file_name: str) -> str:
     return f"Document '{file_name}' containing various notes."
 
 
-def is_ollama_available() -> bool:
-    """Check if Ollama server is available for summarization."""
+def is_summarizer_llm_available() -> bool:
+    """Check if the local LLM server is reachable for summarization."""
     try:
+        url = f"{settings.local_llm_url.rstrip('/')}/health"
         with httpx.Client(timeout=2.0) as client:
-            response = client.get(settings.ollama_host)
+            response = client.get(url)
             return response.status_code == 200
     except Exception:
         return False

--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -394,6 +394,11 @@ def emit_sync_stats(stats: dict) -> None:
     bypassing brittle regex inference. Each top-level sync script should call
     this once with its final tallies. Only int-valued keys are read by the
     parser; nested dicts and strings are ignored for forwards-compat.
+
+    The output is intentionally single-line — the parser regex
+    ``SYNC_STATS:(\\{[^\\n]*\\})`` will not match across newlines, so the
+    JSON payload must not contain literal newlines (``json.dumps`` doesn't
+    add any). Don't pretty-print the dict here.
     """
     import json as _json
     # Keep on its own line so the parser regex matches cleanly even when the
@@ -754,6 +759,9 @@ def detect_silent_source_entity_drift(
     warnings: list[dict] = []
 
     try:
+        # Both DBs run in WAL mode (see InteractionStore / SourceEntityStore
+        # init). Read connections see a consistent snapshot at open time;
+        # concurrent writes by an ongoing sync don't block us or skew rows.
         i_conn = sqlite3.connect(str(interactions_path))
         c_conn = sqlite3.connect(str(crm_path))
         try:

--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -387,6 +387,64 @@ def _init_schema(conn: sqlite3.Connection):
         logger.info(f"Migrated sync_runs table: added {len(migrations)} columns")
 
 
+def emit_sync_stats(stats: dict) -> None:
+    """Print the canonical ``SYNC_STATS:{json}`` line consumed by run_all_syncs.
+
+    The orchestrator's ``_parse_sync_output`` treats this as authoritative,
+    bypassing brittle regex inference. Each top-level sync script should call
+    this once with its final tallies. Only int-valued keys are read by the
+    parser; nested dicts and strings are ignored for forwards-compat.
+    """
+    import json as _json
+    # Keep on its own line so the parser regex matches cleanly even when the
+    # surrounding output has interleaved logging.
+    print("SYNC_STATS:" + _json.dumps(stats), flush=True)
+
+
+def reap_orphan_sync_runs(max_age_hours: int = 8) -> int:
+    """Mark stale ``status='running'`` rows as failed.
+
+    A row can stay in the running state forever if the sync process was killed
+    without unwinding (SIGKILL, kernel OOM, lost ssh, system reboot). Without
+    cleanup, the dashboard shows phantom in-progress syncs and the staleness
+    check uses the wrong "last completed" timestamp.
+
+    Args:
+        max_age_hours: rows older than this are reaped. Default 8h covers even
+            the longest vault reindex (4h) with a generous safety margin.
+
+    Returns:
+        Number of orphan rows reaped.
+    """
+    conn = get_sync_health_db()
+    try:
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=max_age_hours)).isoformat()
+        cursor = conn.execute(
+            """
+            UPDATE sync_runs
+            SET status = ?,
+                completed_at = ?,
+                error_message = COALESCE(error_message, 'Reaped orphan: process died without unwinding'),
+                errors = MAX(errors, 1)
+            WHERE status = ?
+              AND started_at < ?
+            """,
+            (
+                SyncStatus.FAILED.value,
+                datetime.now(timezone.utc).isoformat(),
+                SyncStatus.RUNNING.value,
+                cutoff,
+            ),
+        )
+        reaped = cursor.rowcount
+        conn.commit()
+        if reaped:
+            logger.warning(f"Reaped {reaped} orphan sync_runs row(s) older than {max_age_hours}h")
+        return reaped
+    finally:
+        conn.close()
+
+
 def record_sync_start(source: str) -> int:
     """
     Record the start of a sync operation.
@@ -646,6 +704,110 @@ def get_sync_summary() -> dict:
         "disabled_sources": [h.source for h in disabled],
         "all_healthy": len(stale) == 0 and len(failed) == 0 and len(never_run) == 0,
     }
+
+
+def detect_silent_source_entity_drift(
+    interactions_db: Optional[str] = None,
+    crm_db: Optional[str] = None,
+    interactions_lookback_days: int = 7,
+    source_entity_stale_days: int = 30,
+) -> list[dict]:
+    """Return per-source warnings when interactions are flowing but source_entities aren't.
+
+    Diagnoses the silent regression pattern from issue #199 §2: a source still
+    persists new interactions every night, but stops producing new
+    ``source_entities`` rows. Without this detector, ``sync_runs`` happily
+    records ``success`` and the dashboard reads "healthy" while entity
+    resolution rots in the background.
+
+    The check is intentionally lenient: we look at MAX(created_at) and only
+    warn when the gap exceeds ``source_entity_stale_days``, so a source that
+    legitimately hasn't observed any new handles (e.g. you didn't message a
+    new phone number this week) won't trip an alert. The intent is to catch
+    the months-long drift, not normal quiet days.
+
+    Args:
+        interactions_db: Path to interactions.db. Defaults to data/interactions.db.
+        crm_db: Path to crm.db. Defaults to data/crm.db.
+        interactions_lookback_days: Only consider sources with interactions
+            newer than this. Avoids false positives for genuinely-defunct sources.
+        source_entity_stale_days: Warn when the newest source_entity is older
+            than this. 30 days is generous — most user behaviour produces at
+            least one new entity per month per active source.
+
+    Returns:
+        List of warnings, each ``{"source": str, "last_interaction": iso8601,
+        "last_source_entity": iso8601 | None, "gap_days": float}``.
+        Empty list when everything looks consistent.
+    """
+    import sqlite3
+    from pathlib import Path
+
+    project_root = Path(__file__).parent.parent.parent
+    interactions_path = Path(interactions_db) if interactions_db else project_root / "data" / "interactions.db"
+    crm_path = Path(crm_db) if crm_db else project_root / "data" / "crm.db"
+
+    if not interactions_path.exists() or not crm_path.exists():
+        return []  # Fresh install or test environment — nothing to compare
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=interactions_lookback_days)).isoformat()
+    warnings: list[dict] = []
+
+    try:
+        i_conn = sqlite3.connect(str(interactions_path))
+        c_conn = sqlite3.connect(str(crm_path))
+        try:
+            # Sources with any interactions in the lookback window
+            active = i_conn.execute(
+                """
+                SELECT source_type, MAX(created_at) AS latest
+                FROM interactions
+                WHERE created_at > ?
+                GROUP BY source_type
+                """,
+                (cutoff,),
+            ).fetchall()
+
+            for source_type, latest_interaction in active:
+                if not source_type or not latest_interaction:
+                    continue
+                row = c_conn.execute(
+                    "SELECT MAX(created_at) FROM source_entities WHERE source_type = ?",
+                    (source_type,),
+                ).fetchone()
+                latest_se = row[0] if row else None
+
+                if latest_se is None:
+                    warnings.append({
+                        "source": source_type,
+                        "last_interaction": latest_interaction,
+                        "last_source_entity": None,
+                        "gap_days": None,
+                    })
+                    continue
+
+                try:
+                    se_dt = datetime.fromisoformat(latest_se.replace("Z", "+00:00"))
+                    if se_dt.tzinfo is None:
+                        se_dt = se_dt.replace(tzinfo=timezone.utc)
+                except (ValueError, AttributeError):
+                    continue
+                gap_days = (datetime.now(timezone.utc) - se_dt).total_seconds() / 86400.0
+                if gap_days > source_entity_stale_days:
+                    warnings.append({
+                        "source": source_type,
+                        "last_interaction": latest_interaction,
+                        "last_source_entity": latest_se,
+                        "gap_days": round(gap_days, 1),
+                    })
+        finally:
+            i_conn.close()
+            c_conn.close()
+    except sqlite3.DatabaseError as e:
+        logger.warning(f"Source-entity drift detector skipped (db error): {e}")
+        return []
+
+    return warnings
 
 
 def check_sync_health() -> tuple[bool, str]:

--- a/config/systemd/lifeos-server-watchdog.service
+++ b/config/systemd/lifeos-server-watchdog.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=LifeOS API server watchdog — reaps duplicate uvicorn PIDs, restarts if unresponsive
+After=lifeos-api.service
+
+[Service]
+Type=oneshot
+User=__USER__
+WorkingDirectory=__LIFEOS_DIR__
+ExecStart=__LIFEOS_DIR__/scripts/server-watchdog.sh

--- a/config/systemd/lifeos-server-watchdog.timer
+++ b/config/systemd/lifeos-server-watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=LifeOS API Server Watchdog Timer (every 5 min)
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=5min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -649,6 +649,11 @@ def main():
     # Emit canonical sync stats for the orchestrator. Aggregates across all
     # sub-imports so run_all_syncs.py records the true row deltas instead of
     # inferring zero from output that doesn't match its regex patterns.
+    #
+    # Each import_* function uses a different result-dict shape (historical),
+    # so the dispatch is explicit per source. An if/elif chain — not unguarded
+    # accumulators — keeps an `import_contacts` that grows new keys later
+    # (e.g. someone adds "sources_created") from being double-counted.
     from api.services.sync_health import emit_sync_stats
     aggregate = {
         "interactions_created": 0,
@@ -659,23 +664,31 @@ def main():
     for name, result in results.items():
         if not isinstance(result, dict):
             continue
-        # Contacts: {"created", "updated", "linked"} from import_contacts.
         if name == "contacts":
+            # import_contacts → {"created", "updated", "linked"}
             aggregate["source_entities_created"] += int(result.get("created", 0) or 0)
             aggregate["people_updated"] += int(result.get("linked", 0) or 0)
-        # Photos faces: "sources_created" + "interactions_created"
-        aggregate["source_entities_created"] += int(result.get("sources_created", 0) or 0)
-        aggregate["interactions_created"] += int(result.get("interactions_created", 0) or 0)
-        # Phone uses "imported" as interactions
-        aggregate["interactions_created"] += int(result.get("imported", 0) or 0)
-        # WhatsApp returns nested {contacts: {...}, messages: {...}}
-        contacts = result.get("contacts")
-        if isinstance(contacts, dict):
-            aggregate["source_entities_created"] += int(contacts.get("source_entities_created", 0) or 0)
-            aggregate["people_updated"] += int(contacts.get("persons_linked", 0) or 0)
-        messages = result.get("messages")
-        if isinstance(messages, dict):
-            aggregate["interactions_created"] += int(messages.get("interactions_created", 0) or 0)
+        elif name == "imessage":
+            # import_imessage just copies the db; the actual source_entity /
+            # interaction creation happens later in sync_imessage_interactions
+            # (which emits its own SYNC_STATS line). Nothing to count here.
+            pass
+        elif name == "phone":
+            # import_phone_calls → {"imported", "skipped", "unresolved"}
+            aggregate["interactions_created"] += int(result.get("imported", 0) or 0)
+        elif name == "photos":
+            # import_photos_faces → {"sources_created", "interactions_created"}
+            aggregate["source_entities_created"] += int(result.get("sources_created", 0) or 0)
+            aggregate["interactions_created"] += int(result.get("interactions_created", 0) or 0)
+        elif name == "whatsapp":
+            # import_whatsapp → {"contacts": {...}, "messages": {...}}
+            contacts = result.get("contacts")
+            if isinstance(contacts, dict):
+                aggregate["source_entities_created"] += int(contacts.get("source_entities_created", 0) or 0)
+                aggregate["people_updated"] += int(contacts.get("persons_linked", 0) or 0)
+            messages = result.get("messages")
+            if isinstance(messages, dict):
+                aggregate["interactions_created"] += int(messages.get("interactions_created", 0) or 0)
     emit_sync_stats(aggregate)
 
     # Non-zero exit on any per-source error so run_all_syncs.run_sync marks

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -646,6 +646,38 @@ def main():
 
     print(json.dumps({"results": results}, indent=2))
 
+    # Emit canonical sync stats for the orchestrator. Aggregates across all
+    # sub-imports so run_all_syncs.py records the true row deltas instead of
+    # inferring zero from output that doesn't match its regex patterns.
+    from api.services.sync_health import emit_sync_stats
+    aggregate = {
+        "interactions_created": 0,
+        "source_entities_created": 0,
+        "people_created": 0,
+        "people_updated": 0,
+    }
+    for name, result in results.items():
+        if not isinstance(result, dict):
+            continue
+        # Contacts: {"created", "updated", "linked"} from import_contacts.
+        if name == "contacts":
+            aggregate["source_entities_created"] += int(result.get("created", 0) or 0)
+            aggregate["people_updated"] += int(result.get("linked", 0) or 0)
+        # Photos faces: "sources_created" + "interactions_created"
+        aggregate["source_entities_created"] += int(result.get("sources_created", 0) or 0)
+        aggregate["interactions_created"] += int(result.get("interactions_created", 0) or 0)
+        # Phone uses "imported" as interactions
+        aggregate["interactions_created"] += int(result.get("imported", 0) or 0)
+        # WhatsApp returns nested {contacts: {...}, messages: {...}}
+        contacts = result.get("contacts")
+        if isinstance(contacts, dict):
+            aggregate["source_entities_created"] += int(contacts.get("source_entities_created", 0) or 0)
+            aggregate["people_updated"] += int(contacts.get("persons_linked", 0) or 0)
+        messages = result.get("messages")
+        if isinstance(messages, dict):
+            aggregate["interactions_created"] += int(messages.get("interactions_created", 0) or 0)
+    emit_sync_stats(aggregate)
+
     # Non-zero exit on any per-source error so run_all_syncs.run_sync marks
     # apple_import as FAILED and sync_health records it. "skipped" is fine —
     # it means nothing to do.

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -49,6 +49,8 @@ from api.services.sync_health import (
     get_sync_health,
     get_sync_summary,
     check_sync_health,
+    reap_orphan_sync_runs,
+    detect_silent_source_entity_drift,
 )
 from config.settings import settings
 
@@ -844,7 +846,13 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
 
 
 def _parse_sync_output(output: str) -> dict:
-    """Parse sync script output for statistics."""
+    """Parse sync script output for statistics.
+
+    Scripts can emit a single canonical line ``SYNC_STATS:{json}`` with their
+    final tallies, which takes precedence over the regex fallbacks below. The
+    regex fallback exists for scripts that haven't been migrated yet and for
+    backwards compatibility with older log captures.
+    """
     import re
 
     stats = {
@@ -858,6 +866,40 @@ def _parse_sync_output(output: str) -> dict:
         "interactions_created": 0,
         "source_entities_created": 0,
     }
+
+    # Authoritative path: a single SYNC_STATS:{json} line emitted by the
+    # script. If present, treat it as ground truth and skip regex inference.
+    # Last occurrence wins, so a top-level wrapper script (e.g.
+    # apple_data_import.py aggregating across sub-imports) can override
+    # earlier emissions.
+    sync_stats_matches = re.findall(r"SYNC_STATS:(\{[^\n]*\})", output)
+    if sync_stats_matches:
+        try:
+            parsed = json.loads(sync_stats_matches[-1])
+            if isinstance(parsed, dict):
+                for key, value in parsed.items():
+                    if isinstance(value, (int, float)):
+                        stats[key] = int(value)
+                # Aggregate generic counters from categorized ones for
+                # backwards compatibility with downstream consumers.
+                stats["created"] = max(
+                    stats["created"],
+                    stats["people_created"]
+                    + stats["interactions_created"]
+                    + stats["source_entities_created"],
+                )
+                stats["updated"] = max(stats["updated"], stats["people_updated"])
+                # Still parse CONSISTENCY_SUMMARY below — it's orthogonal.
+                consistency_match = re.search(r"CONSISTENCY_SUMMARY:(\{.*\})", output)
+                if consistency_match:
+                    try:
+                        consistency_data = json.loads(consistency_match.group(1))
+                        stats.update(consistency_data)
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+                return stats
+        except (json.JSONDecodeError, ValueError):
+            pass  # Fall through to regex parsing
 
     # Generic patterns (for backwards compatibility)
     generic_patterns = [
@@ -960,6 +1002,15 @@ def run_all_syncs(
     logger.info(f"Sync triggered: {trigger}")
     logger.info(f"Starting sync run for {len(sources)} sources...")
     logger.info(f"Log file: {log_file}")
+
+    # Clean up sync_runs rows left in status='running' by killed/crashed
+    # processes. Otherwise they pin the dashboard's "last completed" timestamp
+    # and make recently-failed sources look healthy.
+    if not dry_run:
+        try:
+            reap_orphan_sync_runs()
+        except Exception as e:
+            logger.warning(f"Failed to reap orphan sync_runs: {e}")
 
     # Trigger Photos.app to open and start iCloud sync in background (macOS only)
     # This runs at the beginning so Photos can sync throughout the entire process
@@ -1123,6 +1174,19 @@ def run_all_syncs(
     # Check overall health
     is_healthy, health_msg = check_sync_health()
     logger.info(f"Overall health: {health_msg}")
+
+    # Silent-regression check: warn if a source keeps creating interactions
+    # but stopped persisting source_entities (issue #199 §2). Run after the
+    # sync so the data we look at is post-tonight, not pre-tonight.
+    try:
+        drift = detect_silent_source_entity_drift()
+        for w in drift:
+            logger.warning(
+                f"source_entity drift: {w['source']} interactions through {w['last_interaction']} "
+                f"but last source_entity={w['last_source_entity']} (gap={w['gap_days']}d)"
+            )
+    except Exception as e:
+        logger.warning(f"Source-entity drift detector failed: {e}")
 
     # Calculate duration
     end_time = datetime.now()

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -1012,6 +1012,17 @@ def run_all_syncs(
         except Exception as e:
             logger.warning(f"Failed to reap orphan sync_runs: {e}")
 
+        # Monarch session expiry check (issue #199 §3 acceptance criterion).
+        # Surfaces re-auth need in the nightly log *before* the monthly
+        # sync hits a 401/525. Cheap — just stats the pickle's mtime.
+        try:
+            from api.services.monarch import get_session_status
+            mstatus = get_session_status()
+            if mstatus["status"] in ("expiring_soon", "expired", "missing"):
+                logger.warning(f"Monarch session: {mstatus['message']}")
+        except Exception as e:
+            logger.warning(f"Monarch session-status check failed: {e}")
+
     # Trigger Photos.app to open and start iCloud sync in background (macOS only)
     # This runs at the beginning so Photos can sync throughout the entire process
     if not dry_run and sys.platform == "darwin":

--- a/scripts/server-watchdog.sh
+++ b/scripts/server-watchdog.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # LifeOS Server Watchdog
-# Run via cron every 5 minutes to detect and fix server issues:
-#   - Duplicate uvicorn processes (causes Telegram 409 errors)
+# Runs every 5 minutes to detect and fix server issues:
+#   - Duplicate uvicorn processes (causes Telegram 409 errors and ghost-server confusion)
 #   - Unresponsive server (stale after long syncs)
 #
-# Cron entry:
+# Linux: triggered by lifeos-server-watchdog.timer (installed by setup-systemd.sh).
+# macOS cron entry:
 #   */5 * * * * /Applications/LifeOS.app/Contents/MacOS/LifeOS server-watchdog
 
 set -euo pipefail

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -67,15 +67,20 @@ get_server_pid() {
 kill_server() {
     log_info "Stopping any existing server processes..."
 
-    # Method 1: Kill by port
+    # Method 1: Kill by port — catches whoever is currently bound.
     local pids=$(get_server_pid)
     if [ -n "$pids" ]; then
         echo "$pids" | xargs kill -9 2>/dev/null || true
         log_info "Killed processes on port $PORT: $pids"
     fi
 
-    # Method 2: Kill by process name (catch any stragglers)
-    pkill -9 -f "uvicorn api.main:app" 2>/dev/null || true
+    # Method 2: Kill by process name — catches stragglers that haven't bound
+    # yet (mid-startup) or have lost the port. The cmdline we actually launch
+    # is `python -c "import uvicorn\nuvicorn.run('api.main:app', ...)"`, NOT
+    # `uvicorn api.main:app`, so the legacy pattern silently missed every
+    # ghost process. Match against the chunk that's stable across both the
+    # script-launched and systemd-launched paths.
+    pkill -9 -f "uvicorn.run.*api.main:app" 2>/dev/null || true
 
     # Method 3: Clean up any HuggingFace lock files that might cause hangs
     rm -f ~/.cache/huggingface/hub/.locks/models--sentence-transformers--all-MiniLM-L6-v2/*.lock 2>/dev/null || true

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -160,6 +160,9 @@ echo "  lifeos-api: $(systemctl is-active lifeos-api.service)"
 systemctl enable --now lifeos-watchdog.timer
 echo "  lifeos-watchdog.timer: $(systemctl is-active lifeos-watchdog.timer)"
 
+systemctl enable --now lifeos-server-watchdog.timer
+echo "  lifeos-server-watchdog.timer: $(systemctl is-active lifeos-server-watchdog.timer)"
+
 systemctl enable --now lifeos-sync.timer
 echo "  lifeos-sync.timer: $(systemctl is-active lifeos-sync.timer)"
 

--- a/scripts/sync_apple_contacts.py
+++ b/scripts/sync_apple_contacts.py
@@ -237,7 +237,7 @@ def sync_apple_contacts(dry_run: bool = True) -> dict:
         person_store.save()
 
     # Log summary
-    logger.info(f"\n=== Apple Contacts Sync Summary ===")
+    logger.info("\n=== Apple Contacts Sync Summary ===")
     logger.info(f"Contacts read: {stats['contacts_read']}")
     logger.info(f"Source entities created: {stats['source_entities_created']}")
     logger.info(f"Source entities updated: {stats['source_entities_updated']}")
@@ -251,6 +251,15 @@ def sync_apple_contacts(dry_run: bool = True) -> dict:
 
     if dry_run:
         logger.info("\nDRY RUN - no changes made")
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output.
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "source_entities_created": stats["source_entities_created"],
+        "people_created": stats["persons_created"],
+        "people_updated": stats["persons_updated"] + stats["persons_linked"],
+        "errors": stats["errors"],
+    })
 
     return stats
 

--- a/scripts/sync_contacts_csv.py
+++ b/scripts/sync_contacts_csv.py
@@ -239,7 +239,7 @@ def sync_contacts_csv(csv_path: str = None, dry_run: bool = True) -> dict:
         person_store.save()
 
     # Log summary
-    logger.info(f"\n=== Contacts CSV Sync Summary ===")
+    logger.info("\n=== Contacts CSV Sync Summary ===")
     logger.info(f"Contacts read: {stats['contacts_read']}")
     logger.info(f"Source entities created: {stats['source_entities_created']}")
     logger.info(f"Source entities updated: {stats['source_entities_updated']}")
@@ -251,6 +251,15 @@ def sync_contacts_csv(csv_path: str = None, dry_run: bool = True) -> dict:
 
     if dry_run:
         logger.info("\nDRY RUN - no changes made")
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output.
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "source_entities_created": stats["source_entities_created"],
+        "people_created": stats["persons_created"],
+        "people_updated": stats["persons_updated"] + stats["persons_linked"],
+        "errors": stats["errors"],
+    })
 
     return stats
 

--- a/scripts/sync_crm_to_vectorstore.py
+++ b/scripts/sync_crm_to_vectorstore.py
@@ -121,11 +121,19 @@ def main():
             min_interactions=args.min_interactions,
         )
 
-        print(f"\nResults:")
+        print("\nResults:")
         print(f"  Indexed: {result['indexed']}")
         print(f"  Skipped: {result['skipped']}")
         print(f"  Errors:  {result['errors']}")
         print(f"  Total checked: {result['total_checked']}")
+
+        # Canonical line consumed by run_all_syncs._parse_sync_output.
+        from api.services.sync_health import emit_sync_stats
+        emit_sync_stats({
+            "processed": int(result.get("total_checked", 0) or 0),
+            "people_updated": int(result.get("indexed", 0) or 0),
+            "errors": int(result.get("errors", 0) or 0),
+        })
 
     else:
         # Dry run
@@ -143,13 +151,13 @@ def main():
         if len(result["eligible"]) > 20:
             print(f"\n  ... and {len(result['eligible']) - 20} more")
 
-        print(f"\nSummary:")
+        print("\nSummary:")
         print(f"  Eligible for indexing: {len(result['eligible'])}")
         print(f"  Skipped (hidden): {result['skipped_hidden']}")
         print(f"  Skipped (low activity): {result['skipped_low_activity']}")
         print(f"  Total people: {result['total']}")
 
-        print(f"\nTo execute, run with --execute flag")
+        print("\nTo execute, run with --execute flag")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_gmail_calendar_interactions.py
+++ b/scripts/sync_gmail_calendar_interactions.py
@@ -864,6 +864,26 @@ def main():
             logger.info(f"Refreshing stats for {len(all_affected)} affected people...")
             refresh_person_stats(list(all_affected))
 
+    # Canonical line consumed by run_all_syncs._parse_sync_output. Aggregates
+    # across gmail + calendar across whichever accounts ran (personal / work /
+    # work2) so the orchestrator records the true total instead of inferring
+    # from interleaved per-account log lines.
+    from api.services.sync_health import emit_sync_stats
+    aggregate = {
+        "interactions_created": 0,
+        "source_entities_created": 0,
+        "errors": 0,
+    }
+    for stats in all_stats.values():
+        if not isinstance(stats, dict):
+            continue
+        # Gmail uses "inserted"; calendar uses "interactions_inserted".
+        aggregate["interactions_created"] += int(stats.get("inserted", 0) or 0)
+        aggregate["interactions_created"] += int(stats.get("interactions_inserted", 0) or 0)
+        aggregate["source_entities_created"] += int(stats.get("source_entities_created", 0) or 0)
+        aggregate["errors"] += int(stats.get("errors", 0) or 0)
+    emit_sync_stats(aggregate)
+
     return all_stats
 
 

--- a/scripts/sync_imessage_interactions.py
+++ b/scripts/sync_imessage_interactions.py
@@ -222,6 +222,15 @@ def sync_imessage_interactions(dry_run: bool = True, limit: int = None) -> dict:
             logger.info(f"Refreshing stats for {len(affected_person_ids)} affected people...")
             refresh_person_stats(list(affected_person_ids))
 
+    # Canonical line consumed by run_all_syncs._parse_sync_output. Existing
+    # human-readable lines above are kept; the parser uses this dict as truth.
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "interactions_created": stats["inserted"],
+        "source_entities_created": stats["source_entities_created"],
+        "errors": stats["errors"],
+    })
+
     return stats
 
 

--- a/scripts/sync_linkedin.py
+++ b/scripts/sync_linkedin.py
@@ -67,11 +67,18 @@ def sync_linkedin(csv_path: str = DEFAULT_CSV_PATH, dry_run: bool = True) -> dic
         entity_resolver=resolver,
     )
 
-    logger.info(f"\n=== LinkedIn Sync Results ===")
+    logger.info("\n=== LinkedIn Sync Results ===")
     logger.info(f"  Connections processed: {results.get('connections_processed', 0)}")
     logger.info(f"  Entities created: {results.get('entities_created', 0)}")
     logger.info(f"  Entities updated: {results.get('entities_updated', 0)}")
     logger.info(f"  Connections skipped: {results.get('connections_skipped', 0)}")
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output.
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "source_entities_created": int(results.get("entities_created", 0) or 0),
+        "people_updated": int(results.get("entities_updated", 0) or 0),
+    })
 
     return results
 

--- a/scripts/sync_phone_calls.py
+++ b/scripts/sync_phone_calls.py
@@ -324,7 +324,7 @@ def sync_phone_calls(
     interaction_conn.close()
 
     # Log summary
-    logger.info(f"\n=== Phone Calls Sync Summary ===")
+    logger.info("\n=== Phone Calls Sync Summary ===")
     logger.info(f"Calls read: {stats['calls_read']}")
     logger.info(f"Interactions created: {stats['interactions_created']}")
     logger.info(f"Source entities created: {stats['source_entities_created']}")
@@ -343,6 +343,15 @@ def sync_phone_calls(
             from api.services.person_stats import refresh_person_stats
             logger.info(f"Refreshing stats for {len(affected_person_ids)} affected people...")
             refresh_person_stats(list(affected_person_ids))
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output.
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "interactions_created": stats["interactions_created"],
+        "source_entities_created": stats["source_entities_created"],
+        "people_updated": stats["persons_linked"],
+        "errors": stats["errors"],
+    })
 
     return stats
 

--- a/scripts/sync_slack.py
+++ b/scripts/sync_slack.py
@@ -56,18 +56,18 @@ def run_slack_sync(full: bool = False, dry_run: bool = True) -> dict:
         results = sync.incremental_sync()
 
     # Log results
-    logger.info(f"\n=== Slack Sync Results ===")
+    logger.info("\n=== Slack Sync Results ===")
 
     if "users" in results and results["users"]:
         users = results["users"]
-        logger.info(f"Users:")
+        logger.info("Users:")
         logger.info(f"  Synced: {users.get('synced', 0)}")
         logger.info(f"  Created: {users.get('created', 0)}")
         logger.info(f"  Updated: {users.get('updated', 0)}")
 
     if "messages" in results and results["messages"]:
         msgs = results["messages"]
-        logger.info(f"Messages:")
+        logger.info("Messages:")
         logger.info(f"  Channels synced: {msgs.get('channels_synced', 0)}")
         logger.info(f"  Messages indexed: {msgs.get('messages_indexed', 0)}")
         logger.info(f"  Interactions created: {msgs.get('interactions_created', 0)}")
@@ -81,6 +81,16 @@ def run_slack_sync(full: bool = False, dry_run: bool = True) -> dict:
 
     if dry_run:
         logger.info("\nDRY RUN - no changes made. Use --execute to apply.")
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output.
+    from api.services.sync_health import emit_sync_stats
+    users = results.get("users") or {}
+    msgs = results.get("messages") or {}
+    emit_sync_stats({
+        "source_entities_created": int(users.get("created", 0) or 0),
+        "people_updated": int(users.get("updated", 0) or 0),
+        "interactions_created": int(msgs.get("interactions_created", 0) or 0),
+    })
 
     return results
 

--- a/scripts/sync_vault_reindex.py
+++ b/scripts/sync_vault_reindex.py
@@ -90,7 +90,7 @@ def sync_vault_reindex(dry_run: bool = True, force: bool = False, skip_summaries
 
     elapsed = time.time() - start_time
 
-    logger.info(f"\n=== Vault Reindex Results ===")
+    logger.info("\n=== Vault Reindex Results ===")
     logger.info(f"  Files indexed: {files_indexed}")
     logger.info(f"  Time elapsed: {elapsed:.1f}s ({elapsed/60:.1f} min)")
 
@@ -101,15 +101,36 @@ def sync_vault_reindex(dry_run: bool = True, force: bool = False, skip_summaries
     }
 
 
+def clear_bm25_index():
+    """Drop all BM25 chunks. Use when the index has stale doc_ids (e.g. after
+    migrating the vault from a different OS path, so the macOS doc_ids
+    accumulated alongside the current Linux ones)."""
+    from api.services.bm25_index import BM25Index
+    index = BM25Index()
+    before = index.count()
+    index.clear()
+    logger.info(f"BM25 index cleared: {before} rows dropped")
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Reindex Obsidian vault')
     parser.add_argument('--execute', action='store_true', help='Actually perform reindex')
     parser.add_argument('--force', action='store_true', help='Force full reindex (not incremental)')
     parser.add_argument('--clear-vectors', action='store_true', help='Clear vector store before indexing (use when changing embedding model)')
+    parser.add_argument('--clear-bm25', action='store_true', help='Clear BM25 index before indexing (use to drop stale doc_ids from a previous vault path)')
     parser.add_argument('--skip-summaries', action='store_true', help='Skip LLM summary generation for faster indexing')
     args = parser.parse_args()
 
     if args.clear_vectors and args.execute:
         clear_vector_store()
+    if args.clear_bm25 and args.execute:
+        clear_bm25_index()
 
-    sync_vault_reindex(dry_run=not args.execute, force=args.force, skip_summaries=args.skip_summaries)
+    result = sync_vault_reindex(dry_run=not args.execute, force=args.force, skip_summaries=args.skip_summaries)
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output. "processed"
+    # is the file count so the orchestrator's generic counter matches reality.
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "processed": int(result.get("files_indexed", 0) or 0),
+    })

--- a/scripts/sync_vault_reindex.py
+++ b/scripts/sync_vault_reindex.py
@@ -130,6 +130,9 @@ if __name__ == '__main__':
 
     # Canonical line consumed by run_all_syncs._parse_sync_output. "processed"
     # is the file count so the orchestrator's generic counter matches reality.
+    # On dry runs result lacks "files_indexed", so emit zero — the orchestrator
+    # never invokes the script with --dry-run during a real sync, but keeping
+    # the line emission unconditional makes ad-hoc test runs less surprising.
     from api.services.sync_health import emit_sync_stats
     emit_sync_stats({
         "processed": int(result.get("files_indexed", 0) or 0),

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -1,0 +1,83 @@
+"""Unit tests for the BM25 keyword index — delete behaviour matters most.
+
+The historical regression was: ``delete_document(path)`` only clears the row
+whose doc_id equals ``path`` exactly, but chunks are keyed
+``{path}_{chunk_idx}`` and the summary is ``{path}::summary`` — so the
+"clean before re-add" path silently leaked all chunks whenever a file's
+chunk count shrank or its underlying path changed (e.g. vault migration
+from macOS to Linux left two parallel sets of rows).
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def bm25(tmp_path):
+    from api.services.bm25_index import BM25Index
+    return BM25Index(db_path=str(tmp_path / "bm25_test.db"))
+
+
+def _seed_file_chunks(bm25, path, chunk_count, with_summary=True):
+    for i in range(chunk_count):
+        bm25.add_document(
+            doc_id=f"{path}_{i}",
+            content=f"chunk {i} content for {path}",
+            file_name=path.split("/")[-1],
+        )
+    if with_summary:
+        bm25.add_document(
+            doc_id=f"{path}::summary",
+            content=f"summary of {path}",
+            file_name=path.split("/")[-1],
+        )
+
+
+class TestDeleteByPath:
+    def test_clears_all_chunks_for_a_file(self, bm25):
+        _seed_file_chunks(bm25, "/notes/foo.md", chunk_count=5)
+        assert bm25.count() == 6  # 5 chunks + 1 summary
+
+        removed = bm25.delete_by_path("/notes/foo.md")
+        assert removed == 6
+        assert bm25.count() == 0
+
+    def test_only_touches_the_named_path(self, bm25):
+        _seed_file_chunks(bm25, "/notes/foo.md", chunk_count=3)
+        _seed_file_chunks(bm25, "/notes/bar.md", chunk_count=2)
+
+        removed = bm25.delete_by_path("/notes/foo.md")
+        assert removed == 4
+        # bar's 2 chunks + 1 summary survive
+        assert bm25.count() == 3
+
+    def test_path_prefix_collision_is_safe(self, bm25):
+        """``/a/foo.md`` deletion must not clobber ``/a/foo.md.bak``.
+
+        GLOB ``{path}_*`` is the underscore-suffix shape we use for numbered
+        chunks; ``foo.md.bak_0`` starts with ``foo.md.b`` not ``foo.md_``, so
+        the safety property here is just that we don't accidentally substring-
+        match the wrong file.
+        """
+        _seed_file_chunks(bm25, "/a/foo.md", chunk_count=2)
+        _seed_file_chunks(bm25, "/a/foo.md.bak", chunk_count=2)
+
+        removed = bm25.delete_by_path("/a/foo.md")
+        # 2 chunks + summary for /a/foo.md only
+        assert removed == 3
+        # /a/foo.md.bak still has 2 chunks + summary
+        assert bm25.count() == 3
+
+    def test_removes_stale_path_alongside_current_path(self, bm25):
+        """The vault migration scenario: old macOS path and new Linux path coexist."""
+        _seed_file_chunks(bm25, "/Users/x/Notes/q.md", chunk_count=3)
+        _seed_file_chunks(bm25, "/home/x/Notes/q.md", chunk_count=3)
+
+        # Drop the legacy macOS rows only.
+        removed = bm25.delete_by_path("/Users/x/Notes/q.md")
+        assert removed == 4
+        # Linux rows survive.
+        assert bm25.count() == 4
+
+    def test_returns_zero_when_nothing_to_delete(self, bm25):
+        assert bm25.delete_by_path("/nonexistent.md") == 0

--- a/tests/test_monarch_session_status.py
+++ b/tests/test_monarch_session_status.py
@@ -1,0 +1,69 @@
+"""Tests for the Monarch session-age detector (issue #199 §3).
+
+The real bug we're guarding against: the cached Monarch session token is just
+a pickle on disk that silently expires every ~30 days. The monthly sync
+notices via a 401/525 from Monarch; by then the operator has missed two
+months of data. This detector surfaces the expiry window early so it's
+visible on the health dashboard before things break.
+"""
+import os
+import time
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def temp_session(tmp_path, monkeypatch):
+    """Point SESSION_PATH at a fresh tempfile each test."""
+    from api.services import monarch as mod
+    path = tmp_path / "monarch_session.pickle"
+    monkeypatch.setattr(mod, "SESSION_PATH", path)
+    return path
+
+
+class TestGetSessionAgeDays:
+    def test_returns_none_when_no_session(self, temp_session):
+        from api.services.monarch import get_session_age_days
+        assert get_session_age_days() is None
+
+    def test_returns_age_in_days(self, temp_session):
+        from api.services.monarch import get_session_age_days
+        temp_session.write_bytes(b"")
+        # Backdate the file mtime by 10 days.
+        ten_days_ago = time.time() - 10 * 86400
+        os.utime(temp_session, (ten_days_ago, ten_days_ago))
+        age = get_session_age_days()
+        assert age is not None
+        assert 9.9 < age < 10.1
+
+
+class TestGetSessionStatus:
+    def test_missing_session(self, temp_session):
+        from api.services.monarch import get_session_status
+        status = get_session_status()
+        assert status["exists"] is False
+        assert status["status"] == "missing"
+
+    def test_fresh_session(self, temp_session):
+        from api.services.monarch import get_session_status
+        temp_session.write_bytes(b"")
+        status = get_session_status()
+        assert status["exists"] is True
+        assert status["status"] == "ok"
+
+    def test_session_expiring_soon(self, temp_session):
+        from api.services.monarch import get_session_status, SESSION_WARNING_DAYS
+        temp_session.write_bytes(b"")
+        # Backdate to one day past the warning threshold.
+        backdate = time.time() - (SESSION_WARNING_DAYS + 1) * 86400
+        os.utime(temp_session, (backdate, backdate))
+        assert get_session_status()["status"] == "expiring_soon"
+
+    def test_session_expired(self, temp_session):
+        from api.services.monarch import get_session_status, SESSION_EXPIRY_DAYS
+        temp_session.write_bytes(b"")
+        backdate = time.time() - (SESSION_EXPIRY_DAYS + 5) * 86400
+        os.utime(temp_session, (backdate, backdate))
+        assert get_session_status()["status"] == "expired"

--- a/tests/test_phase9_integration.py
+++ b/tests/test_phase9_integration.py
@@ -11,7 +11,7 @@ import pytest
 import tempfile
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 
 @pytest.mark.integration
@@ -123,7 +123,7 @@ class TestPhase9Integration:
 
     def test_document_summary_generation(self):
         """Verify document summaries are generated correctly."""
-        from api.services.summarizer import generate_summary, _fallback_summary
+        from api.services.summarizer import _fallback_summary
 
         # Test fallback summary (no Ollama needed)
         content = """# Budget Review Meeting
@@ -172,35 +172,35 @@ Meeting with Kevin and Sarah to discuss Q4 projections.
 
     def test_all_services_can_be_imported(self):
         """Verify all Phase 9 services can be imported."""
-        # This tests that there are no import errors
+        # Import-only smoke test — the assertions ARE the imports succeeding.
+        # noqa keeps ruff from stripping the "unused" imports.
 
         # P9.1 - Contextual Chunking
-        from api.services.chunker import (
+        from api.services.chunker import (  # noqa: F401
             generate_chunk_context,
             add_context_to_chunks,
             _infer_topic,
         )
 
         # P9.2 - Cross-Encoder Re-ranking
-        from api.services.reranker import (
+        from api.services.reranker import (  # noqa: F401
             RerankerService,
             get_reranker,
         )
 
         # P9.3 - Overlapping Chunks (deduplication)
-        from api.services.hybrid_search import (
+        from api.services.hybrid_search import (  # noqa: F401
             deduplicate_overlapping_chunks,
         )
 
         # P9.4 - Document Summaries
-        from api.services.summarizer import (
+        from api.services.summarizer import (  # noqa: F401
             generate_summary,
-            is_ollama_available,
+            is_summarizer_llm_available,
             create_summary_chunk,
             _fallback_summary,
         )
 
-        # All imports succeeded
         assert True
 
 
@@ -329,7 +329,7 @@ class TestPhase9EndToEnd:
 
         # Time the search (without reranker to get base latency)
         start = time.time()
-        results = hybrid.search("test content", top_k=10, use_reranker=False)
+        hybrid.search("test content", top_k=10, use_reranker=False)
         elapsed = time.time() - start
 
         # Should complete in under 500ms for 100 docs

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -180,6 +180,12 @@ def _run_llm_test(
     fail_sources = fail_sources or set()
     run_sync_mock = MagicMock(side_effect=_make_run_sync_side_effect(fail_sources))
 
+    # Without patching subprocess.run, every test would trigger a real
+    # `scripts/server.sh restart` (the post-sync server reload) and wait
+    # ~12s per test for systemd. Mock it to a clean exit so each test runs
+    # in milliseconds. Same for telegram + drift detector (need real DBs).
+    fake_restart = MagicMock(returncode=0, stdout="", stderr="")
+
     with (
         patch("scripts.run_all_syncs.SYNC_SOURCES", LLM_TEST_SYNC_SOURCES),
         patch("scripts.run_all_syncs.SYNC_ORDER", LLM_TEST_SYNC_ORDER),
@@ -188,6 +194,10 @@ def _run_llm_test(
         patch("scripts.run_all_syncs.get_disabled_work_sources", return_value=set()),
         patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
         patch("scripts.run_all_syncs.backup_interactions"),
+        patch("scripts.run_all_syncs.send_sync_summary_telegram"),
+        patch("scripts.run_all_syncs.reap_orphan_sync_runs", return_value=0),
+        patch("scripts.run_all_syncs.detect_silent_source_entity_drift", return_value=[]),
+        patch("scripts.run_all_syncs.subprocess.run", return_value=fake_restart),
         patch("urllib.request.urlopen"),
         patch("scripts.run_all_syncs._is_llm_running", return_value=llm_running),
         patch("scripts.run_all_syncs._get_available_gpu_memory_mb", return_value=gpu_memory_mb),
@@ -403,6 +413,64 @@ class TestTimeoutBytesDecoding:
 
         assert success is False
         assert "timed out" in stats["error"].lower()
+
+
+class TestParseSyncOutput:
+    """Tests for _parse_sync_output, the bridge between sync scripts and sync_runs."""
+
+    def test_sync_stats_line_is_authoritative(self):
+        """SYNC_STATS:{json} overrides anything the regex fallback would infer."""
+        from scripts.run_all_syncs import _parse_sync_output
+
+        # Regex would parse "inserted: 5" as interactions_created=5, but the
+        # canonical line says 100 — the canonical line must win.
+        output = (
+            "Some preamble\n"
+            "Inserted: 5\n"
+            'SYNC_STATS:{"interactions_created": 100, "source_entities_created": 42}\n'
+            "Trailing log\n"
+        )
+        stats = _parse_sync_output(output)
+        assert stats["interactions_created"] == 100
+        assert stats["source_entities_created"] == 42
+        # Generic "created" is derived from categorized values.
+        assert stats["created"] == 142
+
+    def test_falls_back_to_regex_when_no_canonical_line(self):
+        """Regex parsing still works for scripts that haven't been migrated."""
+        from scripts.run_all_syncs import _parse_sync_output
+
+        output = (
+            "=== iMessage Sync Summary ===\n"
+            "Inserted: 47\n"
+            "Source entities created: 12\n"
+        )
+        stats = _parse_sync_output(output)
+        assert stats["interactions_created"] == 47
+        assert stats["source_entities_created"] == 12
+
+    def test_malformed_sync_stats_falls_back_to_regex(self):
+        """A bad JSON payload shouldn't blank out everything — fall back to regex."""
+        from scripts.run_all_syncs import _parse_sync_output
+
+        output = (
+            "SYNC_STATS:{not valid json\n"
+            "Inserted: 7\n"
+        )
+        stats = _parse_sync_output(output)
+        assert stats["interactions_created"] == 7
+
+    def test_later_sync_stats_line_wins(self):
+        """Wrappers (e.g. apple_data_import aggregating sub-imports) can override."""
+        from scripts.run_all_syncs import _parse_sync_output
+
+        output = (
+            'SYNC_STATS:{"interactions_created": 5}\n'
+            'SYNC_STATS:{"interactions_created": 50, "source_entities_created": 3}\n'
+        )
+        stats = _parse_sync_output(output)
+        assert stats["interactions_created"] == 50
+        assert stats["source_entities_created"] == 3
 
 
 class TestGetAvailableSystemRAM:

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -89,7 +89,7 @@ class TestGenerateSummary:
 
     @patch("api.services.summarizer.httpx.Client")
     def test_returns_none_on_timeout(self, mock_client_class):
-        """Should return (None, False) on Ollama timeout for retry tracking."""
+        """Should return (None, False) on LLM timeout for retry tracking."""
         import httpx
         from api.services.summarizer import generate_summary
 
@@ -191,7 +191,7 @@ class TestIsSummarizerLLMAvailable:
 
     @patch("api.services.summarizer.httpx.Client")
     def test_returns_true_when_available(self, mock_client_class):
-        """Should return True when Ollama responds."""
+        """Should return True when the local LLM server responds."""
         from api.services.summarizer import is_summarizer_llm_available
 
         mock_client = MagicMock()
@@ -205,7 +205,7 @@ class TestIsSummarizerLLMAvailable:
 
     @patch("api.services.summarizer.httpx.Client")
     def test_returns_false_on_error(self, mock_client_class):
-        """Should return False when Ollama fails."""
+        """Should return False when the local LLM server fails."""
         from api.services.summarizer import is_summarizer_llm_available
 
         mock_client = MagicMock()
@@ -241,16 +241,16 @@ class TestCreateSummaryChunk:
 
 
 class TestSummarizerIntegration:
-    """Integration tests with actual Ollama (requires running server)."""
+    """Integration tests with the local LLM server (requires llama-server running)."""
 
     @pytest.mark.slow
     @pytest.mark.integration
     def test_real_summary_generation(self):
-        """Test actual summary generation with Ollama."""
+        """Test actual summary generation against the local LLM server."""
         from api.services.summarizer import generate_summary, is_summarizer_llm_available
 
         if not is_summarizer_llm_available():
-            pytest.skip("Ollama not available")
+            pytest.skip("Local LLM server not available")
 
         content = """# Meeting Notes - Q4 Budget Review
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -30,8 +30,8 @@ class TestGenerateSummary:
         assert success is True  # Not a failure, just skipped
 
     @patch("api.services.summarizer.httpx.Client")
-    def test_calls_ollama_with_prompt(self, mock_client_class):
-        """Should call Ollama with the summary prompt."""
+    def test_calls_llm_with_prompt(self, mock_client_class):
+        """Should POST a chat completion to the local LLM with the prompt."""
         from api.services.summarizer import generate_summary
 
         # Setup mock
@@ -40,7 +40,11 @@ class TestGenerateSummary:
         mock_client_class.return_value.__exit__ = MagicMock(return_value=False)
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "response": "This is a meeting note about Q4 budget planning with Kevin and Sarah."
+            "choices": [{
+                "message": {
+                    "content": "This is a meeting note about Q4 budget planning with Kevin and Sarah."
+                }
+            }]
         }
         mock_client.post.return_value = mock_response
 
@@ -52,6 +56,10 @@ class TestGenerateSummary:
         assert summary is not None
         assert "meeting note" in summary.lower() or "budget" in summary.lower()
         mock_client.post.assert_called_once()
+        # Hits the OpenAI-compatible chat endpoint, not legacy Ollama /api/generate.
+        call_args = mock_client.post.call_args
+        url = call_args[0][0]
+        assert url.endswith("/v1/chat/completions")
 
     @patch("api.services.summarizer.httpx.Client")
     def test_truncates_long_content(self, mock_client_class):
@@ -63,17 +71,20 @@ class TestGenerateSummary:
         mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_class.return_value.__exit__ = MagicMock(return_value=False)
         mock_response = MagicMock()
-        mock_response.json.return_value = {"response": "A valid summary text here."}
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "A valid summary text here."}}]
+        }
         mock_client.post.return_value = mock_response
 
         # Call with very long content
         long_content = "A" * 5000
-        result = generate_summary(long_content, "test.md", max_content_chars=2000)
+        generate_summary(long_content, "test.md", max_content_chars=2000)
 
         # Verify the call was made with truncated content
         call_args = mock_client.post.call_args
         payload = call_args[1]["json"]
-        prompt = payload["prompt"]
+        # OpenAI chat format: prompt lives inside messages[0].content
+        prompt = payload["messages"][0]["content"]
         assert "[... content truncated ...]" in prompt
 
     @patch("api.services.summarizer.httpx.Client")
@@ -175,13 +186,13 @@ This is the actual content.
         assert len(result) < 200
 
 
-class TestIsOllamaAvailable:
-    """Test the is_ollama_available function."""
+class TestIsSummarizerLLMAvailable:
+    """Test the is_summarizer_llm_available function."""
 
     @patch("api.services.summarizer.httpx.Client")
     def test_returns_true_when_available(self, mock_client_class):
         """Should return True when Ollama responds."""
-        from api.services.summarizer import is_ollama_available
+        from api.services.summarizer import is_summarizer_llm_available
 
         mock_client = MagicMock()
         mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
@@ -190,19 +201,19 @@ class TestIsOllamaAvailable:
         mock_response.status_code = 200
         mock_client.get.return_value = mock_response
 
-        assert is_ollama_available() is True
+        assert is_summarizer_llm_available() is True
 
     @patch("api.services.summarizer.httpx.Client")
     def test_returns_false_on_error(self, mock_client_class):
         """Should return False when Ollama fails."""
-        from api.services.summarizer import is_ollama_available
+        from api.services.summarizer import is_summarizer_llm_available
 
         mock_client = MagicMock()
         mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_class.return_value.__exit__ = MagicMock(return_value=False)
         mock_client.get.side_effect = Exception("connection failed")
 
-        assert is_ollama_available() is False
+        assert is_summarizer_llm_available() is False
 
 
 class TestCreateSummaryChunk:
@@ -236,9 +247,9 @@ class TestSummarizerIntegration:
     @pytest.mark.integration
     def test_real_summary_generation(self):
         """Test actual summary generation with Ollama."""
-        from api.services.summarizer import generate_summary, is_ollama_available
+        from api.services.summarizer import generate_summary, is_summarizer_llm_available
 
-        if not is_ollama_available():
+        if not is_summarizer_llm_available():
             pytest.skip("Ollama not available")
 
         content = """# Meeting Notes - Q4 Budget Review

--- a/tests/test_sync_health.py
+++ b/tests/test_sync_health.py
@@ -27,6 +27,9 @@ from api.services.sync_health import (
     get_recent_errors,
     get_sync_summary,
     check_sync_health,
+    reap_orphan_sync_runs,
+    emit_sync_stats,
+    detect_silent_source_entity_drift,
 )
 
 
@@ -362,6 +365,152 @@ class TestSyncHealthIntegration:
             health = get_sync_health("calendar")
             assert health.last_status == SyncStatus.SUCCESS
             assert health.last_error is None
+
+
+class TestOrphanReaper:
+    """Tests for reap_orphan_sync_runs — cleans up rows from killed processes."""
+
+    def test_reaps_old_running_rows(self, temp_db):
+        """Rows in status=running older than max_age_hours are marked failed."""
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            conn = get_sync_health_db()
+            # 10h ago — should be reaped at default 8h cutoff
+            old = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
+            conn.execute(
+                "INSERT INTO sync_runs (source, status, started_at) VALUES (?, ?, ?)",
+                ("gmail_personal", "running", old),
+            )
+            conn.commit()
+            conn.close()
+
+            reaped = reap_orphan_sync_runs()
+            assert reaped == 1
+
+            health = get_sync_health("gmail_personal")
+            assert health.last_status == SyncStatus.FAILED
+
+    def test_leaves_fresh_running_rows_alone(self, temp_db):
+        """A sync that started 1h ago is still legitimately running."""
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            conn = get_sync_health_db()
+            recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+            conn.execute(
+                "INSERT INTO sync_runs (source, status, started_at) VALUES (?, ?, ?)",
+                ("gmail_personal", "running", recent),
+            )
+            conn.commit()
+            conn.close()
+
+            reaped = reap_orphan_sync_runs()
+            assert reaped == 0
+
+    def test_returns_zero_when_no_orphans(self, temp_db):
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            assert reap_orphan_sync_runs() == 0
+
+
+class TestSourceEntityDriftDetector:
+    """Tests for the silent-regression detector from issue #199 §2."""
+
+    def _seed(self, tmp_path, interactions: list, source_entities: list):
+        """Seed minimal interactions.db / crm.db with given rows."""
+        import sqlite3
+        i_path = tmp_path / "interactions.db"
+        c_path = tmp_path / "crm.db"
+        i_conn = sqlite3.connect(str(i_path))
+        i_conn.execute(
+            "CREATE TABLE interactions (id TEXT, source_type TEXT, created_at TEXT)"
+        )
+        i_conn.executemany(
+            "INSERT INTO interactions (id, source_type, created_at) VALUES (?, ?, ?)",
+            interactions,
+        )
+        i_conn.commit()
+        i_conn.close()
+
+        c_conn = sqlite3.connect(str(c_path))
+        c_conn.execute(
+            "CREATE TABLE source_entities (id TEXT, source_type TEXT, created_at TEXT)"
+        )
+        c_conn.executemany(
+            "INSERT INTO source_entities (id, source_type, created_at) VALUES (?, ?, ?)",
+            source_entities,
+        )
+        c_conn.commit()
+        c_conn.close()
+        return str(i_path), str(c_path)
+
+    def test_flags_drift_when_interactions_flow_but_entities_stale(self, tmp_path):
+        now = datetime.now(timezone.utc)
+        recent_iso = now.isoformat()
+        stale_iso = (now - timedelta(days=60)).isoformat()
+
+        i_path, c_path = self._seed(
+            tmp_path,
+            interactions=[("i1", "imessage", recent_iso)],
+            source_entities=[("se1", "imessage", stale_iso)],
+        )
+
+        warnings = detect_silent_source_entity_drift(
+            interactions_db=i_path, crm_db=c_path
+        )
+        assert len(warnings) == 1
+        assert warnings[0]["source"] == "imessage"
+        assert warnings[0]["gap_days"] > 30
+
+    def test_quiet_source_does_not_trip(self, tmp_path):
+        """A source with no recent interactions shouldn't be flagged at all."""
+        now = datetime.now(timezone.utc)
+        old_interaction = (now - timedelta(days=90)).isoformat()
+        stale_iso = (now - timedelta(days=60)).isoformat()
+
+        i_path, c_path = self._seed(
+            tmp_path,
+            interactions=[("i1", "slack", old_interaction)],
+            source_entities=[("se1", "slack", stale_iso)],
+        )
+        # Default lookback = 7 days; slack interaction is 90 days old, so it
+        # isn't considered "active" and shouldn't warn.
+        warnings = detect_silent_source_entity_drift(
+            interactions_db=i_path, crm_db=c_path
+        )
+        assert warnings == []
+
+    def test_healthy_source_does_not_trip(self, tmp_path):
+        now = datetime.now(timezone.utc)
+        recent_iso = now.isoformat()
+
+        i_path, c_path = self._seed(
+            tmp_path,
+            interactions=[("i1", "gmail", recent_iso)],
+            source_entities=[("se1", "gmail", recent_iso)],
+        )
+        assert detect_silent_source_entity_drift(
+            interactions_db=i_path, crm_db=c_path
+        ) == []
+
+    def test_missing_dbs_returns_empty(self, tmp_path):
+        """Fresh install or test environment without dbs: no false alerts."""
+        assert detect_silent_source_entity_drift(
+            interactions_db=str(tmp_path / "nope.db"),
+            crm_db=str(tmp_path / "also-nope.db"),
+        ) == []
+
+
+class TestEmitSyncStats:
+    """Tests for emit_sync_stats — the canonical stats-reporting helper."""
+
+    def test_prints_machine_readable_line(self, capsys):
+        emit_sync_stats({"interactions_created": 5, "source_entities_created": 2})
+        captured = capsys.readouterr()
+        # Single line, parseable by the orchestrator's regex.
+        import re
+        import json
+        match = re.search(r"SYNC_STATS:(\{.*\})", captured.out)
+        assert match, f"Expected SYNC_STATS line in: {captured.out!r}"
+        payload = json.loads(match.group(1))
+        assert payload["interactions_created"] == 5
+        assert payload["source_entities_created"] == 2
 
 
 class TestSyncHealthDailyCheck:


### PR DESCRIPTION
## Summary

Closes #199 — addresses all five sub-problems from the audit in one PR.

- **§4 Stats reporting**: New `emit_sync_stats({…})` helper writes a canonical `SYNC_STATS:{json}` line that `run_all_syncs._parse_sync_output` treats as ground truth (regex fallback preserved). Wired into the eight scripts that produce source_entities / interactions so dashboard counts stop reading 0 for everything except iMessage.
- **§1 Vault reindex**: `summarizer.py` routes to llama-server's OpenAI-compatible endpoint (was 404ing the dead Ollama :11434 for weeks). `BM25Index.delete_by_path()` clears all chunks + summary for a file in one query — fixes both the every-reindex chunk leak and the macOS→Linux path migration leftovers. `embeddings.py` retries with `HF_HUB_OFFLINE=1` on network errors so DNS storms don't take down a reindex with a cached snapshot. New `sync_vault_reindex.py --clear-bm25` exposes a one-shot reseed.
- **§3 Monarch**: `get_session_status()` + `GET /api/monarch/session_status` surface "expiring_soon" (≥25d) and "expired" (≥30d) from the session pickle's mtime, so the dashboard sees the impending re-auth before the monthly sync 401s.
- **§5 Server stacking**: `kill_server` pkill pattern now matches the actual `python -c "...uvicorn.run('api.main:app', ...)"` cmdline instead of the never-launched `uvicorn api.main:app` form. New `lifeos-server-watchdog.service` + `.timer` wire `server-watchdog.sh` into systemd on Linux (the existing `lifeos-watchdog` only watched ChromaDB).
- **§2 source_entities drift**: New `detect_silent_source_entity_drift()` warns when a source still records interactions but stopped persisting source_entities for >30 days — the silent-regression pattern from the issue. Lenient threshold to avoid false positives on genuinely quiet sources. Also added `reap_orphan_sync_runs()` at sync start so killed/crashed runs don't pin the dashboard's "last success" timestamp forever.

## Test evidence

`bash scripts/test.sh unit` — 2340 passed, 10 failed, 35 skipped.

The 10 pre-existing failures all need production data files or specific .env defaults that the worktree lacks; none caused by this PR. New test coverage:
- `tests/test_bm25_index.py` — 5 tests for `delete_by_path` including the macOS→Linux migration scenario.
- `tests/test_monarch_session_status.py` — 6 tests for session-age status.
- `tests/test_sync_health.py` — `TestOrphanReaper` (3), `TestSourceEntityDriftDetector` (4), `TestEmitSyncStats` (1).
- `tests/test_run_all_syncs.py` — `TestParseSyncOutput` (4) verifying SYNC_STATS precedence + regex fallback.

Pre-push hook ran 1562 unit tests in 31s on the final push — all passed.

## Review focus

- **`api/services/sync_health.py`** — three new public helpers (`emit_sync_stats`, `reap_orphan_sync_runs`, `detect_silent_source_entity_drift`). Drift detector opens both `interactions.db` and `crm.db` from disk on each post-sync call; check the SQLite handling looks right.
- **`api/services/bm25_index.py:107`** — new `delete_by_path` uses GLOB with three patterns (legacy bare path, `::summary`, `{path}_*`). Worth a careful read on the prefix-collision test in `tests/test_bm25_index.py`.
- **`api/services/embeddings.py`** — offline-retry fallback mutates `os.environ["HF_HUB_OFFLINE"]` in a try/finally. Verify the env restoration logic preserves whatever was there.
- **`scripts/run_all_syncs.py`** — `_parse_sync_output` short-circuits to the canonical line; the regex fallback path still runs if the JSON is malformed.
- **`scripts/server.sh:90`** — the pkill pattern change is the main behavioral fix; double-check it can't sweep up unrelated subprocesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)