### PR TITLE
fix(phone): unlinked source_entity for unresolved phones (closes #226)

### DIFF
--- a/api/services/entity_resolver.py
+++ b/api/services/entity_resolver.py
@@ -782,14 +782,23 @@ class EntityResolver:
         2. Phone exact match (if phone provided, E.164 format)
         3. Name exact match
         4. Fuzzy name match with context boost
-        5. Create new entity (if create_if_missing)
+        5. Create new entity from email or name (if create_if_missing)
+
+        Phone-only never creates a PersonEntity — see issue #226. A raw phone
+        observation with no name or email tells you very little about who the
+        caller is, and auto-creating a person per observation would pollute
+        the People graph with one row per spam call. Importers handle the
+        "unknown caller" case by storing an unlinked source_entity instead;
+        ``scripts/link_source_entities.py`` then retro-links it whenever the
+        same number later shows up associated with a known Contact / email.
 
         Args:
             name: Person's name
             email: Person's email
             phone: Person's phone (E.164 format, e.g., +1XXXXXXXXXX)
             context_path: Vault path for context boost
-            create_if_missing: Create new entity if not found
+            create_if_missing: Create new entity (from email or name) if not
+                found. Has no effect when only ``phone`` is provided.
 
         Returns:
             ResolutionResult or None

--- a/api/services/entity_resolver.py
+++ b/api/services/entity_resolver.py
@@ -787,10 +787,13 @@ class EntityResolver:
         Phone-only never creates a PersonEntity — see issue #226. A raw phone
         observation with no name or email tells you very little about who the
         caller is, and auto-creating a person per observation would pollute
-        the People graph with one row per spam call. Importers handle the
-        "unknown caller" case by storing an unlinked source_entity instead;
-        ``scripts/link_source_entities.py`` then retro-links it whenever the
-        same number later shows up associated with a known Contact / email.
+        the People graph with one row per spam call. ``apple_data_import``
+        handles the "unknown caller" case by storing an unlinked source_entity
+        instead so ``scripts/link_source_entities.py`` can retro-link it when
+        the same number later shows up linked to a Contact or email.
+        ``scripts/sync_phone_calls.py`` and ``api/services/whatsapp.py`` still
+        drop unresolved observations today and should adopt the same pattern
+        in a follow-up.
 
         Args:
             name: Person's name

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -261,19 +261,20 @@ def _extract_phone_from_title(title: str) -> str | None:
 def import_phone_calls(dry_run: bool = False) -> dict:
     """Import phone call history from the Mac Mini's JSON export.
 
-    Mirrors the source_entity behaviour of ``scripts/sync_phone_calls.py``
-    (the macOS-native version). For each call whose phone number resolves
-    to an existing PersonEntity, we ensure a phone-keyed SourceEntity
-    exists (``phone_{e164}``), update its ``observed_at`` to the most
-    recent call we've seen for that number in this batch, link it to the
-    person if it isn't already, then create the Interaction.
+    For every observed phone number we ensure a phone-keyed SourceEntity
+    exists (``phone_{e164}``) with its ``observed_at`` set to the most-
+    recent call we've seen for that number in this batch:
 
-    Scope: only resolvable callers get source_entities. Callers we've never
-    associated with a Person (spam, robocalls, first-time inbound) stay in
-    ``unresolved``. The entity-resolver has no phone-only create-if-missing
-    branch (see ``api/services/entity_resolver.py:881``) and adding one
-    here would mint a junk PersonEntity per spam call. Filed as a separate
-    follow-up.
+    - If the number resolves to an existing PersonEntity, link the
+      source_entity to that person (unless a manual link already exists)
+      and create the Interaction record for the call.
+    - If the number doesn't resolve to any Person, the source_entity is
+      stored **unlinked** (``canonical_person_id IS NULL``). This is
+      issue #226's policy: phone alone never creates a Person — auto-
+      creating one per spam call would pollute the People graph — but we
+      keep the forensic observation so ``scripts/link_source_entities.py``
+      can retro-link it later when the matching Contact / email arrives.
+      No Interaction is created (interactions require ``person_id``).
 
     The source_entity update happens BEFORE the "interaction already
     exists?" check so that re-imports still close the issue #199 §2 drift
@@ -345,23 +346,16 @@ def import_phone_calls(dry_run: bool = False) -> dict:
             unresolved += 1
             continue
 
-        # Resolve to PersonEntity by phone. Note: the resolver has no
-        # "create from phone alone" branch (see entity_resolver.py:881 —
-        # only email and name create-if-missing paths exist), so callers
-        # whose phone we've never linked to a known Person are deliberately
-        # left in ``unresolved``. Adding a phone-only create branch is a
-        # separate, broader change (filed as a follow-up); doing it here
-        # would auto-create a junk Person for every spam call.
+        # Resolve to an existing PersonEntity by phone — phone alone never
+        # CREATES a Person (issue #226). May return None.
         result = resolver.resolve(phone=phone, create_if_missing=False)
         person = result.entity if result else None
-        if not person:
-            unresolved += 1
-            continue
 
-        # Ensure a phone-keyed source_entity exists and is linked.
-        # This happens BEFORE the "existing interaction?" check so that
-        # already-imported calls still contribute to source_entity
-        # accumulation when the resolver / entity store grows new rows.
+        # Ensure a phone-keyed source_entity exists for the observed number.
+        # We do this even when no Person matches: the row stays unlinked
+        # (``canonical_person_id IS NULL``) and ``link_source_entities.py``
+        # will retro-link it on a future pass when the matching Contact /
+        # email finally appears.
         # ``seen_phones`` dedups within this run; per-call freshness is
         # preserved by computing the merged observed_at across all calls
         # seen for the same phone before the first DB write.
@@ -408,17 +402,26 @@ def import_phone_calls(dry_run: bool = False) -> dict:
                 se = se_store.add(se)
                 source_entities_created += 1
             # Only re-link from auto-quality data: never clobber a manual
-            # link (link_status == "manual") because that represents a
-            # human's judgement that this number belongs to a specific
-            # person, possibly across a merge or rename.
+            # link (link_status == "manual"). Skip link entirely if there's
+            # no matching Person yet — the source_entity stays unlinked
+            # until retro-linking finds a match.
             if (
-                se.canonical_person_id != person.id
+                person is not None
+                and se.canonical_person_id != person.id
                 and (se.link_status or "auto") != "manual"
             ):
                 se_store.link_to_person(
                     se.id, person.id,
                     confidence=0.95, status=LINK_STATUS_AUTO,
                 )
+
+        # No Person → no Interaction row (the interactions schema requires
+        # person_id). The source_entity is what carries the observation
+        # forward; ``unresolved`` still tracks the count so dashboards can
+        # see how many calls didn't link to a known person tonight.
+        if person is None:
+            unresolved += 1
+            continue
 
         # Skip calls already in the interaction store.
         existing = store.get_by_source(source_type, source_id)

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -318,9 +318,30 @@ def import_phone_calls(dry_run: bool = False) -> dict:
     # has no timestamp; recomputing in the hot loop just adds noise.
     now = datetime.now(timezone.utc)
 
+    # Pre-compute max-timestamp per unique phone in ONE pass so the main
+    # loop doesn't go quadratic. With ~50-100 unique phones in a typical
+    # 800-call export, the naive per-phone scan was running the
+    # _extract_phone_from_title regex tens of thousands of times.
+    phone_max_ts: dict[str, datetime] = {}
+    for c in calls:
+        ts_str = c.get("timestamp")
+        if not ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except (ValueError, TypeError):
+            continue
+        c_phone = _extract_phone_from_title(c.get("title", ""))
+        if not c_phone:
+            continue
+        existing = phone_max_ts.get(c_phone)
+        if existing is None or ts > existing:
+            phone_max_ts[c_phone] = ts
+
     imported = 0
     skipped = 0
-    unresolved = 0
+    unresolved_no_phone = 0
+    orphan_observations = 0       # call from a phone we couldn't link to any Person
     source_entities_created = 0
     source_entities_updated = 0
 
@@ -343,7 +364,7 @@ def import_phone_calls(dry_run: bool = False) -> dict:
         title = call.get("title", "")
         phone = _extract_phone_from_title(title)
         if not phone:
-            unresolved += 1
+            unresolved_no_phone += 1
             continue
 
         # Resolve to an existing PersonEntity by phone — phone alone never
@@ -357,28 +378,12 @@ def import_phone_calls(dry_run: bool = False) -> dict:
         # will retro-link it on a future pass when the matching Contact /
         # email finally appears.
         # ``seen_phones`` dedups within this run; per-call freshness is
-        # preserved by computing the merged observed_at across all calls
-        # seen for the same phone before the first DB write.
+        # preserved using the pre-computed ``phone_max_ts`` table built
+        # above (O(N) instead of O(N²)).
         if phone not in seen_phones:
             seen_phones.add(phone)
             se_source_id = f"phone_{phone}"
-            # The most-recent valid timestamp among any call for this phone
-            # in this batch — prevents observed_at from ratcheting backwards
-            # when the export isn't strictly chronological. Malformed
-            # timestamps inside other calls are skipped silently.
-            same_phone_timestamps: list[datetime] = []
-            for c in calls:
-                if (
-                    c.get("timestamp")
-                    and _extract_phone_from_title(c.get("title", "")) == phone
-                ):
-                    try:
-                        same_phone_timestamps.append(
-                            datetime.fromisoformat(c["timestamp"])
-                        )
-                    except (ValueError, TypeError):
-                        continue
-            this_phone_max_ts = max(same_phone_timestamps, default=timestamp or now)
+            this_phone_max_ts = phone_max_ts.get(phone, timestamp or now)
             existing_se = se_store.get_by_source("phone", se_source_id)
             if existing_se:
                 # Preserve fields we don't have authoritative data for in
@@ -416,11 +421,13 @@ def import_phone_calls(dry_run: bool = False) -> dict:
                 )
 
         # No Person → no Interaction row (the interactions schema requires
-        # person_id). The source_entity is what carries the observation
-        # forward; ``unresolved`` still tracks the count so dashboards can
-        # see how many calls didn't link to a known person tonight.
+        # person_id). The unlinked source_entity is what carries the
+        # observation forward; the ``orphan_observations`` counter is the
+        # right "we saw this call but couldn't link it" metric — distinct
+        # from ``unresolved_no_phone`` which is a true failure (the title
+        # didn't contain a number we could extract at all).
         if person is None:
-            unresolved += 1
+            orphan_observations += 1
             continue
 
         # Skip calls already in the interaction store.
@@ -444,7 +451,8 @@ def import_phone_calls(dry_run: bool = False) -> dict:
 
     logger.info(
         f"Phone calls: {imported} imported, {skipped} skipped (existing/invalid), "
-        f"{unresolved} unresolved (no phone in title), "
+        f"{unresolved_no_phone} bad (no phone in title), "
+        f"{orphan_observations} orphan observations (phone-only, no matching Person yet), "
         f"{source_entities_created} source_entities created, "
         f"{source_entities_updated} updated"
     )
@@ -452,7 +460,11 @@ def import_phone_calls(dry_run: bool = False) -> dict:
         "status": "ok",
         "imported": imported,
         "skipped": skipped,
-        "unresolved": unresolved,
+        # Kept as a back-compat alias for any consumer still reading the
+        # old name. New code should prefer the two split counters below.
+        "unresolved": unresolved_no_phone + orphan_observations,
+        "unresolved_no_phone": unresolved_no_phone,
+        "orphan_observations": orphan_observations,
         "source_entities_created": source_entities_created,
         "source_entities_updated": source_entities_updated,
     }

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -499,6 +499,53 @@ class TestPhoneImport:
             "unresolved phone observations must NOT auto-link to any person"
         assert se.observed_phone == "+18005551234"
 
+    def test_multiple_calls_from_unknown_caller_dedup_to_one_se(self, tmp_path):
+        """Multiple calls from the same unknown number in a single batch
+        produce exactly one source_entity (deduped via seen_phones) and
+        increment orphan_observations once per call (so dashboards can see
+        how many calls weren't linked tonight, not just how many unique
+        numbers)."""
+        from scripts.apple_data_import import import_phone_calls
+        from unittest.mock import MagicMock
+
+        import_dir = tmp_path / "apple-imports"
+        self._write_calls(import_dir, [
+            {
+                "id": f"call-{i}",
+                "source_id": f"SRC-{i}",
+                "source_type": "phone",
+                "person_id": "",
+                "timestamp": f"2026-01-15T10:0{i}:00+00:00",
+                "title": "Incoming Phone - +18005550199",
+            }
+            for i in range(3)
+        ])
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = None  # never matches
+
+        se_store, mock_interaction_store, stack = self._wire_phone_import(
+            tmp_path, import_dir, mock_resolver,
+        )
+        with stack:
+            result = import_phone_calls(dry_run=False)
+
+        assert result["imported"] == 0
+        assert result["source_entities_created"] == 1, \
+            "seen_phones should dedup three calls from the same number to one SE"
+        assert result["orphan_observations"] == 3, \
+            "every call (not just the first) counts as an orphan observation"
+        mock_interaction_store.add_if_not_exists.assert_not_called()
+
+        # Exactly one row landed in source_entities for this number.
+        rows = []
+        for c_phone in ("+18005550199",):
+            row = se_store.get_by_source("phone", f"phone_{c_phone}")
+            if row is not None:
+                rows.append(row)
+        assert len(rows) == 1
+        assert rows[0].canonical_person_id in (None, "")
+
     def test_no_phone_in_title_skipped(self, tmp_path):
         """Call with no extractable phone number should be skipped."""
         from scripts.apple_data_import import import_phone_calls

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -376,8 +376,49 @@ class TestPhoneImport:
         with open(import_dir / "phone_calls.json", "w") as f:
             json.dump({"calls": calls, "exported_at": "2026-01-01T00:00:00+00:00"}, f)
 
-    def test_resolved_call_imported(self, tmp_path):
-        """Call with a phone number matching a known person should be imported."""
+    def _wire_phone_import(self, tmp_path, import_dir, mock_resolver):
+        """Common test scaffolding: real ``SourceEntityStore`` on tmp_path,
+        mock interaction store + entity resolver. Returns the
+        ``SourceEntityStore`` and a ``MagicMock`` interaction store so
+        callers can inspect both sides of the dual-write."""
+        from unittest.mock import MagicMock
+        from api.services.source_entity import SourceEntityStore
+
+        se_store = SourceEntityStore(db_path=str(tmp_path / "crm.db"))
+        mock_interaction_store = MagicMock()
+        mock_interaction_store.get_by_source.return_value = None
+
+        # PersonEntityStore is consulted indirectly via SourceEntityStore.add
+        # for the ``validate_person`` path; pass a permissive mock that
+        # claims every person id exists.
+        mock_person_store = MagicMock()
+        mock_person_store.get_canonical_id.side_effect = lambda pid: pid
+        mock_person_store.get_by_id.side_effect = lambda pid: MagicMock(id=pid)
+
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch("scripts.apple_data_import.IMPORT_DIR", import_dir))
+        stack.enter_context(patch(
+            "api.services.interaction_store.get_interaction_store",
+            return_value=mock_interaction_store,
+        ))
+        stack.enter_context(patch(
+            "api.services.entity_resolver.get_entity_resolver",
+            return_value=mock_resolver,
+        ))
+        stack.enter_context(patch(
+            "api.services.source_entity.get_source_entity_store",
+            return_value=se_store,
+        ))
+        stack.enter_context(patch(
+            "api.services.person_entity.get_person_entity_store",
+            return_value=mock_person_store,
+        ))
+        return se_store, mock_interaction_store, stack
+
+    def test_resolved_call_imported_and_linked(self, tmp_path):
+        """Call with a phone matching a known person creates a linked
+        source_entity + the Interaction."""
         from scripts.apple_data_import import import_phone_calls
         from unittest.mock import MagicMock
 
@@ -393,28 +434,36 @@ class TestPhoneImport:
 
         mock_person = MagicMock()
         mock_person.id = "person-abc"
-
         mock_resolver = MagicMock()
-        mock_resolver.resolve_by_phone.return_value = mock_person
+        mock_resolver.resolve.return_value = MagicMock(entity=mock_person)
 
-        mock_store = MagicMock()
-        mock_store.get_by_source.return_value = None
-
-        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir), \
-             patch("api.services.interaction_store.get_interaction_store", return_value=mock_store), \
-             patch("api.services.entity_resolver.get_entity_resolver", return_value=mock_resolver):
+        se_store, mock_interaction_store, stack = self._wire_phone_import(
+            tmp_path, import_dir, mock_resolver,
+        )
+        with stack:
             result = import_phone_calls(dry_run=False)
 
         assert result["status"] == "ok"
         assert result["imported"] == 1
         assert result["unresolved"] == 0
-        mock_resolver.resolve_by_phone.assert_called_once_with("+15551234567")
-        # Verify person_id was set on the Interaction
-        added = mock_store.add_if_not_exists.call_args[0][0]
+        # Resolver was called with the new shape.
+        mock_resolver.resolve.assert_called_once()
+        kwargs = mock_resolver.resolve.call_args.kwargs
+        assert kwargs == {"phone": "+15551234567", "create_if_missing": False}
+        # Interaction was created with the resolved person.
+        added = mock_interaction_store.add_if_not_exists.call_args[0][0]
         assert added.person_id == "person-abc"
+        # source_entity exists AND is linked.
+        se = se_store.get_by_source("phone", "phone_+15551234567")
+        assert se is not None
+        assert se.canonical_person_id == "person-abc"
 
-    def test_unresolved_call_skipped(self, tmp_path):
-        """Call with no matching person should be skipped."""
+    def test_unresolved_call_stores_orphan_source_entity(self, tmp_path):
+        """Issue #226 policy: an unresolved phone observation still produces
+        an unlinked source_entity (``canonical_person_id IS NULL``), so
+        ``link_source_entities`` can retro-link it once the matching Contact
+        / email arrives. No Interaction is created — those require a person.
+        """
         from scripts.apple_data_import import import_phone_calls
         from unittest.mock import MagicMock
 
@@ -429,19 +478,26 @@ class TestPhoneImport:
         }])
 
         mock_resolver = MagicMock()
-        mock_resolver.resolve_by_phone.return_value = None
+        mock_resolver.resolve.return_value = None  # no match
 
-        mock_store = MagicMock()
-        mock_store.get_by_source.return_value = None
-
-        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir), \
-             patch("api.services.interaction_store.get_interaction_store", return_value=mock_store), \
-             patch("api.services.entity_resolver.get_entity_resolver", return_value=mock_resolver):
+        se_store, mock_interaction_store, stack = self._wire_phone_import(
+            tmp_path, import_dir, mock_resolver,
+        )
+        with stack:
             result = import_phone_calls(dry_run=False)
 
+        # The call is counted as unresolved AND no interaction is added…
         assert result["imported"] == 0
         assert result["unresolved"] == 1
-        mock_store.add_if_not_exists.assert_not_called()
+        mock_interaction_store.add_if_not_exists.assert_not_called()
+        # …but the observation IS captured as an unlinked source_entity,
+        # ready for ``link_source_entities`` to pick up next time around.
+        assert result["source_entities_created"] == 1
+        se = se_store.get_by_source("phone", "phone_+18005551234")
+        assert se is not None, "orphan source_entity should exist for unknown caller"
+        assert se.canonical_person_id in (None, ""), \
+            "unresolved phone observations must NOT auto-link to any person"
+        assert se.observed_phone == "+18005551234"
 
     def test_no_phone_in_title_skipped(self, tmp_path):
         """Call with no extractable phone number should be skipped."""


### PR DESCRIPTION
## Summary

Codifies the rule **\"phone alone never creates a PersonEntity\"** and preserves the observation as an unlinked source_entity so retro-linking can pick it up later when the matching Contact / email arrives.

This is the agreed-upon resolution to #226 after the PR #225 review caught the original \"add a phone-create branch\" proposal as a spam-risk footgun.

Closes #226.

## The rule

\`EntityResolver.resolve(phone=..., create_if_missing=True)\` returns None when nothing matches. Email and name can create-if-missing; phone alone never does. Documented in the resolver's docstring with a pointer back to this issue.

## What importers do now

For every observed phone in \`apple_data_import.import_phone_calls\`:

1. Try to resolve to an existing PersonEntity by phone.
2. **Always** ensure a phone-keyed source_entity exists (\`phone_{e164}\`) — even if no Person matched.
   - If a Person matched: link the source_entity to that person (unless a manual link already exists).
   - If no Person matched: source_entity stays unlinked (\`canonical_person_id IS NULL\`).
3. If no Person, no Interaction is created — \`interactions\` schema requires \`person_id\`.

\`scripts/link_source_entities.py:160\` already calls \`resolver.resolve(name=..., email=..., phone=..., create_if_missing=False)\` for every orphan source_entity on its nightly pass, so retro-linking comes for free. The first time an unknown caller becomes known (via Contacts sync, an email exchange, anything that creates a Person with the same number), the orphan source_entity links itself automatically.

## Live verification

Backfill against today's export against my own data:

| | Total phone SEs | Unlinked phone SEs |
|---|---|---|
| Before | 440 | 204 |
| After | **501** (+61) | **265** (+61) |

All 61 new entries are unlinked — they're observations of callers I'd never had a Contact entry for. Previously they were dropped entirely. Drift detector still reports \`NO_DRIFT\`.

## Test evidence

- \`tests/test_apple_pipeline.py::TestPhoneImport\` rewritten — the existing tests were already broken (mocked \`resolve_by_phone\` instead of \`resolve\` after the PR #225 refactor, hit MagicMock defaults and produced false greens). Now uses a real \`SourceEntityStore\` on tmp_path:
  - \`test_resolved_call_imported_and_linked\` — known caller → linked source_entity + Interaction
  - \`test_unresolved_call_stores_orphan_source_entity\` — unknown caller → unlinked source_entity, zero Interactions
- \`pytest tests/test_apple_pipeline.py tests/test_entity_resolver.py tests/test_interaction_store.py tests/test_sync_health.py\` → **160 passed**.

## Review focus

- **\`api/services/entity_resolver.py:777-803\`** — the docstring change. Codifies the rule, but doesn't change runtime behaviour (the function already returned None for phone-only).
- **\`scripts/apple_data_import.py:348-432\`** — the loop reorganization. Specifically: source_entity creation moved BEFORE the \`if person is None: continue\` check; the link_to_person call gained an \`if person is not None\` guard.
- **\`scripts/sync_phone_calls.py\` and \`api/services/whatsapp.py\` are NOT in this PR** — they have the same drop-on-unresolved pattern and would benefit from the same fix, but each is its own importer with its own quirks (sync_phone_calls also has Address Book name access). Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)