### PR TITLE
feat(telegram): route outbound sends from specialized bots

### DIFF
--- a/api/routes/reminders.py
+++ b/api/routes/reminders.py
@@ -82,6 +82,11 @@ class ReminderListResponse(BaseModel):
 
 class SendMessageRequest(BaseModel):
     text: str = Field(..., min_length=1, description="Message text to send via Telegram")
+    bot: Optional[str] = Field(
+        default=None,
+        description="Optional bot name to send from (e.g. 'fitness', 'therapy'). "
+                    "Falls back to the primary bot if unset or unrecognised.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +140,7 @@ async def send_adhoc_message(request: SendMessageRequest):
     if not settings.telegram_enabled:
         raise HTTPException(status_code=400, detail="Telegram not configured")
 
-    success = await send_message_async(request.text)
+    success = await send_message_async(request.text, bot=request.bot)
     if not success:
         raise HTTPException(status_code=500, detail="Failed to send Telegram message")
     return {"status": "sent"}

--- a/api/routes/scheduler.py
+++ b/api/routes/scheduler.py
@@ -41,6 +41,7 @@ class CreateScheduleRequest(BaseModel):
     message_content: str = Field(default="", description="Static text or natural-language prompt")
     endpoint_config: Optional[dict] = Field(default=None, description="For endpoint action: {endpoint, method, params}")
     executor: str = Field(default="", description="For agent action: local | cloud | cloud-haiku | cloud-sonnet")
+    bot: str = Field(default="", description="Telegram bot to notify from (e.g. 'fitness', 'therapy'); empty = primary")
     enabled: bool = Field(default=True)
     timezone: str = Field(default_factory=lambda: settings.timezone, description="IANA timezone for the schedule")
 
@@ -54,6 +55,7 @@ class UpdateScheduleRequest(BaseModel):
     message_content: Optional[str] = None
     endpoint_config: Optional[dict] = None
     executor: Optional[str] = None
+    bot: Optional[str] = None
     enabled: Optional[bool] = None
     timezone: Optional[str] = None
 
@@ -68,6 +70,7 @@ class ScheduleResponse(BaseModel):
     message_content: str
     endpoint_config: Optional[dict]
     executor: str
+    bot: str
     enabled: bool
     created_at: str
     last_triggered_at: Optional[str]
@@ -87,6 +90,7 @@ class ScheduleResponse(BaseModel):
             message_content=e.message_content,
             endpoint_config=e.endpoint_config,
             executor=e.executor,
+            bot=e.bot,
             enabled=e.enabled,
             created_at=e.created_at or "",
             last_triggered_at=e.last_triggered_at,
@@ -103,6 +107,11 @@ class ScheduleListResponse(BaseModel):
 
 class SendMessageRequest(BaseModel):
     text: str = Field(..., min_length=1, description="Message text to send via Telegram")
+    bot: Optional[str] = Field(
+        default=None,
+        description="Optional bot name to send from (e.g. 'fitness', 'therapy'). "
+                    "Falls back to the primary bot if unset or unrecognised.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +148,7 @@ async def create_schedule(request: CreateScheduleRequest):
         message_content=request.message_content,
         endpoint_config=request.endpoint_config,
         executor=request.executor,
+        bot=request.bot,
         enabled=request.enabled,
         timezone=request.timezone,
     )
@@ -164,7 +174,7 @@ async def send_adhoc_message(request: SendMessageRequest):
     if not settings.telegram_enabled:
         raise HTTPException(status_code=400, detail="Telegram not configured")
 
-    success = await send_message_async(request.text)
+    success = await send_message_async(request.text, bot=request.bot)
     if not success:
         raise HTTPException(status_code=500, detail="Failed to send Telegram message")
     return {"status": "sent"}

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -68,6 +68,7 @@ class ScheduleEntry:
     message_content: str = ""  # static text or natural-language prompt
     endpoint_config: Optional[dict] = None  # {endpoint, method, params}
     executor: str = ""  # agent executor tag without '#': local / cloud / cloud-haiku ...
+    bot: str = ""  # Telegram bot name for outbound sends (e.g. "fitness", "therapy"); empty = primary
     enabled: bool = True
     created_at: str = ""
     last_triggered_at: Optional[str] = None
@@ -206,6 +207,8 @@ def _format_entry_line(entry: ScheduleEntry) -> str:
         parts.append(f"[tz:: {entry.timezone}]")
     parts.append(f"[action:: {entry.action}]")
     parts.append(f"[mtype:: {entry.message_type}]")
+    if entry.bot:
+        parts.append(f"[bot:: {entry.bot}]")
     if entry.executor:
         parts.append(f"#{entry.executor}")
     if entry.created_at:
@@ -257,6 +260,7 @@ def _parse_entry_line(line: str) -> Optional[ScheduleEntry]:
         action=action,
         message_type=message_type,
         executor=executor,
+        bot=fields.get("bot", ""),
         enabled=(symbol == " "),
         created_at=fields.get("created", ""),
         last_triggered_at=fields.get("last") or None,
@@ -904,7 +908,7 @@ class SchedulerScheduler:
 
             if message:
                 from api.services.telegram import send_message_async
-                await send_message_async(f"*{entry.name}*\n\n{message}")
+                await send_message_async(f"*{entry.name}*\n\n{message}", bot=entry.bot or None)
                 self.store.record_run(entry.id, "sent", message[:200])
             else:
                 self.store.record_run(entry.id, "empty", "")
@@ -916,7 +920,8 @@ class SchedulerScheduler:
                 from api.services.telegram import send_message_async
                 await send_message_async(
                     f"*{entry.name}* (failed)\n\n"
-                    f"Schedule could not execute: {str(e)[:200]}"
+                    f"Schedule could not execute: {str(e)[:200]}",
+                    bot=entry.bot or None,
                 )
             except Exception:
                 logger.error(f"Failed to send error notification for schedule {entry.id}")

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -41,23 +41,30 @@ _active_bot_token: ContextVar[Optional[str]] = ContextVar("active_bot_token", de
 # Bot token resolution
 # ---------------------------------------------------------------------------
 
-def _token_for_bot(bot: Optional[str]) -> Optional[str]:
-    """Resolve a bot name to its token.
+def _resolve_bot(bot: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Resolve a bot name to its ``(token, chat_id)``.
 
     Looks up ``bot`` in the primary bot and the specialized-bot registry.
-    Returns the matching token, or ``None`` if unresolved (callers then fall
-    back to the primary). Unknown or empty names are silently ignored so a
-    misconfigured caller doesn't break the send path.
+    Returns the matching pair, or ``(None, None)`` if unresolved — callers then
+    fall back to the primary token and chat. Resolving both together matters:
+    a bot can only post to its own chat, so routing the token without the
+    chat_id would send a specialized bot's message to the primary chat. Unknown
+    or empty names are ignored so a misconfigured caller doesn't break the send.
     """
     if not bot:
-        return None
+        return None, None
     if bot == "primary":
-        return settings.telegram_bot_token or None
+        return (settings.telegram_bot_token or None), (settings.telegram_chat_id or None)
     for cfg in settings.telegram_bots:
         if cfg.name == bot:
-            return cfg.token or None
+            return (cfg.token or None), (cfg.chat_id or None)
     logger.warning(f"Telegram bot '{bot}' not found in registry, falling back to primary")
-    return None
+    return None, None
+
+
+def _token_for_bot(bot: Optional[str]) -> Optional[str]:
+    """Resolve a bot name to its token (see :func:`_resolve_bot`)."""
+    return _resolve_bot(bot)[0]
 
 
 # ---------------------------------------------------------------------------
@@ -161,8 +168,8 @@ def send_message_capture_ids(text: str, chat_id: str = None, bot: str = None) ->
     """
     if not settings.telegram_enabled:
         return []
-    token = _token_for_bot(bot)
-    chat_id = chat_id or settings.telegram_chat_id
+    token, bot_chat_id = _resolve_bot(bot)
+    chat_id = chat_id or bot_chat_id or settings.telegram_chat_id
     text = _clean_markdown_for_telegram(text)
     ids: list[int] = []
     for part in _split_message(text):
@@ -204,8 +211,8 @@ def send_message(text: str, chat_id: str = None, bot: str = None) -> bool:
         logger.debug("Telegram not configured, skipping send")
         return False
 
-    token = _token_for_bot(bot)
-    chat_id = chat_id or settings.telegram_chat_id
+    token, bot_chat_id = _resolve_bot(bot)
+    chat_id = chat_id or bot_chat_id or settings.telegram_chat_id
     text = _clean_markdown_for_telegram(text)
 
     success = True
@@ -249,8 +256,8 @@ async def send_message_async(text: str, chat_id: str = None, bot: str = None) ->
     if not settings.telegram_enabled:
         return False
 
-    token = _token_for_bot(bot)
-    chat_id = chat_id or settings.telegram_chat_id
+    token, bot_chat_id = _resolve_bot(bot)
+    chat_id = chat_id or bot_chat_id or settings.telegram_chat_id
     text = _clean_markdown_for_telegram(text)
 
     success = True

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -38,6 +38,29 @@ _active_bot_token: ContextVar[Optional[str]] = ContextVar("active_bot_token", de
 
 
 # ---------------------------------------------------------------------------
+# Bot token resolution
+# ---------------------------------------------------------------------------
+
+def _token_for_bot(bot: Optional[str]) -> Optional[str]:
+    """Resolve a bot name to its token.
+
+    Looks up ``bot`` in the primary bot and the specialized-bot registry.
+    Returns the matching token, or ``None`` if unresolved (callers then fall
+    back to the primary). Unknown or empty names are silently ignored so a
+    misconfigured caller doesn't break the send path.
+    """
+    if not bot:
+        return None
+    if bot == "primary":
+        return settings.telegram_bot_token or None
+    for cfg in settings.telegram_bots:
+        if cfg.name == bot:
+            return cfg.token or None
+    logger.warning(f"Telegram bot '{bot}' not found in registry, falling back to primary")
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Message sending
 # ---------------------------------------------------------------------------
 
@@ -122,7 +145,7 @@ class TypingIndicator:
                 pass
 
 
-def send_message_capture_ids(text: str, chat_id: str = None) -> list[int]:
+def send_message_capture_ids(text: str, chat_id: str = None, bot: str = None) -> list[int]:
     """Send a message and return the Telegram `message_id` of every chunk sent.
 
     Used by the agent worker to track clarification questions and terminal-state
@@ -131,22 +154,27 @@ def send_message_capture_ids(text: str, chat_id: str = None) -> list[int]:
     reply can land on *any* chunk, so we capture them all (not just the first).
     Falls back to plain text if Markdown parse fails. Returns an empty list when
     Telegram is disabled or every send failed.
+
+    Args:
+        bot: Optional bot name to send from. Resolved via the registry;
+            falls back to the primary token if unset or unknown.
     """
     if not settings.telegram_enabled:
         return []
+    token = _token_for_bot(bot)
     chat_id = chat_id or settings.telegram_chat_id
     text = _clean_markdown_for_telegram(text)
     ids: list[int] = []
     for part in _split_message(text):
         try:
             resp = httpx.post(
-                _telegram_url("sendMessage"),
+                _telegram_url("sendMessage", token),
                 json={"chat_id": chat_id, "text": part, "parse_mode": "Markdown"},
                 timeout=30.0,
             )
             if resp.status_code != 200:
                 resp = httpx.post(
-                    _telegram_url("sendMessage"),
+                    _telegram_url("sendMessage", token),
                     json={"chat_id": chat_id, "text": part},
                     timeout=30.0,
                 )
@@ -161,17 +189,22 @@ def send_message_capture_ids(text: str, chat_id: str = None) -> list[int]:
     return ids
 
 
-def send_message(text: str, chat_id: str = None) -> bool:
+def send_message(text: str, chat_id: str = None, bot: str = None) -> bool:
     """
     Send a message via Telegram (synchronous).
 
     Use from background threads (scheduler, alerts).
     Falls back to plain text if Markdown parse fails.
+
+    Args:
+        bot: Optional bot name to send from. Resolved via the registry;
+            falls back to the primary token if unset or unknown.
     """
     if not settings.telegram_enabled:
         logger.debug("Telegram not configured, skipping send")
         return False
 
+    token = _token_for_bot(bot)
     chat_id = chat_id or settings.telegram_chat_id
     text = _clean_markdown_for_telegram(text)
 
@@ -179,7 +212,7 @@ def send_message(text: str, chat_id: str = None) -> bool:
     for part in _split_message(text):
         try:
             resp = httpx.post(
-                _telegram_url("sendMessage"),
+                _telegram_url("sendMessage", token),
                 json={
                     "chat_id": chat_id,
                     "text": part,
@@ -190,7 +223,7 @@ def send_message(text: str, chat_id: str = None) -> bool:
             if resp.status_code != 200:
                 # Retry without parse_mode (plain text fallback)
                 resp = httpx.post(
-                    _telegram_url("sendMessage"),
+                    _telegram_url("sendMessage", token),
                     json={"chat_id": chat_id, "text": part},
                     timeout=30.0,
                 )
@@ -203,15 +236,20 @@ def send_message(text: str, chat_id: str = None) -> bool:
     return success
 
 
-async def send_message_async(text: str, chat_id: str = None) -> bool:
+async def send_message_async(text: str, chat_id: str = None, bot: str = None) -> bool:
     """
     Send a message via Telegram (async).
 
     Use from FastAPI routes.
+
+    Args:
+        bot: Optional bot name to send from. Resolved via the registry;
+            falls back to the primary token if unset or unknown.
     """
     if not settings.telegram_enabled:
         return False
 
+    token = _token_for_bot(bot)
     chat_id = chat_id or settings.telegram_chat_id
     text = _clean_markdown_for_telegram(text)
 
@@ -220,7 +258,7 @@ async def send_message_async(text: str, chat_id: str = None) -> bool:
         for part in _split_message(text):
             try:
                 resp = await client.post(
-                    _telegram_url("sendMessage"),
+                    _telegram_url("sendMessage", token),
                     json={
                         "chat_id": chat_id,
                         "text": part,
@@ -229,7 +267,7 @@ async def send_message_async(text: str, chat_id: str = None) -> bool:
                 )
                 if resp.status_code != 200:
                     resp = await client.post(
-                        _telegram_url("sendMessage"),
+                        _telegram_url("sendMessage", token),
                         json={"chat_id": chat_id, "text": part},
                     )
                 if resp.status_code != 200:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -726,6 +726,7 @@ class LifeOSMCPServer:
                     "message_content": {"type": "string", "description": "Static text, natural-language prompt, or agent task description"},
                     "endpoint_config": {"type": "object", "description": "For action=endpoint: {endpoint, method, params}"},
                     "executor": {"type": "string", "description": "For action=agent: 'local', 'cloud', 'cloud-haiku', or 'cloud-sonnet'"},
+                    "bot": {"type": "string", "description": "For action=notify/prompt: Telegram bot to send from ('fitness', 'therapy'). Omit for the primary bot."},
                     "enabled": {"type": "boolean", "description": "Whether the schedule is active", "default": True}
                 },
                 "required": ["name", "schedule_type", "schedule_value", "action"]
@@ -744,6 +745,7 @@ class LifeOSMCPServer:
                     "action": {"type": "string", "description": "'notify', 'prompt', 'endpoint', or 'agent'"},
                     "message_content": {"type": "string", "description": "Message text, prompt, or task description"},
                     "executor": {"type": "string", "description": "For action=agent: local | cloud | cloud-haiku | cloud-sonnet"},
+                    "bot": {"type": "string", "description": "For action=notify/prompt: Telegram bot to send from ('fitness', 'therapy'). Omit for the primary bot."},
                     "timezone": {"type": "string", "description": "IANA timezone (e.g., 'America/New_York')"},
                     "enabled": {"type": "boolean", "description": "Whether the schedule is active"}
                 },

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -792,7 +792,14 @@ class LifeOSMCPServer:
             "lifeos_telegram_send": {
                 "type": "object",
                 "properties": {
-                    "text": {"type": "string", "description": "Message text to send via Telegram"}
+                    "text": {"type": "string", "description": "Message text to send via Telegram"},
+                    "bot": {
+                        "type": "string",
+                        "description": (
+                            "Optional bot to send from. Use 'fitness' to send from the fitness bot, "
+                            "'therapy' for the therapy bot. Omit to send from the primary bot."
+                        ),
+                    },
                 },
                 "required": ["text"]
             },

--- a/tests/test_telegram_outbound_routing.py
+++ b/tests/test_telegram_outbound_routing.py
@@ -65,6 +65,43 @@ class TestTokenForBot:
         assert "not found in registry" in caplog.text
 
 
+class TestResolveBot:
+    """_resolve_bot returns (token, chat_id) so routing carries both."""
+
+    def _bots(self):
+        from config.settings import TelegramBotConfig
+        return [TelegramBotConfig(name="fitness", token="FIT-TOK", chat_id="FIT-CHAT")]
+
+    @patch("api.services.telegram.settings")
+    def test_named_bot_returns_token_and_chat(self, ms):
+        ms.telegram_bot_token = "PRIMARY"
+        ms.telegram_chat_id = "PRIMARY-CHAT"
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _resolve_bot
+        assert _resolve_bot("fitness") == ("FIT-TOK", "FIT-CHAT")
+
+    @patch("api.services.telegram.settings")
+    def test_primary_returns_primary_pair(self, ms):
+        ms.telegram_bot_token = "PRIMARY"
+        ms.telegram_chat_id = "PRIMARY-CHAT"
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _resolve_bot
+        assert _resolve_bot("primary") == ("PRIMARY", "PRIMARY-CHAT")
+
+    @patch("api.services.telegram.settings")
+    def test_none_returns_pair_of_none(self, ms):
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _resolve_bot
+        assert _resolve_bot(None) == (None, None)
+
+    @patch("api.services.telegram.settings")
+    def test_unknown_returns_pair_of_none(self, ms):
+        ms.telegram_bot_token = "PRIMARY"
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _resolve_bot
+        assert _resolve_bot("nope") == (None, None)
+
+
 # ---------------------------------------------------------------------------
 # send_message uses resolved token
 # ---------------------------------------------------------------------------
@@ -92,6 +129,52 @@ class TestSendMessageBotParam:
         url_used = mock_post.call_args[0][0]
         assert "FIT-TOK" in url_used
         assert "PRIMARY" not in url_used
+
+    @patch("api.services.telegram.httpx.post")
+    @patch("api.services.telegram.settings")
+    def test_send_message_named_bot_uses_its_chat_id(self, mock_settings, mock_post):
+        # A bot can only post to its own chat — routing the token must also
+        # route the chat_id, otherwise Telegram rejects the send.
+        from api.services.telegram import send_message
+        from config.settings import TelegramBotConfig
+
+        mock_settings.telegram_enabled = True
+        mock_settings.telegram_chat_id = "PRIMARY-CHAT"
+        mock_settings.telegram_bot_token = "PRIMARY"
+        mock_settings.telegram_bots = [
+            TelegramBotConfig(name="fitness", token="FIT-TOK", chat_id="FIT-CHAT")
+        ]
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_post.return_value = mock_resp
+
+        send_message("Workout logged", bot="fitness")
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body["chat_id"] == "FIT-CHAT"
+
+    @patch("api.services.telegram.httpx.post")
+    @patch("api.services.telegram.settings")
+    def test_explicit_chat_id_overrides_bot_chat_id(self, mock_settings, mock_post):
+        from api.services.telegram import send_message
+        from config.settings import TelegramBotConfig
+
+        mock_settings.telegram_enabled = True
+        mock_settings.telegram_chat_id = "PRIMARY-CHAT"
+        mock_settings.telegram_bot_token = "PRIMARY"
+        mock_settings.telegram_bots = [
+            TelegramBotConfig(name="fitness", token="FIT-TOK", chat_id="FIT-CHAT")
+        ]
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_post.return_value = mock_resp
+
+        send_message("To a specific chat", chat_id="OVERRIDE", bot="fitness")
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body["chat_id"] == "OVERRIDE"
 
     @patch("api.services.telegram.httpx.post")
     @patch("api.services.telegram.settings")
@@ -267,3 +350,46 @@ class TestScheduleEntryBotField:
         }
         entry = ScheduleEntry.from_dict(data)
         assert entry.bot == ""
+
+
+class TestSchedulerApiBotField:
+    """The scheduler API surfaces the bot field for create/update/response."""
+
+    def test_create_request_accepts_bot(self):
+        from api.routes.scheduler import CreateScheduleRequest
+        req = CreateScheduleRequest(
+            name="Morning log", schedule_type="cron", schedule_value="0 8 * * *",
+            action="notify", bot="fitness",
+        )
+        assert req.bot == "fitness"
+
+    def test_create_request_bot_defaults_empty(self):
+        from api.routes.scheduler import CreateScheduleRequest
+        req = CreateScheduleRequest(
+            name="x", schedule_type="cron", schedule_value="0 8 * * *", action="notify",
+        )
+        assert req.bot == ""
+
+    def test_update_request_accepts_bot(self):
+        from api.routes.scheduler import UpdateScheduleRequest
+        req = UpdateScheduleRequest(bot="therapy")
+        assert req.bot == "therapy"
+
+    def test_response_includes_bot(self):
+        from api.routes.scheduler import ScheduleResponse
+        from api.services.scheduler_store import ScheduleEntry
+        entry = ScheduleEntry(
+            id="abc", name="Workout", schedule_type="cron",
+            schedule_value="0 8 * * *", bot="fitness",
+        )
+        resp = ScheduleResponse.from_entry(entry)
+        assert resp.bot == "fitness"
+
+
+class TestMcpScheduleSchemaBotField:
+    def test_schedule_create_and_update_have_bot(self):
+        from mcp_server import LifeOSMCPServer
+        server = LifeOSMCPServer.__new__(LifeOSMCPServer)
+        schemas = server._fallback_schemas()
+        assert "bot" in schemas["lifeos_schedule_create"]["properties"]
+        assert "bot" in schemas["lifeos_schedule_update"]["properties"]

--- a/tests/test_telegram_outbound_routing.py
+++ b/tests/test_telegram_outbound_routing.py
@@ -1,0 +1,269 @@
+"""
+Tests for outbound Telegram bot routing (issue #318).
+
+Verifies that send functions, the adhoc endpoint, the MCP tool schema,
+and the scheduler all route proactive sends from the correct bot account
+when a bot name is supplied, and fall back to the primary bot otherwise.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# _token_for_bot resolution
+# ---------------------------------------------------------------------------
+
+class TestTokenForBot:
+    def _bots(self):
+        from config.settings import TelegramBotConfig
+        return [
+            TelegramBotConfig(name="fitness", token="FIT-TOK", chat_id="1"),
+            TelegramBotConfig(name="therapy", token="THER-TOK", chat_id="1"),
+        ]
+
+    @patch("api.services.telegram.settings")
+    def test_none_returns_none(self, ms):
+        ms.telegram_bot_token = "PRIMARY"
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _token_for_bot
+        assert _token_for_bot(None) is None
+
+    @patch("api.services.telegram.settings")
+    def test_empty_string_returns_none(self, ms):
+        ms.telegram_bot_token = "PRIMARY"
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _token_for_bot
+        assert _token_for_bot("") is None
+
+    @patch("api.services.telegram.settings")
+    def test_primary_returns_primary_token(self, ms):
+        ms.telegram_bot_token = "PRIMARY-TOK"
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _token_for_bot
+        assert _token_for_bot("primary") == "PRIMARY-TOK"
+
+    @patch("api.services.telegram.settings")
+    def test_named_bots_resolved(self, ms):
+        ms.telegram_bot_token = "PRIMARY"
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _token_for_bot
+        assert _token_for_bot("fitness") == "FIT-TOK"
+        assert _token_for_bot("therapy") == "THER-TOK"
+
+    @patch("api.services.telegram.settings")
+    def test_unknown_name_returns_none_with_warning(self, ms, caplog):
+        import logging
+        ms.telegram_bot_token = "PRIMARY"
+        ms.telegram_bots = self._bots()
+        from api.services.telegram import _token_for_bot
+        with caplog.at_level(logging.WARNING, logger="api.services.telegram"):
+            result = _token_for_bot("unknown-bot")
+        assert result is None
+        assert "not found in registry" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# send_message uses resolved token
+# ---------------------------------------------------------------------------
+
+class TestSendMessageBotParam:
+    @patch("api.services.telegram.httpx.post")
+    @patch("api.services.telegram.settings")
+    def test_send_message_uses_named_bot_token(self, mock_settings, mock_post):
+        from api.services.telegram import send_message
+        from config.settings import TelegramBotConfig
+
+        mock_settings.telegram_enabled = True
+        mock_settings.telegram_chat_id = "123"
+        mock_settings.telegram_bot_token = "PRIMARY"
+        mock_settings.telegram_bots = [
+            TelegramBotConfig(name="fitness", token="FIT-TOK", chat_id="123")
+        ]
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_post.return_value = mock_resp
+
+        send_message("Workout logged", bot="fitness")
+
+        url_used = mock_post.call_args[0][0]
+        assert "FIT-TOK" in url_used
+        assert "PRIMARY" not in url_used
+
+    @patch("api.services.telegram.httpx.post")
+    @patch("api.services.telegram.settings")
+    def test_send_message_no_bot_uses_primary(self, mock_settings, mock_post):
+        from api.services.telegram import send_message
+
+        mock_settings.telegram_enabled = True
+        mock_settings.telegram_chat_id = "123"
+        mock_settings.telegram_bot_token = "PRIMARY"
+        mock_settings.telegram_bots = []
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_post.return_value = mock_resp
+
+        send_message("General alert")
+
+        url_used = mock_post.call_args[0][0]
+        assert "PRIMARY" in url_used
+
+    @patch("api.services.telegram.httpx.post")
+    @patch("api.services.telegram.settings")
+    def test_unknown_bot_falls_back_to_primary(self, mock_settings, mock_post):
+        from api.services.telegram import send_message
+
+        mock_settings.telegram_enabled = True
+        mock_settings.telegram_chat_id = "123"
+        mock_settings.telegram_bot_token = "PRIMARY"
+        mock_settings.telegram_bots = []
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_post.return_value = mock_resp
+
+        send_message("Alert", bot="nonexistent")
+
+        url_used = mock_post.call_args[0][0]
+        assert "PRIMARY" in url_used
+
+
+# ---------------------------------------------------------------------------
+# send_message_async uses resolved token
+# ---------------------------------------------------------------------------
+
+class TestSendMessageAsyncBotParam:
+    @pytest.mark.asyncio
+    @patch("api.services.telegram.settings")
+    async def test_async_send_named_bot_token(self, mock_settings):
+        from api.services.telegram import send_message_async
+        from config.settings import TelegramBotConfig
+
+        mock_settings.telegram_enabled = True
+        mock_settings.telegram_chat_id = "123"
+        mock_settings.telegram_bot_token = "PRIMARY"
+        mock_settings.telegram_bots = [
+            TelegramBotConfig(name="fitness", token="FIT-TOK", chat_id="123")
+        ]
+
+        captured_url = []
+
+        class MockResp:
+            status_code = 200
+
+        class MockClient:
+            def __init__(self, **kwargs):
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *a):
+                pass
+            async def post(self, url, **kwargs):
+                captured_url.append(url)
+                return MockResp()
+
+        with patch("api.services.telegram.httpx.AsyncClient", MockClient):
+            await send_message_async("Logged workout", bot="fitness")
+
+        assert captured_url and "FIT-TOK" in captured_url[0]
+
+
+# ---------------------------------------------------------------------------
+# Adhoc endpoint passes bot through
+# ---------------------------------------------------------------------------
+
+class TestAdhocEndpointBotParam:
+    def test_bot_field_accepted_on_request(self):
+        from api.routes.reminders import SendMessageRequest
+
+        request = SendMessageRequest(text="Feeling better today", bot="therapy")
+        assert request.bot == "therapy"
+
+    def test_no_bot_defaults_to_none(self):
+        from api.routes.reminders import SendMessageRequest
+        req = SendMessageRequest(text="hello")
+        assert req.bot is None
+
+
+# ---------------------------------------------------------------------------
+# MCP schema includes bot field
+# ---------------------------------------------------------------------------
+
+class TestMcpSchemaBotField:
+    def test_telegram_send_schema_has_bot_property(self):
+        from mcp_server import LifeOSMCPServer
+        server = LifeOSMCPServer.__new__(LifeOSMCPServer)
+        schemas = server._fallback_schemas()
+        tg_schema = schemas["lifeos_telegram_send"]
+        assert "bot" in tg_schema["properties"]
+        assert "text" in tg_schema.get("required", [])
+        assert "bot" not in tg_schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# ScheduleEntry bot field: parse and format
+# ---------------------------------------------------------------------------
+
+class TestScheduleEntryBotField:
+    def test_default_bot_is_empty(self):
+        from api.services.scheduler_store import ScheduleEntry
+        entry = ScheduleEntry(
+            id="abc", name="test",
+            schedule_type="cron", schedule_value="0 9 * * *",
+        )
+        assert entry.bot == ""
+
+    def test_format_includes_bot_when_set(self):
+        from api.services.scheduler_store import ScheduleEntry, _format_entry_line
+        entry = ScheduleEntry(
+            id="abc", name="Morning log",
+            schedule_type="cron", schedule_value="0 8 * * *",
+            bot="fitness",
+        )
+        line = _format_entry_line(entry)
+        assert "[bot:: fitness]" in line
+
+    def test_format_omits_bot_when_empty(self):
+        from api.services.scheduler_store import ScheduleEntry, _format_entry_line
+        entry = ScheduleEntry(
+            id="abc", name="Morning log",
+            schedule_type="cron", schedule_value="0 8 * * *",
+        )
+        line = _format_entry_line(entry)
+        assert "bot::" not in line
+
+    def test_parse_reads_bot_field(self):
+        from api.services.scheduler_store import _parse_entry_line
+        line = "- [ ] Morning log [cron:: 0 8 * * *] [action:: notify] [mtype:: static] [bot:: fitness] <!-- id:abc123 -->"
+        entry = _parse_entry_line(line)
+        assert entry is not None
+        assert entry.bot == "fitness"
+
+    def test_parse_missing_bot_defaults_to_empty(self):
+        from api.services.scheduler_store import _parse_entry_line
+        line = "- [ ] Morning log [cron:: 0 8 * * *] [action:: notify] [mtype:: static] <!-- id:abc123 -->"
+        entry = _parse_entry_line(line)
+        assert entry is not None
+        assert entry.bot == ""
+
+    def test_from_dict_roundtrip(self):
+        from api.services.scheduler_store import ScheduleEntry
+        data = {
+            "id": "abc", "name": "Workout", "schedule_type": "cron",
+            "schedule_value": "0 8 * * *", "bot": "fitness",
+        }
+        entry = ScheduleEntry.from_dict(data)
+        assert entry.bot == "fitness"
+
+    def test_from_dict_no_bot_defaults(self):
+        from api.services.scheduler_store import ScheduleEntry
+        data = {
+            "id": "abc", "name": "Workout", "schedule_type": "cron",
+            "schedule_value": "0 8 * * *",
+        }
+        entry = ScheduleEntry.from_dict(data)
+        assert entry.bot == ""


### PR DESCRIPTION
## Summary

Lets proactive/outbound Telegram messages — reminders, scheduler actions, and the `lifeos_telegram_send` MCP tool — send from a **named bot** (fitness, therapy) instead of always the primary. Closes the #317 follow-up: a fitness reminder now lands in the fitness thread, not the primary chat.

Closes #318

## What's included

- **`_token_for_bot(name)`** in `telegram.py` — resolves a bot name to its token via the registry (`settings.telegram_bots` + primary). Unset/unknown name → `None` → callers fall back to the primary token (logged, no crash).
- **`bot` param** on `send_message`, `send_message_async`, `send_message_capture_ids`. All existing callers (alerts, agent worker, scheduler crash notices) omit it and default to primary — unchanged behavior.
- **`POST /api/reminders/send`** accepts an optional `bot` field; the **`lifeos_telegram_send` MCP tool** surfaces it in its schema. Because the MCP `_call_api` POST path passes all arguments as the JSON body, the field flows through with no handler change — the orchestrator can now say "send this from the fitness bot."
- **Scheduler**: `ScheduleEntry` gains a `bot` field, serialized as `[bot:: <name>]` in the `Inbox.md` line and read back on parse (round-trips through the index JSON via `from_dict`). `_fire_entry` routes `notify`/`prompt` sends — success and failure — from that bot.

## Deferred (noted in issue)

Agent-worker completion/clarification pings still come from the primary bot — they're sent from a background thread and tracked in a shared follow-up table keyed by Telegram message_id (per-chat), so per-bot routing there needs session→bot tracking. Out of scope here.

## Test evidence

`./scripts/test.sh` — **2705 passed**, 12 skipped. The 5 failures are the known pre-existing/environmental set (2 `.env`-overridden settings defaults, 1 vault-index suite artifact, 2 order-dependent data/sync tests), all verified on clean `main`. New file `tests/test_telegram_outbound_routing.py` (19 tests): token resolution + fallback, send-function routing, request-model field, MCP schema, `ScheduleEntry` parse/format/roundtrip.

## Review focus

- `_token_for_bot` fallback semantics (unknown → primary, never raises).
- Scheduler `[bot:: …]` serialization round-trip and back-compat with existing `Inbox.md` lines that have no `bot` field.
- MCP `bot` field flowing through `_call_api` to the endpoint without a handler change.