### PR TITLE
docs(chat-ui): document the local/cloud route badge on agent threads

### DIFF
--- a/docs/specs/product/chat-ui.md
+++ b/docs/specs/product/chat-ui.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Chat
-> **Last Updated:** 2026-05-28
+> **Last Updated:** 2026-05-29
 
 The primary chat interface for LifeOS, providing AI-powered search and synthesis across your personal knowledge base.
 
@@ -201,8 +201,8 @@ The orchestrator LLM (Claude Haiku via Anthropic API by default; configurable vi
 
 Web `/chat` speaks to the same agent-thread model as Telegram (#236, Phase 3 of #233):
 
-- **Threads panel** (sidebar) — lists recent/resumable agent sessions (root sessions only) with a status badge (running / completed / failed / budget / blocked). Backed by `GET /api/agents/threads`; polled for live-ish updates (the `/agents` page uses the `/api/agents/stream` SSE for the full graph).
-- **Open a thread** — clicking a thread loads its full conversation into the main chat body: user prompts and the agent's replies render as chat bubbles, with the agent's tool calls shown as collapsible detail under each reply. Backed by `GET /api/agents/threads/{id}`, which returns a reconstructed `conversation` (from the session's message history, or the managed transcript for cloud sessions). A banner marks the thread; **Exit to chat** (or **+**) returns to normal chat.
+- **Threads panel** (sidebar) — lists recent/resumable agent sessions (root sessions only) with a status badge (running / completed / failed / budget / blocked) and a route badge showing where the agent runs: **🖥 local** (Gemma) or **☁ cloud** (Claude / Managed Agents), with the model name on hover. Backed by `GET /api/agents/threads`; polled for live-ish updates (the `/agents` page uses the `/api/agents/stream` SSE for the full graph).
+- **Open a thread** — clicking a thread loads its full conversation into the main chat body: user prompts and the agent's replies render as chat bubbles, with the agent's tool calls shown as collapsible detail under each reply. Backed by `GET /api/agents/threads/{id}`, which returns a reconstructed `conversation` (from the session's message history, or the managed transcript for cloud sessions). A banner — carrying the same local/cloud route badge — marks the thread; **Exit to chat** (or **+**) returns to normal chat.
 - **Reply / continue** — while a thread is open the composer continues *that thread*: sending a message posts to `POST /api/agents/threads/{id}/reply`, which reopens the session as a follow-up turn via the shared follow-up table (the same path a Telegram reply takes). The view polls and re-renders as the agent's new turns land. Only completed/failed threads are continuable; a running thread opens read-only.
 - **Run as agent** — the composer has a model selector (auto / local / cloud) and a spawn button; it sends the composer text to `POST /api/agents/spawn` (Phase 2's `create_operator_session`), and the new thread appears in the panel. `auto` routes via preflight; an ambiguous auto-route returns 409 asking for an explicit model.
 


### PR DESCRIPTION
## Summary

Documents the #262 local/cloud indicator (🖥 local / ☁ cloud) in the chat-ui Agent Threads spec — #262 was frontend-only and missed the doc update. Closes a documentation gap found while auditing recent changes against `docs/AGENTS.md`.

Docs-only; no code change.

Relates to #233 / #236.