### PR TITLE
feat: unified agent threads — interactive replies + on-demand spawn (#233)

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -315,6 +315,131 @@ async def stream_snapshots() -> StreamingResponse:
     )
 
 
+# ---------------------------------------------------------------------------
+# Agent threads for web /chat (#236, Phase 3 of #233)
+# ---------------------------------------------------------------------------
+
+
+class SpawnRequest(BaseModel):
+    """Body for POST /api/agents/spawn — operator agent spawn from web chat."""
+    prompt: str
+    # "local" | "claude" force the model; "auto"/None routes via preflight.
+    routing: str | None = None
+
+
+class ReplyRequest(BaseModel):
+    """Body for POST /api/agents/threads/{id}/reply."""
+    text: str
+
+
+def _thread_dict(s: Session) -> dict[str, Any]:
+    """Lightweight thread projection for the panel — no transcript read.
+
+    The list endpoint is polled, so it avoids `_session_to_dict`'s per-session
+    JSONL read (whose event-summary fields the panel doesn't use). `label`
+    resolves via the cached TaskManager lookup, not the transcript.
+    """
+    return {
+        "session_id": s.session_id,
+        "task_id": s.task_id,
+        "status": s.status,
+        "routing": s.routing,
+        "parent_session_id": s.parent_session_id,
+        "root_session_id": s.root_session_id,
+        "started_at": s.started_at,
+        "last_activity_at": s.last_activity_at,
+        "total_dollars": round(s.total_dollars, 6),
+        "expected_output": s.expected_output,
+        "label": _label_for_session(s, []),
+        "model_label": _model_label_for_routing(s.routing),
+        "origin": getattr(s, "origin", None),
+        "resumable": s.status in TERMINAL_STATUSES,
+    }
+
+
+@router.get("/threads")
+async def list_threads(limit: int = Query(50, ge=1, le=200)) -> dict[str, Any]:
+    """List recent/resumable agent threads (root sessions only) for /chat.
+
+    Spawned children are internal to a parent's flow, so only top-level
+    sessions (no `parent_session_id`) are surfaced as conversable threads.
+    """
+    session_store = _get_session_store()
+    sessions = session_store.list_sessions(limit=_SNAPSHOT_LIMIT)
+    threads = [_thread_dict(s) for s in sessions if not s.parent_session_id]
+    return {"threads": threads[:limit], "total": len(threads)}
+
+
+@router.get("/threads/{session_id}")
+async def get_thread(
+    session_id: str,
+    limit: int = Query(200, ge=1, le=2000),
+) -> dict[str, Any]:
+    """A single thread: session metadata + a transcript tail."""
+    session_store = _get_session_store()
+    transcript_store = _get_transcript_store()
+    session = session_store.get_by_session_id(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    try:
+        events = transcript_store.read(session_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    tail = events[-limit:] if len(events) > limit else events
+    return {"thread": _thread_dict(session), "events": tail, "total": len(events)}
+
+
+@router.post("/threads/{session_id}/reply")
+async def reply_to_thread(session_id: str, body: ReplyRequest) -> dict[str, Any]:
+    """Reply to a completed/failed thread to resume it as a follow-up turn.
+
+    Deposits into the same follow-up path a Telegram reply consumes — the
+    worker's next tick reopens the session via `_resume_as_followup`.
+    """
+    text = (body.text or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="reply text is required")
+    session_store = _get_session_store()
+    session = session_store.get_by_session_id(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    if session.status not in TERMINAL_STATUSES:
+        raise HTTPException(
+            status_code=409,
+            detail=f"thread is {session.status}; can only reply to a finished thread",
+        )
+    session_store.enqueue_web_followup(session_id, session.task_id, text)
+    return {"ok": True, "session_id": session_id, "status": "queued"}
+
+
+@router.post("/spawn")
+async def spawn_agent(body: SpawnRequest) -> dict[str, Any]:
+    """Spawn an operator agent on demand (#235's create_operator_session)."""
+    prompt = (body.prompt or "").strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail="prompt is required")
+    routing = body.routing
+    explicit = routing if routing in ("local", "claude") else None  # "auto"/None → preflight
+    from api.services.agent_worker.operator_spawn import create_operator_session
+
+    session_store = _get_session_store()
+    result = await asyncio.to_thread(
+        create_operator_session, session_store, prompt, explicit_routing=explicit,
+    )
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "spawn failed"))
+    if result.get("needs_routing"):
+        # Preflight was ambiguous about the model. The web surface has no inline
+        # routing-clarification flow (unlike Telegram), so don't leave a parked
+        # session that never runs — tear it down and ask for an explicit model.
+        session_store.delete_session(result["session_id"])
+        raise HTTPException(
+            status_code=409,
+            detail="Ambiguous which model to use — retry with routing 'local' or 'claude'.",
+        )
+    return result
+
+
 class KillRequest(BaseModel):
     reason: str = ""
 

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -897,6 +897,58 @@ class SaveToVaultRequest(BaseModel):
     guidance: Optional[str] = None
 
 
+async def _handle_agent_slash(stripped: str, conversation_id, store):
+    """Stream the SSE response for a `/agent [local|claude] <task>` chat command.
+
+    Operator agent spawn from web chat (#235), calling the same
+    `create_operator_session` entry point as the Telegram `/agent` command.
+    Web has no inline reply mechanism yet (added in Phase 3 / #236), so an
+    ambiguous auto-route asks the user to re-run with an explicit model.
+    """
+    rest = stripped[len("/agent"):].strip()
+    explicit = None
+    parts = rest.split(maxsplit=1)
+    if parts and parts[0].lower() in ("local", "claude"):
+        explicit = parts[0].lower()
+        task = parts[1].strip() if len(parts) > 1 else ""
+    else:
+        task = rest
+
+    yield f"data: {json.dumps({'type': 'routing', 'sources': ['agent'], 'reasoning': 'Operator agent spawn', 'latency_ms': 0})}\n\n"
+
+    if not task:
+        msg = "Usage: `/agent [local|claude] <task>` — e.g. `/agent claude refactor the parser`."
+    else:
+        try:
+            from api.services.agent_worker.operator_spawn import create_operator_session
+            from api.services.agent_worker.session_store import SessionStore
+            result = await asyncio.to_thread(
+                create_operator_session, SessionStore(), task, explicit_routing=explicit,
+            )
+        except Exception as exc:
+            result = {"ok": False, "error": str(exc)[:200]}
+
+        if not result.get("ok"):
+            msg = f"Couldn't spawn agent: {result.get('error')}"
+        elif result.get("needs_routing"):
+            msg = (
+                "I couldn't tell whether to use the local or cloud model — "
+                "re-run as `/agent local <task>` or `/agent claude <task>`."
+            )
+        else:
+            label = "Claude (cloud)" if result["routing"] == "claude" else "local Gemma"
+            msg = (
+                f"🤖 Spawned {label} agent: {task[:120]}\n\n"
+                f"Track it on the Agents page; the result appears there when it's done."
+            )
+
+    for chunk in msg:
+        yield f"data: {json.dumps({'type': 'content', 'content': chunk})}\n\n"
+        await asyncio.sleep(0.002)
+    store.add_message(conversation_id, "assistant", msg)
+    yield f"data: {json.dumps({'type': 'done'})}\n\n"
+
+
 @router.post("/ask/stream")
 async def ask_stream(request: AskStreamRequest):
     """
@@ -933,6 +985,15 @@ async def ask_stream(request: AskStreamRequest):
 
             # Save user message
             store.add_message(conversation_id, "user", request.question)
+
+            # `/agent [local|claude] <task>` — spawn an operator agent on demand
+            # (#235). Equivalent affordance to Telegram's /agent command, calling
+            # the same create_operator_session entry point.
+            _stripped = request.question.strip()
+            if _stripped.lower() == "/agent" or _stripped.lower().startswith("/agent "):
+                async for _ev in _handle_agent_slash(_stripped, conversation_id, store):
+                    yield _ev
+                return
 
             # Get conversation history for context in follow-up questions
             conversation_history = store.get_messages(conversation_id, limit=10)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -919,11 +919,13 @@ async def _handle_agent_slash(stripped: str, conversation_id, store):
     if not task:
         msg = "Usage: `/agent [local|claude] <task>` — e.g. `/agent claude refactor the parser`."
     else:
+        sess_store = None
         try:
             from api.services.agent_worker.operator_spawn import create_operator_session
             from api.services.agent_worker.session_store import SessionStore
+            sess_store = SessionStore()
             result = await asyncio.to_thread(
-                create_operator_session, SessionStore(), task, explicit_routing=explicit,
+                create_operator_session, sess_store, task, explicit_routing=explicit,
             )
         except Exception as exc:
             result = {"ok": False, "error": str(exc)[:200]}
@@ -931,6 +933,13 @@ async def _handle_agent_slash(stripped: str, conversation_id, store):
         if not result.get("ok"):
             msg = f"Couldn't spawn agent: {result.get('error')}"
         elif result.get("needs_routing"):
+            # No inline routing-clarification flow on the web surface — tear the
+            # parked session down so it doesn't linger as a blocked thread.
+            if sess_store is not None:
+                try:
+                    sess_store.delete_session(result["session_id"])
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
             msg = (
                 "I couldn't tell whether to use the local or cloud model — "
                 "re-run as `/agent local <task>` or `/agent claude <task>`."

--- a/api/services/agent_worker/operator_spawn.py
+++ b/api/services/agent_worker/operator_spawn.py
@@ -1,0 +1,116 @@
+"""Operator root-spawn (#235, Phase 2 of #233).
+
+`lifeos_agent_spawn` (inter_agent.py) is same-lineage only — it requires a
+parent agent session. This module adds the operator-initiated *root* spawn: a
+parentless session created on demand from Telegram or chat, with no backing
+`#agent` vault task.
+
+Routing follows the override-then-preflight rule locked with the user:
+explicit ``local`` / ``claude`` wins; otherwise ``run_preflight`` decides,
+falling back to the existing Telegram clarification flow on ``ROUTE_ASK``.
+
+The created session is marked ``origin='operator'`` so the worker's
+``_dispatch_spawned_sessions`` claims it even though it has no parent. The
+prompt is enqueued as a pending message (the worker drains it as the task
+description on dispatch), mirroring how spawned children are seeded.
+"""
+from __future__ import annotations
+
+import logging
+
+from config.settings import settings
+
+from .preflight import ROUTE_ASK, ROUTE_CLAUDE, ROUTE_LOCAL, run_preflight
+from .session_store import (
+    STATUS_BLOCKED,
+    STATUS_CLAIMED,
+    SessionStore,
+    new_session_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _operator_budget() -> dict:
+    return {
+        "wall_seconds": settings.agent_default_wall_seconds,
+        "max_tokens": settings.agent_default_max_tokens,
+        "max_dollars": settings.agent_default_budget_dollars,
+    }
+
+
+def create_operator_session(
+    session_store: SessionStore,
+    prompt: str,
+    *,
+    explicit_routing: str | None = None,
+    preflight_caller=None,
+    budget: dict | None = None,
+) -> dict:
+    """Create a parentless operator-spawned session.
+
+    Returns a result dict:
+      {"ok": True, "session_id", "task_id", "routing", "needs_routing",
+       "routing_source"}  on success, or
+      {"ok": False, "error"}  when the prompt is empty or preflight rejects it.
+
+    When ``needs_routing`` is True the routing came back ``ask``: the session
+    is parked at ``blocked`` with ``routing='ask'`` and the caller must send the
+    "local or claude?" clarification (registering a pending_question) so the
+    worker resolves it. Otherwise the session is ``claimed`` and the worker's
+    next tick dispatches it.
+    """
+    prompt = (prompt or "").strip()
+    if not prompt:
+        return {"ok": False, "error": "prompt is required"}
+
+    routing_source = "explicit"
+    if explicit_routing in (ROUTE_LOCAL, ROUTE_CLAUDE):
+        routing = explicit_routing
+    else:
+        routing_source = "preflight"
+        pre = run_preflight(title=prompt, tags=[], caller=preflight_caller)
+        if not pre.sane:
+            return {
+                "ok": False,
+                "error": f"preflight flagged this task as unsafe to run: {pre.sane_reason}",
+            }
+        routing = pre.routing  # local / claude / ask
+
+    needs_routing = routing == ROUTE_ASK
+    status = STATUS_BLOCKED if needs_routing else STATUS_CLAIMED
+    session_id = new_session_id()
+    task_id = f"op_{session_id.removeprefix('sess_')}"
+
+    # Enqueue the prompt BEFORE the session row exists. The worker is a separate
+    # process ticking against the shared DB; if it observed a CLAIMED operator
+    # session before the prompt landed, _dispatch_spawned_sessions would drain
+    # zero pending messages and run the agent with the synthetic session id as
+    # its task description. pending_messages has no FK on session_id, so seeding
+    # it first is safe — the row is only ever read once the session is dispatched.
+    # The prompt becomes the dispatched session's task description (drained by
+    # _dispatch_spawned_sessions) so the executor seeds the real task.
+    session_store.enqueue_message(session_id, "operator", prompt)
+    session = session_store.create(
+        task_id=task_id,
+        session_id=session_id,
+        status=status,
+        routing=routing,
+        budget=budget or _operator_budget(),
+        expected_output="text",
+        parent_session_id=None,
+        origin="operator",
+    )
+
+    logger.info(
+        "operator spawn: session=%s routing=%s (%s) needs_routing=%s",
+        session.session_id, routing, routing_source, needs_routing,
+    )
+    return {
+        "ok": True,
+        "session_id": session.session_id,
+        "task_id": task_id,
+        "routing": routing,
+        "needs_routing": needs_routing,
+        "routing_source": routing_source,
+    }

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -972,6 +972,42 @@ class SessionStore:
             )
         return True
 
+    def delete_session(self, session_id: str) -> None:
+        """Hard-delete a session and its queued messages/questions/turns.
+
+        Used to clean up an operator spawn that couldn't be routed (preflight
+        returned `ask` but the calling surface has no clarification flow), so it
+        doesn't linger as a permanently-blocked thread.
+        """
+        with self._connect() as conn:
+            conn.execute("DELETE FROM pending_messages WHERE session_id = ?", (session_id,))
+            conn.execute("DELETE FROM pending_questions WHERE session_id = ?", (session_id,))
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
+
+    def enqueue_web_followup(self, session_id: str, task_id: str, answer: str) -> int:
+        """Queue a follow-up turn from a non-Telegram surface (web /chat, #236).
+
+        Inserts a pre-answered `kind='followup'` row so the worker's
+        `_process_clarification_answers` tick picks it up and reopens the
+        session via `_resume_as_followup` — the same path a Telegram reply
+        takes. There's no Telegram message to match, so `sent_message_id` is a
+        sentinel 0 (web follow-ups are created already-answered, so they never
+        participate in reply-id matching via `deposit_answer`).
+        """
+        now = _now()
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO pending_questions (
+                    session_id, task_id, question, sent_message_id, sent_at,
+                    kind, answer, answered_at
+                ) VALUES (?, ?, '', 0, ?, 'followup', ?, ?)
+                """,
+                (session_id, task_id, now, answer, now),
+            )
+        return cur.lastrowid
+
     def get_recent_resumable_followup(self, within_seconds: int) -> dict | None:
         """Return the most recent open follow-up whose notification was sent
         within `within_seconds`, or None.

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -71,6 +71,11 @@ class Session:
     root_session_id: str | None = None
     spawn_depth: int = 0
     yield_waiting_for: list[str] | None = None
+    # Provenance of the session. NULL/"agent" = claimed from an #agent vault
+    # task; "operator" = root-spawned on demand from Telegram/chat with no
+    # backing task. The worker's spawned-session dispatch picks up operator
+    # sessions even though they have no parent (#235).
+    origin: str | None = None
 
 
 _SCHEMA = """
@@ -94,7 +99,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     spawn_depth               INTEGER NOT NULL DEFAULT 0,
     yield_waiting_for         TEXT,  -- JSON array of session_ids the agent is waiting on
     managed_agent_session_id  TEXT,
-    preset_class              TEXT
+    preset_class              TEXT,
+    origin                    TEXT   -- NULL/"agent" = #agent task; "operator" = root-spawned (#235)
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -282,6 +288,10 @@ class SessionStore:
                 conn.execute(
                     "ALTER TABLE sessions ADD COLUMN preset_class TEXT"
                 )
+            # Idempotent migration for the per-session origin column (#235).
+            # Old rows stay NULL (treated as "agent").
+            if "origin" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN origin TEXT")
             # Idempotent migrations for the runaway detection counters on
             # managed_cursor (#139 Section 5).
             mc_cols = {row["name"] for row in conn.execute("PRAGMA table_info(managed_cursor)")}
@@ -313,6 +323,7 @@ class SessionStore:
         parent_session_id: str | None = None,
         root_session_id: str | None = None,
         spawn_depth: int = 0,
+        origin: str | None = None,
     ) -> Session:
         """Insert a new session row. Raises sqlite3.IntegrityError if `task_id`
         already has a row — the caller should treat that as a lost-race signal.
@@ -320,6 +331,9 @@ class SessionStore:
         For root sessions (no parent), `root_session_id` defaults to the new
         session's own id. Children inherit the parent's `root_session_id` so
         lineage queries can find an entire family with one indexed lookup.
+
+        `origin="operator"` marks a root-spawned session (no #agent task) so
+        the worker's spawned-session dispatch claims it (#235).
         """
         sid = session_id or new_session_id()
         root_sid = root_session_id or sid
@@ -331,15 +345,15 @@ class SessionStore:
                     task_id, session_id, status, routing, budget_json,
                     started_at, last_activity_at,
                     expected_output, parent_session_id,
-                    root_session_id, spawn_depth
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    root_session_id, spawn_depth, origin
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     task_id, sid, status, routing,
                     json.dumps(budget) if budget else None,
                     now, now,
                     expected_output, parent_session_id,
-                    root_sid, spawn_depth,
+                    root_sid, spawn_depth, origin,
                 ),
             )
         return Session(
@@ -354,6 +368,7 @@ class SessionStore:
             parent_session_id=parent_session_id,
             root_session_id=root_sid,
             spawn_depth=spawn_depth,
+            origin=origin,
         )
 
     def get(self, task_id: str) -> Session | None:
@@ -1064,4 +1079,5 @@ class SessionStore:
                 if "yield_waiting_for" in row.keys() and row["yield_waiting_for"]
                 else None
             ),
+            origin=(row["origin"] if "origin" in row.keys() else None),
         )

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -999,6 +999,25 @@ class SessionStore:
             ).fetchone()
         return dict(row) if row else None
 
+    def get_open_question_by_message_id(self, sent_message_id: int) -> dict | None:
+        """Return the open (unanswered, not-timed-out) question a reply to
+        `sent_message_id` matches — on any chunk — or None.
+
+        Read-only sibling of `deposit_answer`: lets a caller inspect the matched
+        row's `kind` and route the reply (e.g. a `code_followup` resumes Claude
+        Code rather than the agent worker) before recording an answer.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM pending_questions "
+                "WHERE answered_at IS NULL AND timed_out = 0 "
+                "AND (sent_message_id = ? OR (sent_message_ids IS NOT NULL "
+                "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?))) "
+                "ORDER BY id ASC LIMIT 1",
+                (int(sent_message_id), int(sent_message_id)),
+            ).fetchone()
+        return dict(row) if row else None
+
     def list_answered_unprocessed_questions(self) -> list[dict]:
         with self._connect() as conn:
             rows = conn.execute(

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -140,7 +140,13 @@ CREATE TABLE IF NOT EXISTS pending_questions (
     answered_at       INTEGER,
     processed         INTEGER NOT NULL DEFAULT 0,
     timed_out         INTEGER NOT NULL DEFAULT 0,
-    kind              TEXT NOT NULL DEFAULT 'clarification'
+    kind              TEXT NOT NULL DEFAULT 'clarification',
+    -- JSON array of every Telegram chunk id for this notification. Long
+    -- completions split across multiple 4096-char messages; a reply can land
+    -- on any chunk, so `deposit_answer` matches membership in this list (not
+    -- just the first chunk in `sent_message_id`). NULL for legacy rows, which
+    -- still match via `sent_message_id`.
+    sent_message_ids  TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_pq_message_id ON pending_questions(sent_message_id);
 CREATE INDEX IF NOT EXISTS idx_pq_open ON pending_questions(answered_at, processed, timed_out);
@@ -246,6 +252,14 @@ class SessionStore:
                 conn.execute(
                     "ALTER TABLE pending_questions ADD COLUMN kind TEXT "
                     "NOT NULL DEFAULT 'clarification'"
+                )
+            # Idempotent migration for `pending_questions.sent_message_ids` —
+            # the full chunk-id list so a reply to any chunk of a split
+            # notification matches. Legacy rows stay NULL and match on
+            # `sent_message_id`.
+            if "sent_message_ids" not in pq_cols:
+                conn.execute(
+                    "ALTER TABLE pending_questions ADD COLUMN sent_message_ids TEXT"
                 )
             # Idempotent migration for the prompt-cache token buckets on
             # `sessions`. Old rows stay at zero — we don't backfill historical
@@ -865,15 +879,27 @@ class SessionStore:
         question: str,
         sent_message_id: int,
         kind: str = "clarification",
+        sent_message_ids: list[int] | None = None,
     ) -> int:
+        """Record a pending question / follow-up keyed by Telegram message id.
+
+        `sent_message_id` is the first (matchable) chunk id; `sent_message_ids`
+        is the full chunk list for a split notification (defaults to just the
+        first chunk). `deposit_answer` matches a reply to any chunk in the list.
+        """
+        ids = sent_message_ids or [int(sent_message_id)]
         with self._connect() as conn:
             cur = conn.execute(
                 """
                 INSERT INTO pending_questions (
-                    session_id, task_id, question, sent_message_id, sent_at, kind
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                    session_id, task_id, question, sent_message_id, sent_at,
+                    kind, sent_message_ids
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (session_id, task_id, question, int(sent_message_id), _now(), kind),
+                (
+                    session_id, task_id, question, int(sent_message_id), _now(),
+                    kind, json.dumps([int(i) for i in ids]),
+                ),
             )
         return cur.lastrowid
 
@@ -881,35 +907,46 @@ class SessionStore:
         self,
         session_id: str,
         task_id: str,
-        sent_message_id: int,
+        sent_message_ids: list[int],
+        label: str = "",
     ) -> int:
-        """Register a completion-message Telegram msg_id so an operator
-        reply to that message reopens the session as a follow-up turn.
+        """Register a terminal-notification's Telegram msg_id(s) so an operator
+        reply to any chunk reopens the session as a follow-up turn.
 
-        The row goes into `pending_questions` with kind='followup' and
-        an empty `question` body — `deposit_answer` matches on
-        `sent_message_id` regardless of kind, and the worker tick
-        branches on `kind` when processing.
+        Used for COMPLETED, FAILED, and BUDGET_EXCEEDED notifications — every
+        terminal state is replyable. The row goes into `pending_questions` with
+        kind='followup'; `label` (the task description) is stored in `question`
+        so the resume path can show a `↪ continuing "<task>"` prefix. The worker
+        tick branches on `kind` when processing.
         """
+        if not sent_message_ids:
+            raise ValueError("register_completion_followup requires at least one message id")
         return self.create_pending_question(
             session_id=session_id,
             task_id=task_id,
-            question="",
-            sent_message_id=sent_message_id,
+            question=label,
+            sent_message_id=sent_message_ids[0],
             kind="followup",
+            sent_message_ids=sent_message_ids,
         )
 
     def deposit_answer(self, sent_message_id: int, answer: str) -> bool:
         """Record an answer for an open question, keyed by Telegram message_id.
 
-        Returns True if a matching open question was found and updated; False
-        otherwise (so the listener can fall through to the chat pipeline).
+        Matches a reply landing on any chunk of a split notification: the id is
+        checked against both the primary `sent_message_id` and membership in the
+        `sent_message_ids` JSON list. Returns True if a matching open question
+        was found and updated; False otherwise (so the listener can fall through
+        to the chat pipeline).
         """
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT id FROM pending_questions "
-                "WHERE sent_message_id = ? AND answered_at IS NULL AND timed_out = 0",
-                (int(sent_message_id),),
+                "WHERE answered_at IS NULL AND timed_out = 0 "
+                "AND (sent_message_id = ? OR (sent_message_ids IS NOT NULL "
+                "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?))) "
+                "ORDER BY id ASC LIMIT 1",
+                (int(sent_message_id), int(sent_message_id)),
             ).fetchone()
             if not row:
                 return False
@@ -919,6 +956,25 @@ class SessionStore:
                 (answer, _now(), row["id"]),
             )
         return True
+
+    def get_recent_resumable_followup(self, within_seconds: int) -> dict | None:
+        """Return the most recent open follow-up whose notification was sent
+        within `within_seconds`, or None.
+
+        Powers the "plain message resumes the last agent thread" path: a
+        non-reply Telegram message within the window resumes the most recently
+        completed/failed thread without requiring the native reply gesture.
+        """
+        cutoff = _now() - int(within_seconds)
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM pending_questions "
+                "WHERE kind = 'followup' AND answered_at IS NULL "
+                "AND processed = 0 AND timed_out = 0 AND sent_at >= ? "
+                "ORDER BY sent_at DESC, id DESC LIMIT 1",
+                (cutoff,),
+            ).fetchone()
+        return dict(row) if row else None
 
     def get_question_by_message_id(self, sent_message_id: int) -> dict | None:
         with self._connect() as conn:

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -149,7 +149,7 @@ class Worker:
         spend_tracker: SpendTracker | None = None,
         poll_seconds: float | None = None,
         telegram_send=None,  # injectable for tests
-        telegram_send_with_id=None,  # injectable; returns sent message_id (or None)
+        telegram_send_with_id=None,  # injectable; returns list of sent chunk message_ids
         http_client: httpx.Client | None = None,
         preflight_caller=None,    # injectable; defaults to Anthropic Haiku
         local_executor=None,      # injectable LocalExecutor for tests
@@ -171,7 +171,7 @@ class Worker:
         def _noop_telegram(text, chat_id=None):
             return False
         def _noop_with_id(text):
-            return None
+            return []
         self._telegram_send = telegram_send if telegram_send is not None else _noop_telegram
         self._telegram_send_with_id = (
             telegram_send_with_id if telegram_send_with_id is not None else _noop_with_id
@@ -624,7 +624,12 @@ class Worker:
         sid = session.session_id
         task_id = session.task_id
 
-        self._swap_tag(task_id, COMPLETED_TAG, RUNNING_TAG)
+        # The task may be parked at any terminal tag — completed, failed, or
+        # budget-exceeded are all replyable now. Swap whichever is current
+        # back to running.
+        for terminal_tag in (COMPLETED_TAG, FAILED_TAG, BUDGET_EXCEEDED_TAG):
+            if self._swap_tag(task_id, terminal_tag, RUNNING_TAG):
+                break
         self._set_task_status(task_id, "in_progress")
         self.session_store.update_status(task_id, STATUS_RUNNING)
         self.transcript_store.append(sid, "followup_received", {
@@ -750,23 +755,25 @@ class Worker:
         — caller should mark the session blocked anyway since we can't ask).
         """
         try:
-            sent_id = self._telegram_send_with_id(question)
+            sent_ids = self._telegram_send_with_id(question) or []
         except Exception as exc:
             logger.warning(f"ask_user_via_telegram failed: {exc}")
             return None
-        if sent_id is None:
+        if not sent_ids:
             return None
         self.session_store.create_pending_question(
             session_id=session_id,
             task_id=task_id,
             question=question,
-            sent_message_id=sent_id,
+            sent_message_id=sent_ids[0],
+            sent_message_ids=sent_ids,
         )
         self.transcript_store.append(session_id, "clarification_sent", {
-            "sent_message_id": sent_id,
+            "sent_message_id": sent_ids[0],
+            "sent_message_ids": sent_ids,
             "question_chars": len(question),
         })
-        return sent_id
+        return sent_ids[0]
 
     def _wake_sleeping_sessions(self) -> None:
         """Resume any sessions whose `sleeps` row has expired."""
@@ -1159,11 +1166,13 @@ class Worker:
                 recovered = self._recover_result_from_transcript(sid) or (
                     "no tool calls or final text recovered"
                 )
-                self._notify(
+                self._notify_terminal(
+                    session,
                     f"⚠️ {_worker_label(session.routing)}: task '{title}' returned "
                     f"empty result with no side-effect tool use — marking failed. "
                     f"What the agent did:\n\n{recovered}\n\n"
-                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`",
+                    label=title,
                 )
                 return
             if not is_spawned:
@@ -1176,25 +1185,8 @@ class Worker:
                 # Send via the with-id sender so we can match a future Telegram
                 # reply to this completion message and resume the task as a
                 # follow-up turn (e.g., "now turn this into a .md in my vault").
-                # When the with-id sender returns None (bot not configured, or
-                # a test stub that doesn't capture ids) fall back to the plain
-                # _notify path so the operator at least sees the result.
                 body = self._completion_summary(session, task, outcome)
-                sent_id = self._telegram_send_with_id(body)
-                if sent_id is None:
-                    self._notify(body)
-                else:
-                    try:
-                        self.session_store.register_completion_followup(
-                            session_id=sid,
-                            task_id=session.task_id,
-                            sent_message_id=sent_id,
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "register_completion_followup failed for %s: %s",
-                            session.task_id, exc,
-                        )
+                self._notify_terminal(session, body, label=title)
             else:
                 # Child completion — record only; parent picks it up via yield_until.
                 self.transcript_store.append(sid, "child_completed_internal", {
@@ -1208,9 +1200,11 @@ class Worker:
             if not is_spawned:
                 self._swap_tag(session.task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
                 self._set_task_status(session.task_id, "cancelled")
-                self._notify(
+                self._notify_terminal(
+                    session,
                     f"⚠️ {label}: task '{title}' hit its budget ({outcome.reason}). "
-                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`",
+                    label=title,
                 )
             else:
                 self.transcript_store.append(sid, "child_budget_exceeded_internal", {
@@ -1223,9 +1217,11 @@ class Worker:
             if not is_spawned:
                 self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
                 self._set_task_status(session.task_id, "cancelled")
-                self._notify(
+                self._notify_terminal(
+                    session,
                     f"⚠️ {label}: task '{title}' failed: {outcome.reason}. "
-                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`"
+                    f"Transcript: `data/agent_transcripts/{sid}.jsonl`",
+                    label=title,
                 )
             else:
                 self.transcript_store.append(sid, "child_failed_internal", {
@@ -1715,6 +1711,37 @@ class Worker:
         except Exception as exc:  # pragma: no cover — defensive
             logger.warning("telegram notify failed: %s", exc)
 
+    def _notify_terminal(self, session: Session, body: str, label: str) -> None:
+        """Send a terminal-state notification (completed / failed / budget) and
+        register a follow-up so a reply — to any chunk — resumes the session.
+
+        Sends via the with-id sender so every chunk's message_id is captured;
+        a reply landing on any of them (or a plain message within the 30-min
+        window) reopens the session as a follow-up turn. Falls back to the
+        plain one-way `_notify` when the with-id sender is unavailable (bot not
+        configured, or a test stub that captures no ids).
+        """
+        sent_ids: list[int] = []
+        try:
+            sent_ids = self._telegram_send_with_id(body) or []
+        except Exception as exc:
+            logger.warning("terminal notify (with id) failed for %s: %s", session.task_id, exc)
+        if not sent_ids:
+            self._notify(body)
+            return
+        try:
+            self.session_store.register_completion_followup(
+                session_id=session.session_id,
+                task_id=session.task_id,
+                sent_message_ids=sent_ids,
+                label=label,
+            )
+        except Exception as exc:
+            logger.warning(
+                "register_completion_followup failed for %s: %s",
+                session.task_id, exc,
+            )
+
 
 def main() -> None:
     logging.basicConfig(
@@ -1728,9 +1755,9 @@ def main() -> None:
     telegram_send = None
     telegram_send_with_id = None
     try:
-        from api.services.telegram import send_message, send_message_capture_id
+        from api.services.telegram import send_message, send_message_capture_ids
         telegram_send = send_message
-        telegram_send_with_id = send_message_capture_id
+        telegram_send_with_id = send_message_capture_ids
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning("Telegram module not importable; running with no-op senders: %s", exc)
     worker = Worker(

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -512,6 +512,12 @@ class Worker:
         for q in answered:
             session_id = q["session_id"]
             task_id = q["task_id"]
+            # `code_followup` rows (#237) point at a Claude Code session, not an
+            # agent-worker session — the Telegram listener resumes those itself.
+            # Skip them here so the worker doesn't treat them as agent threads.
+            if q.get("kind") == "code_followup":
+                self.session_store.mark_question_processed(q["id"])
+                continue
             session = self.session_store.get_by_session_id(session_id)
             if session is None:
                 # Stale — session was deleted? Mark processed so we don't loop.
@@ -744,7 +750,16 @@ class Worker:
         cutoff = int(time.time()) - timeout_seconds
         stale = self.session_store.list_timed_out_questions(cutoff)
         for q in stale:
+            # Close every stale row, but only nudge for actual clarifications
+            # (agent BLOCKED awaiting input). Completion follow-ups —
+            # kind='followup' (#234) and kind='code_followup' (#237) — are just
+            # replyable notifications; a "re-tag with #agent to retry" nudge is
+            # wrong for them (and a code_followup points at a Claude Code
+            # session with no #agent task at all). Marking them timed out also
+            # keeps stale follow-up rows from accumulating.
             self.session_store.mark_question_timed_out(q["id"])
+            if (q.get("kind") or "clarification") != "clarification":
+                continue
             self.transcript_store.append(q["session_id"], "clarification_timed_out", {
                 "question_id": q["id"],
             })

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -416,10 +416,11 @@ class Worker:
         """
         claimed = self.session_store.list_by_status(STATUS_CLAIMED)
         for session in claimed:
-            # Skip top-level claimed sessions (those came from the tick claim
-            # path and will be dispatched by _dispatch). Spawned children have
-            # a parent_session_id set.
-            if not session.parent_session_id:
+            # Skip top-level claimed sessions from the #agent tick claim path
+            # (those are dispatched by _dispatch). Pick up spawned children
+            # (parent set) and operator root-spawns (#235, no parent but
+            # origin='operator').
+            if not session.parent_session_id and session.origin != "operator":
                 continue
             # The first pending message is the prompt from the parent — drain
             # it so the executor's seeded user turn picks it up.
@@ -549,6 +550,18 @@ class Worker:
                 self.transcript_store.append(session_id, "routing_resolved", {
                     "from": "ask", "to": resolved,
                 })
+                if session.origin == "operator":
+                    # Operator root-spawn: flip back to CLAIMED so the
+                    # spawned-session dispatch picks it up next tick (it drains
+                    # the enqueued prompt as the task description). The #agent
+                    # inline path below would look up a non-existent vault task
+                    # and lose the prompt.
+                    self.session_store.update_status(task_id, STATUS_CLAIMED)
+                    self.session_store.mark_question_processed(q["id"])
+                    self.transcript_store.append(
+                        session_id, "operator_routing_resolved", {"to": resolved},
+                    )
+                    continue
                 # Refresh the session view so downstream code sees the new routing.
                 session = self.session_store.get_by_session_id(session_id)
 
@@ -626,11 +639,13 @@ class Worker:
 
         # The task may be parked at any terminal tag — completed, failed, or
         # budget-exceeded are all replyable now. Swap whichever is current
-        # back to running.
-        for terminal_tag in (COMPLETED_TAG, FAILED_TAG, BUDGET_EXCEEDED_TAG):
-            if self._swap_tag(task_id, terminal_tag, RUNNING_TAG):
-                break
-        self._set_task_status(task_id, "in_progress")
+        # back to running. Operator root-spawns (#235) have no backing vault
+        # task, so skip the tag/status mutations (they would 404).
+        if session.origin != "operator":
+            for terminal_tag in (COMPLETED_TAG, FAILED_TAG, BUDGET_EXCEEDED_TAG):
+                if self._swap_tag(task_id, terminal_tag, RUNNING_TAG):
+                    break
+            self._set_task_status(task_id, "in_progress")
         self.session_store.update_status(task_id, STATUS_RUNNING)
         self.transcript_store.append(sid, "followup_received", {
             "question_id": q["id"], "answer_chars": len(answer),
@@ -1134,6 +1149,11 @@ class Worker:
         # leaks to the operator with the parent's internal prompt as
         # the "task description" — confusing and operator-irrelevant.
         is_spawned = bool(session.parent_session_id)
+        # Operator root-spawns (#235) are root sessions (no parent) so they DO
+        # notify the operator, but they have no backing #agent vault task — the
+        # vault mutations (complete / swap-tag / set-status) would 404. Gate
+        # those on `has_vault_task`; notifications + follow-up still fire.
+        has_vault_task = not is_spawned and session.origin != "operator"
 
         if outcome.status == STATUS_COMPLETED:
             # Guard against silent "I gave up" completions. When the agent
@@ -1161,8 +1181,9 @@ class Worker:
                 and not self._had_side_effect_tool_use(sid)
                 and spent < 0.05
             ):
-                self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
-                self._set_task_status(session.task_id, "cancelled")
+                if has_vault_task:
+                    self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
+                    self._set_task_status(session.task_id, "cancelled")
                 recovered = self._recover_result_from_transcript(sid) or (
                     "no tool calls or final text recovered"
                 )
@@ -1176,12 +1197,13 @@ class Worker:
                 )
                 return
             if not is_spawned:
-                self._complete_task(session.task_id)  # mark `done` in the vault
-                # Swap the tag so the task surfaces as #agent-completed for symmetry
-                # with the failed / budget-exceeded / blocked terminal tags. Failure
-                # of the swap is non-critical — _swap_tag logs and the task is
-                # already marked done in the vault.
-                self._swap_tag(session.task_id, RUNNING_TAG, COMPLETED_TAG)
+                if has_vault_task:
+                    self._complete_task(session.task_id)  # mark `done` in the vault
+                    # Swap the tag so the task surfaces as #agent-completed for symmetry
+                    # with the failed / budget-exceeded / blocked terminal tags. Failure
+                    # of the swap is non-critical — _swap_tag logs and the task is
+                    # already marked done in the vault.
+                    self._swap_tag(session.task_id, RUNNING_TAG, COMPLETED_TAG)
                 # Send via the with-id sender so we can match a future Telegram
                 # reply to this completion message and resume the task as a
                 # follow-up turn (e.g., "now turn this into a .md in my vault").
@@ -1198,8 +1220,9 @@ class Worker:
         label = _worker_label(session.routing)
         if outcome.status == STATUS_BUDGET_EXCEEDED:
             if not is_spawned:
-                self._swap_tag(session.task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
-                self._set_task_status(session.task_id, "cancelled")
+                if has_vault_task:
+                    self._swap_tag(session.task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
+                    self._set_task_status(session.task_id, "cancelled")
                 self._notify_terminal(
                     session,
                     f"⚠️ {label}: task '{title}' hit its budget ({outcome.reason}). "
@@ -1215,8 +1238,9 @@ class Worker:
 
         if outcome.status == STATUS_FAILED:
             if not is_spawned:
-                self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
-                self._set_task_status(session.task_id, "cancelled")
+                if has_vault_task:
+                    self._swap_tag(session.task_id, RUNNING_TAG, FAILED_TAG)
+                    self._set_task_status(session.task_id, "cancelled")
                 self._notify_terminal(
                     session,
                     f"⚠️ {label}: task '{title}' failed: {outcome.reason}. "

--- a/api/services/claude_orchestrator.py
+++ b/api/services/claude_orchestrator.py
@@ -247,6 +247,10 @@ class ClaudeOrchestrator:
         self._heartbeat: Optional[threading.Timer] = None
         self._typing_stop: Optional[threading.Event] = None
         self._notification_callback: Optional[Callable[[str], None]] = None
+        # Fired once when a session completes successfully (status "completed",
+        # session_id known). Used to register the completion message in the
+        # shared follow-up table so a reply resumes the session (#237).
+        self._on_complete: Optional[Callable[["ClaudeSession"], None]] = None
 
     def is_busy(self) -> bool:
         return self._active_session is not None and self._active_session.status in (
@@ -262,6 +266,7 @@ class ClaudeOrchestrator:
         working_dir: str,
         plan_mode: bool = False,
         notification_callback: Optional[Callable[[str], None]] = None,
+        on_complete: Optional[Callable[["ClaudeSession"], None]] = None,
     ) -> ClaudeSession:
         """Spawn a Claude Code subprocess for the given task."""
         with self._lock:
@@ -275,6 +280,7 @@ class ClaudeOrchestrator:
             )
             self._active_session = session
             self._notification_callback = notification_callback
+            self._on_complete = on_complete
 
         prompt = task
         if plan_mode:
@@ -344,6 +350,7 @@ class ClaudeOrchestrator:
         self,
         message: str,
         notification_callback: Optional[Callable[[str], None]] = None,
+        on_complete: Optional[Callable[["ClaudeSession"], None]] = None,
     ) -> Optional[ClaudeSession]:
         """Resume a recently completed session with a follow-up message."""
         with self._lock:
@@ -359,6 +366,7 @@ class ClaudeOrchestrator:
             self._active_session = session
             self._last_completed = None
             self._notification_callback = notification_callback
+            self._on_complete = on_complete
 
         self._spawn(message, session, resume_session_id=session.session_id)
         return session
@@ -676,7 +684,17 @@ class ClaudeOrchestrator:
             # Keep completed sessions for follow-up resumption
             if final_status == "completed" and session and session.session_id:
                 self._last_completed = session
+                # Register the completion in the shared follow-up table so a
+                # reply resumes this session uniformly with #agent threads
+                # (#237). Fired after the final notification was sent, so the
+                # callback can match against that message's id.
+                if self._on_complete:
+                    try:
+                        self._on_complete(session)
+                    except Exception as exc:  # pragma: no cover — defensive
+                        logger.warning(f"on_complete callback failed: {exc}")
             self._active_session = None
+            self._on_complete = None
         self._process = None
 
 

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -112,20 +112,21 @@ class TypingIndicator:
                 pass
 
 
-def send_message_capture_id(text: str, chat_id: str = None) -> int | None:
-    """Send a message and return its Telegram `message_id` (or None on failure).
+def send_message_capture_ids(text: str, chat_id: str = None) -> list[int]:
+    """Send a message and return the Telegram `message_id` of every chunk sent.
 
-    Used by the agent worker to track clarification questions so reply-
-    threaded answers can be matched back to the right pending question.
-    Falls back to plain text if Markdown parse fails. Returns the id from
-    the first sent chunk so reply-threading lands on the start of the
-    question.
+    Used by the agent worker to track clarification questions and terminal-state
+    notifications so reply-threaded answers can be matched back to the right
+    pending question. Long messages split across multiple 4096-char chunks; a
+    reply can land on *any* chunk, so we capture them all (not just the first).
+    Falls back to plain text if Markdown parse fails. Returns an empty list when
+    Telegram is disabled or every send failed.
     """
     if not settings.telegram_enabled:
-        return None
+        return []
     chat_id = chat_id or settings.telegram_chat_id
     text = _clean_markdown_for_telegram(text)
-    first_id: int | None = None
+    ids: list[int] = []
     for part in _split_message(text):
         try:
             resp = httpx.post(
@@ -139,14 +140,15 @@ def send_message_capture_id(text: str, chat_id: str = None) -> int | None:
                     json={"chat_id": chat_id, "text": part},
                     timeout=30.0,
                 )
-            if resp.status_code == 200 and first_id is None:
-                payload = resp.json()
-                first_id = (payload.get("result") or {}).get("message_id")
-            elif resp.status_code != 200:
+            if resp.status_code == 200:
+                msg_id = (resp.json().get("result") or {}).get("message_id")
+                if msg_id is not None:
+                    ids.append(int(msg_id))
+            else:
                 logger.error(f"Telegram send failed: {resp.status_code} {resp.text[:200]}")
         except Exception as e:
             logger.error(f"Telegram send error: {e}")
-    return first_id
+    return ids
 
 
 def send_message(text: str, chat_id: str = None) -> bool:
@@ -382,6 +384,10 @@ class TelegramBotListener:
 
     _STATE_FILE = Path("data/telegram_state.json")
     _DEDUP_WINDOW = 1000  # Track last N message IDs for deduplication
+    # A plain (non-reply) message within this window of an agent thread's
+    # terminal notification resumes that thread instead of starting a fresh
+    # chat query. Beyond it, plain messages route to the chat pipeline.
+    _AGENT_THREAD_RESUME_WINDOW_SECONDS = 30 * 60
 
     def __init__(self):
         self._stop_event = threading.Event()
@@ -509,6 +515,39 @@ class TelegramBotListener:
             logger.warning(f"agent-worker deposit_answer failed: {exc}")
             return False
 
+    async def _maybe_resume_recent_agent_thread(self, text: str, chat_id: str) -> bool:
+        """Resume the most recent completed/failed agent thread when a plain
+        (non-reply) message arrives within the resume window.
+
+        Deposits the message into that thread's open follow-up so the worker
+        reopens the session as a new user turn, then shows a visible
+        continuation prefix. Returns True if the message was consumed as a
+        resume; False to fall through to the chat pipeline.
+
+        Like the native reply-deposit path (`_maybe_deposit_agent_answer`),
+        this hands off to the agent worker via the shared `pending_questions`
+        table; if that process is down the deposited turn waits until it comes
+        back rather than running immediately. Accepted edge — both deposit
+        paths share this property.
+        """
+        try:
+            from api.services.agent_worker.session_store import SessionStore
+            store = SessionStore()
+            row = store.get_recent_resumable_followup(
+                within_seconds=self._AGENT_THREAD_RESUME_WINDOW_SECONDS,
+            )
+            if not row:
+                return False
+            if not store.deposit_answer(row["sent_message_id"], text):
+                return False
+        except Exception as exc:
+            logger.warning(f"agent-thread resume check failed: {exc}")
+            return False
+
+        label = (row.get("question") or "").strip() or "your last agent task"
+        await send_message_async(f'↪ continuing "{label}"', chat_id=chat_id)
+        return True
+
     async def _handle_update(self, update: dict):
         """Process a single Telegram update."""
         message = update.get("message")
@@ -565,6 +604,14 @@ class TelegramBotListener:
 
         # Check for follow-up to a recently completed Claude Code session
         if await self._check_code_followup(text, chat_id):
+            return
+
+        # Plain message (no native reply gesture) within the resume window:
+        # resume the most recent completed/failed agent thread so a quick
+        # "actually, also do X" continues the conversation instead of
+        # silently starting a fresh chat query. Native reply-to (handled
+        # above) still targets a specific, possibly older, thread.
+        if await self._maybe_resume_recent_agent_thread(text, chat_id):
             return
 
         # Send through chat pipeline (intent classification happens there)

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -548,6 +548,75 @@ class TelegramBotListener:
         await send_message_async(f'↪ continuing "{label}"', chat_id=chat_id)
         return True
 
+    async def _handle_agent_spawn(self, rest: str, chat_id: str):
+        """Spawn an operator agent on demand: `/agent [local|claude] <task>`.
+
+        Explicit `local`/`claude` forces the model; otherwise preflight
+        auto-routes (and asks via the clarification flow when ambiguous). The
+        completion notification is replyable via the Phase 1 follow-up model.
+        """
+        explicit = None
+        parts = rest.split(maxsplit=1)
+        if parts and parts[0].lower() in ("local", "claude"):
+            explicit = parts[0].lower()
+            task = parts[1].strip() if len(parts) > 1 else ""
+        else:
+            task = rest.strip()
+
+        if not task:
+            await send_message_async(
+                "Usage: /agent [local|claude] <task>\n"
+                "e.g. `/agent draft a reply to the landlord` (auto-routes), "
+                "or `/agent claude refactor the parser`.",
+                chat_id=chat_id,
+            )
+            return
+
+        try:
+            from api.services.agent_worker.operator_spawn import create_operator_session
+            from api.services.agent_worker.session_store import SessionStore
+            store = SessionStore()
+            result = await asyncio.to_thread(
+                create_operator_session, store, task, explicit_routing=explicit,
+            )
+        except Exception as exc:
+            logger.warning(f"operator spawn failed: {exc}")
+            await send_message_async(
+                f"Couldn't spawn agent: {str(exc)[:200]}", chat_id=chat_id,
+            )
+            return
+
+        if not result.get("ok"):
+            await send_message_async(
+                f"Couldn't spawn agent: {result.get('error')}", chat_id=chat_id,
+            )
+            return
+
+        if result.get("needs_routing"):
+            # Preflight couldn't pick a model — ask, and register the answer so
+            # the worker resolves routing and dispatches. Operator replies to
+            # this message (the reply-deposit hook matches it).
+            question = (
+                "Should I run this on the local Gemma model or on Claude? "
+                "Reply 'local' or 'claude'."
+            )
+            ids = send_message_capture_ids(question, chat_id)
+            if ids:
+                store.create_pending_question(
+                    session_id=result["session_id"], task_id=result["task_id"],
+                    question=question, sent_message_id=ids[0],
+                    sent_message_ids=ids, kind="clarification",
+                )
+            return
+
+        label = "Claude (cloud)" if result["routing"] == "claude" else "local Gemma"
+        await send_message_async(
+            f"🤖 Spawned {label} agent: {task[:120]}\n"
+            f"I'll send the result here when it's done — reply to it (or just message "
+            f"me within 30 min) to continue the thread.",
+            chat_id=chat_id,
+        )
+
     async def _handle_update(self, update: dict):
         """Process a single Telegram update."""
         message = update.get("message")
@@ -678,6 +747,9 @@ class TelegramBotListener:
             else:
                 await self._handle_code_command(task, chat_id)
 
+        elif command == "/agent":
+            await self._handle_agent_spawn(text[len("/agent"):].strip(), chat_id)
+
         elif command in ("/code_status", "/codestatus"):
             await self._handle_code_status(chat_id)
 
@@ -695,6 +767,7 @@ class TelegramBotListener:
                 "/new or /clear - Start a new conversation\n"
                 "/status - Check LifeOS server health\n"
                 "/inspect - Show sources checked in last response\n"
+                "/agent [local|claude] <task> - Spawn an agent (auto-routes if no model given)\n"
                 "/code <task> - Run a task with Claude Code\n"
                 "/code\\_status - Check active Claude Code session\n"
                 "/code\\_cancel - Cancel active Claude Code session\n"

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -647,7 +647,13 @@ class TelegramBotListener:
         # the answer and short-circuit — don't route to the chat pipeline.
         reply_to = message.get("reply_to_message")
         if reply_to and reply_to.get("message_id"):
-            if self._maybe_deposit_agent_answer(int(reply_to["message_id"]), text):
+            reply_to_id = int(reply_to["message_id"])
+            # A reply to a /code completion resumes that Claude Code session
+            # (#237) — checked before the agent-worker deposit since both use
+            # the shared follow-up table but resume different subsystems.
+            if await self._maybe_handle_code_reply(reply_to_id, text, chat_id):
+                return
+            if self._maybe_deposit_agent_answer(reply_to_id, text):
                 return
 
         logger.info(f"Telegram message: {text[:100]}")
@@ -844,6 +850,79 @@ class TelegramBotListener:
         else:
             await send_message_async("No session waiting for clarification.", chat_id=chat_id)
 
+    def _code_callbacks(self, chat_id: str):
+        """Build the (notify, on_complete) callbacks for a Claude Code session.
+
+        `notify` sends each message via the id-capturing sender and remembers
+        the last message's chunk ids; `on_complete` registers those ids in the
+        shared follow-up table so a reply to the completion message resumes the
+        session uniformly with #agent threads (#237).
+        """
+        last_ids: list[int] = []
+
+        def notify(msg: str):
+            ids = send_message_capture_ids(msg, chat_id)
+            if ids:
+                last_ids[:] = ids
+
+        def on_complete(session):
+            self._register_code_followup(session, list(last_ids))
+
+        return notify, on_complete
+
+    def _register_code_followup(self, session, ids: list[int]) -> None:
+        """Register a completed Claude Code session in the shared follow-up
+        table (kind='code_followup') keyed to its completion message id(s)."""
+        session_id = getattr(session, "session_id", None)
+        if not ids or not session_id:
+            return
+        try:
+            from api.services.agent_worker.session_store import SessionStore
+            SessionStore().create_pending_question(
+                session_id=session_id,
+                task_id=f"code_{session_id}",
+                question=(getattr(session, "task", "") or "")[:200],
+                sent_message_id=ids[0],
+                sent_message_ids=ids,
+                kind="code_followup",
+            )
+        except Exception as exc:
+            logger.warning(f"register code followup failed: {exc}")
+
+    async def _maybe_handle_code_reply(self, reply_to_message_id: int, text: str, chat_id: str) -> bool:
+        """If a reply targets a Claude Code completion message (any chunk),
+        resume that session via the orchestrator's existing resume path (#237).
+
+        Returns True if the reply was consumed as a /code follow-up.
+        """
+        try:
+            from api.services.agent_worker.session_store import SessionStore
+            store = SessionStore()
+            q = store.get_open_question_by_message_id(reply_to_message_id)
+        except Exception as exc:
+            logger.warning(f"code reply lookup failed: {exc}")
+            return False
+        if not q or q.get("kind") != "code_followup":
+            return False
+
+        # Close the row so neither the worker nor a duplicate reply reprocesses it.
+        store.deposit_answer(reply_to_message_id, text)
+        store.mark_question_processed(q["id"])
+
+        from api.services.claude_orchestrator import get_orchestrator
+        orch = get_orchestrator()
+        notify, on_complete = self._code_callbacks(chat_id)
+        resumed = orch.followup(text, notification_callback=notify, on_complete=on_complete)
+        if resumed:
+            await send_message_async("Resuming Claude Code session...", chat_id=chat_id)
+        else:
+            await send_message_async(
+                "That Claude Code session can't be resumed (it expired or another "
+                "session is active). Start a fresh one with /code.",
+                chat_id=chat_id,
+            )
+        return True
+
     async def _check_code_followup(self, text: str, chat_id: str) -> bool:
         """Check if this message is a follow-up to a recently completed Claude Code session.
 
@@ -861,10 +940,8 @@ class TelegramBotListener:
         if not session:
             return False
 
-        def notify(msg: str):
-            send_message(msg, chat_id=chat_id)
-
-        resumed = orch.followup(text, notification_callback=notify)
+        notify, on_complete = self._code_callbacks(chat_id)
+        resumed = orch.followup(text, notification_callback=notify, on_complete=on_complete)
         if resumed:
             await send_message_async("Resuming Claude Code session...", chat_id=chat_id)
             return True
@@ -898,11 +975,13 @@ class TelegramBotListener:
             chat_id=chat_id,
         )
 
-        def notify(msg: str):
-            send_message(msg, chat_id=chat_id)
+        notify, on_complete = self._code_callbacks(chat_id)
 
         try:
-            orch.run_task(task, working_dir, plan_mode=plan_mode, notification_callback=notify)
+            orch.run_task(
+                task, working_dir, plan_mode=plan_mode,
+                notification_callback=notify, on_complete=on_complete,
+            )
         except RuntimeError as e:
             await send_message_async(f"Error: {e}", chat_id=chat_id)
 

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-26
+> **Last Updated:** 2026-05-28
 
 LifeOS includes an external **agent worker** that picks up tasks you've tagged `#agent` and completes them autonomously — running locally on a self-hosted LLM or on Anthropic's Managed Agents cloud, with budget caps you can specify in the task title and full audit transcripts on every run. When the agent finishes (or gets stuck), it notifies you on Telegram. If it has a question mid-run, it asks via Telegram and waits for your reply.
 
@@ -121,6 +121,10 @@ The agent worker uses your existing Telegram bot (no second bot needed). Three m
 2. **Clarification requests** — if the preflight can't determine routing OR if a task title is genuinely ambiguous (e.g., "reply to Alex" with no email reference), the worker pauses the task at `#agent-blocked` and asks one targeted question on Telegram. Reply by using Telegram's native reply feature (long-press the bot's message, hit Reply). The worker picks up your answer within the next poll cycle and resumes.
 
 3. **Failure notifications** — short message naming the task and the failure reason, plus a transcript path so you can debug. Examples: "task X failed: managed_create_session 4xx" or "task Y hit its budget (max_dollars)".
+
+**Replying to a thread.** Every terminal notification — completion, failure, or budget cut-off — is replyable: reply to it (Telegram's native reply, on any chunk of a long message) and the agent reopens that thread as a follow-up turn with full prior context ("actually, also CC Jane"). For convenience, a plain message sent within 30 minutes of a notification continues the most recent thread without needing the reply gesture; after 30 minutes a plain message goes to normal chat.
+
+**Starting an agent on demand.** You don't have to create a `#agent` task — send `/agent <task>` to spawn one immediately. The model is auto-routed by preflight; force it with `/agent local <task>` or `/agent claude <task>`. If routing is ambiguous, the bot asks you "local or claude?" before starting. The same `/agent` command works in web chat. The resulting thread notifies and is replyable exactly like a `#agent` task.
 
 Default clarification timeout is 72 hours (`LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS`). After that the task is abandoned permanently and you get a Telegram heads-up. The transcript is preserved.
 

--- a/docs/specs/product/chat-ui.md
+++ b/docs/specs/product/chat-ui.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Chat
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-05-28
 
 The primary chat interface for LifeOS, providing AI-powered search and synthesis across your personal knowledge base.
 
@@ -194,6 +194,16 @@ The orchestrator LLM (Claude Haiku via Anthropic API by default; configurable vi
 - Supports both personal and work accounts
 
 ---
+
+## Agent Threads
+
+**Status:** Complete
+
+Web `/chat` speaks to the same agent-thread model as Telegram (#236, Phase 3 of #233):
+
+- **Threads panel** (sidebar) — lists recent/resumable agent sessions (root sessions only) with a status badge (running / completed / failed / budget / blocked). Backed by `GET /api/agents/threads`; polled for live-ish updates (the `/agents` page uses the `/api/agents/stream` SSE for the full graph).
+- **Reply** — completed/failed threads show a reply box; sending it (`POST /api/agents/threads/{id}/reply`) reopens the session as a follow-up turn via the shared follow-up table — the same path a Telegram reply takes.
+- **Run as agent** — the composer has a model selector (auto / local / cloud) and a spawn button; it sends the composer text to `POST /api/agents/spawn` (Phase 2's `create_operator_session`), and the new thread appears in the panel. `auto` routes via preflight.
 
 ## Implementation Details
 

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-26
+> **Last Updated:** 2026-05-28
 
 Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
 
@@ -298,17 +298,25 @@ A managed session's `managed_agent_session_id` is durable across worker restarts
 
 When the worker needs operator input mid-task — preflight routing=ask, ambiguity question, or `lifeos_agent_user_ask` mid-loop — it:
 
-1. Sends a Telegram message via `send_message_capture_id()` (returns the Telegram `message_id`).
-2. Persists `(session_id, telegram_message_id, question)` in `pending_questions`.
+1. Sends a Telegram message via `send_message_capture_ids()` (returns the `message_id` of **every** 4096-char chunk).
+2. Persists `(session_id, telegram_message_ids, question)` in `pending_questions` — the full chunk list in `sent_message_ids` (JSON), with the first chunk in `sent_message_id`.
 3. Swaps the tag to `#agent-blocked` and parks the session.
 4. For managed sessions: also calls `driver.kill_session` to stop session-hour billing while waiting.
 
-When the operator replies (using Telegram's native reply feature), the bot's `_maybe_deposit_agent_answer()` hook intercepts the `reply_to_message_id` and calls `SessionStore.deposit_answer()`. The worker's `_process_clarification_answers()` runs each tick, picks up answered questions, parses the answer (for routing questions: extracts `local` / `claude` from free-text), updates the session, and re-dispatches.
+When the operator replies (using Telegram's native reply feature), the bot's `_maybe_deposit_agent_answer()` hook intercepts the `reply_to_message_id` and calls `SessionStore.deposit_answer()`, which matches a reply landing on **any** chunk (membership in `sent_message_ids`, not just the first). The worker's `_process_clarification_answers()` runs each tick, picks up answered questions, parses the answer (for routing questions: extracts `local` / `claude` from free-text), updates the session, and re-dispatches.
 
 For local sessions, the parent session resumes via the existing pending_messages drain.
 For managed sessions, a new remote session is created with the resolved routing.
 
 Clarifications older than `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` (default 72h) are abandoned with a Telegram heads-up; the transcript stays preserved.
+
+### Replyable terminal threads
+
+Every terminal-state notification — `#agent-completed`, `#agent-failed`, and `#agent-budget-exceeded` — registers a follow-up (`kind='followup'`) via `register_completion_followup()`, so a reply reopens the session as a new user turn (`_resume_as_followup()` swaps whichever terminal tag is current back to `#agent-running`). This makes failures and budget cut-offs replyable, not just clean completions.
+
+Two ways to target a thread:
+- **Native reply** to any chunk of a notification → resumes that specific thread (works regardless of age).
+- **Plain message** (no reply gesture) within `_AGENT_THREAD_RESUME_WINDOW_SECONDS` (30 min) → resumes the most recent resumable thread (`get_recent_resumable_followup()`), prefixed with a visible `↪ continuing "<task>"`. Beyond the window, a plain message routes to the normal chat pipeline.
 
 ---
 

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -269,6 +269,14 @@ Security: lineage checks ensure a session can only message / kill / yield-on its
 
 Lineage budgets: every session tracks `root_session_id` + `spawn_depth`. Budget breaches at any descendant cascade-kill the entire lineage. Limits configurable via `LIFEOS_AGENT_MAX_SPAWN_DEPTH`, `LIFEOS_AGENT_MAX_DESCENDANTS_PER_ROOT`, `LIFEOS_AGENT_MAX_CONCURRENT_LOCAL`, `LIFEOS_AGENT_MAX_CONCURRENT_MANAGED`.
 
+### Operator root-spawn (#235)
+
+`lifeos_agent_spawn` is same-lineage only (requires a parent session). Operators start agents on demand — with no backing `#agent` vault task — via `create_operator_session()` (`api/services/agent_worker/operator_spawn.py`), reachable from Telegram (`/agent [local|claude] <task>`) and web chat (the same `/agent` slash command).
+
+- **Routing** follows override-then-preflight: an explicit `local`/`claude` keyword wins; otherwise `run_preflight()` decides. On `ROUTE_ASK` the session parks at `blocked` with `routing='ask'` and the caller sends the "local or claude?" clarification (the worker resolves it on reply).
+- **Provenance** is marked with the additive `sessions.origin = 'operator'` column. The worker's `_dispatch_spawned_sessions` skip is relaxed to claim parentless sessions when `origin='operator'`, so they dispatch alongside spawned children without colliding with the top-level `#agent` claim path (which uses NULL origin). The prompt is enqueued as a pending message and drained as the task description on dispatch.
+- Operator sessions are root sessions (`parent_session_id=None`), so their terminal notifications surface to the operator and register a replyable follow-up (Phase 1 / #234). Because they have no backing vault task, `_handle_outcome` and `_resume_as_followup` skip the vault mutations (`_complete_task` / `_swap_tag` / `_set_task_status`) for `origin='operator'` — gated on `has_vault_task` — while still sending the notification + follow-up. The prompt is enqueued *before* the session row is created so the worker can never observe a CLAIMED operator session whose prompt hasn't landed. Default budget comes from the `agent_default_*` settings; local concurrency cap of 1 means operator local spawns queue behind running ones.
+
 ---
 
 ## Budget enforcement

--- a/docs/specs/technical/claude-code-orchestration.md
+++ b/docs/specs/technical/claude-code-orchestration.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** Orchestrator
-**Last Updated:** 2026-05-27
+**Last Updated:** 2026-05-28
 
 Implementation view of `api/services/claude_orchestrator.py` — how the Telegram `/code` command spawns and supervises a `claude` CLI subprocess. For the consumer view (`/code` command, plan mode, clarifications, budgets) see [product/claude-code-orchestration.md](../product/claude-code-orchestration.md). For operator setup see [guides/claude-code-orchestration.md](../../guides/claude-code-orchestration.md).
 
@@ -146,6 +146,18 @@ If Claude emits `[CLARIFY] <question>` mid-session, the orchestrator:
 5. State returns to `RUNNING`.
 
 If the operator wants to cancel during a clarification, they send `/code_cancel`. The orchestrator distinguishes commands from clarification answers by the leading slash.
+
+---
+
+## Replyable completions (#237)
+
+A reply to a `/code` completion message resumes that session, uniform with `#agent` thread replies. The mechanism reuses the shared `pending_questions` follow-up table rather than a `/code`-specific path:
+
+1. `run_task` / `followup` accept an `on_complete(session)` callback, fired once from `_cleanup` when a session completes successfully (status `completed`, `session_id` known) — after the final notification is sent.
+2. The Telegram listener's `_code_callbacks(chat_id)` builds the notify callback (which captures each sent message's chunk ids via `send_message_capture_ids`) plus an `on_complete` that registers a `pending_questions` row with `kind='code_followup'`, keyed to the completion message's chunk ids and storing the Claude `session_id`.
+3. On an incoming reply, `_maybe_handle_code_reply` looks up the open row (any-chunk match, `get_open_question_by_message_id`); if `kind='code_followup'` it closes the row and resumes via the orchestrator's existing `followup()` → `resume_session_id` path. The agent worker skips `code_followup` rows (they point at a Claude Code session, not an agent-worker session).
+
+This is **option A** (light build): reply *matching* is unified, but `/code` still runs as a separate session model and resume is bound to the orchestrator's `_last_completed` + `FOLLOWUP_WINDOW`. The deeper merge (routing `/code` through the unified worker, persisting the session id so resume survives restarts) is tracked as option B in #248.
 
 ---
 

--- a/tests/test_agent_threads_api.py
+++ b/tests/test_agent_threads_api.py
@@ -1,0 +1,195 @@
+"""API tests for the web /chat agent-threads endpoints (#236, Phase 3).
+
+Covers GET /api/agents/threads, GET /api/agents/threads/{id},
+POST /api/agents/threads/{id}/reply, and POST /api/agents/spawn.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services.agent_worker.session_store import (
+    STATUS_COMPLETED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    agents_route._label_cache.clear()
+    yield session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+# ---------------------------------------------------------------------------
+# GET /threads
+# ---------------------------------------------------------------------------
+
+
+def test_list_threads_returns_only_root_sessions(stores, client):
+    session_store, _ = stores
+    root = session_store.create(task_id="root", status=STATUS_COMPLETED, routing="local")
+    session_store.create(
+        task_id="child", status=STATUS_RUNNING, routing="local",
+        parent_session_id=root.session_id, root_session_id=root.session_id, spawn_depth=1,
+    )
+
+    resp = client.get("/api/agents/threads")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = {t["session_id"] for t in data["threads"]}
+    assert root.session_id in ids
+    # The spawned child is internal — not surfaced as a conversable thread.
+    assert all(t["parent_session_id"] is None for t in data["threads"])
+    # Completed root is resumable.
+    root_t = next(t for t in data["threads"] if t["session_id"] == root.session_id)
+    assert root_t["resumable"] is True
+
+
+def test_running_thread_not_resumable(stores, client):
+    session_store, _ = stores
+    session_store.create(task_id="r", status=STATUS_RUNNING, routing="local")
+    resp = client.get("/api/agents/threads")
+    t = resp.json()["threads"][0]
+    assert t["resumable"] is False
+
+
+# ---------------------------------------------------------------------------
+# GET /threads/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_thread_detail(stores, client):
+    session_store, transcript_store = stores
+    s = session_store.create(task_id="t", status=STATUS_COMPLETED, routing="claude")
+    transcript_store.append(s.session_id, "claim", {"task_id": "t"})
+
+    resp = client.get(f"/api/agents/threads/{s.session_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["thread"]["session_id"] == s.session_id
+    assert data["total"] == 1
+    assert data["events"][0]["kind"] == "claim"
+
+
+def test_get_thread_404(stores, client):
+    resp = client.get("/api/agents/threads/sess_does_not_exist")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /threads/{id}/reply
+# ---------------------------------------------------------------------------
+
+
+def test_reply_to_completed_thread_queues_followup(stores, client):
+    session_store, _ = stores
+    s = session_store.create(task_id="t", status=STATUS_COMPLETED, routing="local")
+
+    resp = client.post(f"/api/agents/threads/{s.session_id}/reply", json={"text": "also CC Jane"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "queued"
+
+    # A pre-answered followup row is now waiting for the worker to resume.
+    pending = session_store.list_answered_unprocessed_questions()
+    assert len(pending) == 1
+    assert pending[0]["kind"] == "followup"
+    assert pending[0]["answer"] == "also CC Jane"
+    assert pending[0]["session_id"] == s.session_id
+
+
+def test_reply_to_running_thread_409(stores, client):
+    session_store, _ = stores
+    s = session_store.create(task_id="t", status=STATUS_RUNNING, routing="local")
+    resp = client.post(f"/api/agents/threads/{s.session_id}/reply", json={"text": "hi"})
+    assert resp.status_code == 409
+
+
+def test_reply_unknown_thread_404(stores, client):
+    resp = client.post("/api/agents/threads/nope/reply", json={"text": "hi"})
+    assert resp.status_code == 404
+
+
+def test_reply_empty_text_400(stores, client):
+    session_store, _ = stores
+    s = session_store.create(task_id="t", status=STATUS_COMPLETED, routing="local")
+    resp = client.post(f"/api/agents/threads/{s.session_id}/reply", json={"text": "   "})
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /spawn
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_explicit_claude(stores, client):
+    session_store, _ = stores
+    resp = client.post("/api/agents/spawn", json={"prompt": "refactor the parser", "routing": "claude"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] and data["routing"] == "claude"
+    # The session landed in the store as an operator root-spawn.
+    s = session_store.get_by_session_id(data["session_id"])
+    assert s is not None and s.origin == "operator" and s.routing == "claude"
+
+
+def test_spawn_empty_prompt_400(stores, client):
+    resp = client.post("/api/agents/spawn", json={"prompt": "  "})
+    assert resp.status_code == 400
+
+
+def test_spawn_auto_routing_uses_preflight(stores, client, monkeypatch):
+    # "auto" → no explicit routing → create_operator_session runs preflight.
+    # Patch it so the test doesn't make a network call.
+    import api.services.agent_worker.operator_spawn as op
+
+    def fake_preflight(title, tags=None, caller=None):
+        from api.services.agent_worker.preflight import PreflightResult, PreflightBudget
+        return PreflightResult(
+            budget=PreflightBudget(wall_seconds=60, max_tokens=100, max_dollars=1.0),
+            routing="local", routing_reason="t", expected_output="text",
+            ambiguity=None, sane=True, sane_reason="", raw={},
+        )
+
+    monkeypatch.setattr(op, "run_preflight", fake_preflight)
+    resp = client.post("/api/agents/spawn", json={"prompt": "summarize my week", "routing": "auto"})
+    assert resp.status_code == 200
+    assert resp.json()["routing"] == "local"
+
+
+def test_spawn_auto_ambiguous_returns_409_and_cleans_up(stores, client, monkeypatch):
+    """When preflight is ambiguous (ROUTE_ASK), the web spawn has no inline
+    clarification flow — it must 409 and not leave a parked session behind."""
+    session_store, _ = stores
+    import api.services.agent_worker.operator_spawn as op
+
+    def ask_preflight(title, tags=None, caller=None):
+        from api.services.agent_worker.preflight import PreflightResult, PreflightBudget
+        return PreflightResult(
+            budget=PreflightBudget(wall_seconds=60, max_tokens=100, max_dollars=1.0),
+            routing="ask", routing_reason="ambiguous", expected_output="text",
+            ambiguity=None, sane=True, sane_reason="", raw={},
+        )
+
+    monkeypatch.setattr(op, "run_preflight", ask_preflight)
+    resp = client.post("/api/agents/spawn", json={"prompt": "do the thing", "routing": "auto"})
+    assert resp.status_code == 409
+    # No parked operator session was left behind.
+    assert session_store.list_sessions(status="blocked") == []

--- a/tests/test_agent_threads_ui_browser.py
+++ b/tests/test_agent_threads_ui_browser.py
@@ -1,0 +1,108 @@
+"""Browser test for the web /chat agent-threads UI (#236, Phase 3).
+
+Drives the Agents panel + "run as agent" composer affordance with the
+`/api/agents/*` endpoints mocked via Playwright route interception, so the
+spawn → appear → reply flow is deterministic and free of real worker/LLM
+side effects. Requires the server serving the chat page on localhost:8000
+(like all browser tests in this repo).
+"""
+import json
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+DESKTOP_VIEWPORT = {"width": 1280, "height": 800}
+
+
+def _install_agent_mocks(page: Page, state: dict):
+    """Route /api/agents/* to in-memory mock responses driven by `state`."""
+
+    def threads_handler(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"threads": state["threads"], "total": len(state["threads"])}),
+        )
+
+    def spawn_handler(route):
+        body = json.loads(route.request.post_data or "{}")
+        state["spawned"].append(body)
+        # The spawned agent now shows up as a running thread.
+        state["threads"].insert(0, {
+            "session_id": "sess_spawned",
+            "task_id": "op_spawned",
+            "parent_session_id": None,
+            "status": "running",
+            "label": body.get("prompt", "agent task")[:40],
+            "resumable": False,
+        })
+        route.fulfill(status=200, content_type="application/json",
+                      body=json.dumps({"ok": True, "session_id": "sess_spawned",
+                                       "task_id": "op_spawned", "routing": "claude",
+                                       "needs_routing": False}))
+
+    def reply_handler(route):
+        state["replies"].append(json.loads(route.request.post_data or "{}"))
+        route.fulfill(status=200, content_type="application/json",
+                      body=json.dumps({"ok": True, "status": "queued"}))
+
+    page.route("**/api/agents/threads*", threads_handler)
+    page.route("**/api/agents/spawn", spawn_handler)
+    page.route("**/api/agents/threads/*/reply", reply_handler)
+
+
+class TestAgentThreadsUI:
+    @pytest.fixture(autouse=True)
+    def setup(self, page: Page):
+        page.set_viewport_size(DESKTOP_VIEWPORT)
+        self.state = {
+            "threads": [{
+                "session_id": "sess_done",
+                "task_id": "op_done",
+                "parent_session_id": None,
+                "status": "completed",
+                "label": "draft the landlord email",
+                "resumable": True,
+            }],
+            "spawned": [],
+            "replies": [],
+        }
+        _install_agent_mocks(page, self.state)
+        page.goto("http://localhost:8000")
+        page.wait_for_selector("#agentsPanel")
+
+    def test_panel_lists_threads_with_status(self, page: Page):
+        expect(page.locator("#agentsThreadsList .agent-thread")).to_have_count(1)
+        expect(page.locator(".agent-badge.completed")).to_be_visible()
+        expect(page.locator(".agent-thread-label")).to_contain_text("landlord")
+
+    def test_composer_has_run_as_agent_controls(self, page: Page):
+        expect(page.locator("#agentRouting")).to_be_visible()
+        expect(page.locator("#agentSpawnBtn")).to_be_visible()
+        # Routing options: auto / local / cloud.
+        values = page.locator("#agentRouting option").evaluate_all(
+            "els => els.map(e => e.value)"
+        )
+        assert set(values) == {"auto", "local", "claude"}
+
+    def test_spawn_from_composer_appears_in_panel(self, page: Page):
+        page.locator("#inputField").fill("research the best CRMs")
+        page.locator("#agentRouting").select_option("claude")
+        page.locator("#agentSpawnBtn").click()
+        # The mock inserts a running thread; the panel polls/refreshes.
+        expect(page.locator(".agent-badge.running")).to_be_visible(timeout=8000)
+        assert self.state["spawned"], "spawn POST should have fired"
+        assert self.state["spawned"][0]["routing"] == "claude"
+
+    def test_reply_to_completed_thread(self, page: Page):
+        # Open the reply box on the completed (resumable) thread and send.
+        page.locator("#reply-sess_done").wait_for(state="attached")
+        page.locator('.agent-thread-top button[title="Reply"]').click()
+        box = page.locator("#reply-sess_done input")
+        box.fill("also CC Jane")
+        box.press("Enter")
+        page.wait_for_timeout(500)
+        assert self.state["replies"], "reply POST should have fired"
+        assert self.state["replies"][0]["text"] == "also CC Jane"

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -13,6 +13,7 @@ Also covers `lifeos_agent_user_ask` (agent-initiated clarification) and the
 """
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 
@@ -22,7 +23,9 @@ import pytest
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
+    STATUS_BUDGET_EXCEEDED,
     STATUS_COMPLETED,
+    STATUS_FAILED,
     STATUS_RUNNING,
     SessionStore,
 )
@@ -30,6 +33,10 @@ from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
 from api.services.agent_worker.worker import (
     BLOCKED_TAG,
+    BUDGET_EXCEEDED_TAG,
+    COMPLETED_TAG,
+    FAILED_TAG,
+    RUNNING_TAG,
     Worker,
 )
 
@@ -79,16 +86,32 @@ class _StubExecutor:
         return self.outcome
 
 
+class _SequenceExecutor:
+    """Returns a queued outcome per call (last one repeats once exhausted)."""
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+    def execute(self, session, task):
+        self.calls.append((session.task_id, task.get("description")))
+        if len(self.calls) <= len(self.outcomes):
+            return self.outcomes[len(self.calls) - 1]
+        return self.outcomes[-1]
+
+
 def _make_worker(tmp_path, api, *, preflight_caller, local_executor):
     transport = httpx.MockTransport(api.handler)
     client = httpx.Client(transport=transport, base_url="http://api")
     sent: list[str] = []
     sent_with_ids: list[tuple[int, str]] = []
     def _send_with_id(text):
+        # Mirror send_message_capture_ids: one id per ~4096-char chunk, all
+        # returned so a reply to any chunk can be matched.
         sent.append(text)
-        msg_id = 1000 + len(sent_with_ids)
-        sent_with_ids.append((msg_id, text))
-        return msg_id
+        n_chunks = max(1, -(-len(text) // 4096))
+        chunk_ids = [1000 + len(sent_with_ids) + i for i in range(n_chunks)]
+        for cid in chunk_ids:
+            sent_with_ids.append((cid, text))
+        return chunk_ids
     store = SessionStore(db_path=tmp_path / "sessions.db")
     w = Worker(
         api_base="http://api",
@@ -334,7 +357,7 @@ def test_lifeos_agent_user_ask_blocks_and_records_question(tmp_path: Path):
     def _send_with_id(text):
         msg_id = 5000 + len(sent_with_ids)
         sent_with_ids.append((msg_id, text))
-        return msg_id
+        return [msg_id]
 
     w = Worker(
         api_base="http://api",
@@ -409,3 +432,164 @@ def test_lifeos_agent_user_ask_fails_when_telegram_unavailable(tmp_path: Path):
     assert result["error"] == "telegram_unavailable"
     # Session NOT blocked (operator-facing failure mode).
     assert store.get("t").status == STATUS_RUNNING
+
+
+# =============================================================================
+# Replyable terminal states + any-chunk matching (Issue #234)
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_failed_task_registers_followup_and_reply_resumes(tmp_path: Path):
+    """A FAILED task's notification is replyable: replying resumes the session,
+    swapping the failed tag back to running, and a clean completion follows."""
+    api = FakeApi([{"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent"]}])
+    executor = _SequenceExecutor([
+        ExecutorOutcome(status=STATUS_FAILED, reason="boom"),
+        ExecutorOutcome(status=STATUS_COMPLETED, final_text="fixed it"),
+    ])
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+    w.tick()
+
+    # Parked at the failed tag, and a follow-up was registered against the
+    # terminal notification's message id (kind='followup', task title as label).
+    assert FAILED_TAG in api.tasks["t1"]["tags"]
+    msg_id, _ = w._sent_with_ids[-1]
+    q = w.session_store.get_question_by_message_id(msg_id)
+    assert q is not None
+    assert q["kind"] == "followup"
+    assert q["question"] == "do the thing"
+
+    # Operator replies → deposit → next tick resumes and completes.
+    assert w.session_store.deposit_answer(msg_id, "try again")
+    w.tick()
+    assert len(executor.calls) == 2, "executor should have been re-invoked on resume"
+    assert COMPLETED_TAG in api.tasks["t1"]["tags"]
+    assert RUNNING_TAG not in api.tasks["t1"]["tags"]
+
+
+@pytest.mark.unit
+def test_budget_exceeded_task_registers_followup(tmp_path: Path):
+    """BUDGET_EXCEEDED notifications are replyable too."""
+    api = FakeApi([{"id": "t1", "description": "big job", "status": "todo", "tags": ["agent"]}])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_BUDGET_EXCEEDED, reason="out of budget"))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+    w.tick()
+
+    assert BUDGET_EXCEEDED_TAG in api.tasks["t1"]["tags"]
+    msg_id, _ = w._sent_with_ids[-1]
+    q = w.session_store.get_question_by_message_id(msg_id)
+    assert q is not None and q["kind"] == "followup"
+
+
+@pytest.mark.unit
+def test_reply_to_non_first_chunk_matches_and_resumes(tmp_path: Path):
+    """A long terminal notification splits into multiple Telegram chunks;
+    replying to a non-first chunk still matches the follow-up and resumes.
+
+    Uses a long FAILED reason (the failure body isn't vault-spilled, so it
+    actually exceeds one 4096-char chunk)."""
+    api = FakeApi([{"id": "t1", "description": "task", "status": "todo", "tags": ["agent"]}])
+    long_reason = "y" * 9000  # forces the notification body across 3 chunks
+    executor = _SequenceExecutor([
+        ExecutorOutcome(status=STATUS_FAILED, reason=long_reason),
+        ExecutorOutcome(status=STATUS_COMPLETED, final_text="done again"),
+    ])
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+    w.tick()
+
+    # The notification spanned multiple chunks.
+    followup = w.session_store.get_recent_resumable_followup(within_seconds=3600)
+    assert followup is not None
+    chunk_ids = json.loads(followup["sent_message_ids"])
+    assert len(chunk_ids) >= 2, "notification should have spanned multiple chunks"
+
+    # Reply lands on the LAST chunk (not the primary first-chunk id).
+    last_chunk = chunk_ids[-1]
+    assert last_chunk != followup["sent_message_id"]
+    assert w.session_store.deposit_answer(last_chunk, "more please")
+    w.tick()
+    assert len(executor.calls) == 2, "reply to a later chunk should resume"
+
+
+@pytest.mark.unit
+def test_get_recent_resumable_followup_window(tmp_path: Path):
+    """get_recent_resumable_followup honors the time window and open-state."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    sess = store.create(
+        task_id="t1", status=STATUS_COMPLETED, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+    )
+    store.register_completion_followup(
+        session_id=sess.session_id, task_id="t1",
+        sent_message_ids=[500, 501], label="recent task",
+    )
+    # Within window → found.
+    row = store.get_recent_resumable_followup(within_seconds=1800)
+    assert row is not None and row["task_id"] == "t1"
+
+    # Once answered, it is no longer resumable via this path.
+    assert store.deposit_answer(500, "go")
+    assert store.get_recent_resumable_followup(within_seconds=1800) is None
+
+
+@pytest.mark.unit
+def test_get_recent_resumable_followup_excludes_clarifications(tmp_path: Path):
+    """Only kind='followup' rows count — open clarifications don't trigger the
+    plain-message resume path."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    sess = store.create(
+        task_id="t1", status=STATUS_BLOCKED, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+    )
+    store.create_pending_question(
+        session_id=sess.session_id, task_id="t1",
+        question="which one?", sent_message_id=42,
+    )
+    assert store.get_recent_resumable_followup(within_seconds=1800) is None
+
+
+@pytest.mark.unit
+def test_get_recent_resumable_followup_respects_cutoff(tmp_path: Path):
+    """A follow-up older than the window is not returned (no surprise resume)."""
+    import sqlite3
+
+    db = tmp_path / "sessions.db"
+    store = SessionStore(db_path=db)
+    sess = store.create(
+        task_id="t1", status=STATUS_COMPLETED, routing="local",
+        budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+    )
+    qid = store.register_completion_followup(
+        session_id=sess.session_id, task_id="t1",
+        sent_message_ids=[700], label="old task",
+    )
+    # Backdate the notification 31 minutes.
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "UPDATE pending_questions SET sent_at = sent_at - ? WHERE id = ?",
+            (31 * 60, qid),
+        )
+    assert store.get_recent_resumable_followup(within_seconds=1800) is None
+    # A wider window still finds it.
+    assert store.get_recent_resumable_followup(within_seconds=3600) is not None
+
+
+@pytest.mark.unit
+def test_native_reply_targets_specific_older_thread(tmp_path: Path):
+    """A native reply to a specific (older) thread's message id targets THAT
+    thread, not merely the most recent one."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    budget = {"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100}
+    s_old = store.create(task_id="old", status=STATUS_COMPLETED, routing="local", budget=budget)
+    s_new = store.create(task_id="new", status=STATUS_COMPLETED, routing="local", budget=budget)
+    store.register_completion_followup(
+        session_id=s_old.session_id, task_id="old", sent_message_ids=[100], label="old",
+    )
+    store.register_completion_followup(
+        session_id=s_new.session_id, task_id="new", sent_message_ids=[200], label="new",
+    )
+    # Native reply to the OLD message id deposits into the OLD follow-up only.
+    assert store.deposit_answer(100, "revisit old")
+    assert store.get_question_by_message_id(100)["answer"] == "revisit old"
+    assert store.get_question_by_message_id(200)["answer"] is None

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -593,3 +593,120 @@ def test_native_reply_targets_specific_older_thread(tmp_path: Path):
     assert store.deposit_answer(100, "revisit old")
     assert store.get_question_by_message_id(100)["answer"] == "revisit old"
     assert store.get_question_by_message_id(200)["answer"] is None
+
+
+# =============================================================================
+# Operator root-spawn dispatch + routing-ask resolution (Issue #235)
+# =============================================================================
+
+
+def _ask_preflight():
+    def _caller(prompt):
+        import json
+        return json.dumps({
+            "budget": {"wall_seconds": 3600, "max_tokens": 1000, "max_dollars": 5.0},
+            "routing": "ask", "routing_reason": "test ambiguous model",
+            "expected_output": "text",
+            "ambiguity": None, "sane": True, "sane_reason": "",
+        })
+    return _caller
+
+
+@pytest.mark.unit
+def test_operator_session_dispatches_and_registers_followup(tmp_path: Path):
+    """An operator root-spawn (no #agent task, origin='operator') is picked up
+    by the spawned-session dispatch, seeded with the enqueued prompt, and its
+    completion registers a replyable follow-up (Phase 1)."""
+    from api.services.agent_worker.operator_spawn import create_operator_session
+
+    api = FakeApi([])  # no #agent vault tasks
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    res = create_operator_session(w.session_store, "do the operator task", explicit_routing="local")
+    assert res["ok"] and res["routing"] == "local"
+
+    w.tick()
+    assert executor.calls, "operator session should dispatch to the executor"
+    # Seeded with the enqueued prompt as the task description (not the task id).
+    assert executor.calls[0][1] == "do the operator task"
+    # Completion registered a follow-up → the notification is replyable.
+    followup = w.session_store.get_recent_resumable_followup(within_seconds=3600)
+    assert followup is not None and followup["kind"] == "followup"
+
+
+@pytest.mark.unit
+def test_operator_ask_resolution_dispatches_after_reply(tmp_path: Path):
+    """An ambiguous operator spawn parks at 'ask'; replying 'local' flips it to
+    claimed and the next tick dispatches it with the prompt intact."""
+    from api.services.agent_worker.operator_spawn import create_operator_session
+
+    api = FakeApi([])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="ok"))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    res = create_operator_session(w.session_store, "ambiguous task", preflight_caller=_ask_preflight())
+    assert res["needs_routing"]
+    # Telegram would register the routing clarification keyed to its message id.
+    w.session_store.create_pending_question(
+        session_id=res["session_id"], task_id=res["task_id"],
+        question="local or claude?", sent_message_id=7777,
+    )
+
+    w.tick()  # still blocked — nothing dispatched
+    assert executor.calls == []
+
+    assert w.session_store.deposit_answer(7777, "local")
+    w.tick()  # _process_clarification_answers flips blocked -> claimed (dispatch runs earlier in the tick)
+    assert executor.calls == []
+    w.tick()  # now spawned-session dispatch picks it up
+    assert executor.calls, "operator session should dispatch after routing resolved"
+    assert executor.calls[0][1] == "ambiguous task"
+
+
+@pytest.mark.unit
+def test_operator_session_coexists_with_agent_task(tmp_path: Path):
+    """An operator spawn and a normal #agent task both run in the same tick
+    without interfering."""
+    from api.services.agent_worker.operator_spawn import create_operator_session
+
+    api = FakeApi([{"id": "t1", "description": "agent task", "status": "todo", "tags": ["agent"]}])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    create_operator_session(w.session_store, "operator task", explicit_routing="local")
+    w.tick()
+
+    descriptions = {c[1] for c in executor.calls}
+    assert "operator task" in descriptions
+    assert "agent task" in descriptions
+    assert COMPLETED_TAG in api.tasks["t1"]["tags"]
+
+
+@pytest.mark.unit
+def test_operator_completion_skips_vault_mutations(tmp_path: Path):
+    """Operator sessions have no backing vault task, so terminal handling must
+    not call _complete_task / _swap_tag / _set_task_status (they would 404).
+    The notification + follow-up still fire."""
+    from api.services.agent_worker.operator_spawn import create_operator_session
+
+    api = FakeApi([])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    res = create_operator_session(w.session_store, "operator task", explicit_routing="local")
+    op_task_id = res["task_id"]
+
+    vault_calls: list[tuple[str, str]] = []
+    orig_complete, orig_swap, orig_status = w._complete_task, w._swap_tag, w._set_task_status
+    w._complete_task = lambda tid: vault_calls.append(("complete", tid)) or orig_complete(tid)
+    w._swap_tag = lambda tid, f, t: vault_calls.append(("swap", tid)) or orig_swap(tid, f, t)
+    w._set_task_status = lambda tid, s: vault_calls.append(("status", tid)) or orig_status(tid, s)
+
+    w.tick()
+
+    assert executor.calls, "operator session should have dispatched"
+    # No vault mutation was attempted against the synthetic operator task id.
+    assert not any(tid == op_task_id for _, tid in vault_calls), vault_calls
+    # The completion still registered a replyable follow-up.
+    assert w.session_store.get_recent_resumable_followup(within_seconds=3600) is not None

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -344,6 +344,31 @@ def test_timeout_marks_question_and_nudges(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_timeout_closes_code_followup_without_nudge(tmp_path: Path):
+    """A stale code_followup row (#237) is timed out (closed) but does NOT get
+    the agent-worker 'still waiting / re-tag with #agent' nudge — it points at a
+    Claude Code session, not an #agent task."""
+    api = FakeApi([])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    qid = w.session_store.create_pending_question(
+        session_id="claude_xyz", task_id="code_claude_xyz",
+        question="fix the bug", sent_message_id=77, kind="code_followup",
+    )
+    with w.session_store._connect() as conn:
+        conn.execute(
+            "UPDATE pending_questions SET sent_at = ? WHERE id = ?",
+            (int(time.time()) - 4 * 86400, qid),
+        )
+
+    w._timeout_stale_clarifications()
+
+    assert w.session_store.get_question_by_message_id(77)["timed_out"] == 1
+    assert not any("still waiting on your reply" in s for s in w._sent)
+
+
+@pytest.mark.unit
 def test_lifeos_agent_user_ask_blocks_and_records_question(tmp_path: Path):
     """An agent calling `lifeos_agent_user_ask` should park the session and record
     a pending_question that the user can reply-thread to."""
@@ -710,3 +735,24 @@ def test_operator_completion_skips_vault_mutations(tmp_path: Path):
     assert not any(tid == op_task_id for _, tid in vault_calls), vault_calls
     # The completion still registered a replyable follow-up.
     assert w.session_store.get_recent_resumable_followup(within_seconds=3600) is not None
+
+
+@pytest.mark.unit
+def test_worker_skips_code_followup_rows(tmp_path: Path):
+    """code_followup rows (#237) point at a Claude Code session, not an
+    agent-worker session — the worker must skip them (mark processed) without
+    crashing or dispatching anything."""
+    api = FakeApi([])
+    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="x"))
+    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+
+    w.session_store.create_pending_question(
+        session_id="claude_xyz", task_id="code_claude_xyz", question="t",
+        sent_message_id=50, kind="code_followup",
+    )
+    assert w.session_store.deposit_answer(50, "answer")
+
+    w.tick()  # must not crash on the code_followup row
+
+    assert w.session_store.get_question_by_message_id(50)["processed"] == 1
+    assert executor.calls == []  # nothing dispatched for a /code row

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -108,10 +108,11 @@ def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_execut
     # returns a deterministic message_id so reply-threading can be tested.
     sent_with_ids: list[tuple[int, str]] = []
     def _fake_send_with_id(text):
+        # Mirror send_message_capture_ids: return a list of chunk ids.
         sent.append(text)
         msg_id = len(sent_with_ids) + 1000
         sent_with_ids.append((msg_id, text))
-        return msg_id
+        return [msg_id]
     w = Worker(
         api_base="http://api",
         session_store=SessionStore(db_path=tmp_path / "sessions.db"),
@@ -370,10 +371,11 @@ def test_claude_routing_with_managed_executor_starts_and_polls(tmp_path: Path):
     sent: list[str] = []
     sent_ids: list[tuple[int, str]] = []
     def _fake_with_id(text):
+        # Mirror send_message_capture_ids: return a list of chunk ids.
         sent.append(text)
         msg_id = len(sent_ids) + 2000
         sent_ids.append((msg_id, text))
-        return msg_id
+        return [msg_id]
     managed = _StubManagedExecutor()
     w = Worker(
         api_base="http://api",

--- a/tests/test_chat_helpers.py
+++ b/tests/test_chat_helpers.py
@@ -97,3 +97,75 @@ class TestImperativeFollowupRegex:
         ]
         for q in should_not_match:
             assert not _IMPERATIVE_FOLLOWUP_RE.search(q), f"Should not match: {q!r}"
+
+
+# =============================================================================
+# Operator agent spawn from chat (Issue #235, AC6)
+# =============================================================================
+
+
+class TestAgentSlashChat:
+    """`/agent ...` operator spawn from the web chat orchestrator."""
+
+    class _FakeStore:
+        def __init__(self):
+            self.msgs = []
+        def add_message(self, cid, role, content):
+            self.msgs.append((role, content))
+
+    @staticmethod
+    def _reassemble(events):
+        """Join the 'content' fields from the SSE stream (the assistant message
+        is streamed char-by-char)."""
+        import json
+        out = []
+        for ev in events:
+            try:
+                data = json.loads(ev[len("data: "):].strip())
+            except ValueError:
+                continue
+            if data.get("type") == "content":
+                out.append(data["content"])
+        return "".join(out)
+
+    @pytest.mark.asyncio
+    async def test_agent_slash_spawns_and_confirms(self):
+        from unittest.mock import patch
+        from api.routes.chat import _handle_agent_slash
+
+        store = self._FakeStore()
+        spawn_result = {"ok": True, "routing": "claude", "needs_routing": False,
+                        "session_id": "s", "task_id": "op_1"}
+        with patch("api.services.agent_worker.operator_spawn.create_operator_session",
+                   return_value=spawn_result) as mock_spawn, \
+             patch("api.services.agent_worker.session_store.SessionStore"):
+            events = [ev async for ev in _handle_agent_slash("/agent claude refactor x", "c1", store)]
+
+        assert mock_spawn.call_args.kwargs.get("explicit_routing") == "claude"
+        assert mock_spawn.call_args.args[1] == "refactor x"
+        assert "Spawned" in self._reassemble(events)
+        assert any(role == "assistant" for role, _ in store.msgs)
+        assert events[-1].strip().endswith('{"type": "done"}')
+
+    @pytest.mark.asyncio
+    async def test_agent_slash_empty_shows_usage(self):
+        from api.routes.chat import _handle_agent_slash
+        store = self._FakeStore()
+        events = [ev async for ev in _handle_agent_slash("/agent", "c1", store)]
+        assert "Usage:" in self._reassemble(events)
+
+    @pytest.mark.asyncio
+    async def test_agent_slash_ask_prompts_for_explicit_model(self):
+        from unittest.mock import patch
+        from api.routes.chat import _handle_agent_slash
+
+        store = self._FakeStore()
+        spawn_result = {"ok": True, "routing": "ask", "needs_routing": True,
+                        "session_id": "s", "task_id": "op_1"}
+        with patch("api.services.agent_worker.operator_spawn.create_operator_session",
+                   return_value=spawn_result), \
+             patch("api.services.agent_worker.session_store.SessionStore"):
+            events = [ev async for ev in _handle_agent_slash("/agent do the thing", "c1", store)]
+
+        body = self._reassemble(events)
+        assert "/agent local" in body and "/agent claude" in body

--- a/tests/test_code_followup.py
+++ b/tests/test_code_followup.py
@@ -1,0 +1,194 @@
+"""Tests for reconciling /code with the unified follow-up table (#237, Phase 4).
+
+Covers: the orchestrator on_complete hook, registering a Claude Code completion
+in the shared `pending_questions` table (kind='code_followup'), any-chunk
+lookup, the Telegram reply hook routing /code replies to the orchestrator's
+resume path, and the worker skipping code_followup rows.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_listener(tmp_path):
+    from api.services.telegram import TelegramBotListener
+    state_file = tmp_path / "telegram_state.json"
+    with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
+        return TelegramBotListener()
+
+
+class _FakeSession:
+    def __init__(self, session_id="claude_abc", task="fix the bug"):
+        self.session_id = session_id
+        self.task = task
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator on_complete hook
+# ---------------------------------------------------------------------------
+
+
+def test_on_complete_fires_on_completion():
+    from api.services.claude_orchestrator import ClaudeOrchestrator, ClaudeSession
+
+    orch = ClaudeOrchestrator()
+    sess = ClaudeSession(session_id="s1", task="t", status="running")
+    orch._active_session = sess
+    called = []
+    orch._on_complete = lambda s: called.append(s)
+
+    orch._cleanup("completed")
+    assert called == [sess]
+
+
+def test_on_complete_does_not_fire_on_failure():
+    from api.services.claude_orchestrator import ClaudeOrchestrator, ClaudeSession
+
+    orch = ClaudeOrchestrator()
+    sess = ClaudeSession(session_id="s2", task="t", status="running")
+    orch._active_session = sess
+    called = []
+    orch._on_complete = lambda s: called.append(s)
+
+    orch._cleanup("failed")
+    assert called == []
+
+
+def test_on_complete_skipped_without_session_id():
+    from api.services.claude_orchestrator import ClaudeOrchestrator, ClaudeSession
+
+    orch = ClaudeOrchestrator()
+    sess = ClaudeSession(session_id=None, task="t", status="running")
+    orch._active_session = sess
+    called = []
+    orch._on_complete = lambda s: called.append(s)
+
+    orch._cleanup("completed")
+    assert called == []  # no resumable session id → nothing to register
+
+
+# ---------------------------------------------------------------------------
+# Registration + any-chunk lookup
+# ---------------------------------------------------------------------------
+
+
+def test_register_code_followup_and_lookup(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    listener = _make_listener(tmp_path)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store):
+        listener._register_code_followup(_FakeSession("claude_abc", "fix the bug"), [10, 11, 12])
+
+    # Reply to any chunk matches; the row carries the Claude session id + kind.
+    q = store.get_open_question_by_message_id(12)
+    assert q is not None
+    assert q["kind"] == "code_followup"
+    assert q["session_id"] == "claude_abc"
+    assert q["question"] == "fix the bug"
+
+
+def test_register_code_followup_noop_without_ids_or_session(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    listener = _make_listener(tmp_path)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store):
+        listener._register_code_followup(_FakeSession("c", "t"), [])  # no ids
+        listener._register_code_followup(_FakeSession(None, "t"), [1])  # no session id
+    assert store.get_open_question_by_message_id(1) is None
+
+
+# ---------------------------------------------------------------------------
+# Telegram reply routing
+# ---------------------------------------------------------------------------
+
+
+class _FakeOrch:
+    def __init__(self, resume_ok=True):
+        self.resume_ok = resume_ok
+        self.followup_calls = []
+
+    def followup(self, message, notification_callback=None, on_complete=None):
+        self.followup_calls.append(message)
+        return object() if self.resume_ok else None
+
+
+@pytest.mark.asyncio
+async def test_code_reply_resumes_via_orchestrator(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    store.create_pending_question(
+        session_id="claude_abc", task_id="code_claude_abc", question="fix the bug",
+        sent_message_id=20, sent_message_ids=[20, 21], kind="code_followup",
+    )
+    listener = _make_listener(tmp_path)
+    orch = _FakeOrch(resume_ok=True)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+         patch("api.services.claude_orchestrator.get_orchestrator", return_value=orch), \
+         patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+        # Reply lands on the second chunk.
+        handled = await listener._maybe_handle_code_reply(21, "now add tests", "123")
+
+    assert handled is True
+    assert orch.followup_calls == ["now add tests"]
+    assert "Resuming Claude Code" in mock_send.await_args.args[0]
+    # Row is closed so it isn't reprocessed.
+    assert store.get_open_question_by_message_id(20) is None
+
+
+@pytest.mark.asyncio
+async def test_code_reply_unresumable_tells_user(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    store.create_pending_question(
+        session_id="claude_abc", task_id="code_claude_abc", question="t",
+        sent_message_id=30, kind="code_followup",
+    )
+    listener = _make_listener(tmp_path)
+    orch = _FakeOrch(resume_ok=False)  # window expired / busy
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+         patch("api.services.claude_orchestrator.get_orchestrator", return_value=orch), \
+         patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+        handled = await listener._maybe_handle_code_reply(30, "continue", "123")
+
+    assert handled is True
+    assert "can't be resumed" in mock_send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_non_code_reply_not_handled(tmp_path: Path):
+    """A reply matching an agent-worker follow-up (kind='followup') is NOT
+    consumed by the code-reply hook — it falls through to the worker deposit."""
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    store.create_pending_question(
+        session_id="sess_x", task_id="t1", question="",
+        sent_message_id=40, kind="followup",
+    )
+    listener = _make_listener(tmp_path)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+         patch("api.services.telegram.send_message_async", new_callable=AsyncMock):
+        handled = await listener._maybe_handle_code_reply(40, "x", "123")
+    assert handled is False
+    # Unconsumed — still open for the worker path.
+    assert store.get_open_question_by_message_id(40) is not None
+
+
+@pytest.mark.asyncio
+async def test_no_match_returns_false(tmp_path: Path):
+    from api.services.agent_worker.session_store import SessionStore
+
+    store = SessionStore(db_path=tmp_path / "s.db")
+    listener = _make_listener(tmp_path)
+    with patch("api.services.agent_worker.session_store.SessionStore", return_value=store):
+        handled = await listener._maybe_handle_code_reply(999, "x", "123")
+    assert handled is False

--- a/tests/test_operator_spawn.py
+++ b/tests/test_operator_spawn.py
@@ -121,6 +121,17 @@ def test_unsafe_preflight_rejected(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_delete_session_removes_row_and_queued_message(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    res = create_operator_session(store, "do X", explicit_routing="local")
+    sid = res["session_id"]
+    assert store.get_by_session_id(sid) is not None
+    store.delete_session(sid)
+    assert store.get_by_session_id(sid) is None
+    assert store.drain_pending_messages(sid) == []
+
+
+@pytest.mark.unit
 def test_operator_budget_defaults_applied(tmp_path: Path):
     store = SessionStore(db_path=tmp_path / "s.db")
     result = create_operator_session(store, "do X", explicit_routing="local")

--- a/tests/test_operator_spawn.py
+++ b/tests/test_operator_spawn.py
@@ -1,0 +1,129 @@
+"""Tests for operator root-spawn (#235, Phase 2 of #233).
+
+Covers `create_operator_session`: explicit-routing override, preflight
+auto-route, the ambiguous (ROUTE_ASK) clarification path, the operator origin
+marker, prompt enqueueing, and input validation.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.operator_spawn import create_operator_session
+from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
+    STATUS_CLAIMED,
+    SessionStore,
+)
+
+
+def _preflight(routing: str, *, sane: bool = True, sane_reason: str = ""):
+    """Build a fake preflight caller that returns the given routing."""
+    def _caller(prompt: str) -> str:
+        return json.dumps({
+            "budget": {"wall_seconds": 3600, "max_tokens": 1000, "max_dollars": 5.0},
+            "routing": routing, "routing_reason": "test",
+            "expected_output": "text",
+            "ambiguity": None, "sane": sane, "sane_reason": sane_reason,
+        })
+    return _caller
+
+
+@pytest.mark.unit
+def test_explicit_claude_routing_skips_preflight(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    # Preflight that would say "local" — explicit should win and it shouldn't
+    # even be consulted (we still pass it to prove override precedence).
+    result = create_operator_session(
+        store, "refactor the parser", explicit_routing="claude",
+        preflight_caller=_preflight("local"),
+    )
+    assert result["ok"]
+    assert result["routing"] == "claude"
+    assert result["routing_source"] == "explicit"
+    assert not result["needs_routing"]
+    sess = store.get_by_session_id(result["session_id"])
+    assert sess.status == STATUS_CLAIMED
+    assert sess.origin == "operator"
+    assert sess.parent_session_id is None
+    assert sess.root_session_id == sess.session_id
+
+
+@pytest.mark.unit
+def test_explicit_local_routing(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = create_operator_session(
+        store, "draft a reply", explicit_routing="local",
+        preflight_caller=_preflight("claude"),
+    )
+    assert result["ok"] and result["routing"] == "local"
+    assert store.get_by_session_id(result["session_id"]).routing == "local"
+
+
+@pytest.mark.unit
+def test_no_keyword_routes_via_preflight(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = create_operator_session(
+        store, "summarize my week", preflight_caller=_preflight("claude"),
+    )
+    assert result["ok"]
+    assert result["routing"] == "claude"
+    assert result["routing_source"] == "preflight"
+    assert not result["needs_routing"]
+    assert store.get_by_session_id(result["session_id"]).status == STATUS_CLAIMED
+
+
+@pytest.mark.unit
+def test_ambiguous_preflight_parks_for_routing(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = create_operator_session(
+        store, "do the thing", preflight_caller=_preflight("ask"),
+    )
+    assert result["ok"]
+    assert result["needs_routing"] is True
+    assert result["routing"] == "ask"
+    sess = store.get_by_session_id(result["session_id"])
+    assert sess.status == STATUS_BLOCKED
+    assert sess.routing == "ask"
+    assert sess.origin == "operator"
+
+
+@pytest.mark.unit
+def test_prompt_is_enqueued_as_pending_message(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = create_operator_session(
+        store, "email the landlord", explicit_routing="local",
+    )
+    pending = store.drain_pending_messages(result["session_id"])
+    assert len(pending) == 1
+    assert pending[0]["content"] == "email the landlord"
+
+
+@pytest.mark.unit
+def test_empty_prompt_rejected(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = create_operator_session(store, "   ", explicit_routing="local")
+    assert not result["ok"]
+    assert "prompt is required" in result["error"]
+
+
+@pytest.mark.unit
+def test_unsafe_preflight_rejected(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = create_operator_session(
+        store, "rm -rf everything",
+        preflight_caller=_preflight("ask", sane=False, sane_reason="destructive"),
+    )
+    assert not result["ok"]
+    assert "unsafe" in result["error"]
+
+
+@pytest.mark.unit
+def test_operator_budget_defaults_applied(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = create_operator_session(store, "do X", explicit_routing="local")
+    sess = store.get_by_session_id(result["session_id"])
+    assert sess.budget is not None
+    assert set(sess.budget) == {"wall_seconds", "max_tokens", "max_dollars"}

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -411,3 +411,80 @@ class TestAgentThreadResume:
 
         mock_resume.assert_awaited_once()
         mock_chat.assert_not_awaited()  # resume short-circuited the chat pipeline
+
+
+# =============================================================================
+# Operator agent spawn command (Issue #235)
+# =============================================================================
+
+
+class TestAgentSpawnCommand:
+    """`/agent [local|claude] <task>` operator spawn from Telegram."""
+
+    def _make_listener(self, tmp_path):
+        from api.services.telegram import TelegramBotListener
+        state_file = tmp_path / "telegram_state.json"
+        with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
+            return TelegramBotListener()
+
+    @pytest.mark.asyncio
+    async def test_explicit_claude_routing_passed_through(self, tmp_path):
+        listener = self._make_listener(tmp_path)
+        spawn_result = {"ok": True, "routing": "claude", "needs_routing": False,
+                        "session_id": "s1", "task_id": "op_1"}
+        with patch("api.services.agent_worker.operator_spawn.create_operator_session",
+                   return_value=spawn_result) as mock_spawn, \
+             patch("api.services.agent_worker.session_store.SessionStore"), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+            await listener._handle_agent_spawn("claude refactor the parser", "123")
+
+        _, kwargs = mock_spawn.call_args
+        assert kwargs.get("explicit_routing") == "claude"
+        # Task text has the keyword stripped.
+        assert mock_spawn.call_args.args[1] == "refactor the parser"
+        assert "Spawned" in mock_send.await_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_no_keyword_auto_routes(self, tmp_path):
+        listener = self._make_listener(tmp_path)
+        spawn_result = {"ok": True, "routing": "local", "needs_routing": False,
+                        "session_id": "s1", "task_id": "op_1"}
+        with patch("api.services.agent_worker.operator_spawn.create_operator_session",
+                   return_value=spawn_result) as mock_spawn, \
+             patch("api.services.agent_worker.session_store.SessionStore"), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock):
+            await listener._handle_agent_spawn("summarize my week", "123")
+
+        _, kwargs = mock_spawn.call_args
+        assert kwargs.get("explicit_routing") is None
+        assert mock_spawn.call_args.args[1] == "summarize my week"
+
+    @pytest.mark.asyncio
+    async def test_empty_task_shows_usage(self, tmp_path):
+        listener = self._make_listener(tmp_path)
+        with patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+            await listener._handle_agent_spawn("", "123")
+        assert "Usage:" in mock_send.await_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_needs_routing_sends_clarification(self, tmp_path):
+        from api.services.agent_worker.session_store import SessionStore
+        listener = self._make_listener(tmp_path)
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        # A real (blocked, ask) operator session to attach the question to.
+        sess = store.create(
+            task_id="op_x", status="blocked", routing="ask", origin="operator",
+            budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+        )
+        spawn_result = {"ok": True, "routing": "ask", "needs_routing": True,
+                        "session_id": sess.session_id, "task_id": "op_x"}
+        with patch("api.services.agent_worker.operator_spawn.create_operator_session",
+                   return_value=spawn_result), \
+             patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+             patch("api.services.telegram.send_message_capture_ids", return_value=[555]), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock):
+            await listener._handle_agent_spawn("do the thing", "123")
+
+        # A routing clarification was registered against the sent message id.
+        q = store.get_question_by_message_id(555)
+        assert q is not None and q["task_id"] == "op_x"

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -330,3 +330,84 @@ class TestMessageDedup:
         listener._processed_ids.append(TelegramBotListener._DEDUP_WINDOW)
         assert 0 not in listener._processed_ids
         assert TelegramBotListener._DEDUP_WINDOW in listener._processed_ids
+
+
+# =============================================================================
+# Plain-message agent-thread resume (Issue #234, Phase 1)
+# =============================================================================
+
+
+class TestAgentThreadResume:
+    """A plain (non-reply) message within the window resumes the most recent
+    completed/failed agent thread instead of starting a fresh chat query."""
+
+    def _make_listener(self, tmp_path):
+        from api.services.telegram import TelegramBotListener
+        state_file = tmp_path / "telegram_state.json"
+        with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
+            return TelegramBotListener()
+
+    def _store_with_followup(self, tmp_path, *, label="email Bob", msg_ids=(900,)):
+        from api.services.agent_worker.session_store import (
+            STATUS_COMPLETED,
+            SessionStore,
+        )
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        sess = store.create(
+            task_id="t1", status=STATUS_COMPLETED, routing="local",
+            budget={"max_dollars": 1.0, "wall_seconds": 60, "max_tokens": 100},
+        )
+        store.register_completion_followup(
+            session_id=sess.session_id, task_id="t1",
+            sent_message_ids=list(msg_ids), label=label,
+        )
+        return store
+
+    @pytest.mark.asyncio
+    async def test_plain_message_within_window_resumes(self, tmp_path):
+        listener = self._make_listener(tmp_path)
+        store = self._store_with_followup(tmp_path, label="email Bob")
+
+        with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+            handled = await listener._maybe_resume_recent_agent_thread("also CC Jane", "123")
+
+        assert handled is True
+        # The message was deposited into the follow-up (now no longer resumable).
+        assert store.get_recent_resumable_followup(within_seconds=1800) is None
+        # A visible continuation prefix was sent.
+        mock_send.assert_awaited_once()
+        assert 'continuing "email Bob"' in mock_send.await_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_no_recent_thread_falls_through(self, tmp_path):
+        from api.services.agent_worker.session_store import SessionStore
+        listener = self._make_listener(tmp_path)
+        empty_store = SessionStore(db_path=tmp_path / "sessions.db")  # no follow-ups
+
+        with patch("api.services.agent_worker.session_store.SessionStore", return_value=empty_store), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
+            handled = await listener._maybe_resume_recent_agent_thread("hello there", "123")
+
+        assert handled is False
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handle_update_routes_plain_message_to_resume(self, tmp_path):
+        """Integration: a plain message with a resumable thread short-circuits
+        the chat pipeline."""
+        listener = self._make_listener(tmp_path)
+        update = {"message": {"message_id": 7, "text": "and add a PS", "chat": {"id": "123"}}}
+
+        with patch.object(listener, "_check_agent_approval", return_value=False), \
+             patch.object(listener, "_check_agent_clarification", return_value=False), \
+             patch.object(listener, "_check_code_followup", new_callable=AsyncMock, return_value=False), \
+             patch.object(listener, "_maybe_resume_recent_agent_thread", new_callable=AsyncMock, return_value=True) as mock_resume, \
+             patch("api.services.telegram.settings") as mock_settings, \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            mock_settings.telegram_chat_id = "123"
+            await listener._handle_update(update)
+
+        mock_resume.assert_awaited_once()
+        mock_chat.assert_not_awaited()  # resume short-circuited the chat pipeline

--- a/web/index.html
+++ b/web/index.html
@@ -2480,6 +2480,32 @@
             margin-bottom: 1rem;
             opacity: 0.5;
         }
+
+        /* Agent threads panel (#236) */
+        .agents-panel { border-top: 1px solid var(--border, #2a2a2a); margin-top: auto; }
+        .agents-panel-header {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 0.6rem 1rem; font-size: 0.8rem; font-weight: 600;
+            text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.7;
+        }
+        .agents-refresh { background: none; border: none; color: inherit; cursor: pointer; font-size: 1rem; opacity: 0.7; }
+        .agents-refresh:hover { opacity: 1; }
+        .agents-threads-list { max-height: 38vh; overflow-y: auto; padding: 0 0.5rem 0.5rem; }
+        .agent-thread { padding: 0.5rem 0.6rem; border-radius: 8px; margin-bottom: 0.35rem; background: rgba(255,255,255,0.03); }
+        .agent-thread-top { display: flex; align-items: center; gap: 0.4rem; }
+        .agent-thread-label { flex: 1; font-size: 0.82rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .agent-badge { font-size: 0.64rem; padding: 0.1rem 0.4rem; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.03em; }
+        .agent-badge.running { background: #1e3a5f; color: #7fb4ff; }
+        .agent-badge.completed { background: #1e4620; color: #7ad17f; }
+        .agent-badge.failed, .agent-badge.budget_exceeded { background: #4a1e1e; color: #ff9d9d; }
+        .agent-badge.blocked, .agent-badge.yielded { background: #4a3a1e; color: #ffd27f; }
+        .agent-reply-row { display: none; gap: 0.3rem; margin-top: 0.4rem; }
+        .agent-reply-row.open { display: flex; }
+        .agent-reply-row input { flex: 1; font-size: 0.78rem; padding: 0.3rem 0.45rem; border-radius: 6px; border: 1px solid var(--border, #2a2a2a); background: rgba(0,0,0,0.2); color: inherit; }
+        .agent-reply-row button { font-size: 0.74rem; padding: 0.3rem 0.5rem; border-radius: 6px; border: none; cursor: pointer; background: #2d5fa3; color: #fff; }
+        .agent-routing-select { font-size: 0.78rem; border-radius: 8px; border: 1px solid var(--border, #2a2a2a); background: rgba(0,0,0,0.2); color: inherit; padding: 0 0.3rem; }
+        .agent-spawn-btn { background: none; border: none; cursor: pointer; font-size: 1.15rem; opacity: 0.75; }
+        .agent-spawn-btn:hover { opacity: 1; }
     </style>
 </head>
 <body>
@@ -2497,6 +2523,16 @@
         </div>
         <div class="conversations-list" id="conversationsList">
             <div class="empty-conversations">No conversations yet</div>
+        </div>
+        <!-- Agent threads (#236): in-flight + completed agent sessions, replyable -->
+        <div class="agents-panel" id="agentsPanel">
+            <div class="agents-panel-header">
+                <span>Agent threads</span>
+                <button class="agents-refresh" onclick="loadAgentThreads()" title="Refresh">⟳</button>
+            </div>
+            <div class="agents-threads-list" id="agentsThreadsList">
+                <div class="empty-conversations">No agent threads</div>
+            </div>
         </div>
     </aside>
 
@@ -2560,6 +2596,12 @@
                 <input type="file" id="fileInput" class="file-input" multiple
                        accept="image/png,image/jpeg,image/jpg,image/gif,image/webp,application/pdf,text/plain,text/markdown,text/csv,application/json">
                 <button class="attach-btn" id="attachBtn" onclick="openFilePicker()" title="Attach files">📎</button>
+                <select id="agentRouting" class="agent-routing-select" title="Agent model (run-as-agent)">
+                    <option value="auto">🤖 auto</option>
+                    <option value="local">local</option>
+                    <option value="claude">cloud</option>
+                </select>
+                <button class="agent-spawn-btn" id="agentSpawnBtn" onclick="spawnAgentFromComposer()" title="Run the composer text as an agent">⚙</button>
                 <button class="send-btn" id="sendBtn" onclick="sendMessage()" title="Send message">➤</button>
             </div>
         </footer>
@@ -2885,7 +2927,108 @@
             inputField.focus();
             setupScrollListener();
             setupAttachmentHandlers();
+            loadAgentThreads();
+            // Light polling for live-ish status; the /api/agents/stream SSE
+            // already drives the dedicated /agents page.
+            setInterval(loadAgentThreads, 5000);
         });
+
+        // --- Agent threads panel (#236) ---
+        async function loadAgentThreads() {
+            const list = document.getElementById('agentsThreadsList');
+            if (!list) return;
+            try {
+                const resp = await fetch('/api/agents/threads?limit=25');
+                if (!resp.ok) return;
+                const data = await resp.json();
+                renderAgentThreads(data.threads || []);
+            } catch (e) { /* worker/API offline — leave the panel as-is */ }
+        }
+
+        function renderAgentThreads(threads) {
+            const list = document.getElementById('agentsThreadsList');
+            if (!list) return;
+            if (!threads.length) {
+                list.innerHTML = '<div class="empty-conversations">No agent threads</div>';
+                return;
+            }
+            list.innerHTML = '';
+            threads.forEach(t => {
+                const label = escapeHtml((t.label || t.task_id || t.session_id || 'agent').toString());
+                // escapeHtml leaves double-quotes intact; escape them for the
+                // title="…" attribute context to prevent attribute breakout.
+                const labelAttr = label.replace(/"/g, '&quot;');
+                const status = (t.status || '').toString();
+                const sid = t.session_id;
+                const div = document.createElement('div');
+                div.className = 'agent-thread';
+                div.innerHTML =
+                    '<div class="agent-thread-top">' +
+                        '<span class="agent-thread-label" title="' + labelAttr + '">' + label + '</span>' +
+                        '<span class="agent-badge ' + escapeHtml(status) + '">' + (escapeHtml(status) || '?') + '</span>' +
+                        (t.resumable ? '<button class="agents-refresh" title="Reply" onclick="toggleAgentReply(\'' + sid + '\')">↩</button>' : '') +
+                    '</div>' +
+                    '<div class="agent-reply-row" id="reply-' + sid + '">' +
+                        '<input type="text" placeholder="Reply to continue…" ' +
+                        'onkeydown="if(event.key===\'Enter\'){sendAgentReply(\'' + sid + '\')}">' +
+                        '<button onclick="sendAgentReply(\'' + sid + '\')">Send</button>' +
+                    '</div>';
+                list.appendChild(div);
+            });
+        }
+
+        function toggleAgentReply(sessionId) {
+            const row = document.getElementById('reply-' + sessionId);
+            if (!row) return;
+            row.classList.toggle('open');
+            const inp = row.querySelector('input');
+            if (inp && row.classList.contains('open')) inp.focus();
+        }
+
+        async function sendAgentReply(sessionId) {
+            const row = document.getElementById('reply-' + sessionId);
+            if (!row) return;
+            const inp = row.querySelector('input');
+            const text = ((inp && inp.value) || '').trim();
+            if (!text) return;
+            try {
+                const resp = await fetch('/api/agents/threads/' + encodeURIComponent(sessionId) + '/reply', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ text }),
+                });
+                if (resp.ok) {
+                    inp.value = '';
+                    row.classList.remove('open');
+                    setTimeout(loadAgentThreads, 500);
+                } else {
+                    const e = await resp.json().catch(() => ({}));
+                    alert('Reply failed: ' + (e.detail || resp.status));
+                }
+            } catch (e) { alert('Reply failed: ' + e); }
+        }
+
+        async function spawnAgentFromComposer() {
+            const prompt = (inputField.value || '').trim();
+            if (!prompt) { inputField.focus(); return; }
+            const sel = document.getElementById('agentRouting');
+            const routing = (sel && sel.value) || 'auto';
+            try {
+                const resp = await fetch('/api/agents/spawn', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ prompt, routing }),
+                });
+                const data = await resp.json().catch(() => ({}));
+                if (resp.ok) {
+                    inputField.value = '';
+                    inputField.style.height = 'auto';
+                    setTimeout(loadAgentThreads, 500);
+                } else {
+                    alert('Spawn failed: ' + (data.detail || resp.status));
+                }
+            } catch (e) { alert('Spawn failed: ' + e); }
+        }
 
         // Sidebar toggle
         function toggleSidebar() {


### PR DESCRIPTION
## Summary

Lands the **Unified Agent Threads** epic (#233) on `main` — all four phases, reconciled with the latest `main` (#238 `agent_viz_summary` merged in cleanly).

`/chat` and Telegram now speak to the same AgentThread model: every terminal notification is replyable (on any chunk; plain message within 30 min resumes), operator agents can be spawned on demand (`/agent [local|claude]`) from Telegram and web, `/code` completions are replyable through the shared follow-up table, and web `/chat` lists/replies/spawns threads.

## Phases (already reviewed + merged onto this integration branch)

| Phase | Issue | Sub-PR |
|-------|-------|--------|
| 1 — Harden & generalize replyable threads | #234 | #239 |
| 2 — Operator root-spawn | #235 | #242 |
| 3 — Agent threads in web /chat | #236 | #250 |
| 4 — Reconcile /code (option A) | #237 | #249 |

Closes #233, #234, #235, #236, #237. Option B (deeper /code merge) tracked in #248.

## Reconciliation with main

`main` advanced past the branch point (#238 added `agent_viz_summary` + prefetch, touching `api/main.py`, `api/routes/agents.py`, `config/settings.py`, `web/agents.html`). `origin/main` was merged into this branch: `api/routes/agents.py` auto-merged (the new threads endpoints and #238's summary fields/`/summary` endpoint live in disjoint regions); all other files were single-sided. No conflict markers; both feature sets verified present.

## Schema

Additive only, idempotent, NULL-safe: `pending_questions.sent_message_ids`, `sessions.origin`.

## Test evidence

Post-reconcile `pytest -m "unit and not slow" tests/`: **1651 passed, 8 skipped, 0 failed**. New suites: `test_operator_spawn.py`, `test_code_followup.py`, `test_agent_threads_api.py`, `test_agent_threads_ui_browser.py` (`[browser, slow]`, per repo pattern).

## Merge strategy

Merge commit (not squash) to preserve the four phase commits on `main`.