### PR TITLE
fix(tests): isolate WEZTERM_PANE in resume-api tests

### DIFF
--- a/tests/test_agent_resume_api.py
+++ b/tests/test_agent_resume_api.py
@@ -575,6 +575,11 @@ def test_resume_injects_wezterm_pane_env_when_launcher_is_wezterm(
     list` first and pins WEZTERM_PANE into the spawn env, preferring the
     `default` workspace's pane."""
     from config.settings import settings
+    # Strip any inherited WEZTERM_PANE — tests must assert on what the
+    # injection helper produces, not whatever value the dev's outer shell
+    # happens to have (running pytest inside a wezterm session leaks
+    # WEZTERM_PANE=<host pane> into the child process and masks the test).
+    monkeypatch.delenv("WEZTERM_PANE", raising=False)
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd",
                         "wezterm cli spawn --cwd {cwd} -- {inner_command}")
@@ -613,6 +618,8 @@ def test_resume_skips_pane_injection_when_launcher_is_not_wezterm(
 ):
     """Operator-overridden non-wezterm launcher → no WEZTERM_PANE meddling."""
     from config.settings import settings
+    # Same env-isolation reason as the sibling test above.
+    monkeypatch.delenv("WEZTERM_PANE", raising=False)
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     monkeypatch.setattr(settings, "cc_resume_cmd", "echo launching")
 


### PR DESCRIPTION
## Summary

Two tests in \`tests/test_agent_resume_api.py\` failed on any host where pytest runs inside a wezterm session, because they inherited \`WEZTERM_PANE\` from the parent shell into the subprocess env they later assert against:

- \`test_resume_injects_wezterm_pane_env_when_launcher_is_wezterm\` — expected the injection helper to set \`WEZTERM_PANE=7\`, got the host pane id instead.
- \`test_resume_skips_pane_injection_when_launcher_is_not_wezterm\` — expected \`WEZTERM_PANE\` to be absent, got the host pane id.

CI passed because CI has no \`WEZTERM_PANE\`. Pre-push on Nathan's dev box failed. PR #218 had to use \`--no-verify\` to bypass.

## Fix

One-line per test: \`monkeypatch.delenv("WEZTERM_PANE", raising=False)\` at the top so the assertion is against the helper's behavior, not the developer's outer-shell state.

## Test plan

- [x] Both tests pass locally (which they didn't before)
- [x] Pre-push runs the full unit suite — 1592 passed (up from 1585)

🤖 Generated with [Claude Code](https://claude.com/claude-code)