### PR TITLE
fix(agent-viz): stop summary prefetch starving on no-content sessions

### DIFF
--- a/api/services/agent_viz_summary.py
+++ b/api/services/agent_viz_summary.py
@@ -386,13 +386,23 @@ async def summarize_session(
         return disk_hit
 
     ctx = _extract_context(events)
-    # If we have nothing to summarize, return a deterministic fallback so the
-    # UI still gets *something*. Don't cache (next time we may have content).
+    # Nothing to summarize: return a deterministic fallback so the UI still
+    # gets *something*. A terminal session will never gain content, so cache
+    # the fallback to keep it out of the prefetch candidate list forever; a
+    # live session might produce content later, so leave it uncached and let
+    # the next access retry.
     if not ctx["first_user"] and not ctx["final_assistant"] and not ctx["prs"]:
-        return SummaryResult(
+        result = SummaryResult(
             short_label=_fallback_label(label),
             summary="(No transcript content yet.)",
         )
+        if _is_terminal(status):
+            now = time.time()
+            if len(_cache) >= _CACHE_MAX:
+                _cache.pop(next(iter(_cache)))
+            _cache[session_id] = (last_activity_at, now, result)
+            _disk_put(session_id, last_activity_at, result)
+        return result
 
     prompt = _build_prompt(label, ctx)
     try:

--- a/api/services/agent_viz_summary_prefetch.py
+++ b/api/services/agent_viz_summary_prefetch.py
@@ -153,8 +153,15 @@ async def _prefetch_loop() -> None:
                         "agent_viz prefetch: summarized %s in %.1fs",
                         sid, elapsed,
                     )
-                else:
-                    cooldown[sid] = tick + _FAILURE_BACKOFF_TICKS
+                # Park every attempted session, success or failure. A real
+                # summary drops out of the candidate list on its own (it now
+                # has a cached short_label), so the cooldown only matters for a
+                # session that "succeeds" without producing a cacheable label —
+                # e.g. a live transcript with only tool calls and no
+                # user/assistant text. Without a cooldown such a session sorts
+                # first every tick, gets re-picked in ~0s, and starves every
+                # other candidate behind it.
+                cooldown[sid] = tick + _FAILURE_BACKOFF_TICKS
                 # Only do one per tick — keeps Gemma queue shallow.
                 break
         except asyncio.CancelledError:

--- a/tests/test_agent_viz_api.py
+++ b/tests/test_agent_viz_api.py
@@ -434,3 +434,55 @@ def test_search_endpoint_requires_query(client, summary_db):
     # The app maps RequestValidationError to 400 (see api/main.py).
     assert client.get("/api/agents/search").status_code == 400
     assert client.get("/api/agents/search", params={"q": ""}).status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# No-content fallback caching. A session whose transcript carries no
+# user/assistant text (only a seed + tool calls — the real agent-worker case)
+# hits the deterministic fallback in summarize_session. A *terminal* such
+# session must cache the fallback so it drops out of the prefetch candidate
+# list; otherwise the prefetch loop re-picks it every tick in ~0s and starves
+# every other candidate behind it (head-of-line starvation).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_no_content_terminal_session_caches_fallback(summary_db):
+    import asyncio
+    from api.services import agent_viz_summary as avs
+
+    sid = "sess_nocontent_terminal"
+    # Only a seed (task_id) + tool calls — no user/assistant text. This is the
+    # shape that produced the production starvation bug.
+    events = [
+        {"kind": "seed", "payload": {"task_id": "t1"}},
+        {"kind": "tool_call", "payload": {"tool": "Bash"}},
+    ]
+    result = asyncio.run(avs.summarize_session(
+        sid, label="Clean Up The Indexer", last_activity_at=1000.0,
+        events=events, status=STATUS_COMPLETED,
+    ))
+    # Fallback derived from the label — no LLM call.
+    assert result.short_label == "Clean Up The Indexer"
+    # Cached, so the snapshot peek returns it and the session drops out of the
+    # prefetch candidate list instead of being re-picked forever.
+    cached = avs.get_cached_summary(sid, 1000.0, status=STATUS_COMPLETED)
+    assert cached is not None
+    assert cached.short_label == "Clean Up The Indexer"
+
+
+@pytest.mark.unit
+def test_no_content_live_session_not_cached(summary_db):
+    import asyncio
+    from api.services import agent_viz_summary as avs
+
+    sid = "sess_nocontent_live"
+    events = [{"kind": "seed", "payload": {"task_id": "t1"}}]
+    result = asyncio.run(avs.summarize_session(
+        sid, label="Running Task", last_activity_at=1000.0,
+        events=events, status=STATUS_RUNNING,
+    ))
+    assert result.short_label == "Running Task"
+    # A live session may gain content later, so the fallback must NOT be
+    # cached — the next access should retry.
+    assert avs.get_cached_summary(sid, 1000.0, status=STATUS_RUNNING) is None


### PR DESCRIPTION
## Problem

The `/agents` summary prefetch loop was permanently stuck re-summarizing a **single** session every tick, so only a handful of sessions ever got a `short_label` and the rest sat unsummarized indefinitely. The local-model auto-naming/summarization that should run continuously behind the scenes effectively stopped.

Observed live: 168 sessions, **4 summarized, 75 pending**, with the same session id re-"summarized" in `0.0s` every 20s tick in `server.log`.

## Root cause — head-of-line starvation

A terminal agent-worker session whose transcript carries **no user/assistant text** (only a `seed` + tool calls — the real worker case) hits the no-content fallback in `summarize_session()`, which returns a deterministic label **but deliberately does not cache it**.

The prefetch loop saw this as `ok=True`, applied **no cooldown**, and `break`s after one-per-tick. Next tick the same uncached session sorted first again (terminal + recent) and got re-picked — **forever** — starving every other candidate behind it.

## Fix

- **`agent_viz_summary_prefetch.py`** — park *every* attempted session with a cooldown, not just failures, so the loop always advances. A real summary drops out of the candidate list on its own (cached `short_label`); the cooldown only matters for a session that "succeeds" without producing a cacheable label (e.g. a live tool-only transcript).
- **`agent_viz_summary.py`** — cache the no-content fallback for **terminal** sessions (they will never gain content) so they leave the candidate list for good. Live sessions stay uncached and retry on next access.

## Tests

- Adds 2 regression tests: terminal no-content session **caches** its fallback; live no-content session does **not**.
- All 24 `test_agent_viz_api.py` tests pass. Full unit suite: 2435 passed; the 9 unrelated failures are pre-existing/environment-specific (verified against clean `origin/main` with these changes stashed).

## Impact

Once deployed, the loop drains the existing ~75-session backlog at one per ~20s (~25 min), then keeps up continuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)