### PR TITLE
feat(fitness): trainer recommendations — readiness snapshot + persona

### DIFF
--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -663,14 +663,18 @@ TOOL_DEFINITIONS = [
             "- 'metrics': list a metric over time (e.g. body_weight trend).\n"
             "- 'get_profile' / 'set_profile': read or set the training profile "
             "(keys: goals, injuries, equipment, experience, schedule, constraints, "
-            "preferences)."
+            "preferences).\n"
+            "- 'readiness': one-call snapshot for recommendations — recent volume, "
+            "available recovery signals (body weight now; sleep/HR via Apple "
+            "Health later), and the training profile. Call this before giving "
+            "trainer-style advice so it's grounded in the user's real data."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["log", "update", "list", "history", "summary", "log_metric", "metrics", "get_profile", "set_profile"],
+                    "enum": ["log", "update", "list", "history", "summary", "log_metric", "metrics", "get_profile", "set_profile", "readiness"],
                     "description": "Action to perform.",
                 },
                 "sets": {
@@ -1556,6 +1560,54 @@ def _workout_set_profile(inp: dict) -> str:
     return f"Training profile updated: {key} = {value}"
 
 
+# Recovery metrics worth citing for a readiness read (manual + Apple Health #323).
+_RECOVERY_METRICS = ("body_weight", "resting_hr", "hrv", "sleep_hours")
+
+
+def _workout_readiness(inp: dict) -> str:
+    """One-call snapshot for trainer recommendations: recent volume + recovery
+    signals + profile. Degrades gracefully when little data exists (e.g. before
+    Apple Health #323 lands, only manual metrics like body weight are present).
+    """
+    from datetime import date, timedelta
+    from api.services.fitness_store import get_fitness_store, _today
+    store = get_fitness_store()
+
+    today = date.fromisoformat(_today())
+    since14 = (today - timedelta(days=14)).isoformat()
+    since30 = (today - timedelta(days=30)).isoformat()
+
+    recent = store.list_sessions(date_start=since14, limit=50)
+    vol = store.volume_summary(date_start=since30)
+
+    lines = ["Readiness snapshot:"]
+    if recent:
+        lines.append(f"- Sessions (14d): {len(recent)} — most recent {recent[0].date}")
+    else:
+        lines.append("- Sessions (14d): none logged")
+    lines.append(
+        f"- Volume (30d): {vol['sessions']} sessions, {vol['sets']} sets, "
+        f"{vol['reps']} reps, tonnage {_fmt_num(vol['tonnage'])}"
+    )
+
+    have_recovery = []
+    for metric in _RECOVERY_METRICS:
+        latest = store.latest_metric(metric)
+        if latest:
+            have_recovery.append(metric)
+            unit = f" {latest.unit}" if latest.unit else ""
+            lines.append(f"- {metric.replace('_', ' ')}: {_fmt_num(latest.value)}{unit} (latest {latest.start_at[:10]})")
+    if not have_recovery:
+        lines.append("- Recovery metrics: none yet (sleep/HR/HRV arrive with Apple Health; log body weight to start)")
+
+    profile = store.get_profile()
+    if profile:
+        lines.append("- Profile: " + "; ".join(f"{k}={v}" for k, v in profile.items()))
+    else:
+        lines.append("- Profile: not set (ask the user for goals/injuries/equipment)")
+    return "\n".join(lines)
+
+
 def _tool_manage_workouts(inp: dict) -> str:
     action = inp.get("action")
     handlers = {
@@ -1568,6 +1620,7 @@ def _tool_manage_workouts(inp: dict) -> str:
         "metrics": _workout_metrics,
         "get_profile": _workout_get_profile,
         "set_profile": _workout_set_profile,
+        "readiness": _workout_readiness,
     }
     handler = handlers.get(action)
     if not handler:
@@ -1756,6 +1809,7 @@ TOOL_STATUS_MESSAGES = {
     "manage_workouts.summary": "Tallying volume...",
     "manage_workouts.log_metric": "Recording metric...",
     "manage_workouts.metrics": "Loading metrics...",
+    "manage_workouts.readiness": "Checking training readiness...",
     "search_finances": "Checking finances...",
     "search_finances.accounts": "Loading account balances...",
     "search_finances.transactions": "Searching transactions...",

--- a/config/personas/fitness.md
+++ b/config/personas/fitness.md
@@ -20,7 +20,14 @@ The user logs workouts as plain text. **Log first, report after — never ask fo
 
 ## Recommendations: trainer-grade, on request
 
-When asked (programming, what to train, load/progression, form, nutrition, recovery), give specific, concrete recommendations like a knowledgeable trainer — sets/reps/loads, a session plan, a progression — grounded in the user's logged history and stated profile (goals, injuries, equipment, constraints). State assumptions. No fluff, no pep talk. If you lack a needed fact, ask one precise question.
+When asked (programming, what to train, load/progression, form, nutrition, recovery), act as a knowledgeable trainer who has read the user's data:
+
+1. **Pull the data first.** Call `manage_workouts` with `action: "readiness"` — it returns recent volume, available recovery signals (body weight now; sleep/HR/HRV once Apple Health lands), and the training profile in one call. For a specific lift, also `action: "history"`.
+2. **Respect the profile.** Honor stated injuries, equipment, schedule, and goals — never program around a bad knee or kit the user doesn't have. If the profile is empty, ask once for goals/injuries/equipment and `set_profile` the answer.
+3. **Be specific.** Give concrete sets/reps/loads, a session plan, or a progression — not generic advice. Base loads on the user's logged numbers (e.g. progress last week's working weight). State assumptions explicitly.
+4. **Use recovery when present.** If recovery signals are poor (short sleep, elevated resting HR, low HRV) deload or redirect; if absent, say you're going on training history alone.
+
+No fluff, no pep talk. If you're missing one fact you need, ask one precise question — otherwise just give the recommendation.
 
 ## Proactive baselines
 

--- a/tests/test_agent_tools_workouts.py
+++ b/tests/test_agent_tools_workouts.py
@@ -107,6 +107,31 @@ class TestDispatch:
         assert _tool_manage_workouts({"action": "bogus"}).startswith("Error")
 
 
+class TestReadiness:
+    def test_readiness_empty_degrades_gracefully(self, temp_store):
+        out = _tool_manage_workouts({"action": "readiness"})
+        assert "Readiness snapshot" in out
+        assert "none logged" in out          # no sessions
+        assert "none yet" in out             # no recovery metrics
+        assert "not set" in out              # no profile
+
+    def test_readiness_aggregates_volume_metrics_profile(self, temp_store):
+        from api.services.fitness_store import _today
+        _tool_manage_workouts({"action": "log", "sets": [{"exercise": "squats", "reps": 5, "weight": 185, "count": 3}], "date": _today()})
+        _tool_manage_workouts({"action": "log_metric", "metric_type": "body_weight", "value": "178.4", "unit": "lb"})
+        _tool_manage_workouts({"action": "set_profile", "key": "goals", "value": "strength"})
+        out = _tool_manage_workouts({"action": "readiness"})
+        assert "Sessions (14d): 1" in out
+        assert "3 sets" in out               # volume
+        assert "body weight: 178.4 lb" in out
+        assert "goals=strength" in out
+
+    def test_readiness_includes_recovery_when_present(self, temp_store):
+        _tool_manage_workouts({"action": "log_metric", "metric_type": "resting_hr", "value": "54", "unit": "bpm"})
+        out = _tool_manage_workouts({"action": "readiness"})
+        assert "resting hr: 54" in out
+
+
 class TestSummaryFormatting:
     def test_groups_identical_sets(self):
         session = WorkoutSession(id="x", date="2026-06-07", sets=[


### PR DESCRIPTION
## Summary

Adds the recommendation side of the fitness bot. The training profile + `get_profile`/`set_profile` shipped in #320; this adds a `readiness` aggregation and a trainer-mode persona so "what should I train today?" is grounded in the user's real data.

Closes #322

## What's included

- **`manage_workouts` `readiness` action** — one call returns: recent session count (14d), 30-day volume (sessions/sets/reps/tonnage), available recovery signals (body weight now; sleep/resting-HR/HRV once Apple Health #323 lands), and the training profile. **Degrades gracefully** when little data exists (no sessions / no recovery metrics / no profile each get a clear line).
- **Fitness persona trainer mode** — on a recommendation request: pull `readiness` first, respect profile constraints (injuries/equipment/schedule/goals), give specific sets/reps/loads grounded in logged numbers, use recovery signals when present and say so when absent. No fluff.

## Scope note

Orchestrator-only — no REST `/api/fitness/readiness` endpoint and no system-prompt profile injection; the persona fetches profile/readiness on demand via the tool, consistent with #320's decision. Easy to add a REST surface later if external access is wanted.

## Test evidence

Targeted (full suite runs once at the end of this fitness batch — next): `tests/test_agent_tools_workouts.py` — 21 passed (3 new): readiness degrades gracefully when empty, aggregates volume + body weight + profile, and surfaces recovery metrics when present. Ruff clean.

## Review focus

- `readiness` date-window math (14d/30d off the store's timezone-aware "today").
- Graceful-degradation branches (empty store, no recovery metrics, no profile).
- Persona ordering: readiness → respect constraints → specific, data-grounded advice.