### PR TITLE
feat(agent-viz): label Claude Code sessions by their /rename title

### DIFF
--- a/api/services/claude_code/session_ingest.py
+++ b/api/services/claude_code/session_ingest.py
@@ -459,11 +459,25 @@ def parse_session(
     last_user_text = ""
     model = ""
     subagents: list[dict[str, Any]] = []
+    # Session titles written by the CLI as their own record types (dropped from
+    # the normalized event stream as noise, but captured here for labeling):
+    #   custom-title → the user's explicit `/rename` value (`customTitle`)
+    #   ai-title     → the CLI's auto-generated summary title (`aiTitle`)
+    # Latest record of each wins (they're appended over the session's life).
+    custom_title = ""
+    ai_title = ""
     # Track open tool_use ids so we can decide if the last assistant turn
     # is "waiting on a tool result" (yielded) vs. final.
     open_tool_uses: set[str] = set()
 
     for raw in _iter_lines(meta.jsonl_path):
+        rtype = raw.get("type")
+        if rtype == "custom-title":
+            custom_title = (raw.get("customTitle") or "").strip() or custom_title
+            continue
+        if rtype == "ai-title":
+            ai_title = (raw.get("aiTitle") or "").strip() or ai_title
+            continue
         ev = normalize_event(raw)
         if ev is None:
             continue
@@ -550,10 +564,17 @@ def parse_session(
         now=now,
         has_live_process=False,
     )
-    # Choose a label: prefer the most recent user prompt (truncated); fall
-    # back to the working-directory basename so the node is at least
-    # locatable. Falls back to session_id last.
-    if last_user_text:
+    # Choose a label, most human-intentful first:
+    #   1. the user's explicit `/rename` (custom-title) — always wins
+    #   2. the CLI's auto-generated summary title (ai-title)
+    #   3. the most recent user prompt (truncated)
+    #   4. the working-directory basename, so the node is at least locatable
+    #   5. the raw session id as a last resort
+    if custom_title:
+        meta.label = _truncate(custom_title.replace("\n", " "), 60)
+    elif ai_title:
+        meta.label = _truncate(ai_title.replace("\n", " "), 60)
+    elif last_user_text:
         meta.label = _truncate(last_user_text.replace("\n", " "), 60)
     elif meta.decoded_cwd:
         meta.label = basename_for(meta.decoded_cwd)

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-27
+> **Last Updated:** 2026-05-28
 
 Engineering view of the `/agents` page — endpoint shapes, ingest paths, status inference, layout, and security boundaries. For the consumer view see [product/agent-viz.md](../product/agent-viz.md).
 
@@ -146,6 +146,8 @@ Event normalization (`normalize_event`) maps three Claude Code message types int
 - **assistant** → `assistant_text`, `tool_call`, `extended_thinking`. Usage block is summed into the session totals (input, output, cache_creation @ 1.25× the input rate, cache_read @ 0.10×).
 - **user** → `user_message` (operator's text input) or `tool_result` (model's tool-call response). Tool results are truncated to 240 chars.
 - **system** → `system_message`. Permission-mode changes etc. are dropped as noise.
+
+**Session label precedence.** `parse_session` picks a Claude Code session's display label, most human-intentful first: the user's explicit `/rename` (the CLI's `custom-title` record → `customTitle`), then the CLI's auto-generated `ai-title` (`aiTitle`), then the most recent user prompt (truncated to 60), then the working-directory basename, then the raw session id. The `custom-title` / `ai-title` records are dropped from the normalized *event* stream as noise but read here for labeling; the latest record of each kind wins.
 
 Subagent spawns are detected when an assistant message contains a `tool_use` block with `name in {"Agent", "Task"}`. Each such tool-use becomes a synthetic session node — `subagent_session_dict(parent, subagent)` — with id `<parent>:agent:<tool_use_id>` and a spawn edge from the parent. These nodes don't have their own jsonl; clicking one currently loads the parent's transcript (filtered-by-tool-use-id is future work).
 

--- a/tests/test_claude_code_ingest.py
+++ b/tests/test_claude_code_ingest.py
@@ -272,6 +272,58 @@ def test_parse_session_sums_tokens_and_cost(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
+# Label precedence (session /rename → custom-title)
+# ---------------------------------------------------------------------------
+
+
+def test_label_prefers_custom_title_from_rename(tmp_path: Path):
+    """A user `/rename` (custom-title record) wins over ai-title and prompt."""
+    proj = tmp_path / "-home-syn-Code-A"
+    path = proj / "s-rename.jsonl"
+    _write_jsonl(path, [
+        _user_event("debug the flaky payment webhook for a while"),
+        {"type": "ai-title", "aiTitle": "Payment webhook debugging", "sessionId": "x"},
+        {"type": "custom-title", "customTitle": "chat-integration", "sessionId": "x"},
+    ])
+    meta, _ = cc.parse_session(cc.discover_sessions(projects_dir=tmp_path)[0])
+    assert meta.label == "chat-integration"
+
+
+def test_label_falls_back_to_ai_title(tmp_path: Path):
+    """With no /rename, the CLI's ai-title beats the raw last prompt."""
+    proj = tmp_path / "-home-syn-Code-A"
+    path = proj / "s-aititle.jsonl"
+    _write_jsonl(path, [
+        _user_event("debug the flaky payment webhook for a while"),
+        {"type": "ai-title", "aiTitle": "Payment webhook debugging", "sessionId": "x"},
+    ])
+    meta, _ = cc.parse_session(cc.discover_sessions(projects_dir=tmp_path)[0])
+    assert meta.label == "Payment webhook debugging"
+
+
+def test_label_latest_custom_title_wins(tmp_path: Path):
+    """A later /rename overrides an earlier one."""
+    proj = tmp_path / "-home-syn-Code-A"
+    path = proj / "s-rerename.jsonl"
+    _write_jsonl(path, [
+        {"type": "custom-title", "customTitle": "first name", "sessionId": "x"},
+        _user_event("hello"),
+        {"type": "custom-title", "customTitle": "second name", "sessionId": "x"},
+    ])
+    meta, _ = cc.parse_session(cc.discover_sessions(projects_dir=tmp_path)[0])
+    assert meta.label == "second name"
+
+
+def test_label_falls_back_to_last_prompt_without_titles(tmp_path: Path):
+    """Unchanged behavior when there are no title records."""
+    proj = tmp_path / "-home-syn-Code-A"
+    path = proj / "s-plain.jsonl"
+    _write_jsonl(path, [_user_event("summarize my unread emails")])
+    meta, _ = cc.parse_session(cc.discover_sessions(projects_dir=tmp_path)[0])
+    assert meta.label == "summarize my unread emails"
+
+
+# ---------------------------------------------------------------------------
 # Status inference
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The `/agents` page labels Claude Code sessions by their raw last user prompt. Claude Code actually persists a session `/rename` as a `custom-title` record (`customTitle`) in the session JSONL — and its auto-summary as `ai-title` (`aiTitle`). The ingest already reads these files but discarded both as noise. This makes an explicit `/rename` the session's label.

Relates to #233.

## What changed

`api/services/claude_code/session_ingest.py` — `parse_session` now captures the `custom-title` / `ai-title` records (latest of each wins) and picks the label most human-intentful first:

**custom-title (`/rename`) → ai-title (auto-summary) → last user prompt → cwd basename → session id**

The title records are still dropped from the normalized *event* stream (they're not timeline events) — they're only read for labeling.

## Test evidence

- `pytest -m "unit and not slow" tests/` (pre-push gate): passed.
- New tests in `test_claude_code_ingest.py`: custom-title wins over ai-title + prompt; ai-title falls back over prompt; latest custom-title wins; unchanged prompt fallback when no titles.

## Review focus

- Label precedence order (is ai-title outranking the last prompt the behavior we want? — yes: both titles are more label-like than a raw prompt).
- Capturing the records before `normalize_event` drops them as noise.