### PR TITLE
fix(summarizer): bump max_tokens so Gemma 4 reasoning doesn't exhaust content budget

### DIFF
--- a/api/services/summarizer.py
+++ b/api/services/summarizer.py
@@ -149,7 +149,7 @@ def generate_summary(
             "model": "local",
             "messages": [{"role": "user", "content": prompt}],
             "temperature": 0.2,
-            "max_tokens": 75,
+            "max_tokens": 512,
             "stream": False,
         }
 


### PR DESCRIPTION
## Summary

- Gemma 4 emits reasoning in a separate `reasoning_content` field and the final answer in `content`. With `max_tokens=75`, the reasoning phase alone consumed the entire token budget, leaving `content` empty. This caused every vault note during reindex to log `Invalid summary length: 0` — summaries were never written to the index.
- Bumping to **512 tokens** gives Gemma enough room (~300 tokens for reasoning + ~100–200 tokens for the actual concise summary).
- Also reverts an incorrect `reasoning_content` fallback that was briefly introduced — `reasoning_content` is the thinking chain, not the answer; using it as a fallback returned 1,000+ char multi-draft outputs instead of concise summaries.

## Root cause

`summarizer.py:152` had `max_tokens: 75` — sized for the old OpenAI/Ollama models which don't do chain-of-thought. Gemma 4 spends ~200–300 tokens reasoning before emitting content, so 75 was always exhausted before the answer was generated. The nightly `vault_reindex` logs `Invalid summary length: 0` for every note, and the retry path fails the same way.

## Test plan

- [ ] `test_real_summary_generation` passes (was failing with `assert None is not None`)
- [ ] Pre-push hook: 24 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)