### PR TITLE
feat(scheduler): API + MCP surface rename with back-compat

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -32,7 +32,7 @@ from fastapi.exceptions import RequestValidationError
 from pathlib import Path
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, tasks, monarch, jobs, perf, agents, vault
+from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, jobs, perf, agents, vault
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -218,6 +218,7 @@ app.include_router(crm.router)
 app.include_router(slack.router)
 app.include_router(photos.router)
 app.include_router(reminders.router)
+app.include_router(scheduler.router)
 app.include_router(tasks.router)
 app.include_router(monarch.router)
 app.include_router(jobs.router)

--- a/api/routes/reminders.py
+++ b/api/routes/reminders.py
@@ -86,11 +86,16 @@ class SendMessageRequest(BaseModel):
 
 # ---------------------------------------------------------------------------
 # Routes (static paths MUST come before {reminder_id} to avoid capture)
+#
+# DEPRECATED: this surface is an alias kept for back-compat. New code should
+# use /api/scheduler (see api/routes/scheduler.py). It shares the same
+# underlying store, so reminders and schedules are the same records.
 # ---------------------------------------------------------------------------
 
 @router.post("", response_model=ReminderResponse)
 async def create_reminder(request: CreateReminderRequest):
-    """Create a new scheduled reminder."""
+    """Create a new scheduled reminder. DEPRECATED — use POST /api/scheduler."""
+    logger.warning("DEPRECATED /api/reminders POST — use /api/scheduler instead")
     if request.schedule_type not in ("once", "cron"):
         raise HTTPException(status_code=400, detail="schedule_type must be 'once' or 'cron'")
     if request.message_type not in ("static", "prompt", "endpoint"):

--- a/api/routes/scheduler.py
+++ b/api/routes/scheduler.py
@@ -1,0 +1,212 @@
+"""
+Scheduler API routes for LifeOS.
+
+CRUD endpoints for schedules (trigger + action) plus ad-hoc Telegram messaging.
+Replaces the legacy ``/api/reminders`` surface (kept as a deprecated alias in
+``api/routes/reminders.py``). A schedule binds a trigger (``once``/``cron``) to
+an ``action`` (notify / prompt / endpoint / agent).
+"""
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from api.services.scheduler_store import (
+    get_scheduler_store,
+    get_scheduler,
+    ScheduleEntry,
+    VALID_ACTIONS,
+)
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/scheduler", tags=["scheduler"])
+
+# Legacy message_type ↔ action, for callers still sending message_type.
+_TYPE_TO_ACTION = {"static": "notify", "prompt": "prompt", "endpoint": "endpoint"}
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+class CreateScheduleRequest(BaseModel):
+    name: str = Field(..., min_length=1, description="Human-readable name")
+    schedule_type: str = Field(..., description="'once' or 'cron'")
+    schedule_value: str = Field(..., description="ISO datetime (once) or cron expression (cron)")
+    action: Optional[str] = Field(default=None, description="notify | prompt | endpoint | agent")
+    message_type: Optional[str] = Field(default=None, description="Legacy: static | prompt | endpoint")
+    message_content: str = Field(default="", description="Static text or natural-language prompt")
+    endpoint_config: Optional[dict] = Field(default=None, description="For endpoint action: {endpoint, method, params}")
+    executor: str = Field(default="", description="For agent action: local | cloud | cloud-haiku | cloud-sonnet")
+    enabled: bool = Field(default=True)
+    timezone: str = Field(default_factory=lambda: settings.timezone, description="IANA timezone for the schedule")
+
+
+class UpdateScheduleRequest(BaseModel):
+    name: Optional[str] = None
+    schedule_type: Optional[str] = None
+    schedule_value: Optional[str] = None
+    action: Optional[str] = None
+    message_type: Optional[str] = None
+    message_content: Optional[str] = None
+    endpoint_config: Optional[dict] = None
+    executor: Optional[str] = None
+    enabled: Optional[bool] = None
+    timezone: Optional[str] = None
+
+
+class ScheduleResponse(BaseModel):
+    id: str
+    name: str
+    schedule_type: str
+    schedule_value: str
+    action: str
+    message_type: str
+    message_content: str
+    endpoint_config: Optional[dict]
+    executor: str
+    enabled: bool
+    created_at: str
+    last_triggered_at: Optional[str]
+    next_trigger_at: Optional[str]
+    last_status: str
+    timezone: str
+
+    @classmethod
+    def from_entry(cls, e: ScheduleEntry) -> "ScheduleResponse":
+        return cls(
+            id=e.id,
+            name=e.name,
+            schedule_type=e.schedule_type,
+            schedule_value=e.schedule_value,
+            action=e.action,
+            message_type=e.message_type,
+            message_content=e.message_content,
+            endpoint_config=e.endpoint_config,
+            executor=e.executor,
+            enabled=e.enabled,
+            created_at=e.created_at or "",
+            last_triggered_at=e.last_triggered_at,
+            next_trigger_at=e.next_trigger_at,
+            last_status=e.last_status,
+            timezone=e.timezone or settings.timezone,
+        )
+
+
+class ScheduleListResponse(BaseModel):
+    schedules: list[ScheduleResponse]
+    total: int
+
+
+class SendMessageRequest(BaseModel):
+    text: str = Field(..., min_length=1, description="Message text to send via Telegram")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_action(action: Optional[str], message_type: Optional[str]) -> str:
+    """Resolve the action from an explicit value or the legacy message_type."""
+    if action:
+        return action
+    return _TYPE_TO_ACTION.get(message_type or "", "notify")
+
+
+# ---------------------------------------------------------------------------
+# Routes (static paths MUST come before {schedule_id} to avoid capture)
+# ---------------------------------------------------------------------------
+
+@router.post("", response_model=ScheduleResponse)
+async def create_schedule(request: CreateScheduleRequest):
+    """Create a new schedule."""
+    if request.schedule_type not in ("once", "cron"):
+        raise HTTPException(status_code=400, detail="schedule_type must be 'once' or 'cron'")
+    action = _resolve_action(request.action, request.message_type)
+    if action not in VALID_ACTIONS:
+        raise HTTPException(status_code=400, detail=f"action must be one of {VALID_ACTIONS}")
+
+    store = get_scheduler_store()
+    entry = store.create(
+        name=request.name,
+        schedule_type=request.schedule_type,
+        schedule_value=request.schedule_value,
+        action=action,
+        message_type=request.message_type or ("static" if action == "notify" else action),
+        message_content=request.message_content,
+        endpoint_config=request.endpoint_config,
+        executor=request.executor,
+        enabled=request.enabled,
+        timezone=request.timezone,
+    )
+    return ScheduleResponse.from_entry(entry)
+
+
+@router.get("", response_model=ScheduleListResponse)
+async def list_schedules():
+    """List all schedules."""
+    store = get_scheduler_store()
+    entries = store.list_all()
+    return ScheduleListResponse(
+        schedules=[ScheduleResponse.from_entry(e) for e in entries],
+        total=len(entries),
+    )
+
+
+@router.post("/send")
+async def send_adhoc_message(request: SendMessageRequest):
+    """Send an ad-hoc message via Telegram."""
+    from api.services.telegram import send_message_async
+
+    if not settings.telegram_enabled:
+        raise HTTPException(status_code=400, detail="Telegram not configured")
+
+    success = await send_message_async(request.text)
+    if not success:
+        raise HTTPException(status_code=500, detail="Failed to send Telegram message")
+    return {"status": "sent"}
+
+
+@router.get("/{schedule_id}", response_model=ScheduleResponse)
+async def get_schedule(schedule_id: str):
+    """Get a specific schedule by ID."""
+    store = get_scheduler_store()
+    entry = store.get(schedule_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    return ScheduleResponse.from_entry(entry)
+
+
+@router.put("/{schedule_id}", response_model=ScheduleResponse)
+async def update_schedule(schedule_id: str, request: UpdateScheduleRequest):
+    """Update an existing schedule."""
+    store = get_scheduler_store()
+    updates = {k: v for k, v in request.model_dump().items() if v is not None}
+    entry = store.update(schedule_id, **updates)
+    if not entry:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    return ScheduleResponse.from_entry(entry)
+
+
+@router.delete("/{schedule_id}")
+async def delete_schedule(schedule_id: str):
+    """Delete a schedule."""
+    store = get_scheduler_store()
+    if not store.delete(schedule_id):
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    return {"status": "deleted", "id": schedule_id}
+
+
+@router.post("/{schedule_id}/trigger")
+async def trigger_schedule(schedule_id: str):
+    """Manually fire a schedule (for testing)."""
+    store = get_scheduler_store()
+    entry = store.get(schedule_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+
+    await get_scheduler()._fire_entry(entry)
+    return {"status": "triggered", "id": schedule_id}

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -301,7 +301,7 @@ TOOL_DEFINITIONS = [
     },
     {
         "name": "manage_reminders",
-        "description": "Manage timed reminders: create or list.",
+        "description": "DEPRECATED — use manage_schedules. Manage timed reminders: create or list.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -326,6 +326,52 @@ TOOL_DEFINITIONS = [
                 "message_content": {
                     "type": "string",
                     "description": "The reminder message to send (for create).",
+                },
+            },
+            "required": ["action"],
+        },
+    },
+    {
+        "name": "manage_schedules",
+        "description": (
+            "Manage schedules: create or list. A schedule binds a trigger "
+            "(once/cron) to an action (notify/prompt/endpoint/agent). Use "
+            "action='agent' to run autonomous work on a schedule."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["create", "list"],
+                    "description": "Operation to perform.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Short schedule name/title (for create).",
+                },
+                "schedule_type": {
+                    "type": "string",
+                    "enum": ["once", "cron"],
+                    "description": "'once' for one-time, 'cron' for recurring (for create).",
+                },
+                "schedule_value": {
+                    "type": "string",
+                    "description": "ISO datetime for 'once', or cron expression for 'cron' (for create).",
+                },
+                "schedule_action": {
+                    "type": "string",
+                    "enum": ["notify", "prompt", "endpoint", "agent"],
+                    "description": "What fires: notify (static text), prompt (run chat), endpoint (call API), agent (hand off to the agent worker).",
+                },
+                "message_content": {
+                    "type": "string",
+                    "description": "Static text, natural-language prompt, or agent task description (for create).",
+                },
+                "executor": {
+                    "type": "string",
+                    "enum": ["local", "cloud", "cloud-haiku", "cloud-sonnet"],
+                    "description": "For schedule_action='agent': which executor the spawned #agent task targets.",
                 },
             },
             "required": ["action"],
@@ -563,7 +609,7 @@ async def execute_tool(name: str, tool_input: dict) -> str:
 
 
 # Sync handlers to wrap in to_thread for parallel execution
-_SYNC_HANDLERS = {"search_vault", "read_vault_file", "search_slack", "get_message_history", "person_info", "manage_tasks", "manage_reminders", "create_calendar_event", "update_calendar_event", "delete_calendar_event", "search_memories"}
+_SYNC_HANDLERS = {"search_vault", "read_vault_file", "search_slack", "get_message_history", "person_info", "manage_tasks", "manage_reminders", "manage_schedules", "create_calendar_event", "update_calendar_event", "delete_calendar_event", "search_memories"}
 
 
 async def execute_tool_parallel(name: str, tool_input: dict) -> str:
@@ -1030,12 +1076,59 @@ def _reminder_list(inp: dict) -> str:
 
 
 def _tool_manage_reminders(inp: dict):
+    # DEPRECATED alias for manage_schedules — kept for back-compat.
     action = inp["action"]
     if action == "create":
         return _reminder_create(inp)
     elif action == "list":
         return _reminder_list(inp)
     return f"Error: Unknown manage_reminders action '{action}'"
+
+
+# -- Schedule helpers --
+
+def _schedule_create(inp: dict) -> str:
+    from api.services.scheduler_store import get_scheduler_store
+    store = get_scheduler_store()
+    # `action` is the manage_schedules operation (create/list); the schedule's
+    # own action is passed as `schedule_action`.
+    action = inp.get("schedule_action") or "notify"
+    entry = store.create(
+        name=inp["name"],
+        schedule_type=inp["schedule_type"],
+        schedule_value=inp["schedule_value"],
+        action=action,
+        message_type=inp.get("message_type", "static" if action == "notify" else action),
+        message_content=inp.get("message_content", ""),
+        executor=inp.get("executor", ""),
+    )
+    label = f"{action} (#{entry.executor})" if action == "agent" and entry.executor else action
+    return (f"Schedule created: \"{entry.name}\" (id: {entry.id}, action: {label}, "
+            f"next: {entry.next_trigger_at})")
+
+
+def _schedule_list(inp: dict) -> str:
+    from api.services.scheduler_store import get_scheduler_store
+    store = get_scheduler_store()
+    entries = store.list_all()
+    if not entries:
+        return "No active schedules."
+    lines = []
+    for e in entries:
+        status = "enabled" if e.enabled else "disabled"
+        label = f"{e.action} (#{e.executor})" if e.action == "agent" and e.executor else e.action
+        lines.append(f"- \"{e.name}\" ({e.schedule_type}: {e.schedule_value}) "
+                     f"[{label}] [{status}] [id:{e.id}]")
+    return "\n".join(lines)
+
+
+def _tool_manage_schedules(inp: dict):
+    action = inp["action"]
+    if action == "create":
+        return _schedule_create(inp)
+    elif action == "list":
+        return _schedule_list(inp)
+    return f"Error: Unknown manage_schedules action '{action}'"
 
 
 async def _tool_create_email_draft(inp: dict) -> str:
@@ -1258,6 +1351,7 @@ _TOOL_HANDLERS = {
     "person_info": _tool_person_info,
     "manage_tasks": _tool_manage_tasks,
     "manage_reminders": _tool_manage_reminders,
+    "manage_schedules": _tool_manage_schedules,
     "search_finances": _tool_search_finances,
     "create_email_draft": _tool_create_email_draft,
     "create_calendar_event": _tool_create_calendar_event,
@@ -1289,6 +1383,9 @@ TOOL_STATUS_MESSAGES = {
     "manage_reminders": "Managing reminders...",
     "manage_reminders.create": "Setting reminder...",
     "manage_reminders.list": "Loading reminders...",
+    "manage_schedules": "Managing schedules...",
+    "manage_schedules.create": "Setting schedule...",
+    "manage_schedules.list": "Loading schedules...",
     "search_finances": "Checking finances...",
     "search_finances.accounts": "Loading account balances...",
     "search_finances.transactions": "Searching transactions...",

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -204,6 +204,30 @@ CURATED_ENDPOINTS = {
         "method": "DELETE",
         "path": "/api/reminders/{reminder_id}"
     },
+    "/api/scheduler:POST": {
+        "name": "lifeos_schedule_create",
+        "description": "Create a schedule. schedule_type=once|cron; action=notify|prompt|endpoint|agent (agent writes an #agent task, executor=local|cloud|cloud-haiku|cloud-sonnet).",
+        "method": "POST",
+        "path": "/api/scheduler"
+    },
+    "/api/scheduler:GET": {
+        "name": "lifeos_schedule_list",
+        "description": "List all schedules with their action, status, next trigger time, and last outcome.",
+        "method": "GET",
+        "path": "/api/scheduler"
+    },
+    "/api/scheduler/{schedule_id}:PUT": {
+        "name": "lifeos_schedule_update",
+        "description": "Update a schedule by schedule_id (from lifeos_schedule_list). Only provided fields change.",
+        "method": "PUT",
+        "path": "/api/scheduler/{schedule_id}"
+    },
+    "/api/scheduler/{schedule_id}:DELETE": {
+        "name": "lifeos_schedule_delete",
+        "description": "Delete a schedule by ID. Use lifeos_schedule_list first to find the ID.",
+        "method": "DELETE",
+        "path": "/api/scheduler/{schedule_id}"
+    },
     "/api/reminders/send": {
         "name": "lifeos_telegram_send",
         "description": "Send an immediate message via Telegram. Use for ad-hoc notifications or testing. Requires Telegram to be configured.",
@@ -674,6 +698,46 @@ class LifeOSMCPServer:
                     "reminder_id": {"type": "string", "description": "ID of the reminder to delete (from lifeos_reminder_list)"}
                 },
                 "required": ["reminder_id"]
+            },
+            "lifeos_schedule_create": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Human-readable name for the schedule"},
+                    "schedule_type": {"type": "string", "description": "'once' (ISO datetime) or 'cron' (cron expression)"},
+                    "schedule_value": {"type": "string", "description": "ISO datetime (e.g., 2026-06-03T15:05:00) or cron expression (e.g., 0 9 * * 6)"},
+                    "action": {"type": "string", "description": "'notify' (static text), 'prompt' (run chat pipeline), 'endpoint' (call API), or 'agent' (hand off to the agent worker)"},
+                    "message_content": {"type": "string", "description": "Static text, natural-language prompt, or agent task description"},
+                    "endpoint_config": {"type": "object", "description": "For action=endpoint: {endpoint, method, params}"},
+                    "executor": {"type": "string", "description": "For action=agent: 'local', 'cloud', 'cloud-haiku', or 'cloud-sonnet'"},
+                    "enabled": {"type": "boolean", "description": "Whether the schedule is active", "default": True}
+                },
+                "required": ["name", "schedule_type", "schedule_value", "action"]
+            },
+            "lifeos_schedule_list": {
+                "type": "object",
+                "properties": {}
+            },
+            "lifeos_schedule_update": {
+                "type": "object",
+                "properties": {
+                    "schedule_id": {"type": "string", "description": "Schedule ID from lifeos_schedule_list"},
+                    "name": {"type": "string", "description": "Display name"},
+                    "schedule_type": {"type": "string", "description": "'once' or 'cron'"},
+                    "schedule_value": {"type": "string", "description": "ISO datetime or cron expression"},
+                    "action": {"type": "string", "description": "'notify', 'prompt', 'endpoint', or 'agent'"},
+                    "message_content": {"type": "string", "description": "Message text, prompt, or task description"},
+                    "executor": {"type": "string", "description": "For action=agent: local | cloud | cloud-haiku | cloud-sonnet"},
+                    "timezone": {"type": "string", "description": "IANA timezone (e.g., 'America/New_York')"},
+                    "enabled": {"type": "boolean", "description": "Whether the schedule is active"}
+                },
+                "required": ["schedule_id"]
+            },
+            "lifeos_schedule_delete": {
+                "type": "object",
+                "properties": {
+                    "schedule_id": {"type": "string", "description": "ID of the schedule to delete (from lifeos_schedule_list)"}
+                },
+                "required": ["schedule_id"]
             },
             "lifeos_sync_trigger": {
                 "type": "object",
@@ -1553,6 +1617,39 @@ class LifeOSMCPServer:
 
         elif tool_name == "lifeos_reminder_delete":
             return f"Reminder deleted: {data.get('id', 'unknown')}"
+
+        elif tool_name in ("lifeos_schedule_create", "lifeos_schedule_update"):
+            name = data.get("name", "")
+            verb = "created" if tool_name.endswith("create") else "updated"
+            action = data.get("action", "")
+            executor = data.get("executor", "")
+            label = f"{action} (#{executor})" if action == "agent" and executor else action
+            next_trigger = data.get("next_trigger_at", "not scheduled")
+            return (f"Schedule {verb}: **{name}** (ID: {data.get('id', '')})\n"
+                    f"Action: {label} | Next: {next_trigger}")
+
+        elif tool_name == "lifeos_schedule_delete":
+            return f"Schedule deleted: {data.get('id', 'unknown')}"
+
+        elif tool_name == "lifeos_schedule_list":
+            schedules = data.get("schedules", [])
+            if not schedules:
+                return "No schedules configured."
+            text = f"Found {len(schedules)} schedules:\n\n"
+            for s in schedules:
+                status = "enabled" if s.get("enabled") else "disabled"
+                emoji = "🗓️" if s.get("enabled") else "🔕"
+                action = s.get("action", "")
+                executor = s.get("executor", "")
+                label = f"{action} (#{executor})" if action == "agent" and executor else action
+                text += f"{emoji} **{s.get('name', 'Untitled')}** ({status})\n"
+                text += f"  Action: {label} | Schedule: {s.get('schedule_type', '')} `{s.get('schedule_value', '')}`\n"
+                if s.get("next_trigger_at"):
+                    text += f"  Next: {s['next_trigger_at']}\n"
+                if s.get("last_status"):
+                    text += f"  Last outcome: {s['last_status']}\n"
+                text += f"  ID: {s.get('id', '')}\n\n"
+            return text
 
         elif tool_name == "lifeos_sync_trigger":
             return f"Sync triggered: {data.get('message', data.get('status', 'started'))}"

--- a/tests/test_scheduler_api.py
+++ b/tests/test_scheduler_api.py
@@ -1,0 +1,187 @@
+"""
+Tests for the Scheduler API routes (/api/scheduler) and the agent-tools
+manage_schedules wrapper — the renamed surface from #246.
+
+CRUD is tested in-process via TestClient with a mocked store; the agent-tools
+path is tested against a real store on a temp vault.
+"""
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+def _sample_entry(**overrides):
+    from api.services.scheduler_store import ScheduleEntry
+    fields = dict(
+        id="sch-1", name="Weekly review", schedule_type="cron",
+        schedule_value="0 9 * * 6", action="agent", message_type="prompt",
+        message_content="Draft my weekly review", executor="cloud", enabled=True,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        next_trigger_at=(datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+        last_status="",
+    )
+    fields.update(overrides)
+    return ScheduleEntry(**fields)
+
+
+class TestSchedulerAPI:
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        from api.main import app
+        return TestClient(app)
+
+    @pytest.fixture
+    def mock_store(self):
+        with patch("api.routes.scheduler.get_scheduler_store") as mock:
+            store = mock.return_value
+            entry = _sample_entry()
+            store.create.return_value = entry
+            store.list_all.return_value = [entry]
+            store.get.return_value = entry
+            store.update.return_value = entry
+            store.delete.return_value = True
+            yield store
+
+    def test_create_schedule_with_action(self, client, mock_store):
+        resp = client.post("/api/scheduler", json={
+            "name": "Weekly review", "schedule_type": "cron",
+            "schedule_value": "0 9 * * 6", "action": "agent",
+            "executor": "cloud", "message_content": "Draft my weekly review",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "agent"
+        assert data["executor"] == "cloud"
+        # The store received the action + executor.
+        kwargs = mock_store.create.call_args.kwargs
+        assert kwargs["action"] == "agent"
+        assert kwargs["executor"] == "cloud"
+
+    def test_create_defaults_action_from_message_type(self, client, mock_store):
+        client.post("/api/scheduler", json={
+            "name": "Ping", "schedule_type": "cron", "schedule_value": "0 9 * * *",
+            "message_type": "static", "message_content": "hi",
+        })
+        assert mock_store.create.call_args.kwargs["action"] == "notify"
+
+    def test_create_invalid_schedule_type(self, client, mock_store):
+        resp = client.post("/api/scheduler", json={
+            "name": "X", "schedule_type": "weekly", "schedule_value": "x", "action": "notify",
+        })
+        assert resp.status_code == 400
+
+    def test_create_invalid_action(self, client, mock_store):
+        resp = client.post("/api/scheduler", json={
+            "name": "X", "schedule_type": "cron", "schedule_value": "0 9 * * *",
+            "action": "explode",
+        })
+        assert resp.status_code == 400
+
+    def test_list_schedules(self, client, mock_store):
+        resp = client.get("/api/scheduler")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["schedules"][0]["action"] == "agent"
+
+    def test_get_schedule(self, client, mock_store):
+        resp = client.get("/api/scheduler/sch-1")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "sch-1"
+
+    def test_get_schedule_not_found(self, client, mock_store):
+        mock_store.get.return_value = None
+        assert client.get("/api/scheduler/nope").status_code == 404
+
+    def test_update_schedule(self, client, mock_store):
+        resp = client.put("/api/scheduler/sch-1", json={"name": "Renamed"})
+        assert resp.status_code == 200
+
+    def test_update_not_found(self, client, mock_store):
+        mock_store.update.return_value = None
+        assert client.put("/api/scheduler/nope", json={"name": "x"}).status_code == 404
+
+    def test_delete_schedule(self, client, mock_store):
+        resp = client.delete("/api/scheduler/sch-1")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+    def test_delete_not_found(self, client, mock_store):
+        mock_store.delete.return_value = False
+        assert client.delete("/api/scheduler/nope").status_code == 404
+
+
+class TestReminderAliasStillWorks:
+    """The legacy /api/reminders surface must keep functioning."""
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        from api.main import app
+        return TestClient(app)
+
+    def test_reminders_create_still_works(self, client):
+        with patch("api.routes.reminders.get_reminder_store") as mock:
+            mock.return_value.create.return_value = _sample_entry(action="notify", message_type="static")
+            resp = client.post("/api/reminders", json={
+                "name": "Legacy", "schedule_type": "cron", "schedule_value": "0 9 * * *",
+                "message_type": "static", "message_content": "hi",
+            })
+        assert resp.status_code == 200
+
+
+class TestManageSchedulesAgentTool:
+    """The chat orchestrator creates schedules (incl. action:agent) via manage_schedules."""
+
+    def test_create_agent_schedule_end_to_end(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore
+        from api.services import agent_tools
+
+        store = SchedulerStore(vault_path=tmp_path / "vault",
+                               index_path=tmp_path / "idx.json")
+        with patch("api.services.scheduler_store.get_scheduler_store", return_value=store):
+            out = agent_tools._tool_manage_schedules({
+                "action": "create",
+                "name": "Weekly review",
+                "schedule_type": "cron",
+                "schedule_value": "0 9 * * 6",
+                "schedule_action": "agent",
+                "executor": "cloud",
+                "message_content": "Draft my weekly review",
+            })
+        assert "Schedule created" in out
+        created = store.list_all()
+        assert len(created) == 1
+        assert created[0].action == "agent"
+        assert created[0].executor == "cloud"
+
+    def test_list_schedules_tool(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore
+        from api.services import agent_tools
+
+        store = SchedulerStore(vault_path=tmp_path / "vault",
+                               index_path=tmp_path / "idx.json")
+        store.create(name="N", schedule_type="cron", schedule_value="0 9 * * *",
+                     action="notify", message_type="static", message_content="x")
+        with patch("api.services.scheduler_store.get_scheduler_store", return_value=store):
+            out = agent_tools._tool_manage_schedules({"action": "list"})
+        assert "\"N\"" in out
+        assert "notify" in out
+
+    def test_manage_reminders_alias_still_works(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore
+        from api.services import agent_tools
+
+        store = SchedulerStore(vault_path=tmp_path / "vault",
+                               index_path=tmp_path / "idx.json")
+        # _reminder_create imports get_reminder_store from the shim at call time.
+        with patch("api.services.reminder_store.get_reminder_store", return_value=store):
+            out = agent_tools._tool_manage_reminders({
+                "action": "create", "name": "Legacy", "schedule_type": "cron",
+                "schedule_value": "0 9 * * *", "message_content": "hi",
+            })
+        assert "created" in out.lower()
+        assert len(store.list_all()) == 1


### PR DESCRIPTION
## Summary

Renames the public "reminder" surfaces to "schedule", exposing the `action` + `executor` fields, with old names kept as deprecated aliases so nothing breaks mid-transition (sub-issue 3 of 4, #242).

- **HTTP** — new `api/routes/scheduler.py` at `/api/scheduler` (CRUD + `{id}/trigger` + `/send`) with `action` (notify/prompt/endpoint/agent) + `executor`. `/api/reminders*` stays mounted as a **deprecation-logged alias** over the same store (same records).
- **MCP** — `lifeos_schedule_create/list/update/delete` added to `mcp_server.py` with `action` + `executor` params and result formatting; `lifeos_reminder_*` kept as aliases. Total tools 55 → 59.
- **Agent tools** — new `manage_schedules` (action `notify/prompt/endpoint/agent` + executor via `schedule_action`/`executor`); `manage_reminders` kept as a deprecated alias.
- The chat orchestrator can now create an `action:agent` schedule **end-to-end** through `manage_schedules`.

Closes #246

## Test evidence

- New `tests/test_scheduler_api.py` — in-process TestClient CRUD against `/api/scheduler` (action/executor passthrough, validation, 404s), reminders-alias still works, and `manage_schedules` agent-tool create/list incl. `action:agent` end-to-end + `manage_reminders` alias — 15 passed.
- `test_reminders_api.py`, `test_mcp_server.py` (unit), `test_agent_worker_mcp_exposure.py`, `test_mcp_http_transport.py`, `test_telegram_intents.py` green; MCP builds 59 tools, no over-length descriptions.
- Full pre-push unit suite: **1690 passed, 8 skipped**.

> Note: the non-unit `TestAPIOpenAPISync::test_openapi_endpoints_match_curated` integration test compares curated endpoints to a **live** server's OpenAPI; it skips when no server runs and passes once this branch is deployed. The new route is verified in-process via TestClient.

## Review focus

- `action` resolution + validation in `scheduler.py` (and legacy `message_type` mapping).
- MCP `lifeos_schedule_*` schemas/dispatch/formatting; `{schedule_id}` path substitution.
- `manage_schedules` `schedule_action` vs operation-`action` naming (avoids collision).
- Back-compat: `/api/reminders*`, `lifeos_reminder_*`, `manage_reminders` all still function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)