### PR TITLE
fix(watchdog): stop false-positive restart loop and cap shutdown drain

### DIFF
--- a/scripts/server-watchdog.sh
+++ b/scripts/server-watchdog.sh
@@ -64,9 +64,13 @@ restart_server() {
 }
 
 # --- Check 1: Duplicate processes ---
-# Count distinct PIDs listening on port 8000 (avoids matching SSH/shell args).
-# Normal state: 1 master PID listening. >1 means conflicting server instances.
-LISTENER_COUNT=$(lsof -ti :8000 2>/dev/null | sort -u | wc -l | tr -d ' ')
+# Count distinct PIDs *listening* on port 8000. The -sTCP:LISTEN filter is
+# load-bearing: a bare `lsof -ti :8000` also matches client processes with
+# an established connection to the API (browser SSE tabs, MCP/agent HTTP
+# clients, the agent worker's poller), which made this fire a destructive
+# restart every 5 minutes. Normal state: 1 listening PID. >1 means a genuine
+# duplicate server (e.g. a stray `uvicorn` bound alongside the systemd one).
+LISTENER_COUNT=$(lsof -ti :8000 -sTCP:LISTEN 2>/dev/null | sort -u | wc -l | tr -d ' ')
 
 if [ "$LISTENER_COUNT" -gt 1 ]; then
     log "DUPLICATE DETECTED: $LISTENER_COUNT processes listening on :8000 — restarting"

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -168,10 +168,16 @@ run_foreground() {
     log_info "ChromaDB: Running"
     log_info "Launching uvicorn on $HOST:$PORT (foreground)..."
 
-    # Exec replaces this process — systemd manages the lifecycle
+    # Exec replaces this process — systemd manages the lifecycle.
+    # timeout_graceful_shutdown caps how long uvicorn waits for in-flight
+    # connections to drain on SIGTERM before force-closing them. Without it,
+    # long-lived connections (the /agents SSE streams, the Telegram
+    # getUpdates long-poll) keep the old process alive until systemd's
+    # 90s TimeoutStopSec fires a SIGKILL — a ~90s window where the dying
+    # process still holds :8000 and every request is connection-refused.
     exec "$HOME/.venvs/lifeos/bin/python" -c "
 import uvicorn
-uvicorn.run('api.main:app', host='$HOST', port=$PORT, log_level='info')
+uvicorn.run('api.main:app', host='$HOST', port=$PORT, log_level='info', timeout_graceful_shutdown=10)
 "
 }
 
@@ -201,7 +207,7 @@ start_server() {
     log_info "Launching uvicorn on $HOST:$PORT..."
     nohup "$HOME/.venvs/lifeos/bin/python" -c "
 import uvicorn
-uvicorn.run('api.main:app', host='$HOST', port=$PORT, log_level='info')
+uvicorn.run('api.main:app', host='$HOST', port=$PORT, log_level='info', timeout_graceful_shutdown=10)
 " >> "$LOG_FILE" 2>&1 &
 
     local pid=$!


### PR DESCRIPTION
## Problem

Users hit intermittent **"Failed to fetch"** errors across the `/agents` UI (most visibly on the **Go To** button). Root cause is a destructive restart loop in the server watchdog, not the endpoint being called.

The watchdog counts "duplicate servers" with `lsof -ti :8000`. That matches **any** process with a socket on port 8000 — including *client* connections to the API: open `/agents` browser tabs holding SSE streams, MCP/agent HTTP clients, and the agent worker's poller. On a busy system the count is routinely >1 (observed live: **9** — 1 real listener + 8 clients), so the watchdog fired a restart **every 5 minutes**.

Each restart then hung the **full 90s** on graceful shutdown — the SSE streams and the Telegram `getUpdates` long-poll never close on their own — until systemd's `TimeoutStopSec` SIGKILLed it (`Failed with result 'timeout'`). During that ~90s window the dying process still held `:8000`, so new connections were refused → the browser reports "Failed to fetch". That's roughly **30% downtime on a 5-minute cycle**.

## Fix

- **`server-watchdog.sh`** — add `-sTCP:LISTEN` to the `lsof` count so only actual *listening* sockets are counted. Verified live: old logic counts `9`, new counts `1`. Genuine duplicate servers (a stray `uvicorn` bound alongside the systemd one) still trip the check; client connections no longer do.
- **`server.sh`** — pass `timeout_graceful_shutdown=10` to both `uvicorn.run` calls so SIGTERM force-closes lingering connections after 10s instead of hanging until the 90s systemd kill. This bounds the outage window of *any* restart (necessary or not).

## Testing

- `pytest -m "unit and not slow"` → **1748 passed** (the pre-push hook suite).
- Full `./scripts/test.sh` → 2575 passed, 4 failed — all 4 are pre-existing, environment-specific failures (local `.env` LLM-default overrides, vault-data integrity, slack-sync) and are unrelated to this change, which touches only two shell scripts (no Python).
- Verified `lsof -ti :8000 -sTCP:LISTEN` returns `1` on the live system, and that `uvicorn.run` accepts `timeout_graceful_shutdown`.

## Note (separate, not in this PR)

The user's *current* Go To symptom ("Couldn't locate pane") was a second, independent issue: the SessionStart pane-binding hook (`scripts/claude-session-pane.sh`) wasn't installed, and the FD-probe fallback can't work because the `claude` CLI doesn't hold its transcript `.jsonl` open. Fixed out-of-band by installing the hook in `~/.claude/settings.json` (verified: Go To now resolves from cache in ~25ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)