### PR TITLE
feat(telegram): multi-bot support with per-bot persona (fitness bot)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -284,6 +284,13 @@ LIFEOS_RELATIONSHIP_FOLDER=Relationship
 # TELEGRAM_BOT_TOKEN=
 # TELEGRAM_CHAT_ID=
 
+# Specialized Telegram bots (optional). Each bot is a separate @BotFather bot
+# that routes to the shared orchestrator with a domain persona (see
+# config/telegram_bots.json + config/personas/). Leave unset to run the primary
+# bot only. CHAT_ID is optional and defaults to TELEGRAM_CHAT_ID.
+# TELEGRAM_FITNESS_BOT_TOKEN=
+# TELEGRAM_FITNESS_CHAT_ID=
+
 # =============================================================================
 # FINANCIAL DATA (optional)
 # =============================================================================

--- a/api/main.py
+++ b/api/main.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 # Background services (initialized on startup)
 _calendar_indexer = None
-_telegram_listener = None
+_telegram_listeners = []
 _reminder_scheduler = None
 _scheduler_watcher = None
 _job_queue = None
@@ -54,7 +54,7 @@ _task_watcher = None
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifespan - startup and shutdown."""
-    global _calendar_indexer, _telegram_listener, _reminder_scheduler, _scheduler_watcher, _job_queue, _task_watcher
+    global _calendar_indexer, _telegram_listeners, _reminder_scheduler, _scheduler_watcher, _job_queue, _task_watcher
 
     # Startup: Recover any incomplete merge operations
     try:
@@ -80,13 +80,14 @@ async def lifespan(app: FastAPI):
     # Health monitoring (previously an in-process 2:30/7:00 scheduler) now runs
     # out-of-band in nbramia/local-processing via the lifeos_health watcher.
 
-    # Startup: Start Telegram bot listener
+    # Startup: Start Telegram bot listeners (primary + any specialized bots)
     try:
-        from api.services.telegram import get_telegram_listener
-        _telegram_listener = get_telegram_listener()
-        _telegram_listener.start()
+        from api.services.telegram import get_telegram_listeners
+        _telegram_listeners = get_telegram_listeners()
+        for _listener in _telegram_listeners:
+            _listener.start()
     except Exception as e:
-        logger.error(f"Failed to start Telegram bot listener: {e}")
+        logger.error(f"Failed to start Telegram bot listeners: {e}")
 
     # Startup: Start the scheduler (cron/one-off triggers → actions) and watch
     # LifeOS/Scheduler/ for external edits (e.g. via Obsidian). Markdown is the
@@ -148,9 +149,10 @@ async def lifespan(app: FastAPI):
         _calendar_indexer.stop_scheduler()
         logger.info("Calendar indexer stopped")
 
-    if _telegram_listener:
-        _telegram_listener.stop()
-        logger.info("Telegram bot listener stopped")
+    for _listener in _telegram_listeners:
+        _listener.stop()
+    if _telegram_listeners:
+        logger.info("Telegram bot listeners stopped")
 
     if _reminder_scheduler:
         _reminder_scheduler.stop()

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -848,6 +848,7 @@ class AskStreamRequest(BaseModel):
     include_sources: bool = True
     conversation_id: Optional[str] = None
     attachments: Optional[list[Attachment]] = None
+    persona: Optional[str] = None
 
     @field_validator("attachments")
     @classmethod
@@ -1214,6 +1215,7 @@ async def ask_stream(request: AskStreamRequest):
                 model_tier=orchestrator_model,
                 max_tool_rounds=5,
                 model=orchestrator_model if escalated else "",
+                persona=request.persona or "",
             ):
                 if event["type"] == "text":
                     yield f"data: {json.dumps({'type': 'content', 'content': event['content']})}\n\n"

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -850,6 +850,15 @@ class AskStreamRequest(BaseModel):
     attachments: Optional[list[Attachment]] = None
     persona: Optional[str] = None
 
+    @field_validator("persona")
+    @classmethod
+    def validate_persona(cls, v):
+        # Per-bot preamble injected into the system prompt. Bounded as cheap
+        # defense-in-depth — personas are short profiles, not documents.
+        if v is not None and len(v) > 8000:
+            raise ValueError(f"persona exceeds 8000 chars (got {len(v)})")
+        return v
+
     @field_validator("attachments")
     @classmethod
     def validate_attachments(cls, v):

--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -382,6 +382,7 @@ async def run_agent_loop(
     model_tier: str = "sonnet",
     max_tool_rounds: int = 5,
     model: str = "",
+    persona: str = "",
 ) -> AsyncGenerator[dict, None]:
     """
     Async generator that runs the agentic chat loop.
@@ -398,12 +399,14 @@ async def run_agent_loop(
             When set on the Anthropic backend, the turn runs on a dedicated
             AnthropicLLMClient with this model instead of the default singleton.
             Ignored on the local backend.
+        persona: Optional per-bot system-prompt preamble (e.g. the fitness bot).
+            Empty for the default chat surface.
 
     Yields:
         Dicts with "type" key: "text", "status", or "result".
     """
     client = _select_client(model)
-    system_prompt = build_system_prompt()
+    system_prompt = build_system_prompt(persona=persona)
 
     # Bind a fresh per-turn email-draft set. The send gate uses this to refuse
     # sending any draft created during this same turn — sends require the user

--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -164,11 +164,16 @@ def _existing_tags_block() -> str | None:
     )
 
 
-def build_system_prompt() -> list[dict]:
+def build_system_prompt(persona: str | None = None) -> list[dict]:
     """Build the system prompt for the agentic loop.
 
     Returns a list of content blocks for the Anthropic ``system`` parameter.
     The first block is static and cached; the rest are dynamic per-request.
+
+    Args:
+        persona: Optional per-bot preamble (e.g. the fitness bot). Injected as an
+            uncached block *after* the static block so the large shared prompt
+            stays a common cache prefix across all bots.
     """
     tz = ZoneInfo(settings.timezone)
     now = datetime.now(tz)
@@ -180,11 +185,17 @@ def build_system_prompt() -> list[dict]:
             "text": _STATIC_PROMPT,
             "cache_control": {"type": "ephemeral"},
         },
+    ]
+
+    if persona and persona.strip():
+        blocks.append({"type": "text", "text": persona.strip()})
+
+    blocks.append(
         {
             "type": "text",
             "text": f"Current date/time: {current_dt}\nTimezone: {settings.timezone}",
-        },
-    ]
+        }
+    )
 
     tags_block = _existing_tags_block()
     if tags_block:

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -15,25 +15,35 @@ import re
 import threading
 import time
 from collections import deque
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Optional
 
 import httpx
 
-from config.settings import settings
+from config.settings import settings, TelegramBotConfig
 
 logger = logging.getLogger(__name__)
 
 TELEGRAM_API = "https://api.telegram.org"
 MAX_MESSAGE_LENGTH = 4096
 
+# The bot token for the message currently being handled. A listener sets this
+# once at the top of _handle_update so every outbound send during that update —
+# of which there are many, scattered across command handlers — goes out from the
+# right bot without threading a token through each call. Unset (None) means the
+# primary bot, which is also the default for non-listener callers (agent worker,
+# reminders, scheduler).
+_active_bot_token: ContextVar[Optional[str]] = ContextVar("active_bot_token", default=None)
+
 
 # ---------------------------------------------------------------------------
 # Message sending
 # ---------------------------------------------------------------------------
 
-def _telegram_url(method: str) -> str:
-    return f"{TELEGRAM_API}/bot{settings.telegram_bot_token}/{method}"
+def _telegram_url(method: str, token: Optional[str] = None) -> str:
+    token = token or _active_bot_token.get() or settings.telegram_bot_token
+    return f"{TELEGRAM_API}/bot{token}/{method}"
 
 
 def _split_message(text: str) -> list[str]:
@@ -235,11 +245,15 @@ async def send_message_async(text: str, chat_id: str = None) -> bool:
 # Internal chat client (consumes SSE from /api/ask/stream)
 # ---------------------------------------------------------------------------
 
-async def chat_via_api(question: str, conversation_id: str = None) -> dict:
+async def chat_via_api(question: str, conversation_id: str = None, persona: str = None) -> dict:
     """
     Run a question through the full LifeOS chat pipeline (non-streaming).
 
     POSTs to the local /api/ask/stream endpoint and collects SSE events.
+
+    Args:
+        persona: Optional per-bot system-prompt preamble (e.g. the fitness bot),
+            forwarded to the orchestrator so its replies are domain-primed.
 
     Returns:
         {"answer": str, "conversation_id": str, "claude_intent": bool, "task": str|None}
@@ -248,6 +262,8 @@ async def chat_via_api(question: str, conversation_id: str = None) -> dict:
     body: dict = {"question": question}
     if conversation_id:
         body["conversation_id"] = conversation_id
+    if persona:
+        body["persona"] = persona
 
     full_text = ""
     conv_id = conversation_id
@@ -388,11 +404,24 @@ class TelegramBotListener:
     _STATE_FILE = Path("data/telegram_state.json")
     _DEDUP_WINDOW = 1000  # Track last N message IDs for deduplication
 
-    def __init__(self):
+    def __init__(self, bot: Optional[TelegramBotConfig] = None):
+        # bot=None means the primary bot (legacy behavior). The primary keeps the
+        # legacy state file so its update offset survives this upgrade; named bots
+        # get their own offset file so concurrent pollers don't clobber each other.
+        self._bot = bot or settings.telegram_primary_bot
+        self._is_primary = self._bot.name == "primary"
+        self._token = self._bot.token
+        self._chat_id = self._bot.chat_id
+        self._persona = self._bot.persona
+        self._state_file = (
+            self._STATE_FILE if self._is_primary
+            else Path(f"data/telegram_state_{self._bot.name}.json")
+        )
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
-        # Conversation state: chat_id -> conversation_id
+        # Conversation state: chat_id -> conversation_id (per-instance, so each
+        # bot's threads stay isolated from the others')
         self._conversations: dict[str, str] = {}
         self._last_result: dict | None = None  # Last chat result for /inspect
         self._last_update_id = self._load_last_update_id()
@@ -401,13 +430,13 @@ class TelegramBotListener:
     def _load_last_update_id(self) -> int:
         """Load persisted update_id from disk, or 0 if unavailable."""
         try:
-            if self._STATE_FILE.exists():
-                data = json.loads(self._STATE_FILE.read_text())
+            if self._state_file.exists():
+                data = json.loads(self._state_file.read_text())
                 update_id = data.get("last_update_id", 0)
                 if not isinstance(update_id, int) or update_id < 0:
                     logger.warning(f"Invalid update_id in state file: {update_id!r}, resetting to 0")
                     return 0
-                logger.info(f"Restored Telegram update offset: {update_id}")
+                logger.info(f"Restored Telegram update offset for '{self._bot.name}': {update_id}")
                 return update_id
         except Exception as e:
             logger.warning(f"Could not load Telegram state: {e}")
@@ -416,26 +445,26 @@ class TelegramBotListener:
     def _save_last_update_id(self):
         """Persist current update_id to disk (atomic write)."""
         try:
-            self._STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-            tmp = self._STATE_FILE.with_suffix(".tmp")
+            self._state_file.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._state_file.with_suffix(".tmp")
             tmp.write_text(json.dumps({"last_update_id": self._last_update_id}))
-            tmp.rename(self._STATE_FILE)
+            tmp.rename(self._state_file)
         except Exception as e:
             logger.warning(f"Could not save Telegram state: {e}")
 
     def start(self):
-        if not settings.telegram_enabled:
-            logger.info("Telegram not configured, bot listener not started")
+        if not (self._token and self._chat_id):
+            logger.info(f"Telegram bot '{self._bot.name}' not configured, listener not started")
             return
 
         self._stop_event.clear()
         self._thread = threading.Thread(
             target=self._run,
             daemon=True,
-            name="TelegramBotListener",
+            name=f"TelegramBotListener-{self._bot.name}",
         )
         self._thread.start()
-        logger.info("Telegram bot listener started")
+        logger.info(f"Telegram bot listener started: {self._bot.name}")
 
     def stop(self):
         self._stop_event.set()
@@ -473,7 +502,7 @@ class TelegramBotListener:
         try:
             async with httpx.AsyncClient(timeout=35.0) as client:
                 resp = await client.get(
-                    _telegram_url("getUpdates"),
+                    _telegram_url("getUpdates", self._token),
                     params={
                         "offset": self._last_update_id + 1,
                         "timeout": 30,
@@ -585,6 +614,10 @@ class TelegramBotListener:
 
     async def _handle_update(self, update: dict):
         """Process a single Telegram update."""
+        # Route every outbound send during this update through this bot's token.
+        # Set once here so the many send sites below need no per-call token.
+        _active_bot_token.set(self._token)
+
         message = update.get("message")
         if not message:
             return
@@ -593,7 +626,7 @@ class TelegramBotListener:
         chat_id = str(message["chat"]["id"])
 
         # Auth check first — don't let unauthorized chats pollute the dedup window
-        if chat_id != settings.telegram_chat_id:
+        if chat_id != self._chat_id:
             logger.warning(f"Ignoring message from unauthorized chat: {chat_id}")
             return
 
@@ -611,8 +644,12 @@ class TelegramBotListener:
         # Agent-worker clarification hook (Issue F). If this message is a
         # reply-thread to a previously-sent clarification question, deposit
         # the answer and short-circuit — don't route to the chat pipeline.
+        # Only the primary bot owns these agent/Claude-Code reply threads:
+        # Telegram message_ids are unique per chat (per bot), so a specialized
+        # bot must not match a reply against the shared follow-up table or it
+        # could collide with the primary's ids. Specialized bots are pure chat.
         reply_to = message.get("reply_to_message")
-        if reply_to and reply_to.get("message_id"):
+        if self._is_primary and reply_to and reply_to.get("message_id"):
             reply_to_id = int(reply_to["message_id"])
             # A reply to a /claude completion resumes that Claude Code session
             # (#237) — checked before the agent-worker deposit since both use
@@ -644,7 +681,7 @@ class TelegramBotListener:
         try:
             async with TypingIndicator(chat_id):
                 conv_id = self._conversations.get(chat_id)
-                result = await chat_via_api(text, conversation_id=conv_id)
+                result = await chat_via_api(text, conversation_id=conv_id, persona=self._persona)
                 self._conversations[chat_id] = result["conversation_id"]
                 self._last_result = result
 
@@ -1000,12 +1037,32 @@ class TelegramBotListener:
 # Singleton
 # ---------------------------------------------------------------------------
 
-_telegram_listener: Optional[TelegramBotListener] = None
+_telegram_listeners: Optional[list[TelegramBotListener]] = None
+
+
+def get_telegram_listeners() -> list[TelegramBotListener]:
+    """Get or create the listeners for the primary bot plus any specialized bots.
+
+    The primary is included only when configured; specialized bots come from the
+    registry (``settings.telegram_bots``), which already drops any whose token is
+    unset — so a fresh clone with no extra tokens yields just the primary.
+    """
+    global _telegram_listeners
+    if _telegram_listeners is None:
+        listeners: list[TelegramBotListener] = []
+        if settings.telegram_enabled:
+            listeners.append(TelegramBotListener(settings.telegram_primary_bot))
+        for bot in settings.telegram_bots:
+            listeners.append(TelegramBotListener(bot))
+        _telegram_listeners = listeners
+    return _telegram_listeners
 
 
 def get_telegram_listener() -> TelegramBotListener:
-    """Get or create TelegramBotListener singleton."""
-    global _telegram_listener
-    if _telegram_listener is None:
-        _telegram_listener = TelegramBotListener()
-    return _telegram_listener
+    """Get or create the primary TelegramBotListener (back-compat singleton)."""
+    for listener in get_telegram_listeners():
+        if listener._is_primary:
+            return listener
+    # No primary configured — return a standalone primary instance so callers
+    # relying on this accessor still get a usable (if inert) listener.
+    return TelegramBotListener(settings.telegram_primary_bot)

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -686,10 +686,20 @@ class TelegramBotListener:
                 self._last_result = result
 
             # Check if the chat pipeline detected a code intent or an explicit
-            # engine handoff ("use codex" / "use claude code", #305b).
+            # engine handoff ("use codex" / "use claude code", #305b). Engine
+            # handoffs spawn background sessions whose follow-ups route to the
+            # primary bot, so only the primary honors them. A specialized bot
+            # redirects instead of falling through to a possibly-empty answer.
             if result.get("claude_intent"):
                 task = result.get("task", text)
                 engine = result.get("engine", "claude_code")
+                if not self._is_primary:
+                    await send_message_async(
+                        "That looks like a coding/agent task — send it to your main "
+                        "LifeOS bot, which runs Claude Code and Codex.",
+                        chat_id=chat_id,
+                    )
+                    return
                 if engine == "codex":
                     logger.info(f"Engine handoff → Codex: {task[:50]}...")
                     await self._handle_codex_command(task, chat_id)
@@ -710,9 +720,28 @@ class TelegramBotListener:
                 chat_id=chat_id,
             )
 
+    # Commands that spawn agent-worker / Claude Code / Codex sessions. Their
+    # completion notices and clarification questions are sent later from a
+    # background thread (where the active-bot token is unset → primary), and the
+    # reply-thread hooks only run on the primary listener. So these belong to the
+    # primary bot only; specialized bots are pure chat surfaces and redirect.
+    _PRIMARY_ONLY_COMMANDS = frozenset({
+        "/agent", "/claude", "/codex",
+        "/claude_status", "/claudestatus", "/claude_cancel", "/claudecancel",
+        "/codex_status", "/codexstatus", "/codex_cancel", "/codexcancel",
+    })
+
     async def _handle_command(self, text: str, chat_id: str) -> bool:
         """Handle known bot commands. Returns True if handled, False to fall through to chat."""
         command = text.split()[0].lower()
+
+        if not self._is_primary and command in self._PRIMARY_ONLY_COMMANDS:
+            await send_message_async(
+                "Agent and Claude Code/Codex commands run on your main LifeOS bot — "
+                "send this there.",
+                chat_id=chat_id,
+            )
+            return True
 
         if command in ("/new", "/clear"):
             self._conversations.pop(chat_id, None)
@@ -1056,13 +1085,3 @@ def get_telegram_listeners() -> list[TelegramBotListener]:
             listeners.append(TelegramBotListener(bot))
         _telegram_listeners = listeners
     return _telegram_listeners
-
-
-def get_telegram_listener() -> TelegramBotListener:
-    """Get or create the primary TelegramBotListener (back-compat singleton)."""
-    for listener in get_telegram_listeners():
-        if listener._is_primary:
-            return listener
-    # No primary configured — return a standalone primary instance so callers
-    # relying on this accessor still get a usable (if inert) listener.
-    return TelegramBotListener(settings.telegram_primary_bot)

--- a/config/personas/fitness.md
+++ b/config/personas/fitness.md
@@ -1,0 +1,19 @@
+You are operating as the **fitness bot** — a specialized Telegram surface of LifeOS focused on training, nutrition, recovery, and health metrics. You have the full LifeOS tool suite available (search, calendar, tasks, notes, finances, people, etc.); this persona only changes your default framing, not your capabilities.
+
+## Default framing
+
+Assume incoming messages are fitness-related unless they clearly aren't. The user texts this bot precisely so they don't have to frame every message — read terse input in a fitness light:
+
+- **Workout logs** arrive without ceremony: `squats 5x5 @185`, `ran 4mi 32:10`, `bench 3x8 135, felt easy`. Treat these as a request to record the session. Capture exercise, sets×reps, load, distance/time, and any noted RPE or sensation. Save via the appropriate notes/task tool and confirm back compactly (e.g. `Logged: squats 5×5 @185 lb`). Don't interrogate — if a detail is missing, log what was given and move on.
+- **Metrics** like `weight 178.4`, `slept 6h20`, `resting HR 54` are health data points — record them the same way.
+- **Questions** (`what'd I squat last week?`, `how many runs this month?`, `am I progressing on bench?`) should pull from logged history and answer with specifics and trend, not generalities.
+
+Prefer concise, scannable replies — this is a phone, mid-set. Lead with the number or the confirmation.
+
+## Cross-domain is fine
+
+You are not walled off. Genuinely cross-cutting questions — `am I overspending on the gym?`, `put my workout on the calendar`, `who did I run with last Saturday?` — should be answered fully using whatever tools fit (finances, calendar, people). The user's whole context is yours.
+
+## Gentle redirect
+
+When a message is *clearly* unrelated to fitness, health, or anything that touches it (e.g. `draft a reply to this work email`, `what's my flight time?`), answer it anyway — never refuse — but add a light one-line note that the general assistant is the better home for it, e.g. _"(Handled — though your main LifeOS bot is better suited to email/scheduling like this.)"_ Keep it to a single unobtrusive aside; don't lecture, and never withhold the answer.

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,9 +1,36 @@
 """
 LifeOS Configuration Settings
 """
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
 from pathlib import Path
+from dotenv import dotenv_values
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+# Registry of specialized Telegram bots (beyond the primary). Committed, no
+# secrets — each entry references the env var holding its token.
+_TELEGRAM_BOTS_FILE = Path("config/telegram_bots.json")
+_BOT_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
+
+
+@dataclass(frozen=True)
+class TelegramBotConfig:
+    """A single Telegram bot surface: its token, authorized chat, and persona.
+
+    ``name`` doubles as the per-bot state-file suffix, so it must be filesystem
+    safe. ``persona`` is a system-prompt preamble injected for this bot's chats
+    (empty for the primary bot).
+    """
+    name: str
+    token: str
+    chat_id: str
+    persona: str = ""
 
 
 class Settings(BaseSettings):
@@ -631,6 +658,77 @@ class Settings(BaseSettings):
     def telegram_enabled(self) -> bool:
         """Check if Telegram bot is configured."""
         return bool(self.telegram_bot_token and self.telegram_chat_id)
+
+    @property
+    def telegram_primary_bot(self) -> "TelegramBotConfig":
+        """The default Telegram bot, driven by TELEGRAM_BOT_TOKEN/CHAT_ID.
+
+        Named "primary" so its update-offset file stays the legacy
+        ``data/telegram_state.json`` and existing behavior is unchanged.
+        """
+        return TelegramBotConfig(
+            name="primary",
+            token=self.telegram_bot_token,
+            chat_id=self.telegram_chat_id,
+            persona="",
+        )
+
+    @property
+    def telegram_bots(self) -> list["TelegramBotConfig"]:
+        """Specialized Telegram bots beyond the primary, from the registry file.
+
+        Each registry entry names an env var holding the bot's token; entries
+        whose token is unset are skipped (logged) so a fresh clone with no extra
+        tokens simply runs the primary bot. Persona text is loaded from the
+        entry's ``persona_file``. ``chat_id_env`` is optional and defaults to the
+        primary ``TELEGRAM_CHAT_ID`` (in Telegram DMs the chat id is your user
+        id, identical across bots).
+        """
+        if not _TELEGRAM_BOTS_FILE.exists():
+            return []
+        try:
+            entries = json.loads(_TELEGRAM_BOTS_FILE.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"Could not read {_TELEGRAM_BOTS_FILE}: {e}")
+            return []
+        if not isinstance(entries, list):
+            logger.warning(f"{_TELEGRAM_BOTS_FILE} must contain a JSON list, ignoring")
+            return []
+
+        # pydantic-settings loads .env into the model but does NOT export to
+        # os.environ, so resolve token/chat-id env vars from the .env file too
+        # (real environment wins over .env on conflict).
+        env_file = self.model_config.get("env_file", ".env")
+        env: dict = {**dotenv_values(env_file), **os.environ}
+
+        bots: list[TelegramBotConfig] = []
+        seen: set[str] = set()
+        for entry in entries:
+            name = (entry.get("name") or "").strip().lower()
+            if not name or not _BOT_NAME_RE.match(name):
+                logger.warning(f"Skipping Telegram bot with invalid name: {entry.get('name')!r}")
+                continue
+            if name in ("primary",) or name in seen:
+                logger.warning(f"Skipping duplicate/reserved Telegram bot name: {name!r}")
+                continue
+            token = (env.get(entry.get("token_env", "")) or "").strip()
+            if not token:
+                logger.info(
+                    f"Telegram bot '{name}' skipped: env var "
+                    f"{entry.get('token_env')!r} is unset"
+                )
+                continue
+            chat_id = (env.get(entry.get("chat_id_env", "")) or "").strip() or self.telegram_chat_id
+            persona = ""
+            persona_file = entry.get("persona_file")
+            if persona_file:
+                try:
+                    persona = Path(persona_file).read_text().strip()
+                except OSError as e:
+                    logger.warning(f"Telegram bot '{name}': could not read persona file {persona_file}: {e}")
+            seen.add(name)
+            bots.append(TelegramBotConfig(name=name, token=token, chat_id=chat_id, persona=persona))
+        return bots
 
     @property
     def photos_db_path(self) -> str:

--- a/config/telegram_bots.json
+++ b/config/telegram_bots.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "fitness",
+    "token_env": "TELEGRAM_FITNESS_BOT_TOKEN",
+    "chat_id_env": "TELEGRAM_FITNESS_CHAT_ID",
+    "persona_file": "config/personas/fitness.md"
+  }
+]

--- a/tests/test_agent_system_prompt.py
+++ b/tests/test_agent_system_prompt.py
@@ -81,3 +81,28 @@ def test_task_manager_failure_is_silent(monkeypatch):
 
 def test_existing_tags_block_helper_returns_none_when_empty(tm):
     assert agent_system_prompt._existing_tags_block() is None
+
+
+def test_no_persona_block_by_default(tm):
+    prompt = build_system_prompt()
+    assert "FITNESS-PERSONA-MARKER" not in "\n".join(_text_blocks(prompt))
+
+
+def test_persona_injected_after_static_block(tm):
+    persona = "FITNESS-PERSONA-MARKER: you are the fitness bot."
+    prompt = build_system_prompt(persona=persona)
+    texts = _text_blocks(prompt)
+    # Persona present...
+    assert any("FITNESS-PERSONA-MARKER" in t for t in texts)
+    # ...and placed AFTER the static block so the static cache prefix is shared.
+    assert prompt[0].get("cache_control") == {"type": "ephemeral"}
+    assert "FITNESS-PERSONA-MARKER" not in prompt[0]["text"]
+    assert "FITNESS-PERSONA-MARKER" in prompt[1]["text"]
+    # Persona block itself is not cached.
+    assert "cache_control" not in prompt[1]
+
+
+def test_blank_persona_adds_no_block(tm):
+    base = build_system_prompt()
+    spaced = build_system_prompt(persona="   ")
+    assert len(spaced) == len(base)

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -292,6 +292,8 @@ class TestMessageDedup:
 
         with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
             listener = TelegramBotListener()
+        # Authorized chat is now per-listener state (captured at construction).
+        listener._chat_id = "123"
 
         # First call — should process (but we mock the rest to avoid side effects)
         update = {"message": {"message_id": 1, "text": "hi", "chat": {"id": "123"}}}
@@ -350,6 +352,8 @@ class TestNoImplicitThreadResume:
         state_file = tmp_path / "telegram_state.json"
         with patch.object(TelegramBotListener, "_STATE_FILE", state_file):
             listener = TelegramBotListener()
+        # Authorized chat is now per-listener state (captured at construction).
+        listener._chat_id = "123"
 
         # A resumable agent thread exists in the store...
         store = SessionStore(db_path=tmp_path / "sessions.db")

--- a/tests/test_telegram_multibot.py
+++ b/tests/test_telegram_multibot.py
@@ -221,6 +221,66 @@ class TestHandleUpdate:
         mock_chat.assert_not_called()
 
 
+class TestPrimaryOnlyCommands:
+    """Agent/Claude-Code/Codex commands belong to the primary bot only."""
+
+    def _listener(self, name, chat_id):
+        from api.services.telegram import TelegramBotListener
+        from config.settings import TelegramBotConfig
+        return TelegramBotListener(TelegramBotConfig(name=name, token="TOK", chat_id=chat_id))
+
+    @pytest.mark.asyncio
+    async def test_specialized_bot_redirects_agent_command(self):
+        listener = self._listener("fitness", "999")
+        with patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send, \
+             patch.object(listener, "_handle_agent_spawn", new_callable=AsyncMock) as mock_spawn:
+            handled = await listener._handle_command("/agent do a thing", "999")
+        assert handled is True
+        mock_spawn.assert_not_called()
+        mock_send.assert_awaited_once()
+        assert "main LifeOS bot" in mock_send.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_primary_bot_allows_agent_command(self):
+        listener = self._listener("primary", "999")
+        with patch.object(listener, "_handle_agent_spawn", new_callable=AsyncMock) as mock_spawn:
+            handled = await listener._handle_command("/agent do a thing", "999")
+        assert handled is True
+        mock_spawn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_specialized_bot_redirects_on_engine_handoff(self):
+        listener = self._listener("fitness", "999")
+        update = {"message": {"text": "use claude code to fix x", "chat": {"id": 999}, "message_id": 5}}
+        with patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock) as mock_send, \
+             patch("api.services.telegram.TypingIndicator", _DummyTyping), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat, \
+             patch.object(listener, "_handle_claude_command", new_callable=AsyncMock) as mock_claude:
+            mock_chat.return_value = {
+                "answer": "", "conversation_id": "c1",
+                "claude_intent": True, "engine": "claude_code", "task": "fix x",
+            }
+            await listener._handle_update(update)
+        # No background session spawned; a redirect was sent instead.
+        mock_claude.assert_not_called()
+        assert any(
+            c.args and "main" in c.args[0].lower() for c in mock_send.call_args_list
+        )
+
+
+class TestPersonaValidation:
+    def test_persona_within_cap_accepted(self):
+        from api.routes.chat import AskStreamRequest
+        req = AskStreamRequest(question="hi", persona="x" * 8000)
+        assert len(req.persona) == 8000
+
+    def test_persona_over_cap_rejected(self):
+        from api.routes.chat import AskStreamRequest
+        with pytest.raises(ValueError):
+            AskStreamRequest(question="hi", persona="x" * 8001)
+
+
 # ---------------------------------------------------------------------------
 # Persona threads through chat_via_api into the request body
 # ---------------------------------------------------------------------------

--- a/tests/test_telegram_multibot.py
+++ b/tests/test_telegram_multibot.py
@@ -1,0 +1,291 @@
+"""
+Tests for multi-bot Telegram support (issue #316).
+
+Covers the registry loader (settings.telegram_bots), per-bot listener wiring,
+token routing via the active-bot ContextVar, and persona forwarding through the
+chat client. Specialized bots route to the shared orchestrator with a domain
+persona while keeping full tool access.
+"""
+import json
+from pathlib import Path
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Registry loader (settings.telegram_bots)
+# ---------------------------------------------------------------------------
+
+class TestRegistryLoader:
+    def test_missing_registry_file_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", tmp_path / "nope.json")
+        from config.settings import settings
+        assert settings.telegram_bots == []
+
+    def test_bot_with_unset_token_is_skipped(self, tmp_path, monkeypatch):
+        reg = tmp_path / "bots.json"
+        reg.write_text(json.dumps([{"name": "fitness", "token_env": "TG_FIT_TOKEN"}]))
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.delenv("TG_FIT_TOKEN", raising=False)
+        from config.settings import settings
+        assert settings.telegram_bots == []
+
+    def test_bot_loaded_with_token_persona_and_chat(self, tmp_path, monkeypatch):
+        persona_file = tmp_path / "fitness.md"
+        persona_file.write_text("FIT PERSONA")
+        reg = tmp_path / "bots.json"
+        reg.write_text(json.dumps([{
+            "name": "fitness",
+            "token_env": "TG_FIT_TOKEN",
+            "chat_id_env": "TG_FIT_CHAT",
+            "persona_file": str(persona_file),
+        }]))
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT_TOKEN", "fit-token-123")
+        monkeypatch.setenv("TG_FIT_CHAT", "555")
+        from config.settings import settings
+        bots = settings.telegram_bots
+        assert len(bots) == 1
+        bot = bots[0]
+        assert (bot.name, bot.token, bot.chat_id, bot.persona) == (
+            "fitness", "fit-token-123", "555", "FIT PERSONA"
+        )
+
+    def test_chat_id_defaults_to_primary(self, tmp_path, monkeypatch):
+        reg = tmp_path / "bots.json"
+        reg.write_text(json.dumps([{"name": "fitness", "token_env": "TG_FIT_TOKEN"}]))
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT_TOKEN", "x")
+        from config.settings import settings
+        assert settings.telegram_bots[0].chat_id == settings.telegram_chat_id
+
+    def test_reserved_and_invalid_names_skipped(self, tmp_path, monkeypatch):
+        reg = tmp_path / "bots.json"
+        reg.write_text(json.dumps([
+            {"name": "primary", "token_env": "TG_A"},      # reserved
+            {"name": "bad name!", "token_env": "TG_B"},    # invalid chars
+            {"name": "fitness", "token_env": "TG_C"},      # ok
+        ]))
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_A", "a")
+        monkeypatch.setenv("TG_B", "b")
+        monkeypatch.setenv("TG_C", "c")
+        from config.settings import settings
+        names = [b.name for b in settings.telegram_bots]
+        assert names == ["fitness"]
+
+    def test_duplicate_names_deduped(self, tmp_path, monkeypatch):
+        reg = tmp_path / "bots.json"
+        reg.write_text(json.dumps([
+            {"name": "fitness", "token_env": "TG_C"},
+            {"name": "fitness", "token_env": "TG_C"},
+        ]))
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_C", "c")
+        from config.settings import settings
+        assert len(settings.telegram_bots) == 1
+
+
+# ---------------------------------------------------------------------------
+# Token routing via the active-bot ContextVar
+# ---------------------------------------------------------------------------
+
+class TestTokenRouting:
+    def test_active_bot_token_used(self):
+        from api.services.telegram import _telegram_url, _active_bot_token
+        tok = _active_bot_token.set("BOTX")
+        try:
+            assert "/botBOTX/" in _telegram_url("sendMessage")
+        finally:
+            _active_bot_token.reset(tok)
+
+    def test_explicit_token_overrides_active(self):
+        from api.services.telegram import _telegram_url, _active_bot_token
+        tok = _active_bot_token.set("BOTX")
+        try:
+            assert "/botEXPLICIT/" in _telegram_url("sendMessage", "EXPLICIT")
+        finally:
+            _active_bot_token.reset(tok)
+
+    def test_defaults_to_primary_when_unset(self):
+        import api.services.telegram as tg
+        from api.services.telegram import _telegram_url, _active_bot_token
+        # No active token set and no explicit token -> primary settings token.
+        assert _active_bot_token.get() is None
+        assert _telegram_url("getMe") == f"{tg.TELEGRAM_API}/bot{tg.settings.telegram_bot_token}/getMe"
+
+
+# ---------------------------------------------------------------------------
+# Per-bot listener wiring
+# ---------------------------------------------------------------------------
+
+class TestListenerWiring:
+    def test_primary_uses_legacy_state_file(self, tmp_path):
+        from api.services.telegram import TelegramBotListener
+        state = tmp_path / "telegram_state.json"
+        with patch.object(TelegramBotListener, "_STATE_FILE", state):
+            listener = TelegramBotListener()  # None -> primary
+            assert listener._is_primary
+            assert listener._state_file == state
+
+    def test_named_bot_has_isolated_state_file_and_config(self):
+        from api.services.telegram import TelegramBotListener
+        from config.settings import TelegramBotConfig
+        bot = TelegramBotConfig(name="fitness", token="T", chat_id="C", persona="P")
+        listener = TelegramBotListener(bot)
+        assert not listener._is_primary
+        assert listener._state_file == Path("data/telegram_state_fitness.json")
+        assert listener._token == "T"
+        assert listener._chat_id == "C"
+        assert listener._persona == "P"
+
+
+# ---------------------------------------------------------------------------
+# Persona forwarding + agent-reply gating in _handle_update
+# ---------------------------------------------------------------------------
+
+class _DummyTyping:
+    """async-context-manager stand-in for TypingIndicator."""
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class TestHandleUpdate:
+    def _listener(self, name, chat_id, persona=""):
+        from api.services.telegram import TelegramBotListener
+        from config.settings import TelegramBotConfig
+        bot = TelegramBotConfig(name=name, token="TOK", chat_id=chat_id, persona=persona)
+        return TelegramBotListener(bot)
+
+    @pytest.mark.asyncio
+    async def test_specialized_bot_forwards_persona_and_skips_agent_hooks(self):
+        listener = self._listener("fitness", "999", persona="FIT PERSONA")
+        update = {"message": {
+            "text": "squats 5x5 @185",
+            "chat": {"id": 999},
+            "message_id": 1,
+            "reply_to_message": {"message_id": 42},  # would trigger hooks on primary
+        }}
+        with patch.object(listener, "_maybe_deposit_agent_answer") as mock_dep, \
+             patch.object(listener, "_maybe_handle_claude_code_reply", new_callable=AsyncMock) as mock_claude, \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock), \
+             patch("api.services.telegram.TypingIndicator", _DummyTyping), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            mock_chat.return_value = {"answer": "Logged", "conversation_id": "c1"}
+            await listener._handle_update(update)
+
+        # Specialized bots are pure chat: agent/Claude reply hooks never run.
+        mock_dep.assert_not_called()
+        mock_claude.assert_not_called()
+        # Persona forwarded to the orchestrator.
+        mock_chat.assert_awaited_once()
+        assert mock_chat.call_args.kwargs.get("persona") == "FIT PERSONA"
+
+    @pytest.mark.asyncio
+    async def test_primary_bot_still_runs_agent_reply_hook(self):
+        listener = self._listener("primary", "999")
+        update = {"message": {
+            "text": "the answer",
+            "chat": {"id": 999},
+            "message_id": 2,
+            "reply_to_message": {"message_id": 42},
+        }}
+        with patch.object(listener, "_maybe_handle_claude_code_reply", new_callable=AsyncMock, return_value=False) as mock_claude, \
+             patch.object(listener, "_maybe_deposit_agent_answer", return_value=True) as mock_dep, \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            await listener._handle_update(update)
+
+        # Primary owns the reply threads; deposit short-circuits before chat.
+        mock_claude.assert_awaited_once()
+        mock_dep.assert_called_once()
+        mock_chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_chat_ignored_per_bot(self):
+        listener = self._listener("fitness", "999", persona="P")
+        update = {"message": {"text": "hi", "chat": {"id": 111}, "message_id": 3}}
+        with patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            await listener._handle_update(update)
+        mock_chat.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Persona threads through chat_via_api into the request body
+# ---------------------------------------------------------------------------
+
+class TestChatViaApiPersona:
+    @pytest.mark.asyncio
+    @patch("api.services.telegram.settings")
+    async def test_persona_added_to_request_body(self, mock_settings):
+        from api.services.telegram import chat_via_api
+        mock_settings.port = 8000
+        captured = {}
+
+        class MockStream:
+            status_code = 200
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+            async def aiter_lines(self):
+                for ev in ['data: {"type": "content", "content": "ok"}', 'data: {"type": "done"}']:
+                    yield ev
+
+        class MockAsyncClient:
+            def __init__(self, **kwargs):
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+            def stream(self, method, url, **kwargs):
+                captured["json"] = kwargs.get("json")
+                return MockStream()
+
+        with patch("api.services.telegram.httpx.AsyncClient", MockAsyncClient):
+            await chat_via_api("hi", persona="FIT PERSONA")
+        assert captured["json"]["persona"] == "FIT PERSONA"
+
+    @pytest.mark.asyncio
+    @patch("api.services.telegram.settings")
+    async def test_no_persona_key_when_absent(self, mock_settings):
+        from api.services.telegram import chat_via_api
+        mock_settings.port = 8000
+        captured = {}
+
+        class MockStream:
+            status_code = 200
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+            async def aiter_lines(self):
+                for ev in ['data: {"type": "done"}']:
+                    yield ev
+
+        class MockAsyncClient:
+            def __init__(self, **kwargs):
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+            def stream(self, method, url, **kwargs):
+                captured["json"] = kwargs.get("json")
+                return MockStream()
+
+        with patch("api.services.telegram.httpx.AsyncClient", MockAsyncClient):
+            await chat_via_api("hi")
+        assert "persona" not in captured["json"]


### PR DESCRIPTION
## Summary

Adds specialized Telegram bots — starting with a **fitness bot** — that route to the shared chat orchestrator with a per-bot system-prompt persona, while keeping the full tool suite. Bots are thin *profiles* over one engine, not separate codepaths: a registry declares them, one listener runs per bot, and a persona string threads down to the system prompt.

Closes #316

## What's included

- **Registry** (`config/telegram_bots.json`, committed, no secrets) references per-bot token env vars. Tokens live in `.env`, persona text in `config/personas/fitness.md`. `settings.telegram_bots` skips bots whose token is unset (logged) → a fresh clone runs the primary bot only. Resolves env vars from the `.env` file directly, since pydantic-settings loads `.env` into the model but does **not** export to `os.environ`.
- **One listener per bot** — own poll thread, own update-offset file (`data/telegram_state_<name>.json`), own conversation map. Bot threads stay isolated; concurrent pollers don't clobber each other's offset. Primary keeps the legacy `data/telegram_state.json`.
- **Outbound token routing** via an `_active_bot_token` ContextVar set once at the top of `_handle_update`, so all ~30 internal send sites use the right bot without per-call threading. Non-listener callers (agent worker, reminders, scheduler) default to primary — unchanged.
- **Persona** threads `chat_via_api` → `/api/ask/stream` → `run_agent_loop` → `build_system_prompt`, injected as an **uncached** block *after* the cached static block so the large shared prompt stays a common cache prefix across all bots.
- **Agent/Claude-Code reply hooks gated to primary** — Telegram message_ids are unique per chat (per bot), so specialized bots must not match replies against the shared follow-up table. Specialized bots are pure chat surfaces.

## Persona steer (fitness)

Prime + gentle-redirect: pre-loaded with workout/nutrition/metrics framing and a terse-logging expectation (`squats 5x5 @185` just logs), answers cross-domain queries fully (e.g. "am I overspending on the gym?"), and for clearly off-topic asks answers anyway with a one-line nudge toward the general assistant.

## Out of scope (follow-up)

The `lifeos_telegram_send` MCP tool and reminders/agent-worker notifications still send from the **primary** bot — proactive pushes won't originate from the fitness bot yet.

## Manual step before it runs

Create the bot in @BotFather and set `TELEGRAM_FITNESS_BOT_TOKEN` in `.env`.

## Test evidence

`./scripts/test.sh` — **2681 passed**, 12 skipped. The 5 failures are pre-existing/environmental, all verified present on clean `main` or order-dependent in the full run (2 settings-default tests overridden by the local `.env`; 1 vault-index artifact of the suite; 2 shared-DB order-dependent sync tests that pass in isolation). New coverage: `tests/test_telegram_multibot.py` (registry loading incl. unset-token skip, token routing via ContextVar, per-bot state isolation, persona forwarding, agent-hook gating) + persona-injection tests in `tests/test_agent_system_prompt.py`. Two existing `test_telegram.py` tests updated for the intentional move of the auth chat-id from global settings to per-bot config.

## Review focus

- ContextVar token routing — correctness of "set once per update", task inheritance through `TypingIndicator`, thread isolation across listeners.
- `settings.telegram_bots` `.env`/`os.environ` merge precedence and skip-on-missing-token behavior.
- Persona block placement vs. prompt caching.