### PR TITLE
feat(chat): web /chat engine handoff (consume claude_intent)

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -1486,8 +1486,14 @@ async def chat_handoff(request: HandoffRequest):
         from api.services.agent_worker.codex_spawn import spawn_codex_session
         result = spawn_codex_session(SessionStore(), task, working_dir=working_dir, chat_id=chat_id)
     else:
-        from api.services.agent_worker.claude_code_spawn import spawn_claude_code_session
-        result = spawn_claude_code_session(SessionStore(), task, working_dir=working_dir, chat_id=chat_id)
+        from api.services.agent_worker.claude_code_spawn import (
+            spawn_claude_code_session,
+            should_use_plan_mode,
+        )
+        result = spawn_claude_code_session(
+            SessionStore(), task, working_dir=working_dir,
+            plan_mode=should_use_plan_mode(task), chat_id=chat_id,
+        )
 
     if not result.get("ok"):
         raise HTTPException(status_code=500, detail=result.get("error", "engine spawn failed"))

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -1448,3 +1448,70 @@ async def save_to_vault(request: SaveToVaultRequest):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save: {e}")
+
+
+class HandoffRequest(BaseModel):
+    """Web-chat → CLI-engine handoff (#305b/c)."""
+    engine: str  # "codex" | "claude_code"
+    task: str
+    conversation_id: Optional[str] = None
+
+
+@router.post("/chat/handoff")
+async def chat_handoff(request: HandoffRequest):
+    """Spawn a CLI engine worker session from the web chat.
+
+    The web UI calls this when the orchestrator emits a `claude_intent` event it
+    can't act on inline (an explicit "use codex" handoff, or the top rung of the
+    escalation ladder). The session runs in the agent worker and reports its
+    result via Telegram and `/agents`; we record an acknowledgment in the
+    conversation thread so the web UI reflects the handoff.
+    """
+    engine = (request.engine or "").strip()
+    task = (request.task or "").strip()
+    if engine not in ("codex", "claude_code"):
+        raise HTTPException(status_code=400, detail="engine must be 'codex' or 'claude_code'")
+    if not task:
+        raise HTTPException(status_code=400, detail="task is required")
+
+    from api.services.directory_resolver import resolve_working_directory
+    from api.services.agent_worker.session_store import SessionStore
+
+    working_dir = resolve_working_directory(task)
+    # Route the worker's completion notification to the operator's Telegram (the
+    # web thread can't receive an async result yet). None if Telegram isn't set.
+    chat_id = getattr(settings, "telegram_chat_id", "") or None
+
+    if engine == "codex":
+        from api.services.agent_worker.codex_spawn import spawn_codex_session
+        result = spawn_codex_session(SessionStore(), task, working_dir=working_dir, chat_id=chat_id)
+    else:
+        from api.services.agent_worker.claude_code_spawn import spawn_claude_code_session
+        result = spawn_claude_code_session(SessionStore(), task, working_dir=working_dir, chat_id=chat_id)
+
+    if not result.get("ok"):
+        raise HTTPException(status_code=500, detail=result.get("error", "engine spawn failed"))
+
+    label = "Codex" if engine == "codex" else "Claude Code"
+    session_id = result.get("session_id", "")
+    ack = (
+        f"🤝 Handed off to **{label}** — running in the background "
+        f"(session `{session_id[:12]}`). The result will arrive via Telegram and "
+        f"appear on the /agents page."
+    )
+    if request.conversation_id:
+        try:
+            get_store().add_message(
+                request.conversation_id, "assistant", ack,
+                routing={"reasoning": f"engine handoff → {label}", "sources": [engine]},
+            )
+        except Exception:
+            logger.warning("failed to record handoff acknowledgment", exc_info=True)
+
+    return {
+        "ok": True,
+        "session_id": session_id,
+        "engine": engine,
+        "working_dir": working_dir,
+        "message": ack,
+    }

--- a/api/services/agent_worker/claude_code_spawn.py
+++ b/api/services/agent_worker/claude_code_spawn.py
@@ -24,6 +24,24 @@ from .session_store import STATUS_CLAIMED, SessionStore, new_session_id
 logger = logging.getLogger(__name__)
 
 
+# Tasks that warrant plan mode (Claude Code presents a plan for approval before
+# making large changes). Shared by every surface that spawns /claude — the
+# Telegram command and the web-chat engine handoff — so the heuristic stays
+# consistent.
+_PLAN_MODE_KEYWORDS = (
+    "refactor", "implement", "redesign", "migrate",
+    "integrate", "build a", "set up a",
+    "rewrite", "overhaul", "replace", "restructure",
+    "add a new", "create a new", "remove all", "delete all",
+)
+
+
+def should_use_plan_mode(task: str) -> bool:
+    """Conservative heuristic: plan mode only for complex-sounding tasks."""
+    t = (task or "").lower()
+    return any(kw in t for kw in _PLAN_MODE_KEYWORDS)
+
+
 def _claude_code_budget() -> dict:
     """Per-session budget. Reuses the Claude wall/cost knobs so operators
     don't have to dual-configure a separate ``LIFEOS_CLAUDE_CODE_*`` set."""

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -766,12 +766,6 @@ class TelegramBotListener:
 
     _APPROVAL_KEYWORDS = {"approve", "approved", "yes", "go", "proceed", "ok"}
     _REJECTION_KEYWORDS = {"reject", "rejected", "no", "cancel", "stop"}
-    _PLAN_MODE_KEYWORDS = [
-        "refactor", "implement", "redesign", "migrate",
-        "integrate", "build a", "set up a",
-        "rewrite", "overhaul", "replace", "restructure",
-        "add a new", "create a new", "remove all", "delete all",
-    ]
 
     async def _maybe_handle_claude_code_reply(self, reply_to_message_id: int, text: str, chat_id: str) -> bool:
         """If a reply targets a CLI (Claude Code or Codex) completion message,
@@ -805,9 +799,10 @@ class TelegramBotListener:
         return True
 
     def _should_use_plan_mode(self, task: str) -> bool:
-        """Conservative heuristic: plan mode only for complex-sounding tasks."""
-        task_lower = task.lower()
-        return any(kw in task_lower for kw in self._PLAN_MODE_KEYWORDS)
+        """Conservative heuristic: plan mode only for complex-sounding tasks.
+        Delegates to the shared helper so Telegram and web-chat stay in sync."""
+        from api.services.agent_worker.claude_code_spawn import should_use_plan_mode
+        return should_use_plan_mode(task)
 
     async def _handle_claude_command(self, task: str, chat_id: str):
         """Spawn a /claude session by writing a routing='claude_code' row

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -275,3 +275,52 @@ class TestComposeIntentDetection:
         assert not detect_compose_intent("what's on my calendar")
         assert not detect_compose_intent("tell me about Kevin")
         assert not detect_compose_intent("search my notes for project updates")
+
+
+class TestHandoffEndpoint:
+    """Test the /api/chat/handoff engine-handoff endpoint (#305b/c, web surface)."""
+
+    @pytest.fixture
+    def client(self):
+        return TestClient(app)
+
+    def test_handoff_spawns_codex(self, client):
+        with patch(
+            "api.services.agent_worker.codex_spawn.spawn_codex_session",
+            return_value={"ok": True, "session_id": "sess_codex_abc123"},
+        ) as m:
+            r = client.post("/api/chat/handoff", json={"engine": "codex", "task": "add the world cup games"})
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["engine"] == "codex"
+        assert d["session_id"] == "sess_codex_abc123"
+        assert m.called
+        # The real task (not a directive phrase) was forwarded.
+        assert m.call_args.args[1] == "add the world cup games"
+
+    def test_handoff_spawns_claude_code(self, client):
+        with patch(
+            "api.services.agent_worker.claude_code_spawn.spawn_claude_code_session",
+            return_value={"ok": True, "session_id": "sess_cc_xyz"},
+        ) as m:
+            r = client.post("/api/chat/handoff", json={"engine": "claude_code", "task": "refactor the parser"})
+        assert r.status_code == 200
+        assert r.json()["engine"] == "claude_code"
+        assert m.called
+
+    def test_handoff_rejects_unknown_engine(self, client):
+        r = client.post("/api/chat/handoff", json={"engine": "gpt", "task": "x"})
+        assert r.status_code == 400
+
+    def test_handoff_rejects_empty_task(self, client):
+        r = client.post("/api/chat/handoff", json={"engine": "codex", "task": "   "})
+        assert r.status_code == 400
+
+    def test_handoff_surfaces_spawn_failure(self, client):
+        with patch(
+            "api.services.agent_worker.codex_spawn.spawn_codex_session",
+            return_value={"ok": False, "error": "no prompt"},
+        ):
+            r = client.post("/api/chat/handoff", json={"engine": "codex", "task": "do a thing"})
+        assert r.status_code == 500

--- a/web/index.html
+++ b/web/index.html
@@ -3933,6 +3933,31 @@
                                 } else if (data.type === 'usage') {
                                     sessionCost += data.cost_usd || 0;
                                     sessionCostEl.textContent = '$' + sessionCost.toFixed(3);
+                                } else if (data.type === 'claude_intent') {
+                                    // Engine handoff (#305b/c): the orchestrator
+                                    // delegated to a CLI worker. Spawn it via the
+                                    // handoff endpoint and reflect it in the thread.
+                                    const engine = data.engine || 'claude_code';
+                                    const label = engine === 'codex' ? 'Codex' : 'Claude Code';
+                                    fullContent = '🤝 Handing off to ' + label + '…';
+                                    updateMessage(msgId, fullContent);
+                                    fetch('/api/chat/handoff', {
+                                        method: 'POST',
+                                        headers: { 'Content-Type': 'application/json' },
+                                        body: JSON.stringify({
+                                            engine: engine,
+                                            task: data.task || '',
+                                            conversation_id: currentConversationId,
+                                        }),
+                                    }).then(r => r.json()).then(d => {
+                                        fullContent = (d && d.message)
+                                            ? d.message
+                                            : '⚠️ Handoff to ' + label + ' failed.';
+                                        updateMessage(msgId, fullContent);
+                                    }).catch(() => {
+                                        fullContent = '⚠️ Handoff to ' + label + ' failed.';
+                                        updateMessage(msgId, fullContent);
+                                    });
                                 } else if (data.type === 'done') {
                                     // Add sources and meta to message
                                     const msgEl = document.getElementById(msgId);


### PR DESCRIPTION
## Summary

The web chat UI silently ignored the `claude_intent` SSE event, so engine handoffs ("use codex", and the #305c escalation-ladder top rung) only worked on Telegram. This wires the web surface to act on it — closing the gap the #309 review flagged.

## What changed

- **`api/routes/chat.py`** — new `POST /api/chat/handoff`: validates the engine (`codex`/`claude_code`), resolves the working dir, spawns the worker session (routing its completion notification to the operator's Telegram), records an acknowledgment in the conversation thread, and returns it.
- **`web/index.html`** — the SSE loop now handles `data.type === 'claude_intent'`: shows "Handing off to {engine}…", POSTs to `/api/chat/handoff`, and reflects the returned acknowledgment in the thread.

## Honest limitation

Result delivery still lands on **Telegram + `/agents`** — the web thread can't *receive* an async result minutes later yet (that needs the worker writing back to the conversation store + the UI polling). The UI says so ("result will arrive via Telegram and appear on /agents"). Streaming the result back into the web thread is a clean follow-up; this PR makes the *trigger* work on web, which is the immediate gap.

## Test evidence

`pytest tests/test_chat_api.py::TestHandoffEndpoint` → **5 passed**: spawns codex/claude_code with the real task forwarded, rejects unknown engines + empty tasks, surfaces spawn failures. Full unit suite → **1839 passed, 0 failed**.

## Review focus

- The spawn endpoint: working-dir resolution, `chat_id` routing to Telegram, and the conversation-record write (failure-tolerant).
- The frontend fetch is fire-and-forget within the SSE loop — the `done` event fires before the spawn POST resolves; the bubble updates async. Acceptable?
- Any auth/abuse surface on a new POST that spawns a worker subprocess (same trust model as `/codex` `/claude` Telegram commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)