### PR TITLE
fix(embeddings): serialize lazy model loads to fix meta-tensor race

### DIFF
--- a/api/services/embeddings.py
+++ b/api/services/embeddings.py
@@ -152,11 +152,9 @@ class EmbeddingService:
         behaviour is to skip the network probe entirely.
 
         Thread safety: mutates ``os.environ`` for the duration of the retry.
-        ``EmbeddingService`` is a process-wide singleton loaded lazily on
-        first access (typically the background sync worker), so concurrent
-        loads don't happen in practice. The try/finally restores the env
-        before any other code can observe it. If a future caller starts
-        triggering loads from multiple threads at once, wrap this in a lock.
+        This runs inside ``EmbeddingService._load_lock`` (the ``model`` property
+        serializes lazy loads), so the env swap can't race a concurrent load,
+        and the try/finally restores it before the lock is released.
         """
         try:
             return st_cls(**load_kwargs)

--- a/api/services/embeddings.py
+++ b/api/services/embeddings.py
@@ -9,6 +9,7 @@ This allows tests to import this module without loading the ML library.
 """
 import logging
 import os
+import threading
 from typing import TYPE_CHECKING, Any
 
 from config.settings import settings
@@ -75,57 +76,70 @@ class EmbeddingService:
         self.cache_dir = cache_dir or getattr(settings, 'embedding_cache_dir', None) or None
         self._model: Any = None
         self._force_cpu: bool = False
+        # Serialize lazy loads. Searches run through execute_tool_parallel →
+        # asyncio.to_thread, so concurrent first-use from multiple tool threads
+        # would otherwise race the (meta-device) model init and leave params on
+        # the meta device — surfacing as "Cannot copy out of meta tensor" when
+        # SentenceTransformer.__init__ calls self.to(device). Loading once under
+        # a lock removes the race.
+        self._load_lock = threading.Lock()
 
     @property
     def model(self) -> "SentenceTransformer":
         """Lazy-load the model, falling back to CPU if GPU fails."""
         if self._model is None:
-            from sentence_transformers import SentenceTransformer
+            with self._load_lock:
+                if self._model is None:
+                    self._load_model()
+        return self._model
 
-            try:
-                import torch
-                load_kwargs = dict(
-                    model_name_or_path=self.model_name,
-                    cache_folder=self.cache_dir,
-                    model_kwargs={"dtype": torch.float16},
-                    local_files_only=True,
-                )
-                if self._force_cpu:
-                    load_kwargs["device"] = "cpu"
+    def _load_model(self) -> None:
+        """Construct the SentenceTransformer (caller holds ``self._load_lock``)."""
+        from sentence_transformers import SentenceTransformer
 
-                self._model = self._load_with_offline_retry(SentenceTransformer, load_kwargs)
-                from api.services.service_health import mark_service_healthy
-                mark_service_healthy("embedding_model")
-            except RuntimeError as e:
-                # GPU errors (HIP OOM, GPU hang, invalid device) — fall back to CPU
-                error_msg = str(e).lower()
-                if any(kw in error_msg for kw in _GPU_ERROR_KEYWORDS):
-                    logger.warning(f"GPU embedding load failed ({e}), falling back to CPU")
-                    try:
-                        cpu_kwargs = dict(
-                            model_name_or_path=self.model_name,
-                            cache_folder=self.cache_dir,
-                            device="cpu",
-                            local_files_only=True,
-                        )
-                        self._model = self._load_with_offline_retry(SentenceTransformer, cpu_kwargs)
-                        self._force_cpu = True
-                        from api.services.service_health import mark_service_healthy
-                        mark_service_healthy("embedding_model")
-                    except Exception as cpu_err:
-                        from api.services.service_health import mark_service_failed, Severity
-                        mark_service_failed("embedding_model", f"CPU fallback also failed: {cpu_err}", Severity.CRITICAL)
-                        raise
-                else:
+        try:
+            import torch
+            load_kwargs = dict(
+                model_name_or_path=self.model_name,
+                cache_folder=self.cache_dir,
+                model_kwargs={"dtype": torch.float16},
+                local_files_only=True,
+            )
+            if self._force_cpu:
+                load_kwargs["device"] = "cpu"
+
+            self._model = self._load_with_offline_retry(SentenceTransformer, load_kwargs)
+            from api.services.service_health import mark_service_healthy
+            mark_service_healthy("embedding_model")
+        except RuntimeError as e:
+            # GPU errors (HIP OOM, GPU hang, invalid device) — fall back to CPU
+            error_msg = str(e).lower()
+            if any(kw in error_msg for kw in _GPU_ERROR_KEYWORDS):
+                logger.warning(f"GPU embedding load failed ({e}), falling back to CPU")
+                try:
+                    cpu_kwargs = dict(
+                        model_name_or_path=self.model_name,
+                        cache_folder=self.cache_dir,
+                        device="cpu",
+                        local_files_only=True,
+                    )
+                    self._model = self._load_with_offline_retry(SentenceTransformer, cpu_kwargs)
+                    self._force_cpu = True
+                    from api.services.service_health import mark_service_healthy
+                    mark_service_healthy("embedding_model")
+                except Exception as cpu_err:
                     from api.services.service_health import mark_service_failed, Severity
-                    mark_service_failed("embedding_model", str(e), Severity.CRITICAL)
+                    mark_service_failed("embedding_model", f"CPU fallback also failed: {cpu_err}", Severity.CRITICAL)
                     raise
-            except Exception as e:
-                # Non-GPU errors — no fallback
+            else:
                 from api.services.service_health import mark_service_failed, Severity
                 mark_service_failed("embedding_model", str(e), Severity.CRITICAL)
                 raise
-        return self._model
+        except Exception as e:
+            # Non-GPU errors — no fallback
+            from api.services.service_health import mark_service_failed, Severity
+            mark_service_failed("embedding_model", str(e), Severity.CRITICAL)
+            raise
 
     def _load_with_offline_retry(self, st_cls, load_kwargs: dict):
         """Load the SentenceTransformer, retrying with HF_HUB_OFFLINE=1 on network errors.

--- a/api/services/reranker.py
+++ b/api/services/reranker.py
@@ -21,6 +21,7 @@ like negation, specificity, and contextual relevance.
     reranked = reranker.rerank(query, results, top_k=10)
 """
 import logging
+import threading
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -47,14 +48,21 @@ class RerankerService:
         """
         self.model_name = model_name
         self._model: Optional["CrossEncoder"] = None
+        # Serialize lazy loads — re-ranking is invoked from search tools that
+        # run concurrently in threads, and a racing CrossEncoder init can leave
+        # params on the meta device ("Cannot copy out of meta tensor"). Loading
+        # once under a lock removes the race. See EmbeddingService for context.
+        self._load_lock = threading.Lock()
 
     def _get_model(self) -> "CrossEncoder":
         """Lazy-load cross-encoder model."""
         if self._model is None:
-            from sentence_transformers import CrossEncoder
-            logger.info(f"Loading cross-encoder model: {self.model_name}")
-            self._model = CrossEncoder(self.model_name)
-            logger.info("Cross-encoder model loaded")
+            with self._load_lock:
+                if self._model is None:
+                    from sentence_transformers import CrossEncoder
+                    logger.info(f"Loading cross-encoder model: {self.model_name}")
+                    self._model = CrossEncoder(self.model_name)
+                    logger.info("Cross-encoder model loaded")
         return self._model
 
     def rerank(

--- a/tests/test_embedding_fallback.py
+++ b/tests/test_embedding_fallback.py
@@ -176,6 +176,43 @@ class TestGpuToCpuFallback:
         assert mock_st_class.call_count == 1
 
     @patch("sentence_transformers.SentenceTransformer")
+    def test_concurrent_first_access_loads_model_once(self, mock_st_class):
+        """Parallel threads hitting .model on first use must construct the model
+        exactly once. Search tools run via execute_tool_parallel → asyncio.to_thread,
+        so an unsynchronized lazy load races the (meta-device) init and surfaces as
+        'Cannot copy out of meta tensor'. A load lock serializes the construction.
+        """
+        import threading
+        import time
+        from api.services.embeddings import EmbeddingService
+
+        def slow_construct(*args, **kwargs):
+            # Widen the race window so unsynchronized loads would double-construct.
+            time.sleep(0.05)
+            return MagicMock()
+
+        mock_st_class.side_effect = slow_construct
+
+        svc = EmbeddingService(model_name="test-model")
+        results = []
+        start = threading.Barrier(8)
+
+        def access():
+            start.wait()  # release all threads into .model at once
+            results.append(svc.model)
+
+        threads = [threading.Thread(target=access) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Constructed once despite 8 concurrent first-accessors.
+        assert mock_st_class.call_count == 1
+        # Every caller sees the same instance.
+        assert all(r is svc._model for r in results)
+
+    @patch("sentence_transformers.SentenceTransformer")
     def test_successful_gpu_load_marks_healthy(self, mock_st_class):
         """Successful GPU model load should mark service healthy."""
         from api.services.embeddings import EmbeddingService

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -67,6 +67,35 @@ class TestRerankerService:
         reranker = RerankerService(model_name="cross-encoder/ms-marco-MiniLM-L12-v2")
         assert reranker.model_name == "cross-encoder/ms-marco-MiniLM-L12-v2"
 
+    def test_concurrent_first_access_loads_model_once(self):
+        """Parallel threads hitting the lazy load must construct the CrossEncoder
+        exactly once — an unsynchronized load races the meta-device init the same
+        way the embedding model did ('Cannot copy out of meta tensor')."""
+        import threading
+        import time
+        from unittest.mock import MagicMock, patch
+        from api.services.reranker import RerankerService
+
+        def slow_construct(*args, **kwargs):
+            time.sleep(0.05)  # widen the race window
+            return MagicMock()
+
+        with patch("sentence_transformers.CrossEncoder", side_effect=slow_construct) as mock_ce:
+            svc = RerankerService(model_name="test-model")
+            start = threading.Barrier(8)
+
+            def access():
+                start.wait()
+                svc._get_model()
+
+            threads = [threading.Thread(target=access) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert mock_ce.call_count == 1
+
 
 class TestRerankerSingleton:
     """Test the get_reranker singleton."""
@@ -189,7 +218,7 @@ class TestHybridSearchWithReranker:
     def test_search_accepts_reranker_parameters(self):
         """Should accept use_reranker and rerank_candidates parameters."""
         from api.services.hybrid_search import HybridSearch
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         mock_vector_store = MagicMock()
         mock_vector_store.search.return_value = []


### PR DESCRIPTION
## Summary

Fixes a **CRITICAL** intermittent crash that poisoned `search_vault` and silently disabled re-ranking: `NotImplementedError: Cannot copy out of meta tensor; no data! Please use torch.nn.Module.to_empty()…`.

Root cause: search tools run via `execute_tool_parallel → asyncio.to_thread`, so the embedding model (and cross-encoder re-ranker) — loaded lazily on first use — could be constructed by **multiple tool threads concurrently**. The racing meta-device init leaves params on the meta device, which surfaces when `SentenceTransformer.__init__` calls `self.to(device)`. The code's own docstring already anticipated this ("if a future caller starts triggering loads from multiple threads at once, wrap this in a lock").

## What changed

- **`api/services/embeddings.py`** — the lazy `model` property now loads under a `threading.Lock` with double-checked locking; the construction logic moved into `_load_model()`. Cost/health/CPU-fallback behavior is unchanged — just serialized.
- **`api/services/reranker.py`** — same load-lock for the `CrossEncoder`.
- **`tests/test_embedding_fallback.py`** — new test: 8 threads released simultaneously (via `Barrier`) into `.model` must construct the model **exactly once**.

## Provenance

This fix was diagnosed, written, and committed by a `#claude` agent worker task that then hit a (subscription-route) cost cap before it could push/PR. Recovered, verified, and shipped here. (The cost-cap behavior that stopped it is fixed separately.)

## Test evidence

`pytest tests/test_embedding_fallback.py` → **10 passed** (incl. the new concurrency test). Full unit suite run in progress.

## Review focus

- Double-checked-locking correctness in `model` / `_get_model`.
- That the CPU-fallback path still works under the lock (the `_force_cpu` retry happens inside `_load_model`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)