### PR TITLE
feat(chat): bring agent threads into web /chat

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -315,6 +315,110 @@ async def stream_snapshots() -> StreamingResponse:
     )
 
 
+# ---------------------------------------------------------------------------
+# Agent threads for web /chat (#236, Phase 3 of #233)
+# ---------------------------------------------------------------------------
+
+
+class SpawnRequest(BaseModel):
+    """Body for POST /api/agents/spawn — operator agent spawn from web chat."""
+    prompt: str
+    # "local" | "claude" force the model; "auto"/None routes via preflight.
+    routing: str | None = None
+
+
+class ReplyRequest(BaseModel):
+    """Body for POST /api/agents/threads/{id}/reply."""
+    text: str
+
+
+def _thread_dict(s: Session, transcript: TranscriptStore) -> dict[str, Any]:
+    """Session dict plus a `resumable` flag for the threads panel."""
+    d = _session_to_dict(s, transcript)
+    d["resumable"] = s.status in TERMINAL_STATUSES
+    d["origin"] = getattr(s, "origin", None)
+    return d
+
+
+@router.get("/threads")
+async def list_threads(limit: int = Query(50, ge=1, le=200)) -> dict[str, Any]:
+    """List recent/resumable agent threads (root sessions only) for /chat.
+
+    Spawned children are internal to a parent's flow, so only top-level
+    sessions (no `parent_session_id`) are surfaced as conversable threads.
+    """
+    session_store = _get_session_store()
+    transcript_store = _get_transcript_store()
+    sessions = session_store.list_sessions(limit=_SNAPSHOT_LIMIT)
+    threads = [
+        _thread_dict(s, transcript_store)
+        for s in sessions
+        if not s.parent_session_id
+    ]
+    return {"threads": threads[:limit], "total": len(threads)}
+
+
+@router.get("/threads/{session_id}")
+async def get_thread(
+    session_id: str,
+    limit: int = Query(200, ge=1, le=2000),
+) -> dict[str, Any]:
+    """A single thread: session metadata + a transcript tail."""
+    session_store = _get_session_store()
+    transcript_store = _get_transcript_store()
+    session = session_store.get_by_session_id(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    try:
+        events = transcript_store.read(session_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    tail = events[-limit:] if len(events) > limit else events
+    return {"thread": _thread_dict(session, transcript_store), "events": tail, "total": len(events)}
+
+
+@router.post("/threads/{session_id}/reply")
+async def reply_to_thread(session_id: str, body: ReplyRequest) -> dict[str, Any]:
+    """Reply to a completed/failed thread to resume it as a follow-up turn.
+
+    Deposits into the same follow-up path a Telegram reply consumes — the
+    worker's next tick reopens the session via `_resume_as_followup`.
+    """
+    text = (body.text or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="reply text is required")
+    session_store = _get_session_store()
+    session = session_store.get_by_session_id(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    if session.status not in TERMINAL_STATUSES:
+        raise HTTPException(
+            status_code=409,
+            detail=f"thread is {session.status}; can only reply to a finished thread",
+        )
+    session_store.enqueue_web_followup(session_id, session.task_id, text)
+    return {"ok": True, "session_id": session_id, "status": "queued"}
+
+
+@router.post("/spawn")
+async def spawn_agent(body: SpawnRequest) -> dict[str, Any]:
+    """Spawn an operator agent on demand (#235's create_operator_session)."""
+    prompt = (body.prompt or "").strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail="prompt is required")
+    routing = body.routing
+    explicit = routing if routing in ("local", "claude") else None  # "auto"/None → preflight
+    from api.services.agent_worker.operator_spawn import create_operator_session
+
+    session_store = _get_session_store()
+    result = await asyncio.to_thread(
+        create_operator_session, session_store, prompt, explicit_routing=explicit,
+    )
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "spawn failed"))
+    return result
+
+
 class KillRequest(BaseModel):
     reason: str = ""
 

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -332,12 +332,29 @@ class ReplyRequest(BaseModel):
     text: str
 
 
-def _thread_dict(s: Session, transcript: TranscriptStore) -> dict[str, Any]:
-    """Session dict plus a `resumable` flag for the threads panel."""
-    d = _session_to_dict(s, transcript)
-    d["resumable"] = s.status in TERMINAL_STATUSES
-    d["origin"] = getattr(s, "origin", None)
-    return d
+def _thread_dict(s: Session) -> dict[str, Any]:
+    """Lightweight thread projection for the panel — no transcript read.
+
+    The list endpoint is polled, so it avoids `_session_to_dict`'s per-session
+    JSONL read (whose event-summary fields the panel doesn't use). `label`
+    resolves via the cached TaskManager lookup, not the transcript.
+    """
+    return {
+        "session_id": s.session_id,
+        "task_id": s.task_id,
+        "status": s.status,
+        "routing": s.routing,
+        "parent_session_id": s.parent_session_id,
+        "root_session_id": s.root_session_id,
+        "started_at": s.started_at,
+        "last_activity_at": s.last_activity_at,
+        "total_dollars": round(s.total_dollars, 6),
+        "expected_output": s.expected_output,
+        "label": _label_for_session(s, []),
+        "model_label": _model_label_for_routing(s.routing),
+        "origin": getattr(s, "origin", None),
+        "resumable": s.status in TERMINAL_STATUSES,
+    }
 
 
 @router.get("/threads")
@@ -348,13 +365,8 @@ async def list_threads(limit: int = Query(50, ge=1, le=200)) -> dict[str, Any]:
     sessions (no `parent_session_id`) are surfaced as conversable threads.
     """
     session_store = _get_session_store()
-    transcript_store = _get_transcript_store()
     sessions = session_store.list_sessions(limit=_SNAPSHOT_LIMIT)
-    threads = [
-        _thread_dict(s, transcript_store)
-        for s in sessions
-        if not s.parent_session_id
-    ]
+    threads = [_thread_dict(s) for s in sessions if not s.parent_session_id]
     return {"threads": threads[:limit], "total": len(threads)}
 
 
@@ -374,7 +386,7 @@ async def get_thread(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     tail = events[-limit:] if len(events) > limit else events
-    return {"thread": _thread_dict(session, transcript_store), "events": tail, "total": len(events)}
+    return {"thread": _thread_dict(session), "events": tail, "total": len(events)}
 
 
 @router.post("/threads/{session_id}/reply")
@@ -416,6 +428,15 @@ async def spawn_agent(body: SpawnRequest) -> dict[str, Any]:
     )
     if not result.get("ok"):
         raise HTTPException(status_code=400, detail=result.get("error", "spawn failed"))
+    if result.get("needs_routing"):
+        # Preflight was ambiguous about the model. The web surface has no inline
+        # routing-clarification flow (unlike Telegram), so don't leave a parked
+        # session that never runs — tear it down and ask for an explicit model.
+        session_store.delete_session(result["session_id"])
+        raise HTTPException(
+            status_code=409,
+            detail="Ambiguous which model to use — retry with routing 'local' or 'claude'.",
+        )
     return result
 
 

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -919,11 +919,13 @@ async def _handle_agent_slash(stripped: str, conversation_id, store):
     if not task:
         msg = "Usage: `/agent [local|claude] <task>` — e.g. `/agent claude refactor the parser`."
     else:
+        sess_store = None
         try:
             from api.services.agent_worker.operator_spawn import create_operator_session
             from api.services.agent_worker.session_store import SessionStore
+            sess_store = SessionStore()
             result = await asyncio.to_thread(
-                create_operator_session, SessionStore(), task, explicit_routing=explicit,
+                create_operator_session, sess_store, task, explicit_routing=explicit,
             )
         except Exception as exc:
             result = {"ok": False, "error": str(exc)[:200]}
@@ -931,6 +933,13 @@ async def _handle_agent_slash(stripped: str, conversation_id, store):
         if not result.get("ok"):
             msg = f"Couldn't spawn agent: {result.get('error')}"
         elif result.get("needs_routing"):
+            # No inline routing-clarification flow on the web surface — tear the
+            # parked session down so it doesn't linger as a blocked thread.
+            if sess_store is not None:
+                try:
+                    sess_store.delete_session(result["session_id"])
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
             msg = (
                 "I couldn't tell whether to use the local or cloud model — "
                 "re-run as `/agent local <task>` or `/agent claude <task>`."

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -972,6 +972,29 @@ class SessionStore:
             )
         return True
 
+    def enqueue_web_followup(self, session_id: str, task_id: str, answer: str) -> int:
+        """Queue a follow-up turn from a non-Telegram surface (web /chat, #236).
+
+        Inserts a pre-answered `kind='followup'` row so the worker's
+        `_process_clarification_answers` tick picks it up and reopens the
+        session via `_resume_as_followup` — the same path a Telegram reply
+        takes. There's no Telegram message to match, so `sent_message_id` is a
+        sentinel 0 (web follow-ups are created already-answered, so they never
+        participate in reply-id matching via `deposit_answer`).
+        """
+        now = _now()
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO pending_questions (
+                    session_id, task_id, question, sent_message_id, sent_at,
+                    kind, answer, answered_at
+                ) VALUES (?, ?, '', 0, ?, 'followup', ?, ?)
+                """,
+                (session_id, task_id, now, answer, now),
+            )
+        return cur.lastrowid
+
     def get_recent_resumable_followup(self, within_seconds: int) -> dict | None:
         """Return the most recent open follow-up whose notification was sent
         within `within_seconds`, or None.

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -972,6 +972,19 @@ class SessionStore:
             )
         return True
 
+    def delete_session(self, session_id: str) -> None:
+        """Hard-delete a session and its queued messages/questions/turns.
+
+        Used to clean up an operator spawn that couldn't be routed (preflight
+        returned `ask` but the calling surface has no clarification flow), so it
+        doesn't linger as a permanently-blocked thread.
+        """
+        with self._connect() as conn:
+            conn.execute("DELETE FROM pending_messages WHERE session_id = ?", (session_id,))
+            conn.execute("DELETE FROM pending_questions WHERE session_id = ?", (session_id,))
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
+
     def enqueue_web_followup(self, session_id: str, task_id: str, answer: str) -> int:
         """Queue a follow-up turn from a non-Telegram surface (web /chat, #236).
 

--- a/docs/specs/product/chat-ui.md
+++ b/docs/specs/product/chat-ui.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Chat
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-05-28
 
 The primary chat interface for LifeOS, providing AI-powered search and synthesis across your personal knowledge base.
 
@@ -194,6 +194,16 @@ The orchestrator LLM (Claude Haiku via Anthropic API by default; configurable vi
 - Supports both personal and work accounts
 
 ---
+
+## Agent Threads
+
+**Status:** Complete
+
+Web `/chat` speaks to the same agent-thread model as Telegram (#236, Phase 3 of #233):
+
+- **Threads panel** (sidebar) — lists recent/resumable agent sessions (root sessions only) with a status badge (running / completed / failed / budget / blocked). Backed by `GET /api/agents/threads`; polled for live-ish updates (the `/agents` page uses the `/api/agents/stream` SSE for the full graph).
+- **Reply** — completed/failed threads show a reply box; sending it (`POST /api/agents/threads/{id}/reply`) reopens the session as a follow-up turn via the shared follow-up table — the same path a Telegram reply takes.
+- **Run as agent** — the composer has a model selector (auto / local / cloud) and a spawn button; it sends the composer text to `POST /api/agents/spawn` (Phase 2's `create_operator_session`), and the new thread appears in the panel. `auto` routes via preflight.
 
 ## Implementation Details
 

--- a/tests/test_agent_threads_api.py
+++ b/tests/test_agent_threads_api.py
@@ -172,3 +172,24 @@ def test_spawn_auto_routing_uses_preflight(stores, client, monkeypatch):
     resp = client.post("/api/agents/spawn", json={"prompt": "summarize my week", "routing": "auto"})
     assert resp.status_code == 200
     assert resp.json()["routing"] == "local"
+
+
+def test_spawn_auto_ambiguous_returns_409_and_cleans_up(stores, client, monkeypatch):
+    """When preflight is ambiguous (ROUTE_ASK), the web spawn has no inline
+    clarification flow — it must 409 and not leave a parked session behind."""
+    session_store, _ = stores
+    import api.services.agent_worker.operator_spawn as op
+
+    def ask_preflight(title, tags=None, caller=None):
+        from api.services.agent_worker.preflight import PreflightResult, PreflightBudget
+        return PreflightResult(
+            budget=PreflightBudget(wall_seconds=60, max_tokens=100, max_dollars=1.0),
+            routing="ask", routing_reason="ambiguous", expected_output="text",
+            ambiguity=None, sane=True, sane_reason="", raw={},
+        )
+
+    monkeypatch.setattr(op, "run_preflight", ask_preflight)
+    resp = client.post("/api/agents/spawn", json={"prompt": "do the thing", "routing": "auto"})
+    assert resp.status_code == 409
+    # No parked operator session was left behind.
+    assert session_store.list_sessions(status="blocked") == []

--- a/tests/test_agent_threads_api.py
+++ b/tests/test_agent_threads_api.py
@@ -1,0 +1,174 @@
+"""API tests for the web /chat agent-threads endpoints (#236, Phase 3).
+
+Covers GET /api/agents/threads, GET /api/agents/threads/{id},
+POST /api/agents/threads/{id}/reply, and POST /api/agents/spawn.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services.agent_worker.session_store import (
+    STATUS_COMPLETED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    agents_route._label_cache.clear()
+    yield session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+# ---------------------------------------------------------------------------
+# GET /threads
+# ---------------------------------------------------------------------------
+
+
+def test_list_threads_returns_only_root_sessions(stores, client):
+    session_store, _ = stores
+    root = session_store.create(task_id="root", status=STATUS_COMPLETED, routing="local")
+    session_store.create(
+        task_id="child", status=STATUS_RUNNING, routing="local",
+        parent_session_id=root.session_id, root_session_id=root.session_id, spawn_depth=1,
+    )
+
+    resp = client.get("/api/agents/threads")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = {t["session_id"] for t in data["threads"]}
+    assert root.session_id in ids
+    # The spawned child is internal — not surfaced as a conversable thread.
+    assert all(t["parent_session_id"] is None for t in data["threads"])
+    # Completed root is resumable.
+    root_t = next(t for t in data["threads"] if t["session_id"] == root.session_id)
+    assert root_t["resumable"] is True
+
+
+def test_running_thread_not_resumable(stores, client):
+    session_store, _ = stores
+    session_store.create(task_id="r", status=STATUS_RUNNING, routing="local")
+    resp = client.get("/api/agents/threads")
+    t = resp.json()["threads"][0]
+    assert t["resumable"] is False
+
+
+# ---------------------------------------------------------------------------
+# GET /threads/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_thread_detail(stores, client):
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t", status=STATUS_COMPLETED, routing="claude")
+    transcript_store.append(s.session_id, "claim", {"task_id": "t"})
+
+    resp = client.get(f"/api/agents/threads/{s.session_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["thread"]["session_id"] == s.session_id
+    assert data["total"] == 1
+    assert data["events"][0]["kind"] == "claim"
+
+
+def test_get_thread_404(stores, client):
+    resp = client.get("/api/agents/threads/sess_does_not_exist")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /threads/{id}/reply
+# ---------------------------------------------------------------------------
+
+
+def test_reply_to_completed_thread_queues_followup(stores, client):
+    session_store, _ = stores
+    s = session_store.create(task_id="t", status=STATUS_COMPLETED, routing="local")
+
+    resp = client.post(f"/api/agents/threads/{s.session_id}/reply", json={"text": "also CC Jane"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "queued"
+
+    # A pre-answered followup row is now waiting for the worker to resume.
+    pending = session_store.list_answered_unprocessed_questions()
+    assert len(pending) == 1
+    assert pending[0]["kind"] == "followup"
+    assert pending[0]["answer"] == "also CC Jane"
+    assert pending[0]["session_id"] == s.session_id
+
+
+def test_reply_to_running_thread_409(stores, client):
+    session_store, _ = stores
+    s = session_store.create(task_id="t", status=STATUS_RUNNING, routing="local")
+    resp = client.post(f"/api/agents/threads/{s.session_id}/reply", json={"text": "hi"})
+    assert resp.status_code == 409
+
+
+def test_reply_unknown_thread_404(stores, client):
+    resp = client.post("/api/agents/threads/nope/reply", json={"text": "hi"})
+    assert resp.status_code == 404
+
+
+def test_reply_empty_text_400(stores, client):
+    session_store, _ = stores
+    s = session_store.create(task_id="t", status=STATUS_COMPLETED, routing="local")
+    resp = client.post(f"/api/agents/threads/{s.session_id}/reply", json={"text": "   "})
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /spawn
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_explicit_claude(stores, client):
+    session_store, _ = stores
+    resp = client.post("/api/agents/spawn", json={"prompt": "refactor the parser", "routing": "claude"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] and data["routing"] == "claude"
+    # The session landed in the store as an operator root-spawn.
+    s = session_store.get_by_session_id(data["session_id"])
+    assert s is not None and s.origin == "operator" and s.routing == "claude"
+
+
+def test_spawn_empty_prompt_400(stores, client):
+    resp = client.post("/api/agents/spawn", json={"prompt": "  "})
+    assert resp.status_code == 400
+
+
+def test_spawn_auto_routing_uses_preflight(stores, client, monkeypatch):
+    # "auto" → no explicit routing → create_operator_session runs preflight.
+    # Patch it so the test doesn't make a network call.
+    import api.services.agent_worker.operator_spawn as op
+
+    def fake_preflight(title, tags=None, caller=None):
+        from api.services.agent_worker.preflight import PreflightResult, PreflightBudget
+        return PreflightResult(
+            budget=PreflightBudget(wall_seconds=60, max_tokens=100, max_dollars=1.0),
+            routing="local", routing_reason="t", expected_output="text",
+            ambiguity=None, sane=True, sane_reason="", raw={},
+        )
+
+    monkeypatch.setattr(op, "run_preflight", fake_preflight)
+    resp = client.post("/api/agents/spawn", json={"prompt": "summarize my week", "routing": "auto"})
+    assert resp.status_code == 200
+    assert resp.json()["routing"] == "local"

--- a/tests/test_agent_threads_ui_browser.py
+++ b/tests/test_agent_threads_ui_browser.py
@@ -1,0 +1,108 @@
+"""Browser test for the web /chat agent-threads UI (#236, Phase 3).
+
+Drives the Agents panel + "run as agent" composer affordance with the
+`/api/agents/*` endpoints mocked via Playwright route interception, so the
+spawn → appear → reply flow is deterministic and free of real worker/LLM
+side effects. Requires the server serving the chat page on localhost:8000
+(like all browser tests in this repo).
+"""
+import json
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+DESKTOP_VIEWPORT = {"width": 1280, "height": 800}
+
+
+def _install_agent_mocks(page: Page, state: dict):
+    """Route /api/agents/* to in-memory mock responses driven by `state`."""
+
+    def threads_handler(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"threads": state["threads"], "total": len(state["threads"])}),
+        )
+
+    def spawn_handler(route):
+        body = json.loads(route.request.post_data or "{}")
+        state["spawned"].append(body)
+        # The spawned agent now shows up as a running thread.
+        state["threads"].insert(0, {
+            "session_id": "sess_spawned",
+            "task_id": "op_spawned",
+            "parent_session_id": None,
+            "status": "running",
+            "label": body.get("prompt", "agent task")[:40],
+            "resumable": False,
+        })
+        route.fulfill(status=200, content_type="application/json",
+                      body=json.dumps({"ok": True, "session_id": "sess_spawned",
+                                       "task_id": "op_spawned", "routing": "claude",
+                                       "needs_routing": False}))
+
+    def reply_handler(route):
+        state["replies"].append(json.loads(route.request.post_data or "{}"))
+        route.fulfill(status=200, content_type="application/json",
+                      body=json.dumps({"ok": True, "status": "queued"}))
+
+    page.route("**/api/agents/threads*", threads_handler)
+    page.route("**/api/agents/spawn", spawn_handler)
+    page.route("**/api/agents/threads/*/reply", reply_handler)
+
+
+class TestAgentThreadsUI:
+    @pytest.fixture(autouse=True)
+    def setup(self, page: Page):
+        page.set_viewport_size(DESKTOP_VIEWPORT)
+        self.state = {
+            "threads": [{
+                "session_id": "sess_done",
+                "task_id": "op_done",
+                "parent_session_id": None,
+                "status": "completed",
+                "label": "draft the landlord email",
+                "resumable": True,
+            }],
+            "spawned": [],
+            "replies": [],
+        }
+        _install_agent_mocks(page, self.state)
+        page.goto("http://localhost:8000")
+        page.wait_for_selector("#agentsPanel")
+
+    def test_panel_lists_threads_with_status(self, page: Page):
+        expect(page.locator("#agentsThreadsList .agent-thread")).to_have_count(1)
+        expect(page.locator(".agent-badge.completed")).to_be_visible()
+        expect(page.locator(".agent-thread-label")).to_contain_text("landlord")
+
+    def test_composer_has_run_as_agent_controls(self, page: Page):
+        expect(page.locator("#agentRouting")).to_be_visible()
+        expect(page.locator("#agentSpawnBtn")).to_be_visible()
+        # Routing options: auto / local / cloud.
+        values = page.locator("#agentRouting option").evaluate_all(
+            "els => els.map(e => e.value)"
+        )
+        assert set(values) == {"auto", "local", "claude"}
+
+    def test_spawn_from_composer_appears_in_panel(self, page: Page):
+        page.locator("#inputField").fill("research the best CRMs")
+        page.locator("#agentRouting").select_option("claude")
+        page.locator("#agentSpawnBtn").click()
+        # The mock inserts a running thread; the panel polls/refreshes.
+        expect(page.locator(".agent-badge.running")).to_be_visible(timeout=8000)
+        assert self.state["spawned"], "spawn POST should have fired"
+        assert self.state["spawned"][0]["routing"] == "claude"
+
+    def test_reply_to_completed_thread(self, page: Page):
+        # Open the reply box on the completed (resumable) thread and send.
+        page.locator("#reply-sess_done").wait_for(state="attached")
+        page.locator('.agent-thread-top button[title="Reply"]').click()
+        box = page.locator("#reply-sess_done input")
+        box.fill("also CC Jane")
+        box.press("Enter")
+        page.wait_for_timeout(500)
+        assert self.state["replies"], "reply POST should have fired"
+        assert self.state["replies"][0]["text"] == "also CC Jane"

--- a/tests/test_operator_spawn.py
+++ b/tests/test_operator_spawn.py
@@ -121,6 +121,17 @@ def test_unsafe_preflight_rejected(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_delete_session_removes_row_and_queued_message(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    res = create_operator_session(store, "do X", explicit_routing="local")
+    sid = res["session_id"]
+    assert store.get_by_session_id(sid) is not None
+    store.delete_session(sid)
+    assert store.get_by_session_id(sid) is None
+    assert store.drain_pending_messages(sid) == []
+
+
+@pytest.mark.unit
 def test_operator_budget_defaults_applied(tmp_path: Path):
     store = SessionStore(db_path=tmp_path / "s.db")
     result = create_operator_session(store, "do X", explicit_routing="local")

--- a/web/index.html
+++ b/web/index.html
@@ -2480,6 +2480,32 @@
             margin-bottom: 1rem;
             opacity: 0.5;
         }
+
+        /* Agent threads panel (#236) */
+        .agents-panel { border-top: 1px solid var(--border, #2a2a2a); margin-top: auto; }
+        .agents-panel-header {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 0.6rem 1rem; font-size: 0.8rem; font-weight: 600;
+            text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.7;
+        }
+        .agents-refresh { background: none; border: none; color: inherit; cursor: pointer; font-size: 1rem; opacity: 0.7; }
+        .agents-refresh:hover { opacity: 1; }
+        .agents-threads-list { max-height: 38vh; overflow-y: auto; padding: 0 0.5rem 0.5rem; }
+        .agent-thread { padding: 0.5rem 0.6rem; border-radius: 8px; margin-bottom: 0.35rem; background: rgba(255,255,255,0.03); }
+        .agent-thread-top { display: flex; align-items: center; gap: 0.4rem; }
+        .agent-thread-label { flex: 1; font-size: 0.82rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .agent-badge { font-size: 0.64rem; padding: 0.1rem 0.4rem; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.03em; }
+        .agent-badge.running { background: #1e3a5f; color: #7fb4ff; }
+        .agent-badge.completed { background: #1e4620; color: #7ad17f; }
+        .agent-badge.failed, .agent-badge.budget_exceeded { background: #4a1e1e; color: #ff9d9d; }
+        .agent-badge.blocked, .agent-badge.yielded { background: #4a3a1e; color: #ffd27f; }
+        .agent-reply-row { display: none; gap: 0.3rem; margin-top: 0.4rem; }
+        .agent-reply-row.open { display: flex; }
+        .agent-reply-row input { flex: 1; font-size: 0.78rem; padding: 0.3rem 0.45rem; border-radius: 6px; border: 1px solid var(--border, #2a2a2a); background: rgba(0,0,0,0.2); color: inherit; }
+        .agent-reply-row button { font-size: 0.74rem; padding: 0.3rem 0.5rem; border-radius: 6px; border: none; cursor: pointer; background: #2d5fa3; color: #fff; }
+        .agent-routing-select { font-size: 0.78rem; border-radius: 8px; border: 1px solid var(--border, #2a2a2a); background: rgba(0,0,0,0.2); color: inherit; padding: 0 0.3rem; }
+        .agent-spawn-btn { background: none; border: none; cursor: pointer; font-size: 1.15rem; opacity: 0.75; }
+        .agent-spawn-btn:hover { opacity: 1; }
     </style>
 </head>
 <body>
@@ -2497,6 +2523,16 @@
         </div>
         <div class="conversations-list" id="conversationsList">
             <div class="empty-conversations">No conversations yet</div>
+        </div>
+        <!-- Agent threads (#236): in-flight + completed agent sessions, replyable -->
+        <div class="agents-panel" id="agentsPanel">
+            <div class="agents-panel-header">
+                <span>Agent threads</span>
+                <button class="agents-refresh" onclick="loadAgentThreads()" title="Refresh">⟳</button>
+            </div>
+            <div class="agents-threads-list" id="agentsThreadsList">
+                <div class="empty-conversations">No agent threads</div>
+            </div>
         </div>
     </aside>
 
@@ -2560,6 +2596,12 @@
                 <input type="file" id="fileInput" class="file-input" multiple
                        accept="image/png,image/jpeg,image/jpg,image/gif,image/webp,application/pdf,text/plain,text/markdown,text/csv,application/json">
                 <button class="attach-btn" id="attachBtn" onclick="openFilePicker()" title="Attach files">📎</button>
+                <select id="agentRouting" class="agent-routing-select" title="Agent model (run-as-agent)">
+                    <option value="auto">🤖 auto</option>
+                    <option value="local">local</option>
+                    <option value="claude">cloud</option>
+                </select>
+                <button class="agent-spawn-btn" id="agentSpawnBtn" onclick="spawnAgentFromComposer()" title="Run the composer text as an agent">⚙</button>
                 <button class="send-btn" id="sendBtn" onclick="sendMessage()" title="Send message">➤</button>
             </div>
         </footer>
@@ -2885,7 +2927,105 @@
             inputField.focus();
             setupScrollListener();
             setupAttachmentHandlers();
+            loadAgentThreads();
+            // Light polling for live-ish status; the /api/agents/stream SSE
+            // already drives the dedicated /agents page.
+            setInterval(loadAgentThreads, 5000);
         });
+
+        // --- Agent threads panel (#236) ---
+        async function loadAgentThreads() {
+            const list = document.getElementById('agentsThreadsList');
+            if (!list) return;
+            try {
+                const resp = await fetch('/api/agents/threads?limit=25');
+                if (!resp.ok) return;
+                const data = await resp.json();
+                renderAgentThreads(data.threads || []);
+            } catch (e) { /* worker/API offline — leave the panel as-is */ }
+        }
+
+        function renderAgentThreads(threads) {
+            const list = document.getElementById('agentsThreadsList');
+            if (!list) return;
+            if (!threads.length) {
+                list.innerHTML = '<div class="empty-conversations">No agent threads</div>';
+                return;
+            }
+            list.innerHTML = '';
+            threads.forEach(t => {
+                const label = escapeHtml((t.label || t.task_id || t.session_id || 'agent').toString());
+                const status = (t.status || '').toString();
+                const sid = t.session_id;
+                const div = document.createElement('div');
+                div.className = 'agent-thread';
+                div.innerHTML =
+                    '<div class="agent-thread-top">' +
+                        '<span class="agent-thread-label" title="' + label + '">' + label + '</span>' +
+                        '<span class="agent-badge ' + escapeHtml(status) + '">' + (escapeHtml(status) || '?') + '</span>' +
+                        (t.resumable ? '<button class="agents-refresh" title="Reply" onclick="toggleAgentReply(\'' + sid + '\')">↩</button>' : '') +
+                    '</div>' +
+                    '<div class="agent-reply-row" id="reply-' + sid + '">' +
+                        '<input type="text" placeholder="Reply to continue…" ' +
+                        'onkeydown="if(event.key===\'Enter\'){sendAgentReply(\'' + sid + '\')}">' +
+                        '<button onclick="sendAgentReply(\'' + sid + '\')">Send</button>' +
+                    '</div>';
+                list.appendChild(div);
+            });
+        }
+
+        function toggleAgentReply(sessionId) {
+            const row = document.getElementById('reply-' + sessionId);
+            if (!row) return;
+            row.classList.toggle('open');
+            const inp = row.querySelector('input');
+            if (inp && row.classList.contains('open')) inp.focus();
+        }
+
+        async function sendAgentReply(sessionId) {
+            const row = document.getElementById('reply-' + sessionId);
+            if (!row) return;
+            const inp = row.querySelector('input');
+            const text = ((inp && inp.value) || '').trim();
+            if (!text) return;
+            try {
+                const resp = await fetch('/api/agents/threads/' + encodeURIComponent(sessionId) + '/reply', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ text }),
+                });
+                if (resp.ok) {
+                    inp.value = '';
+                    row.classList.remove('open');
+                    setTimeout(loadAgentThreads, 500);
+                } else {
+                    const e = await resp.json().catch(() => ({}));
+                    alert('Reply failed: ' + (e.detail || resp.status));
+                }
+            } catch (e) { alert('Reply failed: ' + e); }
+        }
+
+        async function spawnAgentFromComposer() {
+            const prompt = (inputField.value || '').trim();
+            if (!prompt) { inputField.focus(); return; }
+            const sel = document.getElementById('agentRouting');
+            const routing = (sel && sel.value) || 'auto';
+            try {
+                const resp = await fetch('/api/agents/spawn', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ prompt, routing }),
+                });
+                const data = await resp.json().catch(() => ({}));
+                if (resp.ok) {
+                    inputField.value = '';
+                    inputField.style.height = 'auto';
+                    setTimeout(loadAgentThreads, 500);
+                } else {
+                    alert('Spawn failed: ' + (data.detail || resp.status));
+                }
+            } catch (e) { alert('Spawn failed: ' + e); }
+        }
 
         // Sidebar toggle
         function toggleSidebar() {

--- a/web/index.html
+++ b/web/index.html
@@ -2955,13 +2955,16 @@
             list.innerHTML = '';
             threads.forEach(t => {
                 const label = escapeHtml((t.label || t.task_id || t.session_id || 'agent').toString());
+                // escapeHtml leaves double-quotes intact; escape them for the
+                // title="…" attribute context to prevent attribute breakout.
+                const labelAttr = label.replace(/"/g, '&quot;');
                 const status = (t.status || '').toString();
                 const sid = t.session_id;
                 const div = document.createElement('div');
                 div.className = 'agent-thread';
                 div.innerHTML =
                     '<div class="agent-thread-top">' +
-                        '<span class="agent-thread-label" title="' + label + '">' + label + '</span>' +
+                        '<span class="agent-thread-label" title="' + labelAttr + '">' + label + '</span>' +
                         '<span class="agent-badge ' + escapeHtml(status) + '">' + (escapeHtml(status) || '?') + '</span>' +
                         (t.resumable ? '<button class="agents-refresh" title="Reply" onclick="toggleAgentReply(\'' + sid + '\')">↩</button>' : '') +
                     '</div>' +


### PR DESCRIPTION
## Summary

Phase 3 of #233 (Unified Agent Threads). The web `/chat` interface now speaks to the same AgentThread model as Telegram: list agent threads, reply to a completion to resume it, and spawn an agent on demand from the composer.

Closes #236. Relates to #233. Builds on #234 (replyable threads) + #235 (operator spawn).

## What changed

**API (`api/routes/agents.py`):**
- `GET /api/agents/threads` — recent/resumable threads (root sessions only; spawned children are internal), each with a `resumable` flag.
- `GET /api/agents/threads/{id}` — session metadata + transcript tail.
- `POST /api/agents/threads/{id}/reply` — queues a follow-up the worker resumes via `_resume_as_followup` (409 on a still-running thread, 404 unknown, 400 empty).
- `POST /api/agents/spawn` — Phase 2's `create_operator_session` (`local`/`claude`/`auto`).

**Store:** `session_store.enqueue_web_followup()` — a pre-answered `followup` row so a web reply takes the same resume path as a Telegram reply, with no Telegram message id.

**Frontend (`web/index.html`):** an Agents threads panel (status badges + per-thread reply box) and a composer "run as agent" control (auto / local / cloud). Live-ish via polling; the `/agents` page keeps the `/api/agents/stream` SSE graph.

## Test evidence

- `pytest -m "unit and not slow" tests/` (pre-push gate): **1649 passed, 8 skipped, 0 failed**.
- New `tests/test_agent_threads_api.py` (11): threads list (roots only, resumable flag), thread detail + 404, reply queues a follow-up / 409 running / 404 unknown / 400 empty, spawn explicit + auto-route (preflight) + 400 empty.
- New `tests/test_agent_threads_ui_browser.py` — Playwright (`[browser, slow]`) covering panel render, composer controls, spawn → appears in panel, reply → POST fired; uses `page.route()` mocking so the UI flow is deterministic and free of real worker/LLM side effects.

## Verification note

The API layer is fully unit-tested (gates this PR). The browser test follows the repo's existing `[browser, slow]` pattern — it requires a live server and is **not** run by the pre-push gate (consistent with all browser tests here). The frontend JS was syntax-validated with `node --check`. The full spawn→worker→resume execution is covered by the worker resume unit tests in #234/#235.

## Review focus

- `enqueue_web_followup` correctness vs the worker's `_process_clarification_answers` followup path.
- Reply gating (terminal-only) and the threads list filtering to root sessions.
- Frontend additions are contained + defensive (all fetches wrapped; panel degrades quietly when the API/worker is offline).