### PR TITLE
feat(agent-viz): manually rename session node labels

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -23,6 +23,7 @@ from api.services.agent_worker.session_store import (
 )
 from api.services.agent_worker.transcript_store import TranscriptStore
 from api.services import agent_viz_summary
+from api.services import agent_viz_label_override
 
 logger = logging.getLogger(__name__)
 
@@ -190,6 +191,9 @@ def _session_to_dict(s: Session, transcript: TranscriptStore) -> dict[str, Any]:
         "short_label": _short_label_for_snapshot(
             s.session_id, s.last_activity_at or 0.0, s.status or "",
         ),
+        # Operator-pinned manual label. When set, the frontend uses it as the
+        # node name in preference to short_label and label.
+        "custom_label": agent_viz_label_override.get_override(s.session_id),
     }
 
 
@@ -244,14 +248,16 @@ def _build_snapshot() -> dict[str, Any]:
     # the short_label field — attach it the same way (cached-only, no LLM in
     # the snapshot path).
     for sd in cc_sessions:
+        sid = sd.get("session_id") or ""
         sd.setdefault(
             "short_label",
             _short_label_for_snapshot(
-                sd.get("session_id") or "",
+                sid,
                 sd.get("last_activity_at") or 0.0,
                 sd.get("status") or "",
             ),
         )
+        sd["custom_label"] = agent_viz_label_override.get_override(sid)
     session_dicts.extend(cc_sessions)
     edges.extend(cc_edges)
 
@@ -374,6 +380,23 @@ async def get_session_summary(session_id: str) -> dict[str, Any]:
         status=status,
     )
     return {"session_id": session_id, **result.as_dict()}
+
+
+class LabelOverrideRequest(BaseModel):
+    """Body for PUT /api/agents/sessions/{id}/label."""
+    label: str = Field(default="", max_length=200)
+
+
+@router.put("/sessions/{session_id}/label")
+async def set_session_label(session_id: str, body: LabelOverrideRequest) -> dict[str, Any]:
+    """Set or clear an operator-pinned manual label for a session node.
+
+    A non-empty label overrides the auto-derived node name (AI short_label /
+    task description) everywhere it's shown. An empty label clears the
+    override and reverts the node to auto-naming. Durable across restarts.
+    """
+    custom = agent_viz_label_override.set_override(session_id, body.label)
+    return {"session_id": session_id, "custom_label": custom or None}
 
 
 @router.get("/search")

--- a/api/services/agent_viz_label_override.py
+++ b/api/services/agent_viz_label_override.py
@@ -1,0 +1,129 @@
+"""Durable per-session manual label overrides for the /agents UI.
+
+A session node's name is normally auto-derived (AI `short_label` →
+task description → model badge). This module lets the operator pin a
+*manual* label that overrides all of those. Stored in SQLite so it
+survives restarts; cached in-process so the snapshot path (every ~2s,
+up to 200 sessions) does dict lookups, not per-session disk reads.
+
+The override wins over both the AI summary label and the derived task
+label everywhere the node name is shown. Clearing it (an empty label)
+reverts the node to auto-naming.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Generous cap — node labels render at ~0.95rem and word-break, so a long
+# manual label degrades gracefully, but we still bound stored size.
+_MAX_LABEL_LEN = 120
+
+_DB_PATH: str | None = None
+_DB_LOCK = threading.Lock()
+
+# In-process mirror of session_id → label. None until first load; kept in
+# sync on every write so reads never touch disk.
+_cache: dict[str, str] | None = None
+
+
+def _resolve_db_path() -> str:
+    global _DB_PATH
+    if _DB_PATH is None:
+        try:
+            from config.settings import settings
+            data_dir = Path(settings.chroma_path).parent
+        except Exception:  # noqa: BLE001
+            data_dir = Path("data")
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _DB_PATH = str(data_dir / "agent_viz_label_overrides.db")
+    return _DB_PATH
+
+
+def _init_db() -> None:
+    with sqlite3.connect(_resolve_db_path()) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_viz_label_override (
+                session_id TEXT PRIMARY KEY,
+                label TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+
+def _load() -> dict[str, str]:
+    global _cache
+    if _cache is None:
+        out: dict[str, str] = {}
+        try:
+            with sqlite3.connect(_resolve_db_path()) as conn:
+                for sid, label in conn.execute(
+                    "SELECT session_id, label FROM agent_viz_label_override"
+                ):
+                    out[sid] = label
+        except sqlite3.Error as exc:
+            logger.warning("label override load failed: %s", exc)
+        _cache = out
+    return _cache
+
+
+def get_override(session_id: str) -> str | None:
+    """Return the manual label for a session, or None if none is set."""
+    return _load().get(session_id)
+
+
+def set_override(session_id: str, label: str) -> str:
+    """Pin a manual label. An empty/blank label clears the override instead.
+
+    Returns the stored label ("" if cleared). Raises on a disk write failure
+    so the caller can surface it — a silently-dropped rename is worse than an
+    error toast.
+    """
+    label = (label or "").strip().replace("\n", " ")
+    if len(label) > _MAX_LABEL_LEN:
+        label = label[: _MAX_LABEL_LEN - 1] + "…"
+    if not label:
+        clear_override(session_id)
+        return ""
+    with _DB_LOCK, sqlite3.connect(_resolve_db_path()) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO agent_viz_label_override "
+            "(session_id, label, created_at) VALUES (?, ?, ?)",
+            (session_id, label, int(time.time())),
+        )
+        conn.commit()
+    _load()[session_id] = label
+    return label
+
+
+def clear_override(session_id: str) -> None:
+    """Drop the manual label for a session (revert to auto-naming)."""
+    try:
+        with _DB_LOCK, sqlite3.connect(_resolve_db_path()) as conn:
+            conn.execute(
+                "DELETE FROM agent_viz_label_override WHERE session_id = ?",
+                (session_id,),
+            )
+            conn.commit()
+    except sqlite3.Error as exc:
+        logger.warning("label override delete failed for %s: %s", session_id, exc)
+    _load().pop(session_id, None)
+
+
+def reset_cache() -> None:
+    """Drop the in-process cache (tests re-point _DB_PATH then reload)."""
+    global _cache
+    _cache = None
+
+
+# Ensure the schema exists on import — cheap, and avoids a first-write race.
+_init_db()

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -121,7 +121,7 @@ Chips re-compute after every snapshot tick, so toggling `include finished` immed
 
 Clicking any node opens a panel on the right with that session's metadata header and a live-tailing event feed. The panel header carries:
 
-- **Label** — derived from the task description (LifeOS), or the first non-empty user message (Claude Code), or the session id as a fallback.
+- **Label** — derived from the task description (LifeOS), or the first non-empty user message (Claude Code), or the session id as a fallback. **Click it to rename:** the title becomes a text box prepopulated with the current name; Enter (or clicking away) saves, Escape cancels. A manual name is pinned durably and overrides the auto-derived label and the AI summary label everywhere the node is named (graph node, panel, search). Saving an empty value clears the override and reverts to auto-naming.
 - **cwd** — Claude Code only; the project directory the session was opened in.
 - **Status badge** — same status the node is colored by, with `(inferred)` if applicable.
 - **Source** — `LifeOS agent` or `Claude Code`.

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -69,6 +69,7 @@ All under `/api/agents`. Local-network only — the kill and resume endpoints mu
 | `GET /sessions/{id}/events?limit=N` | Last N transcript events (default 200, max 2000). Dispatches by `cc:` prefix to the Claude Code ingest path. |
 | `GET /sessions/{id}/stream?backfill=N` | Per-session SSE: backfill last N events (default 50, max 500), then live-tail. Closes cleanly when the session reaches terminal status (LifeOS) or after 5 min idle (Claude Code). |
 | `POST /sessions/{id}/kill` | Operator kill — body `{reason: ""}`. LifeOS sessions only. Cascades to descendants in the subtree. |
+| `PUT /sessions/{id}/label` | Set or clear an operator-pinned manual label — body `{label: ""}`. Non-empty pins a custom node name that overrides the auto-derived label and AI summary label everywhere it's shown; empty clears it. Durable in `data/agent_viz_label_overrides.db` (in-process cache, lazy-loaded). Works for both LifeOS and `cc:` sessions. |
 | `POST /sessions/{id}/resume` | Resume a Claude Code session — body `{extra_env: {}}`. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Spawns a WezTerm tab via `wezterm cli spawn`, captures the pane id from stdout, and stores `session_id → pane_id` in `data/cc_wezterm.db` so Focus can target it later. |
 | `POST /sessions/{id}/focus` | Activate the WezTerm pane for this session (Go To). `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Resolves the pane id from the cached mapping first, then falls back to an FD probe (lsof + /proc + wezterm cli list) so it works for sessions never opened via Resume. 404 only when both the cache *and* the probe come up empty; 410 when the pane existed but is gone and no replacement is found. |
 | `POST /cc-pane-bind` | Localhost-only endpoint called by the Claude Code SessionStart hook. Body `{session_id, pane_id, cwd}`. Upserts the mapping in `cc_wezterm.db` so Go To can target newly-started `claude` invocations without a probe. 403 from non-loopback callers. |
@@ -107,6 +108,7 @@ One session row, unified shape (both sources):
 | `total_active_seconds` | float | LifeOS wall-time accounting. Always 0 for Claude Code (no wall meter). |
 | `expected_output` | str \| null | LifeOS preflight classification — `text` / `file` / `external_action` / `structured`. |
 | `label` | str | Display name. Cached per session id. |
+| `custom_label` | str \| null | Operator-pinned manual label (via `PUT /sessions/{id}/label`). When set, the frontend uses it as the node name in preference to the AI `short_label` and `label`. |
 | `model_label` | str | Short badge — `Local` / `Haiku` / `Sonnet` / `Opus` / `Claude Code`. |
 | `last_event_kind` | str | Most recent transcript event kind — drives the side-panel "last" tooltip. |
 | `tool_call_count`, `error_count` | int | Summed across the transcript tail (last 100 events). |

--- a/tests/test_agent_viz_api.py
+++ b/tests/test_agent_viz_api.py
@@ -486,3 +486,76 @@ def test_no_content_live_session_not_cached(summary_db):
     # A live session may gain content later, so the fallback must NOT be
     # cached — the next access should retry.
     assert avs.get_cached_summary(sid, 1000.0, status=STATUS_RUNNING) is None
+
+
+# ---------------------------------------------------------------------------
+# Manual label overrides — a node name the operator pins by hand, overriding
+# the auto-derived label everywhere. Store + PUT endpoint + snapshot wiring.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def label_override_db(tmp_path: Path, monkeypatch):
+    """Point the label-override store at a temp DB."""
+    from api.services import agent_viz_label_override as alo
+
+    monkeypatch.setattr(alo, "_DB_PATH", str(tmp_path / "label_overrides.db"))
+    alo._init_db()
+    alo.reset_cache()
+    return alo
+
+
+@pytest.mark.unit
+def test_label_override_set_get_clear(label_override_db):
+    alo = label_override_db
+    assert alo.get_override("s1") is None
+    assert alo.set_override("s1", "  My Custom Name  ") == "My Custom Name"
+    assert alo.get_override("s1") == "My Custom Name"
+    # Empty / blank clears the override.
+    assert alo.set_override("s1", "   ") == ""
+    assert alo.get_override("s1") is None
+
+
+@pytest.mark.unit
+def test_label_override_persists_across_cache_reset(label_override_db):
+    alo = label_override_db
+    alo.set_override("s1", "Durable Label")
+    alo.reset_cache()  # forces a reload from disk
+    assert alo.get_override("s1") == "Durable Label"
+
+
+@pytest.mark.unit
+def test_label_override_clamps_length(label_override_db):
+    alo = label_override_db
+    stored = alo.set_override("s1", "x" * 500)
+    assert len(stored) == 120
+    assert stored.endswith("…")
+
+
+@pytest.mark.unit
+def test_put_label_sets_and_clears(client, stores, label_override_db):
+    session_store, _ = stores
+    s = session_store.create(task_id="t-rename", status=STATUS_RUNNING)
+
+    r = client.put(
+        f"/api/agents/sessions/{s.session_id}/label",
+        json={"label": "Renamed Session"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"session_id": s.session_id, "custom_label": "Renamed Session"}
+
+    # Snapshot surfaces the override so the node + panel can use it.
+    snap = client.get("/api/agents/snapshot").json()
+    sess = next(x for x in snap["sessions"] if x["session_id"] == s.session_id)
+    assert sess["custom_label"] == "Renamed Session"
+
+    # Empty label clears it (revert to auto-naming).
+    r2 = client.put(
+        f"/api/agents/sessions/{s.session_id}/label",
+        json={"label": ""},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["custom_label"] is None
+    snap2 = client.get("/api/agents/snapshot").json()
+    sess2 = next(x for x in snap2["sessions"] if x["session_id"] == s.session_id)
+    assert sess2["custom_label"] is None

--- a/web/agents.html
+++ b/web/agents.html
@@ -335,7 +335,13 @@
     font-size: 0.95rem;
     font-weight: 600;
     word-break: break-word;
+    cursor: pointer;
+    border-radius: 4px;
+    padding: 1px 4px;
+    margin: -1px -4px;
+    transition: background 0.12s;
   }
+  .panel-header .label:hover { background: var(--bg-elev); }
   .panel-header .meta {
     color: var(--text-secondary);
     font-size: 0.75rem;
@@ -1090,6 +1096,8 @@
     // operator what the session is actually about, which is far more useful
     // than knowing it ran on Opus vs. Sonnet. Falls back to the model badge
     // until the summary is fetched (lazy, on panel open).
+    // An operator-pinned manual label wins over everything else.
+    if (d.custom_label) return d.custom_label;
     if (d.short_label) return d.short_label;
     const isCc = d.source === 'claude_code';
     let label = d.model_label || routingLabel(d.routing) || d.session_id.slice(0, 8);
@@ -1380,7 +1388,7 @@
         ${showKill ? '<button class="panel-kill" id="panel-kill">Kill</button>' : ''}
         ${showResume ? '<button class="panel-resume" id="panel-resume" title="Open a new wezterm tab and run claude --resume">Resume</button>' : ''}
         ${showGoTo ? '<button class="panel-focus" id="panel-focus" title="Jump to the existing wezterm pane for this session (or run Resume if there isn\'t one). Double-clicking the node does the same. Wayland disallows cross-app window raise — click the wezterm dock icon to bring it forward; it will already be on the right pane.">Go To</button>' : ''}
-        <div class="label" data-field="label">${escapeHtml(s.label || s.session_id)}</div>
+        <div class="label" data-field="label" title="Click to rename this session">${escapeHtml(s.custom_label || s.label || s.session_id)}</div>
         <div class="cwd-hint" data-field="cwd-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-all">${s.decoded_cwd ? escapeHtml(s.decoded_cwd) : ''}</div>
         <div class="meta" data-field="meta">
           <span data-field="live-dot">${live ? '<span class="live-dot" title="live"></span>' : ''}</span>
@@ -1400,6 +1408,8 @@
       <div class="events" id="events"></div>
     `;
     document.getElementById('panel-close').onclick = closePanel;
+    const labelEl = panelEl.querySelector('[data-field="label"]');
+    if (labelEl) labelEl.onclick = () => startLabelEdit(s);
     if (showKill) {
       document.getElementById('panel-kill').onclick = () => openKillModal(s);
     }
@@ -1528,7 +1538,10 @@
     const inferredHint = s.status_inferred ? ' (inferred)' : '';
     const isClaudeCode = (s.source === 'claude_code');
     const sourceLabel = isClaudeCode ? 'Claude Code' : 'LifeOS agent';
-    setText('label', s.label || s.session_id);
+    // Don't overwrite the title while the operator is mid-rename.
+    if (!panelEl.querySelector('#label-edit-input')) {
+      setText('label', s.custom_label || s.label || s.session_id);
+    }
     setText('status', s.status + inferredHint);
     setText('source', sourceLabel);
     setText('routing', routingLabel(s.routing));
@@ -1707,6 +1720,80 @@
   // Track the in-flight summary fetch so a new openPanel can abort the old
   // one — otherwise stale long-running fetches pile up behind Gemma.
   let summaryAbort = null;
+
+  // Turn the panel title into an inline text box prepopulated with the
+  // current label. Enter (or blur) saves, Escape cancels. An empty save
+  // clears the override and reverts the node to auto-naming.
+  function startLabelEdit(s) {
+    if (!panelEl) return;
+    const labelEl = panelEl.querySelector('[data-field="label"]');
+    if (!labelEl || labelEl.querySelector('#label-edit-input')) return;
+    const current = s.custom_label || s.label || '';
+    const input = document.createElement('input');
+    input.id = 'label-edit-input';
+    input.type = 'text';
+    input.maxLength = 120;
+    input.value = current;
+    input.style.cssText =
+      'width:100%;box-sizing:border-box;font:inherit;font-weight:600;' +
+      'color:var(--text-primary,#fff);background:var(--bg-elev);' +
+      'border:1px solid var(--accent);border-radius:4px;padding:2px 6px';
+    labelEl.textContent = '';
+    labelEl.appendChild(input);
+    input.focus();
+    input.select();
+
+    let done = false;
+    const finish = (save) => {
+      if (done) return;
+      done = true;
+      if (save) {
+        saveLabelEdit(s, input.value);
+      } else {
+        labelEl.textContent = s.custom_label || s.label || s.session_id;
+      }
+    };
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); finish(true); }
+      else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
+    });
+    input.addEventListener('blur', () => finish(true));
+  }
+
+  // Persist a manual label (durably, server-side) and reflect it immediately
+  // on the open panel and the graph node so the operator doesn't wait for the
+  // next snapshot tick.
+  async function saveLabelEdit(s, rawValue) {
+    const labelEl = panelEl ? panelEl.querySelector('[data-field="label"]') : null;
+    const fallback = () => { if (labelEl) labelEl.textContent = s.custom_label || s.label || s.session_id; };
+    try {
+      const r = await fetch(
+        `/api/agents/sessions/${encodeURIComponent(s.session_id)}/label`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ label: (rawValue || '').trim() }),
+        },
+      );
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const data = await r.json();
+      const custom = data.custom_label || null;
+      s.custom_label = custom;
+      // Keep the canonical in-memory copy in sync so snapshot ticks agree.
+      const canonical = allSessions.find(x => x.session_id === s.session_id);
+      if (canonical) canonical.custom_label = custom;
+      if (labelEl) labelEl.textContent = custom || s.label || s.session_id;
+      // Nudge the node label immediately (custom_label || short_label || …).
+      nodeLayer.selectAll('.node')
+        .filter(d => d.session_id === s.session_id)
+        .each(function(d) { d.custom_label = custom; })
+        .select('text.node-label')
+        .text(d => nodeLabel(d));
+    } catch (err) {
+      console.warn('label save failed', err);
+      fallback();
+    }
+  }
 
   // Fetch and render the LLM-generated session summary. Decoupled from the
   // event stream — slow LLM calls won't block transcript display. The panel
@@ -2109,7 +2196,7 @@
   const SEARCH_BADGE = { label: 'name', short_label: 'label', summary: 'summary' };
 
   function sessionDisplayName(s) {
-    return s.short_label || s.label || s.session_id.slice(0, 8);
+    return s.custom_label || s.short_label || s.label || s.session_id.slice(0, 8);
   }
 
   // Escape, then wrap the first case-insensitive occurrence of `q` in <mark>.
@@ -2140,9 +2227,11 @@
       entries.set(sessionId, { session: s, field, snippet, visible: visibleIds.has(sessionId) });
     }
 
-    // Tier 0: label — client-side, covers every session.
+    // Tier 0: label — client-side, covers every session. Matches the
+    // displayed name, so an operator-pinned custom label is findable too.
     for (const s of allSessions) {
-      if ((s.label || '').toLowerCase().includes(q)) consider(s.session_id, 'label', s.label);
+      const name = s.custom_label || s.label || '';
+      if (name.toLowerCase().includes(q)) consider(s.session_id, 'label', name);
     }
     // Tiers 1/2: short_label / paragraph summary — from the backend.
     for (const [sid, m] of summaryMatches) consider(sid, m.field, m.snippet);


### PR DESCRIPTION
## What

Lets you give any `/agents` session node a manual name. **Click the title in the side panel** → it becomes a text box prepopulated with the current name → **Enter (or click away) saves, Escape cancels**. The manual label is stored durably and **overrides the auto-derived label and the AI summary label everywhere the node is named** (graph node, panel title, search). **Saving an empty value clears it** and reverts to auto-naming.

## How

**Backend**
- `api/services/agent_viz_label_override.py` — durable SQLite store (`data/agent_viz_label_overrides.db`) with an in-process cache so the ~2s snapshot path does dict lookups, not per-session disk reads. `get`/`set`/`clear`, empty-clears, 120-char clamp.
- `api/routes/agents.py` — `PUT /api/agents/sessions/{id}/label` (set/clear); `custom_label` attached to every session dict (LifeOS + `cc:`).

**Frontend (`web/agents.html`)**
- `nodeLabel` precedence: `custom_label > short_label > label/model`.
- Inline click-to-edit on the panel title; optimistic update of both the panel and the graph node (no waiting for the next snapshot tick). Snapshot ticks won't clobber an in-progress edit.
- Search matches the displayed name, so a custom label is findable.
- Hover/cursor affordance on the title.

## Tests

4 new in `test_agent_viz_api.py`: store round-trip + clear, disk persistence across cache reset, length clamp, and the PUT endpoint (set + clear) reflected in the snapshot. `test_agent_viz_api.py`: **28 passed**. JS syntax-checked; imports + ruff clean. Full unit suite green (the 5 unrelated failures are pre-existing/environment-specific — CRM data-health, entity-resolver, me-page, machine-specific `local_llm_model_default` — none touch agent-viz).

## Docs

Product + technical agent-viz specs updated (rename behavior, endpoint, `custom_label` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)