### PR TITLE
fix(chat): bound thread-view render so large transcripts don't freeze the tab

### DIFF
--- a/tests/test_agent_threads_ui_browser.py
+++ b/tests/test_agent_threads_ui_browser.py
@@ -128,3 +128,92 @@ class TestAgentThreadsUI:
         page.wait_for_timeout(500)
         assert self.state["replies"], "reply POST should have fired"
         assert self.state["replies"][0]["text"] == "also CC the property manager"
+
+    def test_small_thread_renders_without_load_earlier(self, page: Page):
+        # The 2-turn fixture is below the cap, so no "load earlier" control
+        # appears and both turns render — small threads stay unchanged (#270).
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        expect(page.locator(".agent-thread-banner")).to_be_visible(timeout=8000)
+        expect(page.locator(".thread-load-earlier")).to_have_count(0)
+        expect(page.locator("#messages .message")).to_have_count(2)
+
+    def test_tool_details_pre_is_built_lazily(self, page: Page):
+        # The collapsed <details> exists but its <pre> is only built on expand,
+        # so a thread with many tool calls doesn't serialize every input up-front.
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        expect(page.locator(".agent-tool-details summary")).to_contain_text("lifeos_gmail_draft")
+        expect(page.locator(".agent-tool-details pre")).to_have_count(0)
+        page.locator(".agent-tool-details summary").first.click()
+        expect(page.locator(".agent-tool-details pre")).to_contain_text("landlord@example.com")
+
+
+def _large_conversation(n_turns: int):
+    """Alternating user/assistant turns; assistant turns carry a tool call."""
+    conv = []
+    for i in range(n_turns):
+        if i % 2 == 0:
+            conv.append({"role": "user", "text": f"user message {i}", "tools": []})
+        else:
+            conv.append({"role": "assistant", "text": f"assistant message {i}",
+                         "tools": [{"name": "lifeos_search", "input": {"q": f"query {i}"}}]})
+    return conv
+
+
+class TestLargeThreadRendering:
+    """#270 — a thread with a very large transcript must render bounded, not
+    freeze the renderer, while keeping full history reachable."""
+
+    N_TURNS = 90  # well above THREAD_INITIAL_TURNS (30)
+
+    @pytest.fixture(autouse=True)
+    def setup(self, page: Page):
+        page.set_viewport_size(DESKTOP_VIEWPORT)
+        conv = _large_conversation(self.N_TURNS)
+        self.state = {
+            "threads": [{
+                "session_id": "sess_big", "task_id": "op_big",
+                "parent_session_id": None, "status": "completed",
+                "label": "huge transcript", "resumable": True,
+                "routing": "claude", "model_label": "Sonnet",
+            }],
+            "detail": {
+                "thread": {"session_id": "sess_big", "task_id": "op_big", "status": "completed",
+                           "label": "huge transcript", "resumable": True,
+                           "routing": "claude", "model_label": "Sonnet"},
+                "conversation": conv,
+            },
+            "spawned": [], "replies": [],
+        }
+        _install_agent_mocks(page, self.state)
+        page.goto("http://localhost:8000")
+        page.wait_for_selector("#agentsPanel")
+
+    def test_initial_render_is_capped_to_newest_turns(self, page: Page):
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        expect(page.locator(".agent-thread-banner")).to_be_visible(timeout=8000)
+        # Only the newest 30 turns render initially, not all 90.
+        expect(page.locator("#messages .message")).to_have_count(30)
+        # The newest turn is present; an early (hidden) turn is not.
+        expect(page.locator("#messages")).to_contain_text(f"message {self.N_TURNS - 1}")
+        expect(page.locator("#messages")).not_to_contain_text("user message 0")
+
+    def test_load_earlier_control_reveals_hidden_turns(self, page: Page):
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        btn = page.locator(".thread-load-earlier")
+        expect(btn).to_be_visible(timeout=8000)
+        expect(btn).to_contain_text("60 hidden")  # 90 - 30 shown
+        btn.click()
+        # Another chunk of 30 loads in; 60 turns now shown, 30 still hidden.
+        expect(page.locator("#messages .message")).to_have_count(60)
+        expect(btn).to_contain_text("30 hidden")
+
+    def test_full_history_reachable_via_repeated_load(self, page: Page):
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        btn = page.locator(".thread-load-earlier")
+        expect(btn).to_be_visible(timeout=8000)
+        btn.click()  # 60 shown
+        btn.click()  # 90 shown — all loaded
+        expect(page.locator("#messages .message")).to_have_count(self.N_TURNS)
+        # Button removes itself once nothing is left to load.
+        expect(page.locator(".thread-load-earlier")).to_have_count(0)
+        expect(page.locator("#messages")).to_contain_text("user message 0")

--- a/tests/test_agent_threads_ui_browser.py
+++ b/tests/test_agent_threads_ui_browser.py
@@ -217,3 +217,30 @@ class TestLargeThreadRendering:
         # Button removes itself once nothing is left to load.
         expect(page.locator(".thread-load-earlier")).to_have_count(0)
         expect(page.locator("#messages")).to_contain_text("user message 0")
+
+    def test_poll_rerender_preserves_expanded_history(self, page: Page):
+        # When new turns land on an active thread (the poll path re-renders),
+        # any history the user expanded via "load earlier" must not collapse
+        # back to the newest-N tail.
+        page.locator("#agentsThreadsList .agent-thread").first.click()
+        btn = page.locator(".thread-load-earlier")
+        expect(btn).to_be_visible(timeout=8000)
+        btn.click()  # 60 shown, earliestShown == 30
+        expect(page.locator("#messages .message")).to_have_count(60)
+        # Simulate the poll re-render: two new turns appended, re-rendered with
+        # the expanded depth preserved (exactly what pollThreadForUpdate does).
+        shown_after = page.evaluate(
+            """(n) => {
+                const conv = [];
+                for (let i = 0; i < n + 2; i++) {
+                    conv.push({ role: i % 2 ? 'assistant' : 'user', text: 'm' + i, tools: [] });
+                }
+                renderThreadConversation(conv, threadRender.earliestShown);
+                return document.querySelectorAll('#messages .message').length;
+            }""",
+            self.N_TURNS,
+        )
+        # Was showing turns [30, 92): the 60 already-visible plus the 2 new ones.
+        assert shown_after == 62, f"expected expansion preserved (62), got {shown_after}"
+        expect(page.locator("#messages")).to_contain_text("m30")
+        expect(page.locator("#messages")).not_to_contain_text("m29")

--- a/web/index.html
+++ b/web/index.html
@@ -3040,7 +3040,10 @@
         const THREAD_INITIAL_TURNS = 30;
         let threadRender = null;  // { conversation, earliestShown, loadBtn }
 
-        function renderThreadConversation(conversation) {
+        // preserveFrom: when re-rendering an already-open thread (e.g. a poll
+        // update appended new turns), keep at least as much history visible as
+        // the user had expanded, so "load earlier" scrollback isn't collapsed.
+        function renderThreadConversation(conversation, preserveFrom = null) {
             messagesEl.innerHTML = '';
             threadRender = null;
             const t = currentAgentThread || {};
@@ -3063,7 +3066,10 @@
                 return;
             }
 
-            const start = Math.max(0, conversation.length - THREAD_INITIAL_TURNS);
+            let start = Math.max(0, conversation.length - THREAD_INITIAL_TURNS);
+            if (preserveFrom != null) {
+                start = Math.min(start, Math.max(0, Math.min(preserveFrom, conversation.length)));
+            }
             threadRender = { conversation, earliestShown: start, loadBtn: null };
             if (start > 0) {
                 const btn = document.createElement('button');
@@ -3203,7 +3209,9 @@
                         currentAgentThread.convCount = conv.length;
                         currentAgentThread.resumable = !!thread.resumable;
                         currentAgentThread.status = (thread.status || '').toString();
-                        renderThreadConversation(conv);
+                        // Keep any history the user expanded via "load earlier".
+                        const keepFrom = threadRender ? threadRender.earliestShown : null;
+                        renderThreadConversation(conv, keepFrom);
                         updateThreadComposer();
                         scrollToBottom();
                         if (thread.resumable) { clearInterval(iv); loadAgentThreads(); }

--- a/web/index.html
+++ b/web/index.html
@@ -2509,6 +2509,8 @@
         .agent-thread-banner { font-size: 0.85rem; padding: 0.6rem 0.8rem; margin-bottom: 0.8rem; border-radius: 8px; background: rgba(45,95,163,0.15); border: 1px solid rgba(45,95,163,0.4); }
         .agent-thread-exit { margin-left: 0.5rem; font-size: 0.74rem; padding: 0.15rem 0.5rem; border-radius: 6px; border: none; cursor: pointer; background: #2d5fa3; color: #fff; }
         .agent-thread-empty { opacity: 0.6; font-size: 0.85rem; padding: 0.5rem 0.2rem; }
+        .thread-load-earlier { display: block; width: 100%; margin: 0 0 0.8rem; font-size: 0.8rem; padding: 0.45rem 0.6rem; border-radius: 8px; cursor: pointer; border: 1px solid rgba(45,95,163,0.4); background: rgba(45,95,163,0.12); color: inherit; }
+        .thread-load-earlier:hover { background: rgba(45,95,163,0.22); }
         .agent-tool-details { margin: -0.4rem 0 0.8rem 0.5rem; }
         .agent-tool-details details { font-size: 0.76rem; margin-bottom: 0.2rem; }
         .agent-tool-details summary { cursor: pointer; opacity: 0.75; }
@@ -3030,8 +3032,17 @@
             scrollToBottom();
         }
 
+        // Cap how many turns the thread view builds up-front. Sessions with
+        // hundreds of turns (each potentially emitting large tool inputs) would
+        // otherwise produce a massive DOM in one synchronous pass and freeze the
+        // renderer (#270). Older turns stay reachable via the "load earlier"
+        // control.
+        const THREAD_INITIAL_TURNS = 30;
+        let threadRender = null;  // { conversation, earliestShown, loadBtn }
+
         function renderThreadConversation(conversation) {
             messagesEl.innerHTML = '';
+            threadRender = null;
             const t = currentAgentThread || {};
             const banner = document.createElement('div');
             banner.className = 'agent-thread-banner';
@@ -3049,19 +3060,63 @@
                 empty.className = 'agent-thread-empty';
                 empty.textContent = 'No conversation recorded yet for this thread.';
                 messagesEl.appendChild(empty);
+                return;
             }
-            conversation.forEach(turn => {
+
+            const start = Math.max(0, conversation.length - THREAD_INITIAL_TURNS);
+            threadRender = { conversation, earliestShown: start, loadBtn: null };
+            if (start > 0) {
+                const btn = document.createElement('button');
+                btn.className = 'thread-load-earlier';
+                btn.onclick = loadEarlierThreadTurns;
+                messagesEl.appendChild(btn);
+                threadRender.loadBtn = btn;
+            }
+            // Build the visible tail into a fragment so the whole batch lands in
+            // one reflow (and without per-turn smooth-scroll thrash).
+            messagesEl.appendChild(renderThreadTurns(conversation, start, conversation.length));
+            updateLoadEarlierLabel();
+        }
+
+        // Render conversation[from, to) into a detached fragment.
+        function renderThreadTurns(conversation, from, to) {
+            const frag = document.createDocumentFragment();
+            for (let i = from; i < to; i++) {
+                const turn = conversation[i];
                 const role = turn.role === 'user' ? 'user' : 'assistant';
                 const body = (turn.text || '').trim()
                     || ((turn.tools && turn.tools.length) ? '_(ran tools — see below)_' : '');
-                addMessage(body, role);
+                addMessage(body, role, [], null, frag);
                 if (role === 'assistant' && turn.tools && turn.tools.length) {
-                    appendToolDetails(turn.tools);
+                    appendToolDetails(turn.tools, frag);
                 }
-            });
+            }
+            return frag;
         }
 
-        function appendToolDetails(tools) {
+        function updateLoadEarlierLabel() {
+            const st = threadRender;
+            if (!st || !st.loadBtn) return;
+            const remaining = st.earliestShown;
+            if (remaining <= 0) { st.loadBtn.remove(); st.loadBtn = null; return; }
+            const chunk = Math.min(THREAD_INITIAL_TURNS, remaining);
+            st.loadBtn.textContent =
+                '⬆ Load ' + chunk + ' earlier message' + (chunk === 1 ? '' : 's') +
+                ' (' + remaining + ' hidden)';
+        }
+
+        function loadEarlierThreadTurns() {
+            const st = threadRender;
+            if (!st || !st.loadBtn) return;
+            const newStart = Math.max(0, st.earliestShown - THREAD_INITIAL_TURNS);
+            const frag = renderThreadTurns(st.conversation, newStart, st.earliestShown);
+            st.loadBtn.after(frag);  // insert the older turns right below the button
+            st.earliestShown = newStart;
+            updateLoadEarlierLabel();
+        }
+
+        function appendToolDetails(tools, target) {
+            const container = target || messagesEl;
             const wrap = document.createElement('div');
             wrap.className = 'agent-tool-details';
             tools.forEach(tl => {
@@ -3069,15 +3124,22 @@
                 const sum = document.createElement('summary');
                 sum.textContent = '🔧 ' + (tl.name || 'tool');
                 det.appendChild(sum);
-                const pre = document.createElement('pre');
-                let inputStr;
-                try { inputStr = JSON.stringify(tl.input, null, 2); }
-                catch (e) { inputStr = String(tl.input); }
-                pre.textContent = inputStr;
-                det.appendChild(pre);
+                // Serialize the tool input lazily, only on first expand. Building
+                // a <pre> for every tool call up-front is what hangs large
+                // threads (#270); collapsed details stay cheap.
+                det.addEventListener('toggle', () => {
+                    if (!det.open || det.dataset.built) return;
+                    det.dataset.built = '1';
+                    const pre = document.createElement('pre');
+                    let inputStr;
+                    try { inputStr = JSON.stringify(tl.input, null, 2); }
+                    catch (e) { inputStr = String(tl.input); }
+                    pre.textContent = inputStr;
+                    det.appendChild(pre);
+                });
                 wrap.appendChild(det);
             });
-            messagesEl.appendChild(wrap);
+            container.appendChild(wrap);
         }
 
         function updateThreadComposer() {
@@ -3648,7 +3710,7 @@
             sendMessage();
         }
 
-        function addMessage(content, type, sources = [], messageId = null) {
+        function addMessage(content, type, sources = [], messageId = null, target = null) {
             // Remove welcome message if exists
             const welcome = messagesEl.querySelector('.welcome');
             if (welcome) welcome.remove();
@@ -3701,8 +3763,11 @@
             }
 
             msg.innerHTML = html;
-            messagesEl.appendChild(msg);
-            scrollToBottom();
+            // When rendering into a detached target (e.g. bulk thread render),
+            // append there and skip the per-message scroll; the caller scrolls
+            // once after the batch lands.
+            (target || messagesEl).appendChild(msg);
+            if (!target) scrollToBottom();
 
             return msg;
         }


### PR DESCRIPTION
## Summary
Opening an agent thread with a very large transcript froze the `/chat` thread view — it rendered the entire reconstructed conversation in one synchronous pass and emitted every tool call's full input as a `<pre>` block, producing a massive DOM that hung the renderer.

This bounds what the DOM holds at once:
- **Cap the initial render** to the newest `THREAD_INITIAL_TURNS` (30) turns, built into a `DocumentFragment` (single reflow, no per-turn smooth-scroll thrash).
- **"Load earlier" control** reveals older turns in chunks — full history stays reachable, nothing is truncated away.
- **Lazy tool details** — each tool-call `<pre>` is serialized only on first expand, not up-front.

Small/normal threads are visually unchanged (the control only appears when the conversation exceeds the cap).

Closes #270

## Test evidence
`tests/test_agent_threads_ui_browser.py` — ran against the actual `web/index.html` (served standalone), **11 passed** (6 existing + 5 new):
- initial render capped to newest 30 turns (90-turn fixture)
- "load earlier" reveals hidden turns in chunks; full history reachable via repeated load; button self-removes when exhausted
- tool-detail `<pre>` built lazily on expand
- small thread renders with no "load earlier" control

Unit suite (`./scripts/test.sh`): 2519 passed. The 9 failures are pre-existing and environmental (local model-default config drift, local person-id config, and server-dependent MCP/CRM tests flaky on the shared box — `test_health_check` passed on retry); none touch this diff, which is `web/index.html` + the browser test only.

## Review focus
- `appendToolDetails` lazy-build: the `<pre>` persists across collapse/expand via the `built` flag; correct?
- `loadEarlierThreadTurns` chronological ordering — older chunks insert directly below the anchored button, before the already-shown tail.
- `addMessage`'s new optional `target` param: when set, appends to the target and skips `scrollToBottom`; default path unchanged.