### PR TITLE
chore: gitignore .mm/ session cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ vault/
 chromadb/
 .ralph/
 .playwright-mcp/
+.mm/
 
 # =============================================================================
 # DATE-PREFIXED DOCS (personal development notes)


### PR DESCRIPTION
## Summary

The `monarchmoney` library writes a copy of the session token to `.mm/mm_session.pickle` in cwd as a side effect of `interactive_login()`, in addition to the explicit `save_session()` path we use (`data/monarch_session.pickle`).

LifeOS only reads the \`data/\` copy via \`api.services.monarch.SESSION_PATH:25\`; the cwd one is a redundant credential file we don't want sitting at the repo root or showing up as untracked after every re-auth.

## Test evidence

- Pre-push hook: 1606 passed in 165.24s.
- Verified byte-identical pickles (md5 \`68704ffb...\`) before deleting the \`.mm/\` directory locally.

## Review focus

One-line gitignore addition next to the other tool-cache patterns (\`.ralph/\`, \`.playwright-mcp/\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)