### PR TITLE
refactor: source-entity + backup hygiene (closes #227, closes #228)

### DIFF
--- a/api/services/backup_retention.py
+++ b/api/services/backup_retention.py
@@ -1,0 +1,176 @@
+"""Tiered backup retention for SQLite database snapshots.
+
+A backup file is kept iff it is the newest one falling into any of these
+buckets:
+
+- The N most recent backups (the **daily** tier, ``daily_keep``) — always kept.
+- 1 per week-of-age between ``daily_keep`` and ``weekly_horizon_days``.
+- 1 per month-of-age between ``weekly_horizon_days`` and ``monthly_horizon_days``.
+- 1 per quarter (~3 months) of age beyond ``monthly_horizon_days``.
+
+At the defaults (5 / 35 / 365 day boundaries), steady state is roughly:
+
+  5 daily + 4 weekly + 11 monthly + ~4/year quarterly ≈ 25 files growing
+  linearly afterwards. Each backup is a full copy of the source DB.
+
+The helper is intentionally parameterised by ``db_basename`` so other
+stores (``crm.db``, ``sync_health.db``, …) can reuse the same retention
+policy without copy-pasting the bucket math. Issue #227.
+
+Filename convention
+-------------------
+
+The writer (``backup_filename``) and the pruner (``prune``) share a single
+naming scheme: ``<basename>.<YYYYMMDD_HHMMSS>.backup``. Files that don't
+match this exact pattern are ignored — operators sometimes drop in
+hand-rolled names like ``interactions.db.pre-upgrade.backup`` for manual
+safekeeping; retention should leave those alone.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_BACKUP_TIMESTAMP_FORMAT = "%Y%m%d_%H%M%S"
+
+
+def backup_filename(db_basename: str, ts: datetime) -> str:
+    """Canonical backup filename for ``db_basename`` at ``ts``.
+
+    Example: ``backup_filename("interactions.db", now)`` →
+    ``interactions.db.20260528_120000.backup``.
+
+    Use this in concert with ``parse_backup_timestamp`` / ``prune`` so the
+    writer and pruner can never silently diverge if the naming scheme is
+    later changed (e.g., to add microseconds).
+    """
+    return f"{db_basename}.{ts.strftime(_BACKUP_TIMESTAMP_FORMAT)}.backup"
+
+
+def _build_pattern(db_basename: str) -> tuple[str, re.Pattern[str]]:
+    """Return the glob + the compiled regex for ``db_basename``.
+
+    Both forms are needed: the glob narrows the directory listing cheaply;
+    the regex pins down the exact ``YYYYMMDD_HHMMSS`` shape so that
+    non-canonical files are excluded from retention math.
+    """
+    glob_pattern = f"{db_basename}.*.backup"
+    # ``re.escape`` so basenames containing ``.`` (every SQLite file)
+    # don't accidentally match other names.
+    regex = re.compile(
+        rf"^{re.escape(db_basename)}\.(\d{{8}}_\d{{6}})\.backup$"
+    )
+    return glob_pattern, regex
+
+
+def parse_backup_timestamp(name: str, db_basename: str) -> Optional[datetime]:
+    """Parse the timestamp embedded in a canonical backup filename.
+
+    Returns ``None`` for files that don't match ``db_basename`` exactly,
+    or whose timestamp portion isn't parseable. Callers should treat
+    ``None`` as "ignore this file" — that's how we leave manual backups
+    (``interactions.db.pre-upgrade.backup``) alone.
+    """
+    _, regex = _build_pattern(db_basename)
+    m = regex.match(name)
+    if not m:
+        return None
+    try:
+        return datetime.strptime(m.group(1), _BACKUP_TIMESTAMP_FORMAT)
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """Tier boundaries (in days) for ``prune``. All defaults match what
+    ``interaction_store.create_backup`` shipped with in PR #225."""
+
+    daily_keep: int = 5
+    weekly_horizon_days: int = 35
+    monthly_horizon_days: int = 365
+    week_days: int = 7
+    month_days: int = 30
+    quarter_days: int = 90
+
+
+DEFAULT_POLICY = RetentionPolicy()
+
+
+def prune(
+    backup_dir: Path,
+    db_basename: str,
+    *,
+    policy: RetentionPolicy = DEFAULT_POLICY,
+    now: Optional[datetime] = None,
+) -> list[Path]:
+    """Apply the tiered retention policy to ``backup_dir`` for one store.
+
+    Args:
+        backup_dir: Directory holding ``<db_basename>.<ts>.backup`` files.
+        db_basename: e.g., ``"interactions.db"`` or ``"crm.db"``. Only
+            files matching this basename's canonical pattern are
+            considered; anything else stays untouched.
+        policy: Tier boundary overrides. Use ``DEFAULT_POLICY`` unless
+            you have a specific reason.
+        now: Reference timestamp for "age" computations; defaults to
+            ``datetime.now()``. Pass an explicit value in tests so bucket
+            math stays deterministic.
+
+    Returns:
+        The list of paths removed. Empty when the directory is fresh or
+        every backup fits within a distinct bucket.
+    """
+    if now is None:
+        now = datetime.now()
+
+    glob_pattern, _ = _build_pattern(db_basename)
+
+    candidates: list[tuple[datetime, Path]] = []
+    for path in backup_dir.glob(glob_pattern):
+        ts = parse_backup_timestamp(path.name, db_basename)
+        if ts is not None:
+            candidates.append((ts, path))
+
+    if not candidates:
+        return []
+
+    # Newest first.
+    candidates.sort(key=lambda x: x[0], reverse=True)
+
+    keep: set[Path] = set()
+
+    # Tier 1: the N most recent — always kept regardless of bucket math.
+    for _, path in candidates[: policy.daily_keep]:
+        keep.add(path)
+
+    # Tiers 2/3/4: bucket the older ones; keep the newest in each bucket.
+    seen_buckets: set[tuple[str, int]] = set()
+    for ts, path in candidates[policy.daily_keep:]:
+        age_days = (now - ts).total_seconds() / 86400.0
+        if age_days < policy.weekly_horizon_days:
+            bucket = ("week", int(age_days // policy.week_days))
+        elif age_days < policy.monthly_horizon_days:
+            bucket = ("month", int(age_days // policy.month_days))
+        else:
+            bucket = ("quarter", int(age_days // policy.quarter_days))
+        if bucket not in seen_buckets:
+            seen_buckets.add(bucket)
+            keep.add(path)
+
+    removed: list[Path] = []
+    for _, path in candidates:
+        if path not in keep:
+            try:
+                path.unlink()
+                removed.append(path)
+            except OSError as e:
+                logger.warning(f"Could not remove old backup {path}: {e}")
+    return removed

--- a/api/services/backup_retention.py
+++ b/api/services/backup_retention.py
@@ -101,6 +101,11 @@ class RetentionPolicy:
     quarter_days: int = 90
 
 
+#: A shared, immutable default. ``frozen=True`` on ``RetentionPolicy`` is
+#: load-bearing here: it makes this safe to use as a function default
+#: parameter (otherwise the standard Python footgun of a mutable default
+#: shared across all callers would apply). Don't change the dataclass to
+#: non-frozen without also auditing every ``policy=`` default.
 DEFAULT_POLICY = RetentionPolicy()
 
 

--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -4,7 +4,6 @@ Interaction Store for LifeOS People System v2.
 Stores lightweight interaction records with links to sources.
 Each interaction represents a single touchpoint (email, meeting, note mention).
 """
-import re
 import sqlite3
 import uuid
 import logging
@@ -18,6 +17,7 @@ from config.settings import settings
 from config.people_config import InteractionConfig
 
 from api.utils.datetime_utils import make_aware as _make_aware
+from api.services import backup_retention as _backup_retention
 
 logger = logging.getLogger(__name__)
 
@@ -214,107 +214,24 @@ def build_calendar_link(event_id: str, calendar_id: str = "primary") -> str:
     return f"https://calendar.google.com/calendar/event?eid={event_id}"
 
 
-# Tiered backup retention buckets, in days. A backup is kept iff it is the
-# newest one falling in any of these buckets:
-#   - the 5 most recent (daily slots) — always kept
-#   - week-numbered buckets between DAILY_KEEP and WEEKLY_HORIZON  (1 per week)
-#   - month-numbered buckets between WEEKLY_HORIZON and MONTHLY_HORIZON (1 per month)
-#   - quarter-numbered buckets beyond MONTHLY_HORIZON               (1 per ~3 months)
-_DAILY_KEEP = 5
-_WEEKLY_HORIZON_DAYS = 35      # past day 35 we step down to monthly
-_MONTHLY_HORIZON_DAYS = 365    # past day 365 we step down to quarterly
-_WEEK_DAYS = 7
-_MONTH_DAYS = 30
-_QUARTER_DAYS = 90
-
-# Shared between the writer (``create_backup``) and the pruner so any
-# future change to the naming scheme — e.g., adding microseconds or
-# switching to ISO-8601 — automatically updates both sides instead of
-# silently desyncing them (which would make every new backup invisible to
-# retention math and let the directory grow unbounded).
-_BACKUP_TIMESTAMP_FORMAT = "%Y%m%d_%H%M%S"
-_BACKUP_FILENAME_TEMPLATE = "interactions.db.{ts}.backup"
-_BACKUP_FILE_GLOB = "interactions.db.*.backup"
-_BACKUP_FILE_RE = re.compile(r"^interactions\.db\.(\d{8}_\d{6})\.backup$")
+# Backup retention is owned by ``api.services.backup_retention`` so other
+# SQLite stores (crm.db, sync_health.db, …) can adopt the same policy
+# without copy-pasting the bucket math. See issue #227. The wrappers
+# below are kept so legacy test code that imported the private helpers
+# from this module keeps working.
+_BACKUP_DB_BASENAME = "interactions.db"
 
 
 def _backup_filename(ts: datetime) -> str:
-    """Canonical backup filename for a given timestamp."""
-    return _BACKUP_FILENAME_TEMPLATE.format(ts=ts.strftime(_BACKUP_TIMESTAMP_FORMAT))
+    return _backup_retention.backup_filename(_BACKUP_DB_BASENAME, ts)
 
 
 def _parse_backup_timestamp(name: str) -> Optional[datetime]:
-    """Parse the timestamp embedded in a backup filename, or None on mismatch.
-
-    Files with non-canonical names (e.g., ``interactions.db.pre-upgrade.backup``)
-    are intentionally returned as None so ``_prune_backups`` leaves them
-    alone — operators sometimes drop those in for manual safekeeping.
-    """
-    m = _BACKUP_FILE_RE.match(name)
-    if not m:
-        return None
-    try:
-        return datetime.strptime(m.group(1), _BACKUP_TIMESTAMP_FORMAT)
-    except ValueError:
-        return None
+    return _backup_retention.parse_backup_timestamp(name, _BACKUP_DB_BASENAME)
 
 
 def _prune_backups(backup_dir: Path, now: Optional[datetime] = None) -> list[Path]:
-    """Apply the tiered backup retention to ``backup_dir``.
-
-    Keeps the 5 most recent backups (daily slots), then one per week back to
-    35 days, then one per month back to a year, then one per quarter beyond.
-    Anything else is deleted. Returns the list of paths removed (useful for
-    logging and tests).
-
-    Backups with names that don't match the standard
-    ``interactions.db.YYYYMMDD_HHMMSS.backup`` pattern are ignored — never
-    counted toward retention slots, never deleted.
-    """
-    if now is None:
-        now = datetime.now()
-
-    candidates: list[tuple[datetime, Path]] = []
-    for path in backup_dir.glob(_BACKUP_FILE_GLOB):
-        ts = _parse_backup_timestamp(path.name)
-        if ts is not None:
-            candidates.append((ts, path))
-
-    if not candidates:
-        return []
-
-    # Newest first
-    candidates.sort(key=lambda x: x[0], reverse=True)
-
-    keep: set[Path] = set()
-
-    # Tier 1: the 5 most recent — always kept.
-    for _, path in candidates[:_DAILY_KEEP]:
-        keep.add(path)
-
-    # Tiers 2/3/4: bucket the older ones; keep the newest in each bucket.
-    seen_buckets: set[tuple[str, int]] = set()
-    for ts, path in candidates[_DAILY_KEEP:]:
-        age_days = (now - ts).total_seconds() / 86400.0
-        if age_days < _WEEKLY_HORIZON_DAYS:
-            bucket = ("week", int(age_days // _WEEK_DAYS))
-        elif age_days < _MONTHLY_HORIZON_DAYS:
-            bucket = ("month", int(age_days // _MONTH_DAYS))
-        else:
-            bucket = ("quarter", int(age_days // _QUARTER_DAYS))
-        if bucket not in seen_buckets:
-            seen_buckets.add(bucket)
-            keep.add(path)
-
-    removed: list[Path] = []
-    for _, path in candidates:
-        if path not in keep:
-            try:
-                path.unlink()
-                removed.append(path)
-            except OSError as e:
-                logger.warning(f"Could not remove old backup {path}: {e}")
-    return removed
+    return _backup_retention.prune(backup_dir, _BACKUP_DB_BASENAME, now=now)
 
 
 class InteractionStore:

--- a/api/services/source_entity.py
+++ b/api/services/source_entity.py
@@ -1210,6 +1210,31 @@ def create_slack_source_entity(
     )
 
 
+def create_phone_source_entity(
+    phone: str,
+    observed_name: Optional[str] = None,
+    observed_at: Optional[datetime] = None,
+    metadata: Optional[dict] = None,
+) -> SourceEntity:
+    """Create a source entity for an observed phone number.
+
+    The ``source_id`` convention is ``phone_{e164}``. Centralising this
+    here keeps the two phone-call import paths
+    (``scripts/apple_data_import.import_phone_calls`` on Linux and
+    ``scripts/sync_phone_calls.py`` native on macOS) from drifting if the
+    format ever changes — silent duplicates were the failure mode that
+    motivated issue #228.
+    """
+    return SourceEntity(
+        source_type="phone",
+        source_id=f"phone_{phone}",
+        observed_name=observed_name,
+        observed_phone=phone,
+        observed_at=observed_at or datetime.now(timezone.utc),
+        metadata=metadata or {},
+    )
+
+
 def create_imessage_source_entity(
     handle: str,
     display_name: Optional[str] = None,

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -300,7 +300,7 @@ def import_phone_calls(dry_run: bool = False) -> dict:
     from api.services.interaction_store import get_interaction_store, Interaction
     from api.services.entity_resolver import get_entity_resolver
     from api.services.source_entity import (
-        SourceEntity,
+        create_phone_source_entity,
         get_source_entity_store,
         LINK_STATUS_AUTO,
     )
@@ -382,9 +382,15 @@ def import_phone_calls(dry_run: bool = False) -> dict:
         # above (O(N) instead of O(N²)).
         if phone not in seen_phones:
             seen_phones.add(phone)
-            se_source_id = f"phone_{phone}"
             this_phone_max_ts = phone_max_ts.get(phone, timestamp or now)
-            existing_se = se_store.get_by_source("phone", se_source_id)
+            # Use the shared factory so the ``phone_{e164}`` source_id format
+            # stays defined in exactly one place (see issue #228 — silent
+            # duplicates were the failure mode if it drifts).
+            template = create_phone_source_entity(
+                phone=phone,
+                observed_at=this_phone_max_ts,
+            )
+            existing_se = se_store.get_by_source(template.source_type, template.source_id)
             if existing_se:
                 # Preserve fields we don't have authoritative data for in
                 # this importer (observed_name comes from Address Book on
@@ -396,15 +402,7 @@ def import_phone_calls(dry_run: bool = False) -> dict:
                 source_entities_updated += 1
                 se = existing_se
             else:
-                se = SourceEntity(
-                    source_type="phone",
-                    source_id=se_source_id,
-                    observed_name=None,
-                    observed_phone=phone,
-                    metadata={},
-                    observed_at=this_phone_max_ts,
-                )
-                se = se_store.add(se)
+                se = se_store.add(template)
                 source_entities_created += 1
             # Only re-link from auto-quality data: never clobber a manual
             # link (link_status == "manual"). Skip link entirely if there's

--- a/scripts/sync_phone_calls.py
+++ b/scripts/sync_phone_calls.py
@@ -20,8 +20,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from api.services.entity_resolver import get_entity_resolver
 from api.services.interaction_store import get_interaction_db_path
 from api.services.source_entity import (
+    create_phone_source_entity,
     get_source_entity_store,
-    SourceEntity,
     LINK_STATUS_AUTO,
 )
 from api.services.person_entity import get_person_entity_store
@@ -196,21 +196,19 @@ def sync_phone_calls(
             continue
 
         try:
-            # Create/update SourceEntity for this phone
-            source_id = f"phone_{phone}"
-
+            # Create/update SourceEntity for this phone via the shared
+            # factory (issue #228) so the ``phone_{e164}`` source_id format
+            # stays defined in exactly one place.
             if phone not in seen_phones:
-                existing_source = source_store.get_by_source('phone', source_id)
-
-                source_entity = SourceEntity(
-                    source_type='phone',
-                    source_id=source_id,
+                source_entity = create_phone_source_entity(
+                    phone=phone,
                     observed_name=name if name else None,
-                    observed_phone=phone,
                     metadata={
                         'last_call_type': CALL_TYPE_NAMES.get(call_type, "Unknown"),
                     },
-                    observed_at=datetime.now(timezone.utc),
+                )
+                existing_source = source_store.get_by_source(
+                    source_entity.source_type, source_entity.source_id,
                 )
 
                 if existing_source:

--- a/tests/test_backup_retention.py
+++ b/tests/test_backup_retention.py
@@ -1,0 +1,143 @@
+"""Tests for the generalised backup_retention helper (issue #227).
+
+The integration tests over ``interaction_store._prune_backups`` live in
+``tests/test_interaction_store.py::TestBackupRetention`` and exercise the
+same code path via the legacy alias. These tests target the helper
+directly so any other store can adopt it with confidence.
+"""
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from api.services.backup_retention import (
+    DEFAULT_POLICY,
+    RetentionPolicy,
+    backup_filename,
+    parse_backup_timestamp,
+    prune,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _touch_backup(d: Path, basename: str, ts: datetime) -> Path:
+    """Create an empty backup file matching the canonical naming scheme."""
+    p = d / backup_filename(basename, ts)
+    p.touch()
+    return p
+
+
+class TestFilenameRoundTrip:
+    """``backup_filename`` and ``parse_backup_timestamp`` must round-trip."""
+
+    def test_roundtrip(self):
+        ts = datetime(2026, 5, 28, 9, 7, 42)
+        name = backup_filename("interactions.db", ts)
+        assert name == "interactions.db.20260528_090742.backup"
+        assert parse_backup_timestamp(name, "interactions.db") == ts
+
+    def test_parser_rejects_wrong_basename(self):
+        # The pruner for crm.db must not consume interactions.db files.
+        name = backup_filename("interactions.db", datetime(2026, 1, 1, 0, 0, 0))
+        assert parse_backup_timestamp(name, "crm.db") is None
+
+    def test_parser_rejects_non_canonical_filenames(self):
+        # Operator's hand-rolled backups stay untouched.
+        assert parse_backup_timestamp(
+            "interactions.db.pre-upgrade.backup", "interactions.db"
+        ) is None
+
+    def test_parser_rejects_corrupt_timestamp(self):
+        # Right shape, wrong digits.
+        assert parse_backup_timestamp(
+            "interactions.db.99999999_999999.backup", "interactions.db"
+        ) is None
+
+    def test_basename_with_dots_doesnt_overmatch(self):
+        # ``re.escape`` on the basename means ``interactions.db`` only
+        # matches that exact filename, not e.g. ``interactionsXdb``.
+        ts = datetime(2026, 5, 28, 12, 0, 0)
+        weird_name = f"interactionsXdb.{ts.strftime('%Y%m%d_%H%M%S')}.backup"
+        assert parse_backup_timestamp(weird_name, "interactions.db") is None
+
+
+class TestPruneSegregation:
+    """``prune`` only touches files matching the requested basename."""
+
+    def test_other_basename_files_ignored(self, tmp_path):
+        now = datetime(2026, 5, 28, 12, 0, 0)
+        # 10 daily snapshots of interactions.db over the past 10 days
+        # (would normally prune days 6/8/9 → 7 kept).
+        for i in range(10):
+            _touch_backup(tmp_path, "interactions.db", now - timedelta(days=i))
+        # And 10 daily snapshots of crm.db — separate retention domain.
+        for i in range(10):
+            _touch_backup(tmp_path, "crm.db", now - timedelta(days=i))
+
+        removed = prune(tmp_path, "interactions.db", now=now)
+
+        # The crm.db files must be fully intact.
+        crm_files = sorted(p.name for p in tmp_path.glob("crm.db.*.backup"))
+        assert len(crm_files) == 10
+        # And the interactions.db retention must have run normally.
+        assert len(removed) == 3
+        for prune_age in (6, 8, 9):
+            stamp = (now - timedelta(days=prune_age)).strftime("%Y%m%d_%H%M%S")
+            assert any(stamp in p.name for p in removed)
+
+    def test_independent_pruning_per_basename(self, tmp_path):
+        """Prune crm.db separately; interactions.db survives untouched."""
+        now = datetime(2026, 5, 28, 12, 0, 0)
+        # Only crm.db has more than 5 backups → exercises bucket math.
+        for i in range(8):
+            _touch_backup(tmp_path, "crm.db", now - timedelta(days=i))
+        interactions_file = _touch_backup(tmp_path, "interactions.db", now)
+
+        prune(tmp_path, "crm.db", now=now)
+
+        # The interactions.db file must still be there — it's a different
+        # retention domain.
+        assert interactions_file.exists()
+
+
+class TestPolicyOverride:
+    """Caller-supplied ``RetentionPolicy`` actually changes the math."""
+
+    def test_higher_daily_keep_retains_more(self, tmp_path):
+        now = datetime(2026, 5, 28, 12, 0, 0)
+        for i in range(10):
+            _touch_backup(tmp_path, "interactions.db", now - timedelta(days=i))
+
+        # Bump daily slots from 5 to 10 — nothing should be pruned.
+        custom = RetentionPolicy(daily_keep=10)
+        removed = prune(tmp_path, "interactions.db", policy=custom, now=now)
+        assert removed == []
+
+    def test_zero_daily_keep_still_keeps_one_per_weekly_bucket(self, tmp_path):
+        """``daily_keep=0`` skips tier-1 entirely; everything goes through
+        the bucket math, so we keep exactly one per week-of-age."""
+        now = datetime(2026, 5, 28, 12, 0, 0)
+        for i in range(10):
+            _touch_backup(tmp_path, "interactions.db", now - timedelta(days=i))
+
+        custom = RetentionPolicy(daily_keep=0)
+        prune(tmp_path, "interactions.db", policy=custom, now=now)
+        kept = sorted(p.name for p in tmp_path.glob("interactions.db.*.backup"))
+        # Days 0..9 split into week-0 (days 0..6) and week-1 (days 7..9).
+        # Newest per bucket kept → 2 survivors.
+        assert len(kept) == 2
+
+
+class TestNoOps:
+    """Empty / nothing-to-do cases."""
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        assert prune(tmp_path, "interactions.db") == []
+
+    def test_default_policy_is_immutable(self):
+        # Defensive: DEFAULT_POLICY is a frozen dataclass, so accidental
+        # in-place mutation by a caller can't bleed into other callers.
+        with pytest.raises((AttributeError, Exception)):
+            DEFAULT_POLICY.daily_keep = 99  # type: ignore[misc]

--- a/tests/test_backup_retention.py
+++ b/tests/test_backup_retention.py
@@ -5,6 +5,7 @@ The integration tests over ``interaction_store._prune_backups`` live in
 same code path via the legacy alias. These tests target the helper
 directly so any other store can adopt it with confidence.
 """
+from dataclasses import FrozenInstanceError
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -139,5 +140,5 @@ class TestNoOps:
     def test_default_policy_is_immutable(self):
         # Defensive: DEFAULT_POLICY is a frozen dataclass, so accidental
         # in-place mutation by a caller can't bleed into other callers.
-        with pytest.raises((AttributeError, Exception)):
+        with pytest.raises(FrozenInstanceError):
             DEFAULT_POLICY.daily_keep = 99  # type: ignore[misc]

--- a/tests/test_source_entity.py
+++ b/tests/test_source_entity.py
@@ -418,6 +418,35 @@ class TestFactoryFunctions:
         assert entity.source_id == "event123:Jane@Example.com"
         assert entity.observed_email == "jane@example.com"
 
+    def test_create_phone_source_entity(self):
+        """Phone factory uses the canonical ``phone_{e164}`` source_id and
+        sets observed_phone (issue #228 — single definition of the format).
+        """
+        from api.services.source_entity import create_phone_source_entity
+
+        entity = create_phone_source_entity(
+            phone="+15551234567",
+            observed_name="Mom",
+        )
+
+        assert entity.source_type == "phone"
+        assert entity.source_id == "phone_+15551234567"
+        assert entity.observed_phone == "+15551234567"
+        assert entity.observed_name == "Mom"
+        # observed_at defaults to "now" when not supplied.
+        assert entity.observed_at is not None
+        # Email is irrelevant here.
+        assert entity.observed_email is None
+
+    def test_create_phone_source_entity_minimal(self):
+        """Only ``phone`` is required; everything else takes safe defaults."""
+        from api.services.source_entity import create_phone_source_entity
+
+        entity = create_phone_source_entity(phone="+15558675309")
+        assert entity.source_id == "phone_+15558675309"
+        assert entity.observed_name is None
+        assert entity.metadata == {}
+
     def test_create_imessage_source_entity_phone(self):
         """Test iMessage source entity with phone number."""
         entity = create_imessage_source_entity(


### PR DESCRIPTION
## Summary

Two related cleanups from the PR #225 review, batched in a single PR since both are storage-layer hygiene with no behaviour change.

Closes #227, closes #228.

## Commit 1 — \`create_phone_source_entity\` factory (#228)

Every other source type has a factory (\`create_gmail_source_entity\`, \`create_imessage_source_entity\`, \`create_slack_source_entity\`, \`create_calendar_source_entity\`, \`create_contacts_source_entity\`, \`create_linkedin_source_entity\`, \`create_vault_source_entity\`, \`create_granola_source_entity\`). Phone didn't. Two import paths — \`apple_data_import.import_phone_calls\` (Linux) and \`scripts/sync_phone_calls.py\` (native macOS) — were each hand-rolling \`SourceEntity(source_type='phone', source_id=f'phone_{phone}', ...)\`. If the \`phone_{e164}\` convention ever changed, one site would update and the other would silently produce duplicates.

- Added \`api/services/source_entity.create_phone_source_entity\` alongside the other factories.
- Both import paths now consume the factory; the upsert / link surrounding logic is unchanged.

## Commit 2 — \`backup_retention\` module (#227)

The tiered retention introduced in PR #225 lived inside \`interaction_store.py\` with a private \`_prune_backups\` hardcoded to \`interactions.db.*.backup\`. The next store to need backups (\`crm.db\`, \`sync_health.db\`, …) would either copy-paste the bucket math or reach into the private helper.

- New \`api/services/backup_retention.py\` module owns the policy:
  - \`backup_filename(basename, ts)\` — canonical name
  - \`parse_backup_timestamp(name, basename)\` — exact round-trip
  - \`prune(backup_dir, basename, *, policy, now)\` — apply tier math
  - \`RetentionPolicy\` dataclass + \`DEFAULT_POLICY\` constant
  - Basenames go through \`re.escape\` so \`crm.db\` can't accidentally match \`crmXdb\`
- \`interaction_store.py\` shrinks by ~90 lines; the private helpers stay as one-line delegating aliases so legacy test imports keep working.
- Dropped now-unused \`import re\` at module top.

## Test evidence

- 11 new tests in \`tests/test_backup_retention.py\`: round-trip; basename overmatch protection; per-basename segregation (deleting \`crm.db\` files doesn't touch \`interactions.db\` files in the same dir); custom \`RetentionPolicy\` actually changes the bucket math; \`DEFAULT_POLICY\` is frozen.
- 2 new tests in \`tests/test_source_entity.py\` for the phone factory.
- Existing \`tests/test_interaction_store.py::TestBackupRetention\` stays as the integration test via the legacy \`_prune_backups\` alias.
- \`pytest tests/test_backup_retention.py tests/test_interaction_store.py tests/test_source_entity.py tests/test_apple_pipeline.py\` → **124 passed**.

## Review focus

- **\`api/services/backup_retention.py\`** is the load-bearing new file. Read end-to-end — it's ~140 lines.
- **\`api/services/interaction_store.py:217-232\`** — the legacy alias block. The wrappers are intentionally thin and keep the private names so any test that imported them directly continues to work without modification.
- **\`scripts/sync_phone_calls.py:198-216\`** and **\`scripts/apple_data_import.py:383-400\`** — the factory call sites. Surrounding upsert / link logic intentionally unchanged.
- No behaviour change: bucket math is identical, retention defaults are identical, backup filenames are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)