### PR TITLE
fix(embeddings): load with local_files_only=True to skip HF network probe

### DIFF
--- a/api/services/embeddings.py
+++ b/api/services/embeddings.py
@@ -88,6 +88,7 @@ class EmbeddingService:
                     model_name_or_path=self.model_name,
                     cache_folder=self.cache_dir,
                     model_kwargs={"dtype": torch.float16},
+                    local_files_only=True,
                 )
                 if self._force_cpu:
                     load_kwargs["device"] = "cpu"
@@ -105,6 +106,7 @@ class EmbeddingService:
                             model_name_or_path=self.model_name,
                             cache_folder=self.cache_dir,
                             device="cpu",
+                            local_files_only=True,
                         )
                         self._model = self._load_with_offline_retry(SentenceTransformer, cpu_kwargs)
                         self._force_cpu = True


### PR DESCRIPTION
## Summary

- `sentence-transformers` contacts `huggingface.co` at model load time to check for updates even when the model is fully cached locally.
- When HuggingFace is transiently unreachable, the primary load fails. The existing offline-mode retry sets `HF_HUB_OFFLINE=1` and retries, but this can also fail if `config_sentence_transformers.json` isn't in the Hub's snapshot cache layout — firing a false CRITICAL alert and marking `embedding_model` unavailable even though the 6.7 GB cached model is fine.
- Fix: pass `local_files_only=True` directly to `SentenceTransformer` (both GPU and CPU paths) so the load never attempts a network call. Production always uses the local cache; there is no reason to probe HuggingFace.

## Root cause

Alert fired 2026-06-01 10:30 UTC: "couldn't connect to huggingface.co... and couldn't find them in the cached files" — the offline retry ran but couldn't find the file in HF Hub's snapshot format. Model loaded fine after API restart at 11:25 UTC.

## Test plan

- [ ] `SentenceTransformer(..., local_files_only=True)` loads successfully (shape: (1, 1536)) ✓ verified
- [ ] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)