### PR TITLE
fix(codex): close parity gaps with Claude Code (tools, notify, replies)

### DIFF
--- a/api/services/agent_worker/AGENTS.md
+++ b/api/services/agent_worker/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Worker
 
-External long-running worker that picks up `#agent`-tagged tasks, executes them via Claude (Managed Agents), local Gemma (llama-server), or the Claude Code CLI, and notifies via Telegram. Lives outside the FastAPI process — talks to LifeOS over HTTP via `/api/tasks`.
+External long-running worker that picks up `#agent`-tagged tasks, executes them via Claude (Managed Agents), local Gemma (llama-server), the Claude Code CLI, or the Codex CLI, and notifies via Telegram. Lives outside the FastAPI process — talks to LifeOS over HTTP via `/api/tasks`.
 
 ## Files in this package
 
@@ -17,11 +17,13 @@ External long-running worker that picks up `#agent`-tagged tasks, executes them 
 | `managed_driver.py` | HTTP client for the Managed Agents API |
 | `claude_code_executor.py` | Claude Code CLI driver (subprocess spawn, stream-json parse, `[NOTIFY]`/`[CLARIFY]` extraction) for `routing='claude_code'` sessions |
 | `claude_code_spawn.py` | Helper that creates a parentless `routing='claude_code'`, `origin='operator'` session row for a fresh `/claude` task |
+| `codex_executor.py` | Codex CLI driver (subprocess spawn, `--json` stream parse, `-o` final-message capture) for `routing='codex'` sessions. Prepends `CAPABILITIES_PREAMBLE` on the opening turn; suppresses intermediate-message streaming so only heartbeats + the final result reach Telegram |
+| `codex_spawn.py` | Helper that creates a parentless `routing='codex'`, `origin='operator'` session row for a fresh `/codex` task |
 | `operator_spawn.py` | Same pattern for non-code operator-initiated agent spawns from Telegram or `/chat` |
 | `inter_agent.py` | Tool surface that lets agents spawn / message / yield-until peers in the same lineage |
 | `tools.py`, `tool_filter.py`, `tool_result_cache.py` | LifeOS-MCP tool catalog, per-preset filtering, repeat-call de-duplication |
 | `pricing.py` | Per-model token rates + session-hour overhead for cost accounting |
-| `capabilities_preamble.py` | Static `<lifeos>` capabilities block prepended to every managed-session user turn |
+| `capabilities_preamble.py` | Static LifeOS capabilities briefing prepended to the opening user turn on the managed, local, and `codex` routes (Claude Code gets the equivalent via `--append-system-prompt`) |
 
 ## Routing destinations
 
@@ -70,7 +72,7 @@ A Telegram reply to a session's completion message — or a reply from the web `
 2. The reply hook deposits the answer (Telegram listener) or enqueues it directly (`/chat` reply endpoint).
 3. `_process_clarification_answers` picks up the answered row; `_resume_as_followup` dispatches to the executor branch for the session's routing.
 
-For `routing='claude_code'` sessions specifically, `_resume_as_followup` queues the reply as a `pending_message` and flips status back to `CLAIMED`, so the next tick's `_dispatch_claude_code_session` calls `CodeExecutor.resume(message)` with the persisted CLI session UUID — resume survives worker restarts and arbitrary time gaps.
+For `routing='claude_code'` sessions specifically, `_resume_as_followup` queues the reply as a `pending_message` and flips status back to `CLAIMED`, so the next tick's `_dispatch_claude_code_session` calls `CodeExecutor.resume(message)` with the persisted CLI session UUID — resume survives worker restarts and arbitrary time gaps. `routing='codex'` works the same way via `_dispatch_codex_session` → `CodexExecutor.resume()`. The anchor is registered only on the **final** completion message; because `CodexExecutor` no longer streams intermediate narration to Telegram, the operator's reply lands on that registered message rather than an un-anchored mid-run chunk.
 
 ## Open-source guardrails
 

--- a/api/services/agent_worker/codex_executor.py
+++ b/api/services/agent_worker/codex_executor.py
@@ -229,14 +229,16 @@ class CodexExecutor:
         return [binary, "exec", *common, prompt]
 
     def _warn_if_mcp_missing(self) -> None:
-        """Best-effort check that Codex has an MCP server configured.
+        """Best-effort check that Codex has the lifeos MCP server configured.
 
-        Codex reaches LifeOS data only through an ``[mcp_servers.*]`` block in
-        ``~/.codex/config.toml`` (or ``$CODEX_HOME/config.toml``). Unlike Claude
-        Code — which inherits the ``lifeos`` server from ``~/.claude.json`` — a
-        fresh Codex install has none, leaving the agent context-blind. We can't
-        fix per-machine config from the repo, so we surface it loudly in logs
-        once per process. Never raises: a config we can't read is not fatal.
+        Codex reaches LifeOS data only through an ``[mcp_servers.lifeos]`` block
+        in ``~/.codex/config.toml`` (or ``$CODEX_HOME/config.toml``). Unlike
+        Claude Code — which inherits the ``lifeos`` server from ``~/.claude.json``
+        — a fresh Codex install has none, leaving the agent context-blind. We
+        check for the lifeos server specifically (not just any MCP block), since
+        an unrelated server would leave LifeOS just as unreachable. We can't fix
+        per-machine config from the repo, so we surface it loudly in logs once
+        per process. Never raises: a config we can't read is not fatal.
         """
         if self._mcp_warned:
             return
@@ -248,9 +250,9 @@ class CodexExecutor:
                 contents = f.read()
         except OSError:
             contents = ""
-        if "[mcp_servers" not in contents:
+        if "[mcp_servers.lifeos]" not in contents:
             logger.warning(
-                "Codex has no [mcp_servers.*] in %s — the agent cannot reach "
+                "Codex has no [mcp_servers.lifeos] in %s — the agent cannot reach "
                 "lifeos_* tools and will be blind to personal data. See "
                 "docs/guides/agent-worker-setup.md § Codex MCP setup.",
                 config_path,

--- a/api/services/agent_worker/codex_executor.py
+++ b/api/services/agent_worker/codex_executor.py
@@ -31,6 +31,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
+from api.services.agent_worker.capabilities_preamble import CAPABILITIES_PREAMBLE
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_BUDGET_EXCEEDED,
@@ -110,7 +111,6 @@ class _RunState:
     cost_cap_exceeded: bool = False
     tool_call_count: int = 0
     last_activity: str = ""
-    notifications_sent: int = 0
     last_usage: dict = field(default_factory=dict)
     started_at: float = field(default_factory=time.time)
     last_notify_at: float = field(default_factory=time.time)
@@ -151,6 +151,7 @@ class CodexExecutor:
         # to need a different budget.
         self._timeout = timeout_seconds if timeout_seconds is not None else settings.claude_timeout_seconds
         self._heartbeat_interval = heartbeat_interval
+        self._mcp_warned = False  # gate the missing-MCP warning to once per process
 
     # ------------------------------------------------------------------
     # Public API
@@ -164,9 +165,18 @@ class CodexExecutor:
             return ExecutorOutcome(status=STATUS_FAILED, reason="empty prompt")
 
         working_dir = task.get("working_dir") or os.getcwd()
+        # Warn (once per process) if Codex can't reach the lifeos MCP server —
+        # without it the agent is context-blind to personal data. See
+        # docs/guides/agent-worker-setup.md § Codex for the config block.
+        self._warn_if_mcp_missing()
+        # Prepend the LifeOS capabilities briefing so the fresh Codex turn has
+        # the same situational awareness as the managed/local routes. Only on
+        # the opening turn — resume() reloads the thread, which already carries
+        # the preamble from this first prompt.
+        full_prompt = f"{CAPABILITIES_PREAMBLE}\n{prompt}"
         return self._run(
             session=session,
-            prompt=prompt,
+            prompt=full_prompt,
             working_dir=working_dir,
             resume_session_id=None,
         )
@@ -217,6 +227,34 @@ class CodexExecutor:
         if resume_session_id:
             return [binary, "exec", "resume", resume_session_id, *common, prompt]
         return [binary, "exec", *common, prompt]
+
+    def _warn_if_mcp_missing(self) -> None:
+        """Best-effort check that Codex has an MCP server configured.
+
+        Codex reaches LifeOS data only through an ``[mcp_servers.*]`` block in
+        ``~/.codex/config.toml`` (or ``$CODEX_HOME/config.toml``). Unlike Claude
+        Code — which inherits the ``lifeos`` server from ``~/.claude.json`` — a
+        fresh Codex install has none, leaving the agent context-blind. We can't
+        fix per-machine config from the repo, so we surface it loudly in logs
+        once per process. Never raises: a config we can't read is not fatal.
+        """
+        if self._mcp_warned:
+            return
+        self._mcp_warned = True
+        codex_home = os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
+        config_path = os.path.join(codex_home, "config.toml")
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                contents = f.read()
+        except OSError:
+            contents = ""
+        if "[mcp_servers" not in contents:
+            logger.warning(
+                "Codex has no [mcp_servers.*] in %s — the agent cannot reach "
+                "lifeos_* tools and will be blind to personal data. See "
+                "docs/guides/agent-worker-setup.md § Codex MCP setup.",
+                config_path,
+            )
 
     @staticmethod
     def _clean_env() -> dict:
@@ -403,13 +441,16 @@ class CodexExecutor:
             if itype == "agent_message":
                 text = (item.get("text") or "").strip()
                 if text:
+                    # Record the message as the running final_text and surface
+                    # a short preview in the heartbeat, but do NOT stream it to
+                    # Telegram. Codex emits a narration message before most tool
+                    # calls; forwarding each one floods the chat. The worker
+                    # sends the final agent message exactly once on completion
+                    # (and registers it as the reply-thread anchor), so the
+                    # operator sees meaningful progress (heartbeats) + the
+                    # result, mirroring Claude's [NOTIFY] selectivity.
                     state.final_text = text
-                    state.notifications_sent += 1
-                    state.last_notify_at = time.time()
-                    try:
-                        self._notify(text)
-                    except Exception as exc:  # pragma: no cover — defensive
-                        logger.warning("notification callback raised: %s", exc)
+                    state.last_activity = text[:40]
                     self.transcript_store.append(sid, "codex_assistant_text", {
                         "text": text, "chars": len(text),
                     })

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -398,8 +398,8 @@ once the MCP server is wired. Add this to `~/.codex/config.toml` (or
 
 ```toml
 [mcp_servers.lifeos]
-command = "<repo>/.venvs/lifeos/bin/python"   # your lifeos venv python
-args = ["<repo>/LifeOS/mcp_server.py"]         # absolute path to mcp_server.py
+command = "<venv>/bin/python"            # your lifeos venv python, e.g. ~/.venvs/lifeos/bin/python
+args = ["<lifeos-repo>/mcp_server.py"]   # absolute path to mcp_server.py in your LifeOS checkout
 ```
 
 `mcp_server.py` already serves stdio for CLI agents (the same entry point

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -1,7 +1,7 @@
 # Agent Worker Setup
 
 > **Status:** Stub — expanded by later issues in the agent-worker series (#98)
-> **Last Updated:** 2026-05-26
+> **Last Updated:** 2026-06-01
 > **Audience:** Operators
 
 One-time setup for the external agent worker that picks up `#agent`-tagged tasks and executes them via Claude Opus (Anthropic Managed Agents) or a local Gemma model. This guide covers **prerequisites only** — the worker itself ships in later issues.
@@ -381,6 +381,44 @@ The Haiku preflight sanity-check is the only guard against destructive-shaped ta
 
 ---
 
+## Codex MCP setup (`#codex` path)
+
+`#agent #codex` tasks (and `/codex`) run the Codex CLI through `CodexExecutor`.
+Unlike Claude Code — which inherits the `lifeos` MCP server from
+`~/.claude.json` automatically — Codex only reaches LifeOS data through an
+`[mcp_servers.*]` block in its own config. A fresh Codex install has none, so
+the agent is **context-blind to personal data**: it can edit files and run
+shell commands, but `lifeos_search`, `lifeos_ask`, `lifeos_calendar_search`,
+etc. don't exist for it.
+
+The worker prepends the same capabilities briefing it gives the managed/local
+routes, so Codex *knows* these tools should exist — but the tools only work
+once the MCP server is wired. Add this to `~/.codex/config.toml` (or
+`$CODEX_HOME/config.toml`):
+
+```toml
+[mcp_servers.lifeos]
+command = "<repo>/.venvs/lifeos/bin/python"   # your lifeos venv python
+args = ["<repo>/LifeOS/mcp_server.py"]         # absolute path to mcp_server.py
+```
+
+`mcp_server.py` already serves stdio for CLI agents (the same entry point
+Claude Code uses), so no extra process or port is involved — Codex spawns it
+on demand.
+
+**Verify** the server is registered:
+
+```bash
+codex mcp list                          # lifeos should appear in the list
+# or, if your codex build has no `mcp` subcommand:
+grep -A2 'mcp_servers.lifeos' ~/.codex/config.toml
+```
+
+If the block is missing, the agent worker logs a one-time warning on the first
+`#codex` dispatch (`Codex has no [mcp_servers.*] …`) so a misconfigured machine
+surfaces in `logs/lifeos-api-error.log` rather than silently producing
+context-blind runs.
+
 ## Cost-aware iteration
 
 Iterating on cloud `#agent` prompts has a hidden tax: every fresh managed
@@ -422,6 +460,7 @@ suggestions to keep iteration cheap:
 | `llama-server` starts but `/v1/models` returns `503 Loading model` or `404`, log shows "sha256 mismatch" + "HEAD failed, status: 404" | Upstream HF model was updated; local cache fails llama.cpp's integrity check and the redownload 404s, leaving the server in router mode with no model loaded | Point at the local GGUF directly: set `LIFEOS_LLM_MODEL_PATH=/absolute/path/to/cached.gguf` (and `LIFEOS_LLM_MMPROJ_PATH` for vision models) in `.env`, then re-run `sudo ./scripts/setup-systemd.sh` |
 | Agent worker logs "daily spend cap reached" | `LIFEOS_AGENT_DAILY_CAP_DOLLARS` is 0 or already exceeded today | Raise the cap or wait until local midnight |
 | Worker doesn't pick up a `#agent` task | Task isn't `status=todo`, or worker isn't enabled | `systemctl status lifeos-agent-worker`; `curl 'http://localhost:8000/api/tasks?status=todo&tag=agent'` |
+| `#codex` agent can't find personal data / doesn't call `lifeos_*` tools | No `[mcp_servers.lifeos]` in `~/.codex/config.toml` | Add the block (see [Codex MCP setup](#codex-mcp-setup-codex-path)); confirm with `codex mcp list` |
 | Managed Agents session stuck running | Worker can't reach the API, or the remote session is genuinely long | Find the `managed_agent_session_id` in `data/agent_sessions.db` (`SELECT task_id, session_id, managed_agent_session_id FROM sessions WHERE status='running'`). Cancel via the Anthropic console, or `curl -X DELETE -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" -H "anthropic-beta: managed-agents-2026-04-01" https://api.anthropic.com/v1/sessions/<remote_id>`. The worker's next poll sees a 404 (mapped to `cancelled`) and finalizes. |
 
 ---

--- a/tests/test_agent_worker_codex_dispatch.py
+++ b/tests/test_agent_worker_codex_dispatch.py
@@ -1,0 +1,115 @@
+"""Worker dispatch wiring for routing='codex' sessions.
+
+Verifies the two behaviors issue #295 hardened on the Codex completion path:
+1. The final agent message is sent to Telegram exactly once (no duplicate) via
+   the id-capturing sender — the executor no longer streams it separately.
+2. That single completion message is registered as a ``kind='followup'``
+   anchor so a threaded Telegram reply resumes the session (parity with
+   ``#claude``).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+import pytest
+
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.session_store import (
+    STATUS_COMPLETED,
+    SessionStore,
+)
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import Worker
+
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _StubCodexExecutor:
+    """Minimal CodexExecutor stand-in: records calls + returns a canned outcome."""
+    outcome: ExecutorOutcome
+    calls: list = field(default_factory=list)
+
+    def execute(self, session, task):
+        self.calls.append((session.task_id, task.get("description")))
+        return self.outcome
+
+
+def _make_worker(tmp_path: Path, codex_executor, *, plain_sends, withid_sends):
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+
+    def plain(text, chat_id=None):
+        plain_sends.append(text)
+        return True
+
+    def with_id(text):
+        withid_sends.append(text)
+        return [777]
+
+    return Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=plain,
+        telegram_send_with_id=with_id,
+        http_client=client,
+        codex_executor=codex_executor,
+    )
+
+
+def test_codex_completion_sends_final_once_and_registers_anchor(tmp_path: Path):
+    plain_sends: list[str] = []
+    withid_sends: list[str] = []
+    stub = _StubCodexExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="Done: 3 events.")
+    )
+    worker = _make_worker(
+        tmp_path, codex_executor=stub,
+        plain_sends=plain_sends, withid_sends=withid_sends,
+    )
+    session = worker.session_store.create(
+        task_id="cx-1", routing="codex", origin="operator",
+    )
+
+    worker._dispatch_codex_session(session, [{"content": "events?"}])
+
+    # Final message sent exactly once, via the id-capturing sender, and never
+    # duplicated through the plain sender.
+    assert withid_sends == ["Done: 3 events."]
+    assert "Done: 3 events." not in plain_sends
+
+    # The completion message is registered as a followup anchor keyed on the
+    # sent message id, so a threaded reply round-trips through the resume path.
+    q = worker.session_store.get_open_question_by_message_id(777)
+    assert q is not None
+    assert q["kind"] == "followup"
+    assert q["session_id"] == session.session_id
+
+
+def test_codex_completion_empty_final_registers_no_anchor(tmp_path: Path):
+    """An empty final message produces no Telegram send and no anchor — there
+    is nothing for the operator to reply to."""
+    plain_sends: list[str] = []
+    withid_sends: list[str] = []
+    stub = _StubCodexExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="")
+    )
+    worker = _make_worker(
+        tmp_path, codex_executor=stub,
+        plain_sends=plain_sends, withid_sends=withid_sends,
+    )
+    session = worker.session_store.create(
+        task_id="cx-2", routing="codex", origin="operator",
+    )
+
+    worker._dispatch_codex_session(session, [{"content": "events?"}])
+
+    assert withid_sends == []
+    assert worker.session_store.get_open_question_by_message_id(777) is None

--- a/tests/test_codex_spawn_executor.py
+++ b/tests/test_codex_spawn_executor.py
@@ -275,6 +275,45 @@ def test_executor_does_not_stream_intermediate_messages(stores, tmp_path):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "config_body, expect_warning",
+    [
+        ("", True),  # no config at all
+        ("model = \"gpt-5.5\"\n", True),  # config but no MCP servers
+        ('[mcp_servers.other]\ncommand = "x"\n', True),  # a different MCP server only
+        ('[mcp_servers.lifeos]\ncommand = "py"\n', False),  # lifeos configured
+    ],
+)
+def test_warn_if_mcp_missing_keys_on_lifeos(
+    stores, tmp_path, monkeypatch, caplog, config_body, expect_warning
+):
+    """The dispatch warning fires unless the *lifeos* MCP server specifically
+    is configured — an unrelated server leaves LifeOS just as unreachable."""
+    import logging
+
+    sess_store, tr_store = stores
+    codex_home = tmp_path / "codex_home"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(config_body)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    executor = CodexExecutor(
+        session_store=sess_store, transcript_store=tr_store,
+        binary_resolver=lambda: "/usr/bin/true", heartbeat_interval=9999,
+    )
+    with caplog.at_level(logging.WARNING):
+        executor._warn_if_mcp_missing()
+
+    warned = any("no [mcp_servers.lifeos]" in r.getMessage() for r in caplog.records)
+    assert warned is expect_warning
+    # Gated to once per process — a second call never re-warns.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        executor._warn_if_mcp_missing()
+    assert not any("mcp_servers.lifeos" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.unit
 def test_executor_binary_not_found(stores, tmp_path):
     sess_store, tr_store = stores
     session = sess_store.create(

--- a/tests/test_codex_spawn_executor.py
+++ b/tests/test_codex_spawn_executor.py
@@ -150,10 +150,128 @@ def test_executor_handles_full_stream(stores, monkeypatch, tmp_path):
     outcome = executor.execute(session, {"description": "say hi", "working_dir": str(tmp_path)})
     assert outcome.status == STATUS_COMPLETED
     assert outcome.final_text == "Hello world"
-    assert notifications == ["Hello world"]
+    # The executor no longer streams agent messages to Telegram — the worker
+    # sends the final message once on completion. Only heartbeats (suppressed
+    # here) would reach the callback mid-run, so it stays empty.
+    assert notifications == []
     # Thread id persisted for future resume.
     reloaded = sess_store.get_by_session_id(session.session_id)
     assert reloaded.claude_code_session_id == "thread-abc"
+
+
+@pytest.mark.unit
+def test_executor_prepends_capabilities_preamble(stores, monkeypatch, tmp_path):
+    """A fresh /codex turn carries the LifeOS capabilities briefing so the
+    agent has the same situational awareness as the managed/local routes."""
+    from api.services.agent_worker.capabilities_preamble import CAPABILITIES_PREAMBLE
+
+    sess_store, tr_store = stores
+    session = sess_store.create(
+        task_id="t_pre", session_id="sess_pre", status="claimed", routing="codex",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 1.0},
+        expected_output="text", origin="operator",
+    )
+
+    captured: dict = {}
+
+    def fake_spawn(cmd, **kwargs):
+        captured["cmd"] = cmd
+        for i, tok in enumerate(cmd):
+            if tok == "-o" and i + 1 < len(cmd):
+                with open(cmd[i + 1], "w") as f:
+                    f.write("ok\n")
+        return _FakeProc([{"type": "session.completed"}], returncode=0)
+
+    executor = CodexExecutor(
+        session_store=sess_store, transcript_store=tr_store,
+        spawn_fn=fake_spawn, binary_resolver=lambda: "/usr/bin/true",
+        heartbeat_interval=9999,
+    )
+    executor.execute(session, {"description": "what's on my calendar?", "working_dir": str(tmp_path)})
+
+    # The prompt is the last positional arg of the codex command.
+    prompt_arg = captured["cmd"][-1]
+    assert "=== LIFEOS BRIEFING" in prompt_arg
+    assert prompt_arg.endswith("what's on my calendar?")
+    assert CAPABILITIES_PREAMBLE in prompt_arg
+
+
+@pytest.mark.unit
+def test_resume_does_not_prepend_preamble(stores, tmp_path):
+    """Resume reloads the Codex thread (which already holds the preamble from
+    the opening turn), so the follow-up message must NOT re-inject it."""
+    sess_store, tr_store = stores
+    session = sess_store.create(
+        task_id="t_res", session_id="sess_res", status="claimed", routing="codex",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 1.0},
+        expected_output="text", origin="operator",
+    )
+    sess_store.set_claude_code_session_id("t_res", "thread-xyz")
+    session = sess_store.get_by_session_id("sess_res")
+
+    captured: dict = {}
+
+    def fake_spawn(cmd, **kwargs):
+        captured["cmd"] = cmd
+        for i, tok in enumerate(cmd):
+            if tok == "-o" and i + 1 < len(cmd):
+                with open(cmd[i + 1], "w") as f:
+                    f.write("ok\n")
+        return _FakeProc([{"type": "session.completed"}], returncode=0)
+
+    executor = CodexExecutor(
+        session_store=sess_store, transcript_store=tr_store,
+        spawn_fn=fake_spawn, binary_resolver=lambda: "/usr/bin/true",
+        heartbeat_interval=9999,
+    )
+    executor.resume(session, "and tomorrow?", working_dir=str(tmp_path))
+
+    prompt_arg = captured["cmd"][-1]
+    assert "=== LIFEOS BRIEFING" not in prompt_arg
+    assert prompt_arg == "and tomorrow?"
+    assert "resume" in captured["cmd"]
+
+
+@pytest.mark.unit
+def test_executor_does_not_stream_intermediate_messages(stores, tmp_path):
+    """Codex narrates before each tool call; those agent messages must not be
+    forwarded to Telegram (the flood the issue describes). The callback only
+    ever sees heartbeats, which are suppressed in tests — so it stays empty,
+    while final_text tracks the last message for the worker to send once."""
+    sess_store, tr_store = stores
+    session = sess_store.create(
+        task_id="t_flood", session_id="sess_flood", status="claimed", routing="codex",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 1.0},
+        expected_output="text", origin="operator",
+    )
+
+    lines = [
+        {"type": "thread.started", "thread_id": "thread-f"},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "Let me search."}},
+        {"type": "item.completed", "item": {"type": "command_executed", "command": "grep"}},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "Now I'll check email."}},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "Final answer: 3 events."}},
+        {"type": "session.completed"},
+    ]
+
+    def fake_spawn(cmd, **kwargs):
+        for i, tok in enumerate(cmd):
+            if tok == "-o" and i + 1 < len(cmd):
+                with open(cmd[i + 1], "w") as f:
+                    f.write("Final answer: 3 events.\n")
+        return _FakeProc(lines, returncode=0)
+
+    notifications: list[str] = []
+    executor = CodexExecutor(
+        session_store=sess_store, transcript_store=tr_store,
+        notification_callback=notifications.append,
+        spawn_fn=fake_spawn, binary_resolver=lambda: "/usr/bin/true",
+        heartbeat_interval=9999,
+    )
+    outcome = executor.execute(session, {"description": "events?", "working_dir": str(tmp_path)})
+
+    assert notifications == []  # no intermediate flooding
+    assert outcome.final_text == "Final answer: 3 events."
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Brings the `#codex` agent path to parity with `#claude` across the three gaps documented in #295: missing LifeOS context/tools, Telegram flooding, and unseen threaded replies.

Closes #295.

## What changed

- **Context briefing (1b).** `CodexExecutor.execute()` now prepends `CAPABILITIES_PREAMBLE` to the opening turn — the same LifeOS briefing the managed/local routes get. `resume()` deliberately skips it (the reloaded Codex thread already carries it).
- **No more Telegram flood + double-send (2).** The executor no longer forwards every `agent_message` to Telegram. Codex narrates before most tool calls; streaming each one flooded the chat *and* double-sent the final message (streamed mid-run, then re-sent by the worker on completion). The worker now sends the final exactly once; heartbeats remain the progress signal.
- **Threaded replies resume the session (3).** With the flood gone, the operator's reply lands on the single registered `kind='followup'` anchor (the completion message) instead of an un-anchored mid-run chunk — matching `#claude`. No worker change was needed beyond the existing anchor.
- **MCP setup discoverable (1a).** Documented the required `[mcp_servers.lifeos]` block for `~/.codex/config.toml` in `agent-worker-setup.md` (with a verification command + troubleshooting row), and added a one-time warning on dispatch when it's missing so a context-blind machine surfaces in logs instead of silently.

## Test evidence

`~/.venvs/lifeos/bin/python -m pytest tests/ -m unit` → **1725 passed, 0 failed** (605s).

New/updated coverage:
- `tests/test_codex_spawn_executor.py` — preamble prepended on `execute()`, **not** on `resume()`; intermediate `agent_message` events are not streamed to Telegram.
- `tests/test_agent_worker_codex_dispatch.py` — worker sends the final message exactly once via the id-capturing sender and registers it as a `kind='followup'` anchor; empty final → no send, no anchor.

## Review focus

- The decision to **fully suppress** intermediate Codex narration (heartbeat + final only) vs. throttling. Rationale: it's the cleanest way to mirror Claude's `[NOTIFY]` selectivity and it's what structurally fixes the reply-anchor problem (gap 3). The operator said they don't mind verbosity but want consistency with `#claude`.
- `_warn_if_mcp_missing` is best-effort (never raises) and gated to once per process — confirm that's the right noise level.
- Whether `resume()` should also re-inject the preamble (current choice: no).

🤖 Generated with [Claude Code](https://claude.com/claude-code)