### PR TITLE
feat(scheduler): action model + agent hand-off

### DIFF
--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -73,6 +73,8 @@ class ScheduleEntry:
     last_triggered_at: Optional[str] = None
     next_trigger_at: Optional[str] = None
     timezone: str = ""  # resolved from settings.timezone when empty
+    last_status: str = ""  # outcome of the most recent fire (sent/suppressed/handed-off/failed)
+    last_result: str = ""  # short snippet of the most recent fire's result
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -448,8 +450,31 @@ class SchedulerStore:
             self._rewrite_line(entry)
             self._save()
 
+    def record_run(self, entry_id: str, status: str, result: str = ""):
+        """Record the outcome of the most recent fire for the dashboard.
+
+        ``last_status``/``last_result`` live only in the index cache (not the
+        markdown definition), so this just refreshes the cache and dashboard.
+        """
+        with self._lock:
+            entry = self._entries.get(entry_id)
+            if not entry:
+                return
+            entry.last_status = status
+            entry.last_result = (result or "")[:200]
+            self._save()
+
     def get_due_reminders(self) -> list[ScheduleEntry]:
-        """Return enabled schedules due to fire (90s cooldown to dedupe restarts)."""
+        """Return enabled schedules due to fire (90s cooldown to dedupe restarts).
+
+        Missed-fire policy — **run-once catch-up**: a schedule whose trigger
+        elapsed while the server was down is past-due on the next tick after
+        startup, so it fires exactly once (the 90s cooldown dedupes overlapping
+        restarts). Cron schedules then advance to their next future slot; a
+        missed one-off fires once and disables. We deliberately do not replay
+        every window missed during an outage — at most one catch-up per
+        schedule.
+        """
         now = datetime.now(timezone.utc)
         due = []
         for entry in self._entries.values():
@@ -537,6 +562,10 @@ class SchedulerStore:
             entry.created_at = prior.created_at
         if not entry.last_triggered_at:
             entry.last_triggered_at = prior.last_triggered_at
+        if not entry.last_status:
+            entry.last_status = prior.last_status
+        if not entry.last_result:
+            entry.last_result = prior.last_result
 
     # ------------------------------------------------------------------
     # Dashboard
@@ -610,13 +639,15 @@ class SchedulerStore:
         if fired:
             lines += [
                 "",
-                "| Name | Fired | Action |",
-                "|------|-------|--------|",
+                "| Name | Fired | Action | Outcome | Result |",
+                "|------|-------|--------|---------|--------|",
             ]
             for e in fired[:20]:
                 tz = e.timezone or settings.timezone
                 when = _format_dt_short(e.last_triggered_at, tz) if e.last_triggered_at else "never"
-                lines.append(f"| {e.name} | {when} | {self._action_label(e)} |")
+                outcome = e.last_status or "—"
+                result = (e.last_result or "").replace("|", "\\|").replace("\n", " ")[:80] or "—"
+                lines.append(f"| {e.name} | {when} | {self._action_label(e)} | {outcome} | {result} |")
         else:
             lines.append("\n_Nothing fired yet._")
         lines.append("")
@@ -633,11 +664,11 @@ class SchedulerScheduler:
     """
     Background thread that fires due schedules every 60 seconds.
 
-    Firing dispatch (notify/prompt/endpoint/agent generalisation) is refined in
-    #245; for now it preserves the legacy message_type behaviour:
-    - static  → send message_content via Telegram
-    - prompt  → run message_content through chat_via_api, send result
-    - endpoint→ call LifeOS API endpoint, send formatted result
+    Firing dispatches on ``entry.action`` (see ``_fire_entry``):
+    - notify   → send message_content via Telegram
+    - prompt   → run message_content through chat_via_api, send result
+    - endpoint → call LifeOS API endpoint, send formatted result
+    - agent    → write an #agent task for the agent worker to run
 
     Crash recovery:
     - Auto-restarts with exponential backoff (5s → 60s cap)
@@ -784,7 +815,7 @@ class SchedulerScheduler:
             try:
                 if self._read_control_file():
                     for entry in self.store.get_due_reminders():
-                        await self._fire_reminder(entry)
+                        await self._fire_entry(entry)
                 else:
                     logger.debug("Scheduler paused via control file")
             except Exception as e:
@@ -815,20 +846,41 @@ class SchedulerScheduler:
             logger.debug(f"Pre-meeting check failed, running pipeline: {e}")
             return False
 
-    async def _fire_reminder(self, entry: ScheduleEntry):
-        """Execute a single schedule with retry and execution logging."""
+    async def _fire_entry(self, entry: ScheduleEntry):
+        """Execute a single schedule, dispatching on ``entry.action``.
+
+        Actions:
+        - ``notify``   — send the static ``message_content`` via Telegram
+        - ``prompt``   — run ``message_content`` through the chat pipeline (with
+          retry) and send the result via Telegram
+        - ``endpoint`` — call a LifeOS API endpoint and send the formatted result
+        - ``agent``    — write an ``#agent`` task (carrying the executor tag) into
+          ``LifeOS/Tasks/Inbox.md`` so the existing agent worker runs it
+
+        For ``notify``/``prompt`` the Telegram message is suppressed when the
+        result is empty or a suppression sentinel (e.g. ``NO_MEETING``). Every
+        fire records ``last_status``/``last_result`` for the dashboard's
+        Recently-Fired section.
+        """
         import time as _time
-        logger.info(f"Firing schedule: {entry.name} ({entry.id})")
+        logger.info(f"Firing schedule: {entry.name} ({entry.id}, action={entry.action})")
 
         # Advance next_trigger_at BEFORE generating/sending to prevent
         # duplicate fires on server restart or scheduler re-entry.
         self.store.mark_triggered(entry.id)
 
-        if entry.message_type == "prompt" and self._should_skip_pre_meeting(entry):
+        if entry.action == "prompt" and self._should_skip_pre_meeting(entry):
+            self.store.record_run(entry.id, "skipped", "no upcoming meeting")
             return
 
         start = _time.monotonic()
         try:
+            if entry.action == "agent":
+                handoff = self._hand_off_to_agent(entry)
+                logger.info(f"Schedule {entry.name}: handed off to agent worker — {handoff}")
+                self.store.record_run(entry.id, "handed-off", handoff)
+                return
+
             message, exec_log = await self._generate_message(entry)
             elapsed = _time.monotonic() - start
 
@@ -841,14 +893,25 @@ class SchedulerScheduler:
                     f"{elapsed:.1f}s"
                 )
 
-            if message and not self._should_suppress(message):
+            # Generalised suppression: notify/prompt with empty or sentinel
+            # results produce no notification.
+            if entry.action in ("notify", "prompt") and (
+                not message or self._should_suppress(message)
+            ):
+                logger.info(f"Schedule {entry.name}: suppressed (no actionable content)")
+                self.store.record_run(entry.id, "suppressed", "")
+                return
+
+            if message:
                 from api.services.telegram import send_message_async
                 await send_message_async(f"*{entry.name}*\n\n{message}")
-            elif message and self._should_suppress(message):
-                logger.info(f"Schedule {entry.name}: suppressed (no actionable content)")
+                self.store.record_run(entry.id, "sent", message[:200])
+            else:
+                self.store.record_run(entry.id, "empty", "")
         except Exception as e:
             elapsed = _time.monotonic() - start
             logger.error(f"Failed to fire schedule {entry.id} after {elapsed:.1f}s: {e}")
+            self.store.record_run(entry.id, "failed", str(e)[:200])
             try:
                 from api.services.telegram import send_message_async
                 await send_message_async(
@@ -858,16 +921,36 @@ class SchedulerScheduler:
             except Exception:
                 logger.error(f"Failed to send error notification for schedule {entry.id}")
 
+    # Back-compat alias: the HTTP trigger route and older tests call _fire_reminder.
+    _fire_reminder = _fire_entry
+
+    def _hand_off_to_agent(self, entry: ScheduleEntry) -> str:
+        """Write an ``#agent`` task so the existing agent worker runs the prompt.
+
+        The schedule's executor tag (``local`` / ``cloud`` / ``cloud-haiku`` /
+        ``cloud-sonnet``) is passed straight through as a task tag — the agent
+        worker's preflight routes on it, so no new execution path is needed.
+        """
+        from api.services.task_manager import get_task_manager
+        tags = ["agent"]
+        if entry.executor:
+            tags.append(entry.executor.lstrip("#"))
+        task = get_task_manager().create(
+            description=entry.message_content or entry.name,
+            tags=tags,
+        )
+        return f"task {task.id} (tags: {', '.join('#' + t for t in tags)})"
+
     async def _generate_message(self, entry: ScheduleEntry) -> tuple[Optional[str], Optional[dict]]:
-        """Generate the message content for a schedule."""
-        if entry.message_type == "static":
+        """Generate the message content for a schedule, dispatching on action."""
+        if entry.action == "notify":
             return entry.message_content, None
-        elif entry.message_type == "prompt":
+        elif entry.action == "prompt":
             return await self._execute_prompt_reminder(entry)
-        elif entry.message_type == "endpoint":
+        elif entry.action == "endpoint":
             return await self._call_endpoint(entry.endpoint_config), None
         else:
-            logger.warning(f"Unknown message type: {entry.message_type}")
+            logger.warning(f"Unsupported action for message generation: {entry.action}")
             return None, None
 
     async def _execute_prompt_reminder(

--- a/tests/test_scheduler_store.py
+++ b/tests/test_scheduler_store.py
@@ -7,7 +7,7 @@ the auto-generated dashboard.
 """
 import pytest
 from datetime import datetime, timezone, timedelta
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 from api.services.scheduler_store import (
     SchedulerStore,
@@ -413,3 +413,140 @@ class TestFormatHelpers:
 
     def test_format_dt_short_handles_garbage(self):
         assert _format_dt_short("not-a-date") == "not-a-date"
+
+
+class TestActionDispatch:
+    """#245 — _fire_entry dispatches on action, records run history, hands off agents."""
+
+    @pytest.fixture
+    def scheduler(self, store):
+        return SchedulerScheduler(store)
+
+    @pytest.mark.asyncio
+    async def test_notify_sends_static_message(self, scheduler):
+        entry = scheduler.store.create(
+            name="Water plants", schedule_type="cron", schedule_value="0 18 * * *",
+            action="notify", message_type="static", message_content="hydrate the ferns",
+        )
+        with patch("api.services.telegram.send_message_async",
+                   new_callable=AsyncMock, return_value=True) as mock_send:
+            await scheduler._fire_entry(entry)
+        mock_send.assert_called_once()
+        assert "hydrate the ferns" in mock_send.call_args[0][0]
+        assert scheduler.store.get(entry.id).last_status == "sent"
+
+    @pytest.mark.asyncio
+    async def test_notify_suppressed_when_empty(self, scheduler):
+        entry = scheduler.store.create(
+            name="Empty", schedule_type="cron", schedule_value="0 9 * * *",
+            action="notify", message_type="static", message_content="",
+        )
+        with patch("api.services.telegram.send_message_async",
+                   new_callable=AsyncMock) as mock_send:
+            await scheduler._fire_entry(entry)
+        mock_send.assert_not_called()
+        assert scheduler.store.get(entry.id).last_status == "suppressed"
+
+    @pytest.mark.asyncio
+    async def test_prompt_suppressed_on_sentinel(self, scheduler):
+        entry = scheduler.store.create(
+            name="Meeting prep", schedule_type="cron", schedule_value="0 9 * * *",
+            action="prompt", message_type="prompt", message_content="check calendar",
+        )
+        mock_result = {"answer": "NO_MEETING", "tool_statuses": [], "cost_usd": 0,
+                       "model": "claude", "input_tokens": 1, "output_tokens": 1}
+        with patch("api.services.telegram.chat_via_api_with_log",
+                   new_callable=AsyncMock, return_value=mock_result):
+            with patch("api.services.telegram.send_message_async",
+                       new_callable=AsyncMock) as mock_send:
+                await scheduler._fire_entry(entry)
+        mock_send.assert_not_called()
+        assert scheduler.store.get(entry.id).last_status == "suppressed"
+
+    @pytest.mark.asyncio
+    async def test_agent_action_creates_tagged_task(self, scheduler):
+        entry = scheduler.store.create(
+            name="Weekly review", schedule_type="cron", schedule_value="0 9 * * 6",
+            action="agent", executor="cloud", message_content="Draft my weekly review",
+        )
+        fake_task = MagicMock(id="task42")
+        fake_tm = MagicMock()
+        fake_tm.create.return_value = fake_task
+        with patch("api.services.task_manager.get_task_manager", return_value=fake_tm):
+            with patch("api.services.telegram.send_message_async",
+                       new_callable=AsyncMock) as mock_send:
+                await scheduler._fire_entry(entry)
+        # The agent worker discovers #agent tasks; the executor tag rides along.
+        fake_tm.create.assert_called_once()
+        kwargs = fake_tm.create.call_args.kwargs
+        assert kwargs["description"] == "Draft my weekly review"
+        assert kwargs["tags"] == ["agent", "cloud"]
+        # No Telegram for an agent hand-off; the worker reports through its channel.
+        mock_send.assert_not_called()
+        refreshed = scheduler.store.get(entry.id)
+        assert refreshed.last_status == "handed-off"
+        assert "task42" in refreshed.last_result
+
+    @pytest.mark.asyncio
+    async def test_agent_action_local_executor_tag(self, scheduler):
+        entry = scheduler.store.create(
+            name="Local job", schedule_type="cron", schedule_value="0 9 * * *",
+            action="agent", executor="local", message_content="summarize inbox",
+        )
+        fake_tm = MagicMock()
+        fake_tm.create.return_value = MagicMock(id="t1")
+        with patch("api.services.task_manager.get_task_manager", return_value=fake_tm):
+            await scheduler._fire_entry(entry)
+        assert fake_tm.create.call_args.kwargs["tags"] == ["agent", "local"]
+
+    @pytest.mark.asyncio
+    async def test_run_history_surfaced_in_dashboard(self, scheduler):
+        entry = scheduler.store.create(
+            name="Briefing", schedule_type="cron", schedule_value="0 9 * * *",
+            action="notify", message_type="static", message_content="Good morning",
+        )
+        with patch("api.services.telegram.send_message_async",
+                   new_callable=AsyncMock, return_value=True):
+            await scheduler._fire_entry(entry)
+        dashboard = (scheduler.store.scheduler_dir / "Dashboard.md").read_text(encoding="utf-8")
+        rf = dashboard.split("## Recently Fired", 1)[1]
+        assert "Briefing" in rf
+        assert "sent" in rf  # outcome column
+
+    @pytest.mark.asyncio
+    async def test_failed_fire_records_failure(self, scheduler):
+        entry = scheduler.store.create(
+            name="Breaks", schedule_type="cron", schedule_value="0 9 * * *",
+            action="prompt", message_type="prompt", message_content="x",
+        )
+        with patch.object(scheduler, "_generate_message",
+                          new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+            with patch("api.services.telegram.send_message_async",
+                       new_callable=AsyncMock, return_value=True) as mock_send:
+                await scheduler._fire_entry(entry)
+        assert scheduler.store.get(entry.id).last_status == "failed"
+        assert "(failed)" in mock_send.call_args[0][0]
+
+    def test_fire_reminder_alias_exists(self, scheduler):
+        # Back-compat: the HTTP trigger route still calls _fire_reminder.
+        assert scheduler._fire_reminder == scheduler._fire_entry
+
+
+class TestMissedFire:
+    """Run-once catch-up: a missed trigger fires once, then advances."""
+
+    def test_missed_cron_is_due_once_then_advances(self, store):
+        past = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        entry = store.create(name="Missed", schedule_type="cron", schedule_value="0 9 * * *",
+                             action="notify", message_type="static", message_content="x")
+        entry.next_trigger_at = past  # simulate a window missed while down
+        # First tick after startup: due exactly once.
+        due = store.get_due_reminders()
+        assert [e.id for e in due] == [entry.id]
+        # Firing advances the trigger into the future and stamps last_triggered.
+        store.mark_triggered(entry.id)
+        refreshed = store.get(entry.id)
+        assert refreshed.next_trigger_at is not None
+        assert datetime.fromisoformat(refreshed.next_trigger_at) > datetime.now(timezone.utc)
+        # No duplicate catch-up: not due again (advanced + within cooldown).
+        assert store.get_due_reminders() == []

--- a/tests/test_scheduler_watcher.py
+++ b/tests/test_scheduler_watcher.py
@@ -102,11 +102,16 @@ class TestEndToEnd:
                                    on_change=store.reindex_file)
         watcher.start()
         try:
+            # Let the observer thread spin up before editing (it can be starved
+            # under heavy parallel test load, so give it a moment).
+            time.sleep(0.2)
             content = store.inbox_path.read_text(encoding="utf-8")
             patched = content.replace("[cron:: 0 9 * * *]", "[cron:: 0 10 * * *]")
             store.inbox_path.write_text(patched, encoding="utf-8")
 
-            for _ in range(50):
+            # Generous poll window (~6s) so the filesystem event + debounce can
+            # land even when CPUs are saturated by xdist workers.
+            for _ in range(120):
                 if store.get(entry.id).schedule_value == "0 10 * * *":
                     break
                 time.sleep(0.05)


### PR DESCRIPTION
## Summary

Generalizes what happens when a schedule fires and adds the new `agent` action that bridges Scheduler → Tasks → agent worker (sub-issue 2 of 4, #242).

`_fire_reminder` → **`_fire_entry`**, dispatching on `entry.action`:
- **notify** — send static `message_content` via Telegram (= old `static`)
- **prompt** — run the chat pipeline (with retry) and send the result (= old `prompt`)
- **endpoint** — call a LifeOS API endpoint and send the formatted result (= old `endpoint`)
- **agent** — *new*: write an `#agent` task carrying the schedule's executor tag (`#local`/`#cloud`/`#cloud-haiku`/`#cloud-sonnet`) and the prompt as the description into `LifeOS/Tasks/Inbox.md` via `TaskManager`. The **existing agent worker** discovers and routes it via preflight — no new execution path.

Also:
- **Generalized suppression**: `notify`/`prompt` suppress the Telegram message when the result is empty *or* a sentinel (`NO_MEETING`, `NOTHING_TO_REPORT`, …).
- **Run history**: each fire records `last_status` + `last_result`, surfaced in the dashboard's **Recently Fired** section (Outcome / Result columns).
- **Missed-fire policy** (documented in `get_due_reminders`): **run-once catch-up** — a trigger missed while the server was down fires once on the next tick (deduped by the 90s cooldown), then advances; we do not replay every missed window.
- `_fire_reminder` kept as a back-compat alias (the HTTP trigger route still calls it until #246).

Closes #245

## Test evidence

- New `TestActionDispatch` + `TestMissedFire` in `tests/test_scheduler_store.py`: notify send/suppress-empty, prompt sentinel-suppress, agent hand-off creates `["agent", <executor>]`-tagged task (no Telegram), run-history in dashboard, failure recording, `_fire_reminder` alias, run-once catch-up — 49 passed.
- Existing scheduler/audit/route/e2e suites green; full pre-push unit suite: **1675 passed, 8 skipped**.
- Watcher E2E hardened against parallel-load timing (observer spin-up + 6s poll window).

## Review focus

- `_fire_entry` dispatch + generalized suppression for notify/prompt.
- `_hand_off_to_agent` tag passthrough — confirm `["agent", executor]` matches the worker's `tag=agent` filter + preflight routing.
- Run-history persistence (`record_run`) and merge-by-ID preservation across reindex.
- Missed-fire policy correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)