### PR TITLE
feat(agent-worker): harden & generalize replyable agent threads

### DIFF
--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -140,7 +140,13 @@ CREATE TABLE IF NOT EXISTS pending_questions (
     answered_at       INTEGER,
     processed         INTEGER NOT NULL DEFAULT 0,
     timed_out         INTEGER NOT NULL DEFAULT 0,
-    kind              TEXT NOT NULL DEFAULT 'clarification'
+    kind              TEXT NOT NULL DEFAULT 'clarification',
+    -- JSON array of every Telegram chunk id for this notification. Long
+    -- completions split across multiple 4096-char messages; a reply can land
+    -- on any chunk, so `deposit_answer` matches membership in this list (not
+    -- just the first chunk in `sent_message_id`). NULL for legacy rows, which
+    -- still match via `sent_message_id`.
+    sent_message_ids  TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_pq_message_id ON pending_questions(sent_message_id);
 CREATE INDEX IF NOT EXISTS idx_pq_open ON pending_questions(answered_at, processed, timed_out);
@@ -246,6 +252,14 @@ class SessionStore:
                 conn.execute(
                     "ALTER TABLE pending_questions ADD COLUMN kind TEXT "
                     "NOT NULL DEFAULT 'clarification'"
+                )
+            # Idempotent migration for `pending_questions.sent_message_ids` —
+            # the full chunk-id list so a reply to any chunk of a split
+            # notification matches. Legacy rows stay NULL and match on
+            # `sent_message_id`.
+            if "sent_message_ids" not in pq_cols:
+                conn.execute(
+                    "ALTER TABLE pending_questions ADD COLUMN sent_message_ids TEXT"
                 )
             # Idempotent migration for the prompt-cache token buckets on
             # `sessions`. Old rows stay at zero — we don't backfill historical
@@ -865,15 +879,27 @@ class SessionStore:
         question: str,
         sent_message_id: int,
         kind: str = "clarification",
+        sent_message_ids: list[int] | None = None,
     ) -> int:
+        """Record a pending question / follow-up keyed by Telegram message id.
+
+        `sent_message_id` is the first (matchable) chunk id; `sent_message_ids`
+        is the full chunk list for a split notification (defaults to just the
+        first chunk). `deposit_answer` matches a reply to any chunk in the list.
+        """
+        ids = sent_message_ids or [int(sent_message_id)]
         with self._connect() as conn:
             cur = conn.execute(
                 """
                 INSERT INTO pending_questions (
-                    session_id, task_id, question, sent_message_id, sent_at, kind
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                    session_id, task_id, question, sent_message_id, sent_at,
+                    kind, sent_message_ids
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (session_id, task_id, question, int(sent_message_id), _now(), kind),
+                (
+                    session_id, task_id, question, int(sent_message_id), _now(),
+                    kind, json.dumps([int(i) for i in ids]),
+                ),
             )
         return cur.lastrowid
 
@@ -881,35 +907,46 @@ class SessionStore:
         self,
         session_id: str,
         task_id: str,
-        sent_message_id: int,
+        sent_message_ids: list[int],
+        label: str = "",
     ) -> int:
-        """Register a completion-message Telegram msg_id so an operator
-        reply to that message reopens the session as a follow-up turn.
+        """Register a terminal-notification's Telegram msg_id(s) so an operator
+        reply to any chunk reopens the session as a follow-up turn.
 
-        The row goes into `pending_questions` with kind='followup' and
-        an empty `question` body — `deposit_answer` matches on
-        `sent_message_id` regardless of kind, and the worker tick
-        branches on `kind` when processing.
+        Used for COMPLETED, FAILED, and BUDGET_EXCEEDED notifications — every
+        terminal state is replyable. The row goes into `pending_questions` with
+        kind='followup'; `label` (the task description) is stored in `question`
+        so the resume path can show a `↪ continuing "<task>"` prefix. The worker
+        tick branches on `kind` when processing.
         """
+        if not sent_message_ids:
+            raise ValueError("register_completion_followup requires at least one message id")
         return self.create_pending_question(
             session_id=session_id,
             task_id=task_id,
-            question="",
-            sent_message_id=sent_message_id,
+            question=label,
+            sent_message_id=sent_message_ids[0],
             kind="followup",
+            sent_message_ids=sent_message_ids,
         )
 
     def deposit_answer(self, sent_message_id: int, answer: str) -> bool:
         """Record an answer for an open question, keyed by Telegram message_id.
 
-        Returns True if a matching open question was found and updated; False
-        otherwise (so the listener can fall through to the chat pipeline).
+        Matches a reply landing on any chunk of a split notification: the id is
+        checked against both the primary `sent_message_id` and membership in the
+        `sent_message_ids` JSON list. Returns True if a matching open question
+        was found and updated; False otherwise (so the listener can fall through
+        to the chat pipeline).
         """
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT id FROM pending_questions "
-                "WHERE sent_message_id = ? AND answered_at IS NULL AND timed_out = 0",
-                (int(sent_message_id),),
+                "WHERE answered_at IS NULL AND timed_out = 0 "
+                "AND (sent_message_id = ? OR (sent_message_ids IS NOT NULL "
+                "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?))) "
+                "ORDER BY id ASC LIMIT 1",
+                (int(sent_message_id), int(sent_message_id)),
             ).fetchone()
             if not row:
                 return False
@@ -919,6 +956,25 @@ class SessionStore:
                 (answer, _now(), row["id"]),
             )
         return True
+
+    def get_recent_resumable_followup(self, within_seconds: int) -> dict | None:
+        """Return the most recent open follow-up whose notification was sent
+        within `within_seconds`, or None.
+
+        Powers the "plain message resumes the last agent thread" path: a
+        non-reply Telegram message within the window resumes the most recently
+        completed/failed thread without requiring the native reply gesture.
+        """
+        cutoff = _now() - int(within_seconds)
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM pending_questions "
+                "WHERE kind = 'followup' AND answered_at IS NULL "
+                "AND processed = 0 AND timed_out = 0 AND sent_at >= ? "
+                "ORDER BY sent_at DESC, id DESC LIMIT 1",
+                (cutoff,),
+            ).fetchone()
+        return dict(row) if row else None
 
     def get_question_by_message_id(self, sent_message_id: int) -> dict | None:
         with self._connect() as conn:

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -149,7 +149,7 @@ class Worker:
         spend_tracker: SpendTracker | None = None,
         poll_seconds: float | None = None,
         telegram_send=None,  # injectable for tests
-        telegram_send_with_id=None,  # injectable; returns sent message_id (or None)
+        telegram_send_with_id=None,  # injectable; returns list of sent chunk message_ids
         http_client: httpx.Client | None = None,
         preflight_caller=None,    # injectable; defaults to Anthropic Haiku
         local_executor=None,      # injectable LocalExecutor for tests
@@ -171,7 +171,7 @@ class Worker:
         def _noop_telegram(text, chat_id=None):
             return False
         def _noop_with_id(text):
-            return None
+            return []
         self._telegram_send = telegram_send if telegram_send is not None else _noop_telegram
         self._telegram_send_with_id = (
             telegram_send_with_id if telegram_send_with_id is not None else _noop_with_id
@@ -624,7 +624,12 @@ class Worker:
         sid = session.session_id
         task_id = session.task_id
 
-        self._swap_tag(task_id, COMPLETED_TAG, RUNNING_TAG)
+        # The task may be parked at any terminal tag — completed, failed, or
+        # budget-exceeded are all replyable now. Swap whichever is current
+        # back to running.
+        for terminal_tag in (COMPLETED_TAG, FAILED_TAG, BUDGET_EXCEEDED_TAG):
+            if self._swap_tag(task_id, terminal_tag, RUNNING_TAG):
+                break
         self._set_task_status(task_id, "in_progress")
         self.session_store.update_status(task_id, STATUS_RUNNING)
         self.transcript_store.append(sid, "followup_received", {
@@ -750,23 +755,25 @@ class Worker:
         — caller should mark the session blocked anyway since we can't ask).
         """
         try:
-            sent_id = self._telegram_send_with_id(question)
+            sent_ids = self._telegram_send_with_id(question) or []
         except Exception as exc:
             logger.warning(f"ask_user_via_telegram failed: {exc}")
             return None
-        if sent_id is None:
+        if not sent_ids:
             return None
         self.session_store.create_pending_question(
             session_id=session_id,
             task_id=task_id,
             question=question,
-            sent_message_id=sent_id,
+            sent_message_id=sent_ids[0],
+            sent_message_ids=sent_ids,
         )
         self.transcript_store.append(session_id, "clarification_sent", {
-            "sent_message_id": sent_id,
+            "sent_message_id": sent_ids[0],
+            "sent_message_ids": sent_ids,
             "question_chars": len(question),
         })
-        return sent_id
+        return sent_ids[0]
 
     def _wake_sleeping_sessions(self) -> None:
         """Resume any sessions whose `sleeps` row has expired."""
@@ -1159,11 +1166,13 @@ class Worker:
                 recovered = self._recover_result_from_transcript(sid) or (
                     "no tool calls or final text recovered"
                 )
-                self._notify(
+                self._notify_terminal(
+                    session,
                     f"⚠️ {_worker_label(session.routing)}: task '{title}' returned "
                     f"empty result with no side-effect tool use — marking failed. "
                     f"What the agent did:\n\n{recovered}\n\n"
-                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`",
+                    label=title,
                 )
                 return
             if not is_spawned:
@@ -1176,25 +1185,8 @@ class Worker:
                 # Send via the with-id sender so we can match a future Telegram
                 # reply to this completion message and resume the task as a
                 # follow-up turn (e.g., "now turn this into a .md in my vault").
-                # When the with-id sender returns None (bot not configured, or
-                # a test stub that doesn't capture ids) fall back to the plain
-                # _notify path so the operator at least sees the result.
                 body = self._completion_summary(session, task, outcome)
-                sent_id = self._telegram_send_with_id(body)
-                if sent_id is None:
-                    self._notify(body)
-                else:
-                    try:
-                        self.session_store.register_completion_followup(
-                            session_id=sid,
-                            task_id=session.task_id,
-                            sent_message_id=sent_id,
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "register_completion_followup failed for %s: %s",
-                            session.task_id, exc,
-                        )
+                self._notify_terminal(session, body, label=title)
             else:
                 # Child completion — record only; parent picks it up via yield_until.
                 self.transcript_store.append(sid, "child_completed_internal", {
@@ -1208,9 +1200,11 @@ class Worker:
             if not is_spawned:
                 self._swap_tag(session.task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
                 self._set_task_status(session.task_id, "cancelled")
-                self._notify(
+                self._notify_terminal(
+                    session,
                     f"⚠️ {label}: task '{title}' hit its budget ({outcome.reason}). "
-                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`",
+                    label=title,
                 )
             else:
                 self.transcript_store.append(sid, "child_budget_exceeded_internal", {
@@ -1223,9 +1217,11 @@ class Worker:
             if not is_spawned:
                 self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
                 self._set_task_status(session.task_id, "cancelled")
-                self._notify(
+                self._notify_terminal(
+                    session,
                     f"⚠️ {label}: task '{title}' failed: {outcome.reason}. "
-                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`",
+                    label=title,
                 )
             else:
                 self.transcript_store.append(sid, "child_failed_internal", {
@@ -1715,6 +1711,37 @@ class Worker:
         except Exception as exc:  # pragma: no cover — defensive
             logger.warning("telegram notify failed: %s", exc)
 
+    def _notify_terminal(self, session: Session, body: str, label: str) -> None:
+        """Send a terminal-state notification (completed / failed / budget) and
+        register a follow-up so a reply — to any chunk — resumes the session.
+
+        Sends via the with-id sender so every chunk's message_id is captured;
+        a reply landing on any of them (or a plain message within the 30-min
+        window) reopens the session as a follow-up turn. Falls back to the
+        plain one-way `_notify` when the with-id sender is unavailable (bot not
+        configured, or a test stub that captures no ids).
+        """
+        sent_ids: list[int] = []
+        try:
+            sent_ids = self._telegram_send_with_id(body) or []
+        except Exception as exc:
+            logger.warning("terminal notify (with id) failed for %s: %s", session.task_id, exc)
+        if not sent_ids:
+            self._notify(body)
+            return
+        try:
+            self.session_store.register_completion_followup(
+                session_id=session.session_id,
+                task_id=session.task_id,
+                sent_message_ids=sent_ids,
+                label=label,
+            )
+        except Exception as exc:
+            logger.warning(
+                "register_completion_followup failed for %s: %s",
+                session.task_id, exc,
+            )
+
 
 def main() -> None:
     logging.basicConfig(
@@ -1728,9 +1755,9 @@ def main() -> None:
     telegram_send = None
     telegram_send_with_id = None
     try:
-        from api.services.telegram import send_message, send_message_capture_id
+        from api.services.telegram import send_message, send_message_capture_ids
         telegram_send = send_message
-        telegram_send_with_id = send_message_capture_id
+        telegram_send_with_id = send_message_capture_ids
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning("Telegram module not importable; running with no-op senders: %s", exc)
     worker = Worker(

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -523,6 +523,12 @@ class TelegramBotListener:
         reopens the session as a new user turn, then shows a visible
         continuation prefix. Returns True if the message was consumed as a
         resume; False to fall through to the chat pipeline.
+
+        Like the native reply-deposit path (`_maybe_deposit_agent_answer`),
+        this hands off to the agent worker via the shared `pending_questions`
+        table; if that process is down the deposited turn waits until it comes
+        back rather than running immediately. Accepted edge — both deposit
+        paths share this property.
         """
         try:
             from api.services.agent_worker.session_store import SessionStore

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -112,20 +112,21 @@ class TypingIndicator:
                 pass
 
 
-def send_message_capture_id(text: str, chat_id: str = None) -> int | None:
-    """Send a message and return its Telegram `message_id` (or None on failure).
+def send_message_capture_ids(text: str, chat_id: str = None) -> list[int]:
+    """Send a message and return the Telegram `message_id` of every chunk sent.
 
-    Used by the agent worker to track clarification questions so reply-
-    threaded answers can be matched back to the right pending question.
-    Falls back to plain text if Markdown parse fails. Returns the id from
-    the first sent chunk so reply-threading lands on the start of the
-    question.
+    Used by the agent worker to track clarification questions and terminal-state
+    notifications so reply-threaded answers can be matched back to the right
+    pending question. Long messages split across multiple 4096-char chunks; a
+    reply can land on *any* chunk, so we capture them all (not just the first).
+    Falls back to plain text if Markdown parse fails. Returns an empty list when
+    Telegram is disabled or every send failed.
     """
     if not settings.telegram_enabled:
-        return None
+        return []
     chat_id = chat_id or settings.telegram_chat_id
     text = _clean_markdown_for_telegram(text)
-    first_id: int | None = None
+    ids: list[int] = []
     for part in _split_message(text):
         try:
             resp = httpx.post(
@@ -139,14 +140,15 @@ def send_message_capture_id(text: str, chat_id: str = None) -> int | None:
                     json={"chat_id": chat_id, "text": part},
                     timeout=30.0,
                 )
-            if resp.status_code == 200 and first_id is None:
-                payload = resp.json()
-                first_id = (payload.get("result") or {}).get("message_id")
-            elif resp.status_code != 200:
+            if resp.status_code == 200:
+                msg_id = (resp.json().get("result") or {}).get("message_id")
+                if msg_id is not None:
+                    ids.append(int(msg_id))
+            else:
                 logger.error(f"Telegram send failed: {resp.status_code} {resp.text[:200]}")
         except Exception as e:
             logger.error(f"Telegram send error: {e}")
-    return first_id
+    return ids
 
 
 def send_message(text: str, chat_id: str = None) -> bool:
@@ -382,6 +384,10 @@ class TelegramBotListener:
 
     _STATE_FILE = Path("data/telegram_state.json")
     _DEDUP_WINDOW = 1000  # Track last N message IDs for deduplication
+    # A plain (non-reply) message within this window of an agent thread's
+    # terminal notification resumes that thread instead of starting a fresh
+    # chat query. Beyond it, plain messages route to the chat pipeline.
+    _AGENT_THREAD_RESUME_WINDOW_SECONDS = 30 * 60
 
     def __init__(self):
         self._stop_event = threading.Event()
@@ -509,6 +515,33 @@ class TelegramBotListener:
             logger.warning(f"agent-worker deposit_answer failed: {exc}")
             return False
 
+    async def _maybe_resume_recent_agent_thread(self, text: str, chat_id: str) -> bool:
+        """Resume the most recent completed/failed agent thread when a plain
+        (non-reply) message arrives within the resume window.
+
+        Deposits the message into that thread's open follow-up so the worker
+        reopens the session as a new user turn, then shows a visible
+        continuation prefix. Returns True if the message was consumed as a
+        resume; False to fall through to the chat pipeline.
+        """
+        try:
+            from api.services.agent_worker.session_store import SessionStore
+            store = SessionStore()
+            row = store.get_recent_resumable_followup(
+                within_seconds=self._AGENT_THREAD_RESUME_WINDOW_SECONDS,
+            )
+            if not row:
+                return False
+            if not store.deposit_answer(row["sent_message_id"], text):
+                return False
+        except Exception as exc:
+            logger.warning(f"agent-thread resume check failed: {exc}")
+            return False
+
+        label = (row.get("question") or "").strip() or "your last agent task"
+        await send_message_async(f'↪ continuing "{label}"', chat_id=chat_id)
+        return True
+
     async def _handle_update(self, update: dict):
         """Process a single Telegram update."""
         message = update.get("message")
@@ -565,6 +598,14 @@ class TelegramBotListener:
 
         # Check for follow-up to a recently completed Claude Code session
         if await self._check_code_followup(text, chat_id):
+            return
+
+        # Plain message (no native reply gesture) within the resume window:
+        # resume the most recent completed/failed agent thread so a quick
+        # "actually, also do X" continues the conversation instead of
+        # silently starting a fresh chat query. Native reply-to (handled
+        # above) still targets a specific, possibly older, thread.
+        if await self._maybe_resume_recent_agent_thread(text, chat_id):
             return
 
         # Send through chat pipeline (intent classification happens there)

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-26
+> **Last Updated:** 2026-05-28
 
 Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
 
@@ -298,17 +298,25 @@ A managed session's `managed_agent_session_id` is durable across worker restarts
 
 When the worker needs operator input mid-task — preflight routing=ask, ambiguity question, or `lifeos_agent_user_ask` mid-loop — it:
 
-1. Sends a Telegram message via `send_message_capture_id()` (returns the Telegram `message_id`).
-2. Persists `(session_id, telegram_message_id, question)` in `pending_questions`.
+1. Sends a Telegram message via `send_message_capture_ids()` (returns the `message_id` of **every** 4096-char chunk).
+2. Persists `(session_id, telegram_message_ids, question)` in `pending_questions` — the full chunk list in `sent_message_ids` (JSON), with the first chunk in `sent_message_id`.
 3. Swaps the tag to `#agent-blocked` and parks the session.
 4. For managed sessions: also calls `driver.kill_session` to stop session-hour billing while waiting.
 
-When the operator replies (using Telegram's native reply feature), the bot's `_maybe_deposit_agent_answer()` hook intercepts the `reply_to_message_id` and calls `SessionStore.deposit_answer()`. The worker's `_process_clarification_answers()` runs each tick, picks up answered questions, parses the answer (for routing questions: extracts `local` / `claude` from free-text), updates the session, and re-dispatches.
+When the operator replies (using Telegram's native reply feature), the bot's `_maybe_deposit_agent_answer()` hook intercepts the `reply_to_message_id` and calls `SessionStore.deposit_answer()`, which matches a reply landing on **any** chunk (membership in `sent_message_ids`, not just the first). The worker's `_process_clarification_answers()` runs each tick, picks up answered questions, parses the answer (for routing questions: extracts `local` / `claude` from free-text), updates the session, and re-dispatches.
 
 For local sessions, the parent session resumes via the existing pending_messages drain.
 For managed sessions, a new remote session is created with the resolved routing.
 
 Clarifications older than `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` (default 72h) are abandoned with a Telegram heads-up; the transcript stays preserved.
+
+### Replyable terminal threads
+
+Every terminal-state notification — `#agent-completed`, `#agent-failed`, and `#agent-budget-exceeded` — registers a follow-up (`kind='followup'`) via `register_completion_followup()`, so a reply reopens the session as a new user turn (`_resume_as_followup()` swaps whichever terminal tag is current back to `#agent-running`). This makes failures and budget cut-offs replyable, not just clean completions.
+
+Two ways to target a thread:
+- **Native reply** to any chunk of a notification → resumes that specific thread (works regardless of age).
+- **Plain message** (no reply gesture) within `_AGENT_THREAD_RESUME_WINDOW_SECONDS` (30 min) → resumes the most recent resumable thread (`get_recent_resumable_followup()`), prefixed with a visible `↪ continuing "<task>"`. Beyond the window, a plain message routes to the normal chat pipeline.
 
 ---
 

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -13,6 +13,7 @@ Also covers `lifeos_agent_user_ask` (agent-initiated clarification) and the
 """
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 
@@ -22,7 +23,9 @@ import pytest
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
+    STATUS_BUDGET_EXCEEDED,
     STATUS_COMPLETED,
+    STATUS_FAILED,
     STATUS_RUNNING,
     SessionStore,
 )
@@ -30,6 +33,10 @@ from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
 from api.services.agent_worker.worker import (
     BLOCKED_TAG,
+    BUDGET_EXCEEDED_TAG,
+    COMPLETED_TAG,
+    FAILED_TAG,
+    RUNNING_TAG,
     Worker,
 )
 
@@ -79,16 +86,32 @@ class _StubExecutor:
         return self.outcome
 
 
+class _SequenceExecutor:
+    """Returns a queued outcome per call (last one repeats once exhausted)."""
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+    def execute(self, session, task):
+        self.calls.append((session.task_id, task.get("description")))
+        if len(self.calls) <= len(self.outcomes):
+            return self.outcomes[len(self.calls) - 1]
+        return self.outcomes[-1]
+
+
 def _make_worker(tmp_path, api, *, preflight_caller, local_executor):
     transport = httpx.MockTransport(api.handler)
     client = httpx.Client(transport=transport, base_url="http://api")
     sent: list[str] = []
     sent_with_ids: list[tuple[int, str]] = []
     def _send_with_id(text):
+        # Mirror send_message_capture_ids: one id per ~4096-char chunk, all
+        # returned so a reply to any chunk can be matched.
         sent.append(text)
-        msg_id = 1000 + len(sent_with_ids)
-        sent_with_ids.append((msg_id, text))
-        return msg_id
+        n_chunks = max(1, -(-len(text) // 4096))
+        chunk_ids = [1000 + len(sent_with_ids) + i for i in range(n_chunks)]
+        for cid in chunk_ids:
+            sent_with_ids.append((cid, text))
+        return chunk_ids
     store = SessionStore(db_path=tmp_path / "sessions.db")
     w = Worker(
         api_base="http://api",
@@ -334,7 +357,7 @@ def test_lifeos_agent_user_ask_blocks_and_records_question(tmp_path: Path):
     def _send_with_id(text):
         msg_id = 5000 + len(sent_with_ids)
         sent_with_ids.append((msg_id, text))
-        return msg_id
+        return [msg_id]
 
     w = Worker(
         api_base="http://api",
@@ -409,3 +432,164 @@ def test_lifeos_agent_user_ask_fails_when_telegram_unavailable(tmp_path: Path):
     assert result["error"] == "telegram_unavailable"
     # Session NOT blocked (operator-facing failure mode).
     assert store.get("t").status == STATUS_RUNNING
+
+
+# =============================================================================
+# Replyable terminal states + any-chunk matching (Issue #234)
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_failed_task_registers_followup_and_reply_resumes(tmp_path: Path):
+    """A FAILED task's notification is replyable: replying resumes the session,
+    swapping the failed tag back to running, and a clean completion follows."""
+    api = FakeApi([{"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent"]}])
+    executor = _SequenceExecutor([
+        ExecutorOutcome(status=STATUS_FAILED, reason="boom"),
+        ExecutorOutcome(status=STATUS_COMPLETED, final_text="fixed it"),
+    ])
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+    w.tick()
+
+    # Parked at the failed tag, and a follow-up was registered against the
+    # terminal notification's message id (kind='followup', task title as label).
+    assert FAILED_TAG in api.tasks["t1"]["tags"]
+    msg_id, _ = w._sent_with_ids[-1]
+    q = w.session_store.get_question_by_message_id(msg_id)
+    assert q is not None
+    assert q["kind"] == "followup"
+    assert q["question"] == "do the thing"
+
+    # Operator replies → deposit → next tick resumes and completes.
+    assert w.session_store.deposit_answer(msg_id, "try again")
+    w.tick()
+    assert len(executor.calls) == 2, "executor should have been re-invoked on resume"
+    assert COMPLETED_TAG in api.tasks["t1"]["tags"]
+    assert RUNNING_TAG not in api.tasks["t1"]["tags"]
+
+
+@pytest.mark.unit
+def test_budget_exceeded_task_registers_followup(tmp_path: Path):
+    """BUDGET_EXCEEDED notifications are replyable too."""
+    api = FakeApi([{"id": "t1", "description": "big job", "status": "todo", "tags": ["agent"]}])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_BUDGET_EXCEEDED, reason="out of budget"))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+    w.tick()
+
+    assert BUDGET_EXCEEDED_TAG in api.tasks["t1"]["tags"]
+    msg_id, _ = w._sent_with_ids[-1]
+    q = w.session_store.get_question_by_message_id(msg_id)
+    assert q is not None and q["kind"] == "followup"
+
+
+@pytest.mark.unit
+def test_reply_to_non_first_chunk_matches_and_resumes(tmp_path: Path):
+    """A long terminal notification splits into multiple Telegram chunks;
+    replying to a non-first chunk still matches the follow-up and resumes.
+
+    Uses a long FAILED reason (the failure body isn't vault-spilled, so it
+    actually exceeds one 4096-char chunk)."""
+    api = FakeApi([{"id": "t1", "description": "task", "status": "todo", "tags": ["agent"]}])
+    long_reason = "y" * 9000  # forces the notification body across 3 chunks
+    executor = _SequenceExecutor([
+        ExecutorOutcome(status=STATUS_FAILED, reason=long_reason),
+        ExecutorOutcome(status=STATUS_COMPLETED, final_text="done again"),
+    ])
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+    w.tick()
+
+    # The notification spanned multiple chunks.
+    followup = w.session_store.get_recent_resumable_followup(within_seconds=3600)
+    assert followup is not None
+    chunk_ids = json.loads(followup["sent_message_ids"])
+    assert len(chunk_ids) >= 2, "notification should have spanned multiple chunks"
+
+    # Reply lands on the LAST chunk (not the primary first-chunk id).
+    last_chunk = chunk_ids[-1]
+    assert last_chunk != followup["sent_message_id"]
+    assert w.session_store.deposit_answer(last_chunk, "more please")
+    w.tick()
+    assert len(executor.calls) == 2, "reply to a later chunk should resume"
+
+
+@pytest.mark.unit
+def test_get_recent_resumable_followup_window(tmp_path: Path):
+    """get_recent_resumable_followup honors the time window and open-state."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    sess = store.create(
+        task_id="t1", status=STATUS_COMPLETED, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+    )
+    store.register_completion_followup(
+        session_id=sess.session_id, task_id="t1",
+        sent_message_ids=[500, 501], label="recent task",
+    )
+    # Within window → found.
+    row = store.get_recent_resumable_followup(within_seconds=1800)
+    assert row is not None and row["task_id"] == "t1"
+
+    # Once answered, it is no longer resumable via this path.
+    assert store.deposit_answer(500, "go")
+    assert store.get_recent_resumable_followup(within_seconds=1800) is None
+
+
+@pytest.mark.unit
+def test_get_recent_resumable_followup_excludes_clarifications(tmp_path: Path):
+    """Only kind='followup' rows count — open clarifications don't trigger the
+    plain-message resume path."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    sess = store.create(
+        task_id="t1", status=STATUS_BLOCKED, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+    )
+    store.create_pending_question(
+        session_id=sess.session_id, task_id="t1",
+        question="which one?", sent_message_id=42,
+    )
+    assert store.get_recent_resumable_followup(within_seconds=1800) is None
+
+
+@pytest.mark.unit
+def test_get_recent_resumable_followup_respects_cutoff(tmp_path: Path):
+    """A follow-up older than the window is not returned (no surprise resume)."""
+    import sqlite3
+
+    db = tmp_path / "sessions.db"
+    store = SessionStore(db_path=db)
+    sess = store.create(
+        task_id="t1", status=STATUS_COMPLETED, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+    )
+    qid = store.register_completion_followup(
+        session_id=sess.session_id, task_id="t1",
+        sent_message_ids=[700], label="old task",
+    )
+    # Backdate the notification 31 minutes.
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "UPDATE pending_questions SET sent_at = sent_at - ? WHERE id = ?",
+            (31 * 60, qid),
+        )
+    assert store.get_recent_resumable_followup(within_seconds=1800) is None
+    # A wider window still finds it.
+    assert store.get_recent_resumable_followup(within_seconds=3600) is not None
+
+
+@pytest.mark.unit
+def test_native_reply_targets_specific_older_thread(tmp_path: Path):
+    """A native reply to a specific (older) thread's message id targets THAT
+    thread, not merely the most recent one."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    budget = {"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100}
+    s_old = store.create(task_id="old", status=STATUS_COMPLETED, routing="local", budget=budget)
+    s_new = store.create(task_id="new", status=STATUS_COMPLETED, routing="local", budget=budget)
+    store.register_completion_followup(
+        session_id=s_old.session_id, task_id="old", sent_message_ids=[100], label="old",
+    )
+    store.register_completion_followup(
+        session_id=s_new.session_id, task_id="new", sent_message_ids=[200], label="new",
+    )
+    # Native reply to the OLD message id deposits into the OLD follow-up only.
+    assert store.deposit_answer(100, "revisit old")
+    assert store.get_question_by_message_id(100)["answer"] == "revisit old"
+    assert store.get_question_by_message_id(200)["answer"] is None

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -108,10 +108,11 @@ def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_execut
     # returns a deterministic message_id so reply-threading can be tested.
     sent_with_ids: list[tuple[int, str]] = []
     def _fake_send_with_id(text):
+        # Mirror send_message_capture_ids: return a list of chunk ids.
         sent.append(text)
         msg_id = len(sent_with_ids) + 1000
         sent_with_ids.append((msg_id, text))
-        return msg_id
+        return [msg_id]
     w = Worker(
         api_base="http://api",
         session_store=SessionStore(db_path=tmp_path / "sessions.db"),
@@ -370,10 +371,11 @@ def test_claude_routing_with_managed_executor_starts_and_polls(tmp_path: Path):
     sent: list[str] = []
     sent_ids: list[tuple[int, str]] = []
     def _fake_with_id(text):
+        # Mirror send_message_capture_ids: return a list of chunk ids.
         sent.append(text)
         msg_id = len(sent_ids) + 2000
         sent_ids.append((msg_id, text))
-        return msg_id
+        return [msg_id]
     managed = _StubManagedExecutor()
     w = Worker(
         api_base="http://api",

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -330,3 +330,84 @@ class TestMessageDedup:
         listener._processed_ids.append(TelegramBotListener._DEDUP_WINDOW)
         assert 0 not in listener._processed_ids
         assert TelegramBotListener._DEDUP_WINDOW in listener._processed_ids
+
+
+# =============================================================================
+# Plain-message agent-thread resume (Issue #234, Phase 1)
+# =============================================================================
+
+
+class TestAgentThreadResume:
+    """A plain (non-reply) message within the window resumes the most recent
+    completed/failed agent thread instead of starting a fresh chat query."""
+
+    def _make_listener(self, tmp_path):
+        from api.services.telegram import TelegramBotListener
+        state_file = tmp_path / "telegram_state.json"
+        with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
+            return TelegramBotListener()
+
+    def _store_with_followup(self, tmp_path, *, label="email Bob", msg_ids=(900,)):
+        from api.services.agent_worker.session_store import (
+            STATUS_COMPLETED,
+            SessionStore,
+        )
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        sess = store.create(
+            task_id="t1", status=STATUS_COMPLETED, routing="local",
+            budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+        )
+        store.register_completion_followup(
+            session_id=sess.session_id, task_id="t1",
+            sent_message_ids=list(msg_ids), label=label,
+        )
+        return store
+
+    @pytest.mark.asyncio
+    async def test_plain_message_within_window_resumes(self, tmp_path):
+        listener = self._make_listener(tmp_path)
+        store = self._store_with_followup(tmp_path, label="email Bob")
+
+        with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+            handled = await listener._maybe_resume_recent_agent_thread("also CC Jane", "123")
+
+        assert handled is True
+        # The message was deposited into the follow-up (now no longer resumable).
+        assert store.get_recent_resumable_followup(within_seconds=1800) is None
+        # A visible continuation prefix was sent.
+        mock_send.assert_awaited_once()
+        assert 'continuing "email Bob"' in mock_send.await_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_no_recent_thread_falls_through(self, tmp_path):
+        from api.services.agent_worker.session_store import SessionStore
+        listener = self._make_listener(tmp_path)
+        empty_store = SessionStore(db_path=tmp_path / "sessions.db")  # no follow-ups
+
+        with patch("api.services.agent_worker.session_store.SessionStore", return_value=empty_store), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+            handled = await listener._maybe_resume_recent_agent_thread("hello there", "123")
+
+        assert handled is False
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handle_update_routes_plain_message_to_resume(self, tmp_path):
+        """Integration: a plain message with a resumable thread short-circuits
+        the chat pipeline."""
+        listener = self._make_listener(tmp_path)
+        update = {"message": {"message_id": 7, "text": "and add a PS", "chat": {"id": "123"}}}
+
+        with patch.object(listener, "_check_agent_approval", return_value=False), \
+             patch.object(listener, "_check_agent_clarification", return_value=False), \
+             patch.object(listener, "_check_code_followup", new_callable=AsyncMock, return_value=False), \
+             patch.object(listener, "_maybe_resume_recent_agent_thread", new_callable=AsyncMock, return_value=True) as mock_resume, \
+             patch("api.services.telegram.settings") as mock_settings, \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            mock_settings.telegram_chat_id = "123"
+            await listener._handle_update(update)
+
+        mock_resume.assert_awaited_once()
+        mock_chat.assert_not_awaited()  # resume short-circuited the chat pipeline


### PR DESCRIPTION
## Summary

Phase 1 of #233 (Unified Agent Threads). Makes every terminal-state notification replyable, matches replies on any message chunk, and lets a plain message resume the last agent thread within a 30-minute window.

Closes #234. Relates to #233.

## What changed

- **All terminal states replyable.** A shared `_notify_terminal()` sends completed/failed/budget notifications with id capture and registers a follow-up — failures and budget cut-offs are now replyable, not just clean completions. `_resume_as_followup` swaps whichever terminal tag is current (`#agent-completed`/`-failed`/`-budget-exceeded`) back to `#agent-running`.
- **Match on any chunk.** `send_message_capture_id` → `send_message_capture_ids` returns every 4096-char chunk id. `pending_questions` gains an additive `sent_message_ids` JSON column; `deposit_answer` matches a reply landing on any chunk (membership via `json_each`). Legacy rows still match on `sent_message_id`.
- **30-min plain-message resume.** New `get_recent_resumable_followup()` + a resume path in the Telegram listener: a plain (non-reply) message within `_AGENT_THREAD_RESUME_WINDOW_SECONDS` (30 min) resumes the most recent thread with a visible `↪ continuing "<task>"` prefix. Beyond the window, plain messages route to the chat pipeline. Native reply-to still targets a specific older thread.

## Schema

Additive only: `pending_questions.sent_message_ids TEXT` (JSON), idempotent migration, NULL-safe for legacy rows. No data migration required.

## Test evidence

- `pytest -m "unit and not slow" tests/` (the pre-push gate): **1608 passed, 8 skipped, 0 failed**.
- New tests cover all six acceptance criteria: FAILED/BUDGET register follow-ups, reply to a non-first chunk resumes, 30-min window honored (and excluded beyond it / for clarifications), native reply targets a specific older thread.

## Review focus

- `deposit_answer` JSON-membership query correctness and the legacy-row fallback.
- Ordering of the new resume check in `_handle_update` (after command/approval/clarification/code-followup, before chat pipeline).
- Generalized terminal-tag swap loop in `_resume_as_followup`.