### PR TITLE
docs(codex): computer use unavailable to worker — route browser to claude_code

### DIFF
--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -117,11 +117,11 @@ NOTIFICATIONS — use [NOTIFY] for:
 
 DELEGATION:
 - Your LifeOS agent session id is {session_id}.
-- If a task needs a capability you lack, delegate it to another engine with
-  the `lifeos_agent_spawn` MCP tool (pass caller_session_id={session_id}).
-  Use model="codex" for tasks that suit Codex's native computer use, or
-  model="local"/"claude" for background research. Monitor the child with
-  `lifeos_agent_check` and read its result with `lifeos_agent_transcript_read`.
+- You already have a browser (--chrome), filesystem, and shell. If you want to
+  run background work in parallel, delegate it with the `lifeos_agent_spawn`
+  MCP tool (pass caller_session_id={session_id}, model="local" or "claude").
+  Monitor the child with `lifeos_agent_check` and read its result with
+  `lifeos_agent_transcript_read`.
 """
 
 

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -139,10 +139,10 @@ def _with_caller(props: dict, required: list[str]) -> dict:
 INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
         "name": "lifeos_agent_spawn",
-        "description": "Spawn a child agent session that runs in parallel. Returns immediately with a `child_session_id` you can monitor with `lifeos_agent_check` or wait on with `lifeos_agent_yield_until`. Budget is drawn from your remaining lineage budget. Use `claude_code` or `codex` to delegate work that needs a capability your own engine lacks — e.g. spawn `claude_code` for browser/GUI automation, or `codex` for its native computer use.",
+        "description": "Spawn a child agent session that runs in parallel. Returns immediately with a `child_session_id` you can monitor with `lifeos_agent_check` or wait on with `lifeos_agent_yield_until`. Budget is drawn from your remaining lineage budget. Use `claude_code` to delegate work that needs a real browser / GUI automation — its `--chrome` browser works headless, unlike Codex's (whose computer use is a desktop-app-only feature, unavailable here).",
         "input_schema": _with_caller({
             "prompt": {"type": "string", "description": "Task description for the child agent"},
-            "model": {"type": "string", "enum": ["claude", "local", "claude_code", "codex"], "description": "Which executor to run the child on. claude=Managed Agents (cloud API), local=Gemma, claude_code=Claude Code CLI (has --chrome browser), codex=Codex CLI (native computer use)."},
+            "model": {"type": "string", "enum": ["claude", "local", "claude_code", "codex"], "description": "Which executor to run the child on. claude=Managed Agents (cloud API), local=Gemma, claude_code=Claude Code CLI (has a working --chrome browser), codex=Codex CLI (code/general tasks; no browser in headless mode)."},
             "max_dollars": {"type": "number", "description": "Optional per-child dollar budget"},
             "max_tokens": {"type": "integer", "description": "Optional per-child token budget"},
             "wall_seconds": {"type": "integer", "description": "Optional per-child wall-clock budget"},

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -439,23 +439,33 @@ skills (`/implement`, `/review-pr`, `/address-review`, `/mine-for-ideas`, `/tune
 are intentionally **not** ported — they drive Claude's subagent loop or the
 LifeOS orchestrator internals and have no Codex equivalent.
 
-### Codex computer use
+### Codex computer use — NOT available to the worker (use delegation)
 
-Codex ships native computer use — `computer_use`, `browser_use`,
-`browser_use_external`, and `in_app_browser` are stable and enabled by default
-(check with `codex features list`). The worker runs Codex with
-`--dangerously-bypass-approvals-and-sandbox`, so nothing in the executor
-suppresses these features. Whether they function under headless `codex exec`
-(no TTY, possibly no display) depends on the host; verify with a real `#codex`
-task that needs the browser before relying on it.
+`codex features list` shows `computer_use` / `browser_use` / `in_app_browser`
+as `stable`+`true`, but those are **capability flags, not runtime availability**.
+Verified empirically (a forced-browser `codex exec` task returns "BROWSER
+UNAVAILABLE") and confirmed against OpenAI's docs — Codex computer use and the
+in-app browser are **Codex *desktop app* features**, not CLI/`exec` features:
 
-**Fallback:** if Codex can't drive the browser headlessly on your host, it can
-delegate to the browser-enabled Claude Code CLI. Every `#codex` (and `#claude`)
-agent is told its LifeOS session id and can call `lifeos_agent_spawn` with
-`model="claude_code"` (for `--chrome`) or `model="codex"` (for native computer
-use) to hand a sub-task to the other engine, then monitor it with
-`lifeos_agent_check`. This bidirectional delegation means either engine can get
-a job done even when its own tool surface falls short.
+- They are documented only under the [Codex **app**](https://developers.openai.com/codex/app/computer-use),
+  and the browser is *in-app* — hosted by the desktop/TUI runtime. Headless
+  `codex exec` (how the worker runs Codex) has no app, so the tool is never
+  registered.
+- Computer use is **macOS/Windows only** — this worker runs on **Linux**, where
+  it isn't offered at all.
+- It also requires a Computer Use **plugin** installed via Codex settings, an
+  active desktop session, and OS screen-recording/accessibility permissions —
+  none of which exist for a background `codex exec` subprocess.
+
+This is an upstream constraint, not a LifeOS misconfiguration — there's no flag
+that makes it work in the worker.
+
+**So browser/GUI work routes to Claude Code instead.** Every `#codex` (and
+`#claude`) agent is told its LifeOS session id and can call `lifeos_agent_spawn`
+with `model="claude_code"` to hand a browser sub-task to the `--chrome`-enabled
+Claude Code CLI (which *does* work headless on Linux), then monitor it with
+`lifeos_agent_check`. This delegation is the supported path for any task that
+needs a real browser.
 
 ## Cost-aware iteration
 


### PR DESCRIPTION
## Summary

Resolves the open question from #297/#298 about whether Codex's native computer use works for the agent worker. Research (empirical test + OpenAI docs) shows it **does not, for unfixable reasons** — so this corrects the setup guide and the in-code delegation hints accordingly.

Relates to #297 / #298.

## Why computer use won't work for the worker

`codex features list` reports `computer_use` / `browser_use` / `in_app_browser` as `stable`+`true`, but those are **capability flags, not runtime availability**:

- **Desktop-app feature, not CLI/exec.** Computer use and the in-app browser are documented only under the [Codex *app*](https://developers.openai.com/codex/app/computer-use); the browser is *in-app*, hosted by the desktop/TUI runtime. The worker runs Codex via headless `codex exec`, which has no app — so the tool is never registered.
- **macOS/Windows only.** The worker runs on **Linux**, where computer use isn't offered at all.
- **Needs a desktop session.** Requires a Computer Use plugin installed via settings, an active visible desktop session, and OS screen-recording/accessibility permissions — none of which a background `codex exec` subprocess has.

Empirically confirmed: a forced-browser `codex exec` task (web_search/shell forbidden) returns `BROWSER UNAVAILABLE`.

## Changes

- `docs/guides/agent-worker-setup.md` — replaced the "verify before relying" note with the definitive finding + the delegation path.
- `inter_agent.py` (`lifeos_agent_spawn` description/enum) and `claude_code_executor.py` (system prompt) — corrected so agents no longer try to delegate browser work *to* codex; browser/GUI work routes to the `--chrome`-enabled `claude_code` (which works headless on Linux).

## Test evidence

`pytest tests/ -m unit` → **1745 passed, 0 failed**. Wording-only changes; 64 executor/inter-agent/mcp tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)