### PR TITLE
chore(schema): drop pending_questions.kind='code_followup' (#277)

### DIFF
--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -302,6 +302,17 @@ class SessionStore:
             # Set only for routing="code" sessions; NULL for everything else.
             if "code_session_id" not in sess_cols:
                 conn.execute("ALTER TABLE sessions ADD COLUMN code_session_id TEXT")
+            # Idempotent cleanup of the legacy `code_followup` pending_question
+            # kind (#277). #237 used these rows to register a Claude Code
+            # completion against the in-memory ClaudeOrchestrator. After #276
+            # retired the orchestrator the rows are unresumable — mark any
+            # leftovers processed so the worker's clarification-answer loop
+            # doesn't try to drain them and the timeout sweeper doesn't keep
+            # nudging the operator.
+            conn.execute(
+                "UPDATE pending_questions SET processed = 1, timed_out = 1 "
+                "WHERE kind = 'code_followup' AND processed = 0"
+            )
             # Idempotent migrations for the runaway detection counters on
             # managed_cursor (#139 Section 5).
             mc_cols = {row["name"] for row in conn.execute("PRAGMA table_info(managed_cursor)")}
@@ -1062,8 +1073,8 @@ class SessionStore:
         `sent_message_id` matches — on any chunk — or None.
 
         Read-only sibling of `deposit_answer`: lets a caller inspect the matched
-        row's `kind` and route the reply (e.g. a `code_followup` resumes Claude
-        Code rather than the agent worker) before recording an answer.
+        row's `kind` before recording an answer (e.g. so the Telegram listener
+        can recognize a ``routing='code'`` follow-up).
         """
         with self._connect() as conn:
             row = conn.execute(

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -520,12 +520,6 @@ class Worker:
         for q in answered:
             session_id = q["session_id"]
             task_id = q["task_id"]
-            # `code_followup` rows (#237) point at a Claude Code session, not an
-            # agent-worker session — the Telegram listener resumes those itself.
-            # Skip them here so the worker doesn't treat them as agent threads.
-            if q.get("kind") == "code_followup":
-                self.session_store.mark_question_processed(q["id"])
-                continue
             session = self.session_store.get_by_session_id(session_id)
             if session is None:
                 # Stale — session was deleted? Mark processed so we don't loop.
@@ -773,12 +767,10 @@ class Worker:
         stale = self.session_store.list_timed_out_questions(cutoff)
         for q in stale:
             # Close every stale row, but only nudge for actual clarifications
-            # (agent BLOCKED awaiting input). Completion follow-ups —
-            # kind='followup' (#234) and kind='code_followup' (#237) — are just
-            # replyable notifications; a "re-tag with #agent to retry" nudge is
-            # wrong for them (and a code_followup points at a Claude Code
-            # session with no #agent task at all). Marking them timed out also
-            # keeps stale follow-up rows from accumulating.
+            # (agent BLOCKED awaiting input). Completion follow-ups
+            # (kind='followup', #234) are just replyable notifications; a
+            # "re-tag with #agent to retry" nudge is wrong for them. Marking
+            # them timed out also keeps stale follow-up rows from accumulating.
             self.session_store.mark_question_timed_out(q["id"])
             if (q.get("kind") or "clarification") != "clarification":
                 continue

--- a/docs/specs/technical/claude-code-orchestration.md
+++ b/docs/specs/technical/claude-code-orchestration.md
@@ -149,15 +149,15 @@ If the operator wants to cancel during a clarification, they send `/code_cancel`
 
 ---
 
-## Replyable completions (#237)
+## Replyable completions (post-#248)
 
-A reply to a `/code` completion message resumes that session, uniform with `#agent` thread replies. The mechanism reuses the shared `pending_questions` follow-up table rather than a `/code`-specific path:
+A reply to a `/code` completion message resumes that session through the same `pending_questions` table the `#agent` thread replies use — there is no `/code`-specific path:
 
-1. `run_task` / `followup` accept an `on_complete(session)` callback, fired once from `_cleanup` when a session completes successfully (status `completed`, `session_id` known) — after the final notification is sent.
-2. The Telegram listener's `_code_callbacks(chat_id)` builds the notify callback (which captures each sent message's chunk ids via `send_message_capture_ids`) plus an `on_complete` that registers a `pending_questions` row with `kind='code_followup'`, keyed to the completion message's chunk ids and storing the Claude `session_id`.
-3. On an incoming reply, `_maybe_handle_code_reply` looks up the open row (any-chunk match, `get_open_question_by_message_id`); if `kind='code_followup'` it closes the row and resumes via the orchestrator's existing `followup()` → `resume_session_id` path. The agent worker skips `code_followup` rows (they point at a Claude Code session, not an agent-worker session).
+1. `_dispatch_code_session` (in the agent worker) sends the final assistant text via the id-capturing Telegram sender and registers a `pending_questions` row with `kind='followup'` keyed to the chunk ids. The linked `sessions` row has `routing='code'` and persists the Claude CLI session UUID in `code_session_id`.
+2. On an incoming reply, `_maybe_handle_code_reply` (Telegram) looks up the row, confirms the linked session has `routing='code'`, and calls `deposit_answer`. The worker's `_process_clarification_answers` tick picks the answered row up, `_resume_as_followup` flips the session back to `CLAIMED`, enqueues the reply text as a pending message, and the next tick's `_dispatch_code_session` invokes `CodeExecutor.resume()` with `-r <code_session_id>`.
+3. Because the CLI session UUID is persisted, resume survives both worker restarts and arbitrary time gaps — there is no `FOLLOWUP_WINDOW`.
 
-This is **option A** (light build): reply *matching* is unified, but `/code` still runs as a separate session model and resume is bound to the orchestrator's `_last_completed` + `FOLLOWUP_WINDOW`. The deeper merge (routing `/code` through the unified worker, persisting the session id so resume survives restarts) is tracked as option B in #248.
+The legacy `kind='code_followup'` rows (from before #276) are auto-closed by the `SessionStore` init migration shipped in #277.
 
 ---
 

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -344,28 +344,37 @@ def test_timeout_marks_question_and_nudges(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_timeout_closes_code_followup_without_nudge(tmp_path: Path):
-    """A stale code_followup row (#237) is timed out (closed) but does NOT get
-    the agent-worker 'still waiting / re-tag with #agent' nudge — it points at a
-    Claude Code session, not an #agent task."""
-    api = FakeApi([])
-    executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
-    w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
+def test_init_migrates_legacy_code_followup_rows_processed(tmp_path: Path):
+    """Schema cleanup (#277): legacy ``kind='code_followup'`` rows left over
+    from the retired ClaudeOrchestrator are unresumable after #276. The
+    SessionStore init sweep marks any open ones as ``processed=1`` +
+    ``timed_out=1`` so the worker's drain loop and the timeout sweeper
+    leave them alone instead of looping or nudging."""
+    from api.services.agent_worker.session_store import SessionStore
 
-    qid = w.session_store.create_pending_question(
-        session_id="claude_xyz", task_id="code_claude_xyz",
+    # First open the DB and seed a legacy row directly — this mirrors what
+    # the production DB would contain post-#276 if a /code completion went
+    # un-replied for a while.
+    store = SessionStore(db_path=tmp_path / "s.db")
+    qid = store.create_pending_question(
+        session_id="claude_legacy", task_id="code_claude_legacy",
         question="fix the bug", sent_message_id=77, kind="code_followup",
     )
-    with w.session_store._connect() as conn:
+    # Force the row open even though create_pending_question stores
+    # processed=0 by default — we want to assert the migration handles
+    # genuinely-open rows.
+    with store._connect() as conn:
         conn.execute(
-            "UPDATE pending_questions SET sent_at = ? WHERE id = ?",
-            (int(time.time()) - 4 * 86400, qid),
+            "UPDATE pending_questions SET processed = 0, timed_out = 0 WHERE id = ?",
+            (qid,),
         )
-
-    w._timeout_stale_clarifications()
-
-    assert w.session_store.get_question_by_message_id(77)["timed_out"] == 1
-    assert not any("still waiting on your reply" in s for s in w._sent)
+    # Re-open the store; _init_db's migration runs again on the second open
+    # and should mark the row closed.
+    store2 = SessionStore(db_path=tmp_path / "s.db")
+    del store2  # silence unused-binding lint; the constructor was the point
+    row = store.get_question_by_message_id(77)
+    assert row["processed"] == 1
+    assert row["timed_out"] == 1
 
 
 @pytest.mark.unit
@@ -738,10 +747,12 @@ def test_operator_completion_skips_vault_mutations(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_worker_skips_code_followup_rows(tmp_path: Path):
-    """code_followup rows (#237) point at a Claude Code session, not an
-    agent-worker session — the worker must skip them (mark processed) without
-    crashing or dispatching anything."""
+def test_worker_does_not_dispatch_for_legacy_code_followup_rows(tmp_path: Path):
+    """After #277, legacy ``code_followup`` rows are auto-closed by the
+    SessionStore init migration. Even if one is created mid-flight (an
+    extremely unlikely race with a downgrade) and answered, the worker
+    never dispatches anything for it because the row is pre-marked
+    processed and ``list_answered_unprocessed_questions`` skips it."""
     api = FakeApi([])
     executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="x"))
     w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
@@ -750,9 +761,12 @@ def test_worker_skips_code_followup_rows(tmp_path: Path):
         session_id="claude_xyz", task_id="code_claude_xyz", question="t",
         sent_message_id=50, kind="code_followup",
     )
-    assert w.session_store.deposit_answer(50, "answer")
+    # Re-init the store to trigger the cleanup migration on the existing row.
+    from api.services.agent_worker.session_store import SessionStore
+    SessionStore(db_path=w.session_store.db_path)
+    w.session_store.deposit_answer(50, "answer")
 
-    w.tick()  # must not crash on the code_followup row
+    w.tick()  # must not crash and must not dispatch anything for the legacy row
 
     assert w.session_store.get_question_by_message_id(50)["processed"] == 1
-    assert executor.calls == []  # nothing dispatched for a /code row
+    assert executor.calls == []


### PR DESCRIPTION
## Summary

Phase 5 of #248. After #276 retired `ClaudeOrchestrator`, any leftover `pending_questions.kind='code_followup'` rows point at a session model that no longer exists. This PR auto-closes them in the `SessionStore` init migration and removes the discriminator branches that were defensively skipping the kind.

Closes #277. Sequenced under #248. With this merged, every target of the epic lands on the integration branch and `feat/code-orchestration` is ready to merge to `main`.

## What changes

**Migration** — `session_store._init_db` gains a one-shot `UPDATE pending_questions SET processed=1, timed_out=1 WHERE kind='code_followup' AND processed=0`. Runs every init so a process restart after a downgrade-followed-by-upgrade still closes things out idempotently.

**Code paths removed**
- `worker._process_clarification_answers` — drop the `code_followup` special-case (the migration ensures none reach the loop)
- `worker._timeout_stale_clarifications` — drop the `code_followup` branch from its filter; only `clarification` and the agent-thread `followup` kind remain
- `session_store.get_open_question_by_message_id` — docstring no longer names `code_followup` in its routing example

**Docs**
- `docs/specs/technical/claude-code-orchestration.md` rewrites the "Replyable Completions" section to describe the actual worker-based flow that replaced #237's option A — no more `FOLLOWUP_WINDOW`, no more orchestrator resume

## Test evidence

- New `test_init_migrates_legacy_code_followup_rows_processed` verifies the SessionStore sweep closes a seeded open `code_followup` row across re-opens
- Replaces `test_worker_skips_code_followup_rows` with `test_worker_does_not_dispatch_for_legacy_code_followup_rows` — confirms `deposit_answer` against such a row still never triggers an executor dispatch (the row is pre-marked processed)
- `pytest tests/test_agent_worker_clarifications.py tests/test_agent_worker_stores.py tests/test_agent_worker_loop.py tests/test_agent_worker_code_*.py tests/test_agents_code_chat_view.py tests/test_telegram.py` — 132/132 pass
- Pre-push hook passed (exit 0)

## Review focus

- The migration: a forever-on `UPDATE ... WHERE kind='code_followup' AND processed=0` runs every init. After all legacy rows are closed it's a no-op write. Cheap, safe, no schema change required.
- No code path now reads or writes `kind='code_followup'`. A future PR can drop the value from the schema docstring entirely once we're confident no operator's DB still carries the rows.