### PR TITLE
feat: reconcile /code completions with the unified follow-up table

### DIFF
--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -999,6 +999,25 @@ class SessionStore:
             ).fetchone()
         return dict(row) if row else None
 
+    def get_open_question_by_message_id(self, sent_message_id: int) -> dict | None:
+        """Return the open (unanswered, not-timed-out) question a reply to
+        `sent_message_id` matches — on any chunk — or None.
+
+        Read-only sibling of `deposit_answer`: lets a caller inspect the matched
+        row's `kind` and route the reply (e.g. a `code_followup` resumes Claude
+        Code rather than the agent worker) before recording an answer.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM pending_questions "
+                "WHERE answered_at IS NULL AND timed_out = 0 "
+                "AND (sent_message_id = ? OR (sent_message_ids IS NOT NULL "
+                "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?))) "
+                "ORDER BY id ASC LIMIT 1",
+                (int(sent_message_id), int(sent_message_id)),
+            ).fetchone()
+        return dict(row) if row else None
+
     def list_answered_unprocessed_questions(self) -> list[dict]:
         with self._connect() as conn:
             rows = conn.execute(

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -750,7 +750,16 @@ class Worker:
         cutoff = int(time.time()) - timeout_seconds
         stale = self.session_store.list_timed_out_questions(cutoff)
         for q in stale:
+            # Close every stale row, but only nudge for actual clarifications
+            # (agent BLOCKED awaiting input). Completion follow-ups —
+            # kind='followup' (#234) and kind='code_followup' (#237) — are just
+            # replyable notifications; a "re-tag with #agent to retry" nudge is
+            # wrong for them (and a code_followup points at a Claude Code
+            # session with no #agent task at all). Marking them timed out also
+            # keeps stale follow-up rows from accumulating.
             self.session_store.mark_question_timed_out(q["id"])
+            if (q.get("kind") or "clarification") != "clarification":
+                continue
             self.transcript_store.append(q["session_id"], "clarification_timed_out", {
                 "question_id": q["id"],
             })

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -512,6 +512,12 @@ class Worker:
         for q in answered:
             session_id = q["session_id"]
             task_id = q["task_id"]
+            # `code_followup` rows (#237) point at a Claude Code session, not an
+            # agent-worker session — the Telegram listener resumes those itself.
+            # Skip them here so the worker doesn't treat them as agent threads.
+            if q.get("kind") == "code_followup":
+                self.session_store.mark_question_processed(q["id"])
+                continue
             session = self.session_store.get_by_session_id(session_id)
             if session is None:
                 # Stale — session was deleted? Mark processed so we don't loop.

--- a/api/services/claude_orchestrator.py
+++ b/api/services/claude_orchestrator.py
@@ -247,6 +247,10 @@ class ClaudeOrchestrator:
         self._heartbeat: Optional[threading.Timer] = None
         self._typing_stop: Optional[threading.Event] = None
         self._notification_callback: Optional[Callable[[str], None]] = None
+        # Fired once when a session completes successfully (status "completed",
+        # session_id known). Used to register the completion message in the
+        # shared follow-up table so a reply resumes the session (#237).
+        self._on_complete: Optional[Callable[["ClaudeSession"], None]] = None
 
     def is_busy(self) -> bool:
         return self._active_session is not None and self._active_session.status in (
@@ -262,6 +266,7 @@ class ClaudeOrchestrator:
         working_dir: str,
         plan_mode: bool = False,
         notification_callback: Optional[Callable[[str], None]] = None,
+        on_complete: Optional[Callable[["ClaudeSession"], None]] = None,
     ) -> ClaudeSession:
         """Spawn a Claude Code subprocess for the given task."""
         with self._lock:
@@ -275,6 +280,7 @@ class ClaudeOrchestrator:
             )
             self._active_session = session
             self._notification_callback = notification_callback
+            self._on_complete = on_complete
 
         prompt = task
         if plan_mode:
@@ -344,6 +350,7 @@ class ClaudeOrchestrator:
         self,
         message: str,
         notification_callback: Optional[Callable[[str], None]] = None,
+        on_complete: Optional[Callable[["ClaudeSession"], None]] = None,
     ) -> Optional[ClaudeSession]:
         """Resume a recently completed session with a follow-up message."""
         with self._lock:
@@ -359,6 +366,7 @@ class ClaudeOrchestrator:
             self._active_session = session
             self._last_completed = None
             self._notification_callback = notification_callback
+            self._on_complete = on_complete
 
         self._spawn(message, session, resume_session_id=session.session_id)
         return session
@@ -676,7 +684,17 @@ class ClaudeOrchestrator:
             # Keep completed sessions for follow-up resumption
             if final_status == "completed" and session and session.session_id:
                 self._last_completed = session
+                # Register the completion in the shared follow-up table so a
+                # reply resumes this session uniformly with #agent threads
+                # (#237). Fired after the final notification was sent, so the
+                # callback can match against that message's id.
+                if self._on_complete:
+                    try:
+                        self._on_complete(session)
+                    except Exception as exc:  # pragma: no cover — defensive
+                        logger.warning(f"on_complete callback failed: {exc}")
             self._active_session = None
+            self._on_complete = None
         self._process = None
 
 

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -647,7 +647,13 @@ class TelegramBotListener:
         # the answer and short-circuit — don't route to the chat pipeline.
         reply_to = message.get("reply_to_message")
         if reply_to and reply_to.get("message_id"):
-            if self._maybe_deposit_agent_answer(int(reply_to["message_id"]), text):
+            reply_to_id = int(reply_to["message_id"])
+            # A reply to a /code completion resumes that Claude Code session
+            # (#237) — checked before the agent-worker deposit since both use
+            # the shared follow-up table but resume different subsystems.
+            if await self._maybe_handle_code_reply(reply_to_id, text, chat_id):
+                return
+            if self._maybe_deposit_agent_answer(reply_to_id, text):
                 return
 
         logger.info(f"Telegram message: {text[:100]}")
@@ -844,6 +850,79 @@ class TelegramBotListener:
         else:
             await send_message_async("No session waiting for clarification.", chat_id=chat_id)
 
+    def _code_callbacks(self, chat_id: str):
+        """Build the (notify, on_complete) callbacks for a Claude Code session.
+
+        `notify` sends each message via the id-capturing sender and remembers
+        the last message's chunk ids; `on_complete` registers those ids in the
+        shared follow-up table so a reply to the completion message resumes the
+        session uniformly with #agent threads (#237).
+        """
+        last_ids: list[int] = []
+
+        def notify(msg: str):
+            ids = send_message_capture_ids(msg, chat_id)
+            if ids:
+                last_ids[:] = ids
+
+        def on_complete(session):
+            self._register_code_followup(session, list(last_ids))
+
+        return notify, on_complete
+
+    def _register_code_followup(self, session, ids: list[int]) -> None:
+        """Register a completed Claude Code session in the shared follow-up
+        table (kind='code_followup') keyed to its completion message id(s)."""
+        session_id = getattr(session, "session_id", None)
+        if not ids or not session_id:
+            return
+        try:
+            from api.services.agent_worker.session_store import SessionStore
+            SessionStore().create_pending_question(
+                session_id=session_id,
+                task_id=f"code_{session_id}",
+                question=(getattr(session, "task", "") or "")[:200],
+                sent_message_id=ids[0],
+                sent_message_ids=ids,
+                kind="code_followup",
+            )
+        except Exception as exc:
+            logger.warning(f"register code followup failed: {exc}")
+
+    async def _maybe_handle_code_reply(self, reply_to_message_id: int, text: str, chat_id: str) -> bool:
+        """If a reply targets a Claude Code completion message (any chunk),
+        resume that session via the orchestrator's existing resume path (#237).
+
+        Returns True if the reply was consumed as a /code follow-up.
+        """
+        try:
+            from api.services.agent_worker.session_store import SessionStore
+            store = SessionStore()
+            q = store.get_open_question_by_message_id(reply_to_message_id)
+        except Exception as exc:
+            logger.warning(f"code reply lookup failed: {exc}")
+            return False
+        if not q or q.get("kind") != "code_followup":
+            return False
+
+        # Close the row so neither the worker nor a duplicate reply reprocesses it.
+        store.deposit_answer(reply_to_message_id, text)
+        store.mark_question_processed(q["id"])
+
+        from api.services.claude_orchestrator import get_orchestrator
+        orch = get_orchestrator()
+        notify, on_complete = self._code_callbacks(chat_id)
+        resumed = orch.followup(text, notification_callback=notify, on_complete=on_complete)
+        if resumed:
+            await send_message_async("Resuming Claude Code session...", chat_id=chat_id)
+        else:
+            await send_message_async(
+                "That Claude Code session can't be resumed (it expired or another "
+                "session is active). Start a fresh one with /code.",
+                chat_id=chat_id,
+            )
+        return True
+
     async def _check_code_followup(self, text: str, chat_id: str) -> bool:
         """Check if this message is a follow-up to a recently completed Claude Code session.
 
@@ -861,10 +940,8 @@ class TelegramBotListener:
         if not session:
             return False
 
-        def notify(msg: str):
-            send_message(msg, chat_id=chat_id)
-
-        resumed = orch.followup(text, notification_callback=notify)
+        notify, on_complete = self._code_callbacks(chat_id)
+        resumed = orch.followup(text, notification_callback=notify, on_complete=on_complete)
         if resumed:
             await send_message_async("Resuming Claude Code session...", chat_id=chat_id)
             return True
@@ -898,11 +975,13 @@ class TelegramBotListener:
             chat_id=chat_id,
         )
 
-        def notify(msg: str):
-            send_message(msg, chat_id=chat_id)
+        notify, on_complete = self._code_callbacks(chat_id)
 
         try:
-            orch.run_task(task, working_dir, plan_mode=plan_mode, notification_callback=notify)
+            orch.run_task(
+                task, working_dir, plan_mode=plan_mode,
+                notification_callback=notify, on_complete=on_complete,
+            )
         except RuntimeError as e:
             await send_message_async(f"Error: {e}", chat_id=chat_id)
 

--- a/docs/specs/technical/claude-code-orchestration.md
+++ b/docs/specs/technical/claude-code-orchestration.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** Orchestrator
-**Last Updated:** 2026-05-27
+**Last Updated:** 2026-05-28
 
 Implementation view of `api/services/claude_orchestrator.py` — how the Telegram `/code` command spawns and supervises a `claude` CLI subprocess. For the consumer view (`/code` command, plan mode, clarifications, budgets) see [product/claude-code-orchestration.md](../product/claude-code-orchestration.md). For operator setup see [guides/claude-code-orchestration.md](../../guides/claude-code-orchestration.md).
 
@@ -146,6 +146,18 @@ If Claude emits `[CLARIFY] <question>` mid-session, the orchestrator:
 5. State returns to `RUNNING`.
 
 If the operator wants to cancel during a clarification, they send `/code_cancel`. The orchestrator distinguishes commands from clarification answers by the leading slash.
+
+---
+
+## Replyable completions (#237)
+
+A reply to a `/code` completion message resumes that session, uniform with `#agent` thread replies. The mechanism reuses the shared `pending_questions` follow-up table rather than a `/code`-specific path:
+
+1. `run_task` / `followup` accept an `on_complete(session)` callback, fired once from `_cleanup` when a session completes successfully (status `completed`, `session_id` known) — after the final notification is sent.
+2. The Telegram listener's `_code_callbacks(chat_id)` builds the notify callback (which captures each sent message's chunk ids via `send_message_capture_ids`) plus an `on_complete` that registers a `pending_questions` row with `kind='code_followup'`, keyed to the completion message's chunk ids and storing the Claude `session_id`.
+3. On an incoming reply, `_maybe_handle_code_reply` looks up the open row (any-chunk match, `get_open_question_by_message_id`); if `kind='code_followup'` it closes the row and resumes via the orchestrator's existing `followup()` → `resume_session_id` path. The agent worker skips `code_followup` rows (they point at a Claude Code session, not an agent-worker session).
+
+This is **option A** (light build): reply *matching* is unified, but `/code` still runs as a separate session model and resume is bound to the orchestrator's `_last_completed` + `FOLLOWUP_WINDOW`. The deeper merge (routing `/code` through the unified worker, persisting the session id so resume survives restarts) is tracked as option B in #248.
 
 ---
 

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -344,6 +344,31 @@ def test_timeout_marks_question_and_nudges(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_timeout_closes_code_followup_without_nudge(tmp_path: Path):
+    """A stale code_followup row (#237) is timed out (closed) but does NOT get
+    the agent-worker 'still waiting / re-tag with #agent' nudge — it points at a
+    Claude Code session, not an #agent task."""
+    api = FakeApi([])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    qid = w.session_store.create_pending_question(
+        session_id="claude_xyz", task_id="code_claude_xyz",
+        question="fix the bug", sent_message_id=77, kind="code_followup",
+    )
+    with w.session_store._connect() as conn:
+        conn.execute(
+            "UPDATE pending_questions SET sent_at = ? WHERE id = ?",
+            (int(time.time()) - 4 * 86400, qid),
+        )
+
+    w._timeout_stale_clarifications()
+
+    assert w.session_store.get_question_by_message_id(77)["timed_out"] == 1
+    assert not any("still waiting on your reply" in s for s in w._sent)
+
+
+@pytest.mark.unit
 def test_lifeos_agent_user_ask_blocks_and_records_question(tmp_path: Path):
     """An agent calling `lifeos_agent_user_ask` should park the session and record
     a pending_question that the user can reply-thread to."""

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -710,3 +710,24 @@ def test_operator_completion_skips_vault_mutations(tmp_path: Path):
     assert not any(tid == op_task_id for _, tid in vault_calls), vault_calls
     # The completion still registered a replyable follow-up.
     assert w.session_store.get_recent_resumable_followup(within_seconds=3600) is not None
+
+
+@pytest.mark.unit
+def test_worker_skips_code_followup_rows(tmp_path: Path):
+    """code_followup rows (#237) point at a Claude Code session, not an
+    agent-worker session — the worker must skip them (mark processed) without
+    crashing or dispatching anything."""
+    api = FakeApi([])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="x"))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    w.session_store.create_pending_question(
+        session_id="claude_xyz", task_id="code_claude_xyz", question="t",
+        sent_message_id=50, kind="code_followup",
+    )
+    assert w.session_store.deposit_answer(50, "answer")
+
+    w.tick()  # must not crash on the code_followup row
+
+    assert w.session_store.get_question_by_message_id(50)["processed"] == 1
+    assert executor.calls == []  # nothing dispatched for a /code row

--- a/tests/test_code_followup.py
+++ b/tests/test_code_followup.py
@@ -1,0 +1,194 @@
+"""Tests for reconciling /code with the unified follow-up table (#237, Phase 4).
+
+Covers: the orchestrator on_complete hook, registering a Claude Code completion
+in the shared `pending_questions` table (kind='code_followup'), any-chunk
+lookup, the Telegram reply hook routing /code replies to the orchestrator's
+resume path, and the worker skipping code_followup rows.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_listener(tmp_path):
+    from api.services.telegram import TelegramBotListener
+    state_file = tmp_path / "telegram_state.json"
+    with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
+        return TelegramBotListener()
+
+
+class _FakeSession:
+    def __init__(self, session_id="claude_abc", task="fix the bug"):
+        self.session_id = session_id
+        self.task = task
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator on_complete hook
+# ---------------------------------------------------------------------------
+
+
+def test_on_complete_fires_on_completion():
+    from api.services.claude_orchestrator import ClaudeOrchestrator, ClaudeSession
+
+    orch = ClaudeOrchestrator()
+    sess = ClaudeSession(session_id="s1", task="t", status="running")
+    orch._active_session = sess
+    called = []
+    orch._on_complete = lambda s: called.append(s)
+
+    orch._cleanup("completed")
+    assert called == [sess]
+
+
+def test_on_complete_does_not_fire_on_failure():
+    from api.services.claude_orchestrator import ClaudeOrchestrator, ClaudeSession
+
+    orch = ClaudeOrchestrator()
+    sess = ClaudeSession(session_id="s2", task="t", status="running")
+    orch._active_session = sess
+    called = []
+    orch._on_complete = lambda s: called.append(s)
+
+    orch._cleanup("failed")
+    assert called == []
+
+
+def test_on_complete_skipped_without_session_id():
+    from api.services.claude_orchestrator import ClaudeOrchestrator, ClaudeSession
+
+    orch = ClaudeOrchestrator()
+    sess = ClaudeSession(session_id=None, task="t", status="running")
+    orch._active_session = sess
+    called = []
+    orch._on_complete = lambda s: called.append(s)
+
+    orch._cleanup("completed")
+    assert called == []  # no resumable session id → nothing to register
+
+
+# ---------------------------------------------------------------------------
+# Registration + any-chunk lookup
+# ---------------------------------------------------------------------------
+
+
+def test_register_code_followup_and_lookup(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    listener = _make_listener(tmp_path)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store):
+        listener._register_code_followup(_FakeSession("claude_abc", "fix the bug"), [10, 11, 12])
+
+    # Reply to any chunk matches; the row carries the Claude session id + kind.
+    q = store.get_open_question_by_message_id(12)
+    assert q is not None
+    assert q["kind"] == "code_followup"
+    assert q["session_id"] == "claude_abc"
+    assert q["question"] == "fix the bug"
+
+
+def test_register_code_followup_noop_without_ids_or_session(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    listener = _make_listener(tmp_path)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store):
+        listener._register_code_followup(_FakeSession("c", "t"), [])  # no ids
+        listener._register_code_followup(_FakeSession(None, "t"), [1])  # no session id
+    assert store.get_open_question_by_message_id(1) is None
+
+
+# ---------------------------------------------------------------------------
+# Telegram reply routing
+# ---------------------------------------------------------------------------
+
+
+class _FakeOrch:
+    def __init__(self, resume_ok=True):
+        self.resume_ok = resume_ok
+        self.followup_calls = []
+
+    def followup(self, message, notification_callback=None, on_complete=None):
+        self.followup_calls.append(message)
+        return object() if self.resume_ok else None
+
+
+@pytest.mark.asyncio
+async def test_code_reply_resumes_via_orchestrator(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    store.create_pending_question(
+        session_id="claude_abc", task_id="code_claude_abc", question="fix the bug",
+        sent_message_id=20, sent_message_ids=[20, 21], kind="code_followup",
+    )
+    listener = _make_listener(tmp_path)
+    orch = _FakeOrch(resume_ok=True)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+         patch("api.services.claude_orchestrator.get_orchestrator", return_value=orch), \
+         patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+        # Reply lands on the second chunk.
+        handled = await listener._maybe_handle_code_reply(21, "now add tests", "123")
+
+    assert handled is True
+    assert orch.followup_calls == ["now add tests"]
+    assert "Resuming Claude Code" in mock_send.await_args.args[0]
+    # Row is closed so it isn't reprocessed.
+    assert store.get_open_question_by_message_id(20) is None
+
+
+@pytest.mark.asyncio
+async def test_code_reply_unresumable_tells_user(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    store.create_pending_question(
+        session_id="claude_abc", task_id="code_claude_abc", question="t",
+        sent_message_id=30, kind="code_followup",
+    )
+    listener = _make_listener(tmp_path)
+    orch = _FakeOrch(resume_ok=False)  # window expired / busy
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+         patch("api.services.claude_orchestrator.get_orchestrator", return_value=orch), \
+         patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+        handled = await listener._maybe_handle_code_reply(30, "continue", "123")
+
+    assert handled is True
+    assert "can't be resumed" in mock_send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_non_code_reply_not_handled(tmp_path: Path):
+    """A reply matching an agent-worker follow-up (kind='followup') is NOT
+    consumed by the code-reply hook — it falls through to the worker deposit."""
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    store.create_pending_question(
+        session_id="sess_x", task_id="t1", question="",
+        sent_message_id=40, kind="followup",
+    )
+    listener = _make_listener(tmp_path)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+         patch("api.services.telegram.send_message_async", new_callable=AsyncMock):
+        handled = await listener._maybe_handle_code_reply(40, "x", "123")
+    assert handled is False
+    # Unconsumed — still open for the worker path.
+    assert store.get_open_question_by_message_id(40) is not None
+
+
+@pytest.mark.asyncio
+async def test_no_match_returns_false(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    listener = _make_listener(tmp_path)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store):
+        handled = await listener._maybe_handle_code_reply(999, "x", "123")
+    assert handled is False


### PR DESCRIPTION
## Summary

Phase 4 of #233 (Unified Agent Threads) — **option A, light build**. Replying to a `/code` (Claude Code) completion message now resumes that session, uniform with `#agent` thread replies, via the shared `pending_questions` follow-up table. The actual resume reuses the orchestrator's existing `resume_session_id` path.

Closes #237. Relates to #233. Option B (deeper merge) filed as #248.

## What changed

- **Orchestrator hook:** `ClaudeOrchestrator` gains `on_complete(session)`, fired once from `_cleanup` on successful completion (status `completed`, `session_id` known). `run_task` / `followup` accept it. No change to existing `/code`, `/code_status`, `/code_cancel` behavior.
- **Registration:** Telegram `_code_callbacks(chat_id)` builds a notify callback that captures each message's chunk ids (`send_message_capture_ids`) plus an `on_complete` that registers a `pending_questions` row with `kind='code_followup'`, keyed to the completion message's chunk ids and storing the Claude `session_id`.
- **Reply routing:** `_maybe_handle_code_reply` (checked before the agent-worker deposit) matches an open `code_followup` row on **any chunk** (`get_open_question_by_message_id`), closes it, and resumes via `orchestrator.followup()` → `resume_session_id`. The agent worker **skips** `code_followup` rows (they point at a Claude Code session, not an agent-worker session).

## Test evidence

- `pytest -m "unit and not slow" tests/` (pre-push gate): **1637 passed, 8 skipped, 0 failed**.
- New `tests/test_code_followup.py` (9): on_complete fires only on completion + with a session id; registration + any-chunk lookup; reply resumes via the orchestrator; unresumable tells the user; non-code / no-match replies fall through.
- Worker-skip test: a `code_followup` row is marked processed without dispatching.

## Review focus

- The `on_complete` seam in `_cleanup` (single completion path) and that it doesn't fire on failure / missing session id.
- Reply routing precedence: `_maybe_handle_code_reply` before `_maybe_deposit_agent_answer`; worker skipping `code_followup`.
- Known option-A limitation (resume bound to orchestrator's `_last_completed` + 5-min window) — deferred to #248.