### PR TITLE
feat(chat): show local/cloud indicator on agent threads

### DIFF
--- a/tests/test_agent_threads_ui_browser.py
+++ b/tests/test_agent_threads_ui_browser.py
@@ -66,10 +66,12 @@ class TestAgentThreadsUI:
                 "session_id": "sess_done", "task_id": "op_done",
                 "parent_session_id": None, "status": "completed",
                 "label": "draft the landlord email", "resumable": True,
+                "routing": "claude", "model_label": "Sonnet",
             }],
             "detail": {
                 "thread": {"session_id": "sess_done", "task_id": "op_done", "status": "completed",
-                           "label": "draft the landlord email", "resumable": True},
+                           "label": "draft the landlord email", "resumable": True,
+                           "routing": "claude", "model_label": "Sonnet"},
                 "conversation": [
                     {"role": "user", "text": "draft the landlord email", "tools": []},
                     {"role": "assistant", "text": "Here's a draft for you.",
@@ -86,6 +88,14 @@ class TestAgentThreadsUI:
         expect(page.locator("#agentsThreadsList .agent-thread")).to_have_count(1)
         expect(page.locator(".agent-badge.completed")).to_be_visible()
         expect(page.locator(".agent-thread-label")).to_contain_text("landlord")
+
+    def test_thread_shows_cloud_local_route_indicator(self, page: Page):
+        # routing="claude" → a cloud badge in the panel.
+        expect(page.locator("#agentsThreadsList .agent-route.cloud")).to_be_visible()
+        expect(page.locator("#agentsThreadsList .agent-route.cloud")).to_contain_text("cloud")
+        # And in the thread banner once opened.
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        expect(page.locator(".agent-thread-banner .agent-route.cloud")).to_be_visible(timeout=8000)
 
     def test_composer_has_run_as_agent_controls(self, page: Page):
         expect(page.locator("#agentRouting")).to_be_visible()

--- a/web/index.html
+++ b/web/index.html
@@ -2497,6 +2497,9 @@
         .agent-thread.active { background: rgba(45,95,163,0.25); outline: 1px solid #2d5fa3; }
         .agent-thread-top { display: flex; align-items: center; gap: 0.4rem; }
         .agent-thread-label { flex: 1; font-size: 0.82rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .agent-route { font-size: 0.62rem; padding: 0.1rem 0.4rem; border-radius: 999px; white-space: nowrap; }
+        .agent-route.cloud { background: #2a2140; color: #c4a7ff; }
+        .agent-route.local { background: #1f3a33; color: #7fe0c4; }
         .agent-badge { font-size: 0.64rem; padding: 0.1rem 0.4rem; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.03em; }
         .agent-badge.running { background: #1e3a5f; color: #7fb4ff; }
         .agent-badge.completed { background: #1e4620; color: #7ad17f; }
@@ -2956,6 +2959,17 @@
             } catch (e) { /* worker/API offline — leave the panel as-is */ }
         }
 
+        // Local (Gemma) vs cloud (Claude/Managed Agents) indicator for an agent
+        // thread, derived from its routing. `model_label` (Sonnet/Opus/…) is the
+        // tooltip. Returns '' for unknown routing.
+        function routeBadgeHtml(routing, modelLabel) {
+            const r = (routing || '').toString();
+            const tip = escapeHtml((modelLabel || (r === 'claude' ? 'Cloud' : 'Local')).toString());
+            if (r === 'claude') return '<span class="agent-route cloud" title="' + tip + '">☁ cloud</span>';
+            if (r === 'local') return '<span class="agent-route local" title="' + tip + '">🖥 local</span>';
+            return '';
+        }
+
         function renderAgentThreads(threads) {
             const list = document.getElementById('agentsThreadsList');
             if (!list) return;
@@ -2979,6 +2993,7 @@
                 div.innerHTML =
                     '<div class="agent-thread-top">' +
                         '<span class="agent-thread-label" title="' + labelAttr + '">' + label + '</span>' +
+                        routeBadgeHtml(t.routing, t.model_label) +
                         '<span class="agent-badge ' + escapeHtml(status) + '">' + (escapeHtml(status) || '?') + '</span>' +
                     '</div>';
                 list.appendChild(div);
@@ -3003,6 +3018,8 @@
                 resumable: !!thread.resumable,
                 label: (thread.label || sessionId).toString(),
                 status: (thread.status || '').toString(),
+                routing: (thread.routing || '').toString(),
+                modelLabel: (thread.model_label || '').toString(),
                 convCount: conversation.length,
             };
             chatTitle.textContent = '🧵 ' + currentAgentThread.label;
@@ -3022,7 +3039,8 @@
                 ? 'Replies below continue this thread.'
                 : 'This thread is ' + escapeHtml(t.status || '') + ' — read-only until it finishes.';
             banner.innerHTML =
-                '🧵 Agent thread · <strong>' + escapeHtml(t.label || '') + '</strong> — ' + cont +
+                '🧵 Agent thread ' + routeBadgeHtml(t.routing, t.modelLabel) +
+                ' · <strong>' + escapeHtml(t.label || '') + '</strong> — ' + cont +
                 ' <button class="agent-thread-exit" onclick="exitAgentThread()">Exit to chat</button>';
             messagesEl.appendChild(banner);
 


### PR DESCRIPTION
## Summary

Agent threads run either locally (Gemma) or in the cloud (Claude / Managed Agents), but the `/chat` Agents panel didn't surface which. This adds a small **🖥 local / ☁ cloud** badge (model name on hover) to each thread in the panel and to the open-thread banner.

Relates to #233 / #236.

## What changed

Frontend-only (`web/index.html`): a `routeBadgeHtml(routing, modelLabel)` helper renders the badge from the `routing` / `model_label` fields **already returned** by `GET /api/agents/threads` — no API change. Added to the thread list item and threaded through `currentAgentThread` into the open-thread banner. Small CSS for the cloud/local badge colors.

## Test evidence

- `pytest -m "unit and not slow" tests/` (pre-push gate): passed (no backend change; API tests unaffected).
- Browser test (`[browser, slow]`, route-mocked) updated: a `routing="claude"` thread shows a `.agent-route.cloud` badge in the panel and in the banner after opening.
- Frontend JS `node --check`-validated.

## Review focus

- `routeBadgeHtml` escaping (model_label into a `title=` attribute) and the `local`/`claude`/other mapping.