### PR TITLE
feat(chat): open agent threads in /chat; drop Telegram 30-min auto-resume

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -440,6 +440,75 @@ def _thread_dict(s: Session) -> dict[str, Any]:
     }
 
 
+def _reconstruct_conversation(messages: list[dict], events: list[dict]) -> list[dict]:
+    """Build a readable conversation — `[{role, text, tools:[{name, input}]}]` —
+    for the web /chat thread view.
+
+    Prefers the local `messages` table (the authoritative structured
+    conversation for local / operator sessions); falls back to the managed
+    transcript events for cloud sessions whose turns live remotely. Tool calls
+    are attached to the assistant turn that issued them so the UI can show them
+    as collapsible detail under the reply.
+    """
+    turns: list[dict] = []
+
+    if messages:
+        for m in messages:
+            role = m.get("role")
+            content = m.get("content")
+            if role == "system":
+                continue
+            if role == "user":
+                # String user content is a real prompt / follow-up. List content
+                # is tool results fed back to the model — internal plumbing, skip.
+                if isinstance(content, str) and content.strip():
+                    turns.append({"role": "user", "text": content.strip(), "tools": []})
+                continue
+            if role == "assistant":
+                text_parts: list[str] = []
+                tools: list[dict] = []
+                if isinstance(content, str):
+                    text_parts.append(content)
+                elif isinstance(content, list):
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") == "text" and block.get("text"):
+                            text_parts.append(block["text"])
+                        elif block.get("type") == "tool_use":
+                            tools.append({
+                                "name": block.get("name", "tool"),
+                                "input": block.get("input", {}),
+                            })
+                text = "\n".join(p.strip() for p in text_parts if p and p.strip()).strip()
+                if text or tools:
+                    turns.append({"role": "assistant", "text": text, "tools": tools})
+        return turns
+
+    # Managed (cloud) sessions: turns live in the transcript, not the DB.
+    pending_tools: list[dict] = []
+    for ev in events:
+        kind = ev.get("kind", "")
+        payload = ev.get("payload") or {}
+        if kind in ("managed_event_agent.mcp_tool_use", "managed_event_agent.tool_use", "tool_call"):
+            pending_tools.append({
+                "name": payload.get("name") or payload.get("tool") or "tool",
+                "input": payload.get("input") or payload.get("arguments") or {},
+            })
+        elif kind == "managed_event_agent.message":
+            text_parts = [
+                c.get("text") for c in (payload.get("content") or [])
+                if isinstance(c, dict) and c.get("text")
+            ]
+            text = "\n".join(t.strip() for t in text_parts if t).strip()
+            if text or pending_tools:
+                turns.append({"role": "assistant", "text": text, "tools": pending_tools})
+                pending_tools = []
+    if pending_tools:
+        turns.append({"role": "assistant", "text": "", "tools": pending_tools})
+    return turns
+
+
 @router.get("/threads")
 async def list_threads(limit: int = Query(50, ge=1, le=200)) -> dict[str, Any]:
     """List recent/resumable agent threads (root sessions only) for /chat.
@@ -469,7 +538,19 @@ async def get_thread(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     tail = events[-limit:] if len(events) > limit else events
-    return {"thread": _thread_dict(session), "events": tail, "total": len(events)}
+    # Reconstructed conversation for the /chat thread view: user/assistant
+    # turns with the agent's tool calls attached (collapsible in the UI).
+    try:
+        messages = session_store.get_messages(session_id)
+    except Exception:  # noqa: BLE001 — never break the read on a messages-table hiccup
+        messages = []
+    conversation = _reconstruct_conversation(messages, events)
+    return {
+        "thread": _thread_dict(session),
+        "conversation": conversation,
+        "events": tail,
+        "total": len(events),
+    }
 
 
 @router.post("/threads/{session_id}/reply")

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -1010,11 +1010,8 @@ class SessionStore:
 
     def get_recent_resumable_followup(self, within_seconds: int) -> dict | None:
         """Return the most recent open follow-up whose notification was sent
-        within `within_seconds`, or None.
-
-        Powers the "plain message resumes the last agent thread" path: a
-        non-reply Telegram message within the window resumes the most recently
-        completed/failed thread without requiring the native reply gesture.
+        within `within_seconds`, or None — a "is there a recently-finished,
+        still-open agent thread?" query.
         """
         cutoff = _now() - int(within_seconds)
         with self._connect() as conn:

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -660,8 +660,10 @@ class Worker:
         task = self._fetch_task(task_id) or {"id": task_id, "description": task_id}
 
         if session.routing == ROUTE_LOCAL:
+            # Surface-neutral prefix: follow-ups arrive from Telegram replies and
+            # the web /chat thread view (#236), so don't hardcode "Telegram".
             self.session_store.append_message(
-                sid, "user", f"(user replied on Telegram) {answer}",
+                sid, "user", f"(operator reply) {answer}",
             )
             executor = self._get_local_executor(caller_session_id=sid)
             try:

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -384,10 +384,6 @@ class TelegramBotListener:
 
     _STATE_FILE = Path("data/telegram_state.json")
     _DEDUP_WINDOW = 1000  # Track last N message IDs for deduplication
-    # A plain (non-reply) message within this window of an agent thread's
-    # terminal notification resumes that thread instead of starting a fresh
-    # chat query. Beyond it, plain messages route to the chat pipeline.
-    _AGENT_THREAD_RESUME_WINDOW_SECONDS = 30 * 60
 
     def __init__(self):
         self._stop_event = threading.Event()
@@ -514,39 +510,6 @@ class TelegramBotListener:
         except Exception as exc:
             logger.warning(f"agent-worker deposit_answer failed: {exc}")
             return False
-
-    async def _maybe_resume_recent_agent_thread(self, text: str, chat_id: str) -> bool:
-        """Resume the most recent completed/failed agent thread when a plain
-        (non-reply) message arrives within the resume window.
-
-        Deposits the message into that thread's open follow-up so the worker
-        reopens the session as a new user turn, then shows a visible
-        continuation prefix. Returns True if the message was consumed as a
-        resume; False to fall through to the chat pipeline.
-
-        Like the native reply-deposit path (`_maybe_deposit_agent_answer`),
-        this hands off to the agent worker via the shared `pending_questions`
-        table; if that process is down the deposited turn waits until it comes
-        back rather than running immediately. Accepted edge — both deposit
-        paths share this property.
-        """
-        try:
-            from api.services.agent_worker.session_store import SessionStore
-            store = SessionStore()
-            row = store.get_recent_resumable_followup(
-                within_seconds=self._AGENT_THREAD_RESUME_WINDOW_SECONDS,
-            )
-            if not row:
-                return False
-            if not store.deposit_answer(row["sent_message_id"], text):
-                return False
-        except Exception as exc:
-            logger.warning(f"agent-thread resume check failed: {exc}")
-            return False
-
-        label = (row.get("question") or "").strip() or "your last agent task"
-        await send_message_async(f'↪ continuing "{label}"', chat_id=chat_id)
-        return True
 
     async def _handle_agent_spawn(self, rest: str, chat_id: str):
         """Spawn an operator agent on demand: `/agent [local|claude] <task>`.
@@ -681,13 +644,10 @@ class TelegramBotListener:
         if await self._check_code_followup(text, chat_id):
             return
 
-        # Plain message (no native reply gesture) within the resume window:
-        # resume the most recent completed/failed agent thread so a quick
-        # "actually, also do X" continues the conversation instead of
-        # silently starting a fresh chat query. Native reply-to (handled
-        # above) still targets a specific, possibly older, thread.
-        if await self._maybe_resume_recent_agent_thread(text, chat_id):
-            return
+        # Agent-thread replies are resumed only via an explicit reply-to gesture
+        # (handled near the top of this method). A plain message is always a
+        # fresh chat query — no implicit "recent thread" capture — so unrelated
+        # questions never get silently swallowed into a finished agent thread.
 
         # Send through chat pipeline (intent classification happens there)
         try:

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -122,7 +122,7 @@ The agent worker uses your existing Telegram bot (no second bot needed). Three m
 
 3. **Failure notifications** — short message naming the task and the failure reason, plus a transcript path so you can debug. Examples: "task X failed: managed_create_session 4xx" or "task Y hit its budget (max_dollars)".
 
-**Replying to a thread.** Every terminal notification — completion, failure, or budget cut-off — is replyable: reply to it (Telegram's native reply, on any chunk of a long message) and the agent reopens that thread as a follow-up turn with full prior context ("actually, also CC Jane"). For convenience, a plain message sent within 30 minutes of a notification continues the most recent thread without needing the reply gesture; after 30 minutes a plain message goes to normal chat.
+**Replying to a thread.** Every terminal notification — completion, failure, or budget cut-off — is replyable: use Telegram's native reply on it (any chunk of a long message) and the agent reopens that thread as a follow-up turn with full prior context ("actually, also CC Jane"). The reply gesture is the *only* way to continue a thread on Telegram — a plain message is always a normal chat query, so unrelated questions are never mistaken for a thread continuation.
 
 **Starting an agent on demand.** You don't have to create a `#agent` task — send `/agent <task>` to spawn one immediately. The model is auto-routed by preflight; force it with `/agent local <task>` or `/agent claude <task>`. If routing is ambiguous, the bot asks you "local or claude?" before starting. The same `/agent` command works in web chat. The resulting thread notifies and is replyable exactly like a `#agent` task.
 

--- a/docs/specs/product/chat-ui.md
+++ b/docs/specs/product/chat-ui.md
@@ -202,8 +202,9 @@ The orchestrator LLM (Claude Haiku via Anthropic API by default; configurable vi
 Web `/chat` speaks to the same agent-thread model as Telegram (#236, Phase 3 of #233):
 
 - **Threads panel** (sidebar) — lists recent/resumable agent sessions (root sessions only) with a status badge (running / completed / failed / budget / blocked). Backed by `GET /api/agents/threads`; polled for live-ish updates (the `/agents` page uses the `/api/agents/stream` SSE for the full graph).
-- **Reply** — completed/failed threads show a reply box; sending it (`POST /api/agents/threads/{id}/reply`) reopens the session as a follow-up turn via the shared follow-up table — the same path a Telegram reply takes.
-- **Run as agent** — the composer has a model selector (auto / local / cloud) and a spawn button; it sends the composer text to `POST /api/agents/spawn` (Phase 2's `create_operator_session`), and the new thread appears in the panel. `auto` routes via preflight.
+- **Open a thread** — clicking a thread loads its full conversation into the main chat body: user prompts and the agent's replies render as chat bubbles, with the agent's tool calls shown as collapsible detail under each reply. Backed by `GET /api/agents/threads/{id}`, which returns a reconstructed `conversation` (from the session's message history, or the managed transcript for cloud sessions). A banner marks the thread; **Exit to chat** (or **+**) returns to normal chat.
+- **Reply / continue** — while a thread is open the composer continues *that thread*: sending a message posts to `POST /api/agents/threads/{id}/reply`, which reopens the session as a follow-up turn via the shared follow-up table (the same path a Telegram reply takes). The view polls and re-renders as the agent's new turns land. Only completed/failed threads are continuable; a running thread opens read-only.
+- **Run as agent** — the composer has a model selector (auto / local / cloud) and a spawn button; it sends the composer text to `POST /api/agents/spawn` (Phase 2's `create_operator_session`), and the new thread appears in the panel. `auto` routes via preflight; an ambiguous auto-route returns 409 asking for an explicit model.
 
 ## Implementation Details
 

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -322,9 +322,7 @@ Clarifications older than `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` (default 72
 
 Every terminal-state notification — `#agent-completed`, `#agent-failed`, and `#agent-budget-exceeded` — registers a follow-up (`kind='followup'`) via `register_completion_followup()`, so a reply reopens the session as a new user turn (`_resume_as_followup()` swaps whichever terminal tag is current back to `#agent-running`). This makes failures and budget cut-offs replyable, not just clean completions.
 
-Two ways to target a thread:
-- **Native reply** to any chunk of a notification → resumes that specific thread (works regardless of age).
-- **Plain message** (no reply gesture) within `_AGENT_THREAD_RESUME_WINDOW_SECONDS` (30 min) → resumes the most recent resumable thread (`get_recent_resumable_followup()`), prefixed with a visible `↪ continuing "<task>"`. Beyond the window, a plain message routes to the normal chat pipeline.
+Targeting a thread on Telegram is **explicit only**: a **native reply** to any chunk of a notification resumes that specific thread (works regardless of age). A plain (non-reply) message is always a fresh chat query — there is no implicit "recent thread" capture, so an unrelated question right after a task finishes is never silently swallowed into the agent thread.
 
 ---
 

--- a/tests/test_agent_threads_api.py
+++ b/tests/test_agent_threads_api.py
@@ -94,6 +94,52 @@ def test_get_thread_404(stores, client):
     assert resp.status_code == 404
 
 
+def test_thread_conversation_from_messages(stores, client):
+    """The thread detail reconstructs a user/assistant conversation (with tool
+    calls attached) from the local messages table."""
+    session_store, _ = stores
+    s = session_store.create(task_id="t", status=STATUS_COMPLETED, routing="local")
+    sid = s.session_id
+    session_store.append_message(sid, "system", "you are an agent")
+    session_store.append_message(sid, "user", "research the best CRMs")
+    session_store.append_message(sid, "assistant", [
+        {"type": "text", "text": "Here are the top 3."},
+        {"type": "tool_use", "id": "x", "name": "lifeos_search", "input": {"q": "CRM"}},
+    ])
+    # Tool results fed back as a user turn — internal plumbing, should be hidden.
+    session_store.append_message(sid, "user", [
+        {"type": "tool_result", "tool_use_id": "x", "content": "12 results"},
+    ])
+    session_store.append_message(sid, "assistant", [{"type": "text", "text": "HubSpot fits best."}])
+
+    conv = client.get(f"/api/agents/threads/{sid}").json()["conversation"]
+    assert [t["role"] for t in conv] == ["user", "assistant", "assistant"]
+    assert conv[0]["text"] == "research the best CRMs"
+    assert conv[1]["text"] == "Here are the top 3."
+    assert conv[1]["tools"] == [{"name": "lifeos_search", "input": {"q": "CRM"}}]
+    assert conv[2]["text"] == "HubSpot fits best."
+
+
+def test_reconstruct_conversation_from_managed_events():
+    """Cloud sessions (no messages-table rows) reconstruct from transcript."""
+    from api.routes.agents import _reconstruct_conversation
+    events = [
+        {"kind": "managed_event_agent.tool_use", "payload": {"name": "drive_search", "input": {"q": "x"}}},
+        {"kind": "managed_event_agent.message", "payload": {"content": [{"text": "Found 3 files."}]}},
+        {"kind": "managed_event_agent.message", "payload": {"content": [{"text": "Done."}]}},
+    ]
+    conv = _reconstruct_conversation([], events)
+    assert conv[0]["role"] == "assistant"
+    assert conv[0]["tools"] == [{"name": "drive_search", "input": {"q": "x"}}]
+    assert conv[0]["text"] == "Found 3 files."
+    assert conv[1]["text"] == "Done." and conv[1]["tools"] == []
+
+
+def test_reconstruct_conversation_empty():
+    from api.routes.agents import _reconstruct_conversation
+    assert _reconstruct_conversation([], []) == []
+
+
 # ---------------------------------------------------------------------------
 # POST /threads/{id}/reply
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_threads_ui_browser.py
+++ b/tests/test_agent_threads_ui_browser.py
@@ -1,12 +1,13 @@
-"""Browser test for the web /chat agent-threads UI (#236, Phase 3).
+"""Browser test for the web /chat agent-threads UI (#236, Phase 3 + thread view).
 
-Drives the Agents panel + "run as agent" composer affordance with the
-`/api/agents/*` endpoints mocked via Playwright route interception, so the
-spawn → appear → reply flow is deterministic and free of real worker/LLM
-side effects. Requires the server serving the chat page on localhost:8000
-(like all browser tests in this repo).
+Drives the Agents panel, the "run as agent" composer affordance, and the
+click-to-open thread view with the `/api/agents/*` endpoints mocked via
+Playwright route interception — so the spawn → appear → open → reply flow is
+deterministic and free of real worker/LLM side effects. Requires the server
+serving the chat page on localhost:8000 (like all browser tests in this repo).
 """
 import json
+import re
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -17,40 +18,43 @@ DESKTOP_VIEWPORT = {"width": 1280, "height": 800}
 
 
 def _install_agent_mocks(page: Page, state: dict):
-    """Route /api/agents/* to in-memory mock responses driven by `state`."""
+    """Single dispatcher for all /api/agents/* calls, driven by `state`."""
 
-    def threads_handler(route):
-        route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({"threads": state["threads"], "total": len(state["threads"])}),
-        )
+    def handler(route):
+        req = route.request
+        path = req.url.split("?")[0]
 
-    def spawn_handler(route):
-        body = json.loads(route.request.post_data or "{}")
-        state["spawned"].append(body)
-        # The spawned agent now shows up as a running thread.
-        state["threads"].insert(0, {
-            "session_id": "sess_spawned",
-            "task_id": "op_spawned",
-            "parent_session_id": None,
-            "status": "running",
-            "label": body.get("prompt", "agent task")[:40],
-            "resumable": False,
-        })
-        route.fulfill(status=200, content_type="application/json",
-                      body=json.dumps({"ok": True, "session_id": "sess_spawned",
-                                       "task_id": "op_spawned", "routing": "claude",
-                                       "needs_routing": False}))
+        if path.endswith("/spawn"):
+            body = json.loads(req.post_data or "{}")
+            state["spawned"].append(body)
+            state["threads"].insert(0, {
+                "session_id": "sess_spawned", "task_id": "op_spawned",
+                "parent_session_id": None, "status": "running",
+                "label": body.get("prompt", "agent task")[:40], "resumable": False,
+            })
+            return route.fulfill(status=200, content_type="application/json",
+                                 body=json.dumps({"ok": True, "session_id": "sess_spawned",
+                                                  "task_id": "op_spawned", "routing": "claude",
+                                                  "needs_routing": False}))
 
-    def reply_handler(route):
-        state["replies"].append(json.loads(route.request.post_data or "{}"))
-        route.fulfill(status=200, content_type="application/json",
-                      body=json.dumps({"ok": True, "status": "queued"}))
+        if path.endswith("/reply"):
+            state["replies"].append(json.loads(req.post_data or "{}"))
+            return route.fulfill(status=200, content_type="application/json",
+                                 body=json.dumps({"ok": True, "status": "queued"}))
 
-    page.route("**/api/agents/threads*", threads_handler)
-    page.route("**/api/agents/spawn", spawn_handler)
-    page.route("**/api/agents/threads/*/reply", reply_handler)
+        # /threads/{id} detail (has a segment after threads/)
+        m = re.search(r"/threads/([^/]+)$", path)
+        if m:
+            return route.fulfill(status=200, content_type="application/json",
+                                 body=json.dumps({"thread": state["detail"]["thread"],
+                                                  "conversation": state["detail"]["conversation"],
+                                                  "events": [], "total": 0}))
+
+        # /threads list
+        return route.fulfill(status=200, content_type="application/json",
+                             body=json.dumps({"threads": state["threads"], "total": len(state["threads"])}))
+
+    page.route("**/api/agents/**", handler)
 
 
 class TestAgentThreadsUI:
@@ -59,15 +63,20 @@ class TestAgentThreadsUI:
         page.set_viewport_size(DESKTOP_VIEWPORT)
         self.state = {
             "threads": [{
-                "session_id": "sess_done",
-                "task_id": "op_done",
-                "parent_session_id": None,
-                "status": "completed",
-                "label": "draft the landlord email",
-                "resumable": True,
+                "session_id": "sess_done", "task_id": "op_done",
+                "parent_session_id": None, "status": "completed",
+                "label": "draft the landlord email", "resumable": True,
             }],
-            "spawned": [],
-            "replies": [],
+            "detail": {
+                "thread": {"session_id": "sess_done", "task_id": "op_done", "status": "completed",
+                           "label": "draft the landlord email", "resumable": True},
+                "conversation": [
+                    {"role": "user", "text": "draft the landlord email", "tools": []},
+                    {"role": "assistant", "text": "Here's a draft for you.",
+                     "tools": [{"name": "lifeos_gmail_draft", "input": {"to": "landlord@example.com"}}]},
+                ],
+            },
+            "spawned": [], "replies": [],
         }
         _install_agent_mocks(page, self.state)
         page.goto("http://localhost:8000")
@@ -81,28 +90,31 @@ class TestAgentThreadsUI:
     def test_composer_has_run_as_agent_controls(self, page: Page):
         expect(page.locator("#agentRouting")).to_be_visible()
         expect(page.locator("#agentSpawnBtn")).to_be_visible()
-        # Routing options: auto / local / cloud.
-        values = page.locator("#agentRouting option").evaluate_all(
-            "els => els.map(e => e.value)"
-        )
+        values = page.locator("#agentRouting option").evaluate_all("els => els.map(e => e.value)")
         assert set(values) == {"auto", "local", "claude"}
 
     def test_spawn_from_composer_appears_in_panel(self, page: Page):
         page.locator("#inputField").fill("research the best CRMs")
         page.locator("#agentRouting").select_option("claude")
         page.locator("#agentSpawnBtn").click()
-        # The mock inserts a running thread; the panel polls/refreshes.
         expect(page.locator(".agent-badge.running")).to_be_visible(timeout=8000)
-        assert self.state["spawned"], "spawn POST should have fired"
-        assert self.state["spawned"][0]["routing"] == "claude"
+        assert self.state["spawned"] and self.state["spawned"][0]["routing"] == "claude"
 
-    def test_reply_to_completed_thread(self, page: Page):
-        # Open the reply box on the completed (resumable) thread and send.
-        page.locator("#reply-sess_done").wait_for(state="attached")
-        page.locator('.agent-thread-top button[title="Reply"]').click()
-        box = page.locator("#reply-sess_done input")
-        box.fill("also CC Jane")
-        box.press("Enter")
+    def test_click_thread_opens_conversation_in_main_body(self, page: Page):
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        # The thread banner + reconstructed conversation render in the main body.
+        expect(page.locator(".agent-thread-banner")).to_be_visible(timeout=8000)
+        expect(page.locator("#messages")).to_contain_text("draft the landlord email")
+        expect(page.locator("#messages")).to_contain_text("Here's a draft for you.")
+        # Tool call shown as collapsible detail.
+        expect(page.locator(".agent-tool-details summary")).to_contain_text("lifeos_gmail_draft")
+
+    def test_reply_from_thread_view_continues_thread(self, page: Page):
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        expect(page.locator(".agent-thread-banner")).to_be_visible(timeout=8000)
+        # The main composer now continues the thread.
+        page.locator("#inputField").fill("also CC the property manager")
+        page.locator("#sendBtn").click()
         page.wait_for_timeout(500)
         assert self.state["replies"], "reply POST should have fired"
-        assert self.state["replies"][0]["text"] == "also CC Jane"
+        assert self.state["replies"][0]["text"] == "also CC the property manager"

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -333,25 +333,28 @@ class TestMessageDedup:
 
 
 # =============================================================================
-# Plain-message agent-thread resume (Issue #234, Phase 1)
+# Plain messages never implicitly resume an agent thread (regression)
 # =============================================================================
 
 
-class TestAgentThreadResume:
-    """A plain (non-reply) message within the window resumes the most recent
-    completed/failed agent thread instead of starting a fresh chat query."""
+class TestNoImplicitThreadResume:
+    """A plain (non-reply) Telegram message is always a fresh chat query, even
+    when a recently-completed agent thread exists. Agent threads are resumed
+    ONLY via an explicit reply-to gesture (handled separately)."""
 
-    def _make_listener(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_plain_message_with_open_thread_goes_to_chat(self, tmp_path):
         from api.services.telegram import TelegramBotListener
-        state_file = tmp_path / "telegram_state.json"
-        with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
-            return TelegramBotListener()
-
-    def _store_with_followup(self, tmp_path, *, label="email Bob", msg_ids=(900,)):
         from api.services.agent_worker.session_store import (
             STATUS_COMPLETED,
             SessionStore,
         )
+
+        state_file = tmp_path / "telegram_state.json"
+        with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
+            listener = TelegramBotListener()
+
+        # A resumable agent thread exists in the store...
         store = SessionStore(db_path=tmp_path / "sessions.db")
         sess = store.create(
             task_id="t1", status=STATUS_COMPLETED, routing="local",
@@ -359,58 +362,27 @@ class TestAgentThreadResume:
         )
         store.register_completion_followup(
             session_id=sess.session_id, task_id="t1",
-            sent_message_ids=list(msg_ids), label=label,
+            sent_message_ids=[900], label="email Bob",
         )
-        return store
 
-    @pytest.mark.asyncio
-    async def test_plain_message_within_window_resumes(self, tmp_path):
-        listener = self._make_listener(tmp_path)
-        store = self._store_with_followup(tmp_path, label="email Bob")
-
+        # ...but a plain (non-reply) message must still route to the chat pipeline.
+        update = {"message": {"message_id": 7, "text": "what's the weather", "chat": {"id": "123"}}}
         with patch("api.services.agent_worker.session_store.SessionStore", return_value=store), \
-             patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
-            handled = await listener._maybe_resume_recent_agent_thread("also CC Jane", "123")
-
-        assert handled is True
-        # The message was deposited into the follow-up (now no longer resumable).
-        assert store.get_recent_resumable_followup(within_seconds=1800) is None
-        # A visible continuation prefix was sent.
-        mock_send.assert_awaited_once()
-        assert 'continuing "email Bob"' in mock_send.await_args.args[0]
-
-    @pytest.mark.asyncio
-    async def test_no_recent_thread_falls_through(self, tmp_path):
-        from api.services.agent_worker.session_store import SessionStore
-        listener = self._make_listener(tmp_path)
-        empty_store = SessionStore(db_path=tmp_path / "sessions.db")  # no follow-ups
-
-        with patch("api.services.agent_worker.session_store.SessionStore", return_value=empty_store), \
-             patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send:
-            handled = await listener._maybe_resume_recent_agent_thread("hello there", "123")
-
-        assert handled is False
-        mock_send.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_handle_update_routes_plain_message_to_resume(self, tmp_path):
-        """Integration: a plain message with a resumable thread short-circuits
-        the chat pipeline."""
-        listener = self._make_listener(tmp_path)
-        update = {"message": {"message_id": 7, "text": "and add a PS", "chat": {"id": "123"}}}
-
-        with patch.object(listener, "_check_agent_approval", return_value=False), \
+             patch.object(listener, "_check_agent_approval", return_value=False), \
              patch.object(listener, "_check_agent_clarification", return_value=False), \
              patch.object(listener, "_check_code_followup", new_callable=AsyncMock, return_value=False), \
-             patch.object(listener, "_maybe_resume_recent_agent_thread", new_callable=AsyncMock, return_value=True) as mock_resume, \
              patch("api.services.telegram.settings") as mock_settings, \
              patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock), \
              patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
             mock_settings.telegram_chat_id = "123"
+            mock_chat.return_value = {"answer": "sunny", "conversation_id": "c1", "code_intent": False}
             await listener._handle_update(update)
 
-        mock_resume.assert_awaited_once()
-        mock_chat.assert_not_awaited()  # resume short-circuited the chat pipeline
+        # Routed to chat, NOT swallowed into the agent thread.
+        mock_chat.assert_awaited_once()
+        # The thread's follow-up is untouched (still resumable via explicit reply).
+        assert store.get_recent_resumable_followup(within_seconds=1800) is not None
 
 
 # =============================================================================

--- a/web/index.html
+++ b/web/index.html
@@ -2492,6 +2492,9 @@
         .agents-refresh:hover { opacity: 1; }
         .agents-threads-list { max-height: 38vh; overflow-y: auto; padding: 0 0.5rem 0.5rem; }
         .agent-thread { padding: 0.5rem 0.6rem; border-radius: 8px; margin-bottom: 0.35rem; background: rgba(255,255,255,0.03); }
+        .agent-thread.clickable { cursor: pointer; }
+        .agent-thread.clickable:hover { background: rgba(255,255,255,0.07); }
+        .agent-thread.active { background: rgba(45,95,163,0.25); outline: 1px solid #2d5fa3; }
         .agent-thread-top { display: flex; align-items: center; gap: 0.4rem; }
         .agent-thread-label { flex: 1; font-size: 0.82rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
         .agent-badge { font-size: 0.64rem; padding: 0.1rem 0.4rem; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.03em; }
@@ -2499,10 +2502,14 @@
         .agent-badge.completed { background: #1e4620; color: #7ad17f; }
         .agent-badge.failed, .agent-badge.budget_exceeded { background: #4a1e1e; color: #ff9d9d; }
         .agent-badge.blocked, .agent-badge.yielded { background: #4a3a1e; color: #ffd27f; }
-        .agent-reply-row { display: none; gap: 0.3rem; margin-top: 0.4rem; }
-        .agent-reply-row.open { display: flex; }
-        .agent-reply-row input { flex: 1; font-size: 0.78rem; padding: 0.3rem 0.45rem; border-radius: 6px; border: 1px solid var(--border, #2a2a2a); background: rgba(0,0,0,0.2); color: inherit; }
-        .agent-reply-row button { font-size: 0.74rem; padding: 0.3rem 0.5rem; border-radius: 6px; border: none; cursor: pointer; background: #2d5fa3; color: #fff; }
+        /* Agent thread view in the main chat body (#236) */
+        .agent-thread-banner { font-size: 0.85rem; padding: 0.6rem 0.8rem; margin-bottom: 0.8rem; border-radius: 8px; background: rgba(45,95,163,0.15); border: 1px solid rgba(45,95,163,0.4); }
+        .agent-thread-exit { margin-left: 0.5rem; font-size: 0.74rem; padding: 0.15rem 0.5rem; border-radius: 6px; border: none; cursor: pointer; background: #2d5fa3; color: #fff; }
+        .agent-thread-empty { opacity: 0.6; font-size: 0.85rem; padding: 0.5rem 0.2rem; }
+        .agent-tool-details { margin: -0.4rem 0 0.8rem 0.5rem; }
+        .agent-tool-details details { font-size: 0.76rem; margin-bottom: 0.2rem; }
+        .agent-tool-details summary { cursor: pointer; opacity: 0.75; }
+        .agent-tool-details pre { font-size: 0.72rem; background: rgba(0,0,0,0.25); padding: 0.4rem 0.5rem; border-radius: 6px; overflow-x: auto; white-space: pre-wrap; }
         .agent-routing-select { font-size: 0.78rem; border-radius: 8px; border: 1px solid var(--border, #2a2a2a); background: rgba(0,0,0,0.2); color: inherit; padding: 0 0.3rem; }
         .agent-spawn-btn { background: none; border: none; cursor: pointer; font-size: 1.15rem; opacity: 0.75; }
         .agent-spawn-btn:hover { opacity: 1; }
@@ -2901,6 +2908,10 @@
         // State
         let isLoading = false;
         let currentConversationId = null;
+        // When set, the main chat view is showing an agent thread (#236 thread
+        // view): the composer continues that thread instead of normal chat.
+        // Shape: {sessionId, resumable, label, status, convCount}.
+        let currentAgentThread = null;
         let sessionCost = 0;
         let attachments = []; // Array of {file, dataUrl, filename, mediaType, sizeBytes}
         let allConversations = []; // Store all conversations for filtering
@@ -2960,52 +2971,165 @@
                 const labelAttr = label.replace(/"/g, '&quot;');
                 const status = (t.status || '').toString();
                 const sid = t.session_id;
+                const isActive = currentAgentThread && currentAgentThread.sessionId === sid;
                 const div = document.createElement('div');
-                div.className = 'agent-thread';
+                div.className = 'agent-thread clickable' + (isActive ? ' active' : '');
+                div.title = 'Open this thread';
+                div.onclick = () => openAgentThread(sid);
                 div.innerHTML =
                     '<div class="agent-thread-top">' +
                         '<span class="agent-thread-label" title="' + labelAttr + '">' + label + '</span>' +
                         '<span class="agent-badge ' + escapeHtml(status) + '">' + (escapeHtml(status) || '?') + '</span>' +
-                        (t.resumable ? '<button class="agents-refresh" title="Reply" onclick="toggleAgentReply(\'' + sid + '\')">↩</button>' : '') +
-                    '</div>' +
-                    '<div class="agent-reply-row" id="reply-' + sid + '">' +
-                        '<input type="text" placeholder="Reply to continue…" ' +
-                        'onkeydown="if(event.key===\'Enter\'){sendAgentReply(\'' + sid + '\')}">' +
-                        '<button onclick="sendAgentReply(\'' + sid + '\')">Send</button>' +
                     '</div>';
                 list.appendChild(div);
             });
         }
 
-        function toggleAgentReply(sessionId) {
-            const row = document.getElementById('reply-' + sessionId);
-            if (!row) return;
-            row.classList.toggle('open');
-            const inp = row.querySelector('input');
-            if (inp && row.classList.contains('open')) inp.focus();
+        // Open an agent thread in the main chat body: load its conversation and
+        // put the composer into "continue this thread" mode (#236 thread view).
+        async function openAgentThread(sessionId) {
+            let data;
+            try {
+                const resp = await fetch('/api/agents/threads/' + encodeURIComponent(sessionId));
+                if (!resp.ok) { alert('Could not load thread: ' + resp.status); return; }
+                data = await resp.json();
+            } catch (e) { alert('Could not load thread: ' + e); return; }
+
+            const thread = data.thread || {};
+            const conversation = data.conversation || [];
+            currentConversationId = null;  // leave any normal-chat conversation
+            currentAgentThread = {
+                sessionId,
+                resumable: !!thread.resumable,
+                label: (thread.label || sessionId).toString(),
+                status: (thread.status || '').toString(),
+                convCount: conversation.length,
+            };
+            chatTitle.textContent = '🧵 ' + currentAgentThread.label;
+            renderThreadConversation(conversation);
+            updateThreadComposer();
+            loadAgentThreads();   // refresh the panel's active highlight
+            closeSidebar();
+            scrollToBottom();
         }
 
-        async function sendAgentReply(sessionId) {
-            const row = document.getElementById('reply-' + sessionId);
-            if (!row) return;
-            const inp = row.querySelector('input');
-            const text = ((inp && inp.value) || '').trim();
-            if (!text) return;
+        function renderThreadConversation(conversation) {
+            messagesEl.innerHTML = '';
+            const t = currentAgentThread || {};
+            const banner = document.createElement('div');
+            banner.className = 'agent-thread-banner';
+            const cont = t.resumable
+                ? 'Replies below continue this thread.'
+                : 'This thread is ' + escapeHtml(t.status || '') + ' — read-only until it finishes.';
+            banner.innerHTML =
+                '🧵 Agent thread · <strong>' + escapeHtml(t.label || '') + '</strong> — ' + cont +
+                ' <button class="agent-thread-exit" onclick="exitAgentThread()">Exit to chat</button>';
+            messagesEl.appendChild(banner);
+
+            if (!conversation.length) {
+                const empty = document.createElement('div');
+                empty.className = 'agent-thread-empty';
+                empty.textContent = 'No conversation recorded yet for this thread.';
+                messagesEl.appendChild(empty);
+            }
+            conversation.forEach(turn => {
+                const role = turn.role === 'user' ? 'user' : 'assistant';
+                const body = (turn.text || '').trim()
+                    || ((turn.tools && turn.tools.length) ? '_(ran tools — see below)_' : '');
+                addMessage(body, role);
+                if (role === 'assistant' && turn.tools && turn.tools.length) {
+                    appendToolDetails(turn.tools);
+                }
+            });
+        }
+
+        function appendToolDetails(tools) {
+            const wrap = document.createElement('div');
+            wrap.className = 'agent-tool-details';
+            tools.forEach(tl => {
+                const det = document.createElement('details');
+                const sum = document.createElement('summary');
+                sum.textContent = '🔧 ' + (tl.name || 'tool');
+                det.appendChild(sum);
+                const pre = document.createElement('pre');
+                let inputStr;
+                try { inputStr = JSON.stringify(tl.input, null, 2); }
+                catch (e) { inputStr = String(tl.input); }
+                pre.textContent = inputStr;
+                det.appendChild(pre);
+                wrap.appendChild(det);
+            });
+            messagesEl.appendChild(wrap);
+        }
+
+        function updateThreadComposer() {
+            if (!currentAgentThread) { inputField.placeholder = 'Ask a question...'; return; }
+            inputField.placeholder = currentAgentThread.resumable
+                ? 'Reply to continue this agent thread…'
+                : 'Thread is ' + currentAgentThread.status + ' — press + for a new chat';
+        }
+
+        function exitAgentThread() {
+            newChat();
+        }
+
+        async function sendThreadReply(text) {
+            const t = currentAgentThread;
+            if (!t) return;
+            if (!t.resumable) {
+                alert('This thread is ' + t.status + ' and can’t be replied to yet. Press + for a new chat.');
+                return;
+            }
+            inputField.value = '';
+            inputField.style.height = 'auto';
+            const sid = t.sessionId;
             try {
-                const resp = await fetch('/api/agents/threads/' + encodeURIComponent(sessionId) + '/reply', {
+                const resp = await fetch('/api/agents/threads/' + encodeURIComponent(sid) + '/reply', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ text }),
                 });
-                if (resp.ok) {
-                    inp.value = '';
-                    row.classList.remove('open');
-                    setTimeout(loadAgentThreads, 500);
-                } else {
+                if (!resp.ok) {
                     const e = await resp.json().catch(() => ({}));
                     alert('Reply failed: ' + (e.detail || resp.status));
+                    return;
                 }
-            } catch (e) { alert('Reply failed: ' + e); }
+            } catch (e) { alert('Reply failed: ' + e); return; }
+            // Show the reply immediately + a status line; the worker resumes the
+            // session asynchronously, so poll the thread for the agent's output.
+            addMessage(text, 'user');
+            addMessage('_↻ resuming agent…_', 'assistant');
+            scrollToBottom();
+            pollThreadForUpdate(sid);
+        }
+
+        function pollThreadForUpdate(sessionId) {
+            let tries = 0;
+            const iv = setInterval(async () => {
+                tries++;
+                if (!currentAgentThread || currentAgentThread.sessionId !== sessionId || tries > 60) {
+                    clearInterval(iv);
+                    return;
+                }
+                try {
+                    const resp = await fetch('/api/agents/threads/' + encodeURIComponent(sessionId));
+                    if (!resp.ok) return;
+                    const data = await resp.json();
+                    const conv = data.conversation || [];
+                    const thread = data.thread || {};
+                    // New turns have landed (worker appended the reply + the
+                    // agent's response) — re-render and stop once it's finished.
+                    if (conv.length > currentAgentThread.convCount) {
+                        currentAgentThread.convCount = conv.length;
+                        currentAgentThread.resumable = !!thread.resumable;
+                        currentAgentThread.status = (thread.status || '').toString();
+                        renderThreadConversation(conv);
+                        updateThreadComposer();
+                        scrollToBottom();
+                        if (thread.resumable) { clearInterval(iv); loadAgentThreads(); }
+                    }
+                } catch (e) { /* transient — keep polling */ }
+            }, 3000);
         }
 
         async function spawnAgentFromComposer() {
@@ -3481,6 +3605,8 @@
 
         function newChat() {
             currentConversationId = null;
+            currentAgentThread = null;   // leave agent-thread mode (#236)
+            inputField.placeholder = 'Ask a question...';
             chatTitle.textContent = 'New conversation';
             messagesEl.innerHTML = `
                 <div class="welcome">
@@ -3615,6 +3741,13 @@
         async function sendMessage() {
             const question = inputField.value.trim();
             if (!question || isLoading) return;
+
+            // In agent-thread mode the composer continues that thread instead
+            // of starting a normal chat query (#236).
+            if (currentAgentThread) {
+                await sendThreadReply(question);
+                return;
+            }
 
             isLoading = true;
             setStatus('loading', 'Thinking...');


### PR DESCRIPTION
## Summary

Two follow-up refinements to the unified agent threads (#233), from operator feedback:

1. **Click a thread → open it in the main `/chat` body to continue from there.** Clicking a thread in the Agents panel now loads its full conversation into the main chat body (instead of a cramped inline reply box), and the composer continues *that* thread.
2. **Drop the Telegram 30-minute plain-message auto-resume.** Threaded reply-to is now the sole way to continue a thread on Telegram; a plain message is always a normal chat query, so unrelated questions are never swallowed into a finished agent thread.

Relates to #233 / #236.

## What changed

**Thread view (#236 refinement):**
- `GET /api/agents/threads/{id}` now returns a reconstructed `conversation` — `[{role, text, tools:[{name, input}]}]` — built from the local `messages` table, or the managed transcript for cloud sessions (`_reconstruct_conversation`).
- `web/index.html`: thread items are clickable → render user/assistant bubbles with the agent's tool calls as **collapsible** detail; a banner + **Exit to chat** mark thread mode; the main composer continues the thread (`POST /threads/{id}/reply`) and polls for the resumed turns. The per-thread inline reply box is removed.
- `worker.py`: the follow-up user-turn prefix is now surface-neutral (`(operator reply)`) since replies come from both Telegram and web.

**Telegram revert (#234):**
- Removed `_maybe_resume_recent_agent_thread` + the 30-min window. Native reply-to (any chunk) remains the only thread selector.

## Test evidence

- `pytest -m "unit and not slow" tests/` (pre-push gate): **1660 passed, 0 failed**.
- New backend tests: conversation reconstruction from the messages table (user/assistant + tools, internal tool-result turns hidden) and from managed transcript events; empty case.
- Telegram regression test: a plain message with an open resumable thread routes to chat (not swallowed) and leaves the thread's follow-up intact.
- Browser test (`[browser, slow]`, route-mocked) updated for the click-to-open flow: thread renders in the main body with collapsible tools; reply via the main composer fires `POST /reply`.

## Verification note

API + reconstruction are fully unit-tested (gate this PR). The frontend JS was `node --check`-validated; the browser test follows the repo's `[browser, slow]` pattern (needs a live server, not run by pre-push) and couldn't be executed here (the systemd server is down).

## Review focus

- `_reconstruct_conversation` correctness for both sources (messages table vs managed transcript).
- Composer mode-switch (`sendMessage` → `sendThreadReply` when a thread is open) and `newChat`/`exitAgentThread` clearing thread state.
- The poll-for-resumed-output loop bounds (stops on terminal status / thread switch / 60 tries).