### PR TITLE
feat(agents): vault write tool, fail-on-empty-result, capabilities preamble

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -32,7 +32,7 @@ from fastapi.exceptions import RequestValidationError
 from pathlib import Path
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, tasks, monarch, jobs, perf, agents
+from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, tasks, monarch, jobs, perf, agents, vault
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -197,6 +197,7 @@ app.include_router(monarch.router)
 app.include_router(jobs.router)
 app.include_router(perf.router)
 app.include_router(agents.router)
+app.include_router(vault.router)
 
 # Serve static files
 web_dir = Path(__file__).parent.parent / "web"

--- a/api/routes/vault.py
+++ b/api/routes/vault.py
@@ -1,0 +1,103 @@
+"""
+Vault write API — lets MCP-only clients (cloud agents) put files into the vault.
+
+Read access is already covered by `lifeos_search`, `lifeos_ask`, etc. There was
+no write path, which made tasks like "produce X.md in the vault" unsolvable for
+the cloud agent (its tool surface is read-only RAG queries). This endpoint
+closes that gap; the MCP server picks it up automatically as `lifeos_vault_write`
+via the OpenAPI→curated-endpoint bridge.
+
+Path validation: requested paths must be relative, must not contain `..`, and
+must resolve under `settings.vault_path` after `Path.resolve()`. Parent dirs
+are created on demand so a single call can write into a new subtree.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/vault", tags=["vault"])
+
+
+class VaultWriteRequest(BaseModel):
+    path: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Vault-relative path (e.g., `Inbox/news monitoring prompt.md`). "
+            "Must not start with `/` or contain `..`. Parent directories are "
+            "created on demand."
+        ),
+    )
+    content: str = Field(
+        ...,
+        description="UTF-8 text to write. Markdown is conventional; any text is allowed.",
+    )
+    mode: Literal["create", "overwrite", "append"] = Field(
+        default="create",
+        description=(
+            "`create` (default) fails if the file exists. `overwrite` replaces. "
+            "`append` adds to the end (creates the file if missing)."
+        ),
+    )
+
+
+class VaultWriteResponse(BaseModel):
+    path: str
+    abs_path: str
+    bytes_written: int
+    mode: str
+    created: bool
+
+
+@router.post("/write", response_model=VaultWriteResponse)
+async def vault_write(request: VaultWriteRequest) -> VaultWriteResponse:
+    rel = request.path.strip()
+    if rel.startswith("/") or rel.startswith("~"):
+        raise HTTPException(400, "path must be vault-relative (no leading / or ~)")
+    if ".." in Path(rel).parts:
+        raise HTTPException(400, "path must not contain `..`")
+
+    vault_root = settings.vault_path.resolve()
+    target = (vault_root / rel).resolve()
+    try:
+        target.relative_to(vault_root)
+    except ValueError:
+        raise HTTPException(400, "path resolves outside the vault root")
+
+    existed = target.exists()
+    if request.mode == "create" and existed:
+        raise HTTPException(
+            409,
+            f"file already exists at {rel}; use mode=overwrite or mode=append",
+        )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if request.mode == "append":
+            with target.open("a", encoding="utf-8") as f:
+                bytes_written = f.write(request.content)
+        else:
+            target.write_text(request.content, encoding="utf-8")
+            bytes_written = len(request.content.encode("utf-8"))
+    except OSError as e:
+        logger.exception("vault write failed for %s", rel)
+        raise HTTPException(500, f"write failed: {e}")
+
+    logger.info("vault write: %s (%d bytes, mode=%s)", rel, bytes_written, request.mode)
+    return VaultWriteResponse(
+        path=rel,
+        abs_path=str(target),
+        bytes_written=bytes_written,
+        mode=request.mode,
+        created=not existed,
+    )

--- a/api/services/agent_worker/capabilities_preamble.py
+++ b/api/services/agent_worker/capabilities_preamble.py
@@ -1,0 +1,79 @@
+"""
+The capabilities preamble injected at the top of every task message.
+
+Why: the agent's preset system prompt is fixed in the Anthropic console and
+covers persona/policy. It does NOT enumerate what data and tools LifeOS
+makes available. Without that, the agent fumbles — searches with the wrong
+terms, misses better tools, returns empty when its first try fails. This
+preamble closes that gap on every task in ~500 tokens.
+
+The text is intentionally compact. Anything longer is read on demand from
+the vault itself (the agent has `lifeos_search` / `lifeos_ask`).
+"""
+
+CAPABILITIES_PREAMBLE = """\
+=== LIFEOS BRIEFING (read first) ===
+
+WHO: Nathan Ramia. Current job: Movement Labs (a progressive political
+technology org — "ML" in notes). Default work context = ML unless the
+task names another company. Previous jobs (BlueLabs, Deck, Rise,
+Murmuration) are in `zArchive/` — ignore unless explicitly asked.
+
+VAULT: Obsidian vault at `~/Notes 2025/`. Indexed and searchable. Key
+top-level folders:
+  - `Work/ML/`               Movement Labs (Daily Notes, Meetings, People,
+                             Strategy and planning, Finance)
+  - `Work/Job Search/`       career exploration
+  - `Personal/`              Relationship, Self-Improvement, Finance,
+                             User Manual, Coding, Lifelogs, Records
+  - `Granola/`, `Omi/`       meeting + ambient-recorder transcripts
+  - `LifeOS/Tasks/Inbox.md`  where `#agent`-tagged tasks (yours) live
+  - `LLM context - Movement Labs 2026.md`  curated ML context doc
+
+DATA YOU CAN REACH (via the `lifeos` MCP server):
+  Read / search:
+    lifeos_ask              RAG synthesis with citations (best for open
+                            questions: "what do we know about X?")
+    lifeos_search           raw chunks with scores (when you want documents
+                            yourself, not a summary)
+    lifeos_drive_search     Google Drive — many ML strategy docs live here,
+                            NOT in the vault. Always try this for org-level
+                            documents (contracts, plans, decks).
+    lifeos_gmail_search     work + personal email
+    lifeos_calendar_search / lifeos_calendar_upcoming
+    lifeos_people_search, lifeos_person_profile, lifeos_person_timeline
+    lifeos_imessage_search, lifeos_slack_search
+    lifeos_photos_*, lifeos_monarch_* (finance)
+  Write / side-effect:
+    lifeos_vault_write      CREATE FILES IN THE VAULT. Use this for any
+                            task that says "output to a doc", "save as a
+                            note", "create a .md". `path` is vault-relative.
+    lifeos_gmail_draft, lifeos_calendar_create, lifeos_task_create,
+    lifeos_reminder_create, lifeos_memories_create,
+    lifeos_telegram_send
+
+SEARCH TIPS (recall can be uneven):
+  - If the first search returns scores near 0.02 and irrelevant titles,
+    re-query with broader OR narrower terms — both, not one. Try the
+    project's *people* and *acronyms* before its mission statement.
+  - For org-wide context on Movement Labs specifically: search for
+    "Listening Tour", "growth plan", "Contest Every Race", individual
+    leaders by name, plus `lifeos_drive_search` (the strategy docs are
+    in Drive, not the vault).
+  - Prefer recent content. Vault goes back years; current thinking is
+    in the last 60-90 days.
+  - If multiple angles all come up empty, that probably means the data
+    really isn't reachable from your current tool surface — say so and
+    suggest what *would* unblock you, rather than fabricating.
+
+COMPLETION CONTRACT (important):
+  - When the task asks for a deliverable file ("output to X.md"), you
+    must call `lifeos_vault_write` to produce it. Returning the content
+    as prose does not count — the operator wants the file.
+  - Always end with a final text reply: what you produced, where it
+    landed, and any caveats. An empty final text is treated as a failed
+    task (since 2026-05-28: the worker tags it `#agent-failed` instead
+    of `#agent-completed`). If you genuinely cannot do the task, say so
+    explicitly with what you tried and what blocked you.
+
+=== TASK ==="""

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -300,10 +300,15 @@ def _output_dir() -> str:
 
 
 def _user_message_for(task: dict) -> str:
-    """Build the opening user turn from the task description."""
+    """Build the opening user turn from the task description.
+
+    Prepended with the LifeOS capabilities preamble so the local-routed
+    agent (Gemma) has the same situational awareness as the cloud route.
+    """
+    from api.services.agent_worker.capabilities_preamble import CAPABILITIES_PREAMBLE
     title = (task.get("description") or "").strip()
     context = task.get("context")
-    parts = [f"Task: {title}"]
+    parts = [CAPABILITIES_PREAMBLE, f"Task: {title}"]
     if context:
         parts.append(f"Context: {context}")
     parts.append("Please complete this task using the tools available.")

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -92,8 +92,13 @@ def _truncate_oversized_tool_result(event: dict) -> dict:
 def _user_message_for(task: dict, session_id: str, expected_output: str, budget: dict) -> str:
     """The initial user turn sent to a managed session.
 
-    Purely task-specific. Persona, ambiguity policy, and output-format
-    requirements all live in the agent preset (Anthropic console).
+    Prepended with the LifeOS capabilities preamble (see
+    `capabilities_preamble.py`) so the agent knows what data and tools
+    are available before it reads the task. The preamble is the same on
+    every call and benefits from prompt caching after the first request.
+
+    Persona, ambiguity policy, and output-format requirements live in
+    the agent preset (Anthropic console).
 
     Budget is framed as a *soft* target: Anthropic doesn't enforce it
     server-side, the worker kills the session externally on breach.
@@ -105,11 +110,12 @@ def _user_message_for(task: dict, session_id: str, expected_output: str, budget:
     can't be inferred server-side because the request crosses a
     process boundary.
     """
+    from api.services.agent_worker.capabilities_preamble import CAPABILITIES_PREAMBLE
     title = (task.get("description") or "").strip()
     context = task.get("context")
     max_dollars = budget.get("max_dollars")
     dollars_str = f"~${max_dollars}" if max_dollars is not None else "unset"
-    parts = [f"Task: {title}"]
+    parts = [CAPABILITIES_PREAMBLE, f"Task: {title}"]
     if context:
         parts.append(f"Context: {context}")
     parts.append(

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1129,6 +1129,32 @@ class Worker:
         is_spawned = bool(session.parent_session_id)
 
         if outcome.status == STATUS_COMPLETED:
+            # Guard against silent "I gave up" completions. When the agent
+            # produces no final text AND no side-effect tool was successfully
+            # called (no draft, no vault write, no calendar event, etc.), the
+            # session is effectively a no-op. Marking it `done` hides the
+            # failure — the operator sees `#agent-completed` and assumes work
+            # happened. Route these through the failure path instead so the
+            # tag becomes `#agent-failed` and the operator can decide whether
+            # to retry. Spawned children keep the old behavior; their parent
+            # consumes their outcome and decides what to surface.
+            if (
+                not is_spawned
+                and not (outcome.final_text or "").strip()
+                and not self._had_side_effect_tool_use(sid)
+            ):
+                self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
+                self._set_task_status(session.task_id, "cancelled")
+                recovered = self._recover_result_from_transcript(sid) or (
+                    "no tool calls or final text recovered"
+                )
+                self._notify(
+                    f"⚠️ {_worker_label(session.routing)}: task '{title}' returned "
+                    f"empty result with no side-effect tool use — marking failed. "
+                    f"What the agent did:\n\n{recovered}\n\n"
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                )
+                return
             if not is_spawned:
                 self._complete_task(session.task_id)  # mark `done` in the vault
                 # Swap the tag so the task surfaces as #agent-completed for symmetry
@@ -1385,6 +1411,58 @@ class Worker:
             logger.warning("recover_result_from_transcript failed for %s: %s",
                           session_id, exc)
         return ""
+
+    # Tool names whose successful invocation is a real-world side effect
+    # (file written, email drafted, calendar event created, memory saved,
+    # task created, etc.). If the agent calls one of these and then idles
+    # without a final text reply, the work happened — don't treat as failed.
+    # Anything ending in these suffixes counts; updates the list as we add
+    # write tools to the MCP server.
+    _SIDE_EFFECT_TOOL_SUFFIXES = (
+        "_create", "_update", "_delete", "_complete", "_write",
+        "_send", "_draft", "_trigger", "_confirm", "_spawn", "_kill",
+    )
+
+    def _had_side_effect_tool_use(self, session_id: str) -> bool:
+        """Return True if the agent successfully invoked any write-side-effect
+        tool during the session. Used by the empty-final-text guard in
+        `_handle_outcome` to distinguish "agent did real work but didn't
+        summarize" (legitimate completion) from "agent gave up after a
+        read-only research spree" (silent failure)."""
+        import json as _json
+        try:
+            path = self.transcript_store.dir / f"{session_id}.jsonl"
+            if not path.exists():
+                return False
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        d = _json.loads(line)
+                    except _json.JSONDecodeError:
+                        continue
+                    kind = d.get("kind", "")
+                    payload = d.get("payload", {}) or {}
+
+                    if kind == "tool_call" and not payload.get("is_error"):
+                        name = str(payload.get("tool") or "")
+                    elif kind in (
+                        "managed_event_agent.mcp_tool_use",
+                        "managed_event_agent.tool_use",
+                    ):
+                        # Pair-with-result would be more accurate, but the
+                        # tool_use event fires only when the call is dispatched
+                        # — an outright permission denial wouldn't reach here.
+                        # Good-enough for the failure guard.
+                        name = str(payload.get("name") or "")
+                    else:
+                        continue
+
+                    if any(name.endswith(s) for s in self._SIDE_EFFECT_TOOL_SUFFIXES):
+                        return True
+        except Exception as exc:
+            logger.warning("had_side_effect_tool_use failed for %s: %s",
+                          session_id, exc)
+        return False
 
     def _build_resume_message(
         self,

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -61,6 +61,11 @@ CURATED_ENDPOINTS = {
         "description": "Search files in Google Drive by name or content. Returns file metadata with links. Use for 'find the document about X' or 'what files do I have about Y?'.",
         "method": "GET"
     },
+    "/api/vault/write": {
+        "name": "lifeos_vault_write",
+        "description": "Write a text file into the Obsidian vault. Use for any task needing a `.md` deliverable. `path` is vault-relative; parents auto-created. `mode`: `create` (default), `overwrite`, `append`.",
+        "method": "POST"
+    },
     "/api/conversations": {
         "name": "lifeos_conversations_list",
         "description": "List recent LifeOS conversations. Returns conversation IDs and titles for continuing previous chats.",

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -928,6 +928,75 @@ def test_empty_final_text_surfaces_last_tool_result_from_transcript(tmp_path: Pa
 
 
 @pytest.mark.unit
+def test_empty_final_text_without_side_effect_marks_failed(tmp_path: Path):
+    """Live bug repro: an agent runs a bunch of read-only searches, finds
+    nothing useful, and idles without a final reply. Previously this got
+    marked #agent-completed and the operator never noticed the silent
+    failure. The empty-final-text guard now routes it through the failure
+    path so the operator gets a Telegram alert and the task carries
+    #agent-failed."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "research thing", "status": "todo",
+         "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+
+    # Empty result + no side-effect tool → failure path
+    assert api.tasks["t1"]["status"] == "cancelled", api.tasks["t1"]
+    assert FAILED_TAG in api.tasks["t1"]["tags"]
+    assert COMPLETED_TAG not in api.tasks["t1"]["tags"]
+
+
+@pytest.mark.unit
+def test_empty_final_text_with_side_effect_tool_still_marks_completed(tmp_path: Path):
+    """Counterpoint to the failure-on-empty test: when the agent DID do
+    real work (e.g., called lifeos_gmail_draft to create a draft) and just
+    didn't write a final summary, the task is legitimately complete. The
+    side-effect-tool check distinguishes "agent gave up" from "agent did
+    the work but skipped the summary".
+
+    Drives `_handle_outcome` directly (not via tick) because tick() would
+    skip a pre-claimed task; the goal here is to exercise the empty-text
+    branch with a transcript that already contains a side-effect tool use.
+    """
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "draft an email", "status": "todo",
+         "tags": ["agent", "running"]},  # already #agent-running for the swap
+    ])
+    # Manually flip the running tag — handle_outcome's success path swaps
+    # RUNNING_TAG → COMPLETED_TAG, so the running tag must be present.
+    api.tasks["t1"]["tags"] = ["agent-running"]
+
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=_StubExecutor(outcome=ExecutorOutcome(
+                         status=STATUS_COMPLETED, final_text="",
+                     )))
+    sess = w.session_store.create(task_id="t1", routing="local",
+                                   expected_output="text")
+    w.transcript_store.append(sess.session_id, "tool_call", {
+        "tool": "lifeos_gmail_draft", "is_error": False,
+    })
+
+    w._handle_outcome(
+        sess,
+        {"id": "t1", "description": "draft an email"},
+        ExecutorOutcome(status=STATUS_COMPLETED, final_text=""),
+    )
+
+    # Side-effect tool was present → completion path took over
+    assert api.tasks["t1"]["status"] == "done", api.tasks["t1"]
+    assert COMPLETED_TAG in api.tasks["t1"]["tags"]
+    assert FAILED_TAG not in api.tasks["t1"]["tags"]
+
+
+@pytest.mark.unit
 def test_claim_sets_vault_status_to_in_progress(tmp_path: Path):
     """When the worker claims a task (swap #agent → #agent-running), the
     vault checkbox status must also flip to "in_progress" so the operator

--- a/tests/test_vault_write_route.py
+++ b/tests/test_vault_write_route.py
@@ -1,0 +1,121 @@
+"""Tests for the /api/vault/write endpoint (lifeos_vault_write MCP tool).
+
+Closes the silent-failure mode where a #cloud agent task asked for a `.md`
+deliverable but the MCP toolset had no write tool — the agent generated the
+content, never wrote it, and the worker marked the task complete based on
+remote_status:idle. With this endpoint the agent can produce the file
+directly; the worker enforces non-empty results separately
+(see test_empty_final_text_without_side_effect_marks_failed).
+"""
+from __future__ import annotations
+
+import importlib
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app_and_vault(monkeypatch):
+    """Spin up a minimal FastAPI app with vault.router mounted on a tmp vault.
+
+    settings is module-scoped so we reload it after pointing LIFEOS_VAULT_PATH
+    at the tmp dir; otherwise the route picks up the user's real vault.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="lifeos-vault-test-")
+    monkeypatch.setenv("LIFEOS_VAULT_PATH", tmpdir)
+    import config.settings
+    importlib.reload(config.settings)
+    from api.routes import vault
+    importlib.reload(vault)
+    app = FastAPI()
+    app.include_router(vault.router)
+    yield TestClient(app), Path(tmpdir)
+    import shutil
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_create_writes_file_with_parents(app_and_vault):
+    c, vault = app_and_vault
+    r = c.post("/api/vault/write", json={
+        "path": "Inbox/news monitoring prompt.md",
+        "content": "# Prompt\n\nbody",
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["created"] is True
+    assert body["mode"] == "create"
+    assert (vault / "Inbox" / "news monitoring prompt.md").read_text() == "# Prompt\n\nbody"
+
+
+def test_create_fails_on_existing_file(app_and_vault):
+    c, vault = app_and_vault
+    (vault / "x.md").write_text("old")
+    r = c.post("/api/vault/write", json={"path": "x.md", "content": "new"})
+    assert r.status_code == 409
+    assert (vault / "x.md").read_text() == "old"
+
+
+def test_overwrite_replaces_content(app_and_vault):
+    c, vault = app_and_vault
+    (vault / "x.md").write_text("old")
+    r = c.post("/api/vault/write", json={
+        "path": "x.md", "content": "new", "mode": "overwrite",
+    })
+    assert r.status_code == 200
+    assert (vault / "x.md").read_text() == "new"
+
+
+def test_append_adds_to_end(app_and_vault):
+    c, vault = app_and_vault
+    (vault / "x.md").write_text("one\n")
+    r = c.post("/api/vault/write", json={
+        "path": "x.md", "content": "two\n", "mode": "append",
+    })
+    assert r.status_code == 200
+    assert (vault / "x.md").read_text() == "one\ntwo\n"
+
+
+def test_append_creates_file_when_missing(app_and_vault):
+    c, vault = app_and_vault
+    r = c.post("/api/vault/write", json={
+        "path": "new.md", "content": "first line", "mode": "append",
+    })
+    assert r.status_code == 200
+    assert (vault / "new.md").read_text() == "first line"
+
+
+@pytest.mark.parametrize("bad_path,expected_fragment", [
+    ("../escape.md", "must not contain `..`"),
+    ("/etc/passwd", "must be vault-relative"),
+    ("~/escape.md", "must be vault-relative"),
+    ("foo/../bar.md", "must not contain `..`"),
+])
+def test_rejects_unsafe_paths(app_and_vault, bad_path, expected_fragment):
+    c, _ = app_and_vault
+    r = c.post("/api/vault/write", json={"path": bad_path, "content": "x"})
+    assert r.status_code == 400, r.text
+    assert expected_fragment in r.json()["detail"]
+
+
+def test_writes_unicode_correctly(app_and_vault):
+    c, vault = app_and_vault
+    content = "héllo — résumé 🚀\n"
+    r = c.post("/api/vault/write", json={
+        "path": "u.md", "content": content,
+    })
+    assert r.status_code == 200
+    assert (vault / "u.md").read_text(encoding="utf-8") == content
+    # bytes_written should reflect UTF-8 byte count, not character count
+    assert r.json()["bytes_written"] == len(content.encode("utf-8"))
+
+
+def test_invalid_mode_rejected_by_pydantic(app_and_vault):
+    c, _ = app_and_vault
+    r = c.post("/api/vault/write", json={
+        "path": "x.md", "content": "x", "mode": "delete",
+    })
+    assert r.status_code == 422  # Pydantic Literal validation


### PR DESCRIPTION
## Summary

Three changes addressing a class of silent agent-worker failures discovered when a #cloud task ("output the prompt into a new doc X.md") spent \$1.10 doing research, returned empty \`final_text\`, and got marked \`#agent-completed\` without producing the deliverable.

- **\`lifeos_vault_write\` MCP tool** — new \`POST /api/vault/write\` endpoint, auto-exposed via \`CURATED_ENDPOINTS\`. Closes the gap where the cloud agent's MCP toolset was read-only and couldn't produce file deliverables. Path validation rejects \`../escape\`, absolute paths, and tilde paths; parents auto-created.
- **Worker treats empty \`final_text\` as failure** — when \`STATUS_COMPLETED\` arrives with empty text AND the transcript shows no successful side-effect tool use (write/draft/create/send/etc.), the task now routes through the failure path (\`#agent-failed\`, status cancelled, Telegram alert with what the agent tried). The existing "agent drafted but didn't summarize" path is preserved by checking for side-effect tools first.
- **Capabilities preamble** — every agent task message now begins with a ~500-token briefing covering: who Nathan is (Movement Labs current job), vault structure, available MCP tools by purpose (read vs write), search tips for when recall is weak, and the new completion contract. Same preamble for cloud and local routes.

## Why

Investigation of task \`614217bb\` (Movement Lab breaking-news prompt). Cloud agent burned 7,484 output tokens on read-only searches that returned irrelevant results (\`Brynne Craig prep\`, \`Patrick Egan interview\` with scores ~0.02), couldn't read the actually-relevant docs in Drive (\`gdrive_fetch\` was broken — separate fix), and gave up with empty text. Worker dutifully marked it complete. Operator lost track of it for hours.

Each of the three changes addresses one layer of that failure:
1. **vault_write** fixes the structural impossibility of "produce a .md" via a read-only MCP surface.
2. **fail-on-empty** removes the silent-completion failure mode.
3. **preamble** gives the agent context about WHAT data exists and HOW to find it, so it doesn't fumble searches in the first place.

## Test plan

- [x] Unit tests pass locally (1587 + 11 new + 2 new = 1600 passed; 3 pre-existing failures unrelated to this PR: \`test_local_llm_*\` and \`test_all_vault_files_exist\` — config/data drift)
- [x] New tests cover: vault write happy path (create/overwrite/append), 4 path-validation rejection cases, unicode, mode enum; empty-final-text → failed path; empty-final-text + side-effect tool → still completed
- [x] Live API restarted; \`/api/vault/write\` is in the OpenAPI spec; \`test_openapi_endpoints_match_curated\` passes
- [x] Description trimmed to ≤30 words (\`test_curated_endpoint_descriptions_average_under_30_words\` passes)
- [ ] Follow-up: re-run task \`614217bb\` after merge to verify the cloud agent uses \`lifeos_vault_write\` to produce the deliverable
- [ ] Follow-up: confirm the Managed Agents preset auto-picks up the new MCP tool (or add to allowlist if needed)

## Open questions

- The capabilities preamble currently lives in \`api/services/agent_worker/capabilities_preamble.py\` as a Python string. If you want to edit it without restarting the worker, we could move it to a vault file (\`Notes 2025/CLAUDE.md\`-style) and read it at start-of-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)