### PR TITLE
docs: update orchestrator docs for escalation + engine handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMe
 | Vector DB | ChromaDB (port 8001) |
 | Keyword Search | SQLite FTS5 (BM25) |
 | Intent classifier | Claude Haiku via Anthropic API (default); pattern-matching fallback when the API is unavailable |
-| LLM (orchestration + synthesis) | Claude via Anthropic API (default), or a local OpenAI-compatible llama-server (`LIFEOS_LLM_BACKEND=local`). Model set by `LIFEOS_ANTHROPIC_MODEL` (defaults to `claude-haiku-4-5`); this is the single knob — there is no per-query model tiering |
+| LLM (orchestration + synthesis) | Claude via Anthropic API (default), or a local OpenAI-compatible llama-server (`LIFEOS_LLM_BACKEND=local`). Base model set by `LIFEOS_ANTHROPIC_MODEL` (defaults to `claude-haiku-4-5`). Per-query escalation (Anthropic backend) sits on top: user-directed ("escalate to opus", "use codex") and automatic on refusal+pushback, via `LIFEOS_AGENT_ESCALATION_MODEL` / `LIFEOS_AGENT_ESCALATION_LADDER` |
 | LLM Client | `api/services/llm_client.py` — unified wrapper with Anthropic↔OpenAI tool format translation |
 | Embeddings | sentence-transformers (GPU via ROCm/CUDA) |
 | Frontend | Vanilla HTML/JS (no build step) |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ Orchestration and synthesis can run against the Claude API (default) or a local 
 
 To stay fully local, set `LIFEOS_LLM_BACKEND=local` and point `LIFEOS_LOCAL_LLM_URL` at a running llama-server. See the [Configuration Guide](docs/guides/configuration.md) for details.
 
-`LIFEOS_ANTHROPIC_MODEL` is the single orchestrator-model knob: every chat round, every intent-classification call, and every per-tool synthesis hop uses it. There is no per-query model tiering today — if you want a heavier model for harder questions, set it here and it applies to all traffic.
+`LIFEOS_ANTHROPIC_MODEL` is the **base** orchestrator model (every chat round, intent-classification call, and per-tool synthesis hop uses it by default). On top of that, per-query **escalation** lets a turn run on a stronger model or hand off to a CLI engine — Anthropic backend only, off unless `LIFEOS_AGENT_ESCALATION_MODEL` is set:
+
+- **User-directed:** "escalate to opus" / "use sonnet" runs that turn on the named model; "use codex" / "use claude code" hands the task to that CLI worker session.
+- **Automatic:** when a turn refuses and you push back ("do research", "you're wrong"), LifeOS retries on `LIFEOS_AGENT_ESCALATION_MODEL`, then — on a second pushback — hands off to Claude Code. Tune the rungs with `LIFEOS_AGENT_ESCALATION_LADDER`.
 
 ---
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -31,8 +31,10 @@ Governs chat synthesis, intent classification, and agentic orchestration. The to
 
 | Variable | Type | Default | Sets |
 |---|---|---|---|
-| `LIFEOS_LLM_BACKEND` | str | `anthropic` | `local` (llama-server on `LIFEOS_LOCAL_LLM_URL`) or `anthropic` (Claude API). The single knob — there is no per-query model tiering. |
-| `LIFEOS_ANTHROPIC_MODEL` | str | `claude-haiku-4-5` | Claude model used when `LIFEOS_LLM_BACKEND=anthropic`. |
+| `LIFEOS_LLM_BACKEND` | str | `anthropic` | `local` (llama-server on `LIFEOS_LOCAL_LLM_URL`) or `anthropic` (Claude API). Recorded in ADR-009. |
+| `LIFEOS_ANTHROPIC_MODEL` | str | `claude-haiku-4-5` | **Base** Claude model for chat orchestration when `LIFEOS_LLM_BACKEND=anthropic`. Per-query escalation can override it for a turn (see below). |
+| `LIFEOS_AGENT_ESCALATION_MODEL` | str | — (off) | Stronger model a chat turn escalates to when the user pushes back on a refusal, or asks ("escalate to opus"). Empty disables escalation. Anthropic backend only. |
+| `LIFEOS_AGENT_ESCALATION_LADDER` | str | — (derived) | Comma-separated escalation rungs (models / engine names `codex`,`claude_code`). Empty derives `[escalation_model, claude_code]` — so a 2nd pushback hands off to Claude Code. Override e.g. `claude-sonnet-4-6,claude-opus-4-8,claude_code`. |
 | `ANTHROPIC_API_KEY` | str | — | Required when `LIFEOS_LLM_BACKEND=anthropic`. Also used by specialized calls regardless of backend (relationship insights, fact extraction, web search). |
 | `LIFEOS_LOCAL_LLM_URL` | str | `http://localhost:8080` | Local llama-server endpoint. |
 | `LIFEOS_LOCAL_LLM_TIMEOUT` | int | `90` | Local LLM HTTP request timeout, seconds. |

--- a/docs/specs/product/chat-ui.md
+++ b/docs/specs/product/chat-ui.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Chat
-> **Last Updated:** 2026-05-29
+> **Last Updated:** 2026-06-03
 
 The primary chat interface for LifeOS, providing AI-powered search and synthesis across your personal knowledge base.
 
@@ -67,7 +67,14 @@ The primary chat interface for LifeOS, providing AI-powered search and synthesis
 
 ## Query Routing
 
-The orchestrator LLM (Claude Haiku via Anthropic API by default; configurable via `LIFEOS_LLM_BACKEND` / `LIFEOS_ANTHROPIC_MODEL`) chooses which tools to call. A lightweight intent classifier runs first to short-circuit two special cases — Claude Code tasks and ambiguous task/reminder phrasing — and everything else flows through the agentic loop where the model picks tools per query.
+The orchestrator LLM (Claude Haiku via Anthropic API by default; configurable via `LIFEOS_LLM_BACKEND` / `LIFEOS_ANTHROPIC_MODEL`) chooses which tools to call. A lightweight intent classifier runs first to short-circuit a few special cases — Claude Code tasks, ambiguous task/reminder phrasing, and explicit engine handoffs (below) — and everything else flows through the agentic loop where the model picks tools per query.
+
+**Per-query escalation & engine handoff.** On the Anthropic backend, a turn can run on a stronger model or hand off to a CLI engine instead of answering inline (off unless `LIFEOS_AGENT_ESCALATION_MODEL` is set):
+
+- **User-directed** (imperative, leading or trailing): "escalate to opus" / "use sonnet" runs that turn on the named model via the API; "use codex" / "use claude code" (also "add the games using codex") hands the task to that CLI worker session. Negations and questions ("why did you use codex?") don't trigger it.
+- **Automatic ladder:** when a turn refuses ("hasn't been released") and the user pushes back ("do research", "you're wrong"), the next turn climbs the escalation ladder — the escalation model on the 1st pushback, a Claude Code handoff on the 2nd (tunable via `LIFEOS_AGENT_ESCALATION_LADDER`). The handoff forwards the *original* request, not the pushback.
+
+CLI handoffs run as async worker sessions and report results via Telegram and `/agents`; on Telegram and the web chat the trigger is the same.
 
 | Source | Content | Example Queries |
 |--------|---------|-----------------|


### PR DESCRIPTION
## Summary

The escalation/handoff work this session (#304, #306, #307, #308, #309, #310, #312) changed orchestrator behavior, leaving three docs stale ("single knob — no per-query model tiering"). This fixes them and documents the new knobs/behavior succinctly.

## Changes

- **README.md / AGENTS.md / configuration.md** — removed the now-false "no per-query model tiering" claim; `LIFEOS_ANTHROPIC_MODEL` is now described as the **base** model with per-query escalation on top.
- **configuration.md** — added `LIFEOS_AGENT_ESCALATION_MODEL` and `LIFEOS_AGENT_ESCALATION_LADDER` to the env-var catalog.
- **docs/specs/product/chat-ui.md** — added a "Per-query escalation & engine handoff" note to Query Routing (user-directed "escalate to opus" / "use codex", auto ladder climbing to a Claude Code handoff on the 2nd pushback, original-task forwarding); updated the "special cases" line; bumped Last Updated.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)