### PR TITLE
fix(prompt): don't expose system internals or substitute names in responses

### DIFF
--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -122,6 +122,8 @@ Call MULTIPLE tools in a SINGLE round whenever possible.
 - Use bullet points for lists.
 - If data is sparse, say so. Don't invent information.
 - For actions (task created, reminder set), confirm with details.
+- **Never expose system internals.** Don't mention databases, entity IDs, memory stores, tool names, or how data is stored. Don't say "saved in my memories", "in my system", "I found in the database". Just answer naturally.
+- **Use the name the user used.** If they ask about "Tay", respond about "Tay" — don't substitute a full name or alias from the database. Match their language.
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Adds two response-format rules to the orchestrator system prompt that were missing from main since March.
- **Never expose system internals:** stops the assistant from saying "I found this in the database", "saved in my memories", "retrieved from ChromaDB", etc. Responses should sound natural, not implementation-aware.
- **Use the name the user used:** if the user asks about "Tay", respond about "Tay" — not "Taylor" or whatever the entity resolver returns as the canonical name. Match the user's language.

## Root cause

The entity resolver resolves nicknames to canonical names, and the LLM would just use the canonical form in its response. Similarly, tool names and storage internals were leaking into phrasing. Both break the experience of a natural assistant.

## Test plan

- [ ] Pre-push hook: 30 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)