### PR TITLE
feat(agent-viz): "Go To" wezterm pane for any active CC session

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1192,8 +1192,8 @@ async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
         if probed is None:
             raise HTTPException(
                 status_code=404,
-                detail="no tracked wezterm tab and pane probe found nothing — "
-                       "install the SessionStart hook or run Resume",
+                detail="couldn't locate pane — session not running, "
+                       "wezterm unreachable, or SessionStart hook not installed",
             )
         mapping = store.get(session_id)
         assert mapping is not None  # _probe_and_store just wrote it

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -12,9 +12,9 @@ import logging
 import time
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from api.services.agent_worker.session_store import (
     TERMINAL_STATUSES,
@@ -527,6 +527,16 @@ class CCResumeRequest(BaseModel):
     extra_env: dict[str, str] = {}
 
 
+class CCPaneBindRequest(BaseModel):
+    """Body for POST /api/agents/cc-pane-bind — written by the SessionStart
+    hook script on every `claude` start. Lets the /agents Focus / Go To
+    button target sessions that were never opened via /agents Resume.
+    """
+    session_id: str = Field(..., min_length=1, max_length=128)
+    pane_id: int = Field(..., ge=0)
+    cwd: str = Field(default="", max_length=4096)
+
+
 def _copy_to_clipboard(text: str, env: dict[str, str]) -> bool:
     """Push `text` to the system clipboard via `wl-copy` (Wayland) or
     `xclip` (X11). Returns True on success, False on any failure. Never
@@ -982,12 +992,121 @@ async def resume_claude_code_session(
     }
 
 
+def _lookup_cc_session_meta(session_id: str):
+    """Resolve a `cc:`-prefixed session id back to its discovered SessionMeta.
+
+    Mirrors the lookup the /resume endpoint does. Returns (meta, bare_id)
+    or raises HTTPException with an appropriate status. Used by /focus to
+    locate the transcript jsonl for the FD probe fallback.
+    """
+    from api.services.claude_code import session_ingest as cc
+    from config.settings import settings
+
+    try:
+        bare = cc.validate_session_id(session_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if ":agent:" in bare:
+        bare = bare.split(":agent:", 1)[0]
+
+    metas = cc.discover_sessions(
+        projects_dir=settings.claude_code_projects_dir,
+        lookback_days=max(int(settings.claude_code_lookback_days), 365),
+    )
+    target = next((m for m in metas if m.raw_session_id == bare), None)
+    if target is None:
+        raise HTTPException(status_code=404, detail=f"session {session_id} not found")
+    return target, bare
+
+
+def _activate_pane(pane_id: int, env: dict[str, str]) -> tuple[bool, str]:
+    """Run `wezterm cli activate-pane --pane-id <id>`. Returns (success, detail).
+
+    Raises HTTPException only for unrecoverable errors (wezterm missing,
+    timeout). A non-zero rc returns (False, stderr) so the caller can
+    decide whether to re-probe.
+    """
+    import shutil
+    import subprocess
+
+    wezterm_bin = shutil.which("wezterm") or "wezterm"
+    argv = [wezterm_bin, "cli", "activate-pane", "--pane-id", str(pane_id)]
+    try:
+        proc = subprocess.run(  # noqa: S603 — fixed argv
+            argv,
+            env=env,
+            capture_output=True,
+            timeout=3.0,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=500, detail=f"wezterm not found: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(status_code=504, detail=f"wezterm activate-pane timed out: {exc}") from exc
+
+    if proc.returncode == 0:
+        return True, ""
+    return False, (proc.stderr.decode("utf-8", errors="replace").strip()
+                   or f"wezterm activate-pane exited rc={proc.returncode}")
+
+
+@router.post("/cc-pane-bind")
+async def cc_pane_bind(request: Request, body: CCPaneBindRequest) -> dict[str, Any]:
+    """Localhost-only endpoint called by the Claude Code SessionStart hook.
+
+    Writes `session_id → pane_id` into `data/cc_wezterm.db` at the moment a
+    `claude` invocation starts inside a wezterm pane, so the /agents
+    Focus / Go To button can later target the pane authoritatively without
+    the FD-probe fallback. The session_id from the hook payload is the
+    bare uuid; we prefix with `cc:` to match the store's keying convention.
+
+    Bound to 127.0.0.1 only — never expose this endpoint publicly. Anyone
+    who can reach it could rewrite the pane mapping for any session.
+    """
+    client_host = request.client.host if request.client else ""
+    if client_host not in ("127.0.0.1", "::1"):
+        raise HTTPException(status_code=403, detail="cc-pane-bind is localhost-only")
+
+    from api.services.claude_code import session_ingest as cc
+
+    try:
+        bare = cc.validate_session_id(body.session_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Storage convention: keys are always `cc:`-prefixed (matches /resume's
+    # upsert). `validate_session_id` strips the prefix from the request, so
+    # we re-prefix unconditionally.
+    storage_id = f"cc:{bare}"
+    cwd = body.cwd or ""
+
+    from api.services.cc_wezterm_store import get_default_store
+    mapping = get_default_store().upsert(storage_id, int(body.pane_id), cwd)
+    return {
+        "bound": True,
+        "session_id": storage_id,
+        "pane_id": mapping.pane_id,
+        "cwd": mapping.cwd,
+    }
+
+
 @router.post("/sessions/{session_id}/focus")
 async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
-    """Activate the WezTerm pane that was opened for this session by a prior
-    Resume click. Returns 404 if there's no stored pane mapping (use
-    Resume to create one) and 410 if the pane no longer exists (mapping
-    cleared).
+    """Activate the WezTerm pane running this Claude Code session.
+
+    Resolution order:
+      1. Cached mapping in `data/cc_wezterm.db` (written by /resume or by
+         the SessionStart hook → /cc-pane-bind).
+      2. FD-probe fallback (`cc_pane_locate`): walk the session's
+         transcript file's holders to a wezterm pane via TTY matching.
+         On hit, cache the mapping so subsequent calls are O(1).
+      3. If activate-pane fails on a cached mapping (typical: user closed
+         the tab), the mapping is cleared and the probe runs once more —
+         the session may have been resumed in a fresh pane.
+
+    Returns 404 only when no mapping exists AND probe finds nothing
+    (session not running, non-wezterm terminal). Returns 410 when a pane
+    existed but is now gone and no replacement can be found.
 
     Caveat: on GNOME Wayland the compositor disallows cross-client window
     raise, so this reliably switches the tab within wezterm but cannot
@@ -995,8 +1114,6 @@ async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
     follows the activate-pane call to flash the dock icon as a hint.
     """
     import shlex
-    import shutil
-    import subprocess
 
     if not session_id.startswith("cc:"):
         raise HTTPException(status_code=400, detail="focus is only available for Claude Code sessions")
@@ -1010,37 +1127,66 @@ async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail="cc resume disabled — set LIFEOS_CC_RESUME_ENABLED=true")
 
     from api.services.cc_wezterm_store import get_default_store
+    from api.services import cc_pane_locate
+
     store = get_default_store()
-    mapping = store.get(session_id)
-    if mapping is None:
-        raise HTTPException(
-            status_code=404,
-            detail="no tracked wezterm tab for this session — use Resume to create one",
-        )
-
-    wezterm_bin = shutil.which("wezterm") or "wezterm"
-    argv = [wezterm_bin, "cli", "activate-pane", "--pane-id", str(mapping.pane_id)]
     env = _resume_env()
-    try:
-        proc = subprocess.run(  # noqa: S603 — fixed argv, no shell=True
-            argv,
-            env=env,
-            capture_output=True,
-            timeout=3.0,
-            check=False,
-        )
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=500, detail=f"wezterm not found: {exc}") from exc
-    except subprocess.TimeoutExpired as exc:
-        raise HTTPException(status_code=504, detail=f"wezterm activate-pane timed out: {exc}") from exc
 
-    if proc.returncode != 0:
-        # Most common cause: the user closed the tab. Clear the stale
-        # mapping so a subsequent Resume can write a fresh one.
+    # Resolve session metadata lazily — only needed if cache misses or the
+    # cached pane is stale and we need to re-probe.
+    meta = None
+    def _meta():
+        nonlocal meta
+        if meta is None:
+            meta, _ = _lookup_cc_session_meta(session_id)
+        return meta
+
+    def _probe_and_store() -> int | None:
+        try:
+            m = _meta()
+        except HTTPException:
+            return None
+        if not m.jsonl_path:
+            return None
+        pane_id = cc_pane_locate.locate_pane_for_transcript(m.jsonl_path, env=env)
+        if pane_id is None:
+            return None
+        store.upsert(session_id, pane_id, m.decoded_cwd or "")
+        return pane_id
+
+    mapping = store.get(session_id)
+    probed_this_request = False
+
+    if mapping is None:
+        # No cache → probe before giving up.
+        probed = _probe_and_store()
+        probed_this_request = True
+        if probed is None:
+            raise HTTPException(
+                status_code=404,
+                detail="no tracked wezterm tab and pane probe found nothing — "
+                       "install the SessionStart hook or run Resume",
+            )
+        mapping = store.get(session_id)
+        assert mapping is not None  # _probe_and_store just wrote it
+
+    ok, detail = _activate_pane(mapping.pane_id, env)
+    if not ok:
+        # Stale mapping — pane was closed, or wezterm restarted and pane
+        # ids reset. Clear the mapping; if the cache came from a prior
+        # request, re-probe once before giving up.
         store.delete(session_id)
-        detail = (proc.stderr.decode("utf-8", errors="replace").strip()
-                  or f"wezterm activate-pane exited rc={proc.returncode}")
-        raise HTTPException(status_code=410, detail=detail)
+        if probed_this_request:
+            raise HTTPException(status_code=410, detail=detail)
+        probed = _probe_and_store()
+        if probed is None:
+            raise HTTPException(status_code=410, detail=detail)
+        mapping = store.get(session_id)
+        assert mapping is not None
+        ok, detail = _activate_pane(mapping.pane_id, env)
+        if not ok:
+            store.delete(session_id)
+            raise HTTPException(status_code=410, detail=detail)
 
     _notify_dock(
         env,

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -995,28 +995,56 @@ async def resume_claude_code_session(
 def _lookup_cc_session_meta(session_id: str):
     """Resolve a `cc:`-prefixed session id back to its discovered SessionMeta.
 
-    Mirrors the lookup the /resume endpoint does. Returns (meta, bare_id)
-    or raises HTTPException with an appropriate status. Used by /focus to
-    locate the transcript jsonl for the FD probe fallback.
+    Used by /focus to locate the transcript jsonl for the FD probe fallback.
+    Returns (meta, bare_id) or raises HTTPException with an appropriate status.
+
+    Searches project dirs directly for `<bare>.jsonl` rather than calling
+    `discover_sessions`, which would parse every transcript under
+    `~/.claude/projects/` on every Go To cache miss. The /focus caller only
+    reads `meta.jsonl_path` and `meta.decoded_cwd`, so we synthesize a
+    minimal SessionMeta with just those two fields populated.
     """
-    from api.services.claude_code import session_ingest as cc
+    import os
+    from pathlib import Path
+
+    from api.services.claude_code.session_ingest import (
+        CC_PREFIX,
+        SessionMeta,
+        decode_project_key,
+        validate_session_id,
+    )
     from config.settings import settings
 
     try:
-        bare = cc.validate_session_id(session_id)
+        bare = validate_session_id(session_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if ":agent:" in bare:
         bare = bare.split(":agent:", 1)[0]
 
-    metas = cc.discover_sessions(
-        projects_dir=settings.claude_code_projects_dir,
-        lookback_days=max(int(settings.claude_code_lookback_days), 365),
-    )
-    target = next((m for m in metas if m.raw_session_id == bare), None)
-    if target is None:
-        raise HTTPException(status_code=404, detail=f"session {session_id} not found")
-    return target, bare
+    root = Path(os.path.expanduser(str(settings.claude_code_projects_dir)))
+    if root.exists() and root.is_dir():
+        for proj in root.iterdir():
+            if not proj.is_dir():
+                continue
+            candidate = proj / f"{bare}.jsonl"
+            if candidate.exists():
+                try:
+                    mtime = candidate.stat().st_mtime
+                except OSError:
+                    mtime = 0.0
+                project_key = proj.name
+                meta = SessionMeta(
+                    session_id=CC_PREFIX + bare,
+                    raw_session_id=bare,
+                    project_key=project_key,
+                    decoded_cwd=decode_project_key(project_key),
+                    jsonl_path=str(candidate),
+                    mtime=mtime,
+                )
+                return meta, bare
+
+    raise HTTPException(status_code=404, detail=f"session {session_id} not found")
 
 
 def _activate_pane(pane_id: int, env: dict[str, str]) -> tuple[bool, str]:

--- a/api/services/cc_pane_locate.py
+++ b/api/services/cc_pane_locate.py
@@ -1,0 +1,169 @@
+"""Locate the wezterm pane running a Claude Code session.
+
+When a CC session was started organically (user opened a wezterm pane and
+ran `claude`) rather than via /agents Resume, the session→pane mapping in
+`data/cc_wezterm.db` is empty, so the Focus / Go To button has nothing to
+target. This module reconstructs the mapping on demand by walking from the
+session's transcript file back to the wezterm pane whose TTY it lives on.
+
+Strategy (Linux-only, uses `/proc`):
+
+1. `lsof -t -- <transcript_path>` → PIDs that have the jsonl open. For an
+   active CC session, the `claude` process holds it.
+2. For each PID, read `/proc/<pid>/fd/0` to recover the controlling TTY
+   (e.g. `/dev/pts/7`). `claude` is interactive so fd 0 points at the pts.
+3. `wezterm cli list --format json` → each pane carries a `tty_name`
+   (`/dev/pts/N`). Match on tty_name.
+
+Cwd alone cannot disambiguate when multiple panes share a project — the
+transcript path can, because every CC session writes to its own jsonl,
+and the jsonl's holder is bound to exactly one pty.
+
+Note: wezterm's JSON output does not expose pane.pid, but does expose
+pane.tty_name reliably across versions, so the probe is keyed on TTY.
+
+macOS would replace step 2 with `ttyname()` via `/dev/fd/0` (no /proc);
+out of scope for now — LifeOS is Linux-targeted on the host running /agents.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_LSOF_TIMEOUT = 2.0
+_WEZTERM_LIST_TIMEOUT = 2.0
+
+
+def _lsof_pids(transcript_path: str) -> set[int]:
+    """Return the set of PIDs that currently have `transcript_path` open.
+
+    Uses `lsof -t -- <path>` which prints one PID per line. Missing lsof,
+    timeouts, and rc=1 (no holders) all collapse to an empty set. Never
+    raises.
+    """
+    lsof_bin = shutil.which("lsof")
+    if not lsof_bin:
+        logger.debug("lsof not found on PATH — pane probe unavailable")
+        return set()
+    try:
+        proc = subprocess.run(  # noqa: S603 — fixed argv
+            [lsof_bin, "-t", "--", transcript_path],
+            capture_output=True,
+            timeout=_LSOF_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("lsof probe failed for %s: %s", transcript_path, exc)
+        return set()
+    pids: set[int] = set()
+    for line in proc.stdout.decode("utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            pids.add(int(line))
+        except ValueError:
+            continue
+    return pids
+
+
+def _tty_of_pid(pid: int, proc_root: str = "/proc") -> Optional[str]:
+    """Resolve `/proc/<pid>/fd/0` to its target — for an interactive
+    process this is `/dev/pts/N`. Returns the path string or None if the
+    fd is gone (process exited) / not a tty / permission denied.
+    """
+    try:
+        target = os.readlink(f"{proc_root}/{pid}/fd/0")
+    except OSError:
+        return None
+    # fd/0 may point at a regular file if stdin was redirected, in which
+    # case it is irrelevant to pane matching. Filter to actual pts paths.
+    if not target.startswith("/dev/pts/"):
+        return None
+    return target
+
+
+def _wezterm_panes(env: Optional[dict[str, str]] = None) -> list[dict]:
+    """Run `wezterm cli list --format json`, return the decoded pane list.
+
+    Empty list on any failure (wezterm missing, socket unavailable, JSON
+    malformed). Never raises.
+    """
+    wezterm_bin = shutil.which("wezterm")
+    if not wezterm_bin:
+        return []
+    try:
+        proc = subprocess.run(  # noqa: S603 — fixed argv
+            [wezterm_bin, "cli", "list", "--format", "json"],
+            env=env if env is not None else os.environ.copy(),
+            capture_output=True,
+            timeout=_WEZTERM_LIST_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("wezterm cli list failed: %s", exc)
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        decoded = json.loads(proc.stdout)
+    except (ValueError, TypeError):
+        return []
+    return decoded if isinstance(decoded, list) else []
+
+
+def locate_pane_for_transcript(
+    transcript_path: str,
+    env: Optional[dict[str, str]] = None,
+    proc_root: str = "/proc",
+) -> Optional[int]:
+    """Probe-time pane resolver: returns the wezterm pane_id whose TTY
+    matches the controlling TTY of any process holding `transcript_path`.
+
+    Returns None if the file isn't open (session ended), wezterm isn't
+    running, or no pane's tty_name intersects the lsof PIDs' TTYs.
+
+    Pure read: no side effects, no exceptions.
+    """
+    if not transcript_path:
+        return None
+
+    holder_pids = _lsof_pids(transcript_path)
+    if not holder_pids:
+        return None
+
+    # Resolve each holder's controlling TTY. Multiple holders are typical
+    # when `claude` has forked workers — they all share the parent's pty,
+    # so any match is sufficient.
+    holder_ttys: set[str] = set()
+    for pid in holder_pids:
+        tty = _tty_of_pid(pid, proc_root=proc_root)
+        if tty:
+            holder_ttys.add(tty)
+
+    if not holder_ttys:
+        return None
+
+    panes = _wezterm_panes(env=env)
+    if not panes:
+        return None
+
+    # First matching pane wins. Each pty maps to exactly one wezterm pane.
+    for pane in panes:
+        if not isinstance(pane, dict):
+            continue
+        pane_tty = pane.get("tty_name")
+        pane_id = pane.get("pane_id")
+        if not isinstance(pane_tty, str) or not isinstance(pane_id, int):
+            continue
+        if pane_tty in holder_ttys:
+            return pane_id
+
+    return None

--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -14,6 +14,7 @@ This directory contains operational guides — how to set up, configure, and run
 - `troubleshooting.md` — Common issues and solutions
 - `claude-code-orchestration.md` — Claude Code multi-agent orchestration patterns
 - `agent-worker-setup.md` — External agent worker prerequisites (Gemma swap, MCP HTTP transport, Cloudflare Tunnel, bearer token)
+- `agents-go-to.md` — /agents "Go To" wezterm pane setup (SessionStart hook + FD probe)
 
 ## Key Principles
 

--- a/docs/guides/agents-go-to.md
+++ b/docs/guides/agents-go-to.md
@@ -1,0 +1,92 @@
+# /agents "Go To" — WezTerm setup
+
+> **Status:** Complete
+> **Last Updated:** 2026-05-28
+> **Audience:** Operators
+
+The /agents page's **Go To** button (and double-clicking an active node) jumps wezterm focus to the pane running the selected Claude Code session — even when several panes are working in the same project directory at once.
+
+Setup is one block in `~/.claude/settings.json` plus making sure `lsof` is installed.
+
+---
+
+## How it works in one paragraph
+
+LifeOS keeps a SQLite table mapping `cc:<session_id> → wezterm pane_id` (`data/cc_wezterm.db`). It gets populated two ways. **Resume** writes a row when it opens a new tab. **The SessionStart hook below** writes a row every time `claude` starts inside a wezterm pane. When the cache misses (e.g. session predates the hook install), `/api/agents/sessions/<id>/focus` falls back to a fast probe: `lsof` finds which process holds the session's transcript file open, and the holder's controlling TTY is matched against `wezterm cli list --format json`'s `tty_name`. Cwd alone cannot disambiguate when multiple panes share a project; the transcript file can.
+
+---
+
+## 1. Verify prerequisites
+
+Both `lsof` (for the probe) and `wezterm` (everywhere) must be on PATH. On a standard Linux desktop both are typically pre-installed.
+
+```bash
+command -v lsof wezterm jq curl
+```
+
+If anything is missing, install via your package manager. `jq` and `curl` are only needed by the hook script — the probe fallback works without them.
+
+Confirm the `LIFEOS_CC_RESUME_ENABLED` flag is on (Go To is gated by the same flag as Resume):
+
+```bash
+grep LIFEOS_CC_RESUME_ENABLED .env
+```
+
+Set it to `true` and restart the API if needed (`./scripts/server.sh restart`).
+
+---
+
+## 2. Install the SessionStart hook
+
+Add the following to `~/.claude/settings.json` (create the file if it doesn't exist):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/absolute/path/to/LifeOS/scripts/claude-session-pane.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Replace the path with the absolute path to your LifeOS checkout. The script:
+
+- No-ops silently when `$WEZTERM_PANE` is unset (non-wezterm terminal).
+- Reads the SessionStart JSON payload from stdin (`session_id`, `cwd`, `transcript_path`).
+- POSTs `{session_id, pane_id, cwd}` to `http://localhost:8000/api/agents/cc-pane-bind`.
+- Times out after 2 seconds — never blocks `claude` startup if the LifeOS API is down.
+
+You can override the API base URL with `LIFEOS_API_URL` if you run on a non-default port.
+
+---
+
+## 3. Try it
+
+Open two wezterm panes in the same project directory, run `claude` in each, then open `/agents` in your browser. Both sessions should show a **Go To** button. Click it (or double-click the node in the graph) — wezterm focuses the right pane. On GNOME Wayland the focus changes inside wezterm but the window won't pop forward (compositor restriction); click the wezterm dock icon to bring it forward, the right pane will already be selected.
+
+If the toast says "Couldn't locate pane", the most likely causes are:
+
+- The SessionStart hook isn't installed yet for sessions started *before* the hook landed. Restart the `claude` invocation; the hook will fire and bind on the new session.
+- `lsof` isn't on PATH (the probe fallback uses it).
+- The session is in a non-wezterm terminal — Go To only works for wezterm.
+
+---
+
+## Related Documents
+
+### Specifications
+- [Agent Viz — Product](../specs/product/agent-viz.md#operator-controls--resume-and-go-to) — Operator-facing controls overview
+- [Agent Viz — Technical](../specs/technical/agent-viz.md#claude-code-resume--go-to) — Endpoint shapes, probe algorithm, security boundaries
+
+### Code References
+- [`api/services/cc_pane_locate.py`](../../api/services/cc_pane_locate.py) — Probe implementation
+- [`scripts/claude-session-pane.sh`](../../scripts/claude-session-pane.sh) — Hook script

--- a/docs/guides/agents-go-to.md
+++ b/docs/guides/agents-go-to.md
@@ -73,9 +73,11 @@ You can override the API base URL with `LIFEOS_API_URL` if you run on a non-defa
 
 Open two wezterm panes in the same project directory, run `claude` in each, then open `/agents` in your browser. Both sessions should show a **Go To** button. Click it (or double-click the node in the graph) — wezterm focuses the right pane. On GNOME Wayland the focus changes inside wezterm but the window won't pop forward (compositor restriction); click the wezterm dock icon to bring it forward, the right pane will already be selected.
 
-If the toast says "Couldn't locate pane", the most likely causes are:
+If the toast says "Couldn't locate pane" — meaning the session isn't running where we can reach it, wezterm itself can't be queried, or no cached mapping exists — the most likely causes are:
 
 - The SessionStart hook isn't installed yet for sessions started *before* the hook landed. Restart the `claude` invocation; the hook will fire and bind on the new session.
+- WezTerm has been restarted since the session began. `wezterm cli list` can no longer see the original pane id, so the probe and any cached mapping are stale. Click **Resume** to open a fresh pane (this rewrites the mapping), or restart `claude` so the SessionStart hook re-binds.
+- WezTerm is unreachable (`wezterm cli list` errors, the gui-sock socket is gone, or the binary isn't on PATH).
 - `lsof` isn't on PATH (the probe fallback uses it).
 - The session is in a non-wezterm terminal — Go To only works for wezterm.
 

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -157,17 +157,21 @@ Claude Code sessions do not get a Kill button — the page has no safe primitive
 
 ---
 
-## Operator controls — resume and focus
+## Operator controls — resume and Go To
 
-Claude Code sessions in `inactive` or terminal states get two buttons:
+Claude Code sessions get up to two buttons:
 
-**Resume** opens a new WezTerm tab at the session's working directory and launches `claude --resume <session_id>` in it. WezTerm prints the new pane id; LifeOS stores it in a sidecar SQLite mapping (`data/cc_wezterm.db`) keyed by session id.
+**Resume** (shown on terminal / `inactive` / `yielded` sessions) opens a new WezTerm tab at the session's working directory and launches `claude --resume <session_id>` in it. WezTerm prints the new pane id; LifeOS stores it in a sidecar SQLite mapping (`data/cc_wezterm.db`) keyed by session id.
 
-**Focus** activates the existing tab for that session — calls `wezterm cli activate-pane --pane-id <id>` against the stored mapping. If WezTerm is the focused window the tab switches immediately; if it's hidden, the pane is selected in the background and a `notify-send` urgency hint pulses the dock icon. The OS-level window-raise across applications is restricted by Wayland compositors (no programmatic foreground steal); WezTerm under XWayland can be raised via `wmctrl`/`xdotool` if the operator needs it.
+**Go To** (shown on every non-subagent Claude Code session, including live ones) jumps focus to the existing WezTerm pane for that session. Double-clicking the node in the graph does the same thing. The endpoint resolves the pane id in three steps:
 
-Focus returns 404 if no Resume has been clicked yet for that session, and 410 if the stored pane no longer exists (e.g. user closed the tab); in both cases the toast prompts the operator to click Resume.
+1. **Cached mapping** — first checks `data/cc_wezterm.db`, populated by either a prior Resume click *or* the optional [SessionStart hook](../../guides/agents-go-to.md) which binds every new `claude` start to its wezterm pane.
+2. **FD probe** — if the cache misses, `lsof` finds which process holds the session's transcript file open; the holder's controlling TTY is matched against `wezterm cli list --format json`'s `tty_name`. Cwd is not enough to disambiguate when multiple panes share a project; the transcript file is. The result is cached for the next click.
+3. **Activate-pane** — once a pane id is known, `wezterm cli activate-pane --pane-id <id>` switches focus. If WezTerm is the focused window the tab switches immediately; if it's hidden, the pane is selected in the background and a `notify-send` urgency hint pulses the dock icon. The OS-level window-raise across applications is restricted by Wayland compositors (no programmatic foreground steal); WezTerm under XWayland can be raised via `wmctrl`/`xdotool` if the operator needs it.
 
-Resume is **off by default** because spawning GUI terminals from a systemd service depends on the operator's desktop environment. Enable with `LIFEOS_CC_RESUME_ENABLED=true` (the same flag also enables Focus). Customize the launcher (`LIFEOS_CC_RESUME_CMD`) if you don't use WezTerm — substitutions `{cwd}`, `{cwd_url}`, `{session_id}`, `{session_id_url}`, and `{inner_command}` are available. The pane-tracking + Focus button assume the launcher prints a pane id on stdout, so non-WezTerm launchers leave Focus inert for those sessions.
+If a cached pane has gone stale (typical: user closed the tab), the activate-pane call fails, the mapping is cleared, and the probe runs once more — the session may have been resumed in a fresh pane. Only when both the cache *and* a fresh probe come up empty does Go To return 404 (toast: "Couldn't locate pane — install the SessionStart hook if claude is running in wezterm"); when a pane existed but is gone and no replacement can be found it returns 410.
+
+Resume + Go To are **off by default** because spawning GUI terminals from a systemd service depends on the operator's desktop environment. Enable with `LIFEOS_CC_RESUME_ENABLED=true` (the same flag also gates Go To). Customize the launcher (`LIFEOS_CC_RESUME_CMD`) if you don't use WezTerm — substitutions `{cwd}`, `{cwd_url}`, `{session_id}`, `{session_id_url}`, and `{inner_command}` are available. The probe-based Go To is WezTerm-specific (it reads `wezterm cli list`'s `tty_name`); non-WezTerm launchers can still use Resume but Go To will respond 404.
 
 ---
 

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -70,7 +70,8 @@ All under `/api/agents`. Local-network only — the kill and resume endpoints mu
 | `GET /sessions/{id}/stream?backfill=N` | Per-session SSE: backfill last N events (default 50, max 500), then live-tail. Closes cleanly when the session reaches terminal status (LifeOS) or after 5 min idle (Claude Code). |
 | `POST /sessions/{id}/kill` | Operator kill — body `{reason: ""}`. LifeOS sessions only. Cascades to descendants in the subtree. |
 | `POST /sessions/{id}/resume` | Resume a Claude Code session — body `{extra_env: {}}`. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Spawns a WezTerm tab via `wezterm cli spawn`, captures the pane id from stdout, and stores `session_id → pane_id` in `data/cc_wezterm.db` so Focus can target it later. |
-| `POST /sessions/{id}/focus` | Activate the WezTerm tab previously opened for this session. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. 404 if no mapping exists; 410 (and mapping cleared) if `wezterm cli activate-pane` fails because the pane no longer exists. |
+| `POST /sessions/{id}/focus` | Activate the WezTerm pane for this session (Go To). `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Resolves the pane id from the cached mapping first, then falls back to an FD probe (lsof + /proc + wezterm cli list) so it works for sessions never opened via Resume. 404 only when both the cache *and* the probe come up empty; 410 when the pane existed but is gone and no replacement is found. |
+| `POST /cc-pane-bind` | Localhost-only endpoint called by the Claude Code SessionStart hook. Body `{session_id, pane_id, cwd}`. Upserts the mapping in `cc_wezterm.db` so Go To can target newly-started `claude` invocations without a probe. 403 from non-loopback callers. |
 
 Heartbeats: per-session SSE emits a `:heartbeat\n\n` comment every 15s when there's no new event, so dropped connections surface quickly through the browser's `EventSource` retry.
 
@@ -273,14 +274,15 @@ The endpoint must not be exposed via Tailscale Funnel or the public MCP HTTP tra
 
 ---
 
-## Claude Code resume + focus
+## Claude Code resume + Go To
 
 ```
 POST /api/agents/sessions/{id}/resume   body: {"extra_env": {...}}
 POST /api/agents/sessions/{id}/focus    body: (none)
+POST /api/agents/cc-pane-bind           body: {session_id, pane_id, cwd}   (localhost only)
 ```
 
-Both opt-in via `LIFEOS_CC_RESUME_ENABLED`. Resume spawns a new WezTerm tab and records the new pane id; Focus revisits that pane.
+All three opt-in via `LIFEOS_CC_RESUME_ENABLED` (except `/cc-pane-bind`, which is gated by client IP only — `127.0.0.1` / `::1`). Resume spawns a new WezTerm tab and records the new pane id; Go To (`/focus`) revisits the pane for a session, falling back to an FD probe when no mapping is cached; `/cc-pane-bind` is the SessionStart hook entry point that pre-populates the mapping at `claude` startup.
 
 ### Resume
 
@@ -295,15 +297,32 @@ Both opt-in via `LIFEOS_CC_RESUME_ENABLED`. Resume spawns a new WezTerm tab and 
 
 Response: `{spawned: true, pid, pane_id, command, cwd, inner_command, clipboard_copied}`. The frontend uses `pane_id` to decide whether the Focus button can target this session; if `null`, Focus will respond 404.
 
-### Focus
+### Go To (`/focus`)
 
 1. Validate `cc:` prefix and the `LIFEOS_CC_RESUME_ENABLED` gate.
-2. `CCWezTermStore.get(session_id)`. 404 if missing — operator must click Resume first.
-3. `subprocess.run(["wezterm", "cli", "activate-pane", "--pane-id", str(pane_id)], capture_output=True, timeout=3.0)`.
-4. rc≠0 → delete the stored mapping and return 410 with stderr preview. The mapping is stale (typically: user closed the tab), so the next Resume click writes a fresh one.
-5. Best-effort `notify-send --urgency=critical` so a hidden WezTerm window pulses the dock icon — GNOME Wayland disallows cross-client window raise, so this is the strongest attention hint we can issue from outside the focused client.
+2. **Cache lookup.** `CCWezTermStore.get(session_id)` — populated by Resume *and* by the SessionStart hook → `/cc-pane-bind` write path.
+3. **Probe fallback (cache miss).** Resolve the session's `transcript_path` via `discover_sessions(...)`, then call `cc_pane_locate.locate_pane_for_transcript(jsonl_path)`:
+   - `lsof -t -- <jsonl_path>` → PIDs holding the file open.
+   - For each PID, read `/proc/<pid>/fd/0` and keep entries that resolve to `/dev/pts/N` (interactive `claude` processes have fd 0 attached to their controlling pts).
+   - `wezterm cli list --format json` → match `tty_name` to the holder's pts; first match wins. Wezterm's JSON output does not expose pane.pid in any supported version, but `tty_name` is reliable.
+   - On hit, upsert the mapping so subsequent calls are O(1).
+   - All subprocess calls are timeout-bounded (lsof 2s, wezterm cli 2s) and any failure (missing binary, malformed JSON, no holders) returns `None` rather than raising.
+4. **Activate.** `subprocess.run(["wezterm", "cli", "activate-pane", "--pane-id", str(pane_id)], capture_output=True, timeout=3.0)`.
+5. **Stale-mapping re-probe.** If activate-pane returns rc≠0 on a *cached* mapping, the pane has likely been closed. Delete the mapping, re-run the probe once; if the second probe finds a new pane, retry activate. Only after both attempts fail does the endpoint return 410. A freshly-probed mapping that fails to activate skips straight to 410 (no second probe — we just generated this pane id).
+6. Best-effort `notify-send --urgency=critical` so a hidden WezTerm window pulses the dock icon — GNOME Wayland disallows cross-client window raise, so this is the strongest attention hint we can issue from outside the focused client.
 
 Response: `{focused: true, pane_id, cwd}`.
+
+404 means neither the cache nor the probe surfaced a pane (session not running, non-wezterm terminal, hook not installed). 410 means a pane was identified at some point but is now gone and no replacement could be found.
+
+### `/cc-pane-bind` (SessionStart hook entry point)
+
+1. Reject any request whose `request.client.host` is not in `{"127.0.0.1", "::1"}` with 403.
+2. `validate_session_id(body.session_id)` — strips any `cc:` prefix and rejects path-traversal characters; 400 on failure.
+3. Re-prefix unconditionally (`storage_id = f"cc:{bare}"`) so the keying matches `/resume`'s upsert convention.
+4. `CCWezTermStore.upsert(storage_id, body.pane_id, body.cwd or "")`. `pane_id` is validated by pydantic (`ge=0`).
+
+The hook script (`scripts/claude-session-pane.sh`) is invoked by Claude Code's SessionStart hook. It reads the standard SessionStart JSON payload (`{session_id, cwd, transcript_path, source}`) from stdin, picks up `$WEZTERM_PANE` from the env, and POSTs to this endpoint. No-ops gracefully if any of those are missing (non-wezterm terminal, `jq`/`curl` not installed, server unreachable) — never blocks `claude` startup.
 
 ---
 
@@ -338,7 +357,8 @@ The threat model: the LifeOS MCP HTTP transport is publicly accessible via Tails
 - Are not registered as MCP tools — so they cannot be invoked through the MCP layer even if an attacker has a bearer token.
 - Kill calls into worker primitives that already have an audit trail (every kill emits a transcript event).
 - Resume runs a configured launcher via `shlex.split` only — no `shell=True`. Template substitutions are URL-encoded where they go into URI strings. The rendered `{inner_command}` is split into individual argv tokens before reaching the launcher, so a malicious inner command cannot smuggle shell metacharacters.
-- Focus calls `wezterm cli activate-pane` with a fixed argv (no template) using the pane id from the local SQLite mapping. The store is only writeable from the same process (no cross-machine exposure), and pane ids are integers — there is no path for an external caller to inject arbitrary argv.
+- Focus calls `wezterm cli activate-pane` with a fixed argv (no template) using the pane id from the local SQLite mapping. The store is only writeable from the same process (no cross-machine exposure), and pane ids are integers — there is no path for an external caller to inject arbitrary argv. The FD-probe fallback never reads attacker-controlled data: `lsof` is invoked with the transcript path that LifeOS itself derived from `discover_sessions`, and `/proc/<pid>/fd/0` is read as a symlink target whose filtering keeps only `/dev/pts/N` paths.
+- `/cc-pane-bind` is bound to loopback by IP check (`127.0.0.1` / `::1`); the public MCP transport runs on the same host but a different prefix and would never route to it. The accepted body is constrained: `session_id` runs through `validate_session_id` (rejects path traversal), `pane_id` must be a non-negative int, `cwd` is opaque text.
 
 Per-source guarantees:
 

--- a/scripts/claude-session-pane.sh
+++ b/scripts/claude-session-pane.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Claude Code SessionStart hook → bind session_id → wezterm pane_id.
+#
+# Install by adding this file as a SessionStart hook in ~/.claude/settings.json:
+#
+#   "hooks": {
+#     "SessionStart": [{
+#       "matcher": "*",
+#       "hooks": [{
+#         "type": "command",
+#         "command": "/path/to/LifeOS/scripts/claude-session-pane.sh"
+#       }]
+#     }]
+#   }
+#
+# What it does: every time a `claude` invocation starts inside a wezterm
+# pane, this hook reads the SessionStart payload from stdin
+# (`{session_id, cwd, transcript_path, source}`), picks up the pane id
+# from $WEZTERM_PANE, and POSTs both to /api/agents/cc-pane-bind so the
+# /agents Focus / Go To button can jump straight to the right pane.
+#
+# Exits 0 silently in all non-fatal cases:
+#   - Not running under wezterm ($WEZTERM_PANE unset)
+#   - LifeOS API unreachable (server stopped, hook running before boot)
+#   - `jq` not installed (won't parse stdin)
+#   - curl missing
+#
+# Never blocks claude startup; total wall time on the happy path is one
+# localhost HTTP round-trip (~10ms).
+
+set -u
+
+# Only act inside wezterm — other terminals don't have a pane id to bind.
+if [[ -z "${WEZTERM_PANE:-}" ]]; then
+    exit 0
+fi
+
+# Need jq to parse the SessionStart JSON payload reliably.
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Buffer stdin once — both extractions read from it.
+PAYLOAD="$(cat 2>/dev/null || true)"
+if [[ -z "$PAYLOAD" ]]; then
+    exit 0
+fi
+
+SESSION_ID="$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null)"
+CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // empty' 2>/dev/null)"
+
+if [[ -z "$SESSION_ID" ]]; then
+    exit 0
+fi
+
+LIFEOS_URL="${LIFEOS_API_URL:-http://localhost:8000}"
+
+# Fire-and-forget. Short timeout so a stalled server never holds up the
+# user's prompt. `|| true` swallows curl's non-zero exit on network error.
+curl -fsS --max-time 2 \
+    -X POST "${LIFEOS_URL}/api/agents/cc-pane-bind" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -nc \
+        --arg sid "$SESSION_ID" \
+        --argjson pid "$WEZTERM_PANE" \
+        --arg cwd "$CWD" \
+        '{session_id: $sid, pane_id: $pid, cwd: $cwd}')" \
+    >/dev/null 2>&1 || true
+
+exit 0

--- a/tests/test_agent_cc_pane_bind.py
+++ b/tests/test_agent_cc_pane_bind.py
@@ -1,0 +1,356 @@
+"""Tests for the /api/agents/cc-pane-bind endpoint + the FD-probe fallback
+in /api/agents/sessions/{id}/focus (issue #251).
+
+`cc-pane-bind` is called by the SessionStart hook each time a `claude`
+process starts in a wezterm pane. The fallback path in /focus runs the
+`cc_pane_locate` probe when the cache misses, so Go To works for
+sessions started outside the /agents Resume flow.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+
+
+@pytest.fixture
+def client():
+    # Pin the client host to loopback so the /cc-pane-bind endpoint's
+    # localhost-only check accepts requests from the test transport
+    # (default TestClient sets host="testclient" which would 403).
+    return TestClient(api_main.app, client=("127.0.0.1", 50000))
+
+
+@pytest.fixture
+def wezterm_store(tmp_path: Path, monkeypatch):
+    """Swap the cc_wezterm singleton for a tmp-path-backed store."""
+    from api.services import cc_wezterm_store as mod
+    store = mod.CCWezTermStore(db_path=tmp_path / "cc_wezterm.db")
+    monkeypatch.setattr(mod, "_default_store", store)
+    yield store
+    store.close()
+
+
+@pytest.fixture
+def synthetic_session(tmp_path: Path, monkeypatch):
+    """Build a synthetic ~/.claude/projects/-tmp-x/<uuid>.jsonl so the
+    focus endpoint's session lookup resolves to a real path. Returns
+    (jsonl_path, session_id_with_cc_prefix).
+    """
+    from config.settings import settings
+
+    proj = tmp_path / "-home-syn-Code-Repo"
+    sid = "focus-target-uuid"
+    proj.mkdir(parents=True, exist_ok=True)
+    jsonl = proj / f"{sid}.jsonl"
+    import json
+    jsonl.write_text(json.dumps({
+        "type": "assistant",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "message": {"role": "assistant", "model": "claude-sonnet-4-6",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "usage": {"input_tokens": 1, "output_tokens": 1}},
+    }) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "claude_code_lookback_days", 365)
+    from api.services.claude_code import session_ingest as cc
+    cc.invalidate_cache()
+    cc.invalidate_process_cache()
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    return jsonl, f"cc:{sid}"
+
+
+# ---------------------------------------------------------------------------
+# /cc-pane-bind — auth + validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_bind_stores_mapping_from_localhost(client, wezterm_store):
+    """TestClient hits the app from 127.0.0.1, so the localhost check passes."""
+    r = client.post("/api/agents/cc-pane-bind", json={
+        "session_id": "abc-def-123",
+        "pane_id": 42,
+        "cwd": "/home/u/Code/X",
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["bound"] is True
+    assert body["session_id"] == "cc:abc-def-123"
+    assert body["pane_id"] == 42
+
+    mapping = wezterm_store.get("cc:abc-def-123")
+    assert mapping is not None
+    assert mapping.pane_id == 42
+    assert mapping.cwd == "/home/u/Code/X"
+
+
+@pytest.mark.unit
+def test_bind_accepts_already_prefixed_session_id(client, wezterm_store):
+    """Hook may pass `cc:<uuid>` or bare `<uuid>` — both store under cc:<uuid>."""
+    r = client.post("/api/agents/cc-pane-bind", json={
+        "session_id": "cc:abc-def-123",
+        "pane_id": 7,
+        "cwd": "/x",
+    })
+    assert r.status_code == 200
+    assert wezterm_store.get("cc:abc-def-123") is not None
+
+
+@pytest.mark.unit
+def test_bind_rejects_non_localhost(client, wezterm_store, monkeypatch):
+    """A request whose client.host isn't loopback must be denied with 403."""
+    # Patch the request.client.host that FastAPI surfaces. Easiest via
+    # TestClient's transport — but more robust: directly call the route
+    # function with a fake request.
+    from api.routes import agents as agents_route
+    from api.routes.agents import CCPaneBindRequest
+
+    class _Client:
+        host = "10.0.0.5"
+
+    class _Req:
+        client = _Client()
+
+    import asyncio
+    with pytest.raises(Exception) as exc_info:
+        asyncio.run(agents_route.cc_pane_bind(
+            _Req(),  # type: ignore[arg-type]
+            CCPaneBindRequest(session_id="x", pane_id=1),
+        ))
+    # FastAPI HTTPException — check status_code attr.
+    assert getattr(exc_info.value, "status_code", None) == 403
+
+
+@pytest.mark.unit
+def test_bind_rejects_path_traversal_session_id(client, wezterm_store):
+    """`validate_session_id` blocks `..` and slashes."""
+    r = client.post("/api/agents/cc-pane-bind", json={
+        "session_id": "../etc/passwd",
+        "pane_id": 1,
+        "cwd": "/x",
+    })
+    assert r.status_code == 400
+
+
+@pytest.mark.unit
+def test_bind_rejects_negative_pane_id(client, wezterm_store):
+    r = client.post("/api/agents/cc-pane-bind", json={
+        "session_id": "abc",
+        "pane_id": -3,
+        "cwd": "/x",
+    })
+    # LifeOS rewrites pydantic 422s to 400; the body still carries the
+    # ge=0 constraint failure so we can assert on it.
+    assert r.status_code == 400
+    body = r.json()
+    assert "pane_id" in str(body)
+
+
+@pytest.mark.unit
+def test_bind_accepts_empty_cwd(client, wezterm_store):
+    """Hook may run before $PWD is reliably set — empty cwd should still bind."""
+    r = client.post("/api/agents/cc-pane-bind", json={
+        "session_id": "abc",
+        "pane_id": 1,
+    })
+    assert r.status_code == 200
+    mapping = wezterm_store.get("cc:abc")
+    assert mapping is not None
+    assert mapping.cwd == ""
+
+
+# ---------------------------------------------------------------------------
+# /focus — probe fallback when cache misses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_focus_probes_when_cache_miss_and_caches_result(
+    client, wezterm_store, synthetic_session, monkeypatch,
+):
+    """Cache empty → probe returns a pane_id → mapping is upserted → activate
+    is called with the probed pane_id.
+    """
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    _jsonl, sid = synthetic_session
+
+    # Probe returns pane 99 — patch the locate helper directly so we
+    # don't need to fake lsof + /proc + wezterm cli list.
+    from api.services import cc_pane_locate
+    monkeypatch.setattr(cc_pane_locate, "locate_pane_for_transcript",
+                        lambda path, env=None, proc_root="/proc": 99)
+
+    # activate-pane succeeds.
+    captured = {}
+
+    class _Completed:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+    def _fake_run(argv, **kwargs):
+        captured.setdefault("calls", []).append(argv)
+        return _Completed()
+
+    monkeypatch.setattr("shutil.which",
+                        lambda name: f"/usr/bin/{name}" if name == "wezterm" else None)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    r = client.post(f"/api/agents/sessions/{sid}/focus")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["focused"] is True
+    assert body["pane_id"] == 99
+
+    # The probed mapping was cached for future calls.
+    mapping = wezterm_store.get(sid)
+    assert mapping is not None
+    assert mapping.pane_id == 99
+
+    # activate-pane was called with the probed id.
+    assert any(
+        argv[0].endswith("wezterm") and argv[1:] == ["cli", "activate-pane", "--pane-id", "99"]
+        for argv in captured["calls"]
+    )
+
+
+@pytest.mark.unit
+def test_focus_404_when_cache_miss_and_probe_finds_nothing(
+    client, wezterm_store, synthetic_session, monkeypatch,
+):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    _, sid = synthetic_session
+
+    from api.services import cc_pane_locate
+    monkeypatch.setattr(cc_pane_locate, "locate_pane_for_transcript",
+                        lambda path, env=None, proc_root="/proc": None)
+
+    r = client.post(f"/api/agents/sessions/{sid}/focus")
+    assert r.status_code == 404
+    detail = r.json()["detail"].lower()
+    assert "probe" in detail or "no tracked" in detail
+
+
+@pytest.mark.unit
+def test_focus_reprobes_when_cached_pane_is_stale_and_finds_new_one(
+    client, wezterm_store, synthetic_session, monkeypatch,
+):
+    """Cached pane 17 is gone → activate fails → store is cleared → probe
+    finds pane 42 → activate succeeds at pane 42.
+    """
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    _, sid = synthetic_session
+
+    wezterm_store.upsert(sid, pane_id=17, cwd="/repo")
+
+    from api.services import cc_pane_locate
+    monkeypatch.setattr(cc_pane_locate, "locate_pane_for_transcript",
+                        lambda path, env=None, proc_root="/proc": 42)
+
+    # First activate (pane 17) fails; second (pane 42) succeeds.
+    calls: list[list[str]] = []
+
+    class _OK:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+    class _Stale:
+        returncode = 1
+        stdout = b""
+        stderr = b"no such pane: 17\n"
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        if "--pane-id" in argv:
+            idx = argv.index("--pane-id")
+            if argv[idx + 1] == "17":
+                return _Stale()
+            return _OK()
+        return _OK()
+
+    monkeypatch.setattr("shutil.which",
+                        lambda name: f"/usr/bin/{name}" if name == "wezterm" else None)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    r = client.post(f"/api/agents/sessions/{sid}/focus")
+    assert r.status_code == 200, r.text
+    assert r.json()["pane_id"] == 42
+
+    # Both activate-pane invocations happened, in that order.
+    activate_calls = [argv for argv in calls if "activate-pane" in argv]
+    assert len(activate_calls) == 2
+    assert "17" in activate_calls[0]
+    assert "42" in activate_calls[1]
+
+    # Final mapping is the new pane.
+    mapping = wezterm_store.get(sid)
+    assert mapping is not None
+    assert mapping.pane_id == 42
+
+
+@pytest.mark.unit
+def test_focus_410_when_cached_pane_stale_and_reprobe_finds_nothing(
+    client, wezterm_store, synthetic_session, monkeypatch,
+):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    _, sid = synthetic_session
+
+    wezterm_store.upsert(sid, pane_id=17, cwd="/repo")
+
+    from api.services import cc_pane_locate
+    monkeypatch.setattr(cc_pane_locate, "locate_pane_for_transcript",
+                        lambda path, env=None, proc_root="/proc": None)
+
+    class _Stale:
+        returncode = 1
+        stdout = b""
+        stderr = b"no such pane\n"
+
+    monkeypatch.setattr("shutil.which",
+                        lambda name: f"/usr/bin/{name}" if name == "wezterm" else None)
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: _Stale())
+
+    r = client.post(f"/api/agents/sessions/{sid}/focus")
+    assert r.status_code == 410
+    # Stale mapping was cleared.
+    assert wezterm_store.get(sid) is None
+
+
+@pytest.mark.unit
+def test_focus_410_when_probed_pane_also_fails(
+    client, wezterm_store, synthetic_session, monkeypatch,
+):
+    """Cache miss + probe success but the just-discovered pane is also dead
+    (rare race) → 410, not 404 — a pane *was* identified, it just won't
+    activate.
+    """
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    _, sid = synthetic_session
+
+    from api.services import cc_pane_locate
+    monkeypatch.setattr(cc_pane_locate, "locate_pane_for_transcript",
+                        lambda path, env=None, proc_root="/proc": 88)
+
+    class _Stale:
+        returncode = 1
+        stdout = b""
+        stderr = b"no such pane: 88\n"
+
+    monkeypatch.setattr("shutil.which",
+                        lambda name: f"/usr/bin/{name}" if name == "wezterm" else None)
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: _Stale())
+
+    r = client.post(f"/api/agents/sessions/{sid}/focus")
+    assert r.status_code == 410
+    assert wezterm_store.get(sid) is None

--- a/tests/test_agent_cc_pane_bind.py
+++ b/tests/test_agent_cc_pane_bind.py
@@ -235,7 +235,7 @@ def test_focus_404_when_cache_miss_and_probe_finds_nothing(
     r = client.post(f"/api/agents/sessions/{sid}/focus")
     assert r.status_code == 404
     detail = r.json()["detail"].lower()
-    assert "probe" in detail or "no tracked" in detail
+    assert "couldn't locate pane" in detail
 
 
 @pytest.mark.unit

--- a/tests/test_agent_cc_pane_bind.py
+++ b/tests/test_agent_cc_pane_bind.py
@@ -354,3 +354,61 @@ def test_focus_410_when_probed_pane_also_fails(
     r = client.post(f"/api/agents/sessions/{sid}/focus")
     assert r.status_code == 410
     assert wezterm_store.get(sid) is None
+
+
+@pytest.mark.unit
+def test_focus_resolves_session_without_calling_discover_sessions(
+    tmp_path: Path, client, wezterm_store, monkeypatch,
+):
+    """The /focus session-meta lookup should glob project dirs directly
+    instead of running the full `discover_sessions` walk (which parses
+    every transcript under ~/.claude/projects/). Build a layout with
+    ≥2 project dirs and monkeypatch `discover_sessions` to fail loudly —
+    if focus still works, we've confirmed the helper no longer relies on it.
+    """
+    from config.settings import settings
+    from api.services.claude_code import session_ingest as cc
+
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+
+    # Two project dirs; target jsonl lives in the second one.
+    proj_a = tmp_path / "-home-syn-Code-Other"
+    proj_b = tmp_path / "-home-syn-Code-Target"
+    proj_a.mkdir(parents=True)
+    proj_b.mkdir(parents=True)
+    (proj_a / "decoy-uuid.jsonl").write_text("{}\n", encoding="utf-8")
+    sid_bare = "real-target-uuid"
+    (proj_b / f"{sid_bare}.jsonl").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "claude_code_lookback_days", 365)
+    cc.invalidate_cache()
+    cc.invalidate_process_cache()
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("discover_sessions must not be called by _lookup_cc_session_meta")
+    monkeypatch.setattr(cc, "discover_sessions", _boom)
+
+    # Probe returns a pane_id so the focus path completes.
+    from api.services import cc_pane_locate
+    captured_jsonl: dict[str, str] = {}
+
+    def _probe(path, env=None, proc_root="/proc"):
+        captured_jsonl["path"] = path
+        return 55
+    monkeypatch.setattr(cc_pane_locate, "locate_pane_for_transcript", _probe)
+
+    class _OK:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+    monkeypatch.setattr("shutil.which",
+                        lambda name: f"/usr/bin/{name}" if name == "wezterm" else None)
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: _OK())
+
+    r = client.post(f"/api/agents/sessions/cc:{sid_bare}/focus")
+    assert r.status_code == 200, r.text
+    assert r.json()["pane_id"] == 55
+
+    # The probe was handed the jsonl from the *target* project dir, not the decoy.
+    assert captured_jsonl["path"] == str(proj_b / f"{sid_bare}.jsonl")

--- a/tests/test_agent_resume_api.py
+++ b/tests/test_agent_resume_api.py
@@ -662,7 +662,7 @@ def test_focus_returns_404_when_no_mapping(client, wezterm_store, monkeypatch):
     monkeypatch.setattr(settings, "cc_resume_enabled", True)
     r = client.post("/api/agents/sessions/cc:no-mapping/focus")
     assert r.status_code == 404
-    assert "resume" in r.json()["detail"].lower()
+    assert "couldn't locate pane" in r.json()["detail"].lower()
 
 
 @pytest.mark.unit

--- a/tests/test_cc_pane_locate.py
+++ b/tests/test_cc_pane_locate.py
@@ -1,0 +1,313 @@
+"""Unit tests for the cc_pane_locate probe (issue #251).
+
+The probe walks: transcript_path → lsof PIDs → /proc/<pid>/fd/0 (tty) →
+wezterm pane.tty_name. Each subprocess and filesystem touch is mocked so
+the suite can exercise disambiguation without needing real pty devices.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from api.services import cc_pane_locate
+
+
+@pytest.fixture
+def fake_proc_tree(tmp_path: Path):
+    """Build a fake /proc layout with two pids, each pointing at its own pts.
+
+    Returns (proc_root, {pid: tty}).
+    """
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+
+    layout = {
+        100: "/dev/pts/4",
+        200: "/dev/pts/7",
+        300: "/dev/pts/11",
+    }
+    for pid, tty in layout.items():
+        fd_dir = proc_root / str(pid) / "fd"
+        fd_dir.mkdir(parents=True)
+        os.symlink(tty, fd_dir / "0")
+
+    return str(proc_root), layout
+
+
+def _patch_lsof(monkeypatch, pids: list[int] | None, *, missing: bool = False,
+                rc: int = 0, timeout: bool = False):
+    """Pretend `lsof -t -- <path>` returns the given pids (or fails)."""
+    if missing:
+        monkeypatch.setattr("shutil.which",
+                            lambda name: None if name == "lsof" else f"/usr/bin/{name}")
+        return
+
+    class _Completed:
+        def __init__(self, stdout: bytes = b"", returncode: int = 0):
+            self.stdout = stdout
+            self.returncode = returncode
+            self.stderr = b""
+
+    body = "\n".join(str(p) for p in (pids or [])).encode("utf-8")
+
+    def _fake_run(argv, **kwargs):
+        if timeout:
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout", 0))
+        # lsof OR wezterm — caller patches wezterm separately
+        if argv[0].endswith("lsof"):
+            return _Completed(stdout=body, returncode=rc)
+        return _Completed()
+
+    monkeypatch.setattr("shutil.which",
+                        lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+
+def _patch_run(monkeypatch, *, lsof_pids: list[int] | None = None, lsof_rc: int = 0,
+               wezterm_panes: list[dict] | None = None, wezterm_rc: int = 0,
+               wezterm_raises: Exception | None = None,
+               which_overrides: dict[str, str | None] | None = None):
+    """Bundle lsof + wezterm mocking into one helper — the probe runs both."""
+
+    class _Completed:
+        def __init__(self, stdout: bytes = b"", returncode: int = 0):
+            self.stdout = stdout
+            self.returncode = returncode
+            self.stderr = b""
+
+    def _fake_run(argv, **kwargs):
+        if argv[0].endswith("lsof"):
+            body = "\n".join(str(p) for p in (lsof_pids or [])).encode("utf-8")
+            return _Completed(stdout=body, returncode=lsof_rc)
+        if argv[0].endswith("wezterm"):
+            if wezterm_raises is not None:
+                raise wezterm_raises
+            import json as _json
+            return _Completed(
+                stdout=_json.dumps(wezterm_panes or []).encode("utf-8"),
+                returncode=wezterm_rc,
+            )
+        return _Completed()
+
+    def _fake_which(name):
+        if which_overrides and name in which_overrides:
+            return which_overrides[name]
+        return f"/usr/bin/{name}"
+
+    monkeypatch.setattr("shutil.which", _fake_which)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+
+# ---------------------------------------------------------------------------
+# Disambiguation — the heart of the issue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_probe_disambiguates_two_panes_same_cwd(monkeypatch, fake_proc_tree):
+    """Two panes both running `claude` in the same cwd, two different
+    sessions. The probe must pick the pane whose tty matches the holder
+    of the requested transcript file — not "first matching cwd".
+    """
+    proc_root, _ttys = fake_proc_tree
+    # Session A's claude lives on pid 100 → /dev/pts/4 (pane 7).
+    # Session B's claude lives on pid 200 → /dev/pts/7 (pane 23).
+    _patch_run(
+        monkeypatch,
+        lsof_pids=[100],
+        wezterm_panes=[
+            {"pane_id": 7,  "tty_name": "/dev/pts/4",  "cwd": "file:///repo"},
+            {"pane_id": 23, "tty_name": "/dev/pts/7",  "cwd": "file:///repo"},
+            {"pane_id": 99, "tty_name": "/dev/pts/11", "cwd": "file:///elsewhere"},
+        ],
+    )
+    result = cc_pane_locate.locate_pane_for_transcript(
+        "/home/u/.claude/projects/-repo/session-a.jsonl",
+        proc_root=proc_root,
+    )
+    assert result == 7
+
+    # Same panes, but lsof reports session B's holder → expect pane 23.
+    _patch_run(
+        monkeypatch,
+        lsof_pids=[200],
+        wezterm_panes=[
+            {"pane_id": 7,  "tty_name": "/dev/pts/4",  "cwd": "file:///repo"},
+            {"pane_id": 23, "tty_name": "/dev/pts/7",  "cwd": "file:///repo"},
+        ],
+    )
+    result = cc_pane_locate.locate_pane_for_transcript(
+        "/home/u/.claude/projects/-repo/session-b.jsonl",
+        proc_root=proc_root,
+    )
+    assert result == 23
+
+
+@pytest.mark.unit
+def test_probe_picks_pane_when_forked_workers_share_pty(monkeypatch, fake_proc_tree):
+    """`claude` may have forked workers that inherited the open jsonl —
+    they share the parent's controlling TTY, so any holder maps to the
+    correct pane.
+    """
+    proc_root, _ = fake_proc_tree
+    _patch_run(
+        monkeypatch,
+        lsof_pids=[100, 300],  # main + a forked worker
+        wezterm_panes=[
+            {"pane_id": 7,  "tty_name": "/dev/pts/4"},
+            {"pane_id": 99, "tty_name": "/dev/pts/11"},
+        ],
+    )
+    result = cc_pane_locate.locate_pane_for_transcript(
+        "/anywhere/x.jsonl",
+        proc_root=proc_root,
+    )
+    # pid 100 maps to /dev/pts/4 (pane 7); pid 300 maps to /dev/pts/11
+    # (pane 99). First match wins — either is acceptable since both panes
+    # legitimately hold the file. We only assert it returned _something_.
+    assert result in {7, 99}
+
+
+# ---------------------------------------------------------------------------
+# Graceful failure paths — probe must never raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_probe_returns_none_when_empty_transcript_path(monkeypatch):
+    assert cc_pane_locate.locate_pane_for_transcript("") is None
+    assert cc_pane_locate.locate_pane_for_transcript(None) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_probe_returns_none_when_lsof_finds_no_holders(monkeypatch, fake_proc_tree):
+    proc_root, _ = fake_proc_tree
+    _patch_run(monkeypatch, lsof_pids=[])
+    assert cc_pane_locate.locate_pane_for_transcript(
+        "/x/y.jsonl", proc_root=proc_root
+    ) is None
+
+
+@pytest.mark.unit
+def test_probe_returns_none_when_lsof_missing(monkeypatch, fake_proc_tree):
+    proc_root, _ = fake_proc_tree
+    _patch_run(monkeypatch, which_overrides={"lsof": None})
+    assert cc_pane_locate.locate_pane_for_transcript(
+        "/x/y.jsonl", proc_root=proc_root
+    ) is None
+
+
+@pytest.mark.unit
+def test_probe_returns_none_when_wezterm_missing(monkeypatch, fake_proc_tree):
+    proc_root, _ = fake_proc_tree
+    _patch_run(
+        monkeypatch,
+        lsof_pids=[100],
+        which_overrides={"wezterm": None},
+    )
+    assert cc_pane_locate.locate_pane_for_transcript(
+        "/x/y.jsonl", proc_root=proc_root
+    ) is None
+
+
+@pytest.mark.unit
+def test_probe_returns_none_when_wezterm_list_fails(monkeypatch, fake_proc_tree):
+    proc_root, _ = fake_proc_tree
+    _patch_run(
+        monkeypatch,
+        lsof_pids=[100],
+        wezterm_rc=2,
+    )
+    assert cc_pane_locate.locate_pane_for_transcript(
+        "/x/y.jsonl", proc_root=proc_root
+    ) is None
+
+
+@pytest.mark.unit
+def test_probe_returns_none_when_wezterm_returns_malformed_json(monkeypatch, fake_proc_tree):
+    proc_root, _ = fake_proc_tree
+
+    class _Completed:
+        stdout = b"not-json-at-all"
+        returncode = 0
+        stderr = b""
+
+    def _fake_run(argv, **kwargs):
+        if argv[0].endswith("lsof"):
+            return _CompletedOK(b"100\n")
+        return _Completed()
+
+    class _CompletedOK:
+        def __init__(self, body): self.stdout, self.returncode, self.stderr = body, 0, b""
+
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    assert cc_pane_locate.locate_pane_for_transcript(
+        "/x/y.jsonl", proc_root=proc_root
+    ) is None
+
+
+@pytest.mark.unit
+def test_probe_returns_none_when_no_pane_tty_matches(monkeypatch, fake_proc_tree):
+    """Holder lives on /dev/pts/4 but no wezterm pane has that tty
+    (e.g. the user is running claude in a non-wezterm terminal).
+    """
+    proc_root, _ = fake_proc_tree
+    _patch_run(
+        monkeypatch,
+        lsof_pids=[100],
+        wezterm_panes=[
+            {"pane_id": 99, "tty_name": "/dev/pts/99"},
+        ],
+    )
+    assert cc_pane_locate.locate_pane_for_transcript(
+        "/x/y.jsonl", proc_root=proc_root
+    ) is None
+
+
+@pytest.mark.unit
+def test_probe_ignores_non_pts_fd_targets(monkeypatch, tmp_path):
+    """If the holder's fd/0 has been redirected (file, /dev/null), the
+    probe must not match — we only trust pts links.
+    """
+    proc_root = tmp_path / "proc"
+    fd_dir = proc_root / "100" / "fd"
+    fd_dir.mkdir(parents=True)
+    # Symlink to a regular file rather than /dev/pts/N.
+    target_file = tmp_path / "redirected"
+    target_file.write_text("")
+    os.symlink(str(target_file), fd_dir / "0")
+
+    _patch_run(
+        monkeypatch,
+        lsof_pids=[100],
+        wezterm_panes=[
+            {"pane_id": 7, "tty_name": "/dev/pts/4"},
+        ],
+    )
+    assert cc_pane_locate.locate_pane_for_transcript(
+        "/x/y.jsonl", proc_root=str(proc_root),
+    ) is None
+
+
+@pytest.mark.unit
+def test_probe_ignores_pane_with_missing_fields(monkeypatch, fake_proc_tree):
+    """Wezterm pane objects missing tty_name or pane_id are skipped."""
+    proc_root, _ = fake_proc_tree
+    _patch_run(
+        monkeypatch,
+        lsof_pids=[100],
+        wezterm_panes=[
+            {"pane_id": 7},  # missing tty_name
+            {"tty_name": "/dev/pts/4"},  # missing pane_id
+            {"pane_id": "not-int", "tty_name": "/dev/pts/4"},
+            {"pane_id": 42, "tty_name": "/dev/pts/4"},  # valid → win
+        ],
+    )
+    assert cc_pane_locate.locate_pane_for_transcript(
+        "/x/y.jsonl", proc_root=proc_root,
+    ) == 42

--- a/web/agents.html
+++ b/web/agents.html
@@ -837,6 +837,10 @@
   // when there's an actual reason to move nodes — never on a same-set
   // snapshot tick, which would otherwise jitter every 2 seconds.
   let _lastVisibleIdsKey = '';
+  // Click-vs-dblclick debounce on graph nodes. See node `.on('click')` /
+  // `.on('dblclick')` handlers — a deferred timer lets a second click
+  // arrive in time to cancel the panel toggle and run Go To instead.
+  let _nodeClickTimer = null;
   function recencyRailSpan() {
     if (visibleCount <= 1) return 0;
     return Math.min(0.84, 0.15 + 0.15 * Math.log2(visibleCount));
@@ -1113,8 +1117,29 @@
           // Leave fx/fy set so the node stays where dropped (mirrors /crm/graph).
         }))
       .on('click', (event, d) => {
-        if (d.session_id === selectedSessionId) closePanel();
-        else openPanel(d.session_id);
+        // Defer the panel toggle so a quick second click can cancel it
+        // and run the dblclick Go To instead. Single-click latency is
+        // ~220ms — noticeable but acceptable for a graph UI where
+        // dblclick is a first-class action.
+        if (_nodeClickTimer) clearTimeout(_nodeClickTimer);
+        _nodeClickTimer = setTimeout(() => {
+          _nodeClickTimer = null;
+          if (d.session_id === selectedSessionId) closePanel();
+          else openPanel(d.session_id);
+        }, 220);
+      })
+      .on('dblclick', (event, d) => {
+        // Double-click = Go To. Only fires for Claude Code sessions
+        // (non-subagent) since the backend endpoint is cc-only.
+        event.preventDefault();
+        event.stopPropagation();  // suppress d3.zoom default dblclick zoom-in
+        if (_nodeClickTimer) {
+          clearTimeout(_nodeClickTimer);
+          _nodeClickTimer = null;
+        }
+        if (d.source === 'claude_code' && !d.is_subagent) {
+          focusCcSession(d);
+        }
       });
     // One shape element per node, type chosen by source.
     entered.append(d => document.createElementNS('http://www.w3.org/2000/svg', nodeShapeTag(d)))
@@ -1249,6 +1274,11 @@
     // Whether the backend will actually accept the click depends on
     // LIFEOS_CC_RESUME_ENABLED on the server; if disabled, click → toast error.
     const showResume = isClaudeCode && !isSubagent && (TERMINAL.has(s.status) || s.status === 'inactive' || s.status === 'yielded');
+    // Go To button: any non-subagent CC session, including live ones. The
+    // backend uses a stored mapping (set by Resume or by the SessionStart
+    // hook) and falls back to an FD probe so this works for sessions
+    // started organically in wezterm.
+    const showGoTo = isClaudeCode && !isSubagent;
     const sourceLabel = isClaudeCode ? 'Claude Code' : 'LifeOS agent';
     const inferredHint = s.status_inferred ? ' (inferred)' : '';
     panelEl.innerHTML = `
@@ -1256,7 +1286,7 @@
         <button class="panel-close" aria-label="Close" id="panel-close">×</button>
         ${showKill ? '<button class="panel-kill" id="panel-kill">Kill</button>' : ''}
         ${showResume ? '<button class="panel-resume" id="panel-resume" title="Open a new wezterm tab and run claude --resume">Resume</button>' : ''}
-        ${showResume ? '<button class="panel-focus" id="panel-focus" title="Select the existing wezterm tab for this session. Wayland disallows cross-app window raise — click the wezterm dock icon to bring it forward; it will already be on the right tab.">Focus</button>' : ''}
+        ${showGoTo ? '<button class="panel-focus" id="panel-focus" title="Jump to the existing wezterm pane for this session (or run Resume if there isn\'t one). Double-clicking the node does the same. Wayland disallows cross-app window raise — click the wezterm dock icon to bring it forward; it will already be on the right pane.">Go To</button>' : ''}
         <div class="label" data-field="label">${escapeHtml(s.label || s.session_id)}</div>
         <div class="cwd-hint" data-field="cwd-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-all">${s.decoded_cwd ? escapeHtml(s.decoded_cwd) : ''}</div>
         <div class="meta" data-field="meta">
@@ -1282,15 +1312,20 @@
     }
     if (showResume) {
       document.getElementById('panel-resume').onclick = () => resumeCcSession(s);
+    }
+    if (showGoTo) {
       document.getElementById('panel-focus').onclick = () => focusCcSession(s);
     }
   }
 
   async function focusCcSession(s) {
+    // Called from both the panel Go To button AND the graph node dblclick.
+    // Button reference may be null if dblclick fires before the panel
+    // header rendered — handle gracefully.
     const btn = document.getElementById('panel-focus');
     if (btn) {
       btn.disabled = true;
-      btn.textContent = 'Focusing…';
+      btn.textContent = 'Locating…';
     }
     try {
       const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/focus`, {
@@ -1301,29 +1336,29 @@
         const text = await r.text();
         let msg = text;
         try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
-        // 404 = no mapping yet (use Resume first). 410 = pane was closed
-        // (mapping cleared on server, click Resume to recreate).
+        // 404 = no cached mapping AND probe couldn't find a pane (session
+        // not running, or in a non-wezterm terminal). 410 = mapping existed
+        // and the pane is gone (typical: closed tab); a re-probe also failed.
         if (r.status === 404) {
-          showToast(`No tracked tab — click Resume first.`, true);
+          showToast(`Couldn't locate pane. If claude is running in wezterm, install the SessionStart hook.`, true);
         } else if (r.status === 410) {
-          showToast(`Tab no longer exists. Click Resume to open a new one.`, true);
+          showToast(`Pane no longer exists. Click Resume to open a new one.`, true);
         } else {
-          showToast(`Focus failed: ${msg}`, true);
+          showToast(`Go To failed: ${msg}`, true);
         }
         return;
       }
-      const result = await r.json();
-      // Wayland disallows cross-client window raise, so the tab is selected
+      // Wayland disallows cross-client window raise, so the pane is selected
       // inside wezterm but the window doesn't pop forward — set the
       // expectation in the toast.
-      showToast(`Tab selected in wezterm. Click the wezterm dock icon to bring it forward.`, false);
+      showToast(`Pane selected in wezterm. Click the wezterm dock icon to bring it forward.`, false);
     } catch (err) {
-      showToast(`Focus failed: ${err.message}`, true);
+      showToast(`Go To failed: ${err.message}`, true);
     } finally {
       setTimeout(() => {
         if (btn) {
           btn.disabled = false;
-          btn.textContent = 'Focus';
+          btn.textContent = 'Go To';
         }
       }, 1500);
     }

--- a/web/agents.html
+++ b/web/agents.html
@@ -1129,17 +1129,20 @@
         }, 220);
       })
       .on('dblclick', (event, d) => {
-        // Double-click = Go To. Only fires for Claude Code sessions
-        // (non-subagent) since the backend endpoint is cc-only.
+        // Double-click = Go To. Only handled for Claude Code sessions
+        // (non-subagent) since the backend endpoint is cc-only — for
+        // anything else, let the deferred single-click panel toggle run
+        // normally rather than silently swallowing it.
+        if (d.source !== 'claude_code' || d.is_subagent) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();  // suppress d3.zoom default dblclick zoom-in
         if (_nodeClickTimer) {
           clearTimeout(_nodeClickTimer);
           _nodeClickTimer = null;
         }
-        if (d.source === 'claude_code' && !d.is_subagent) {
-          focusCcSession(d);
-        }
+        focusCcSession(d);
       });
     // One shape element per node, type chosen by source.
     entered.append(d => document.createElementNS('http://www.w3.org/2000/svg', nodeShapeTag(d)))
@@ -1340,7 +1343,7 @@
         // not running, or in a non-wezterm terminal). 410 = mapping existed
         // and the pane is gone (typical: closed tab); a re-probe also failed.
         if (r.status === 404) {
-          showToast(`Couldn't locate pane. If claude is running in wezterm, install the SessionStart hook.`, true);
+          showToast(`Couldn't locate pane — session not running, wezterm unreachable, or SessionStart hook not installed.`, true);
         } else if (r.status === 410) {
           showToast(`Pane no longer exists. Click Resume to open a new one.`, true);
         } else {


### PR DESCRIPTION
## Summary

Adds a **Go To** button (and node double-click) to /agents that focuses the wezterm pane running any active Claude Code session — including sessions started organically in wezterm, not just ones opened via Resume. Handles the common case of multiple panes in the same project cwd by disambiguating on the session's transcript file, not just cwd.

Closes #251.

## What changed

**Two-pronged pane resolution:**

1. **SessionStart hook** (`scripts/claude-session-pane.sh`) → new endpoint **`POST /api/agents/cc-pane-bind`** (localhost-only, 403 otherwise). The hook reads `$WEZTERM_PANE` + the SessionStart JSON payload and posts the mapping every time `claude` starts in a wezterm pane. Authoritative, no probe needed for fresh sessions. Manual install in `~/.claude/settings.json` — see [`docs/guides/agents-go-to.md`](docs/guides/agents-go-to.md).

2. **FD-probe fallback** (`api/services/cc_pane_locate.py`) for sessions that pre-date the hook: `lsof -t -- <transcript_path>` → PID → `/proc/<pid>/fd/0` → `/dev/pts/N` → match against `wezterm cli list`'s `tty_name`. Result is cached in `cc_wezterm.db` so subsequent clicks are O(1).

**Extended `/focus` endpoint** now does cache → probe → activate in a single round trip, plus one re-probe if a cached pane has gone stale. 404 only when both cache *and* probe come up empty; 410 when a pane was identified but is gone with no replacement.

**Frontend:** the existing Focus button (now labeled "Go To") is shown on all non-subagent CC sessions, not just terminal/inactive ones. Double-click on a graph node triggers the same action; a 220ms click debounce keeps the panel-toggle on single click and Go To on double click from fighting.

## Test evidence

- 11 new tests in `tests/test_cc_pane_locate.py` covering probe disambiguation (two panes, two sessions, same cwd → each lookup finds the right pane), forked-worker matching, and every graceful-failure path (lsof missing, wezterm missing, malformed JSON, no pty match, redirected stdin).
- 11 new tests in `tests/test_agent_cc_pane_bind.py` covering `/cc-pane-bind` (localhost-only enforcement, path-traversal rejection, pane_id validation, prefix handling) and the extended `/focus` flow (probe on cache miss + caching, 404 when probe empty, stale-mapping re-probe + retry, 410 when re-probe finds nothing).
- All 28 existing tests in `tests/test_agent_resume_api.py` still pass — no regression in Resume / Focus behavior.

Full test suite: `./scripts/test.sh` — 2401 passed, 6 pre-existing failures unrelated to this change (Gemma model default mismatch, personal config UUID).

## Review focus

- **Probe correctness**: `api/services/cc_pane_locate.py` — TTY-based matching via `/proc/<pid>/fd/0`. macOS support is explicitly out of scope; the probe returns None gracefully if `lsof` or `wezterm` are missing.
- **`/focus` re-probe logic**: the cache→probe→activate→re-probe sequence in `api/routes/agents.py`. Verify the bookkeeping of "did we already probe this request?" — we never want an infinite probe loop, and a freshly-probed-then-failed pane should not re-probe again.
- **Localhost check on `/cc-pane-bind`**: `request.client.host in {"127.0.0.1", "::1"}`. The test fixture uses `TestClient(app, client=("127.0.0.1", 50000))` to satisfy this; rejection of non-loopback is tested by calling the route function directly with a stub request.
- **Frontend dblclick debounce**: `web/agents.html` — the 220ms timer adds latency to single-click panel toggle. Acceptable trade for a clean dblclick experience, but worth flagging.
- **Hook script safety**: `scripts/claude-session-pane.sh` no-ops in all failure modes (no `$WEZTERM_PANE`, no `jq`, no `curl`, server unreachable) so it can never block `claude` startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)