### PR TITLE
feat(agent-viz): per-session summary + LLM short labels

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -117,6 +117,14 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to start task file watcher: {e}")
 
+    # Startup: Background prefetch for /agents session summaries — so the
+    # graph already shows real short labels by the time the operator looks.
+    try:
+        from api.services import agent_viz_summary_prefetch
+        agent_viz_summary_prefetch.start()
+    except Exception as e:
+        logger.error(f"Failed to start agent_viz prefetch loop: {e}")
+
     # Hint for new users who haven't set their person ID yet
     if not settings.my_person_id and settings.user_name and settings.user_name != "User":
         logger.info(
@@ -157,6 +165,12 @@ async def lifespan(app: FastAPI):
     if _job_queue:
         _job_queue.stop_worker()
         logger.info("Job queue worker stopped")
+
+    try:
+        from api.services import agent_viz_summary_prefetch
+        agent_viz_summary_prefetch.stop()
+    except Exception:
+        pass
 
 
 app = FastAPI(

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -188,13 +188,13 @@ def _session_to_dict(s: Session, transcript: TranscriptStore) -> dict[str, Any]:
         # block on the LLM — short labels for unfetched sessions appear when
         # the operator opens the panel.
         "short_label": _short_label_for_snapshot(
-            s.session_id, s.last_activity_at or 0.0
+            s.session_id, s.last_activity_at or 0.0, s.status or "",
         ),
     }
 
 
-def _short_label_for_snapshot(session_id: str, last_activity_at: float) -> str | None:
-    cached = agent_viz_summary.get_cached_summary(session_id, last_activity_at)
+def _short_label_for_snapshot(session_id: str, last_activity_at: float, status: str = "") -> str | None:
+    cached = agent_viz_summary.get_cached_summary(session_id, last_activity_at, status)
     return cached.short_label if cached else None
 
 
@@ -246,7 +246,11 @@ def _build_snapshot() -> dict[str, Any]:
     for sd in cc_sessions:
         sd.setdefault(
             "short_label",
-            _short_label_for_snapshot(sd.get("session_id") or "", sd.get("last_activity_at") or 0.0),
+            _short_label_for_snapshot(
+                sd.get("session_id") or "",
+                sd.get("last_activity_at") or 0.0,
+                sd.get("status") or "",
+            ),
         )
     session_dicts.extend(cc_sessions)
     edges.extend(cc_edges)
@@ -325,9 +329,10 @@ async def get_session_summary(session_id: str) -> dict[str, Any]:
     Cached by (session_id, last_activity_at). A session that hasn't moved
     since the last call gets a cache hit and zero LLM cost.
     """
-    # Resolve the session's label + last_activity_at + events.
+    # Resolve the session's label + last_activity_at + status + events.
     last_activity = 0.0
     label = session_id
+    status = ""
 
     if session_id.startswith("cc:"):
         if not _claude_code_enabled():
@@ -346,6 +351,7 @@ async def get_session_summary(session_id: str) -> dict[str, Any]:
         if match:
             label = str(match.get("label") or session_id)
             last_activity = float(match.get("last_activity_at") or 0.0)
+            status = str(match.get("status") or "")
     else:
         session_store = _get_session_store()
         s = session_store.get_by_session_id(session_id)
@@ -358,12 +364,14 @@ async def get_session_summary(session_id: str) -> dict[str, Any]:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         label = _label_for_session(s, events)
         last_activity = float(s.last_activity_at or 0.0)
+        status = s.status or ""
 
     result = await agent_viz_summary.summarize_session(
         session_id,
         label=label,
         last_activity_at=last_activity,
         events=events,
+        status=status,
     )
     return {"session_id": session_id, **result.as_dict()}
 

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -22,6 +22,7 @@ from api.services.agent_worker.session_store import (
     SessionStore,
 )
 from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services import agent_viz_summary
 
 logger = logging.getLogger(__name__)
 
@@ -182,7 +183,19 @@ def _session_to_dict(s: Session, transcript: TranscriptStore) -> dict[str, Any]:
         "last_event_kind": summary["last_event_kind"],
         "tool_call_count": summary["tool_call_count"],
         "error_count": summary["error_count"],
+        # Populated only if a previous /summary call has cached a result for
+        # this session at its current last_activity_at. Snapshot ticks never
+        # block on the LLM — short labels for unfetched sessions appear when
+        # the operator opens the panel.
+        "short_label": _short_label_for_snapshot(
+            s.session_id, s.last_activity_at or 0.0
+        ),
     }
+
+
+def _short_label_for_snapshot(session_id: str, last_activity_at: float) -> str | None:
+    cached = agent_viz_summary.get_cached_summary(session_id, last_activity_at)
+    return cached.short_label if cached else None
 
 
 def _claude_code_enabled() -> bool:
@@ -227,6 +240,14 @@ def _build_snapshot() -> dict[str, Any]:
     ]
 
     cc_sessions, cc_edges = _claude_code_snapshot()
+    # CC session dicts come from claude_code/session_ingest.py and don't carry
+    # the short_label field — attach it the same way (cached-only, no LLM in
+    # the snapshot path).
+    for sd in cc_sessions:
+        sd.setdefault(
+            "short_label",
+            _short_label_for_snapshot(sd.get("session_id") or "", sd.get("last_activity_at") or 0.0),
+        )
     session_dicts.extend(cc_sessions)
     edges.extend(cc_edges)
 
@@ -291,6 +312,60 @@ async def get_session_events(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     tail = events[-limit:] if len(events) > limit else events
     return {"session_id": session_id, "events": tail, "total": len(events)}
+
+
+@router.get("/sessions/{session_id}/summary")
+async def get_session_summary(session_id: str) -> dict[str, Any]:
+    """Concise "what did this session work on" summary for the /agents panel.
+
+    Pulls the first user message, final assistant message, and any PR
+    references out of the transcript, then asks the local Gemma LLM to
+    produce a short node label (2-6 words) and a 1-2 sentence recap.
+
+    Cached by (session_id, last_activity_at). A session that hasn't moved
+    since the last call gets a cache hit and zero LLM cost.
+    """
+    # Resolve the session's label + last_activity_at + events.
+    last_activity = 0.0
+    label = session_id
+
+    if session_id.startswith("cc:"):
+        if not _claude_code_enabled():
+            raise HTTPException(status_code=404, detail="claude_code viz disabled")
+        try:
+            from config.settings import settings
+            from api.services.claude_code import session_ingest as cc
+
+            events = cc.read_normalized_events(session_id, settings.claude_code_projects_dir)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        # Find this CC session in the cached snapshot to pull label + activity.
+        cc_sessions, _ = _claude_code_snapshot()
+        match = next((s for s in cc_sessions if s.get("session_id") == session_id), None)
+        if match:
+            label = str(match.get("label") or session_id)
+            last_activity = float(match.get("last_activity_at") or 0.0)
+    else:
+        session_store = _get_session_store()
+        s = session_store.get_by_session_id(session_id)
+        if s is None:
+            raise HTTPException(status_code=404, detail="session not found")
+        transcript_store = _get_transcript_store()
+        try:
+            events = transcript_store.read(session_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        label = _label_for_session(s, events)
+        last_activity = float(s.last_activity_at or 0.0)
+
+    result = await agent_viz_summary.summarize_session(
+        session_id,
+        label=label,
+        last_activity_at=last_activity,
+        events=events,
+    )
+    return {"session_id": session_id, **result.as_dict()}
 
 
 @router.get("/stream")

--- a/api/services/agent_viz_summary.py
+++ b/api/services/agent_viz_summary.py
@@ -45,11 +45,56 @@ class SummaryResult:
         return {"short_label": self.short_label, "summary": self.summary}
 
 
-# In-process cache key: session_id → (last_activity_at, SummaryResult). When
-# the session's last_activity_at advances, the entry is recomputed. Disk cache
-# (below) is the durable layer; this just keeps hot reads fingertip-fast.
-_cache: dict[str, tuple[float, SummaryResult]] = {}
+# In-process cache: session_id → (last_activity_at, created_at, SummaryResult).
+# Disk cache (below) is the durable layer; this just keeps hot reads
+# fingertip-fast. `created_at` is wall-clock seconds at write time and feeds
+# the live-session grace window below.
+_cache: dict[str, tuple[float, float, SummaryResult]] = {}
 _CACHE_MAX = 500
+
+# Non-terminal sessions move `last_activity_at` on every tool call. Without
+# a grace window the cache would be stale within seconds of being written
+# and the prefetch loop would burn Gemma cycles re-summarizing the same hot
+# session every tick. A cached summary for a live session counts as "fresh
+# enough" for this many seconds — only after that do we re-summarize on
+# next access. Terminal sessions ignore this grace and use cache forever.
+_LIVE_REFRESH_GRACE_SECONDS = 60 * 60  # 60 min
+
+# Statuses that mean the session is done and `last_activity_at` is frozen.
+# Imported lazily inside _is_terminal so this module stays importable
+# without the agent_worker package on tests/standalone scripts.
+_TERMINAL_STATUSES_CACHE: frozenset[str] | None = None
+
+
+def _is_terminal(status: str) -> bool:
+    global _TERMINAL_STATUSES_CACHE
+    if _TERMINAL_STATUSES_CACHE is None:
+        try:
+            from api.services.agent_worker.session_store import TERMINAL_STATUSES
+            _TERMINAL_STATUSES_CACHE = frozenset(TERMINAL_STATUSES)
+        except Exception:  # noqa: BLE001
+            _TERMINAL_STATUSES_CACHE = frozenset({
+                "completed", "failed", "budget_exceeded", "killed", "cascade_killed",
+            })
+    return (status or "") in _TERMINAL_STATUSES_CACHE
+
+
+def _is_fresh_enough(cached_activity: float, cached_created_at: float,
+                     new_activity: float, status: str) -> bool:
+    """True iff the cached summary can be served even though the session
+    may have advanced. Terminal: always (activity is frozen). Live: only
+    if the cache is within the grace window AND we haven't already
+    invalidated it via the activity timestamp."""
+    # Exact match on activity → never stale regardless of status.
+    if cached_activity >= new_activity:
+        return True
+    # Activity moved forward. Terminal sessions shouldn't reach here
+    # (activity is frozen), but if status is somehow misreported treat
+    # them as not-fresh and re-summarize.
+    if _is_terminal(status):
+        return False
+    # Live session: cached entry stays valid for the grace window.
+    return (time.time() - cached_created_at) < _LIVE_REFRESH_GRACE_SECONDS
 
 # --- Disk cache (SQLite) ---------------------------------------------------
 # Survives server restarts so we never re-summarize a terminal session twice.
@@ -91,11 +136,14 @@ def _init_db() -> None:
         conn.commit()
 
 
-def _disk_get(session_id: str, last_activity_at: float) -> SummaryResult | None:
+def _disk_get(session_id: str, last_activity_at: float, status: str = "") -> SummaryResult | None:
+    """Read the disk cache. Honors the live-session grace window so a hot
+    session doesn't get re-summarized on every tick of the prefetch loop.
+    """
     try:
         with sqlite3.connect(_resolve_db_path()) as conn:
             row = conn.execute(
-                "SELECT last_activity_at, short_label, summary "
+                "SELECT last_activity_at, short_label, summary, created_at "
                 "FROM agent_viz_summary WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
@@ -104,9 +152,8 @@ def _disk_get(session_id: str, last_activity_at: float) -> SummaryResult | None:
         return None
     if not row:
         return None
-    cached_activity, short_label, summary = row
-    # Stale: the session has moved since we summarized it.
-    if cached_activity < last_activity_at:
+    cached_activity, short_label, summary, created_at = row
+    if not _is_fresh_enough(cached_activity, float(created_at), last_activity_at, status):
         return None
     return SummaryResult(short_label=short_label, summary=summary)
 
@@ -312,22 +359,30 @@ async def summarize_session(
     label: str,
     last_activity_at: float,
     events: list[dict[str, Any]],
+    status: str = "",
 ) -> SummaryResult:
     """Return cached summary or compute a fresh one.
 
     Caller passes events (already fetched) so this module doesn't take a
     dependency on the transcript store / claude_code ingest dispatch logic
     that already lives in api/routes/agents.py.
+
+    `status` controls live-session staleness handling — terminal sessions
+    cache forever; non-terminal ones get a grace window
+    (_LIVE_REFRESH_GRACE_SECONDS) before being re-summarized even when
+    `last_activity_at` advances.
     """
     cached = _cache.get(session_id)
-    if cached and cached[0] >= last_activity_at:
-        return cached[1]
+    if cached:
+        cached_activity, cached_created_at, cached_result = cached
+        if _is_fresh_enough(cached_activity, cached_created_at, last_activity_at, status):
+            return cached_result
 
     # Disk cache check — populated by a previous call (possibly across a
     # restart). Promotes into the in-process cache on hit.
-    disk_hit = _disk_get(session_id, last_activity_at)
+    disk_hit = _disk_get(session_id, last_activity_at, status)
     if disk_hit is not None:
-        _cache[session_id] = (last_activity_at, disk_hit)
+        _cache[session_id] = (last_activity_at, time.time(), disk_hit)
         return disk_hit
 
     ctx = _extract_context(events)
@@ -378,24 +433,27 @@ async def summarize_session(
     result = SummaryResult(short_label=short_label, summary=summary)
     if len(_cache) >= _CACHE_MAX:
         _cache.pop(next(iter(_cache)))
-    _cache[session_id] = (last_activity_at, result)
+    now = time.time()
+    _cache[session_id] = (last_activity_at, now, result)
     _disk_put(session_id, last_activity_at, result)
     return result
 
 
-def get_cached_summary(session_id: str, last_activity_at: float) -> SummaryResult | None:
+def get_cached_summary(session_id: str, last_activity_at: float, status: str = "") -> SummaryResult | None:
     """Synchronous peek for the snapshot path — never triggers an LLM call.
 
     Checks the in-process cache first, then the disk cache. A hit on disk is
     promoted into the in-process cache so subsequent snapshot ticks are
-    free.
+    free. Honors the live-session grace window via `status`.
     """
     cached = _cache.get(session_id)
-    if cached and cached[0] >= last_activity_at:
-        return cached[1]
-    disk = _disk_get(session_id, last_activity_at)
+    if cached:
+        cached_activity, cached_created_at, cached_result = cached
+        if _is_fresh_enough(cached_activity, cached_created_at, last_activity_at, status):
+            return cached_result
+    disk = _disk_get(session_id, last_activity_at, status)
     if disk is not None:
-        _cache[session_id] = (last_activity_at, disk)
+        _cache[session_id] = (last_activity_at, time.time(), disk)
         return disk
     return None
 

--- a/api/services/agent_viz_summary.py
+++ b/api/services/agent_viz_summary.py
@@ -226,14 +226,15 @@ async def summarize_session(
     prompt = _build_prompt(label, ctx)
     try:
         # Gemma 4 burns most of its budget on reasoning_content; only
-        # `content` is returned in `text` by LocalLLMClient. A tight cap
-        # (e.g. 600) regularly truncates the JSON mid-string. 2000 leaves
-        # ample room for the actual response body after reasoning.
+        # `content` is returned in `text` by LocalLLMClient. Anything under
+        # ~3000 tokens regularly hits the cap mid-reasoning, leaving content
+        # empty. Observed real CC sessions used ~2400 completion tokens
+        # (≈9.5k chars reasoning + 200 chars JSON), so 4096 is the floor.
         text = await generate_text(
             prompt,
-            max_tokens=2000,
+            max_tokens=4096,
             temperature=0.2,
-            timeout=90.0,
+            timeout=120.0,
         )
         data = extract_json(text)
         short_label = str(data.get("short_label") or "").strip()

--- a/api/services/agent_viz_summary.py
+++ b/api/services/agent_viz_summary.py
@@ -1,0 +1,272 @@
+"""Per-session "what did this agent work on?" summaries for the /agents UI.
+
+Extracts a small context window from a session's transcript — the first user
+message, the final assistant message, and any PR titles/URLs mentioned — and
+asks the local Gemma LLM to produce two outputs:
+
+    short_label: 2-6 word node label
+    summary:     1-2 sentence / bullet recap
+
+Results are cached by (session_id, last_activity_at) so a session that hasn't
+moved doesn't re-summarize on every panel open or snapshot tick.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from api.services.llm_client import extract_json, generate_text
+
+logger = logging.getLogger(__name__)
+
+# Cap how much text we ship to Gemma. Generous enough that a chunky final
+# message survives, tight enough that a 5000-event transcript doesn't drown
+# the prompt.
+_FIRST_MSG_CAP = 1500
+_FINAL_MSG_CAP = 2500
+_PR_CAP = 8
+
+_GH_PR_URL_RE = re.compile(r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
+_GH_PR_CREATE_RE = re.compile(r"gh\s+pr\s+create\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    short_label: str
+    summary: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"short_label": self.short_label, "summary": self.summary}
+
+
+# Cache key: session_id → (last_activity_at, SummaryResult). When the session's
+# last_activity_at advances, the entry is recomputed.
+_cache: dict[str, tuple[float, SummaryResult]] = {}
+_CACHE_MAX = 500
+
+
+def _trim(text: str, cap: int) -> str:
+    text = (text or "").strip()
+    if len(text) <= cap:
+        return text
+    return text[: cap - 1] + "…"
+
+
+def _extract_text_from_payload(payload: Any) -> str:
+    """Pull a plain-text body from a normalized transcript payload."""
+    if not isinstance(payload, dict):
+        return ""
+    text = payload.get("text")
+    if isinstance(text, str) and text.strip():
+        return text
+    # CC assistant_message has tool_uses but no text — return ""
+    final_text = payload.get("final_text")
+    if isinstance(final_text, str):
+        return final_text
+    return ""
+
+
+def _scan_prs(events: list[dict[str, Any]]) -> list[str]:
+    """Find PR references in tool calls and assistant text.
+
+    Returns a list of short descriptors (URL or `gh pr create` title fragment).
+    Deduped, capped at _PR_CAP.
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def add(s: str) -> None:
+        s = s.strip()
+        if not s or s in seen:
+            return
+        seen.add(s)
+        found.append(s)
+
+    for ev in events:
+        if len(found) >= _PR_CAP:
+            break
+        payload = ev.get("payload") or {}
+        if not isinstance(payload, dict):
+            continue
+        kind = ev.get("kind") or ""
+
+        # LifeOS-style tool_call payload
+        if kind == "tool_call":
+            tool = str(payload.get("tool") or "")
+            args = payload.get("arguments") or {}
+            if isinstance(args, dict):
+                cmd = str(args.get("command") or "")
+                if tool == "Bash" and _GH_PR_CREATE_RE.search(cmd):
+                    title_match = re.search(r"--title\s+['\"]([^'\"]+)", cmd)
+                    body_match = re.search(r"--body\s+['\"]([^'\"]+)", cmd)
+                    bits = []
+                    if title_match:
+                        bits.append(title_match.group(1))
+                    if body_match:
+                        bits.append(body_match.group(1)[:200])
+                    if bits:
+                        add(" — ".join(bits))
+                    else:
+                        add("gh pr create (no title parsed)")
+
+        # Free-form text in any payload — assistant_message / completed / etc.
+        for key in ("text", "final_text"):
+            val = payload.get(key)
+            if isinstance(val, str):
+                for m in _GH_PR_URL_RE.findall(val):
+                    add(m)
+
+        # CC tool_result content_preview can contain a PR URL too
+        results = payload.get("tool_results")
+        if isinstance(results, list):
+            for tr in results:
+                if isinstance(tr, dict):
+                    preview = tr.get("content_preview")
+                    if isinstance(preview, str):
+                        for m in _GH_PR_URL_RE.findall(preview):
+                            add(m)
+    return found
+
+
+def _extract_context(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Pull the three context fragments Gemma will summarize."""
+    first_user = ""
+    final_assistant = ""
+
+    for ev in events:
+        if first_user:
+            break
+        kind = ev.get("kind") or ""
+        if kind in ("user_message", "seed"):
+            txt = _extract_text_from_payload(ev.get("payload"))
+            if txt:
+                first_user = txt
+
+    # Walk backwards for the final assistant/completed message.
+    for ev in reversed(events):
+        if final_assistant:
+            break
+        kind = ev.get("kind") or ""
+        if kind in ("assistant_message", "completed"):
+            txt = _extract_text_from_payload(ev.get("payload"))
+            if txt:
+                final_assistant = txt
+
+    return {
+        "first_user": _trim(first_user, _FIRST_MSG_CAP),
+        "final_assistant": _trim(final_assistant, _FINAL_MSG_CAP),
+        "prs": _scan_prs(events),
+    }
+
+
+def _build_prompt(label: str, ctx: dict[str, Any]) -> str:
+    parts: list[str] = [
+        "You are summarizing an AI coding agent's work session for a status dashboard.",
+        "Return STRICT JSON with two fields:",
+        '  "short_label": 2-6 words, Title Case, no trailing period — a node label',
+        '  "summary": 1-2 sentences OR up to 4 short bullets (markdown "- "), max ~80 words',
+        "",
+        "Focus on WHAT the agent worked on / accomplished, not the framing.",
+        "Be concrete: name the feature/bug/file area. Do not hedge.",
+        "",
+        f"Session label (from task description): {label}",
+        "",
+    ]
+    if ctx["first_user"]:
+        parts.append("--- Original request ---")
+        parts.append(ctx["first_user"])
+        parts.append("")
+    if ctx["prs"]:
+        parts.append("--- Pull requests produced ---")
+        for pr in ctx["prs"]:
+            parts.append(f"- {pr}")
+        parts.append("")
+    if ctx["final_assistant"]:
+        parts.append("--- Final agent message ---")
+        parts.append(ctx["final_assistant"])
+        parts.append("")
+    parts.append('Respond with JSON only, no prose: {"short_label": "...", "summary": "..."}')
+    return "\n".join(parts)
+
+
+def _fallback_label(label: str) -> str:
+    """Heuristic short label when LLM is unavailable or returns garbage."""
+    words = re.findall(r"[A-Za-z0-9][A-Za-z0-9'_-]*", label or "")
+    return " ".join(words[:5]).strip() or "Untitled"
+
+
+async def summarize_session(
+    session_id: str,
+    *,
+    label: str,
+    last_activity_at: float,
+    events: list[dict[str, Any]],
+) -> SummaryResult:
+    """Return cached summary or compute a fresh one.
+
+    Caller passes events (already fetched) so this module doesn't take a
+    dependency on the transcript store / claude_code ingest dispatch logic
+    that already lives in api/routes/agents.py.
+    """
+    cached = _cache.get(session_id)
+    if cached and cached[0] >= last_activity_at:
+        return cached[1]
+
+    ctx = _extract_context(events)
+    # If we have nothing to summarize, return a deterministic fallback so the
+    # UI still gets *something*. Don't cache (next time we may have content).
+    if not ctx["first_user"] and not ctx["final_assistant"] and not ctx["prs"]:
+        return SummaryResult(
+            short_label=_fallback_label(label),
+            summary="(No transcript content yet.)",
+        )
+
+    prompt = _build_prompt(label, ctx)
+    try:
+        # Gemma 4 burns most of its budget on reasoning_content; only
+        # `content` is returned in `text` by LocalLLMClient. A tight cap
+        # (e.g. 600) regularly truncates the JSON mid-string. 2000 leaves
+        # ample room for the actual response body after reasoning.
+        text = await generate_text(
+            prompt,
+            max_tokens=2000,
+            temperature=0.2,
+            timeout=90.0,
+        )
+        data = extract_json(text)
+        short_label = str(data.get("short_label") or "").strip()
+        summary = str(data.get("summary") or "").strip()
+        if not short_label:
+            short_label = _fallback_label(label)
+        if not summary:
+            summary = "(empty summary)"
+        # Clamp short_label hard so a runaway response doesn't blow up the node.
+        words = short_label.split()
+        if len(words) > 7:
+            short_label = " ".join(words[:7])
+    except Exception as exc:  # noqa: BLE001 — never break the panel on summary failure
+        logger.warning("session summary failed for %s: %s", session_id, exc)
+        return SummaryResult(
+            short_label=_fallback_label(label),
+            summary=f"(Summary unavailable: {type(exc).__name__})",
+        )
+
+    result = SummaryResult(short_label=short_label, summary=summary)
+    if len(_cache) >= _CACHE_MAX:
+        _cache.pop(next(iter(_cache)))
+    _cache[session_id] = (last_activity_at, result)
+    return result
+
+
+def get_cached_summary(session_id: str, last_activity_at: float) -> SummaryResult | None:
+    """Synchronous peek for the snapshot path — never triggers an LLM call."""
+    cached = _cache.get(session_id)
+    if cached and cached[0] >= last_activity_at:
+        return cached[1]
+    return None
+
+
+def reset_cache() -> None:
+    _cache.clear()

--- a/api/services/agent_viz_summary.py
+++ b/api/services/agent_viz_summary.py
@@ -230,11 +230,16 @@ async def summarize_session(
         # ~3000 tokens regularly hits the cap mid-reasoning, leaving content
         # empty. Observed real CC sessions used ~2400 completion tokens
         # (≈9.5k chars reasoning + 200 chars JSON), so 4096 is the floor.
+        #
+        # 240s timeout: a fresh fast-path summary lands in ~25-30s, but when
+        # Gemma is already serving chat / the agent worker, the queue can push
+        # past 120s. The frontend has its own 5-minute abort, so this is the
+        # outer bound for "Gemma will finish eventually" before we give up.
         text = await generate_text(
             prompt,
             max_tokens=4096,
             temperature=0.2,
-            timeout=120.0,
+            timeout=240.0,
         )
         data = extract_json(text)
         short_label = str(data.get("short_label") or "").strip()

--- a/api/services/agent_viz_summary.py
+++ b/api/services/agent_viz_summary.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 
 import logging
 import re
+import sqlite3
+import threading
+import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from api.services.llm_client import extract_json, generate_text
@@ -41,10 +45,115 @@ class SummaryResult:
         return {"short_label": self.short_label, "summary": self.summary}
 
 
-# Cache key: session_id → (last_activity_at, SummaryResult). When the session's
-# last_activity_at advances, the entry is recomputed.
+# In-process cache key: session_id → (last_activity_at, SummaryResult). When
+# the session's last_activity_at advances, the entry is recomputed. Disk cache
+# (below) is the durable layer; this just keeps hot reads fingertip-fast.
 _cache: dict[str, tuple[float, SummaryResult]] = {}
 _CACHE_MAX = 500
+
+# --- Disk cache (SQLite) ---------------------------------------------------
+# Survives server restarts so we never re-summarize a terminal session twice.
+# Co-located under data/ next to other observability stores. WAL so concurrent
+# request handlers don't serialize on writes.
+
+_DB_PATH: str | None = None
+_DB_LOCK = threading.Lock()
+
+
+def _resolve_db_path() -> str:
+    global _DB_PATH
+    if _DB_PATH is None:
+        try:
+            from config.settings import settings
+            data_dir = Path(settings.chroma_path).parent
+        except Exception:  # noqa: BLE001
+            data_dir = Path("data")
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _DB_PATH = str(data_dir / "agent_viz_summaries.db")
+    return _DB_PATH
+
+
+def _init_db() -> None:
+    path = _resolve_db_path()
+    with sqlite3.connect(path) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_viz_summary (
+                session_id TEXT PRIMARY KEY,
+                last_activity_at REAL NOT NULL,
+                short_label TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+
+def _disk_get(session_id: str, last_activity_at: float) -> SummaryResult | None:
+    try:
+        with sqlite3.connect(_resolve_db_path()) as conn:
+            row = conn.execute(
+                "SELECT last_activity_at, short_label, summary "
+                "FROM agent_viz_summary WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+    except sqlite3.Error as exc:
+        logger.debug("disk cache read failed for %s: %s", session_id, exc)
+        return None
+    if not row:
+        return None
+    cached_activity, short_label, summary = row
+    # Stale: the session has moved since we summarized it.
+    if cached_activity < last_activity_at:
+        return None
+    return SummaryResult(short_label=short_label, summary=summary)
+
+
+def _disk_put(session_id: str, last_activity_at: float, result: SummaryResult) -> None:
+    try:
+        with _DB_LOCK, sqlite3.connect(_resolve_db_path()) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO agent_viz_summary "
+                "(session_id, last_activity_at, short_label, summary, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (session_id, last_activity_at, result.short_label, result.summary, int(time.time())),
+            )
+            conn.commit()
+    except sqlite3.Error as exc:
+        # Persistence is best-effort — never block a successful summary on
+        # a disk write failure (full disk, permissions, locked DB, …).
+        logger.warning("disk cache write failed for %s: %s", session_id, exc)
+
+
+def prune_disk_cache(max_age_days: int = 90, max_rows: int = 5000) -> int:
+    """Drop rows older than `max_age_days`; if still over `max_rows`, drop
+    oldest. Returns count deleted. Safe to call from a periodic task or
+    leave unscheduled — the table is bounded by session count anyway.
+    """
+    cutoff = int(time.time()) - max_age_days * 86400
+    deleted = 0
+    try:
+        with _DB_LOCK, sqlite3.connect(_resolve_db_path()) as conn:
+            cur = conn.execute(
+                "DELETE FROM agent_viz_summary WHERE created_at < ?", (cutoff,)
+            )
+            deleted += cur.rowcount
+            (count,) = conn.execute("SELECT COUNT(*) FROM agent_viz_summary").fetchone()
+            if count > max_rows:
+                cur = conn.execute(
+                    "DELETE FROM agent_viz_summary WHERE session_id IN ("
+                    "  SELECT session_id FROM agent_viz_summary "
+                    "  ORDER BY created_at ASC LIMIT ?"
+                    ")",
+                    (count - max_rows,),
+                )
+                deleted += cur.rowcount
+            conn.commit()
+    except sqlite3.Error as exc:
+        logger.warning("disk cache prune failed: %s", exc)
+    return deleted
 
 
 def _trim(text: str, cap: int) -> str:
@@ -214,6 +323,13 @@ async def summarize_session(
     if cached and cached[0] >= last_activity_at:
         return cached[1]
 
+    # Disk cache check — populated by a previous call (possibly across a
+    # restart). Promotes into the in-process cache on hit.
+    disk_hit = _disk_get(session_id, last_activity_at)
+    if disk_hit is not None:
+        _cache[session_id] = (last_activity_at, disk_hit)
+        return disk_hit
+
     ctx = _extract_context(events)
     # If we have nothing to summarize, return a deterministic fallback so the
     # UI still gets *something*. Don't cache (next time we may have content).
@@ -263,16 +379,33 @@ async def summarize_session(
     if len(_cache) >= _CACHE_MAX:
         _cache.pop(next(iter(_cache)))
     _cache[session_id] = (last_activity_at, result)
+    _disk_put(session_id, last_activity_at, result)
     return result
 
 
 def get_cached_summary(session_id: str, last_activity_at: float) -> SummaryResult | None:
-    """Synchronous peek for the snapshot path — never triggers an LLM call."""
+    """Synchronous peek for the snapshot path — never triggers an LLM call.
+
+    Checks the in-process cache first, then the disk cache. A hit on disk is
+    promoted into the in-process cache so subsequent snapshot ticks are
+    free.
+    """
     cached = _cache.get(session_id)
     if cached and cached[0] >= last_activity_at:
         return cached[1]
+    disk = _disk_get(session_id, last_activity_at)
+    if disk is not None:
+        _cache[session_id] = (last_activity_at, disk)
+        return disk
     return None
 
 
 def reset_cache() -> None:
+    """Clear in-process cache only. Use for tests; disk cache survives."""
     _cache.clear()
+
+
+# Initialize the DB lazily on first import — cheap (just ensures the schema
+# exists) and avoids forcing every test that imports this module to set up
+# a temp DB path. _resolve_db_path() picks up settings at call time.
+_init_db()

--- a/api/services/agent_viz_summary_prefetch.py
+++ b/api/services/agent_viz_summary_prefetch.py
@@ -104,7 +104,11 @@ async def _summarize_one(session: dict[str, Any]) -> bool:
 
     try:
         await agent_viz_summary.summarize_session(
-            sid, label=label, last_activity_at=last_activity, events=events,
+            sid,
+            label=label,
+            last_activity_at=last_activity,
+            events=events,
+            status=str(session.get("status") or ""),
         )
         return True
     except Exception as exc:  # noqa: BLE001

--- a/api/services/agent_viz_summary_prefetch.py
+++ b/api/services/agent_viz_summary_prefetch.py
@@ -1,0 +1,188 @@
+"""Background worker that pre-computes /agents session summaries.
+
+The lazy click-on-demand model (api/services/agent_viz_summary.py) means a
+fresh first view spends ~25-30s in Gemma. This worker walks the snapshot
+between user actions, summarizes any session that doesn't have a cached
+short_label yet, and yields when the agent worker is actively using Gemma —
+so a node label is usually ready by the time the operator looks.
+
+Disabled by default in tests; enabled via LIFEOS_AGENT_VIZ_PREFETCH_ENABLED.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from api.services import agent_viz_summary
+
+logger = logging.getLogger(__name__)
+
+# Tick cadence — how often to look for a session to summarize. One summary
+# per tick keeps the queue depth shallow and avoids hogging Gemma.
+_TICK_SECONDS = 20.0
+
+# When the agent worker is hot, skip our turn entirely so the worker's
+# real-time Gemma calls aren't queued behind a cosmetic prefetch.
+_BUSY_SKIP_TICKS = 1
+
+# A session that just failed to summarize gets this many ticks of cooldown
+# before we try it again — bounds retry loops on permanently-broken inputs.
+_FAILURE_BACKOFF_TICKS = 30
+
+_task: asyncio.Task[None] | None = None
+
+
+def _agent_worker_busy() -> bool:
+    """Return True if a LifeOS agent worker session is actively running.
+
+    We avoid competing with the worker for Gemma cycles — a real agent
+    Gemma call already takes seconds; piling a 30s summary on top is the
+    fastest way to make the worker feel sluggish. Best-effort: any failure
+    in the lookup is treated as "not busy" so a broken store doesn't
+    permanently stall the prefetcher.
+    """
+    try:
+        from api.services.agent_worker.session_store import SessionStore, STATUS_RUNNING
+        store = SessionStore()
+        for s in store.list_sessions(limit=50):
+            if s.status == STATUS_RUNNING and (s.routing or "local") == "local":
+                return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("agent worker busy check failed: %s", exc)
+    return False
+
+
+def _candidate_sessions() -> list[dict[str, Any]]:
+    """Sessions worth prefetching: no cached short_label, ordered by
+    "summary will be most valuable" — terminal sessions first (their
+    summary is permanently valid), then live ones (in case the operator
+    is about to look)."""
+    try:
+        from api.routes.agents import _build_snapshot
+        snap = _build_snapshot()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("prefetch snapshot build failed: %s", exc)
+        return []
+    from api.services.agent_worker.session_store import TERMINAL_STATUSES
+
+    pending: list[dict[str, Any]] = []
+    for s in snap.get("sessions", []):
+        if s.get("short_label"):
+            continue
+        # is_subagent CC nodes synthesize from a parent transcript — skip.
+        if s.get("is_subagent"):
+            continue
+        pending.append(s)
+    pending.sort(key=lambda s: (
+        0 if s.get("status") in TERMINAL_STATUSES else 1,  # terminal first
+        -(s.get("last_activity_at") or 0),                  # recent within bucket
+    ))
+    return pending
+
+
+async def _summarize_one(session: dict[str, Any]) -> bool:
+    """Summarize a single session. Returns True on success, False on failure."""
+    sid = session["session_id"]
+    last_activity = float(session.get("last_activity_at") or 0.0)
+    label = session.get("label") or sid
+
+    # Pull events the same way the /summary route does — dispatch by cc:
+    # prefix because the two stores live in different modules.
+    try:
+        if sid.startswith("cc:"):
+            from config.settings import settings
+            from api.services.claude_code import session_ingest as cc
+            events = cc.read_normalized_events(sid, settings.claude_code_projects_dir)
+        else:
+            from api.services.agent_worker.transcript_store import TranscriptStore
+            events = TranscriptStore().read(sid)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("prefetch event load failed for %s: %s", sid, exc)
+        return False
+
+    try:
+        await agent_viz_summary.summarize_session(
+            sid, label=label, last_activity_at=last_activity, events=events,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("prefetch summarize failed for %s: %s", sid, exc)
+        return False
+
+
+async def _prefetch_loop() -> None:
+    """Main loop. One summary per tick; backs off when worker is busy or
+    when a candidate just failed."""
+    # Per-session cooldown: session_id → tick index when we may retry.
+    cooldown: dict[str, int] = {}
+    tick = 0
+    consecutive_busy = 0
+
+    while True:
+        tick += 1
+        try:
+            if _agent_worker_busy():
+                consecutive_busy += 1
+                # Log a heartbeat occasionally so the operator can see why
+                # the queue isn't draining when the worker is running hot.
+                if consecutive_busy % 10 == 1:
+                    logger.info(
+                        "agent_viz prefetch yielding to agent worker "
+                        "(%d ticks)", consecutive_busy,
+                    )
+                await asyncio.sleep(_TICK_SECONDS * _BUSY_SKIP_TICKS)
+                continue
+            consecutive_busy = 0
+
+            for session in _candidate_sessions():
+                sid = session["session_id"]
+                cd = cooldown.get(sid, 0)
+                if cd > tick:
+                    continue
+                started = time.time()
+                ok = await _summarize_one(session)
+                elapsed = time.time() - started
+                if ok:
+                    logger.info(
+                        "agent_viz prefetch: summarized %s in %.1fs",
+                        sid, elapsed,
+                    )
+                else:
+                    cooldown[sid] = tick + _FAILURE_BACKOFF_TICKS
+                # Only do one per tick — keeps Gemma queue shallow.
+                break
+        except asyncio.CancelledError:
+            logger.info("agent_viz prefetch loop cancelled")
+            raise
+        except Exception:  # noqa: BLE001 — never let the loop die quietly
+            logger.exception("agent_viz prefetch loop tick failed")
+        await asyncio.sleep(_TICK_SECONDS)
+
+
+def start() -> None:
+    """Launch the background loop. Idempotent — calling twice is a no-op."""
+    global _task
+    if _task is not None and not _task.done():
+        return
+    try:
+        from config.settings import settings
+        enabled = bool(getattr(settings, "agent_viz_prefetch_enabled", True))
+    except Exception:  # noqa: BLE001
+        enabled = True
+    if not enabled:
+        logger.info("agent_viz prefetch disabled via settings")
+        return
+    loop = asyncio.get_event_loop()
+    _task = loop.create_task(_prefetch_loop(), name="agent_viz_prefetch")
+    logger.info("agent_viz prefetch loop started (tick=%ds)", int(_TICK_SECONDS))
+
+
+def stop() -> None:
+    """Cancel the loop on shutdown."""
+    global _task
+    if _task is None:
+        return
+    _task.cancel()
+    _task = None

--- a/config/settings.py
+++ b/config/settings.py
@@ -176,6 +176,15 @@ class Settings(BaseSettings):
                     "Set to 0 to disable confirmation (auto-dispatch all "
                     "managed tasks regardless of estimate)."
     )
+    agent_viz_prefetch_enabled: bool = Field(
+        default=True,
+        alias="LIFEOS_AGENT_VIZ_PREFETCH_ENABLED",
+        description="When true, a background loop walks the /agents snapshot "
+                    "between user actions and pre-computes Gemma summaries for "
+                    "any session that doesn't already have one cached, yielding "
+                    "to the agent worker when it's running. Set false to make "
+                    "summaries strictly click-on-demand."
+    )
     claude_code_viz_enabled: bool = Field(
         default=True,
         alias="LIFEOS_CLAUDE_CODE_VIZ_ENABLED",

--- a/web/agents.html
+++ b/web/agents.html
@@ -284,6 +284,40 @@
     text-align: center;
     font-size: 0.85rem;
   }
+  .session-summary {
+    padding: 0.55rem 0.7rem 0.65rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-elev);
+    font-size: 0.78rem;
+    line-height: 1.45;
+  }
+  .session-summary .ss-label {
+    font-size: 0.65rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.25rem;
+  }
+  .session-summary .ss-short {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 0.92rem;
+    margin-bottom: 0.35rem;
+  }
+  .session-summary .ss-body {
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .session-summary .ss-body ul {
+    margin: 0.1rem 0 0;
+    padding-left: 1.1rem;
+  }
+  .session-summary .ss-body li { margin: 0.1rem 0; }
+  .session-summary.loading .ss-body {
+    color: var(--text-dim);
+    font-style: italic;
+  }
   .events {
     flex: 1;
     overflow-y: auto;
@@ -958,6 +992,11 @@
   }
 
   function nodeLabel(d) {
+    // Prefer the LLM-generated short label when we have one — it tells the
+    // operator what the session is actually about, which is far more useful
+    // than knowing it ran on Opus vs. Sonnet. Falls back to the model badge
+    // until the summary is fetched (lazy, on panel open).
+    if (d.short_label) return d.short_label;
     const isCc = d.source === 'claude_code';
     let label = d.model_label || routingLabel(d.routing) || d.session_id.slice(0, 8);
     if (isCc && label === 'Claude Code') label = '?';
@@ -1229,6 +1268,11 @@
           <span class="badge" data-field="tokens">${s.total_input_tokens}↓ / ${s.total_output_tokens}↑</span>
           <span data-field="depth">${s.spawn_depth ? `<span class="badge">depth ${s.spawn_depth}</span>` : ''}</span>
         </div>
+      </div>
+      <div class="session-summary loading" id="session-summary">
+        <div class="ss-label">Summary</div>
+        <div class="ss-short" data-field="ss-short">${escapeHtml(s.short_label || '')}</div>
+        <div class="ss-body" data-field="ss-body">Summarizing…</div>
       </div>
       <div class="events" id="events"></div>
     `;
@@ -1502,6 +1546,7 @@
     const s = allSessions.find(x => x.session_id === sessionId);
     if (!s) return;
     renderPanelHeader(s);
+    fetchSessionSummary(sessionId);
 
     // Backfill then live tail.
     fetch(`/api/agents/sessions/${encodeURIComponent(sessionId)}/events?limit=200`)
@@ -1529,6 +1574,58 @@
         const e = document.getElementById('events');
         if (e) e.innerHTML = `<div class="event">Failed to load events: ${escapeHtml(String(err))}</div>`;
       });
+  }
+
+  // Fetch and render the LLM-generated session summary. Decoupled from the
+  // event stream — slow LLM calls won't block transcript display. The panel
+  // header shows "Summarizing…" until this resolves.
+  async function fetchSessionSummary(sessionId) {
+    try {
+      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(sessionId)}/summary`);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const data = await r.json();
+      // Bail if the operator moved on to a different session while we waited.
+      if (sessionId !== selectedSessionId) return;
+      const wrap = document.getElementById('session-summary');
+      if (!wrap) return;
+      wrap.classList.remove('loading');
+      const shortEl = wrap.querySelector('[data-field="ss-short"]');
+      const bodyEl = wrap.querySelector('[data-field="ss-body"]');
+      if (shortEl) shortEl.textContent = data.short_label || '';
+      if (bodyEl) bodyEl.innerHTML = renderSummaryBody(data.summary || '');
+      // Patch the in-memory session so subsequent snapshot ticks pick up the
+      // short label. Also nudge the corresponding node immediately so the
+      // operator doesn't wait up to 2s for the next tick.
+      const s = allSessions.find(x => x.session_id === sessionId);
+      if (s && data.short_label) {
+        s.short_label = data.short_label;
+        nodeLayer.selectAll('.node')
+          .filter(d => d.session_id === sessionId)
+          .each(function(d) { d.short_label = data.short_label; })
+          .select('text.node-label')
+          .text(d => nodeLabel(d));
+      }
+    } catch (err) {
+      if (sessionId !== selectedSessionId) return;
+      const bodyEl = document.querySelector('#session-summary [data-field="ss-body"]');
+      if (bodyEl) bodyEl.textContent = `Summary unavailable: ${err.message}`;
+    }
+  }
+
+  // Minimal markdown — only converts leading `- ` lines into a <ul>. Anything
+  // else is rendered as escaped text with line breaks preserved. We control
+  // the Gemma prompt so the only expected formatting is bullets vs. paragraph.
+  function renderSummaryBody(text) {
+    const lines = (text || '').split(/\r?\n/);
+    const isBullet = l => /^\s*[-*]\s+/.test(l);
+    if (lines.some(isBullet)) {
+      const items = lines.filter(isBullet).map(l => {
+        const content = l.replace(/^\s*[-*]\s+/, '');
+        return `<li>${escapeHtml(content)}</li>`;
+      });
+      return `<ul>${items.join('')}</ul>`;
+    }
+    return escapeHtml(text);
   }
 
   // Kind filter state for the side-panel feed. null = show all; otherwise

--- a/web/agents.html
+++ b/web/agents.html
@@ -1576,12 +1576,26 @@
       });
   }
 
+  // Track the in-flight summary fetch so a new openPanel can abort the old
+  // one — otherwise stale long-running fetches pile up behind Gemma.
+  let summaryAbort = null;
+
   // Fetch and render the LLM-generated session summary. Decoupled from the
   // event stream — slow LLM calls won't block transcript display. The panel
   // header shows "Summarizing…" until this resolves.
   async function fetchSessionSummary(sessionId) {
+    if (summaryAbort) summaryAbort.abort();
+    const ac = new AbortController();
+    summaryAbort = ac;
+    // 5 minutes — covers worst-case Gemma queueing (a big CC session behind
+    // the agent worker can easily push past 60s). The browser will return
+    // an AbortError if the LLM is genuinely stuck so the user can retry.
+    const timeoutId = setTimeout(() => ac.abort(), 5 * 60 * 1000);
     try {
-      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(sessionId)}/summary`);
+      const r = await fetch(
+        `/api/agents/sessions/${encodeURIComponent(sessionId)}/summary`,
+        { signal: ac.signal },
+      );
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const data = await r.json();
       // Bail if the operator moved on to a different session while we waited.
@@ -1606,9 +1620,27 @@
           .text(d => nodeLabel(d));
       }
     } catch (err) {
+      // AbortError from a panel switch is expected — just bail silently.
+      if (err.name === 'AbortError' && sessionId !== selectedSessionId) return;
       if (sessionId !== selectedSessionId) return;
       const bodyEl = document.querySelector('#session-summary [data-field="ss-body"]');
-      if (bodyEl) bodyEl.textContent = `Summary unavailable: ${err.message}`;
+      if (!bodyEl) return;
+      const friendly = err.name === 'AbortError'
+        ? 'Timed out — Gemma may be busy.'
+        : `Summary unavailable: ${err.message}.`;
+      bodyEl.innerHTML = `${escapeHtml(friendly)} <a href="#" data-action="retry-summary" style="color:var(--accent)">Retry</a>`;
+      const retry = bodyEl.querySelector('[data-action="retry-summary"]');
+      if (retry) {
+        retry.addEventListener('click', e => {
+          e.preventDefault();
+          bodyEl.textContent = 'Summarizing…';
+          document.getElementById('session-summary')?.classList.add('loading');
+          fetchSessionSummary(sessionId);
+        });
+      }
+    } finally {
+      clearTimeout(timeoutId);
+      if (summaryAbort === ac) summaryAbort = null;
     }
   }
 


### PR DESCRIPTION
## Summary
- Right panel now shows a Gemma-generated 1-2 sentence recap and a 2-6 word short label at the top of every session.
- Short label replaces the model badge (Opus/Sonnet/Local) on the graph node. Model info still lives in the panel metadata row.
- Summaries are extracted from the first user message, final assistant message, and any PRs scraped from transcript tool calls / text.

## Implementation notes
- New module `api/services/agent_viz_summary.py` does extraction + Gemma call + caching by `(session_id, last_activity_at)`.
- New endpoint `GET /api/agents/sessions/{id}/summary` is called lazily on panel open — snapshot ticks never block on the LLM.
- Snapshot dict gains a `short_label` field, populated from the cache only. Once a session is summarized, the short label survives across snapshot ticks and page reloads (in-process cache).
- Frontend (`web/agents.html`): summary block with loading state, `nodeLabel()` prefers `short_label` over model badge, node text refreshes immediately when the fetch resolves so the operator doesn't wait for the next snapshot tick.
- Gemma 4 26B reasons heavily before emitting `content`; `max_tokens=2000` is required to avoid truncated JSON mid-string.

## Test plan
- [x] Unit tests pass (1598 passed)
- [x] Smoke-tested `summarize_session` end-to-end against running local Gemma (produced "Fix Mobile Notification Badge Count" / 1-sentence summary for a synthetic transcript with seed + gh-pr-create + completed events)
- [ ] Browser verify on `/agents`: click a node → summary block appears, node label updates, switching nodes doesn't blink the events feed
- [ ] Verify CC sessions also get summaries (cc: prefix path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)