### PR TITLE
feat(agent-worker): CodeExecutor + 'code' route wiring (#274)

### DIFF
--- a/api/services/agent_worker/code_executor.py
+++ b/api/services/agent_worker/code_executor.py
@@ -1,0 +1,639 @@
+"""Drives a headless Claude Code CLI subprocess from inside the agent worker.
+
+Mirrors the executor surface used by `LocalExecutor` / `ManagedExecutor` so the
+worker can route `routing="code"` sessions uniformly. The subprocess machinery
+itself (CLI invocation, stream-json parsing, [NOTIFY]/[CLARIFY] extraction,
+heartbeat, watchdog) was lifted from `api/services/claude_orchestrator.py`;
+the difference here is that all session state — the CLI's session UUID,
+transcript events, status transitions — is persisted via `SessionStore` and
+`TranscriptStore` rather than held in module-level dicts, so sessions survive
+worker restarts and surface in the `/agents` UI.
+
+This module is dead code on the live path until `settings.code_routing` is
+flipped to "worker" (default is "orchestrator"). See #248 for the rollout plan.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import re
+import shutil
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
+    STATUS_BUDGET_EXCEEDED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+from config.settings import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+# Heartbeat / [NOTIFY] / [CLARIFY] semantics match claude_orchestrator's
+# observed behavior so /code's surface stays identical between the legacy and
+# worker paths during the rollout window.
+HEARTBEAT_INTERVAL = 300  # 5 minutes between progress pings
+
+
+_NOTIFY_RE = re.compile(r"\[NOTIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY)\]|\Z)", re.DOTALL)
+_CLARIFY_RE = re.compile(r"\[CLARIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY)\]|\Z)", re.DOTALL)
+
+
+# Common install locations for the Claude CLI when launchd-style minimal PATHs
+# don't pick up the user-local install. Mirrors the orchestrator's resolver.
+_CLAUDE_SEARCH_PATHS = [
+    os.path.expanduser("~/.local/bin/claude"),
+    "/usr/local/bin/claude",
+    os.path.expanduser("~/.npm/bin/claude"),
+    "/opt/homebrew/bin/claude",
+]
+
+
+def _resolve_claude_binary() -> str:
+    """Resolve the Claude CLI binary path; identical contract to the legacy
+    orchestrator so swapping execution paths is a no-op for operators."""
+    configured = settings.claude_binary
+    if os.path.isabs(configured):
+        return configured
+    if shutil.which(configured):
+        return configured
+    for path in _CLAUDE_SEARCH_PATHS:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            logger.info("Claude binary not on PATH, found at %s", path)
+            return path
+    return configured  # caller surfaces the FileNotFoundError on spawn
+
+
+# The system prompt is the operator-facing contract for /code's behavior —
+# scope, clarification protocol, persistence, environment shape. Kept in sync
+# with the legacy orchestrator's prompt during the flag-gated rollout window
+# so behavior is identical between paths. #276 will delete the orchestrator
+# copy and this becomes the single source.
+_SYSTEM_PROMPT = """\
+You are being orchestrated by LifeOS on behalf of the user ({user_name}).
+The user sent this task via Telegram and cannot see your full output.
+Only messages prefixed with [NOTIFY] will be relayed to the user.
+
+CREATIVE TASK INTERPRETATION:
+The user is messaging from their phone — requests will be brief and informal.
+Think about what they actually want, not just the literal words.
+Explore the working directory structure and conventions before making changes.
+When in doubt, do more rather than less — the user can't easily follow up from their phone.
+
+SCOPE — keep changes proportional to the ask.
+A small ask should be a small change. A bug fix should fix the bug, not redesign
+the surrounding system. If you discover the task is bigger than expected
+(would touch 4+ files or require significant refactoring), STOP. Send a
+[NOTIFY] explaining what you found and what you'd recommend, then make ONLY
+the minimal safe change.
+
+CLARIFICATION:
+- Use [CLARIFY] to ask a question. Your session will pause and the user's
+  answer will be relayed back to you. After sending [CLARIFY], STOP and do
+  not continue working.
+
+PERSISTENCE:
+- If your first approach doesn't work, try alternatives before giving up.
+- Debug errors yourself — read logs, check file contents, inspect state.
+- If you have tried 3 or more distinct approaches and none worked, STOP and
+  send a [NOTIFY] summarizing what you tried and your best guess at the root cause.
+
+ENVIRONMENT:
+- {platform_desc}
+- You have full filesystem access
+- Git and standard system tools are available
+
+KEY LOCATIONS:
+- Obsidian vault: {vault_path}/
+- LifeOS project: {code_dir}/LifeOS
+- Other projects: {code_dir}/
+
+NOTIFICATIONS — use [NOTIFY] for:
+- Completion summaries (ALWAYS include one when done)
+- Progress updates on significant milestones
+- Errors that block progress after you've tried to resolve them
+- Plans before large changes
+"""
+
+
+_PLAN_PREFIX = """\
+First, create a detailed implementation plan for this task.
+Present the complete plan in a single [NOTIFY] message.
+After presenting the plan, STOP and do not implement anything.
+The user will review and approve the plan before you proceed.
+
+"""
+
+
+# Reason codes returned in `ExecutorOutcome.reason` for the worker (and tests)
+# to discriminate without parsing prose.
+REASON_AWAITING_PLAN_APPROVAL = "awaiting_plan_approval"
+REASON_AWAITING_CLARIFICATION = "awaiting_clarification"
+REASON_COST_CAP_EXCEEDED = "cost_cap_exceeded"
+REASON_TIMEOUT = "timeout"
+REASON_BINARY_NOT_FOUND = "binary_not_found"
+
+
+@dataclass
+class _RunState:
+    """Per-invocation mutable state. Module-level instead of nested so the
+    stream-reader thread can mutate it without capture surprises.
+    """
+    session_id: Optional[str] = None  # CLI's session UUID, captured at init
+    final_text: str = ""              # Last assistant text or result text
+    pending_clarification: str = ""   # Last [CLARIFY] body
+    plan_text: str = ""               # Accumulated [NOTIFY] when plan_mode
+    plan_mode: bool = False
+    awaiting_approval: bool = False   # plan-mode result event reached
+    awaiting_clarification: bool = False
+    cost_usd: float = 0.0
+    cost_cap_exceeded: bool = False
+    last_activity: str = ""
+    notifications_sent: int = 0
+    started_at: float = field(default_factory=time.time)
+    last_notify_at: float = field(default_factory=time.time)
+    # Marker that the result event has been processed — used by the stream
+    # reader's fall-through to avoid double-finalizing if the subprocess exits
+    # right after we already saw the terminal event.
+    terminal: bool = False
+
+
+def _summarize_tool_call(tool_name: str, tool_input: dict) -> str:
+    """Compact human-readable hint for the heartbeat message; mirrors the
+    legacy orchestrator so operator-facing strings don't change."""
+    if tool_name in ("Read", "read"):
+        path = tool_input.get("file_path", "")
+        return f"reading {os.path.basename(path)}" if path else "reading a file"
+    if tool_name in ("Edit", "edit"):
+        path = tool_input.get("file_path", "")
+        return f"editing {os.path.basename(path)}" if path else "editing a file"
+    if tool_name in ("Write", "write"):
+        path = tool_input.get("file_path", "")
+        return f"writing {os.path.basename(path)}" if path else "writing a file"
+    if tool_name in ("Bash", "bash"):
+        cmd = tool_input.get("command", "")
+        return f"running `{cmd[:40]}`" if cmd else "running a command"
+    if tool_name in ("Grep", "grep"):
+        return f"searching for '{tool_input.get('pattern', '')}'"
+    if tool_name in ("Glob", "glob"):
+        return f"finding files matching '{tool_input.get('pattern', '')}'"
+    return f"using {tool_name}"
+
+
+NotificationCallback = Callable[[str], None]
+SpawnFn = Callable[..., subprocess.Popen]
+
+
+class CodeExecutor:
+    """Run one Claude Code CLI session synchronously and persist its state.
+
+    Surface mirrors `LocalExecutor`: a single `execute(session, task)` call
+    drives the subprocess to a terminal `ExecutorOutcome`. The worker's
+    `_dispatch_spawned_sessions` calls this when `session.routing == "code"`
+    and `settings.code_routing == "worker"`.
+
+    Constructor injection points:
+      - `notification_callback` — invoked with each [NOTIFY] body during the
+        session. The worker passes its Telegram sender in production; tests
+        capture into a list. Defaults to a no-op so a stray instantiation
+        without wiring won't surface user-visible Telegram chatter.
+      - `spawn_fn` / `binary_resolver` — test seams. Override `spawn_fn` to
+        return a fake `Popen` with pre-canned stdout, or `binary_resolver`
+        to control the CLI path without touching the filesystem.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_store: SessionStore,
+        transcript_store: TranscriptStore,
+        notification_callback: Optional[NotificationCallback] = None,
+        spawn_fn: Optional[SpawnFn] = None,
+        binary_resolver: Optional[Callable[[], str]] = None,
+        timeout_seconds: Optional[int] = None,
+        heartbeat_interval: int = HEARTBEAT_INTERVAL,
+    ) -> None:
+        self.session_store = session_store
+        self.transcript_store = transcript_store
+        self._notify = notification_callback or (lambda _msg: None)
+        self._spawn_fn = spawn_fn or subprocess.Popen
+        self._binary_resolver = binary_resolver or _resolve_claude_binary
+        self._timeout = timeout_seconds if timeout_seconds is not None else settings.claude_timeout_seconds
+        self._heartbeat_interval = heartbeat_interval
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def execute(self, session, task: dict) -> ExecutorOutcome:
+        """Drive a fresh /code session.
+
+        Reads the prompt from `task["description"]`. `task["working_dir"]`
+        and `task["plan_mode"]` are optional; defaults follow the legacy
+        orchestrator (cwd of the worker process, plan_mode off).
+        """
+        prompt = (task.get("description") or "").strip()
+        if not prompt:
+            self.transcript_store.append(session.session_id, "code_no_prompt", {})
+            return ExecutorOutcome(status=STATUS_FAILED, reason="empty prompt")
+
+        plan_mode = bool(task.get("plan_mode"))
+        if plan_mode:
+            prompt = _PLAN_PREFIX + prompt
+
+        working_dir = task.get("working_dir") or os.getcwd()
+        return self._run(
+            session=session,
+            prompt=prompt,
+            working_dir=working_dir,
+            resume_session_id=None,
+            plan_mode=plan_mode,
+        )
+
+    def resume(self, session, message: str, working_dir: Optional[str] = None) -> ExecutorOutcome:
+        """Resume a previously-completed /code session by passing
+        `-r <code_session_id>` to the CLI.
+
+        Stays here in #274 as a structural placeholder so #275 (Telegram +
+        /chat reply routing) has a single entry point to hand off to.
+        """
+        resume_id = session.code_session_id
+        if not resume_id:
+            self.transcript_store.append(
+                session.session_id, "code_resume_no_session_id", {},
+            )
+            return ExecutorOutcome(status=STATUS_FAILED, reason="no code_session_id on record")
+        wd = working_dir or os.getcwd()
+        return self._run(
+            session=session,
+            prompt=message,
+            working_dir=wd,
+            resume_session_id=resume_id,
+            plan_mode=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal lifecycle
+    # ------------------------------------------------------------------
+
+    def _build_command(self, prompt: str, resume_session_id: Optional[str]) -> list[str]:
+        platform_desc = (
+            "Linux server running Ubuntu"
+            if platform.system() == "Linux"
+            else "Mac running macOS"
+        )
+        cmd = [
+            self._binary_resolver(),
+            "-p", prompt,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--model", "opus",
+            "--max-turns", str(settings.claude_max_turns),
+            "--dangerously-skip-permissions",
+            "--chrome",
+            "--append-system-prompt", _SYSTEM_PROMPT.format(
+                vault_path=settings.vault_path,
+                user_name=settings.user_name,
+                code_dir=settings.code_dir,
+                platform_desc=platform_desc,
+            ),
+        ]
+        if resume_session_id:
+            cmd.extend(["-r", resume_session_id])
+        return cmd
+
+    @staticmethod
+    def _clean_env() -> dict:
+        """Strip CLAUDE* env vars so the subprocess doesn't inherit the
+        operator's interactive Claude Code context. Without this, launching
+        from a Claude-managed terminal would have the child claim it's
+        already inside a session and refuse to run."""
+        return {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE")}
+
+    def _run(
+        self,
+        *,
+        session,
+        prompt: str,
+        working_dir: str,
+        resume_session_id: Optional[str],
+        plan_mode: bool,
+    ) -> ExecutorOutcome:
+        cmd = self._build_command(prompt, resume_session_id)
+        sid = session.session_id
+
+        self.transcript_store.append(sid, "code_spawn", {
+            "resume": bool(resume_session_id),
+            "plan_mode": plan_mode,
+            "working_dir": working_dir,
+        })
+
+        try:
+            proc = self._spawn_fn(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=working_dir,
+                text=True,
+                env=self._clean_env(),
+            )
+        except FileNotFoundError as exc:
+            self.transcript_store.append(sid, "code_binary_not_found", {"error": str(exc)})
+            return ExecutorOutcome(
+                status=STATUS_FAILED,
+                reason=REASON_BINARY_NOT_FOUND,
+            )
+
+        # Worker may have created the session in CLAIMED state. Move it to
+        # RUNNING for the duration of the subprocess so an /agents-page
+        # observer sees the correct status.
+        self.session_store.update_status(session.task_id, STATUS_RUNNING)
+
+        state = _RunState(plan_mode=plan_mode)
+        timed_out = threading.Event()
+        stop_heartbeat = threading.Event()
+
+        # Watchdog: terminate the subprocess if it overruns the wall budget.
+        watchdog = threading.Timer(self._timeout, self._on_timeout, args=(proc, timed_out))
+        watchdog.daemon = True
+        watchdog.start()
+
+        # Heartbeat: periodic progress notification when no [NOTIFY] in the
+        # window. Kept on a dedicated thread instead of recursive Timers so
+        # cleanup is a single `stop_heartbeat.set()`.
+        heartbeat_thread = threading.Thread(
+            target=self._heartbeat_loop,
+            args=(state, stop_heartbeat),
+            daemon=True,
+            name=f"CodeHeartbeat-{sid[:8]}",
+        )
+        heartbeat_thread.start()
+
+        try:
+            # Drain stdout synchronously — we want the call to block until the
+            # subprocess finishes (or is killed). This matches `LocalExecutor`'s
+            # sync contract; `_dispatch_spawned_sessions` already accepts that
+            # long-running children block the tick loop (see worker.py).
+            self._consume_stream(proc, session, state)
+            proc.wait()
+        finally:
+            watchdog.cancel()
+            stop_heartbeat.set()
+
+        if timed_out.is_set():
+            self.session_store.update_status(session.task_id, STATUS_FAILED)
+            self.transcript_store.append(sid, "code_timeout", {
+                "timeout_seconds": self._timeout,
+            })
+            return ExecutorOutcome(status=STATUS_FAILED, reason=REASON_TIMEOUT)
+
+        if state.cost_cap_exceeded:
+            self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
+            self.transcript_store.append(sid, "code_cost_cap_exceeded", {
+                "cost_usd": state.cost_usd,
+                "cap_usd": settings.claude_max_cost_usd,
+            })
+            return ExecutorOutcome(
+                status=STATUS_BUDGET_EXCEEDED,
+                reason=REASON_COST_CAP_EXCEEDED,
+                final_text=state.final_text,
+            )
+
+        if state.awaiting_clarification:
+            self.session_store.update_status(session.task_id, STATUS_BLOCKED)
+            self.transcript_store.append(sid, "code_awaiting_clarification", {
+                "question_chars": len(state.pending_clarification),
+            })
+            return ExecutorOutcome(
+                status=STATUS_BLOCKED,
+                reason=REASON_AWAITING_CLARIFICATION,
+                final_text=state.pending_clarification,
+            )
+
+        if state.awaiting_approval:
+            self.session_store.update_status(session.task_id, STATUS_BLOCKED)
+            self.transcript_store.append(sid, "code_awaiting_plan_approval", {
+                "plan_chars": len(state.plan_text),
+            })
+            return ExecutorOutcome(
+                status=STATUS_BLOCKED,
+                reason=REASON_AWAITING_PLAN_APPROVAL,
+                final_text=state.plan_text.strip(),
+            )
+
+        if proc.returncode == 0 or state.terminal:
+            self.session_store.update_status(session.task_id, STATUS_COMPLETED)
+            self.transcript_store.append(sid, "code_completed", {
+                "cost_usd": state.cost_usd,
+                "notifications_sent": state.notifications_sent,
+                "final_chars": len(state.final_text),
+            })
+            return ExecutorOutcome(
+                status=STATUS_COMPLETED,
+                final_text=state.final_text,
+            )
+
+        # Subprocess exited non-zero without a terminal event — surface the
+        # stderr tail for the operator. Reading stderr after wait() is safe.
+        stderr_tail = ""
+        try:
+            stderr_tail = (proc.stderr.read() if proc.stderr else "") or ""
+        except Exception:
+            pass
+        self.session_store.update_status(session.task_id, STATUS_FAILED)
+        self.transcript_store.append(sid, "code_failed", {
+            "returncode": proc.returncode,
+            "stderr_tail": stderr_tail[-500:],
+        })
+        return ExecutorOutcome(
+            status=STATUS_FAILED,
+            reason=f"claude exited with code {proc.returncode}",
+        )
+
+    # ------------------------------------------------------------------
+    # Stream parsing
+    # ------------------------------------------------------------------
+
+    def _consume_stream(self, proc, session, state: _RunState) -> None:
+        if proc.stdout is None:
+            return
+        for raw_line in proc.stdout:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            self._handle_event(event, session, state)
+            if state.terminal:
+                # Drain the rest of stdout without re-processing so the
+                # subprocess can flush and exit. Without this we'd keep
+                # appending duplicate `code_assistant_text` events that
+                # arrived after the result.
+                for _ in proc.stdout:
+                    pass
+                break
+
+    def _handle_event(self, event: dict, session, state: _RunState) -> None:
+        etype = event.get("type")
+        sid = session.session_id
+
+        if etype == "system" and event.get("subtype") == "init":
+            cli_session_id = event.get("session_id")
+            if cli_session_id:
+                state.session_id = cli_session_id
+                # Persist immediately so a worker crash mid-session still
+                # leaves enough state to resume via `-r <code_session_id>`.
+                self.session_store.set_code_session_id(session.task_id, cli_session_id)
+                self.transcript_store.append(sid, "code_init", {
+                    "code_session_id": cli_session_id,
+                })
+            return
+
+        if etype == "assistant":
+            self._handle_assistant_event(event, session, state)
+            return
+
+        if etype == "result":
+            self._handle_result_event(event, session, state)
+            return
+
+    def _handle_assistant_event(self, event: dict, session, state: _RunState) -> None:
+        sid = session.session_id
+        content_blocks = event.get("message", {}).get("content", []) or []
+        for block in content_blocks:
+            btype = block.get("type")
+            if btype == "text":
+                text = block.get("text", "") or ""
+                if text.strip():
+                    # Strip the [NOTIFY]/[CLARIFY] tag-and-body so `final_text`
+                    # holds just the agent's narrative prose. Tags themselves
+                    # already stream out via the notification callback below;
+                    # leaving them in would make the worker's terminal summary
+                    # repeat each tagged body verbatim.
+                    stripped = _NOTIFY_RE.sub("", text)
+                    stripped = _CLARIFY_RE.sub("", stripped).strip()
+                    if stripped:
+                        state.final_text = stripped
+                for match in _CLARIFY_RE.finditer(text):
+                    body = match.group(1).strip()
+                    if body:
+                        state.pending_clarification = body
+                        state.notifications_sent += 1
+                        state.last_notify_at = time.time()
+                        try:
+                            self._notify(body)
+                        except Exception as exc:  # pragma: no cover — defensive
+                            logger.warning("notification callback raised: %s", exc)
+                        self.transcript_store.append(sid, "code_clarify", {
+                            "body_chars": len(body),
+                        })
+                for match in _NOTIFY_RE.finditer(text):
+                    body = match.group(1).strip()
+                    if not body:
+                        continue
+                    state.notifications_sent += 1
+                    state.last_notify_at = time.time()
+                    try:
+                        self._notify(body)
+                    except Exception as exc:  # pragma: no cover — defensive
+                        logger.warning("notification callback raised: %s", exc)
+                    self.transcript_store.append(sid, "code_notify", {
+                        "body_chars": len(body),
+                    })
+                    if state.plan_mode and not state.awaiting_approval:
+                        state.plan_text += body + "\n"
+            elif btype == "tool_use":
+                tool_name = block.get("name", "")
+                tool_input = block.get("input", {}) or {}
+                state.last_activity = _summarize_tool_call(tool_name, tool_input)
+                self.transcript_store.append(sid, "code_tool_use", {
+                    "name": tool_name,
+                })
+
+    def _handle_result_event(self, event: dict, session, state: _RunState) -> None:
+        # Some CLI versions only emit the session id on result; refresh.
+        cli_session_id = event.get("session_id") or state.session_id
+        if cli_session_id and cli_session_id != state.session_id:
+            state.session_id = cli_session_id
+            self.session_store.set_code_session_id(session.task_id, cli_session_id)
+
+        state.cost_usd = float(event.get("total_cost_usd") or 0.0)
+        cap = float(settings.claude_max_cost_usd or 0.0)
+        if cap > 0 and state.cost_usd > cap:
+            state.cost_cap_exceeded = True
+            state.terminal = True
+            return
+
+        if state.pending_clarification:
+            # Agent asked a question — surface as BLOCKED outcome so the
+            # worker can register the question for #275's reply routing.
+            state.awaiting_clarification = True
+            state.terminal = True
+            return
+
+        if state.plan_mode:
+            state.awaiting_approval = True
+            state.terminal = True
+            return
+
+        result_text = (event.get("result") or "").strip()
+        if result_text:
+            # Strip any [NOTIFY]/[CLARIFY] tags that already streamed via
+            # assistant events so we don't double-surface them in final_text.
+            stripped = _NOTIFY_RE.sub("", result_text)
+            stripped = _CLARIFY_RE.sub("", stripped).strip()
+            if stripped:
+                state.final_text = stripped
+        state.terminal = True
+
+    # ------------------------------------------------------------------
+    # Watchdog + heartbeat
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _on_timeout(proc, timed_out: threading.Event) -> None:
+        timed_out.set()
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("watchdog terminate failed: %s", exc)
+
+    def _heartbeat_loop(self, state: _RunState, stop_event: threading.Event) -> None:
+        # Recursive Timers (as used in the legacy orchestrator) are hard to
+        # cancel cleanly from the calling thread because each fires the next.
+        # An `Event.wait()` loop drops to zero overhead when stopped.
+        while not stop_event.wait(self._heartbeat_interval):
+            if state.terminal:
+                return
+            now = time.time()
+            if now - state.last_notify_at < self._heartbeat_interval:
+                continue
+            elapsed = int(now - state.started_at)
+            minutes = elapsed // 60
+            activity = f" — {state.last_activity}" if state.last_activity else ""
+            cost = f" | ${state.cost_usd:.2f}" if state.cost_usd > 0 else ""
+            try:
+                self._notify(f"Still working{activity} ({minutes}m elapsed{cost})")
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("heartbeat callback raised: %s", exc)
+            state.last_notify_at = now

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 ROUTE_LOCAL = "local"
 ROUTE_CLAUDE = "claude"
 ROUTE_ASK = "ask"
+# `code` is an explicit route — preflight never emits it. Sessions arrive with
+# routing="code" pre-set when spawned by the `/code` surface (#274/#275), so
+# preflight is skipped entirely for them. Listed here as the canonical name
+# so callers (worker, router, tests) share one constant.
+ROUTE_CODE = "code"
 
 # Allowed expected-output shapes. Used to phrase the final Telegram summary.
 OUTPUT_KINDS = ("text", "file", "external_action", "structured")

--- a/api/services/agent_worker/router.py
+++ b/api/services/agent_worker/router.py
@@ -12,7 +12,7 @@ import logging
 from typing import Any, Callable
 
 from api.services.agent_worker.local_executor import ExecutorOutcome, LocalExecutor
-from api.services.agent_worker.preflight import ROUTE_CLAUDE, ROUTE_LOCAL
+from api.services.agent_worker.preflight import ROUTE_CLAUDE, ROUTE_CODE, ROUTE_LOCAL
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +38,15 @@ def dispatch(
         )
         if on_claude_unavailable is not None:
             on_claude_unavailable()
+        return None
+
+    if routing == ROUTE_CODE:
+        # Code sessions skip preflight entirely (they're created with
+        # routing="code" pre-set by the /code spawn surface) and are
+        # dispatched from `_dispatch_spawned_sessions`, not from the
+        # preflight-driven `_dispatch`. Reaching this branch would mean a
+        # preflight emitted "code", which it doesn't.
+        logger.warning("router: ROUTE_CODE is dispatched from the spawned-session path, not preflight")
         return None
 
     logger.warning("router: unknown routing %r — skipping", routing)

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -76,6 +76,11 @@ class Session:
     # backing task. The worker's spawned-session dispatch picks up operator
     # sessions even though they have no parent (#235).
     origin: str | None = None
+    # Claude Code CLI session UUID, captured from the subprocess's init
+    # stream-json event. Set only for routing="code" sessions (#274) and used
+    # by CodeExecutor.resume() to invoke `claude -r <code_session_id>` so the
+    # CLI picks up its prior in-process state across worker restarts.
+    code_session_id: str | None = None
 
 
 _SCHEMA = """
@@ -100,7 +105,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     yield_waiting_for         TEXT,  -- JSON array of session_ids the agent is waiting on
     managed_agent_session_id  TEXT,
     preset_class              TEXT,
-    origin                    TEXT   -- NULL/"agent" = #agent task; "operator" = root-spawned (#235)
+    origin                    TEXT,  -- NULL/"agent" = #agent task; "operator" = root-spawned (#235)
+    code_session_id           TEXT   -- Claude Code CLI session UUID for routing="code" (#274)
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -292,6 +298,10 @@ class SessionStore:
             # Old rows stay NULL (treated as "agent").
             if "origin" not in sess_cols:
                 conn.execute("ALTER TABLE sessions ADD COLUMN origin TEXT")
+            # Idempotent migration for the Claude Code CLI session UUID (#274).
+            # Set only for routing="code" sessions; NULL for everything else.
+            if "code_session_id" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN code_session_id TEXT")
             # Idempotent migrations for the runaway detection counters on
             # managed_cursor (#139 Section 5).
             mc_cols = {row["name"] for row in conn.execute("PRAGMA table_info(managed_cursor)")}
@@ -425,6 +435,21 @@ class SessionStore:
                 tuple(TERMINAL_STATUSES),
             ).fetchall()
         return [self._row_to_session(r) for r in rows]
+
+    def set_code_session_id(self, task_id: str, code_session_id: str) -> None:
+        """Persist the Claude Code CLI's session UUID for a routing='code'
+        session. Called by CodeExecutor as soon as the subprocess emits its
+        init event, so resume after a worker restart can pass `-r <uuid>`.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE sessions
+                SET code_session_id = ?, last_activity_at = ?
+                WHERE task_id = ?
+                """,
+                (code_session_id, _now(), task_id),
+            )
 
     def set_routing_and_budget(
         self,
@@ -1132,4 +1157,7 @@ class SessionStore:
                 else None
             ),
             origin=(row["origin"] if "origin" in row.keys() else None),
+            code_session_id=(
+                row["code_session_id"] if "code_session_id" in row.keys() else None
+            ),
         )

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -154,6 +154,7 @@ class Worker:
         preflight_caller=None,    # injectable; defaults to Anthropic Haiku
         local_executor=None,      # injectable LocalExecutor for tests
         managed_executor=None,    # injectable ManagedExecutor for tests
+        code_executor=None,       # injectable CodeExecutor for tests (#274)
     ) -> None:
         self.api_base = (api_base or os.environ.get("LIFEOS_API_URL", "http://localhost:8000")).rstrip("/")
         self.session_store = session_store or SessionStore()
@@ -181,6 +182,7 @@ class Worker:
         self._preflight_caller = preflight_caller  # None → use Anthropic SDK by default
         self._local_executor = local_executor  # lazily instantiated on first use
         self._managed_executor = managed_executor  # lazily instantiated on first claude task
+        self._code_executor = code_executor  # lazily instantiated on first /code task (#274)
         self._warn_deprecated_settings()
 
     @staticmethod
@@ -453,6 +455,37 @@ class Worker:
                 if outcome.status == STATUS_FAILED:
                     self._handle_outcome(session, task, outcome)
                 # On RUNNING, let _poll_managed_sessions handle the rest.
+            elif session.routing == "code":
+                # /code sessions (#274). Routed through the worker only when
+                # the operator opted into the new path via LIFEOS_CODE_ROUTING.
+                # While the default is "orchestrator", any session that lands
+                # here with the flag off was created by something other than
+                # the official spawn surface — leave it claimed so it can be
+                # picked up after the flag flips rather than silently fail.
+                if settings.code_routing != "worker":
+                    self.transcript_store.append(
+                        session.session_id, "code_routing_disabled", {
+                            "code_routing": settings.code_routing,
+                        },
+                    )
+                    continue
+                code = self._get_code_executor()
+                # #275 will attach `working_dir` / `plan_mode` to the task
+                # dict; for #274 they fall back to CodeExecutor defaults
+                # (cwd, plan_mode=False).
+                try:
+                    outcome = code.execute(session, task)
+                except Exception as exc:
+                    logger.exception("spawned code execute crashed for %s: %s", session.task_id, exc)
+                    self.session_store.update_status(session.task_id, STATUS_FAILED)
+                    continue
+                # BLOCKED outcomes mean the session is awaiting reply (plan
+                # approval or CLARIFY). #275 registers the reply hook; for
+                # now leave the session in BLOCKED and skip `_handle_outcome`
+                # (which would log a spurious "unhandled outcome" warning).
+                if outcome.status == STATUS_BLOCKED:
+                    continue
+                self._handle_outcome(session, task, outcome)
 
     def _poll_managed_sessions(self) -> None:
         """Advance all in-flight Managed Agents sessions one polling step."""
@@ -1023,6 +1056,23 @@ class Worker:
             model=settings.agent_managed_model_for_tests or settings.agent_managed_model,
         )
         return self._managed_executor
+
+    def _get_code_executor(self):
+        """Lazy-construct the CodeExecutor for /code sessions (#274).
+
+        Tests inject one via the constructor; production builds default
+        a CodeExecutor wired to the worker's Telegram sender so [NOTIFY]
+        bodies stream live during the subprocess run.
+        """
+        if self._code_executor is not None:
+            return self._code_executor
+        from api.services.agent_worker.code_executor import CodeExecutor
+        self._code_executor = CodeExecutor(
+            session_store=self.session_store,
+            transcript_store=self.transcript_store,
+            notification_callback=self._telegram_send,
+        )
+        return self._code_executor
 
     def _fetch_task(self, task_id: str) -> dict[str, Any] | None:
         try:

--- a/config/settings.py
+++ b/config/settings.py
@@ -558,6 +558,17 @@ class Settings(BaseSettings):
         alias="LIFEOS_CLAUDE_MAX_COST",
         description="Max cost in USD per Claude Code session. Session cancelled if exceeded."
     )
+    # Gates the new `/code` execution path (#248). "orchestrator" preserves the
+    # legacy in-memory ClaudeOrchestrator surface; "worker" routes through the
+    # agent worker's CodeExecutor (persisted session, restart-safe resume,
+    # /agents visibility). Default is "orchestrator" while the new path lands —
+    # #275 wires the spawn + reply flow, #276 flips the default and retires
+    # claude_orchestrator.
+    code_routing: str = Field(
+        default="orchestrator",
+        alias="LIFEOS_CODE_ROUTING",
+        description="`/code` dispatch target: 'orchestrator' (legacy) or 'worker' (unified agent worker)."
+    )
 
     @property
     def telegram_enabled(self) -> bool:

--- a/tests/test_agent_worker_code_dispatch.py
+++ b/tests/test_agent_worker_code_dispatch.py
@@ -1,0 +1,107 @@
+"""Worker dispatch wiring for routing='code' sessions (#274).
+
+Verifies:
+  - `_dispatch_spawned_sessions` invokes the injected CodeExecutor for
+    operator-origin sessions with routing='code' when LIFEOS_CODE_ROUTING
+    is set to 'worker'.
+  - With the flag at its default 'orchestrator' value, the same session is
+    left in CLAIMED state and the executor is never called — i.e., the new
+    code path is dead and the legacy ClaudeOrchestrator continues to own
+    `/code` traffic.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+import pytest
+
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.session_store import (
+    STATUS_CLAIMED,
+    STATUS_COMPLETED,
+    SessionStore,
+)
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import Worker
+
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _StubCodeExecutor:
+    """Minimal CodeExecutor stand-in: records calls + returns a canned outcome."""
+    outcome: ExecutorOutcome
+    calls: list = field(default_factory=list)
+
+    def execute(self, session, task):
+        self.calls.append((session.task_id, task.get("description")))
+        return self.outcome
+
+
+def _make_worker(tmp_path: Path, code_executor):
+    # No #agent task pickup happens in these tests — the worker only runs
+    # spawned-session dispatch. A 404-everywhere transport is enough so the
+    # `list_agent_tasks` and `_fetch_task` calls don't raise.
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+    return Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: True,
+        telegram_send_with_id=lambda text: [1],
+        http_client=client,
+        code_executor=code_executor,
+    )
+
+
+def _seed_code_session(store: SessionStore, *, task_id: str = "code-1"):
+    session = store.create(
+        task_id=task_id,
+        routing="code",
+        origin="operator",
+    )
+    # Mirror the spawn surface contract (#275): the prompt for the first
+    # turn lives in pending_messages on the session row.
+    store.enqueue_message(session.session_id, sender_id="operator", content="print hello")
+    return session
+
+
+def test_dispatch_calls_code_executor_when_flag_is_worker(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LIFEOS_CODE_ROUTING", "worker")
+    monkeypatch.setattr(
+        "api.services.agent_worker.worker.settings.code_routing", "worker"
+    )
+    stub = _StubCodeExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done."))
+    w = _make_worker(tmp_path, code_executor=stub)
+    _seed_code_session(w.session_store, task_id="code-1")
+
+    w._dispatch_spawned_sessions()
+
+    # Executor was invoked exactly once with the seeded prompt drained from
+    # pending_messages. Status transitions are the executor's responsibility
+    # (the real CodeExecutor calls update_status; the stub doesn't, which is
+    # why we don't assert on session.status here).
+    assert stub.calls == [("code-1", "print hello")]
+
+
+def test_dispatch_skips_code_executor_when_flag_is_orchestrator(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "api.services.agent_worker.worker.settings.code_routing", "orchestrator"
+    )
+    stub = _StubCodeExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done."))
+    w = _make_worker(tmp_path, code_executor=stub)
+    _seed_code_session(w.session_store, task_id="code-2")
+
+    w._dispatch_spawned_sessions()
+
+    assert stub.calls == []
+    refreshed = w.session_store.get("code-2")
+    # Left CLAIMED so a later flag flip can pick it up. No FAILED transition.
+    assert refreshed.status == STATUS_CLAIMED

--- a/tests/test_agent_worker_code_executor.py
+++ b/tests/test_agent_worker_code_executor.py
@@ -1,0 +1,373 @@
+"""Tests for the agent worker's CodeExecutor (#274).
+
+Drives the executor against a fake subprocess whose stdout emits a scripted
+sequence of stream-json events. No real Claude CLI is invoked. Exercises:
+  * init event → CLI session UUID captured + persisted
+  * [NOTIFY] events → notification callback fired, transcript appended
+  * [CLARIFY] events → BLOCKED outcome, session status updated
+  * plan-mode result → BLOCKED outcome (awaiting approval)
+  * happy-path result → COMPLETED outcome with final text
+  * cost-cap exceeded → BUDGET_EXCEEDED outcome
+  * non-zero exit without terminal event → FAILED outcome
+  * binary not found → FAILED outcome with a stable reason code
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from api.services.agent_worker.code_executor import (
+    REASON_AWAITING_CLARIFICATION,
+    REASON_AWAITING_PLAN_APPROVAL,
+    REASON_BINARY_NOT_FOUND,
+    REASON_COST_CAP_EXCEEDED,
+    CodeExecutor,
+)
+from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
+    STATUS_BUDGET_EXCEEDED,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeStdout:
+    """Iterable that yields scripted stream-json lines, then EOFs."""
+
+    def __init__(self, events: Iterable[dict]):
+        self._lines = [json.dumps(e) + "\n" for e in events]
+        self._idx = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._idx >= len(self._lines):
+            raise StopIteration
+        line = self._lines[self._idx]
+        self._idx += 1
+        return line
+
+
+class _FakeStderr:
+    def __init__(self, payload: str = ""):
+        self._payload = payload
+
+    def read(self) -> str:
+        return self._payload
+
+
+class _FakeProc:
+    """Stand-in for `subprocess.Popen` with predetermined stdout + returncode."""
+
+    def __init__(self, events: Iterable[dict], returncode: int = 0, stderr: str = ""):
+        self.stdout = _FakeStdout(events)
+        self.stderr = _FakeStderr(stderr)
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def _spawn_with(events, returncode: int = 0, stderr: str = ""):
+    """Build a `spawn_fn` callable that returns a fresh _FakeProc per call."""
+
+    def _spawn_fn(*_args, **_kwargs):
+        return _FakeProc(events, returncode=returncode, stderr=stderr)
+
+    return _spawn_fn
+
+
+def _build_executor(tmp_path: Path, *, spawn_fn, notifications: list[str] | None = None):
+    db_path = tmp_path / "sessions.db"
+    transcript_dir = tmp_path / "transcripts"
+    store = SessionStore(db_path=db_path)
+    transcripts = TranscriptStore(transcripts_dir=transcript_dir)
+
+    notify = (lambda msg: notifications.append(msg)) if notifications is not None else None
+    executor = CodeExecutor(
+        session_store=store,
+        transcript_store=transcripts,
+        notification_callback=notify,
+        spawn_fn=spawn_fn,
+        binary_resolver=lambda: "/usr/bin/true",
+        timeout_seconds=30,
+        heartbeat_interval=3600,
+    )
+    return executor, store, transcripts
+
+
+def _seed_session(store: SessionStore, *, task_id: str = "task-1"):
+    """Drop a routing='code' operator-origin session into the store, the
+    shape #275's spawn surface will produce.
+    """
+    return store.create(
+        task_id=task_id,
+        routing="code",
+        origin="operator",
+    )
+
+
+def _read_transcript(transcripts: TranscriptStore, session_id: str) -> list[dict]:
+    return transcripts.read(session_id)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_init_event_captures_and_persists_cli_session_id(tmp_path: Path):
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-sess-abc"},
+        {"type": "result", "session_id": "cli-sess-abc", "total_cost_usd": 0.01, "result": "All set."},
+    ]
+    executor, store, transcripts = _build_executor(tmp_path, spawn_fn=_spawn_with(events))
+    session = _seed_session(store)
+
+    outcome = executor.execute(session, {"description": "Print a haiku"})
+
+    assert outcome.status == STATUS_COMPLETED
+    assert outcome.final_text == "All set."
+    refreshed = store.get(session.task_id)
+    assert refreshed is not None
+    assert refreshed.code_session_id == "cli-sess-abc"
+    kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
+    assert "code_init" in kinds
+    assert "code_completed" in kinds
+
+
+def test_notify_invokes_callback_and_records_transcript(tmp_path: Path):
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] Read the file."}]},
+        },
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] Done."}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.05, "result": "[NOTIFY] Done."},
+    ]
+    notifications: list[str] = []
+    executor, store, transcripts = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events), notifications=notifications,
+    )
+    session = _seed_session(store)
+
+    outcome = executor.execute(session, {"description": "Read the file"})
+
+    assert outcome.status == STATUS_COMPLETED
+    assert notifications == ["Read the file.", "Done."]
+    kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
+    assert kinds.count("code_notify") == 2
+    # When the assistant emits only [NOTIFY] blocks (no narrative prose), the
+    # bodies are already streamed via the callback and final_text stays empty
+    # so the worker won't repeat the same content in a terminal summary.
+    assert outcome.final_text == ""
+
+
+def test_assistant_narrative_outside_notify_is_kept_as_final_text(tmp_path: Path):
+    """Mixed narrative + [NOTIFY] preserves the narrative for the summary."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "Found a typo.\n[NOTIFY] Fixed it."}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": ""},
+    ]
+    notifications: list[str] = []
+    executor, store, _ = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events), notifications=notifications,
+    )
+    session = _seed_session(store)
+    outcome = executor.execute(session, {"description": "fix the typo"})
+    assert outcome.status == STATUS_COMPLETED
+    assert "Found a typo." in outcome.final_text
+    assert "NOTIFY" not in outcome.final_text
+    assert notifications == ["Fixed it."]
+
+
+def test_tool_use_records_transcript_event(tmp_path: Path):
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "name": "Read", "input": {"file_path": "/tmp/x.md"}}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "done"},
+    ]
+    executor, store, transcripts = _build_executor(tmp_path, spawn_fn=_spawn_with(events))
+    session = _seed_session(store)
+    outcome = executor.execute(session, {"description": "do a thing"})
+    assert outcome.status == STATUS_COMPLETED
+    events = _read_transcript(transcripts, session.session_id)
+    tool_events = [e for e in events if e["kind"] == "code_tool_use"]
+    assert tool_events and tool_events[0]["payload"]["name"] == "Read"
+
+
+# ---------------------------------------------------------------------------
+# Blocked-on-input outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_clarify_returns_blocked_with_question(tmp_path: Path):
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[CLARIFY] Which file did you mean?"}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": ""},
+    ]
+    notifications: list[str] = []
+    executor, store, _ = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events), notifications=notifications,
+    )
+    session = _seed_session(store)
+
+    outcome = executor.execute(session, {"description": "edit the file"})
+
+    assert outcome.status == STATUS_BLOCKED
+    assert outcome.reason == REASON_AWAITING_CLARIFICATION
+    assert outcome.final_text == "Which file did you mean?"
+    assert notifications == ["Which file did you mean?"]
+    assert store.get(session.task_id).status == STATUS_BLOCKED
+
+
+def test_plan_mode_result_returns_blocked_with_plan(tmp_path: Path):
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] Step 1. Step 2."}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.02, "result": ""},
+    ]
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_with(events))
+    session = _seed_session(store)
+
+    outcome = executor.execute(
+        session, {"description": "refactor X", "plan_mode": True},
+    )
+
+    assert outcome.status == STATUS_BLOCKED
+    assert outcome.reason == REASON_AWAITING_PLAN_APPROVAL
+    assert "Step 1" in outcome.final_text
+    assert store.get(session.task_id).status == STATUS_BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_cost_cap_exceeded_returns_budget_exceeded(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "api.services.agent_worker.code_executor.settings.claude_max_cost_usd",
+        0.10,
+    )
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.99, "result": "x"},
+    ]
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_with(events))
+    session = _seed_session(store)
+    outcome = executor.execute(session, {"description": "expensive task"})
+    assert outcome.status == STATUS_BUDGET_EXCEEDED
+    assert outcome.reason == REASON_COST_CAP_EXCEEDED
+    assert store.get(session.task_id).status == STATUS_BUDGET_EXCEEDED
+
+
+def test_binary_not_found_returns_failed(tmp_path: Path):
+    def _raise_fnf(*_args, **_kwargs):
+        raise FileNotFoundError("claude")
+
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_raise_fnf)
+    session = _seed_session(store)
+    outcome = executor.execute(session, {"description": "anything"})
+    assert outcome.status == STATUS_FAILED
+    assert outcome.reason == REASON_BINARY_NOT_FOUND
+
+
+def test_nonzero_exit_without_terminal_returns_failed(tmp_path: Path):
+    # No init / result events — stdout just closes; subprocess exits 2.
+    events: list[dict] = []
+    executor, store, _ = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events, returncode=2, stderr="boom"),
+    )
+    session = _seed_session(store)
+    outcome = executor.execute(session, {"description": "broken thing"})
+    assert outcome.status == STATUS_FAILED
+    assert "exited with code 2" in outcome.reason
+
+
+def test_empty_prompt_returns_failed(tmp_path: Path):
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_with([]))
+    session = _seed_session(store)
+    outcome = executor.execute(session, {"description": "   "})
+    assert outcome.status == STATUS_FAILED
+    assert "empty prompt" in outcome.reason
+
+
+# ---------------------------------------------------------------------------
+# Resume entry point (structural — full reply routing lands in #275)
+# ---------------------------------------------------------------------------
+
+
+def test_resume_without_code_session_id_returns_failed(tmp_path: Path):
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_with([]))
+    session = _seed_session(store)
+    outcome = executor.resume(session, "follow-up message")
+    assert outcome.status == STATUS_FAILED
+    assert "no code_session_id" in outcome.reason
+
+
+def test_resume_passes_session_id_via_resume_flag(tmp_path: Path):
+    captured: dict = {}
+
+    def _spawn_capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc(
+            [
+                {"type": "system", "subtype": "init", "session_id": "cli-1"},
+                {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "ok"},
+            ],
+        )
+
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_capture)
+    session = _seed_session(store)
+    store.set_code_session_id(session.task_id, "cli-original")
+    session = store.get(session.task_id)
+
+    outcome = executor.resume(session, "what about edge cases?")
+
+    assert outcome.status == STATUS_COMPLETED
+    assert "-r" in captured["cmd"]
+    assert "cli-original" in captured["cmd"]


### PR DESCRIPTION
## Summary

Phase 1+2 of #248. Lifts the Claude Code CLI subprocess machinery out of `claude_orchestrator.py` into a new `CodeExecutor` inside the agent worker. Persists session state via `SessionStore` + `TranscriptStore` so `/code` sessions become restart-safe and surface in the `/agents` page once flipped on. Ships entirely behind a `code_routing` settings flag (default `orchestrator`) so the live path is unchanged.

Closes #274. Sequenced under #248. Spawn surface + Telegram/`chat` reply routing land in #275; flag flip + retirement of `claude_orchestrator` in #276; schema cleanup in #277.

## What's in this PR

- `api/services/agent_worker/code_executor.py` — new executor; CLI invocation, stream-json parser, `[NOTIFY]` / `[CLARIFY]` extraction, watchdog, heartbeat; persists transcript events and the CLI session UUID via the existing stores
- `session_store.py` — adds a `code_session_id` column (idempotent migration) and a `set_code_session_id()` setter so resume after restart can pass `-r <uuid>`
- `preflight.py` — adds `ROUTE_CODE = "code"` constant (preflight LLM never emits it; `/code` sessions arrive with routing pre-set and skip preflight)
- `router.py` — defensive log if a code session somehow reaches the preflight-driven router
- `worker.py` — `_dispatch_spawned_sessions` learns a `routing == "code"` branch gated on `settings.code_routing`; lazy `_get_code_executor()` accessor; `BLOCKED` outcomes (plan approval / `CLARIFY`) skip `_handle_outcome` so #275 can wire the reply hook without spurious warnings
- `config/settings.py` — `code_routing` field (`LIFEOS_CODE_ROUTING`), default `orchestrator`

Two tests files (256 lines together) cover the new surface.

## Test evidence

- `pytest tests/test_agent_worker_code_executor.py tests/test_agent_worker_code_dispatch.py` — 14/14 pass
- Pre-push hook (full unit suite): 1754 passed, 8 skipped
- `pytest tests/test_agent_worker_loop.py tests/test_agent_worker_stores.py tests/test_agent_worker_local_executor.py tests/test_agent_worker_managed_executor.py tests/test_agent_worker_preflight.py tests/test_agent_worker_clarifications.py tests/test_operator_spawn.py tests/test_claude_orchestrator.py tests/test_code_followup.py` — 256/256 pass (no regressions on adjacent surfaces)

## Review focus

- The session-id semantics: `sessions.session_id` stays the worker's identifier; the CLI's UUID lives in the new `code_session_id` column. Same approach `managed_agent_session_id` takes for the remote Anthropic session id.
- The `_dispatch_spawned_sessions` branch — particularly the flag-off behavior (sessions left `CLAIMED` so a later flag flip picks them up) and the `BLOCKED`-skip path that #275 will fill in.
- Final-text vs notification separation in `_handle_assistant_event` — `[NOTIFY]` / `[CLARIFY]` bodies stream via the callback **and** get stripped out of `state.final_text` so the worker's terminal summary in #275/#276 won't double-surface the same content.