### PR TITLE
chore(sudoers): grant reset-failed for lifeos-* units

### DIFF
--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -207,7 +207,29 @@ echo ""
 echo "Installing sudoers rule for passwordless systemctl..."
 SUDOERS_FILE="/etc/sudoers.d/lifeos"
 TMP_SUDOERS=$(mktemp)
-echo "$REAL_USER ALL=(root) NOPASSWD: /usr/bin/systemctl start lifeos-api, /usr/bin/systemctl stop lifeos-api, /usr/bin/systemctl restart lifeos-api, /usr/bin/systemctl start lifeos-api.service, /usr/bin/systemctl stop lifeos-api.service, /usr/bin/systemctl restart lifeos-api.service, /usr/bin/systemctl start lifeos-llm, /usr/bin/systemctl stop lifeos-llm, /usr/bin/systemctl start lifeos-llm.service, /usr/bin/systemctl stop lifeos-llm.service, /usr/bin/systemctl start lifeos-mcp-http, /usr/bin/systemctl stop lifeos-mcp-http, /usr/bin/systemctl restart lifeos-mcp-http, /usr/bin/systemctl start lifeos-mcp-http.service, /usr/bin/systemctl stop lifeos-mcp-http.service, /usr/bin/systemctl restart lifeos-mcp-http.service, /usr/bin/systemctl start lifeos-agent-worker, /usr/bin/systemctl stop lifeos-agent-worker, /usr/bin/systemctl restart lifeos-agent-worker, /usr/bin/systemctl start lifeos-agent-worker.service, /usr/bin/systemctl stop lifeos-agent-worker.service, /usr/bin/systemctl restart lifeos-agent-worker.service" > "$TMP_SUDOERS"
+# Build the NOPASSWD command list programmatically. Each unit gets
+# start/stop/reset-failed (in both name and name.service forms); units
+# that should also restart get restart entries too. `reset-failed` is
+# required to recover units that have tripped systemd's StartLimit (e.g.
+# the agent worker getting cascade-restarted past the rate limit during
+# a dev session); without it, plain `restart` can't break out of the
+# failed state. lifeos-llm intentionally lacks `restart` because of GPU
+# memory cleanup concerns — operator uses stop + start instead.
+_sudo_cmds=()
+for unit in lifeos-api lifeos-mcp-http lifeos-agent-worker; do
+    for verb in start stop restart reset-failed; do
+        _sudo_cmds+=("/usr/bin/systemctl $verb $unit" "/usr/bin/systemctl $verb $unit.service")
+    done
+done
+for verb in start stop reset-failed; do
+    _sudo_cmds+=("/usr/bin/systemctl $verb lifeos-llm" "/usr/bin/systemctl $verb lifeos-llm.service")
+done
+# Join with ", " for the sudoers Cmnd_Alias line
+IFS=','
+_sudo_csv="${_sudo_cmds[*]}"
+unset IFS
+_sudo_csv="${_sudo_csv//,/, }"
+echo "$REAL_USER ALL=(root) NOPASSWD: $_sudo_csv" > "$TMP_SUDOERS"
 if visudo -c -f "$TMP_SUDOERS" > /dev/null 2>&1; then
     mv "$TMP_SUDOERS" "$SUDOERS_FILE"
     chmod 440 "$SUDOERS_FILE"


### PR DESCRIPTION
## Summary

Adds \`systemctl reset-failed\` for all lifeos units to \`/etc/sudoers.d/lifeos\`. Required for any automation to recover a unit that has tripped systemd's \`StartLimit\` — plain \`restart\` won't break out of the failed state until the rate-limit window naturally ages out.

Yesterday's silent worker outage (3+ hours, no agent task pickup) traced to exactly this: \`lifeos-agent-worker\` hit \`start-limit-hit\` at 22:57 EDT after lifeos-api was restarted many times in quick succession during a dev session; the BindsTo cascade past the rate limit left it stuck. Recovery only worked once enough time elapsed for the 300s window to age out.

Also refactors the inline sudoers \`echo\` from a 1200-char one-liner into a programmatic loop. Same coverage as before (\`start\`/\`stop\`/\`restart\` for each unit, both bare name and \`.service\` forms) plus the new \`reset-failed\` entries. \`lifeos-llm\` keeps its no-restart policy (GPU memory cleanup concern) but gains \`reset-failed\`.

## Companion changes

- LifeOS PR #216 (agent worker fixes) is independent.
- \`nbramia/local-processing\` commit \`00f6c95\` adds the \`agent_worker_health\` watcher on the macbook. Without this sudoers grant, that watcher will detect failures but its auto-recovery path hangs on a password prompt.

## Note on push

Pushed with \`--no-verify\` (per Nathan's explicit OK) to bypass 2 pre-existing test failures in \`test_agent_resume_api.py\` (from PR #215) that fail on any host where \`WEZTERM_PANE\` is set in the environment. Those are unrelated to this change and need their own fix.

## Test plan

- [x] Generated sudoers file passes \`visudo -c\`
- [x] Loop produces commands covering all 4 units (api, mcp-http, agent-worker, llm) with the appropriate verbs
- [ ] After merge: run \`sudo ./scripts/setup-systemd.sh\` on nathan-linux to apply
- [ ] After apply: verify \`sudo -n -l | grep reset-failed\` lists the new entries
- [ ] After apply: trigger \`agent_worker_health\` watcher tick on macbook to confirm recovery path succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)