### PR TITLE
fix(chat): escalation ladder hands off to engine after 2 pushbacks

### DIFF
--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -164,13 +164,16 @@ def _original_request(conversation_history, fallback: str) -> str:
 def _escalation_ladder(escalation_model: str) -> list[str]:
     """Ordered escalation rungs. Uses settings.agent_escalation_ladder if set
     (comma-separated model ids / engine names), else derives a default from
-    ``escalation_model``: [escalation_model, opus, claude_code]. Empty when
-    escalation isn't configured. Deduped, order preserved."""
+    ``escalation_model``: [escalation_model, claude_code] — so the engine
+    handoff lands on the 2nd pushback (1st → stronger model, 2nd → Claude Code).
+    Set the env var to e.g. 'claude-sonnet-4-6,claude-opus-4-8,claude_code' to
+    insert an opus rung in between. Empty when escalation isn't configured.
+    Deduped, order preserved."""
     raw = (getattr(settings, "agent_escalation_ladder", "") or "").strip()
     if raw:
         rungs = [r.strip() for r in raw.split(",") if r.strip()]
     elif escalation_model:
-        rungs = [escalation_model, _MODEL_ALIASES["opus"], "claude_code"]
+        rungs = [escalation_model, "claude_code"]
     else:
         return []
     seen, out = set(), []

--- a/config/settings.py
+++ b/config/settings.py
@@ -185,9 +185,10 @@ class Settings(BaseSettings):
                     "successive refusal+pushback cycle (#305c). Each rung is a "
                     "model id or an engine name (codex / claude_code, which hand "
                     "off to a worker session). Empty (default) derives a ladder "
-                    "from LIFEOS_AGENT_ESCALATION_MODEL: that model, then "
-                    "claude-opus-4-8, then claude_code. Example override: "
-                    "'claude-sonnet-4-6,claude-opus-4-8'."
+                    "from LIFEOS_AGENT_ESCALATION_MODEL: [that model, claude_code] "
+                    "— so the Claude Code handoff lands on the 2nd pushback. "
+                    "Override to insert rungs, e.g. "
+                    "'claude-sonnet-4-6,claude-opus-4-8,claude_code'."
     )
     agent_cost_confirm_threshold_dollars: float = Field(
         default=1.0,

--- a/tests/test_agent_escalation.py
+++ b/tests/test_agent_escalation.py
@@ -278,10 +278,9 @@ def _refusal_history(n):
 
 
 @pytest.mark.parametrize("n_refusals, expected", [
-    (1, "claude-sonnet-4-6"),   # rung 0 — the escalation model
-    (2, "claude-opus-4-8"),     # rung 1 — opus
-    (3, "claude_code"),         # rung 2 — engine handoff
-    (4, "claude_code"),         # capped at the top rung
+    (1, "claude-sonnet-4-6"),   # rung 0 — the escalation model (1st pushback)
+    (2, "claude_code"),         # rung 1 — engine handoff (2nd pushback)
+    (3, "claude_code"),         # capped at the top rung
 ])
 def test_ladder_climbs_with_each_refusal(n_refusals, expected):
     model, escalated = resolve_orchestrator_model(
@@ -351,9 +350,13 @@ def test_engine_handoff_recovers_original_request():
     assert _original_request(history, "fallback") == "add the world cup games to my calendar"
 
 
-def test_base_model_filtered_from_ladder():
-    # base=opus is mid-ladder ([sonnet, opus, claude_code]); filtering opus keeps
-    # the climb going instead of stalling on the rung that equals base.
+def test_base_model_filtered_from_ladder(monkeypatch):
+    # Explicit 3-rung ladder with base=opus mid-ladder; filtering opus keeps the
+    # climb going instead of stalling on the rung that equals base.
+    monkeypatch.setattr(
+        "api.services.agent_loop.settings.agent_escalation_ladder",
+        "claude-sonnet-4-6,claude-opus-4-8,claude_code", raising=False,
+    )
     model, escalated = resolve_orchestrator_model(
         _refusal_history(2), _PUSHBACK,
         base_model="claude-opus-4-8", escalation_model="claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

Per operator request, the default escalation ladder drops the middle opus rung so the **Claude Code handoff lands on the 2nd pushback** (1st → escalation model, 2nd → engine) instead of the 3rd.

## What changed

- `agent_loop.py` — derived default ladder is now `[escalation_model, claude_code]` (was `[escalation_model, opus, claude_code]`).
- `settings.py` — updated the `LIFEOS_AGENT_ESCALATION_LADDER` doc. Operators who want the opus rung back can set `claude-sonnet-4-6,claude-opus-4-8,claude_code`.

## Test evidence

`pytest tests/ -m unit` → **1838 passed**. Ladder-climb test updated (1→sonnet, 2→engine, 3→capped); base-filter test rewritten to use an explicit 3-rung ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)