### PR TITLE
feat(codex): #claude parity — shared context, computer use, skills, gws

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,6 +350,19 @@ curl "http://localhost:8000/api/tasks?status=todo" | jq
 curl -X PUT http://localhost:8000/api/tasks/{id}/complete | jq
 ```
 
+### Google Workspace CLI (`gws`)
+
+`gws` is the Google Workspace CLI — direct, typed access to Drive, Gmail, Sheets, and Calendar via the user's authenticated account. Useful for raw API calls the `lifeos_*` tools don't wrap (creating a Sheet, downloading a Drive file by id). Available to any agent with shell access (Claude Code, Codex).
+
+```bash
+gws drive files list --params '{"pageSize": 10}'
+gws gmail users messages list --params '{"userId": "me"}'
+gws sheets spreadsheets get --params '{"spreadsheetId": "..."}'
+gws schema drive.files.list          # discover params for any call
+```
+
+Prefer `lifeos_*` tools for search/synthesis; reach for `gws` for direct Google API calls.
+
 ---
 
 ## Apple Data Agent (optional, macOS only)

--- a/api/services/agent_worker/AGENTS.md
+++ b/api/services/agent_worker/AGENTS.md
@@ -20,7 +20,8 @@ External long-running worker that picks up `#agent`-tagged tasks, executes them 
 | `codex_executor.py` | Codex CLI driver (subprocess spawn, `--json` stream parse, `-o` final-message capture) for `routing='codex'` sessions. Prepends `CAPABILITIES_PREAMBLE` on the opening turn; suppresses intermediate-message streaming so only heartbeats + the final result reach Telegram |
 | `codex_spawn.py` | Helper that creates a parentless `routing='codex'`, `origin='operator'` session row for a fresh `/codex` task |
 | `operator_spawn.py` | Same pattern for non-code operator-initiated agent spawns from Telegram or `/chat` |
-| `inter_agent.py` | Tool surface that lets agents spawn / message / yield-until peers in the same lineage |
+| `inter_agent.py` | Tool surface that lets agents spawn / message / yield-until peers in the same lineage. `lifeos_agent_spawn` accepts `claude`/`local`/`claude_code`/`codex` — the CLI routes enable cross-engine capability fallback (e.g. delegate browser work to a `claude_code` child) |
+| `codex_skill_sync.py` | Converts engine-agnostic `.claude/skills/` into Codex's `SKILL.md` format; installed into `~/.codex/skills/` by `scripts/install_codex_skills.py` |
 | `tools.py`, `tool_filter.py`, `tool_result_cache.py` | LifeOS-MCP tool catalog, per-preset filtering, repeat-call de-duplication |
 | `pricing.py` | Per-model token rates + session-hour overhead for cost accounting |
 | `capabilities_preamble.py` | Static LifeOS capabilities briefing prepended to the opening user turn on the managed, local, and `codex` routes (Claude Code gets the equivalent via `--append-system-prompt`) |

--- a/api/services/agent_worker/capabilities_preamble.py
+++ b/api/services/agent_worker/capabilities_preamble.py
@@ -52,6 +52,17 @@ DATA YOU CAN REACH (via the `lifeos` MCP server):
     lifeos_reminder_create, lifeos_memories_create,
     lifeos_telegram_send
 
+SHELL TOOLS (if you have a shell): the `gws` CLI is the Google Workspace
+CLI — direct Drive / Gmail / Sheets / Calendar access via the user's
+authenticated account. Useful when you need raw API access the `lifeos_*`
+tools don't wrap (e.g. creating a Sheet, downloading a Drive file by id):
+  gws drive files list --params '{"pageSize": 10}'
+  gws gmail users messages list --params '{"userId": "me"}'
+  gws sheets spreadsheets get --params '{"spreadsheetId": "..."}'
+  gws schema <service.resource.method>   # discover params for any call
+Prefer `lifeos_*` for search/synthesis; reach for `gws` for direct,
+typed Google API calls.
+
 SEARCH TIPS (recall can be uneven):
   - If the first search returns scores near 0.02 and irrelevant titles,
     re-query with broader OR narrower terms — both, not one. Try the

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -114,6 +114,14 @@ NOTIFICATIONS — use [NOTIFY] for:
 - Progress updates on significant milestones
 - Errors that block progress after you've tried to resolve them
 - Plans before large changes
+
+DELEGATION:
+- Your LifeOS agent session id is {session_id}.
+- If a task needs a capability you lack, delegate it to another engine with
+  the `lifeos_agent_spawn` MCP tool (pass caller_session_id={session_id}).
+  Use model="codex" for tasks that suit Codex's native computer use, or
+  model="local"/"claude" for background research. Monitor the child with
+  `lifeos_agent_check` and read its result with `lifeos_agent_transcript_read`.
 """
 
 
@@ -276,7 +284,7 @@ class ClaudeCodeExecutor:
     # Internal lifecycle
     # ------------------------------------------------------------------
 
-    def _build_command(self, prompt: str, resume_session_id: Optional[str]) -> list[str]:
+    def _build_command(self, prompt: str, resume_session_id: Optional[str], session_id: str = "") -> list[str]:
         platform_desc = (
             "Linux server running Ubuntu"
             if platform.system() == "Linux"
@@ -296,6 +304,7 @@ class ClaudeCodeExecutor:
                 user_name=settings.user_name,
                 code_dir=settings.code_dir,
                 platform_desc=platform_desc,
+                session_id=session_id,
             ),
         ]
         if resume_session_id:
@@ -319,8 +328,8 @@ class ClaudeCodeExecutor:
         resume_session_id: Optional[str],
         plan_mode: bool,
     ) -> ExecutorOutcome:
-        cmd = self._build_command(prompt, resume_session_id)
         sid = session.session_id
+        cmd = self._build_command(prompt, resume_session_id, session_id=sid)
 
         self.transcript_store.append(sid, "claude_code_spawn", {
             "resume": bool(resume_session_id),

--- a/api/services/agent_worker/codex_executor.py
+++ b/api/services/agent_worker/codex_executor.py
@@ -88,6 +88,20 @@ def _resolve_codex_binary() -> str:
     return configured  # caller surfaces FileNotFoundError on spawn
 
 
+def _delegation_header(session_id: str) -> str:
+    """Per-session preamble line telling Codex its LifeOS session id and how to
+    hand off work it can't do (e.g. browser automation) to another engine."""
+    return (
+        f"=== YOUR SESSION ===\n"
+        f"Your LifeOS agent session id is {session_id}. If a task needs a "
+        f"capability you lack — e.g. browser/GUI automation you can't perform "
+        f"headlessly — delegate it with the `lifeos_agent_spawn` MCP tool "
+        f"(caller_session_id={session_id}, model=\"claude_code\" for the "
+        f"browser-enabled Claude Code CLI). Monitor with `lifeos_agent_check` "
+        f"and read the result with `lifeos_agent_transcript_read`."
+    )
+
+
 # Reason codes returned in ``ExecutorOutcome.reason``.
 REASON_COST_CAP_EXCEEDED = "cost_cap_exceeded"
 REASON_TIMEOUT = "timeout"
@@ -170,10 +184,13 @@ class CodexExecutor:
         # docs/guides/agent-worker-setup.md § Codex for the config block.
         self._warn_if_mcp_missing()
         # Prepend the LifeOS capabilities briefing so the fresh Codex turn has
-        # the same situational awareness as the managed/local routes. Only on
-        # the opening turn — resume() reloads the thread, which already carries
-        # the preamble from this first prompt.
-        full_prompt = f"{CAPABILITIES_PREAMBLE}\n{prompt}"
+        # the same situational awareness as the managed/local routes, plus a
+        # per-session delegation header so the agent can hand off work it can't
+        # do (e.g. browser automation → a claude_code child). Only on the
+        # opening turn — resume() reloads the thread, which already carries
+        # this from the first prompt.
+        delegation = _delegation_header(session.session_id)
+        full_prompt = f"{delegation}\n{CAPABILITIES_PREAMBLE}\n{prompt}"
         return self._run(
             session=session,
             prompt=full_prompt,

--- a/api/services/agent_worker/codex_skill_sync.py
+++ b/api/services/agent_worker/codex_skill_sync.py
@@ -1,0 +1,105 @@
+"""Materialize engine-agnostic LifeOS skills into Codex's skill format.
+
+LifeOS skills live in `.claude/skills/<name>/SKILL.md` and are authored in
+Claude Code's slash-command dialect: YAML frontmatter with `argument-hint`, a
+`$ARGUMENTS` placeholder, and `` !`cmd` `` bash-injection blocks in the Context
+section. Codex discovers skills only from `$CODEX_HOME/skills` (or
+`~/.codex/skills`) — there is no project-level `.codex/skills` — and its
+`SKILL.md` format is a plain prompt doc with no `$ARGUMENTS` / bash injection.
+
+This module converts the portable subset (no Claude subagent orchestration)
+to Codex's format and installs them. It is import-safe and side-effect-free
+until `install_skills()` is called, so the transform can be unit-tested without
+touching the filesystem.
+
+Only engine-agnostic skills are ported. The Claude-orchestration skills
+(`implement`, `review-pr`, `address-review`, `mine-for-ideas`) drive Claude's
+`Task`/`Skill` subagent loop and are deliberately left Claude-only; `tune`
+edits the LifeOS Claude-orchestrator internals and is also excluded.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+# Engine-agnostic skills safe to expose to Codex (verified free of Claude
+# subagent-orchestration references). Keep this list conservative — when in
+# doubt, leave a skill Claude-only rather than hand Codex instructions that
+# reference primitives it doesn't have.
+PORTABLE_SKILLS = (
+    "standup",
+    "catchup",
+    "stale",
+    "sync-health",
+    "draft-issue",
+    "pr-check",
+    "merge-pr",
+    "remove-worktree",
+)
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+_BASH_INJECT_RE = re.compile(r"!`([^`]+)`")
+
+
+def transform_skill(text: str) -> str:
+    """Convert one Claude `SKILL.md` body to Codex's format.
+
+    - Keep only `name` and `description` in the frontmatter (drop
+      `argument-hint`, which Codex doesn't use).
+    - Replace `$ARGUMENTS` with prose, since Codex skills aren't parameterized
+      the same way — the user's request *is* the argument.
+    - Rewrite `` !`cmd` `` bash-injection into an explicit "run this" hint;
+      Codex has shell access and runs the command itself rather than having it
+      pre-expanded.
+
+    Raises ValueError if the input has no parseable frontmatter.
+    """
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        raise ValueError("SKILL.md has no YAML frontmatter")
+    frontmatter, body = match.group(1), match.group(2)
+
+    kept = [
+        line for line in frontmatter.splitlines()
+        if line.startswith("name:") or line.startswith("description:")
+    ]
+
+    body = body.replace("$ARGUMENTS", "the request you were given")
+    body = _BASH_INJECT_RE.sub(r"(run `\1` to get this)", body)
+
+    return "---\n" + "\n".join(kept) + "\n---\n" + body
+
+
+def _codex_skills_dir() -> Path:
+    """Codex's skill discovery directory: $CODEX_HOME/skills, else ~/.codex/skills."""
+    codex_home = os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
+    return Path(codex_home) / "skills"
+
+
+def install_skills(
+    claude_skills_dir: Path | str,
+    codex_skills_dir: Path | str | None = None,
+    skills: tuple[str, ...] = PORTABLE_SKILLS,
+) -> list[str]:
+    """Write the portable skills into Codex's skill directory.
+
+    Returns the list of skill names installed. Skips any allowlisted skill
+    that has no source `SKILL.md` (rather than failing the whole run), so a
+    partial `.claude/skills` checkout still installs what it can.
+    """
+    claude_dir = Path(claude_skills_dir)
+    codex_dir = Path(codex_skills_dir) if codex_skills_dir is not None else _codex_skills_dir()
+
+    installed: list[str] = []
+    for name in skills:
+        src = claude_dir / name / "SKILL.md"
+        if not src.is_file():
+            continue
+        converted = transform_skill(src.read_text(encoding="utf-8"))
+        dest_dir = codex_dir / name
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "SKILL.md").write_text(converted, encoding="utf-8")
+        installed.append(name)
+    return installed

--- a/api/services/agent_worker/codex_skill_sync.py
+++ b/api/services/agent_worker/codex_skill_sync.py
@@ -23,6 +23,8 @@ import os
 import re
 from pathlib import Path
 
+import yaml
+
 
 # Engine-agnostic skills safe to expose to Codex (verified free of Claude
 # subagent-orchestration references). Keep this list conservative — when in
@@ -41,35 +43,52 @@ PORTABLE_SKILLS = (
 
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
 _BASH_INJECT_RE = re.compile(r"!`([^`]+)`")
+# `argument-hint` values use Claude's bracket dialect (e.g. `[hours] [me|others]`)
+# which isn't valid YAML, and we drop the key anyway — strip it before parsing.
+_ARGUMENT_HINT_RE = re.compile(r"(?m)^argument-hint:.*\n?")
 
 
 def transform_skill(text: str) -> str:
     """Convert one Claude `SKILL.md` body to Codex's format.
 
     - Keep only `name` and `description` in the frontmatter (drop
-      `argument-hint`, which Codex doesn't use).
-    - Replace `$ARGUMENTS` with prose, since Codex skills aren't parameterized
-      the same way — the user's request *is* the argument.
+      `argument-hint`, which Codex doesn't use). The frontmatter is parsed as
+      YAML so multi-line `description: >` / `description: |` folded scalars
+      survive — re-emitted as a single (possibly long) line.
     - Rewrite `` !`cmd` `` bash-injection into an explicit "run this" hint;
       Codex has shell access and runs the command itself rather than having it
-      pre-expanded.
+      pre-expanded. Done before the `$ARGUMENTS` swap so a command containing
+      `$ARGUMENTS` isn't corrupted mid-rewrite.
+    - Replace `$ARGUMENTS` with prose, since Codex skills aren't parameterized
+      the same way — the user's request *is* the argument.
 
-    Raises ValueError if the input has no parseable frontmatter.
+    Raises ValueError if the input has no parseable frontmatter or is missing
+    the required `name` / `description` keys.
     """
     match = _FRONTMATTER_RE.match(text)
     if not match:
         raise ValueError("SKILL.md has no YAML frontmatter")
     frontmatter, body = match.group(1), match.group(2)
 
-    kept = [
-        line for line in frontmatter.splitlines()
-        if line.startswith("name:") or line.startswith("description:")
-    ]
+    # Drop argument-hint first: its bracket dialect isn't valid YAML and would
+    # break the parse. name/description are the only keys Codex needs.
+    frontmatter = _ARGUMENT_HINT_RE.sub("", frontmatter)
+    meta = yaml.safe_load(frontmatter) or {}
+    name, description = meta.get("name"), meta.get("description")
+    if not name or not description:
+        raise ValueError("SKILL.md frontmatter is missing name or description")
 
-    body = body.replace("$ARGUMENTS", "the request you were given")
+    # Re-emit as valid YAML; width=inf keeps the (possibly long folded)
+    # description on one line instead of re-wrapping it.
+    new_frontmatter = yaml.safe_dump(
+        {"name": name, "description": description},
+        sort_keys=False, allow_unicode=True, width=float("inf"),
+    ).strip()
+
     body = _BASH_INJECT_RE.sub(r"(run `\1` to get this)", body)
+    body = body.replace("$ARGUMENTS", "the request you were given")
 
-    return "---\n" + "\n".join(kept) + "\n---\n" + body
+    return "---\n" + new_frontmatter + "\n---\n" + body
 
 
 def _codex_skills_dir() -> Path:

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -47,6 +47,15 @@ from api.services.agent_worker.transcript_store import TranscriptStore
 logger = logging.getLogger(__name__)
 
 
+# Engines an in-flight agent may spawn a child on. `claude`/`local` are the
+# in-process routes (Managed Agents API / Gemma); `claude_code`/`codex` are the
+# CLI routes, used for capability fallback (browser/GUI, native computer use).
+# CLI routes are subscription-billed, so they skip the per-token dollar ceiling
+# and reuse the managed concurrency cap.
+CLI_ROUTINGS = ("claude_code", "codex")
+SPAWN_MODELS = ("claude", "local", *CLI_ROUTINGS)
+
+
 # Caps enforced on spawn. Operator overrides via settings (see `Caps` dataclass).
 DEFAULT_MAX_SPAWN_DEPTH = 3
 DEFAULT_MAX_DESCENDANTS_PER_ROOT = 50
@@ -130,10 +139,10 @@ def _with_caller(props: dict, required: list[str]) -> dict:
 INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
         "name": "lifeos_agent_spawn",
-        "description": "Spawn a child agent session that runs in parallel. Returns immediately with a `child_session_id` you can monitor with `lifeos_agent_check` or wait on with `lifeos_agent_yield_until`. Budget is drawn from your remaining lineage budget.",
+        "description": "Spawn a child agent session that runs in parallel. Returns immediately with a `child_session_id` you can monitor with `lifeos_agent_check` or wait on with `lifeos_agent_yield_until`. Budget is drawn from your remaining lineage budget. Use `claude_code` or `codex` to delegate work that needs a capability your own engine lacks — e.g. spawn `claude_code` for browser/GUI automation, or `codex` for its native computer use.",
         "input_schema": _with_caller({
             "prompt": {"type": "string", "description": "Task description for the child agent"},
-            "model": {"type": "string", "enum": ["claude", "local"], "description": "Which executor to run the child on"},
+            "model": {"type": "string", "enum": ["claude", "local", "claude_code", "codex"], "description": "Which executor to run the child on. claude=Managed Agents (cloud API), local=Gemma, claude_code=Claude Code CLI (has --chrome browser), codex=Codex CLI (native computer use)."},
             "max_dollars": {"type": "number", "description": "Optional per-child dollar budget"},
             "max_tokens": {"type": "integer", "description": "Optional per-child token budget"},
             "wall_seconds": {"type": "integer", "description": "Optional per-child wall-clock budget"},
@@ -184,7 +193,7 @@ INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
         "description": "List recent agent sessions, optionally filtered by status / routing / parent.",
         "input_schema": _with_caller({
             "status": {"type": "string"},
-            "routing": {"type": "string", "enum": ["claude", "local"]},
+            "routing": {"type": "string", "enum": ["claude", "local", "claude_code", "codex"]},
             "parent_session_id": {"type": "string"},
             "limit": {"type": "integer"},
         }, required=[]),
@@ -211,8 +220,11 @@ def spawn(ctx: InterAgentContext, args: dict) -> dict:
     if not prompt:
         return _err("prompt is required", code="invalid_arg")
     model = args.get("model")
-    if model not in ("claude", "local"):
-        return _err("model must be 'claude' or 'local'", code="invalid_arg")
+    if model not in SPAWN_MODELS:
+        return _err(
+            "model must be one of 'claude', 'local', 'claude_code', 'codex'",
+            code="invalid_arg",
+        )
 
     caller = ctx.session_store.get_by_session_id(ctx.caller_session_id)
     if caller is None:
@@ -249,23 +261,30 @@ def spawn(ctx: InterAgentContext, args: dict) -> dict:
                 code="cap_concurrency_local",
             )
     else:
-        active = ctx.session_store.count_active_by_routing("claude") - caller_excluded
+        # claude (managed) and the CLI routes (claude_code/codex) share the
+        # managed concurrency cap, counted per their own routing.
+        active = ctx.session_store.count_active_by_routing(model) - caller_excluded
         if active >= ctx.caps.max_concurrent_managed:
             return _err(
-                f"{active} managed sessions already running (cap {ctx.caps.max_concurrent_managed})",
+                f"{active} {model} sessions already running (cap {ctx.caps.max_concurrent_managed})",
                 code="cap_concurrency_managed",
             )
 
-    # Budget: child's max_dollars cannot exceed parent's remaining.
+    # Budget: child's max_dollars cannot exceed parent's remaining. CLI routes
+    # are subscription-billed (no per-token draw), so they skip the ceiling —
+    # mirrors the worker's cost-gate skip for claude_code/codex.
     parent_budget = caller.budget or {}
     spent = caller.total_dollars or 0.0
     parent_remaining = (parent_budget.get("max_dollars", 0.0) or 0.0) - spent
-    requested_dollars = float(args.get("max_dollars") or parent_remaining)
-    if requested_dollars > parent_remaining + 1e-6:
-        return _err(
-            f"requested ${requested_dollars:.2f} exceeds parent remaining ${parent_remaining:.2f}",
-            code="budget_exceeded",
-        )
+    if model in CLI_ROUTINGS:
+        requested_dollars = max(0.0, float(args.get("max_dollars") or parent_remaining or 0.0))
+    else:
+        requested_dollars = float(args.get("max_dollars") or parent_remaining)
+        if requested_dollars > parent_remaining + 1e-6:
+            return _err(
+                f"requested ${requested_dollars:.2f} exceeds parent remaining ${parent_remaining:.2f}",
+                code="budget_exceeded",
+            )
 
     child_budget = {
         "wall_seconds": int(args.get("wall_seconds") or parent_budget.get("wall_seconds", 14400)),

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -415,9 +415,47 @@ grep -A2 'mcp_servers.lifeos' ~/.codex/config.toml
 ```
 
 If the block is missing, the agent worker logs a one-time warning on the first
-`#codex` dispatch (`Codex has no [mcp_servers.*] …`) so a misconfigured machine
-surfaces in `logs/lifeos-api-error.log` rather than silently producing
+`#codex` dispatch (`Codex has no [mcp_servers.lifeos] …`) so a misconfigured
+machine surfaces in `logs/lifeos-api-error.log` rather than silently producing
 context-blind runs.
+
+### Codex skills (`#codex` parity with `#claude`)
+
+The engine-agnostic LifeOS workflow skills (`/standup`, `/catchup`, `/stale`,
+`/sync-health`, `/draft-issue`, `/pr-check`, `/merge-pr`, `/remove-worktree`)
+can be installed for Codex. Codex discovers skills only from
+`~/.codex/skills/` (or `$CODEX_HOME/skills`) — there's no project-level skills
+dir — so this is a machine-local install, like the MCP block above:
+
+```bash
+~/.venvs/lifeos/bin/python scripts/install_codex_skills.py
+# Restart Codex to pick them up.
+```
+
+The script converts each skill from Claude Code's slash-command dialect
+(`$ARGUMENTS`, `` !`cmd` `` injection) into Codex's `SKILL.md` format. Re-run
+after editing the source skills under `.claude/skills/`. The Claude-orchestration
+skills (`/implement`, `/review-pr`, `/address-review`, `/mine-for-ideas`, `/tune`)
+are intentionally **not** ported — they drive Claude's subagent loop or the
+LifeOS orchestrator internals and have no Codex equivalent.
+
+### Codex computer use
+
+Codex ships native computer use — `computer_use`, `browser_use`,
+`browser_use_external`, and `in_app_browser` are stable and enabled by default
+(check with `codex features list`). The worker runs Codex with
+`--dangerously-bypass-approvals-and-sandbox`, so nothing in the executor
+suppresses these features. Whether they function under headless `codex exec`
+(no TTY, possibly no display) depends on the host; verify with a real `#codex`
+task that needs the browser before relying on it.
+
+**Fallback:** if Codex can't drive the browser headlessly on your host, it can
+delegate to the browser-enabled Claude Code CLI. Every `#codex` (and `#claude`)
+agent is told its LifeOS session id and can call `lifeos_agent_spawn` with
+`model="claude_code"` (for `--chrome`) or `model="codex"` (for native computer
+use) to hand a sub-task to the other engine, then monitor it with
+`lifeos_agent_check`. This bidirectional delegation means either engine can get
+a job done even when its own tool surface falls short.
 
 ## Cost-aware iteration
 

--- a/scripts/install_codex_skills.py
+++ b/scripts/install_codex_skills.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Install the portable LifeOS skills into Codex's skill directory.
+
+Codex discovers skills from ``$CODEX_HOME/skills`` (or ``~/.codex/skills``) —
+machine-local, like the Codex MCP config. This script converts the
+engine-agnostic LifeOS skills from ``.claude/skills/`` into Codex's ``SKILL.md``
+format and writes them there, so ``#codex`` agents get the same workflow
+helpers as ``#claude`` (standup, catchup, pr-check, merge-pr, etc.).
+
+Re-run after editing the source skills. Idempotent.
+
+Usage:
+    ~/.venvs/lifeos/bin/python scripts/install_codex_skills.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.services.agent_worker.codex_skill_sync import install_skills  # noqa: E402
+
+
+def main() -> int:
+    claude_skills = REPO_ROOT / ".claude" / "skills"
+    if not claude_skills.is_dir():
+        print(f"No skills source at {claude_skills}", file=sys.stderr)
+        return 1
+    installed = install_skills(claude_skills)
+    if not installed:
+        print("No portable skills found to install.", file=sys.stderr)
+        return 1
+    print(f"Installed {len(installed)} Codex skills: {', '.join(installed)}")
+    print("Restart Codex to pick them up.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -371,3 +371,30 @@ def test_resume_passes_session_id_via_resume_flag(tmp_path: Path):
     assert outcome.status == STATUS_COMPLETED
     assert "-r" in captured["cmd"]
     assert "cli-original" in captured["cmd"]
+
+
+def test_system_prompt_carries_session_id_for_delegation(tmp_path: Path):
+    """The appended system prompt tells the agent its LifeOS session id and how
+    to delegate (so it can pass caller_session_id to lifeos_agent_spawn)."""
+    captured: dict = {}
+
+    def _spawn_capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc(
+            [
+                {"type": "system", "subtype": "init", "session_id": "cli-1"},
+                {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "ok"},
+            ],
+        )
+
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_capture)
+    session = _seed_session(store)
+    store.enqueue_message(session.session_id, "operator", "do a thing")
+
+    executor.execute(session, {"id": session.task_id, "description": "do a thing"})
+
+    # The --append-system-prompt value is the arg right after the flag.
+    cmd = captured["cmd"]
+    appended = cmd[cmd.index("--append-system-prompt") + 1]
+    assert session.session_id in appended
+    assert "lifeos_agent_spawn" in appended

--- a/tests/test_agent_worker_inter_agent.py
+++ b/tests/test_agent_worker_inter_agent.py
@@ -101,6 +101,42 @@ def test_spawn_rejects_invalid_model(ctx):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("model", ["claude_code", "codex"])
+def test_spawn_cli_child_for_capability_fallback(ctx, store, parent, model):
+    """An agent can delegate to a CLI engine (claude_code/codex) — the child is
+    created with that routing so the worker's spawned-dispatcher runs it."""
+    result = dispatch(ctx, "lifeos_agent_spawn", {
+        "prompt": "open the dashboard and screenshot it", "model": model,
+    })
+    assert result["ok"]
+    child = store.get_by_session_id(result["child_session_id"])
+    assert child.routing == model
+    assert child.parent_session_id == parent.session_id
+    assert child.status == STATUS_CLAIMED
+    # Plain-string prompt — the codex/claude_code payload parsers fall back to
+    # treating it as the prompt, so no JSON wrapping is required.
+    pending = store.drain_pending_messages(child.session_id)
+    assert pending[0]["content"] == "open the dashboard and screenshot it"
+
+
+@pytest.mark.unit
+def test_spawn_cli_child_skips_dollar_ceiling(store, transcript):
+    """CLI routes are subscription-billed, so a CLI child spawns even when the
+    parent has no remaining per-token dollar budget."""
+    broke_parent = store.create(
+        task_id="broke", status=STATUS_RUNNING, routing="codex",
+        budget={"wall_seconds": 3600, "max_tokens": 100_000, "max_dollars": 0.0},
+        expected_output="text",
+    )
+    ctx = InterAgentContext(
+        session_store=store, transcript_store=transcript,
+        caller_session_id=broke_parent.session_id, caps=Caps(),
+    )
+    result = dispatch(ctx, "lifeos_agent_spawn", {"prompt": "x", "model": "claude_code"})
+    assert result["ok"]  # would be budget_exceeded for a managed child
+
+
+@pytest.mark.unit
 def test_spawn_rejects_at_depth_cap(store, transcript, parent):
     # Build a chain parent → grandchild already at depth 3 — next spawn from
     # grandchild would exceed depth cap.

--- a/tests/test_codex_skill_sync.py
+++ b/tests/test_codex_skill_sync.py
@@ -62,6 +62,54 @@ def test_transform_raises_without_frontmatter():
         transform_skill("# No frontmatter here\n")
 
 
+_FOLDED = """\
+---
+name: draft-issue
+description: >
+  Draft and create a GitHub issue from a description or investigation.
+  Use when a problem is too large for a quick fix, or the user says
+  "file an issue".
+argument-hint: <issue description>
+---
+
+# Draft Issue
+
+Body.
+"""
+
+
+def test_transform_preserves_folded_scalar_description():
+    """A multi-line `description: >` must survive — Codex uses description for
+    skill triggering, so an empty one makes the skill undiscoverable."""
+    out = transform_skill(_FOLDED)
+    assert "Draft and create a GitHub issue" in out
+    assert 'file an issue' in out
+    # No dangling YAML folded-scalar marker, no argument-hint.
+    assert "description: >" not in out
+    assert "argument-hint" not in out
+
+
+def test_transform_raises_on_empty_description():
+    text = "---\nname: x\ndescription:\nargument-hint: y\n---\nbody\n"
+    with pytest.raises(ValueError):
+        transform_skill(text)
+
+
+def test_real_portable_skills_convert_with_nonempty_description():
+    """Guard against silently shipping an untriggerable skill: every portable
+    skill in the repo must convert with a non-empty description line."""
+    repo_skills = Path(__file__).resolve().parent.parent / ".claude" / "skills"
+    for name in PORTABLE_SKILLS:
+        src = repo_skills / name / "SKILL.md"
+        if not src.is_file():
+            continue
+        out = transform_skill(src.read_text(encoding="utf-8"))
+        desc_line = next(
+            (ln for ln in out.splitlines() if ln.startswith("description:")), ""
+        )
+        assert len(desc_line) > len("description: ") + 10, f"{name} has a thin description"
+
+
 def test_install_skills_writes_portable_set(tmp_path: Path):
     claude_dir = tmp_path / "claude_skills"
     codex_dir = tmp_path / "codex_skills"

--- a/tests/test_codex_skill_sync.py
+++ b/tests/test_codex_skill_sync.py
@@ -1,0 +1,101 @@
+"""Tests for converting LifeOS skills into Codex's skill format."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.codex_skill_sync import (
+    PORTABLE_SKILLS,
+    install_skills,
+    transform_skill,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+_SAMPLE = """\
+---
+name: standup
+description: Daily summary of shipped work
+argument-hint: [hours]
+---
+
+# Standup
+
+Summarize work for: $ARGUMENTS
+
+## Context
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -5`
+
+Do the thing.
+"""
+
+
+def test_transform_keeps_name_and_description_drops_argument_hint():
+    out = transform_skill(_SAMPLE)
+    assert "name: standup" in out
+    assert "description: Daily summary of shipped work" in out
+    assert "argument-hint" not in out
+
+
+def test_transform_rewrites_arguments_and_bash_injection():
+    out = transform_skill(_SAMPLE)
+    assert "$ARGUMENTS" not in out
+    assert "the request you were given" in out
+    # `` !`cmd` `` becomes an explicit run-this hint, not a pre-expanded value.
+    assert "!`" not in out
+    assert "(run `git branch --show-current` to get this)" in out
+    assert "(run `git log --oneline -5` to get this)" in out
+
+
+def test_transform_preserves_body_prose():
+    out = transform_skill(_SAMPLE)
+    assert "# Standup" in out
+    assert "Do the thing." in out
+
+
+def test_transform_raises_without_frontmatter():
+    with pytest.raises(ValueError):
+        transform_skill("# No frontmatter here\n")
+
+
+def test_install_skills_writes_portable_set(tmp_path: Path):
+    claude_dir = tmp_path / "claude_skills"
+    codex_dir = tmp_path / "codex_skills"
+    # Seed two portable skills + one that isn't on the allowlist.
+    for name in ("standup", "pr-check", "implement"):
+        d = claude_dir / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(_SAMPLE.replace("standup", name), encoding="utf-8")
+
+    installed = install_skills(claude_dir, codex_dir)
+
+    assert "standup" in installed
+    assert "pr-check" in installed
+    # Claude-orchestration skill is not on the allowlist → never installed.
+    assert "implement" not in installed
+    assert not (codex_dir / "implement").exists()
+    # Converted file exists and is in Codex format.
+    written = (codex_dir / "standup" / "SKILL.md").read_text(encoding="utf-8")
+    assert "argument-hint" not in written
+    assert "$ARGUMENTS" not in written
+
+
+def test_install_skips_missing_sources(tmp_path: Path):
+    """A partial .claude/skills checkout installs what it can without failing."""
+    claude_dir = tmp_path / "claude_skills"
+    codex_dir = tmp_path / "codex_skills"
+    d = claude_dir / "standup"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(_SAMPLE, encoding="utf-8")
+
+    installed = install_skills(claude_dir, codex_dir)
+    assert installed == ["standup"]
+
+
+def test_orchestration_skills_excluded_from_allowlist():
+    for excluded in ("implement", "review-pr", "address-review", "tune", "mine-for-ideas"):
+        assert excluded not in PORTABLE_SKILLS

--- a/tests/test_codex_spawn_executor.py
+++ b/tests/test_codex_spawn_executor.py
@@ -197,6 +197,40 @@ def test_executor_prepends_capabilities_preamble(stores, monkeypatch, tmp_path):
 
 
 @pytest.mark.unit
+def test_executor_injects_delegation_header_with_session_id(stores, tmp_path):
+    """The opening Codex turn tells the agent its session id and how to
+    delegate work it can't do (e.g. browser) to a claude_code child."""
+    sess_store, tr_store = stores
+    session = sess_store.create(
+        task_id="t_del", session_id="sess_del", status="claimed", routing="codex",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 1.0},
+        expected_output="text", origin="operator",
+    )
+
+    captured: dict = {}
+
+    def fake_spawn(cmd, **kwargs):
+        captured["cmd"] = cmd
+        for i, tok in enumerate(cmd):
+            if tok == "-o" and i + 1 < len(cmd):
+                with open(cmd[i + 1], "w") as f:
+                    f.write("ok\n")
+        return _FakeProc([{"type": "session.completed"}], returncode=0)
+
+    executor = CodexExecutor(
+        session_store=sess_store, transcript_store=tr_store,
+        spawn_fn=fake_spawn, binary_resolver=lambda: "/usr/bin/true",
+        heartbeat_interval=9999,
+    )
+    executor.execute(session, {"description": "do a thing", "working_dir": str(tmp_path)})
+
+    prompt_arg = captured["cmd"][-1]
+    assert "sess_del" in prompt_arg
+    assert "lifeos_agent_spawn" in prompt_arg
+    assert 'model="claude_code"' in prompt_arg
+
+
+@pytest.mark.unit
 def test_resume_does_not_prepend_preamble(stores, tmp_path):
     """Resume reloads the Codex thread (which already holds the preamble from
     the opening turn), so the follow-up message must NOT re-inject it."""


### PR DESCRIPTION
## Summary

Brings the `#codex` agent path toward full `#claude` parity across the four items in #297 (the irreducible gpt-5.5-vs-Opus model gap aside): shared agent context + the `gws` CLI, native computer-use documentation, skills exposure, and bidirectional cross-engine delegation.

Closes #297.

## What changed

**Shared context + gws (item 1 + 4)** — Added the `gws` Google Workspace CLI to `capabilities_preamble.py` (reaches codex/managed/local) and root `AGENTS.md` (reaches Claude Code), so both engines know they can shell out to Drive/Gmail/Sheets/Calendar. Don't-degrade-Claude honored: `gws` lives in `AGENTS.md` (both read it); nothing was removed from `CLAUDE.md`.

**Computer use (item 2)** — Codex's native `computer_use`/`browser_use` are stable and on by default; the executor's `--dangerously-bypass-approvals-and-sandbox` doesn't suppress them. Documented availability + the headless-`codex exec` caveat in the setup guide, with delegation (below) as the documented fallback. *Live headless verification is an operator step — flagged as such, not claimed done.*

**Skills (item 3)** — New `codex_skill_sync.py` converts the engine-agnostic LifeOS skills (`standup`, `catchup`, `stale`, `sync-health`, `draft-issue`, `pr-check`, `merge-pr`, `remove-worktree`) from Claude's slash-command dialect (`$ARGUMENTS`, `` !`cmd` ``) into Codex's `SKILL.md` format; `scripts/install_codex_skills.py` installs them into `~/.codex/skills/` (machine-local — Codex has **no** project-level skills dir). The Claude-orchestration skills (`implement`, `review-pr`, `address-review`, `mine-for-ideas`, `tune`) are intentionally left Claude-only.

**Bidirectional routing (item 5)** — `lifeos_agent_spawn` now accepts `model=claude_code|codex` (CLI routes skip the per-token dollar ceiling and reuse the managed concurrency cap). Both CLI executors now inject the agent's LifeOS session id + a delegation hint, so a `#codex` agent can hand browser work to a `claude_code` child (and vice versa) via the existing spawned-session dispatch.

## Test evidence

`~/.venvs/lifeos/bin/python -m pytest tests/ -m unit` → **1741 passed, 0 failed** (613s).

New coverage:
- `tests/test_codex_skill_sync.py` — frontmatter/`$ARGUMENTS`/bash-injection transform, allowlist install, orchestration-skill exclusion.
- `tests/test_agent_worker_inter_agent.py` — CLI-routed spawn creates the right routing; CLI child skips the dollar ceiling.
- `tests/test_codex_spawn_executor.py` / `tests/test_agent_worker_claude_code_executor.py` — delegation header carries the session id + `lifeos_agent_spawn` in both CLI prompts.

Smoke-tested `scripts/install_codex_skills.py` against a temp `CODEX_HOME`: 8 skills installed, converted cleanly (no `argument-hint`, zero `` !`cmd` `` leftovers).

## Review focus

- **MCP/inter-agent tool surface change:** `lifeos_agent_spawn`'s `model` enum gained `claude_code`/`codex`. Per AGENTS.md this is an "ask first" area — the issue scoped it and the operator approved attempting the whole issue.
- **CLI budget bypass** in `inter_agent.spawn()` — CLI routes are subscription-billed, so they skip the dollar ceiling and floor requested dollars at 0. Confirm that's the right call vs. enforcing a notional budget.
- **Skills are machine-local**, so the install is a setup step, not committed files — matches the #295 MCP-config pattern. Is `scripts/install_codex_skills.py` + a guide section the right delivery?
- **Computer-use verification is deferred to a live operator run** — the OR branch of the acceptance criterion (document + route to claude) is what's delivered in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)