### PR TITLE
feat(chat): escalate to a stronger model when orchestrator wrongly refuses

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -1109,7 +1109,7 @@ async def ask_stream(request: AskStreamRequest):
             # =============================================================
             # Agentic synthesis path: Claude decides what to fetch
             # =============================================================
-            from api.services.agent_loop import run_agent_loop
+            from api.services.agent_loop import run_agent_loop, resolve_orchestrator_model
 
             # Expand follow-up queries with conversation context
             with trace_span("query_expand"):
@@ -1137,6 +1137,21 @@ async def ask_stream(request: AskStreamRequest):
             # in perf_traces.db is `model_tier` — but the value is now a model id
             # (e.g. "claude-haiku-4-5"), not a tier label ("haiku"/"sonnet"/"opus").
             orchestrator_model = getattr(settings, "anthropic_model", "claude-haiku-4-5")
+            # Escalation (#303): if the prior turn refused/claimed-impossible and
+            # this message pushes back, retry on a stronger model. Only on the
+            # Anthropic backend, only when LIFEOS_AGENT_ESCALATION_MODEL is set.
+            escalation_model = (
+                getattr(settings, "agent_escalation_model", "") or ""
+                if getattr(settings, "llm_backend", "anthropic").lower() == "anthropic"
+                else ""
+            )
+            orchestrator_model, escalated = resolve_orchestrator_model(
+                conversation_history, request.question, orchestrator_model, escalation_model
+            )
+            if escalated:
+                logger.info(
+                    "escalating chat turn to %s (refusal+pushback detected)", orchestrator_model
+                )
             _trace = _current_trace.get()
             if _trace:
                 _trace.model_tier = orchestrator_model
@@ -1158,7 +1173,11 @@ async def ask_stream(request: AskStreamRequest):
                     for att in request.attachments
                 ]
 
-            yield f"data: {json.dumps({'type': 'routing', 'sources': ['agent'], 'reasoning': f'Agentic loop ({orchestrator_model})', 'latency_ms': 0})}\n\n"
+            _routing_reason = (
+                f'Agentic loop — escalated to {orchestrator_model}'
+                if escalated else f'Agentic loop ({orchestrator_model})'
+            )
+            yield f"data: {json.dumps({'type': 'routing', 'sources': ['agent'], 'reasoning': _routing_reason, 'latency_ms': 0})}\n\n"
 
             # Consume the async generator from the agent loop
             agent_result = None
@@ -1168,6 +1187,7 @@ async def ask_stream(request: AskStreamRequest):
                 attachments=attachments_for_api,
                 model_tier=orchestrator_model,
                 max_tool_rounds=5,
+                model=orchestrator_model if escalated else "",
             ):
                 if event["type"] == "text":
                     yield f"data: {json.dumps({'type': 'content', 'content': event['content']})}\n\n"

--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -64,17 +64,21 @@ def _looks_like_giving_up(text: str) -> bool:
 # impossible / unavailable / "not released" from stale training and won't budge.
 # When the PRIOR assistant turn refused like that AND the user's NEW message pushes
 # back, we retry the turn on a stronger model rather than re-refusing.
+# Scoped to the *stale-knowledge / world-fact* refusal class — claims that
+# something about the current world isn't released/announced/scheduled/known.
+# A stronger model + web search fixes these. Deliberately NOT matching generic
+# data-lookup negatives ("I can't find any emails from Sarah", "no such
+# contact", "that file doesn't exist") — those are usually correct, and a
+# pricier model can't find data that isn't there. The give-up patterns
+# (knowledge-cutoff / can't-access-live) are also treated as refusals (see
+# should_escalate).
 _REFUSAL_PATTERNS = re.compile(
     r"(?i)("
-    r"hasn'?t (yet )?(been )?(released|announced|published|come out|happened|finalized)"
-    r"|haven'?t (yet )?(been )?(released|announced|published)"
-    r"|not (yet )?(been )?(released|announced|available|published|out|finalized)"
-    r"|isn'?t (yet )?(available|out|released)|aren'?t (yet )?available"
-    r"|hasn'?t been (set|scheduled|determined)"
-    r"|doesn'?t exist|does not exist|no such"
-    r"|not possible|isn'?t possible|impossible"
-    r"|I can'?t (add|create|do|find|provide)|I cannot (add|create|do|find|provide)"
-    r"|I'?m unable to|I am unable to"
+    r"(hasn'?t|has not|haven'?t|have not)\s+(yet\s+)?(been\s+)?"
+    r"(released|announced|published|scheduled|finalized|determined|set|made public|come out)"
+    r"|not\s+(yet\s+)?(been\s+)?(released|announced|published|scheduled|finalized|determined|available|out)"
+    r"|isn'?t\s+(yet\s+)?(available|out|released|published|finalized)"
+    r"|aren'?t\s+(yet\s+)?(available|released|published)"
     r")"
 )
 _PUSHBACK_PATTERNS = re.compile(
@@ -106,7 +110,13 @@ def should_escalate(conversation_history, question: str) -> bool:
     """True when the prior assistant turn refused/claimed-impossible AND the
     current user message pushes back — the signal to retry on a stronger model."""
     prior = _last_assistant_text(conversation_history)
-    if not prior or not _REFUSAL_PATTERNS.search(prior):
+    if not prior:
+        return False
+    # Refusal = a stale-knowledge world-fact negative OR a give-up phrase
+    # (knowledge cutoff / "can't access live data") — both are fixable by a
+    # stronger model + web search.
+    refused = _REFUSAL_PATTERNS.search(prior) or _GIVE_UP_PATTERNS.search(prior)
+    if not refused:
         return False
     return bool(_PUSHBACK_PATTERNS.search(question or ""))
 

--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -24,6 +24,7 @@ from api.services.synthesizer import build_message_content
 from api.services.perf_trace import trace_span
 from api.services.llm_client import get_local_llm, openai_tool_calls_to_anthropic, LLMUsage
 from api.services.resilience import is_retryable_api_error
+from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,81 @@ def _looks_like_giving_up(text: str) -> bool:
     return bool(_GIVE_UP_PATTERNS.search(text))
 
 
+# Cross-turn escalation (#303). A weak orchestrator sometimes declares something
+# impossible / unavailable / "not released" from stale training and won't budge.
+# When the PRIOR assistant turn refused like that AND the user's NEW message pushes
+# back, we retry the turn on a stronger model rather than re-refusing.
+_REFUSAL_PATTERNS = re.compile(
+    r"(?i)("
+    r"hasn'?t (yet )?(been )?(released|announced|published|come out|happened|finalized)"
+    r"|haven'?t (yet )?(been )?(released|announced|published)"
+    r"|not (yet )?(been )?(released|announced|available|published|out|finalized)"
+    r"|isn'?t (yet )?(available|out|released)|aren'?t (yet )?available"
+    r"|hasn'?t been (set|scheduled|determined)"
+    r"|doesn'?t exist|does not exist|no such"
+    r"|not possible|isn'?t possible|impossible"
+    r"|I can'?t (add|create|do|find|provide)|I cannot (add|create|do|find|provide)"
+    r"|I'?m unable to|I am unable to"
+    r")"
+)
+_PUSHBACK_PATTERNS = re.compile(
+    r"(?i)("
+    r"do (the )?research|do more research"
+    r"|you'?re wrong|that'?s wrong|that'?s (not|in)correct|that'?s not (true|right)"
+    r"|look it up|search (for it|again|the web|online)|try again|check again"
+    r"|it should be possible|it is possible|yes it (has|is|did|does)"
+    r"|i'?m telling you|i know (it|they|you|for a fact)"
+    r"|that'?s not true|actually,? (it|that|they|the)"
+    r"|they have been|it has been (released|announced|published)"
+    r")"
+)
+
+
+def _last_assistant_text(conversation_history) -> str:
+    """Return the most recent assistant message's text, or '' if none."""
+    for msg in reversed(conversation_history or []):
+        role = getattr(msg, "role", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        if role == "assistant":
+            content = getattr(msg, "content", None)
+            if content is None and isinstance(msg, dict):
+                content = msg.get("content")
+            return content or ""
+    return ""
+
+
+def should_escalate(conversation_history, question: str) -> bool:
+    """True when the prior assistant turn refused/claimed-impossible AND the
+    current user message pushes back — the signal to retry on a stronger model."""
+    prior = _last_assistant_text(conversation_history)
+    if not prior or not _REFUSAL_PATTERNS.search(prior):
+        return False
+    return bool(_PUSHBACK_PATTERNS.search(question or ""))
+
+
+def resolve_orchestrator_model(
+    conversation_history, question: str, base_model: str, escalation_model: str
+) -> tuple[str, bool]:
+    """Pick the model for this turn. Returns (model, escalated).
+
+    Escalates to ``escalation_model`` only when it's configured, differs from
+    ``base_model``, and the refuse→pushback pattern is present. Otherwise returns
+    ``base_model`` unchanged.
+    """
+    if escalation_model and escalation_model != base_model and should_escalate(conversation_history, question):
+        return escalation_model, True
+    return base_model, False
+
+
+def _select_client(model: str = ""):
+    """Pick the LLM client for a turn. With a per-turn `model` on the Anthropic
+    backend (escalation, #303), build a dedicated client for that model;
+    otherwise use the shared singleton. The local backend ignores `model`."""
+    if model and getattr(settings, "llm_backend", "anthropic").lower() == "anthropic":
+        from api.services.llm_client import AnthropicLLMClient
+        return AnthropicLLMClient(model=model)
+    return get_local_llm()
+
+
 @dataclass
 class AgentResult:
     """Result of an agentic chat loop run."""
@@ -78,6 +154,7 @@ async def run_agent_loop(
     attachments: list[dict] | None = None,
     model_tier: str = "sonnet",
     max_tool_rounds: int = 5,
+    model: str = "",
 ) -> AsyncGenerator[dict, None]:
     """
     Async generator that runs the agentic chat loop.
@@ -90,11 +167,15 @@ async def run_agent_loop(
         attachments: Optional file attachments (list of dicts with filename, media_type, data).
         model_tier: "haiku", "sonnet", or "opus" (ignored for local model, kept for API compat).
         max_tool_rounds: Max number of tool-use rounds before forcing a text response.
+        model: Optional Anthropic model id override for this turn (escalation, #303).
+            When set on the Anthropic backend, the turn runs on a dedicated
+            AnthropicLLMClient with this model instead of the default singleton.
+            Ignored on the local backend.
 
     Yields:
         Dicts with "type" key: "text", "status", or "result".
     """
-    client = get_local_llm()
+    client = _select_client(model)
     system_prompt = build_system_prompt()
 
     # Bind a fresh per-turn email-draft set. The send gate uses this to refuse

--- a/config/settings.py
+++ b/config/settings.py
@@ -167,6 +167,17 @@ class Settings(BaseSettings):
                     "This only changes client-side dollar accounting; the "
                     "actual remote model is still the agent preset's setting."
     )
+    agent_escalation_model: str = Field(
+        default="",
+        alias="LIFEOS_AGENT_ESCALATION_MODEL",
+        description="Anthropic model the chat orchestrator retries a turn on when "
+                    "it detects a refusal/impossibility claim followed by the user "
+                    "pushing back ('do research', 'you're wrong'). Empty (default) "
+                    "disables escalation — safe for fresh clones and the local "
+                    "backend. Set to a stronger model than LIFEOS_ANTHROPIC_MODEL "
+                    "(e.g. claude-sonnet-4-6 or claude-opus-4-8) to enable. Only "
+                    "applies to the Anthropic backend."
+    )
     agent_cost_confirm_threshold_dollars: float = Field(
         default=1.0,
         alias="LIFEOS_AGENT_COST_CONFIRM_THRESHOLD_DOLLARS",

--- a/tests/test_agent_escalation.py
+++ b/tests/test_agent_escalation.py
@@ -93,6 +93,31 @@ def test_various_pushback_phrasings(pushback):
     assert should_escalate(history, pushback) is True
 
 
+@pytest.mark.parametrize("correct_negative", [
+    "I couldn't find any emails from Sarah in your inbox.",
+    "There's no such contact named Bob in your CRM.",
+    "That file doesn't exist in your vault.",
+    "I can't find a calendar event matching that.",
+])
+def test_correct_data_lookup_negatives_do_not_escalate(correct_negative):
+    """A true 'not in your data' answer must NOT escalate on pushback — a
+    stronger model can't find data that isn't there (only wastes the spend)."""
+    history = [FakeMessage("assistant", correct_negative)]
+    assert should_escalate(history, "you're wrong, look it up again") is False
+
+
+@pytest.mark.parametrize("giveup", [
+    "I can't access live data, so I don't know the current standings.",
+    "Based on my knowledge cutoff, I can't provide real-time results.",
+    "I don't have access to up-to-date information on that.",
+])
+def test_giveup_phrases_count_as_refusal(giveup):
+    """Knowledge-cutoff / can't-access-live phrasing is a stale-knowledge refusal
+    that escalation should also catch."""
+    history = [FakeMessage("assistant", giveup)]
+    assert should_escalate(history, "do research") is True
+
+
 # ---------------------------------------------------------------------------
 # resolve_orchestrator_model
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_escalation.py
+++ b/tests/test_agent_escalation.py
@@ -1,0 +1,155 @@
+"""Orchestrator escalation (#303).
+
+When the prior assistant turn refused / claimed something impossible and the
+user's new message pushes back, the chat orchestrator retries on a stronger
+model. These tests cover the detection (`should_escalate`), the model decision
+(`resolve_orchestrator_model`), and the per-turn client selection
+(`_select_client`).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from api.services.agent_loop import (
+    resolve_orchestrator_model,
+    should_escalate,
+    _select_client,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class FakeMessage:
+    role: str
+    content: str
+
+
+# A realistic refusal (the World Cup failure shape) and a pushback.
+_REFUSAL = "I found the tournament dates, but FIFA hasn't released the specific USA match schedule yet."
+_PUSHBACK = "yes fifa has released dates, do research"
+
+
+# ---------------------------------------------------------------------------
+# should_escalate
+# ---------------------------------------------------------------------------
+
+def test_escalates_on_refusal_then_pushback():
+    history = [
+        FakeMessage("user", "add the world cup games to my calendar"),
+        FakeMessage("assistant", _REFUSAL),
+    ]
+    assert should_escalate(history, _PUSHBACK) is True
+
+
+def test_no_escalation_when_prior_turn_did_not_refuse():
+    history = [FakeMessage("assistant", "Done — I added all three games to your calendar.")]
+    assert should_escalate(history, _PUSHBACK) is False
+
+
+def test_no_escalation_without_pushback():
+    history = [FakeMessage("assistant", _REFUSAL)]
+    assert should_escalate(history, "thanks, sounds good") is False
+
+
+def test_no_escalation_on_empty_history():
+    assert should_escalate([], _PUSHBACK) is False
+    assert should_escalate(None, _PUSHBACK) is False
+
+
+def test_only_assistant_refusal_counts_not_user_text():
+    # A user message containing refusal-like words must not trigger escalation —
+    # only the model's own prior refusal does.
+    history = [FakeMessage("user", "isn't it true the schedule hasn't been released?")]
+    assert should_escalate(history, _PUSHBACK) is False
+
+
+def test_uses_most_recent_assistant_turn():
+    history = [
+        FakeMessage("assistant", _REFUSAL),
+        FakeMessage("user", "ok"),
+        FakeMessage("assistant", "Here is the answer you wanted."),
+    ]
+    # Most recent assistant turn didn't refuse → no escalation.
+    assert should_escalate(history, _PUSHBACK) is False
+
+
+def test_works_with_dict_shaped_messages():
+    history = [{"role": "assistant", "content": _REFUSAL}]
+    assert should_escalate(history, _PUSHBACK) is True
+
+
+@pytest.mark.parametrize("pushback", [
+    "you're wrong, look it up",
+    "do research",
+    "that's not true, it has been released",
+    "I'm telling you it should be possible",
+    "try again",
+])
+def test_various_pushback_phrasings(pushback):
+    history = [FakeMessage("assistant", _REFUSAL)]
+    assert should_escalate(history, pushback) is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_orchestrator_model
+# ---------------------------------------------------------------------------
+
+def test_resolve_escalates_when_configured_and_triggered():
+    history = [FakeMessage("assistant", _REFUSAL)]
+    model, escalated = resolve_orchestrator_model(
+        history, _PUSHBACK, base_model="claude-haiku-4-5", escalation_model="claude-opus-4-8"
+    )
+    assert (model, escalated) == ("claude-opus-4-8", True)
+
+
+def test_resolve_no_escalation_when_model_unset():
+    history = [FakeMessage("assistant", _REFUSAL)]
+    model, escalated = resolve_orchestrator_model(
+        history, _PUSHBACK, base_model="claude-haiku-4-5", escalation_model=""
+    )
+    assert (model, escalated) == ("claude-haiku-4-5", False)
+
+
+def test_resolve_no_escalation_when_model_equals_base():
+    history = [FakeMessage("assistant", _REFUSAL)]
+    model, escalated = resolve_orchestrator_model(
+        history, _PUSHBACK, base_model="claude-haiku-4-5", escalation_model="claude-haiku-4-5"
+    )
+    assert escalated is False
+
+
+def test_resolve_no_escalation_when_not_triggered():
+    history = [FakeMessage("assistant", "Here are your three games.")]
+    model, escalated = resolve_orchestrator_model(
+        history, "thanks", base_model="claude-haiku-4-5", escalation_model="claude-opus-4-8"
+    )
+    assert (model, escalated) == ("claude-haiku-4-5", False)
+
+
+# ---------------------------------------------------------------------------
+# _select_client
+# ---------------------------------------------------------------------------
+
+def test_select_client_uses_escalation_model_on_anthropic_backend(monkeypatch):
+    monkeypatch.setattr("api.services.agent_loop.settings.llm_backend", "anthropic", raising=False)
+    client = _select_client("claude-opus-4-8")
+    from api.services.llm_client import AnthropicLLMClient
+    assert isinstance(client, AnthropicLLMClient)
+    assert client._model == "claude-opus-4-8"
+
+
+def test_select_client_falls_back_to_singleton_without_model(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr("api.services.agent_loop.get_local_llm", lambda: sentinel)
+    assert _select_client("") is sentinel
+
+
+def test_select_client_ignores_model_on_local_backend(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr("api.services.agent_loop.settings.llm_backend", "local", raising=False)
+    monkeypatch.setattr("api.services.agent_loop.get_local_llm", lambda: sentinel)
+    # Even with a model requested, the local backend uses the singleton.
+    assert _select_client("claude-opus-4-8") is sentinel


### PR DESCRIPTION
## Summary

When the prior assistant turn refused or claimed something impossible ("FIFA hasn't released the schedule") and the user's next message pushes back ("do research", "you're wrong", "look it up"), the chat orchestrator now retries that turn on a stronger model instead of re-refusing on the same weak one.

Closes #303.

## What changed

- **`agent_loop.py`** — `should_escalate(history, question)` detects the prior-assistant-refusal + current-pushback pattern (`_REFUSAL_PATTERNS` / `_PUSHBACK_PATTERNS`); `resolve_orchestrator_model(...)` returns `(model, escalated)`. `_select_client(model)` builds a dedicated `AnthropicLLMClient(model=…)` for an escalated turn.
- **`chat.py`** — gates on the Anthropic backend + `LIFEOS_AGENT_ESCALATION_MODEL`, resolves the per-turn model, passes it to the loop **only when escalated** (normal turns keep the shared singleton), and surfaces escalation in the routing reason, perf trace, and a log line.
- **`settings.py`** — `agent_escalation_model` (empty default → disabled).

## Why a real client swap (not `model_tier`)

While implementing I found `model_tier` is **vestigial** — `run_agent_loop` uses a singleton `get_local_llm()` client and never passes `model_tier` to it, so bumping it would have been a no-op. Escalation therefore constructs a dedicated `AnthropicLLMClient(model=escalation_model)` for the turn. (Cleaning up the dead `model_tier` param is out of scope here.)

## Safety / scope

- **Off by default**: empty `agent_escalation_model` → no escalation. Safe for fresh clones and the **local backend** (which ignores a per-turn model entirely).
- **Bounded**: one escalation decision per turn; normal turns are untouched (still the singleton).
- **Observable**: routing reason ("escalated to …"), `perf_trace.model_tier`, and a log line.

## Test evidence

`pytest tests/ -m unit` → **1768 passed, 0 failed**.

New `tests/test_agent_escalation.py`: the refuse→pushback trigger (and its negatives — no prior refusal, no pushback, empty history, user-text-isn't-assistant, most-recent-turn-wins, dict-shaped messages, varied pushback phrasings), the model decision (escalates only when configured + differs + triggered), and `_select_client` (escalation model on Anthropic, singleton otherwise, ignored on local).

## Review focus

- The `_REFUSAL_PATTERNS` / `_PUSHBACK_PATTERNS` heuristics — false-positive risk (escalating when it shouldn't) vs. false-negatives. They only fire when the *prior assistant* turn matches refusal AND the *current* user msg matches pushback.
- Relationship to the prompt-only mitigation on `fix/response-tuning-verify-current-facts` — complementary, not conflicting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)