### PR TITLE
perf(agent-worker): run spawned CLI children off the tick loop

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -155,7 +155,7 @@ class _SynchronousPool:
         fn(*args, **kwargs)
         return None
 
-    def shutdown(self, wait: bool = True) -> None:  # noqa: D401 - parity with executor API
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:  # noqa: D401 - parity with executor API
         pass
 
 
@@ -254,9 +254,13 @@ class Worker:
     def stop(self) -> None:
         """Mark the loop for graceful shutdown. Safe to call from a signal."""
         self._stop = True
-        # Don't block shutdown on in-flight CLI children; any left RUNNING are
-        # reconciled by resume_pending() on the next start (SIGKILL-safe path).
-        self._cli_pool.shutdown(wait=False)
+        # Drop any *queued* CLI dispatches and don't block the caller. Children
+        # already running aren't force-killed here — their own watchdog times
+        # them out, and on a hard stop systemd's TimeoutStopSec SIGKILLs the
+        # process; either way resume_pending() reconciles them on next start.
+        # (Pool threads are non-daemon, so a still-running child can delay a
+        # natural interpreter exit until its watchdog fires.)
+        self._cli_pool.shutdown(wait=False, cancel_futures=True)
 
     def run(self) -> None:
         """Main loop. Runs until `stop()` is called or the process is killed."""
@@ -464,6 +468,13 @@ class Worker:
             # origin='operator').
             if not session.parent_session_id and session.origin != "operator":
                 continue
+            # CLI children already handed to the pool: skip BEFORE draining, so a
+            # re-scan in the CLAIMED→RUNNING window doesn't consume (and discard)
+            # the session's pending messages while the running dispatch skips them.
+            if session.routing in ("claude_code", "codex"):
+                with self._cli_lock:
+                    if session.session_id in self._cli_inflight:
+                        continue
             # The first pending message is the prompt from the parent — drain
             # it so the executor's seeded user turn picks it up.
             pending = self.session_store.drain_pending_messages(session.session_id)
@@ -516,6 +527,9 @@ class Worker:
                 return
             self._cli_inflight.add(sid)
 
+        # The closure captures the tick-time `session` snapshot; the dispatch
+        # only reads immutable fields (ids, routing) and re-reads mutable state
+        # from the store, so the snapshot going stale is harmless.
         def _run() -> None:
             try:
                 dispatch_fn(session, pending)

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -20,7 +20,9 @@ import json
 import logging
 import os
 import signal
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import httpx
@@ -141,6 +143,22 @@ BUDGET_EXCEEDED_TAG = "agent-budget-exceeded"
 AGENT_PICKUP_STATUSES = ("todo", "urgent")
 
 
+class _SynchronousPool:
+    """A ``submit()``-compatible pool that runs work inline.
+
+    The default CLI dispatch pool is a real ``ThreadPoolExecutor``; tests inject
+    this instead so spawned-child dispatch stays deterministic (the work runs
+    before ``submit`` returns, so assertions don't race a background thread).
+    """
+
+    def submit(self, fn, *args, **kwargs):
+        fn(*args, **kwargs)
+        return None
+
+    def shutdown(self, wait: bool = True) -> None:  # noqa: D401 - parity with executor API
+        pass
+
+
 class Worker:
     """Single-process poll loop. One instance per process."""
 
@@ -159,6 +177,7 @@ class Worker:
         managed_executor=None,    # injectable ManagedExecutor for tests
         claude_code_executor=None,  # injectable ClaudeCodeExecutor for tests
         codex_executor=None,        # injectable CodexExecutor for tests
+        cli_pool=None,              # injectable dispatch pool; tests pass _SynchronousPool
     ) -> None:
         self.api_base = (api_base or os.environ.get("LIFEOS_API_URL", "http://localhost:8000")).rstrip("/")
         self.session_store = session_store or SessionStore()
@@ -188,6 +207,18 @@ class Worker:
         self._managed_executor = managed_executor  # lazily instantiated on first claude task
         self._claude_code_executor = claude_code_executor  # lazily instantiated on first /claude task
         self._codex_executor = codex_executor  # lazily instantiated on first /codex task
+        # Spawned CLI children (claude_code/codex) are long-running subprocesses.
+        # Running them off the tick keeps the poll loop free to claim new tasks
+        # and dispatch siblings. Bounded so concurrent subprocesses stay capped;
+        # tests inject a _SynchronousPool for deterministic dispatch. `_cli_inflight`
+        # guards against the next tick re-dispatching a child that's been submitted
+        # but hasn't yet flipped CLAIMED→RUNNING.
+        self._cli_pool = cli_pool or ThreadPoolExecutor(
+            max_workers=max(2, 2 * settings.agent_max_concurrent_managed),
+            thread_name_prefix="cli-dispatch",
+        )
+        self._cli_inflight: set[str] = set()
+        self._cli_lock = threading.Lock()
         self._warn_deprecated_settings()
 
     @staticmethod
@@ -223,6 +254,9 @@ class Worker:
     def stop(self) -> None:
         """Mark the loop for graceful shutdown. Safe to call from a signal."""
         self._stop = True
+        # Don't block shutdown on in-flight CLI children; any left RUNNING are
+        # reconciled by resume_pending() on the next start (SIGKILL-safe path).
+        self._cli_pool.shutdown(wait=False)
 
     def run(self) -> None:
         """Main loop. Runs until `stop()` is called or the process is killed."""
@@ -417,9 +451,10 @@ class Worker:
         """Pick up sessions created via lifeos_agent_spawn that have no #agent
         task backing — they show up with status=claimed and an explicit routing.
 
-        Synchronous in this MVP: a long-running local child blocks the tick
-        loop. Acceptable while local concurrency cap = 1; a future PR could
-        move to a worker pool.
+        CLI children (claude_code/codex) are long-running subprocesses, so they
+        run on the bounded `_cli_pool` rather than blocking the tick (#299). The
+        `local` route stays inline — it's in-process, GPU-bound, and capped at
+        one concurrent session, so a pool wouldn't buy real parallelism.
         """
         claimed = self.session_store.list_by_status(STATUS_CLAIMED)
         for session in claimed:
@@ -462,10 +497,39 @@ class Worker:
                 # On RUNNING, let _poll_managed_sessions handle the rest.
             elif session.routing == "claude_code":
                 # /claude sessions — operator-spawned via claude_code_spawn.spawn_claude_code_session.
-                self._dispatch_claude_code_session(session, pending)
+                self._submit_cli_dispatch(session, pending, self._dispatch_claude_code_session)
             elif session.routing == "codex":
                 # /codex sessions — operator-spawned via codex_spawn.spawn_codex_session.
-                self._dispatch_codex_session(session, pending)
+                self._submit_cli_dispatch(session, pending, self._dispatch_codex_session)
+
+    def _submit_cli_dispatch(self, session, pending, dispatch_fn) -> None:
+        """Run a CLI child's dispatch on the pool instead of inline.
+
+        Guards with `_cli_inflight` so a re-scan on the next tick doesn't submit
+        the same session twice in the window between submission and the
+        executor flipping the row CLAIMED→RUNNING. The session_id is cleared
+        when the dispatch finishes (success or failure).
+        """
+        sid = session.session_id
+        with self._cli_lock:
+            if sid in self._cli_inflight:
+                return
+            self._cli_inflight.add(sid)
+
+        def _run() -> None:
+            try:
+                dispatch_fn(session, pending)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.exception("async CLI dispatch crashed for %s: %s", session.task_id, exc)
+                try:
+                    self.session_store.update_status(session.task_id, STATUS_FAILED)
+                except Exception:
+                    logger.exception("failed to mark %s failed after dispatch crash", session.task_id)
+            finally:
+                with self._cli_lock:
+                    self._cli_inflight.discard(sid)
+
+        self._cli_pool.submit(_run)
 
     def _poll_managed_sessions(self) -> None:
         """Advance all in-flight Managed Agents sessions one polling step."""

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-28
+> **Last Updated:** 2026-06-02
 
 Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
 
@@ -276,6 +276,10 @@ Lineage budgets: every session tracks `root_session_id` + `spawn_depth`. Budget 
 - **Routing** follows override-then-preflight: an explicit `local`/`claude` keyword wins; otherwise `run_preflight()` decides. On `ROUTE_ASK` the session parks at `blocked` with `routing='ask'` and the caller sends the "local or claude?" clarification (the worker resolves it on reply).
 - **Provenance** is marked with the additive `sessions.origin = 'operator'` column. The worker's `_dispatch_spawned_sessions` skip is relaxed to claim parentless sessions when `origin='operator'`, so they dispatch alongside spawned children without colliding with the top-level `#agent` claim path (which uses NULL origin). The prompt is enqueued as a pending message and drained as the task description on dispatch.
 - Operator sessions are root sessions (`parent_session_id=None`), so their terminal notifications surface to the operator and register a replyable follow-up (Phase 1 / #234). Because they have no backing vault task, `_handle_outcome` and `_resume_as_followup` skip the vault mutations (`_complete_task` / `_swap_tag` / `_set_task_status`) for `origin='operator'` — gated on `has_vault_task` — while still sending the notification + follow-up. The prompt is enqueued *before* the session row is created so the worker can never observe a CLAIMED operator session whose prompt hasn't landed. Default budget comes from the `agent_default_*` settings; local concurrency cap of 1 means operator local spawns queue behind running ones.
+
+### Off-tick CLI dispatch (#299)
+
+Spawned `claude_code` / `codex` children are long-running subprocesses. `_dispatch_spawned_sessions` runs them on a bounded `ThreadPoolExecutor` (`_cli_pool`, sized `2 × agent_max_concurrent_managed`) via `_submit_cli_dispatch`, rather than inline — so one delegated child can't park the poll loop and starve new `#agent` claims or sibling dispatch. An `_cli_inflight` set (lock-guarded) prevents a re-scan from re-submitting a child in the window before its executor flips the row `CLAIMED→RUNNING`; for CLI routes the guard is checked *before* draining pending messages so a skipped re-scan can't discard them. Per-routing concurrency stays bounded at `lifeos_agent_spawn` time (`count_active_by_routing`), independent of dispatch timing. The `local` route stays inline (in-process, GPU-bound, cap 1). `stop()` calls `shutdown(wait=False, cancel_futures=True)`; children still running are reconciled by `resume_pending()` on restart. Tests inject a `_SynchronousPool` for deterministic dispatch.
 
 ---
 

--- a/tests/test_agent_worker_async_cli_dispatch.py
+++ b/tests/test_agent_worker_async_cli_dispatch.py
@@ -1,0 +1,140 @@
+"""Spawned CLI children (claude_code/codex) dispatch off the tick (#299).
+
+A long-running CLI subprocess must not block the worker's poll loop from
+claiming new tasks or dispatching siblings. These tests use a capturing pool
+(records submissions without running them) to prove the dispatch is handed off
+rather than executed inline, and that the in-flight guard prevents a re-scan
+from submitting the same child twice.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+import pytest
+
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.session_store import STATUS_COMPLETED, SessionStore
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import Worker
+
+
+pytestmark = pytest.mark.unit
+
+
+class _CapturingPool:
+    """Records submitted callables without running them, so a test can assert
+    the dispatch was handed off (not run inline) and then run it on demand."""
+
+    def __init__(self):
+        self.submitted: list = []
+
+    def submit(self, fn, *args, **kwargs):
+        self.submitted.append((fn, args, kwargs))
+        return None
+
+    def shutdown(self, wait: bool = True) -> None:
+        pass
+
+    def run_all(self) -> None:
+        for fn, args, kwargs in self.submitted:
+            fn(*args, **kwargs)
+
+
+@dataclass
+class _StubCliExecutor:
+    outcome: ExecutorOutcome
+    calls: list = field(default_factory=list)
+
+    def execute(self, session, task):
+        self.calls.append((session.task_id, task.get("description")))
+        return self.outcome
+
+
+def _worker(tmp_path: Path, pool, *, claude_code_executor=None, codex_executor=None):
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+    return Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: True,
+        telegram_send_with_id=lambda text: [1],
+        http_client=client,
+        claude_code_executor=claude_code_executor,
+        codex_executor=codex_executor,
+        cli_pool=pool,
+    )
+
+
+def _seed_spawned_child(store: SessionStore, routing: str, *, task_id="cli-child"):
+    """A spawned CLI child: parent set, claimed, prompt queued."""
+    session = store.create(task_id=task_id, routing=routing, parent_session_id="sess_parent")
+    store.enqueue_message(session.session_id, sender_id="sess_parent", content="do work")
+    return session
+
+
+def test_claude_code_child_dispatched_off_tick(tmp_path: Path):
+    stub = _StubCliExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done."))
+    pool = _CapturingPool()
+    w = _worker(tmp_path, pool, claude_code_executor=stub)
+    _seed_spawned_child(w.session_store, "claude_code")
+
+    w._dispatch_spawned_sessions()
+
+    # Handed to the pool, NOT run inline — the tick returned without blocking on
+    # the (would-be long) subprocess.
+    assert len(pool.submitted) == 1
+    assert stub.calls == []
+    # Running the submitted work executes the child and clears the in-flight mark.
+    pool.run_all()
+    assert stub.calls == [("cli-child", "do work")]
+    assert w._cli_inflight == set()
+
+
+def test_codex_child_dispatched_off_tick(tmp_path: Path):
+    stub = _StubCliExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done."))
+    pool = _CapturingPool()
+    w = _worker(tmp_path, pool, codex_executor=stub)
+    _seed_spawned_child(w.session_store, "codex")
+
+    w._dispatch_spawned_sessions()
+
+    assert len(pool.submitted) == 1
+    assert stub.calls == []
+    pool.run_all()
+    assert stub.calls == [("cli-child", "do work")]
+
+
+def test_inflight_guard_prevents_double_dispatch_across_ticks(tmp_path: Path):
+    """While a child is in flight (submitted, not yet finished), a subsequent
+    tick must not submit it again."""
+    stub = _StubCliExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done."))
+    pool = _CapturingPool()  # never runs → child stays in-flight
+    w = _worker(tmp_path, pool, claude_code_executor=stub)
+    _seed_spawned_child(w.session_store, "claude_code")
+
+    w._dispatch_spawned_sessions()
+    w._dispatch_spawned_sessions()  # next tick, child still CLAIMED + in-flight
+
+    assert len(pool.submitted) == 1  # submitted exactly once
+
+
+def test_local_child_still_runs_inline(tmp_path: Path):
+    """The local route is intentionally not pooled — it must still run inline
+    (capped at one concurrent session)."""
+    stub = _StubCliExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done."))
+    pool = _CapturingPool()
+    w = _worker(tmp_path, pool)
+    # Inject the local executor via the lazy accessor seam.
+    w._local_executor = stub
+    _seed_spawned_child(w.session_store, "local")
+
+    w._dispatch_spawned_sessions()
+
+    assert pool.submitted == []        # local never touches the CLI pool
+    assert stub.calls == [("cli-child", "do work")]  # ran inline

--- a/tests/test_agent_worker_claude_code_dispatch.py
+++ b/tests/test_agent_worker_claude_code_dispatch.py
@@ -18,7 +18,7 @@ from api.services.agent_worker.session_store import (
 )
 from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
-from api.services.agent_worker.worker import Worker
+from api.services.agent_worker.worker import Worker, _SynchronousPool
 
 
 pytestmark = pytest.mark.unit
@@ -51,6 +51,7 @@ def _make_worker(tmp_path: Path, claude_code_executor):
         telegram_send_with_id=lambda text: [1],
         http_client=client,
         claude_code_executor=claude_code_executor,
+        cli_pool=_SynchronousPool(),
     )
 
 
@@ -88,6 +89,7 @@ def _recording_worker(tmp_path: Path, claude_code_executor):
         telegram_send_with_id=lambda text: [1],
         http_client=client,
         claude_code_executor=claude_code_executor,
+        cli_pool=_SynchronousPool(),
     )
     return worker, calls
 

--- a/tests/test_agent_worker_claude_code_resume.py
+++ b/tests/test_agent_worker_claude_code_resume.py
@@ -31,7 +31,7 @@ from api.services.agent_worker.session_store import (
 )
 from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
-from api.services.agent_worker.worker import Worker
+from api.services.agent_worker.worker import Worker, _SynchronousPool
 
 
 pytestmark = pytest.mark.unit
@@ -78,6 +78,7 @@ def _make_worker(tmp_path: Path, claude_code_executor, monkeypatch=None):
         telegram_send_with_id=_send_with_id,
         http_client=client,
         claude_code_executor=claude_code_executor,
+        cli_pool=_SynchronousPool(),
     )
     w._sent = sent  # type: ignore[attr-defined]
     w._sent_with_ids = sent_with_ids  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Spawned `claude_code`/`codex` children (cross-engine delegation from #298) are long-running subprocesses. `_dispatch_spawned_sessions` ran them inline, so a single delegated browser task could park the worker tick for minutes — blocking new `#agent` claims and sibling dispatch. They now run on a bounded thread pool instead.

Closes #299.

## What changed

- Spawned CLI children dispatch on a bounded `ThreadPoolExecutor` (sized to `2 × agent_max_concurrent_managed`) via a new `_submit_cli_dispatch` helper, instead of running inline in the tick.
- An `_cli_inflight` set (+ lock) guards against a re-scan on the next tick re-submitting a child in the window before it flips `CLAIMED→RUNNING`.
- `stop()` shuts the pool down with `wait=False`; any children left `RUNNING` are reconciled by `resume_pending()` on restart (the existing SIGKILL-safe path).
- The `local` route stays **inline** (in-process, GPU-bound, cap=1 — a pool buys no real parallelism there).

## Thread-safety

- `SessionStore` opens a per-call WAL connection with a timeout → safe across threads.
- `TranscriptStore` writes one JSONL per session → no cross-child contention.
- `httpx.Client` (vault reconcile) and the executors (only per-call local `_RunState`) are safe to use concurrently.

## Scope boundary

`#299` is about **spawned** children. The vault `#claude`/`#codex` **claim path** (`_dispatch`) is still synchronous — pre-existing behavior, not what this issue describes. Can be a follow-up if it proves to matter.

## Test evidence

`pytest tests/ -m unit` → **1749 passed, 0 failed**.

New `tests/test_agent_worker_async_cli_dispatch.py`: CLI children are handed to the pool (not run inline), the in-flight guard prevents double-dispatch across ticks, and `local` still runs inline. The two existing tests that drive `_dispatch_spawned_sessions` now inject a `_SynchronousPool` for deterministic assertions.

## Review focus

- Concurrency correctness of `_submit_cli_dispatch` / the in-flight guard (the CLAIMED→RUNNING race window).
- Pool sizing (`2 × max_concurrent_managed`) and `stop()` shutdown semantics.
- Whether leaving the vault-claim CLI path synchronous is the right scope call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)