### PR TITLE
feat(agent-viz): shape nodes by routing so subagents match their agent type

### DIFF
--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-27
+> **Last Updated:** 2026-05-29
 
 LifeOS exposes a single live page at `/agents` that shows every agent session running on the box — both LifeOS agent worker tasks (`#agent`-tagged) and local Claude Code CLI sessions discovered on the filesystem. The graph updates every 2 seconds, clicking a node opens that session's transcript in a resizable side panel, and the operator can kill any in-flight LifeOS agent or relaunch any Claude Code session straight from the page.
 
@@ -31,15 +31,17 @@ The page is a force-directed graph of sessions, laid out left-to-right by recenc
 
 | Encoding | Meaning |
 |---|---|
-| **Shape — circle** | LifeOS agent worker session |
-| **Shape — rounded square** | Claude Code CLI session |
-| **Shape — diamond** | Claude Code subagent (Task/Agent tool-use) |
+| **Shape — circle** | Cloud agent — routed to Claude (`routing: claude`) |
+| **Shape — diamond** | Local agent — routed to local Gemma (`routing: local`) |
+| **Shape — rounded square** | Claude Code CLI session (`routing: claude_code`) |
 | **Color** | Status — green running, blue claimed, amber blocked / paused, grey done, red failed |
 | **Size** | Log-scaled by total tokens (input + output + cache). A 100k-token session is roughly 2× a 1k-token session, not 100×. Capped so one fat node can't dominate the canvas. |
 | **White pulsing border** | Session is `running` AND has written to its transcript in the last 60 seconds (i.e. *actively producing output right now*) |
 | **Edge** | Spawn relationship — parent → subagent |
 | **X position** | Last-activity recency. Most recent sessions to the right, ≥24h old pinned to the left. The recency rail compresses around center when few nodes are visible — one filtered-down node ends up centered, two sit on a narrow band — and stretches to the full width as more nodes appear. |
 | **Edge styling** | Plain curved paths (no arrowheads) between parents and subagents. When a node is selected, edges adjacent to it brighten to white. |
+
+Shape encodes *where the agent runs*, not whether it is a subagent — a Task/Agent-tool subagent takes the same shape as any other session with its routing (a Claude Code subagent is a rounded square, like its parent). Subagents are distinguished by the spawn edge connecting them to their parent, not by shape.
 
 The simulation converges in ~8 seconds and then stops, so the graph stops jittering once it settles. New snapshots arrive every 2 seconds and only nudge nodes whose positions are now misleading.
 

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-28
+> **Last Updated:** 2026-05-29
 
 Engineering view of the `/agents` page — endpoint shapes, ingest paths, status inference, layout, and security boundaries. For the consumer view see [product/agent-viz.md](../product/agent-viz.md).
 
@@ -227,7 +227,7 @@ setTimeout(() => simulation.alpha(0).stop(), 8000);  // 8s convergence backstop
 | `forceCollide radius = nodeRadius + 14, strength 0.9` | Hard guarantee that token-based-sized nodes never overlap. |
 | `velocityDecay 0.45`, `alphaDecay 0.025` | Settles in ~6s; the 8s `alpha(0).stop()` is a backstop in case extreme node counts prevent natural convergence. |
 
-Node shape varies by source — `circle` (LifeOS), `rect` (Claude Code, `rx`/`ry` rounded), `polygon` (subagent diamond). The simulation tick re-positions whichever element is bound to each datum; size and color are re-applied on every snapshot tick via `applyShapeAttrs`. The actively-writing pulse (white border, 1.4s ease-in-out) is a CSS keyframe applied via the `.pulsing` class — far simpler than the previous vis-network `DataSet.update` polling.
+Node shape varies by routing (`nodeShapeTag`) — `rect` (Claude Code CLI, `rx`/`ry` rounded; `source`/`routing` = `claude_code`), `polygon` (local-agent diamond; `routing` local/unset), `circle` (cloud-agent dot; routed to Claude). Subagents follow the same routing rule rather than getting a dedicated shape. The simulation tick re-positions whichever element is bound to each datum; size and color are re-applied on every snapshot tick via `applyShapeAttrs`. The actively-writing pulse (white border, 1.4s ease-in-out) is a CSS keyframe applied via the `.pulsing` class — far simpler than the previous vis-network `DataSet.update` polling.
 
 The `viewBox` is `1600 × 1100` with `preserveAspectRatio="xMidYMid meet"` and `overflow: visible` so collision-pushed nodes don't get clipped at the edges.
 
@@ -290,7 +290,7 @@ All three opt-in via `LIFEOS_CC_RESUME_ENABLED` (except `/cc-pane-bind`, which i
 
 ### Resume
 
-1. Validate the session id (must start with `cc:`, must pass `validate_session_id`). Strip a `:agent:...` suffix if present — operator clicks on a subagent diamond mean "resume the parent terminal".
+1. Validate the session id (must start with `cc:`, must pass `validate_session_id`). Strip a `:agent:...` suffix if present — operator clicks on a subagent node mean "resume the parent terminal".
 2. Look up the meta via `discover_sessions(...)` with a widened 365-day lookback (resume is fine on old sessions). 404 if not found or no `decoded_cwd`.
 3. Render `LIFEOS_CC_RESUME_INNER_CMD` with `{session_id}` / `{cwd}` first, then render `LIFEOS_CC_RESUME_CMD` with the same substitutions plus `{session_id_url}` / `{cwd_url}` (URL-encoded for legacy URI-scheme launchers) and `{inner_command}` (which expands to the rendered inner command's argv tokens, picked apart by `shlex.split`).
 4. `shlex.split(rendered)` — no `shell=True`, ever.

--- a/web/agents.html
+++ b/web/agents.html
@@ -781,10 +781,10 @@
     <span class="chip">recent <strong id="chip-recent">0</strong></span>
     <span class="chip" title="Claude Code CLI sessions (shown as boxes)">cc <strong id="chip-cc">0</strong></span>
     <span class="chip spend" title="API-billed spend: only LifeOS agent worker sessions (Claude Code CLI uses your subscription, not the API).">API spend <strong id="chip-spend">$0.00</strong></span>
-    <span class="chip legend" title="Node shapes: circle = LifeOS agent worker · square = Claude Code CLI · diamond = Task-tool subagent">
-      <span style="opacity:0.6">●</span> agent &nbsp;
-      <span style="opacity:0.6">■</span> cli &nbsp;
-      <span style="opacity:0.6">◆</span> sub
+    <span class="chip legend" title="Node shapes: circle = cloud agent (Claude) · diamond = local agent · square = Claude Code CLI">
+      <span style="opacity:0.6">●</span> cloud &nbsp;
+      <span style="opacity:0.6">◆</span> local &nbsp;
+      <span style="opacity:0.6">■</span> cli
     </span>
   </div>
 </header>
@@ -1078,7 +1078,7 @@
   }
 
   // Build the SVG content for a node group: shape + label. Shape varies by
-  // source (circle / rounded rect / diamond) but the per-frame transform
+  // routing (circle / rounded rect / diamond) but the per-frame transform
   // is handled by the simulation tick. Status color → fill; token volume →
   // size; recent activity (<60s) → `.pulsing` class for CSS keyframe.
   function nodeColors(d) {
@@ -1203,9 +1203,12 @@
   }
 
   function nodeShapeTag(d) {
-    if (d.is_subagent) return 'polygon';   // diamond
-    if (d.source === 'claude_code') return 'rect';  // rounded square
-    return 'circle';                       // dot
+    // Shape encodes where the agent runs — applied uniformly to top-level
+    // sessions and subagents. CLI = rounded square, local agent = diamond,
+    // cloud agent (Claude) = circle. Mirrors routingLabel()'s buckets.
+    if (d.source === 'claude_code' || d.routing === 'claude_code') return 'rect';
+    if (!d.routing || d.routing === 'local') return 'polygon';  // local: diamond
+    return 'circle';                       // cloud (Claude): dot
   }
 
   // Set shape-specific attrs (radius/width/points). Called on enter+update.
@@ -1318,7 +1321,7 @@
         }
         focusCcSession(d);
       });
-    // One shape element per node, type chosen by source.
+    // One shape element per node, type chosen by routing (see nodeShapeTag).
     entered.append(d => document.createElementNS('http://www.w3.org/2000/svg', nodeShapeTag(d)))
       .attr('class', 'node-shape');
     entered.append('title');


### PR DESCRIPTION
## What

In `/agents`, node **shape** now encodes *where an agent runs* (its routing) rather than singling out subagents:

| Shape | Meaning |
|---|---|
| ● circle | Cloud agent — `routing: claude` |
| ◆ diamond | Local agent — `routing: local` (or unset) |
| ■ rounded square | Claude Code CLI — `routing: claude_code` |

`nodeShapeTag` mirrors `routingLabel()`'s buckets, so shape and the routing badge always agree.

## Subagents

Task/Agent-tool subagents previously always rendered as diamonds. They now take the shape of their **own** routing — a Claude Code subagent is a square like its parent — and are distinguished by the spawn edge rather than by shape. (CC subagents are ingested with `source`/`routing = claude_code`, so they resolve to squares.)

## Changes

- `web/agents.html` — rewrote `nodeShapeTag`, updated the header legend chip (`cloud / local / cli`) and two stale "by source" comments.
- `docs/specs/product/agent-viz.md` — updated the shape table + added a note that shape is routing-based and applies to subagents.
- `docs/specs/technical/agent-viz.md` — updated the shape-logic line and the "subagent diamond" → "subagent node" reference.

## Testing

Full unit suite green (1686 passed via pre-push hook; 2517 passed in the broader `test.sh` run). Frontend-only logic change — no Python touched. The 5 non-unit failures seen in the full `test.sh` run (data-integrity, settings defaults, slack-sync) are pre-existing and environmental, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)