### PR TITLE
fix(agent-worker): reconcile vault task on CLI (claude_code/codex) completion

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -934,6 +934,35 @@ class Worker:
             logger.warning("set_task_status(%s, %s) failed: %s", task_id, status, exc)
             return False
 
+    def _reconcile_vault_terminal(self, session, status: str) -> None:
+        """Update the backing #agent vault task when a CLI session ends.
+
+        The ``claude_code`` / ``codex`` dispatch paths don't go through
+        ``_handle_outcome`` (which owns vault reconciliation for the local
+        and managed routes), so terminal outcomes there must reconcile the
+        vault themselves — otherwise a vault-routed ``#agent #claude`` /
+        ``#codex`` task is stranded at ``[/]`` / ``#agent-running`` forever
+        even though the agent finished.
+
+        Operator-spawned sessions (``origin='operator'``) and spawned
+        children (``parent_session_id`` set) have no backing #agent vault
+        row, so the complete / swap-tag / set-status calls would 404 — skip
+        them. This mirrors ``has_vault_task`` in ``_handle_outcome``.
+        """
+        has_vault_task = session.origin != "operator" and not session.parent_session_id
+        if not has_vault_task:
+            return
+        task_id = session.task_id
+        if status == STATUS_COMPLETED:
+            self._complete_task(task_id)  # mark `done` ([x]) in the vault
+            self._swap_tag(task_id, RUNNING_TAG, COMPLETED_TAG)
+        elif status == STATUS_BUDGET_EXCEEDED:
+            self._swap_tag(task_id, RUNNING_TAG, BUDGET_EXCEEDED_TAG)
+            self._set_task_status(task_id, "cancelled")
+        elif status == STATUS_FAILED:
+            self._swap_tag(task_id, RUNNING_TAG, FAILED_TAG)
+            self._set_task_status(task_id, "cancelled")
+
     # ------------------------------------------------------------------
     # Claim + dispatch
     # ------------------------------------------------------------------
@@ -1161,16 +1190,19 @@ class Worker:
             self.transcript_store.append(sid, "code_handled_completion", {
                 "final_chars": len(body),
             })
+            self._reconcile_vault_terminal(session, STATUS_COMPLETED)
             return
 
         # FAILED / BUDGET_EXCEEDED — surface a brief operator notification.
-        # Skip _handle_outcome (which assumes an #agent vault task) since
-        # /claude sessions don't have one.
+        # Skip _handle_outcome here (it owns the local/managed routes), but a
+        # vault-routed #claude task still needs its tag/checkbox reconciled —
+        # operator-spawned /claude sessions have no vault row and are no-ops.
         label = "Code session"
         if outcome.status == STATUS_BUDGET_EXCEEDED:
             self._telegram_send(f"⚠️ {label} hit its budget ({outcome.reason}).")
         elif outcome.status == STATUS_FAILED:
             self._telegram_send(f"⚠️ {label} failed: {outcome.reason}.")
+        self._reconcile_vault_terminal(session, outcome.status)
 
     def _get_claude_code_executor(self):
         """Lazy-construct the ClaudeCodeExecutor for /claude sessions.
@@ -1256,6 +1288,7 @@ class Worker:
             self.transcript_store.append(sid, "codex_handled_completion", {
                 "final_chars": len(body),
             })
+            self._reconcile_vault_terminal(session, STATUS_COMPLETED)
             return
 
         label = "Codex session"
@@ -1263,6 +1296,7 @@ class Worker:
             self._telegram_send(f"⚠️ {label} hit its budget ({outcome.reason}).")
         elif outcome.status == STATUS_FAILED:
             self._telegram_send(f"⚠️ {label} failed: {outcome.reason}.")
+        self._reconcile_vault_terminal(session, outcome.status)
 
     def _get_codex_executor(self):
         """Lazy-construct the CodexExecutor for /codex sessions."""

--- a/tests/test_agent_worker_claude_code_dispatch.py
+++ b/tests/test_agent_worker_claude_code_dispatch.py
@@ -66,6 +66,67 @@ def _seed_code_session(store: SessionStore, *, task_id: str = "code-1"):
     return session
 
 
+def _recording_worker(tmp_path: Path, claude_code_executor):
+    """Like ``_make_worker`` but records the vault-mutating HTTP calls so a
+    test can assert the task was completed + tag-swapped (or not)."""
+    calls: list[tuple[str, str]] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls.append((req.method, req.url.path))
+        if req.url.path.endswith("/swap-tag"):
+            return httpx.Response(200, json={"swapped": True})
+        return httpx.Response(200, json={"tasks": []})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://api")
+    worker = Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: True,
+        telegram_send_with_id=lambda text: [1],
+        http_client=client,
+        claude_code_executor=claude_code_executor,
+    )
+    return worker, calls
+
+
+def test_vault_claude_task_marked_complete_on_finish(tmp_path: Path):
+    """A vault-routed ``#agent #claude`` task (origin != 'operator', no parent)
+    must be reconciled in the vault when the Claude Code session completes:
+    PUT .../complete and a #agent-running → #agent-completed swap. Regression
+    for CLI tasks stranded at ``[/]`` / ``#agent-running`` forever (the CLI
+    dispatch path bypasses ``_handle_outcome``)."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done.")
+    )
+    worker, calls = _recording_worker(tmp_path, claude_code_executor=stub)
+    # origin defaults to None → vault-backed task (not an operator spawn).
+    session = worker.session_store.create(task_id="vault-1", routing="claude_code")
+
+    worker._dispatch_claude_code_session(session, [{"content": "print hello"}])
+
+    assert ("PUT", "/api/tasks/vault-1/complete") in calls
+    assert ("POST", "/api/tasks/vault-1/swap-tag") in calls
+
+
+def test_operator_spawn_does_not_touch_vault_on_finish(tmp_path: Path):
+    """Operator-spawned /claude sessions have no backing #agent vault row, so
+    completion must NOT issue complete / swap-tag calls (they would 404)."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done.")
+    )
+    worker, calls = _recording_worker(tmp_path, claude_code_executor=stub)
+    session = worker.session_store.create(
+        task_id="spawn-1", routing="claude_code", origin="operator"
+    )
+
+    worker._dispatch_claude_code_session(session, [{"content": "print hello"}])
+
+    assert not any(path.endswith(("/complete", "/swap-tag")) for _, path in calls)
+
+
 def test_dispatch_calls_claude_code_executor(tmp_path: Path):
     """``_dispatch_spawned_sessions`` invokes the injected ClaudeCodeExecutor for
     an operator-origin routing='claude_code' session, draining the prompt from


### PR DESCRIPTION
## Problem

Vault-routed `#agent #claude` and `#agent #codex` tasks were **stranded at `[/]` / `#agent-running` forever** even after the agent finished the work and sent its completion message to Telegram. The vault checkbox never flipped to `[x]` and the tag never advanced to `#agent-completed`.

Observed: every stuck task in the Tasks inbox was `#claude` or `#codex`; every correctly-completed one was `#cloud` or `#local`.

## Root cause

`#agent` tasks reconcile the vault on completion via `_handle_outcome` — but only the **local** and **managed** routes go through it. The **CLI** routes are dispatched by `_dispatch_claude_code_session` / `_dispatch_codex_session`, which **bypass `_handle_outcome` entirely**. On `STATUS_COMPLETED` they send the Telegram message and return — never calling `_complete_task` or swapping `#agent-running` → `#agent-completed`.

These dispatch functions were originally written for **operator-spawned** `/claude` sessions (synthetic task IDs, no backing vault row, so skipping the vault write was correct). Commit #291 (Codex executor + session viz) then **reused them** as the dispatch path for real vault `#agent` CLI tasks — which *do* have a vault row to reconcile — without adding the vault write. So those tasks claim (`[/]` + `#agent-running`), run to completion, notify, and strand.

## Fix

Add `_reconcile_vault_terminal(session, status)`, called on every terminal outcome in both CLI dispatch paths. It mirrors `has_vault_task` in `_handle_outcome`:

- **Operator-spawned** sessions (`origin='operator'`) and **spawned children** (`parent_session_id` set) → no vault row, skipped (calls would 404).
- **Vault-backed** tasks → `COMPLETED`: complete + swap to `#agent-completed`; `FAILED` / `BUDGET_EXCEEDED`: swap to the matching terminal tag + status `cancelled`.

## Tests

- `test_vault_claude_task_marked_complete_on_finish` — vault-routed `#claude` task issues `PUT .../complete` + `#agent-running`→`#agent-completed` swap on completion (regression).
- `test_operator_spawn_does_not_touch_vault_on_finish` — operator-spawned `/claude` sessions issue no vault calls.

Full unit suite: 2544 passed. The 4 failures are pre-existing/environmental (settings defaults driven by this machine's `.env`, vault-file integrity, a flaky slack test that passes in isolation) — all reproduce with this branch's changes stashed and none touch the agent worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)