### PR TITLE
feat(code): spawn surface + Telegram/chat reply routing (#275)

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -524,6 +524,13 @@ def _reconstruct_conversation(messages: list[dict], events: list[dict]) -> list[
                     turns.append({"role": "assistant", "text": text, "tools": tools})
         return turns
 
+    # /code sessions: turns are reconstructed from the dedicated `code_*`
+    # transcript events (the CLI doesn't write to the `messages` table).
+    # Detect by event-kind shape rather than by routing so unit-test fixtures
+    # work without a session row.
+    if any(ev.get("kind", "").startswith("code_") for ev in events):
+        return _reconstruct_code_conversation(events)
+
     # Managed (cloud) sessions: turns live in the transcript, not the DB.
     pending_tools: list[dict] = []
     for ev in events:
@@ -545,6 +552,61 @@ def _reconstruct_conversation(messages: list[dict], events: list[dict]) -> list[
                 pending_tools = []
     if pending_tools:
         turns.append({"role": "assistant", "text": "", "tools": pending_tools})
+    return turns
+
+
+def _reconstruct_code_conversation(events: list[dict]) -> list[dict]:
+    """Build /chat-friendly turns from a routing='code' transcript (#275).
+
+    Events of interest:
+      - ``code_user_prompt`` — operator prompt or threaded reply, starts a
+        new user turn
+      - ``code_notify`` / ``code_clarify`` — assistant body, accumulated
+        into the current assistant turn
+      - ``code_tool_use`` — attached to the current assistant turn
+    Everything else (init, completion markers, failure events) is metadata
+    that the events panel already surfaces, so it's skipped here.
+    """
+    turns: list[dict] = []
+    cur_assistant: dict | None = None
+
+    def _flush():
+        nonlocal cur_assistant
+        if cur_assistant and (cur_assistant["text"] or cur_assistant["tools"]):
+            turns.append(cur_assistant)
+        cur_assistant = None
+
+    for ev in events:
+        kind = ev.get("kind", "")
+        payload = ev.get("payload") or {}
+        if kind == "code_user_prompt":
+            _flush()
+            text = (payload.get("text") or "").strip()
+            if text:
+                turns.append({"role": "user", "text": text, "tools": []})
+            continue
+        if kind in ("code_notify", "code_clarify"):
+            body = (payload.get("body") or payload.get("text") or "").strip()
+            if not body:
+                # The executor stores `body_chars` for these events to keep the
+                # transcript small; the full body lives in messages streamed to
+                # Telegram. /chat falls back to the cardinal label.
+                body = "(notification)" if kind == "code_notify" else "(clarification)"
+            if cur_assistant is None:
+                cur_assistant = {"role": "assistant", "text": body, "tools": []}
+            else:
+                cur_assistant["text"] = (cur_assistant["text"] + "\n\n" + body).strip()
+            continue
+        if kind == "code_tool_use":
+            if cur_assistant is None:
+                cur_assistant = {"role": "assistant", "text": "", "tools": []}
+            cur_assistant["tools"].append({
+                "name": payload.get("name") or "tool",
+                "input": payload.get("input") or {},
+            })
+            continue
+
+    _flush()
     return turns
 
 

--- a/api/services/agent_worker/code_executor.py
+++ b/api/services/agent_worker/code_executor.py
@@ -540,7 +540,7 @@ class CodeExecutor:
                         except Exception as exc:  # pragma: no cover — defensive
                             logger.warning("notification callback raised: %s", exc)
                         self.transcript_store.append(sid, "code_clarify", {
-                            "body_chars": len(body),
+                            "body": body, "body_chars": len(body),
                         })
                 for match in _NOTIFY_RE.finditer(text):
                     body = match.group(1).strip()
@@ -553,7 +553,7 @@ class CodeExecutor:
                     except Exception as exc:  # pragma: no cover — defensive
                         logger.warning("notification callback raised: %s", exc)
                     self.transcript_store.append(sid, "code_notify", {
-                        "body_chars": len(body),
+                        "body": body, "body_chars": len(body),
                     })
                     if state.plan_mode and not state.awaiting_approval:
                         state.plan_text += body + "\n"
@@ -562,7 +562,7 @@ class CodeExecutor:
                 tool_input = block.get("input", {}) or {}
                 state.last_activity = _summarize_tool_call(tool_name, tool_input)
                 self.transcript_store.append(sid, "code_tool_use", {
-                    "name": tool_name,
+                    "name": tool_name, "input": tool_input,
                 })
 
     def _handle_result_event(self, event: dict, session, state: _RunState) -> None:

--- a/api/services/agent_worker/code_spawn.py
+++ b/api/services/agent_worker/code_spawn.py
@@ -1,0 +1,120 @@
+"""Operator spawn for `routing='code'` agent-worker sessions (#275).
+
+`/code` (Telegram + `/chat`) calls this helper to create a parentless,
+operator-origin session with routing pre-set to ``code``. The prompt and
+optional dispatch metadata (``working_dir``, ``plan_mode``, originating
+``chat_id``) are enqueued as a JSON pending-message so the worker's
+``_dispatch_spawned_sessions`` drains them on the next tick and hands off
+to ``CodeExecutor.execute``.
+
+Mirrors ``operator_spawn.create_operator_session`` in shape, but skips
+preflight entirely — the route is explicit and the per-task budget reuses
+the existing Claude Code wall/cost knobs (``LIFEOS_CLAUDE_TIMEOUT`` etc.).
+
+This helper does not check ``settings.code_routing``. The caller (the
+Telegram listener or ``/code`` HTTP route) is responsible for flag-gating
+so the legacy ``ClaudeOrchestrator`` path remains the default until
+``#276`` flips the switch and ``#276`` retires this module's sibling.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from config.settings import settings
+
+from .session_store import STATUS_CLAIMED, SessionStore, new_session_id
+
+
+logger = logging.getLogger(__name__)
+
+
+def _code_budget() -> dict:
+    """Per-session budget. Falls back to the legacy Claude Code knobs so
+    operators don't have to dual-configure ``LIFEOS_CLAUDE_*`` and a new
+    ``LIFEOS_CODE_*`` set during the rollout window."""
+    return {
+        "wall_seconds": int(settings.claude_timeout_seconds),
+        # Token cap is informational for the code route — the CLI manages its
+        # own context. Mirror the operator default so budget reporting in
+        # ``/agents`` stays meaningful.
+        "max_tokens": int(settings.agent_default_max_tokens),
+        "max_dollars": float(settings.claude_max_cost_usd),
+    }
+
+
+def spawn_code_session(
+    session_store: SessionStore,
+    prompt: str,
+    *,
+    working_dir: str | None = None,
+    plan_mode: bool = False,
+    chat_id: str | None = None,
+) -> dict:
+    """Create a parentless ``routing='code'`` session.
+
+    Returns ``{"ok": True, "session_id", "task_id"}`` on success, or
+    ``{"ok": False, "error"}`` when ``prompt`` is empty.
+
+    The prompt and dispatch hints are bundled into a single pending-message
+    payload (JSON) so the worker can drain them as one unit. Keeping it on
+    the same row preserves the operator_spawn invariant that the prompt is
+    available before the session row is observable, even though the worker
+    runs in a separate process.
+    """
+    prompt = (prompt or "").strip()
+    if not prompt:
+        return {"ok": False, "error": "prompt is required"}
+
+    session_id = new_session_id()
+    task_id = f"code_{session_id.removeprefix('sess_')}"
+
+    payload = {
+        "prompt": prompt,
+        "working_dir": working_dir,
+        "plan_mode": bool(plan_mode),
+        "chat_id": chat_id,
+    }
+    # See operator_spawn for the rationale on enqueueing the prompt before
+    # the session row exists.
+    session_store.enqueue_message(session_id, "operator", json.dumps(payload))
+    session = session_store.create(
+        task_id=task_id,
+        session_id=session_id,
+        status=STATUS_CLAIMED,
+        routing="code",
+        budget=_code_budget(),
+        expected_output="text",
+        parent_session_id=None,
+        origin="operator",
+    )
+
+    logger.info(
+        "code spawn: session=%s plan_mode=%s working_dir=%s",
+        session.session_id, plan_mode, working_dir,
+    )
+    return {
+        "ok": True,
+        "session_id": session.session_id,
+        "task_id": task_id,
+    }
+
+
+def parse_code_spawn_payload(content: str) -> dict:
+    """Decode a pending-message body produced by :func:`spawn_code_session`.
+
+    Falls back to treating ``content`` as a bare prompt so legacy callers
+    (and tests that pre-seed a string-only message) keep working.
+    """
+    try:
+        data = json.loads(content)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {"prompt": content or "", "working_dir": None, "plan_mode": False, "chat_id": None}
+    if not isinstance(data, dict) or "prompt" not in data:
+        return {"prompt": content or "", "working_dir": None, "plan_mode": False, "chat_id": None}
+    return {
+        "prompt": str(data.get("prompt") or ""),
+        "working_dir": data.get("working_dir"),
+        "plan_mode": bool(data.get("plan_mode")),
+        "chat_id": data.get("chat_id"),
+    }

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -456,12 +456,13 @@ class Worker:
                     self._handle_outcome(session, task, outcome)
                 # On RUNNING, let _poll_managed_sessions handle the rest.
             elif session.routing == "code":
-                # /code sessions (#274). Routed through the worker only when
-                # the operator opted into the new path via LIFEOS_CODE_ROUTING.
-                # While the default is "orchestrator", any session that lands
-                # here with the flag off was created by something other than
-                # the official spawn surface — leave it claimed so it can be
-                # picked up after the flag flips rather than silently fail.
+                # /code sessions (#274/#275). Routed through the worker only
+                # when the operator opted into the new path via
+                # LIFEOS_CODE_ROUTING. While the default is "orchestrator",
+                # any session that lands here with the flag off was created
+                # by something other than the official spawn surface — leave
+                # it claimed so it can be picked up after the flag flips
+                # rather than silently fail.
                 if settings.code_routing != "worker":
                     self.transcript_store.append(
                         session.session_id, "code_routing_disabled", {
@@ -469,23 +470,7 @@ class Worker:
                         },
                     )
                     continue
-                code = self._get_code_executor()
-                # #275 will attach `working_dir` / `plan_mode` to the task
-                # dict; for #274 they fall back to CodeExecutor defaults
-                # (cwd, plan_mode=False).
-                try:
-                    outcome = code.execute(session, task)
-                except Exception as exc:
-                    logger.exception("spawned code execute crashed for %s: %s", session.task_id, exc)
-                    self.session_store.update_status(session.task_id, STATUS_FAILED)
-                    continue
-                # BLOCKED outcomes mean the session is awaiting reply (plan
-                # approval or CLARIFY). #275 registers the reply hook; for
-                # now leave the session in BLOCKED and skip `_handle_outcome`
-                # (which would log a spurious "unhandled outcome" warning).
-                if outcome.status == STATUS_BLOCKED:
-                    continue
-                self._handle_outcome(session, task, outcome)
+                self._dispatch_code_session(session, pending)
 
     def _poll_managed_sessions(self) -> None:
         """Advance all in-flight Managed Agents sessions one polling step."""
@@ -708,6 +693,18 @@ class Worker:
                 return
             self.session_store.mark_question_processed(q["id"])
             self._handle_outcome(session, task, outcome)
+            return
+
+        if session.routing == "code":
+            # /code follow-ups (#275). Hand the reply off as a fresh pending
+            # message so _dispatch_code_session drains it and resumes via
+            # CodeExecutor.resume(). Flipping status back to CLAIMED puts the
+            # session in the same shape as a freshly-claimed one — the
+            # dispatcher's resume branch keys on session.code_session_id
+            # being set, so it knows this is a resume rather than first run.
+            self.session_store.enqueue_message(sid, "operator", answer)
+            self.session_store.update_status(task_id, STATUS_CLAIMED)
+            self.session_store.mark_question_processed(q["id"])
             return
 
         if session.routing == ROUTE_CLAUDE:
@@ -1056,6 +1053,128 @@ class Worker:
             model=settings.agent_managed_model_for_tests or settings.agent_managed_model,
         )
         return self._managed_executor
+
+    def _dispatch_code_session(self, session, pending: list[dict]) -> None:
+        """Drive one ``routing='code'`` session through ``CodeExecutor`` (#275).
+
+        Handles both the fresh-spawn case (``code_session_id`` is NULL — call
+        ``execute()``) and the resume case (``code_session_id`` set — call
+        ``resume(message)`` with the latest drained pending message). On a
+        BLOCKED outcome the operator-facing reply prompt is sent via the
+        id-capturing Telegram sender and registered in ``pending_questions``
+        so a threaded reply round-trips through ``_resume_as_followup``.
+        """
+        from api.services.agent_worker.code_executor import (
+            REASON_AWAITING_CLARIFICATION,
+            REASON_AWAITING_PLAN_APPROVAL,
+        )
+        from api.services.agent_worker.code_spawn import parse_code_spawn_payload
+
+        code = self._get_code_executor()
+        sid = session.session_id
+
+        # Build the task dict + resume message from drained pending messages.
+        # Fresh spawns carry the JSON payload produced by ``spawn_code_session``;
+        # resumes carry plain reply text (enqueued by ``_resume_as_followup``
+        # below or by the Telegram reply hook).
+        is_resume = bool(session.code_session_id)
+        if is_resume:
+            resume_message = pending[0]["content"] if pending else ""
+            task: dict = {"id": session.task_id, "description": resume_message}
+            self.transcript_store.append(sid, "code_user_prompt", {
+                "text": resume_message, "resume": True,
+            })
+            try:
+                outcome = code.resume(session, resume_message)
+            except Exception as exc:
+                logger.exception("code resume crashed for %s: %s", session.task_id, exc)
+                self.session_store.update_status(session.task_id, STATUS_FAILED)
+                return
+        else:
+            payload = parse_code_spawn_payload(pending[0]["content"]) if pending else {
+                "prompt": "", "working_dir": None, "plan_mode": False, "chat_id": None,
+            }
+            task = {
+                "id": session.task_id,
+                "description": payload["prompt"],
+                "working_dir": payload["working_dir"],
+                "plan_mode": payload["plan_mode"],
+                "chat_id": payload["chat_id"],
+            }
+            self.transcript_store.append(sid, "code_user_prompt", {
+                "text": payload["prompt"], "resume": False,
+            })
+            try:
+                outcome = code.execute(session, task)
+            except Exception as exc:
+                logger.exception("code execute crashed for %s: %s", session.task_id, exc)
+                self.session_store.update_status(session.task_id, STATUS_FAILED)
+                return
+
+        if outcome.status == STATUS_BLOCKED:
+            if outcome.reason == REASON_AWAITING_PLAN_APPROVAL:
+                prompt = "Plan ready — reply 'approve' to proceed, 'reject' to cancel, or send feedback to refine."
+            elif outcome.reason == REASON_AWAITING_CLARIFICATION:
+                prompt = "Awaiting your reply — answer the question above to continue."
+            else:
+                prompt = "Awaiting your reply to continue."
+            try:
+                sent_ids = self._telegram_send_with_id(prompt) or []
+            except Exception as exc:
+                logger.warning("code blocked reply prompt send failed: %s", exc)
+                sent_ids = []
+            if sent_ids:
+                # kind='followup' so _resume_as_followup picks the reply up
+                # alongside agent threads (unified routing model, #248). The
+                # session.routing == 'code' tells _resume_as_followup which
+                # executor branch to take.
+                self.session_store.create_pending_question(
+                    session_id=sid,
+                    task_id=session.task_id,
+                    question=prompt,
+                    sent_message_id=sent_ids[0],
+                    sent_message_ids=sent_ids,
+                    kind="followup",
+                )
+                self.transcript_store.append(sid, "code_block_prompt_registered", {
+                    "reason": outcome.reason, "message_ids": sent_ids,
+                })
+            return
+
+        if outcome.status == STATUS_COMPLETED:
+            # Send the final assistant text (if any) to Telegram with id
+            # capture so a threaded reply can resume the session via
+            # _resume_as_followup. [NOTIFY] bodies that already streamed
+            # during execution are stripped from final_text by the executor.
+            body = outcome.final_text.strip() if outcome.final_text else ""
+            if body:
+                try:
+                    sent_ids = self._telegram_send_with_id(body) or []
+                except Exception as exc:
+                    logger.warning("code completion send failed: %s", exc)
+                    sent_ids = []
+                if sent_ids:
+                    self.session_store.create_pending_question(
+                        session_id=sid,
+                        task_id=session.task_id,
+                        question=body[:200],
+                        sent_message_id=sent_ids[0],
+                        sent_message_ids=sent_ids,
+                        kind="followup",
+                    )
+            self.transcript_store.append(sid, "code_handled_completion", {
+                "final_chars": len(body),
+            })
+            return
+
+        # FAILED / BUDGET_EXCEEDED — surface a brief operator notification.
+        # Skip _handle_outcome (which assumes an #agent vault task) since
+        # /code sessions don't have one.
+        label = "Code session"
+        if outcome.status == STATUS_BUDGET_EXCEEDED:
+            self._telegram_send(f"⚠️ {label} hit its budget ({outcome.reason}).")
+        elif outcome.status == STATUS_FAILED:
+            self._telegram_send(f"⚠️ {label} failed: {outcome.reason}.")
 
     def _get_code_executor(self):
         """Lazy-construct the CodeExecutor for /code sessions (#274).

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -762,6 +762,12 @@ class TelegramBotListener:
 
     def _check_agent_approval(self, text: str) -> bool:
         """Check if text is a short approval/rejection for a pending plan."""
+        # When LIFEOS_CODE_ROUTING='worker', plan approval flows through the
+        # threaded-reply path (#275) — the worker registers a pending_question
+        # whose reply lands in _resume_as_followup. There is no active
+        # orchestrator session to consult in that mode, so short-circuit.
+        if settings.code_routing == "worker":
+            return False
         from api.services.claude_orchestrator import get_orchestrator
         orch = get_orchestrator()
         session = orch.get_active_session()
@@ -792,6 +798,10 @@ class TelegramBotListener:
 
     def _check_agent_clarification(self) -> bool:
         """Check if a session is waiting for a clarification response."""
+        # Worker route uses the threaded-reply path; no in-memory session to
+        # consult (see _check_agent_approval).
+        if settings.code_routing == "worker":
+            return False
         from api.services.claude_orchestrator import get_orchestrator
         orch = get_orchestrator()
         session = orch.get_active_session()
@@ -851,7 +861,15 @@ class TelegramBotListener:
 
     async def _maybe_handle_code_reply(self, reply_to_message_id: int, text: str, chat_id: str) -> bool:
         """If a reply targets a Claude Code completion message (any chunk),
-        resume that session via the orchestrator's existing resume path (#237).
+        resume that session.
+
+        Worker route (#275): rows are registered with kind='followup' against
+        a session_store row whose ``routing='code'``. Depositing the answer is
+        enough — the worker's ``_resume_as_followup`` picks it up on the next
+        tick and routes through ``CodeExecutor.resume``.
+
+        Legacy orchestrator route (#237): rows are kind='code_followup'; the
+        in-memory ``ClaudeOrchestrator`` handles resume directly.
 
         Returns True if the reply was consumed as a /code follow-up.
         """
@@ -862,10 +880,30 @@ class TelegramBotListener:
         except Exception as exc:
             logger.warning(f"code reply lookup failed: {exc}")
             return False
-        if not q or q.get("kind") != "code_followup":
+        if not q:
+            return False
+        kind = q.get("kind")
+
+        # Worker-route follow-up: the pending_questions row already references
+        # a session_store row. Recognize it by kind='followup' + routing='code'
+        # on the linked session.
+        if kind == "followup":
+            session_id = q.get("session_id")
+            if not session_id:
+                return False
+            session = store.get_by_session_id(session_id)
+            if not session or session.routing != "code":
+                return False
+            # Deposit the answer; the worker tick drains it via
+            # _resume_as_followup → _dispatch_code_session → resume.
+            store.deposit_answer(reply_to_message_id, text)
+            await send_message_async("Resuming Claude Code session...", chat_id=chat_id)
+            return True
+
+        if kind != "code_followup":
             return False
 
-        # Close the row so neither the worker nor a duplicate reply reprocesses it.
+        # Legacy in-memory orchestrator path.
         store.deposit_answer(reply_to_message_id, text)
         store.mark_question_processed(q["id"])
 
@@ -889,6 +927,13 @@ class TelegramBotListener:
         Routes follow-ups to Claude Code via session resume so the context is preserved.
         Returns True if the message was handled as a follow-up.
         """
+        # Worker route (#275): no FOLLOWUP_WINDOW — the operator must
+        # thread-reply to a specific completion message. A bare non-threaded
+        # message is always a fresh chat query, never an implicit follow-up,
+        # so the main feed stays independent of any /code session.
+        if settings.code_routing == "worker":
+            return False
+
         from api.services.claude_orchestrator import get_orchestrator
         orch = get_orchestrator()
 
@@ -914,9 +959,36 @@ class TelegramBotListener:
 
     async def _handle_code_command(self, task: str, chat_id: str):
         """Spawn a Claude Code session for the given task."""
-        from api.services.claude_orchestrator import get_orchestrator
         from api.services.directory_resolver import resolve_working_directory
 
+        working_dir = resolve_working_directory(task)
+        plan_mode = self._should_use_plan_mode(task)
+        mode_label = " (plan mode)" if plan_mode else ""
+
+        if settings.code_routing == "worker":
+            # Worker route (#275): create a routing='code' session row and
+            # let the worker pick it up on the next tick. No in-memory
+            # lock — concurrency is bounded by the worker's tick loop.
+            from api.services.agent_worker.code_spawn import spawn_code_session
+            from api.services.agent_worker.session_store import SessionStore
+
+            await send_message_async(
+                f"Starting Claude Code{mode_label}...\nDirectory: `{working_dir}`",
+                chat_id=chat_id,
+            )
+            result = spawn_code_session(
+                SessionStore(),
+                task,
+                working_dir=working_dir,
+                plan_mode=plan_mode,
+                chat_id=chat_id,
+            )
+            if not result.get("ok"):
+                await send_message_async(f"Error: {result.get('error')}", chat_id=chat_id)
+            return
+
+        # Legacy in-memory orchestrator route.
+        from api.services.claude_orchestrator import get_orchestrator
         orch = get_orchestrator()
         if orch.is_busy():
             session = orch.get_active_session()
@@ -926,10 +998,6 @@ class TelegramBotListener:
             )
             return
 
-        working_dir = resolve_working_directory(task)
-        plan_mode = self._should_use_plan_mode(task)
-
-        mode_label = " (plan mode)" if plan_mode else ""
         await send_message_async(
             f"Starting Claude Code{mode_label}...\nDirectory: `{working_dir}`",
             chat_id=chat_id,
@@ -947,6 +1015,9 @@ class TelegramBotListener:
 
     async def _handle_code_status(self, chat_id: str):
         """Report on the active Claude Code session."""
+        if settings.code_routing == "worker":
+            await self._handle_code_status_worker(chat_id)
+            return
         from api.services.claude_orchestrator import get_orchestrator
         orch = get_orchestrator()
         session = orch.get_active_session()
@@ -967,8 +1038,35 @@ class TelegramBotListener:
         )
         await send_message_async(status_text, chat_id=chat_id)
 
+    async def _handle_code_status_worker(self, chat_id: str):
+        """Worker-route /code_status: list non-terminal routing='code'
+        sessions from the agent worker's session store (#275)."""
+        from api.services.agent_worker.session_store import (
+            TERMINAL_STATUSES, SessionStore,
+        )
+        store = SessionStore()
+        active = [
+            s for s in store.list_sessions(routing="code", limit=10)
+            if s.status not in TERMINAL_STATUSES
+        ]
+        if not active:
+            await send_message_async("No active Claude Code session.", chat_id=chat_id)
+            return
+        lines = ["*Claude Code Sessions*"]
+        for s in active:
+            elapsed = max(0, int(time.time() - (s.started_at or 0)))
+            minutes, seconds = divmod(elapsed, 60)
+            lines.append(
+                f"- `{s.session_id[:8]}` status: {s.status} "
+                f"({minutes}m {seconds}s, ${s.total_dollars:.4f})"
+            )
+        await send_message_async("\n".join(lines), chat_id=chat_id)
+
     async def _handle_code_cancel(self, chat_id: str):
         """Cancel the active Claude Code session."""
+        if settings.code_routing == "worker":
+            await self._handle_code_cancel_worker(chat_id)
+            return
         from api.services.claude_orchestrator import get_orchestrator
         orch = get_orchestrator()
 
@@ -978,6 +1076,34 @@ class TelegramBotListener:
 
         orch.cancel()
         await send_message_async("Claude Code session cancelled.", chat_id=chat_id)
+
+    async def _handle_code_cancel_worker(self, chat_id: str):
+        """Worker-route /code_cancel: mark non-terminal routing='code'
+        sessions as FAILED so the worker won't pick them up again.
+
+        Note: a subprocess already running in a worker tick keeps running
+        until it finishes or hits the watchdog — true mid-flight subprocess
+        kill requires a cross-process signal that the worker isn't wired for
+        in this PR. The status update is enough to prevent further dispatch
+        and to surface 'cancelled' in /agents.
+        """
+        from api.services.agent_worker.session_store import (
+            STATUS_FAILED, TERMINAL_STATUSES, SessionStore,
+        )
+        store = SessionStore()
+        active = [
+            s for s in store.list_sessions(routing="code", limit=20)
+            if s.status not in TERMINAL_STATUSES
+        ]
+        if not active:
+            await send_message_async("No active Claude Code session.", chat_id=chat_id)
+            return
+        for s in active:
+            store.update_status(s.task_id, STATUS_FAILED)
+        await send_message_async(
+            f"Marked {len(active)} Claude Code session(s) cancelled.",
+            chat_id=chat_id,
+        )
 
     async def _handle_inspect(self, chat_id: str):
         """Show sources checked and results from the last query."""

--- a/tests/test_agent_worker_code_resume.py
+++ b/tests/test_agent_worker_code_resume.py
@@ -1,0 +1,194 @@
+"""Worker integration tests for /code resume + BLOCKED flow (#275).
+
+Verifies:
+- ``_resume_as_followup`` treats a code-routed answer as a fresh pending
+  message that flips the session back to CLAIMED (so the spawned-session
+  dispatch picks it up on the next tick and calls ``CodeExecutor.resume``).
+- ``_dispatch_code_session`` calls ``resume()`` (not ``execute()``) when
+  ``session.code_session_id`` is set.
+- ``BLOCKED`` outcomes send a reply prompt with ID capture and register a
+  ``kind='followup'`` row keyed to those IDs.
+- ``COMPLETED`` outcomes with non-empty ``final_text`` register a followup row.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+import pytest
+
+from api.services.agent_worker.code_executor import (
+    REASON_AWAITING_CLARIFICATION,
+    REASON_AWAITING_PLAN_APPROVAL,
+)
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
+    STATUS_CLAIMED,
+    STATUS_COMPLETED,
+    SessionStore,
+)
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import Worker
+
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _StubCodeExecutor:
+    execute_outcome: ExecutorOutcome
+    resume_outcome: ExecutorOutcome | None = None
+    execute_calls: list = field(default_factory=list)
+    resume_calls: list = field(default_factory=list)
+
+    def execute(self, session, task):
+        self.execute_calls.append((session.task_id, task.get("description")))
+        return self.execute_outcome
+
+    def resume(self, session, message, working_dir=None):
+        self.resume_calls.append((session.task_id, message))
+        return self.resume_outcome or self.execute_outcome
+
+
+def _make_worker(tmp_path: Path, code_executor, monkeypatch):
+    monkeypatch.setattr(
+        "api.services.agent_worker.worker.settings.code_routing", "worker"
+    )
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+    sent: list[str] = []
+    sent_with_ids: list[tuple[int, str]] = []
+
+    def _send_with_id(text):
+        msg_id = len(sent_with_ids) + 4000
+        sent_with_ids.append((msg_id, text))
+        return [msg_id]
+
+    w = Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        telegram_send_with_id=_send_with_id,
+        http_client=client,
+        code_executor=code_executor,
+    )
+    w._sent = sent  # type: ignore[attr-defined]
+    w._sent_with_ids = sent_with_ids  # type: ignore[attr-defined]
+    return w
+
+
+def _seed_fresh_code_session(store: SessionStore, *, task_id="code-1"):
+    """Mirror what spawn_code_session writes."""
+    from api.services.agent_worker.code_spawn import spawn_code_session
+    result = spawn_code_session(store, "print hello", chat_id="123")
+    assert result["ok"]
+    # Patch the auto-generated task_id to the deterministic one tests use.
+    # Simpler: just return what we got.
+    return store.get_by_session_id(result["session_id"])
+
+
+def test_blocked_outcome_sends_prompt_and_registers_followup(tmp_path: Path, monkeypatch):
+    stub = _StubCodeExecutor(execute_outcome=ExecutorOutcome(
+        status=STATUS_BLOCKED,
+        reason=REASON_AWAITING_PLAN_APPROVAL,
+        final_text="step 1; step 2",
+    ))
+    w = _make_worker(tmp_path, stub, monkeypatch)
+    session = _seed_fresh_code_session(w.session_store)
+
+    w._dispatch_spawned_sessions()
+
+    assert len(stub.execute_calls) == 1
+    # Reply prompt was sent and captured with an id.
+    assert w._sent_with_ids and "approve" in w._sent_with_ids[0][1]
+    # pending_questions row registered keyed to the captured message id.
+    q = w.session_store.get_open_question_by_message_id(w._sent_with_ids[0][0])
+    assert q is not None
+    assert q["kind"] == "followup"
+    assert q["session_id"] == session.session_id
+
+
+def test_clarification_block_sends_specific_prompt(tmp_path: Path, monkeypatch):
+    stub = _StubCodeExecutor(execute_outcome=ExecutorOutcome(
+        status=STATUS_BLOCKED,
+        reason=REASON_AWAITING_CLARIFICATION,
+        final_text="which file?",
+    ))
+    w = _make_worker(tmp_path, stub, monkeypatch)
+    _seed_fresh_code_session(w.session_store)
+    w._dispatch_spawned_sessions()
+    assert "reply" in w._sent_with_ids[-1][1].lower()
+
+
+def test_completed_outcome_registers_followup_for_reply(tmp_path: Path, monkeypatch):
+    stub = _StubCodeExecutor(execute_outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="Here is the result.",
+    ))
+    w = _make_worker(tmp_path, stub, monkeypatch)
+    session = _seed_fresh_code_session(w.session_store)
+    w._dispatch_spawned_sessions()
+    assert any("result" in body for _id, body in w._sent_with_ids)
+    q = w.session_store.get_open_question_by_message_id(w._sent_with_ids[-1][0])
+    assert q is not None
+    assert q["session_id"] == session.session_id
+
+
+def test_resume_dispatch_calls_resume_not_execute(tmp_path: Path, monkeypatch):
+    stub = _StubCodeExecutor(
+        execute_outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="ok"),
+        resume_outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="resumed"),
+    )
+    w = _make_worker(tmp_path, stub, monkeypatch)
+    session = _seed_fresh_code_session(w.session_store)
+    # Drain the spawn payload, mark a code_session_id (as the executor would),
+    # then enqueue a reply.
+    w.session_store.drain_pending_messages(session.session_id)
+    w.session_store.set_code_session_id(session.task_id, "cli-abc")
+    w.session_store.enqueue_message(session.session_id, "operator", "follow up please")
+
+    w._dispatch_spawned_sessions()
+
+    assert stub.execute_calls == []
+    assert stub.resume_calls == [(session.task_id, "follow up please")]
+
+
+def test_resume_as_followup_for_code_session_flips_to_claimed(tmp_path: Path, monkeypatch):
+    """Telegram reply hook deposits answer → worker.tick processes the
+    answered question → _resume_as_followup for routing='code' just
+    re-claims the session and queues the reply as a pending message."""
+    stub = _StubCodeExecutor(execute_outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="completed",
+    ))
+    w = _make_worker(tmp_path, stub, monkeypatch)
+    session = _seed_fresh_code_session(w.session_store)
+    # Pretend the first dispatch ran and completed: drain the prompt, mark
+    # code_session_id, then a followup row was created on completion.
+    w.session_store.drain_pending_messages(session.session_id)
+    w.session_store.set_code_session_id(session.task_id, "cli-xyz")
+    # Park the session at COMPLETED to mirror the post-run state.
+    w.session_store.update_status(session.task_id, STATUS_COMPLETED)
+    w.session_store.create_pending_question(
+        session_id=session.session_id,
+        task_id=session.task_id,
+        question="result",
+        sent_message_id=5500,
+        sent_message_ids=[5500],
+        kind="followup",
+    )
+    # Operator replies — the telegram hook calls deposit_answer which marks
+    # the question as answered.
+    w.session_store.deposit_answer(5500, "yes do that")
+
+    w._process_clarification_answers()
+
+    refreshed = w.session_store.get(session.task_id)
+    assert refreshed.status == STATUS_CLAIMED
+    # The reply was queued for the resume dispatch.
+    pending = w.session_store.drain_pending_messages(session.session_id)
+    assert [p["content"] for p in pending] == ["yes do that"]

--- a/tests/test_agent_worker_code_spawn.py
+++ b/tests/test_agent_worker_code_spawn.py
@@ -1,0 +1,56 @@
+"""Tests for the routing='code' operator-spawn helper (#275)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.code_spawn import (
+    parse_code_spawn_payload,
+    spawn_code_session,
+)
+from api.services.agent_worker.session_store import (
+    STATUS_CLAIMED,
+    SessionStore,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_spawn_creates_routing_code_operator_session(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = spawn_code_session(
+        store, "write a haiku",
+        working_dir="/tmp/wd", plan_mode=True, chat_id="123",
+    )
+    assert result["ok"]
+    session = store.get_by_session_id(result["session_id"])
+    assert session is not None
+    assert session.routing == "code"
+    assert session.origin == "operator"
+    assert session.parent_session_id is None
+    assert session.status == STATUS_CLAIMED
+    # Prompt + dispatch metadata are bundled into the first pending message.
+    pending = store.drain_pending_messages(session.session_id)
+    assert len(pending) == 1
+    payload = parse_code_spawn_payload(pending[0]["content"])
+    assert payload["prompt"] == "write a haiku"
+    assert payload["working_dir"] == "/tmp/wd"
+    assert payload["plan_mode"] is True
+    assert payload["chat_id"] == "123"
+
+
+def test_spawn_rejects_empty_prompt(tmp_path: Path):
+    store = SessionStore(db_path=tmp_path / "s.db")
+    result = spawn_code_session(store, "   ")
+    assert result["ok"] is False
+    assert "required" in result["error"]
+
+
+def test_parse_legacy_string_payload_falls_back_to_prompt():
+    payload = parse_code_spawn_payload("just a plain string")
+    assert payload["prompt"] == "just a plain string"
+    assert payload["working_dir"] is None
+    assert payload["plan_mode"] is False
+    assert payload["chat_id"] is None

--- a/tests/test_agents_code_chat_view.py
+++ b/tests/test_agents_code_chat_view.py
@@ -1,0 +1,67 @@
+"""Tests for the /chat thread-view reconstruction of routing='code' sessions (#275)."""
+from __future__ import annotations
+
+import pytest
+
+from api.routes.agents import _reconstruct_code_conversation, _reconstruct_conversation
+
+
+pytestmark = pytest.mark.unit
+
+
+def _ev(kind: str, **payload):
+    return {"kind": kind, "payload": payload}
+
+
+def test_dispatcher_picks_code_branch_when_events_have_code_prefix():
+    events = [
+        _ev("code_init", code_session_id="cli-1"),
+        _ev("code_user_prompt", text="hi", resume=False),
+        _ev("code_notify", body="hello back!", body_chars=11),
+    ]
+    turns = _reconstruct_conversation(messages=[], events=events)
+    assert turns == [
+        {"role": "user", "text": "hi", "tools": []},
+        {"role": "assistant", "text": "hello back!", "tools": []},
+    ]
+
+
+def test_tool_use_attaches_to_current_assistant_turn():
+    events = [
+        _ev("code_user_prompt", text="edit foo.py", resume=False),
+        _ev("code_tool_use", name="Read", input={"file_path": "foo.py"}),
+        _ev("code_notify", body="Read it.", body_chars=8),
+        _ev("code_tool_use", name="Edit", input={"file_path": "foo.py"}),
+        _ev("code_notify", body="Made the edit.", body_chars=14),
+    ]
+    turns = _reconstruct_code_conversation(events)
+    assert len(turns) == 2
+    assert turns[0] == {"role": "user", "text": "edit foo.py", "tools": []}
+    assert turns[1]["role"] == "assistant"
+    assert "Read it." in turns[1]["text"]
+    assert "Made the edit." in turns[1]["text"]
+    assert [t["name"] for t in turns[1]["tools"]] == ["Read", "Edit"]
+
+
+def test_resume_starts_new_user_turn():
+    events = [
+        _ev("code_user_prompt", text="first ask", resume=False),
+        _ev("code_notify", body="first answer", body_chars=12),
+        _ev("code_user_prompt", text="follow up", resume=True),
+        _ev("code_notify", body="second answer", body_chars=13),
+    ]
+    turns = _reconstruct_code_conversation(events)
+    roles = [t["role"] for t in turns]
+    texts = [t["text"] for t in turns]
+    assert roles == ["user", "assistant", "user", "assistant"]
+    assert texts == ["first ask", "first answer", "follow up", "second answer"]
+
+
+def test_clarify_without_body_still_renders_a_marker():
+    events = [
+        _ev("code_user_prompt", text="ambiguous task", resume=False),
+        _ev("code_clarify", body_chars=20),  # legacy event missing 'body'
+    ]
+    turns = _reconstruct_code_conversation(events)
+    assert turns[-1]["role"] == "assistant"
+    assert "clarification" in turns[-1]["text"]


### PR DESCRIPTION
## Summary

Phase 3 of #248. Adds the operator-facing surface that connects the `CodeExecutor` (#274) to Telegram and `/chat`. Still gated behind `LIFEOS_CODE_ROUTING`: default `orchestrator` preserves every legacy behavior, `worker` opt-in routes through the unified agent worker with persistent session IDs, restart-safe resume, and `/agents`-page visibility.

Closes #275. Sequenced under #248. Flag flip + `claude_orchestrator` retirement land in #276; schema cleanup in #277.

## What's in this PR

**Spawn**
- `api/services/agent_worker/code_spawn.py` — `spawn_code_session()` creates a parentless `routing='code'`, `origin='operator'` session row and bundles prompt + working_dir + plan_mode + chat_id into the first `pending_message`.

**Worker dispatch**
- `_dispatch_spawned_sessions` hands `routing=='code'` to a dedicated `_dispatch_code_session()` that picks `execute()` vs `resume()` based on whether `code_session_id` has been captured yet.
- BLOCKED outcomes (plan approval, clarification) send an id-capturing reply prompt and register a `kind='followup'` pending_question keyed to those Telegram message ids.
- COMPLETED outcomes register a followup row so threaded replies resume the session.
- `_resume_as_followup` learns a `routing=='code'` branch — instead of running an executor inline, it queues the reply as a `pending_message` and flips the session back to CLAIMED so the spawn-dispatch path picks it up on the next tick.

**Telegram (`api/services/telegram.py`)** — every `/code` touchpoint flag-switches:
- `_handle_code_command` → `spawn_code_session()` in worker mode
- `_handle_code_status` / `_handle_code_cancel` query the session_store for non-terminal `routing='code'` sessions
- `_maybe_handle_code_reply` recognizes both legacy `kind='code_followup'` rows AND the new `kind='followup'` rows whose linked session is `routing='code'`
- `_check_code_followup`, `_check_agent_approval`, `_check_agent_clarification` short-circuit in worker mode — the main feed is independent of any specific session; the reply path is threaded-only

**`/chat` (`api/routes/agents.py`)**
- `_reconstruct_conversation` detects `code_*` events in the transcript and delegates to a new `_reconstruct_code_conversation` that builds the standard `[{role, text, tools}]` shape from the CLI transcript so the existing thread-view renderer (with #270's render bounds in place) works unchanged.

**Transcript fidelity (`code_executor.py`)**
- `code_notify` / `code_clarify` events now carry the full body; `code_tool_use` carries the tool input — the `/chat` reconstruction needs both.

## Test evidence

- 12 new tests across 3 files (spawn helper, /chat reconstruction, worker dispatch + resume + reply round-trip) — all pass
- Pre-push hook (full unit suite): 1766 passed, 8 skipped
- `pytest tests/test_agent_worker_loop.py tests/test_agent_worker_stores.py tests/test_agent_worker_clarifications.py tests/test_operator_spawn.py tests/test_claude_orchestrator.py tests/test_code_followup.py tests/test_telegram.py tests/test_agent_viz_api.py` — 209/209 pass (no regressions on adjacent surfaces)

## Review focus

- The two-step reply round-trip: Telegram hook deposits the answer → worker tick's `_resume_as_followup` flips to CLAIMED + enqueues the message → next tick's `_dispatch_code_session` sees `code_session_id` set, calls `resume()`. Each step is a small, restart-safe DB update; nothing depends on in-memory state surviving across ticks.
- The `pending_question` kind unification: legacy `code_followup` rows stay valid for the orchestrator path; the worker path registers `kind='followup'` rows that the Telegram hook discriminates by checking the linked session's routing.
- `/code_cancel` worker-mode behavior — sets sessions to FAILED but doesn't kill in-flight subprocesses (cross-process signal is a follow-up). Acceptable as a stub since `/code` is low-traffic and the watchdog still terminates runaway subprocesses.