### PR TITLE
fix(mcp): anchor inter-agent stores to repo, not the spawn cwd

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -16,6 +16,7 @@ import sys
 import httpx
 import logging
 import os
+from pathlib import Path
 
 # Configure logging to stderr (stdout is for MCP protocol)
 logging.basicConfig(
@@ -24,6 +25,17 @@ logging.basicConfig(
     stream=sys.stderr
 )
 logger = logging.getLogger(__name__)
+
+# Repo-anchored agent-worker store locations. This server is spawned as a
+# stdio MCP child by CLI agents (codex / claude_code) with the agent's `-C`
+# working dir as cwd — NOT the repo — so the stores' default cwd-relative
+# paths would open a phantom empty DB and every inter-agent call would fail
+# with "no_caller". Anchoring to this file's directory (the repo root) keeps
+# inter-agent tools pointed at the real worker store regardless of cwd. Tests
+# monkeypatch these to sandbox.
+_REPO_ROOT = Path(__file__).resolve().parent
+AGENT_SESSIONS_DB = _REPO_ROOT / "data" / "agent_sessions.db"
+AGENT_TRANSCRIPTS_DIR = _REPO_ROOT / "data" / "agent_transcripts"
 
 API_BASE = os.environ.get("LIFEOS_API_URL", "http://localhost:8000")
 OPENAPI_URL = f"{API_BASE}/openapi.json"
@@ -962,9 +974,12 @@ class LifeOSMCPServer:
         except Exception as exc:
             logger.warning("inter-agent: managed_driver init failed: %s", exc)
 
+        # Anchor the stores to the repo's data/ dir (see AGENT_SESSIONS_DB) so
+        # inter-agent tools hit the real worker store regardless of the cwd this
+        # MCP server was spawned with.
         ctx = InterAgentContext(
-            session_store=SessionStore(),
-            transcript_store=TranscriptStore(),
+            session_store=SessionStore(db_path=AGENT_SESSIONS_DB),
+            transcript_store=TranscriptStore(transcripts_dir=AGENT_TRANSCRIPTS_DIR),
             caller_session_id=caller_session_id,
             caps=Caps(
                 max_spawn_depth=_settings.agent_max_spawn_depth,

--- a/tests/test_agent_worker_mcp_exposure.py
+++ b/tests/test_agent_worker_mcp_exposure.py
@@ -17,15 +17,33 @@ import mcp_server
 def server(monkeypatch, tmp_path: Path):
     """A LifeOSMCPServer with the agent stack pointed at a temp DB.
 
-    SessionStore reads `DEFAULT_DB_PATH` only at function-default-binding
-    time, so monkeypatching the module attribute doesn't redirect new
-    instances. We chdir into tmp_path instead so the relative default
-    `data/agent_sessions.db` lands inside the test sandbox.
+    `_handle_inter_agent` anchors its SessionStore/TranscriptStore to the
+    repo-root constants (`AGENT_SESSIONS_DB` / `AGENT_TRANSCRIPTS_DIR`) so it
+    works regardless of the cwd the MCP server was spawned with. We point those
+    constants at the sandbox, and also chdir so a bare `SessionStore()` in a
+    test resolves to the same place.
     """
     monkeypatch.setenv("LIFEOS_AGENT_VAULT_ID", "")
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mcp_server, "AGENT_SESSIONS_DB", tmp_path / "data" / "agent_sessions.db")
+    monkeypatch.setattr(mcp_server, "AGENT_TRANSCRIPTS_DIR", tmp_path / "data" / "agent_transcripts")
     srv = mcp_server.LifeOSMCPServer()
     return srv
+
+
+@pytest.mark.unit
+def test_inter_agent_stores_anchored_to_repo_not_cwd(monkeypatch, tmp_path: Path):
+    """Regression: the MCP server is spawned by CLI agents with the agent's
+    `-C` dir as cwd, so inter-agent tools must NOT resolve the session store
+    relative to cwd (that opened a phantom empty DB → every call failed
+    'no_caller'). The anchored paths must be absolute and repo-rooted even when
+    cwd is elsewhere."""
+    monkeypatch.chdir(tmp_path)
+    assert mcp_server.AGENT_SESSIONS_DB.is_absolute()
+    assert mcp_server.AGENT_SESSIONS_DB == mcp_server._REPO_ROOT / "data" / "agent_sessions.db"
+    assert mcp_server.AGENT_TRANSCRIPTS_DIR == mcp_server._REPO_ROOT / "data" / "agent_transcripts"
+    # The anchor is the repo root (where mcp_server.py lives), not the cwd.
+    assert mcp_server._REPO_ROOT != Path(tmp_path)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Cross-engine delegation shipped in #298 (closes #297) was broken end-to-end: a `#codex`/`#claude` CLI agent calling `lifeos_agent_spawn` via the stdio MCP server always got `Error: no_caller`.

**Root cause:** codex/claude_code spawn the MCP server with the agent's `-C` working dir as cwd (not the repo). `_handle_inter_agent` built `SessionStore()`/`TranscriptStore()` with their cwd-relative default paths, so the server opened a phantom empty `<workdir>/data/agent_sessions.db` — the caller session (written by the worker under the repo) was never found, and any spawned child would have landed in the wrong DB too.

**Fix:** anchor the inter-agent stores to repo-root constants (`AGENT_SESSIONS_DB` / `AGENT_TRANSCRIPTS_DIR`, derived from `__file__`) so they resolve to the real worker store regardless of spawn cwd.

Relates to #297 / #298.

## How it was found

Live end-to-end testing of the #298 delegation path (requested after merge). With the codex MCP server configured, a `codex exec -C <tempdir>` agent instructed to call `lifeos_agent_spawn(model="claude_code")` returned `no_caller` while `lifeos_health` succeeded — proving the transport worked but the session store was wrong. A stray `<tempdir>/data/agent_sessions.db` confirmed the cwd-relative resolution.

## Test evidence

- **Live, post-fix:** codex (run with `-C` a tempdir) called `lifeos_agent_spawn` → created `routing=claude_code` child in the **repo** DB; the worker picked it up and ran a real Claude Code CLI session to completion. Full chain verified.
- `~/.venvs/lifeos/bin/python -m pytest tests/ -m unit` → **1745 passed, 0 failed**.
- New `test_inter_agent_stores_anchored_to_repo_not_cwd` regression test; `mcp-exposure` fixture updated to monkeypatch the new constants for sandboxing.

## Review focus

- The anchor is `Path(__file__).resolve().parent` (mcp_server.py is at repo root). Confirm that holds for all deploy layouts.
- Same cwd class of bug could affect other relative-path usage spawned by CLI agents; this fix covers the inter-agent chokepoint (the only one CLI agents reach the session store through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)