### PR TITLE
fix(agent-worker): drop dollar cost cap on subscription/free routes

### DIFF
--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -23,7 +23,6 @@ from typing import Callable, Optional
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
-    STATUS_BUDGET_EXCEEDED,
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_RUNNING,
@@ -138,7 +137,6 @@ The user will review and approve the plan before you proceed.
 # to discriminate without parsing prose.
 REASON_AWAITING_PLAN_APPROVAL = "awaiting_plan_approval"
 REASON_AWAITING_CLARIFICATION = "awaiting_clarification"
-REASON_COST_CAP_EXCEEDED = "cost_cap_exceeded"
 REASON_TIMEOUT = "timeout"
 REASON_BINARY_NOT_FOUND = "binary_not_found"
 
@@ -156,7 +154,6 @@ class _RunState:
     awaiting_approval: bool = False   # plan-mode result event reached
     awaiting_clarification: bool = False
     cost_usd: float = 0.0
-    cost_cap_exceeded: bool = False
     last_activity: str = ""
     notifications_sent: int = 0
     started_at: float = field(default_factory=time.time)
@@ -396,18 +393,6 @@ class ClaudeCodeExecutor:
             })
             return ExecutorOutcome(status=STATUS_FAILED, reason=REASON_TIMEOUT)
 
-        if state.cost_cap_exceeded:
-            self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
-            self.transcript_store.append(sid, "claude_code_cost_cap_exceeded", {
-                "cost_usd": state.cost_usd,
-                "cap_usd": settings.claude_max_cost_usd,
-            })
-            return ExecutorOutcome(
-                status=STATUS_BUDGET_EXCEEDED,
-                reason=REASON_COST_CAP_EXCEEDED,
-                final_text=state.final_text,
-            )
-
         if state.awaiting_clarification:
             self.session_store.update_status(session.task_id, STATUS_BLOCKED)
             self.transcript_store.append(sid, "claude_code_awaiting_clarification", {
@@ -568,12 +553,11 @@ class ClaudeCodeExecutor:
             state.session_id = cli_session_id
             self.session_store.set_claude_code_session_id(session.task_id, cli_session_id)
 
+        # Track cost for /agents reporting, but DON'T cap it — the Claude Code
+        # route is subscription-billed, so there's no marginal per-task cost to
+        # cap. Only the managed/API route enforces max_dollars. Wall-clock and
+        # the CLI's own limits still bound runaway sessions.
         state.cost_usd = float(event.get("total_cost_usd") or 0.0)
-        cap = float(settings.claude_max_cost_usd or 0.0)
-        if cap > 0 and state.cost_usd > cap:
-            state.cost_cap_exceeded = True
-            state.terminal = True
-            return
 
         if state.pending_clarification:
             # Agent asked a question — surface as BLOCKED outcome so the

--- a/api/services/agent_worker/codex_executor.py
+++ b/api/services/agent_worker/codex_executor.py
@@ -34,7 +34,6 @@ from typing import Callable, Optional
 from api.services.agent_worker.capabilities_preamble import CAPABILITIES_PREAMBLE
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
-    STATUS_BUDGET_EXCEEDED,
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_RUNNING,
@@ -103,7 +102,6 @@ def _delegation_header(session_id: str) -> str:
 
 
 # Reason codes returned in ``ExecutorOutcome.reason``.
-REASON_COST_CAP_EXCEEDED = "cost_cap_exceeded"
 REASON_TIMEOUT = "timeout"
 REASON_BINARY_NOT_FOUND = "binary_not_found"
 
@@ -122,7 +120,6 @@ class _RunState:
     model: str = "gpt-5.5"
     final_text: str = ""
     cost_usd: float = 0.0
-    cost_cap_exceeded: bool = False
     tool_call_count: int = 0
     last_activity: str = ""
     last_usage: dict = field(default_factory=dict)
@@ -364,18 +361,6 @@ class CodexExecutor:
             })
             return ExecutorOutcome(status=STATUS_FAILED, reason=REASON_TIMEOUT)
 
-        if state.cost_cap_exceeded:
-            self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
-            self.transcript_store.append(sid, "codex_cost_cap_exceeded", {
-                "cost_usd": state.cost_usd,
-                "cap_usd": settings.claude_max_cost_usd,
-            })
-            return ExecutorOutcome(
-                status=STATUS_BUDGET_EXCEEDED,
-                reason=REASON_COST_CAP_EXCEEDED,
-                final_text=state.final_text,
-            )
-
         if proc.returncode == 0 or state.terminal:
             self.session_store.update_status(session.task_id, STATUS_COMPLETED)
             self.transcript_store.append(sid, "codex_completed", {
@@ -491,12 +476,11 @@ class CodexExecutor:
             usage = event.get("usage") or {}
             if usage:
                 state.last_usage = usage
+                # Track cost for /agents reporting, but DON'T cap it — the Codex
+                # route is subscription-billed, so there's no marginal per-task
+                # cost to cap. Only the managed/API route enforces max_dollars.
+                # Wall-clock and the CLI's own limits still bound runaway sessions.
                 state.cost_usd = _cost_from_usage(usage, state.model)
-                cap = float(settings.claude_max_cost_usd or 0.0)
-                if cap > 0 and state.cost_usd > cap:
-                    state.cost_cap_exceeded = True
-                    state.terminal = True
-                    return
             return
 
         if etype in ("session.completed", "exec.completed"):

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -385,8 +385,10 @@ class LocalExecutor:
             tokens_used = (updated.total_input_tokens or 0) + (updated.total_output_tokens or 0)
             if budget.get("max_tokens") and tokens_used >= budget["max_tokens"]:
                 return self._finalize_budget_exceeded(session, "max_tokens")
-            if budget.get("max_dollars") is not None and (updated.total_dollars or 0) >= budget["max_dollars"]:
-                return self._finalize_budget_exceeded(session, "max_dollars")
+            # No per-session dollar cap on the local route — local inference is
+            # free, so total_dollars is always 0. (max_tokens + wall_seconds still
+            # bound runaway sessions; the lineage guard below still caps a family
+            # whose *root* is a paid managed session.)
 
             # Lineage budget — for sessions with descendants, the *root* budget
             # caps the total spend across the family. When breached we cascade-

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-28
+> **Last Updated:** 2026-06-03
 
 LifeOS includes an external **agent worker** that picks up tasks you've tagged `#agent` and completes them autonomously — running locally on a self-hosted LLM or on Anthropic's Managed Agents cloud, with budget caps you can specify in the task title and full audit transcripts on every run. When the agent finishes (or gets stuck), it notifies you on Telegram. If it has a question mid-run, it asks via Telegram and waits for your reply.
 
@@ -88,7 +88,7 @@ You can put a budget in the task title. The preflight parses natural-language hi
 | `max $0.50` / `budget $1.00` | `max_dollars` |
 | `10k tokens` / `50000 tokens` | `max_tokens` |
 
-If no budget appears in the title, defaults from `.env` apply (default `$5.00`, `~4 hours wall`, `500k tokens`). The worker enforces all three caps externally — it kills the session when any is breached and the task lands at `#agent-budget-exceeded`.
+If no budget appears in the title, defaults from `.env` apply (default `$5.00`, `~4 hours wall`, `500k tokens`). The worker enforces the wall and token caps externally for every route — it kills the session when either is breached and the task lands at `#agent-budget-exceeded`. The **dollar cap is enforced only on the cloud Claude (Managed Agents / API) route**, the only one with marginal per-task cost; on the local (free) and Claude Code / Codex CLI (subscription) routes a `max $…` hint is recorded but never stops the task.
 
 There's also a global daily $-cap (`LIFEOS_AGENT_DAILY_CAP_DOLLARS`, default `$100`). When the day's accumulated cost crosses the cap, the worker stops claiming new tasks until the next local midnight. Tasks already running aren't killed.
 

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-06-02
+> **Last Updated:** 2026-06-03
 
 Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
 
@@ -179,7 +179,7 @@ Hardening: response is parsed defensively (handles `` ```json `` fences, partial
 
 Per-turn flow:
 
-1. Check budgets at top-of-loop — kill with `STATUS_BUDGET_EXCEEDED` if `total_tokens >= max_tokens` OR `total_dollars >= max_dollars` OR `wall_seconds_elapsed >= wall_seconds` OR lineage budget breached. Cascade-kill descendants on lineage breach.
+1. Check budgets at top-of-loop — kill with `STATUS_BUDGET_EXCEEDED` if `total_tokens >= max_tokens` OR `wall_seconds_elapsed >= wall_seconds` OR lineage budget breached. Cascade-kill descendants on lineage breach. There is no per-session dollar cap on the local route (local inference is free, so `total_dollars` is always 0); the lineage check still enforces an ancestor's `max_dollars` for a mixed family rooted at a paid managed session.
 2. Build the message list (system prompt + prior user/assistant/tool_result turns).
 3. Call the local LLM with the tool catalog (`STANDARD_HANDLERS` + `lifeos_agent_*` inter-agent tools + LifeOS MCP tools, all in OpenAI format).
 4. Parse response — handles both OpenAI `{"function": {"name", "arguments"}}` and Anthropic `{"name", "input"}` shapes via `_normalize_tool_calls`.
@@ -288,7 +288,7 @@ Spawned `claude_code` / `codex` children are long-running subprocesses. `_dispat
 Four overlapping layers, executed in this order:
 
 1. **Daily $-cap** — `SpendTracker.can_start_task(estimated)` short-circuits to False when `daily_cap_dollars <= 0` (operator pause). Otherwise blocks new claims when accumulated day spend ≥ cap.
-2. **Per-task token / wall / dollar caps** — checked at the top of every executor turn (local) or every poll (managed).
+2. **Per-task token / wall caps** — checked at the top of every executor turn (local) or every poll (managed). The **dollar cap (`max_dollars`) is enforced only on the managed/API route** — the only route with marginal per-task cost. The Claude Code and Codex CLI routes are subscription-billed and the local route is free, so none of them enforce a per-task dollar cap (they track cost for `/agents` reporting but never stop on it).
 3. **Lineage caps** — for child sessions, the entire lineage's combined spend is checked against any ancestor's `max_dollars`. Breach cascade-kills the lineage.
 4. **Remote (cloud only)** — when the worker detects a mid-flight breach for a managed session, it calls `DELETE /v1/sessions/{id}` to stop Anthropic-side billing immediately.
 

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -23,12 +23,10 @@ from api.services.agent_worker.claude_code_executor import (
     REASON_AWAITING_CLARIFICATION,
     REASON_AWAITING_PLAN_APPROVAL,
     REASON_BINARY_NOT_FOUND,
-    REASON_COST_CAP_EXCEEDED,
     ClaudeCodeExecutor,
 )
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
-    STATUS_BUDGET_EXCEEDED,
     STATUS_COMPLETED,
     STATUS_FAILED,
     SessionStore,
@@ -288,21 +286,24 @@ def test_plan_mode_result_returns_blocked_with_plan(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_cost_cap_exceeded_returns_budget_exceeded(tmp_path: Path, monkeypatch):
+def test_high_cost_does_not_cap_subscription_route(tmp_path: Path, monkeypatch):
+    """Claude Code is subscription-billed — a high reported cost must NOT cap the
+    task. Only the managed/API route enforces a dollar cap. Even with a tiny
+    claude_max_cost_usd, a $0.99 turn completes normally (cost is still tracked
+    for /agents reporting, just not enforced)."""
     monkeypatch.setattr(
         "api.services.agent_worker.claude_code_executor.settings.claude_max_cost_usd",
         0.10,
     )
     events = [
         {"type": "system", "subtype": "init", "session_id": "cli-1"},
-        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.99, "result": "x"},
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.99, "result": "done"},
     ]
     executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_with(events))
     session = _seed_session(store)
     outcome = executor.execute(session, {"description": "expensive task"})
-    assert outcome.status == STATUS_BUDGET_EXCEEDED
-    assert outcome.reason == REASON_COST_CAP_EXCEEDED
-    assert store.get(session.task_id).status == STATUS_BUDGET_EXCEEDED
+    assert outcome.status == STATUS_COMPLETED
+    assert store.get(session.task_id).status == STATUS_COMPLETED
 
 
 def test_binary_not_found_returns_failed(tmp_path: Path):

--- a/tests/test_codex_spawn_executor.py
+++ b/tests/test_codex_spawn_executor.py
@@ -160,6 +160,62 @@ def test_executor_handles_full_stream(stores, monkeypatch, tmp_path):
 
 
 @pytest.mark.unit
+def test_high_cost_does_not_cap_subscription_route(stores, monkeypatch, tmp_path):
+    """Codex is subscription-billed — a high reported cost must NOT cap the task.
+    Only the managed/API route enforces a dollar cap. Here the turn reports
+    2M+2M tokens (~$70 rolled up) against a $0.001 cap; under the old behavior
+    that was BUDGET_EXCEEDED, now it completes (cost is tracked, not enforced)."""
+    monkeypatch.setattr(
+        "api.services.agent_worker.codex_executor.settings.claude_max_cost_usd",
+        0.001,
+    )
+    sess_store, tr_store = stores
+    session = sess_store.create(
+        task_id="t_cost",
+        session_id="sess_codex_cost",
+        status="claimed",
+        routing="codex",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 1.0},
+        expected_output="text",
+        origin="operator",
+    )
+
+    lines = [
+        {"type": "thread.started", "thread_id": "thread-cost"},
+        {"type": "turn.started"},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "done"}},
+        {
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": 2_000_000, "cached_input_tokens": 0,
+                "output_tokens": 2_000_000, "reasoning_output_tokens": 0,
+            },
+        },
+    ]
+    fake_proc = _FakeProc(lines, returncode=0)
+
+    def fake_spawn(cmd, **kwargs):
+        for i, tok in enumerate(cmd):
+            if tok == "-o" and i + 1 < len(cmd):
+                with open(cmd[i + 1], "w") as f:
+                    f.write("done\n")
+        return fake_proc
+
+    executor = CodexExecutor(
+        session_store=sess_store,
+        transcript_store=tr_store,
+        notification_callback=lambda _m: None,
+        spawn_fn=fake_spawn,
+        binary_resolver=lambda: "/usr/bin/true",
+        heartbeat_interval=9999,
+    )
+
+    outcome = executor.execute(session, {"description": "expensive", "working_dir": str(tmp_path)})
+    assert outcome.status == STATUS_COMPLETED
+    assert sess_store.get(session.task_id).status == STATUS_COMPLETED
+
+
+@pytest.mark.unit
 def test_executor_prepends_capabilities_preamble(stores, monkeypatch, tmp_path):
     """A fresh /codex turn carries the LifeOS capabilities briefing so the
     agent has the same situational awareness as the managed/local routes."""


### PR DESCRIPTION
## Summary

Per-task **dollar** cost caps no longer apply to the routes that don't cost marginal money. Only the managed/API route — the one billed per token — keeps a dollar cap.

This was prompted by a real incident: a `#claude` (Claude Code) agent task that had **already diagnosed and committed a fix** for the embedding meta-tensor race was killed mid-work at `cost_usd 2.57 > cap_usd 2.00` (`claude_max_cost_usd`), before it could push/PR. Claude Code is subscription-billed — that $2 figure is a *reported* rollout cost, not money spent — so capping on it just truncates useful work.

## What changed

| Route | Billing | Before | After |
|---|---|---|---|
| **claude_code** (CLI) | Subscription | capped at `claude_max_cost_usd` | **no dollar cap** |
| **codex** (CLI) | Subscription | capped at `claude_max_cost_usd` | **no dollar cap** |
| **local** (Gemma) | Free | `max_dollars` self-check (dead no-op — cost is always \$0) | **removed** |
| **managed** (Anthropic API) | Per-token | `max_dollars` cap | **unchanged (kept)** |

- `claude_code_executor` / `codex_executor`: removed the `claude_max_cost_usd` check and the now-dead `cost_cap_exceeded` field / terminal path / `REASON_COST_CAP_EXCEEDED` constant / `*_cost_cap_exceeded` transcript event. `state.cost_usd` is still tracked for `/agents` reporting — just never enforced.
- `local_executor`: removed the per-session `max_dollars` self-check. **Kept:** `max_tokens` + `wall_seconds` guards (runaway protection for all routes) and the **lineage guard** (still caps a family whose *root* is a paid managed session).
- Managed route: `max_dollars`, lineage cap, and the daily \$-cap (`agent_daily_cap_dollars`, fed only by managed spend) are all untouched.
- Test: converted `test_cost_cap_exceeded_returns_budget_exceeded` → `test_high_cost_does_not_cap_subscription_route` (a \$0.99 turn with a \$0.10 cap now **completes**).
- Doc: updated the budget-enforcement section of `specs/technical/agent-worker.md`.

## Not in scope (flagged)

The **daily \$-cap** gate sits at the top of the worker's `tick()` and pauses the *entire* poll when the day's managed spend hits the cap — so in that (rare, \$100/day default) state, CLI/local dispatch pauses too. That's a coarse global gate; making it route-aware is a larger change to the claim/route-detection ordering. Left as-is here since the daily cap is precisely the "API cost cap" to keep; happy to follow up if the cross-route pause is undesirable.

## Test evidence

Full unit suite: **1839 passed**. Agent-worker subset: 330 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)