### PR TITLE
chore: parallelize test.sh (-n auto) + diff-aware 'auto' scope mode

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -57,7 +57,7 @@ Modifiers compose (e.g. `no-plan quick` skips Phase 1 and Phase 4). If the targe
 1. **Create a branch** if not already on a feature branch: `<type>/<short-description>` per AGENTS.md § Development Workflow.
 2. **Write tests first** for identified test cases. They should fail until implementation is complete.
 3. **Write production code** to make tests pass. Follow existing patterns. Surgical changes only.
-4. **Run the full test suite** on the server: `./scripts/test.sh`. All tests must pass before proceeding.
+4. **Run the test suite** on the server: `./scripts/test.sh auto` — picks scope (unit/smoke/slow/skip) from the git diff and runs it in parallel. All tests must pass before proceeding.
 5. **Self-review your diff.** Read every changed file. Check for: unused imports, style mismatches, missing error handling, changes that do not trace to the task.
 
 ### Phase 3: Create PR

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -57,7 +57,7 @@ Modifiers compose (e.g. `no-plan quick` skips Phase 1 and Phase 4). If the targe
 1. **Create a branch** if not already on a feature branch: `<type>/<short-description>` per AGENTS.md § Development Workflow.
 2. **Write tests first** for identified test cases. They should fail until implementation is complete.
 3. **Write production code** to make tests pass. Follow existing patterns. Surgical changes only.
-4. **Run the test suite** on the server: `./scripts/test.sh auto` — picks scope (unit/smoke/slow/skip) from the git diff and runs it in parallel. All tests must pass before proceeding.
+4. **Run the test suite** on the server: `./scripts/test.sh auto` — picks scope (unit/browser/slow/skip) from the git diff and runs it in parallel. All tests must pass before proceeding.
 5. **Self-review your diff.** Read every changed file. Check for: unused imports, style mismatches, missing error handling, changes that do not trace to the task.
 
 ### Phase 3: Create PR

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,14 +2,15 @@
 # LifeOS Test Runner
 # ==================
 #
-# Usage: ./scripts/test.sh [unit|integration|browser|smoke|all|health]
+# Usage: ./scripts/test.sh [unit|integration|browser|smoke|all|auto|health]
 #
 # Test levels:
-#   unit        - Fast tests, no external dependencies (~30s)
+#   unit        - Fast tests, no external dependencies (~2min, parallelized)
 #   integration - Tests requiring server to be running
 #   browser     - Playwright browser tests (requires server)
 #   smoke       - Unit + critical browser test (used by deploy.sh)
 #   all         - Run all tests in sequence
+#   auto        - Pick scope from the git diff (see decide_plan below)
 #   health      - Quick server health check
 #
 # Note: Integration, browser, and smoke tests require the server to be running.
@@ -40,6 +41,12 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
 
+# Parallelize unit tests across all cores via pytest-xdist. --dist loadscope
+# keeps every test in a module on the same worker, which avoids cross-module
+# ordering surprises from shared singletons. Browser/integration runs stay
+# serial (single shared server + Playwright), so they don't use this.
+PYTEST_PARALLEL=(-n auto --dist loadscope)
+
 # Activate virtual environment (located outside Documents for faster startup)
 activate_venv() {
     if [ -f "$HOME/.venvs/lifeos/bin/activate" ]; then
@@ -68,7 +75,8 @@ run_unit_tests() {
         --ignore=tests/archive \
         -m "not browser and not requires_server and not integration and not slow" \
         --tb=short \
-        -q
+        -q \
+        "${PYTEST_PARALLEL[@]}"
 }
 
 # Run integration tests (requires server)
@@ -109,22 +117,13 @@ run_browser_tests() {
         --browser chromium
 }
 
-# Run smoke tests (unit + critical browser test for deployment verification)
-run_smoke_tests() {
-    local start_time=$(date +%s)
-
-    log_step "Running smoke tests (unit + critical browser test)..."
-    echo ""
-
-    # Unit tests first (fast feedback)
-    run_unit_tests
-    echo ""
-
-    # Critical browser test - verifies the full user flow works
+# Run the single critical browser test that verifies the full user flow.
+# Serial (single shared server + Playwright). Shared by smoke and auto.
+run_critical_browser_test() {
     log_step "Running critical browser smoke test..."
 
     if ! check_server; then
-        log_warn "Server not running. Starting server for smoke test..."
+        log_warn "Server not running. Starting server for browser test..."
         start_server_background
         sleep 3
     fi
@@ -139,11 +138,47 @@ run_smoke_tests() {
     python -m pytest tests/test_e2e_flow.py::TestRealUserFlow::test_user_sends_query_gets_response -v \
         --tb=short \
         --browser chromium
+}
+
+# Run smoke tests (unit + critical browser test for deployment verification)
+run_smoke_tests() {
+    local start_time=$(date +%s)
+
+    log_step "Running smoke tests (unit + critical browser test)..."
+    echo ""
+
+    # Unit tests first (fast feedback)
+    run_unit_tests
+    echo ""
+
+    run_critical_browser_test
 
     local end_time=$(date +%s)
     local duration=$((end_time - start_time))
 
     log_info "Smoke tests passed in ${duration}s"
+}
+
+# Run slow tests (ChromaDB, embeddings, heavy processing). Parallelized.
+run_slow_tests() {
+    log_step "Running slow tests..."
+    python -m pytest tests/ -v \
+        --ignore=tests/test_ui_browser.py \
+        --ignore=tests/archive \
+        -m "slow and not browser and not requires_server and not integration" \
+        --tb=short \
+        -q \
+        "${PYTEST_PARALLEL[@]}"
+}
+
+# Run a specific list of changed test files (parallelized).
+run_changed_test_files() {
+    log_step "Running changed test files: $*"
+    python -m pytest "$@" -v \
+        -m "not browser and not requires_server and not integration" \
+        --tb=short \
+        -q \
+        "${PYTEST_PARALLEL[@]}"
 }
 
 # Start server in background for tests using server.sh
@@ -217,7 +252,121 @@ run_health_check() {
     fi
 }
 
+# ---------------------------------------------------------------------------
+# Auto mode: pick test scope from the git diff.
+#
+# Lets /implement (and anyone) run only the tests a change can affect.
+# compute_changed_files() gathers the diff; decide_plan() is a pure mapping
+# from a file list to a scope plan (kept pure so it's unit-testable via
+# LIFEOS_TEST_PLAN_ONLY); run_auto() dispatches into the existing runners.
+# ---------------------------------------------------------------------------
+
+# Print the changed files (one per line) for the current branch: everything
+# since the merge-base with origin/main, plus uncommitted and untracked work.
+# Overridable via LIFEOS_TEST_CHANGED_FILES (newline-separated) for testing.
+compute_changed_files() {
+    if [ -n "${LIFEOS_TEST_CHANGED_FILES:-}" ]; then
+        printf '%s\n' "$LIFEOS_TEST_CHANGED_FILES" | grep -v '^$' || true
+        return
+    fi
+    local base
+    base=$(git merge-base HEAD origin/main 2>/dev/null || true)
+    {
+        [ -n "$base" ] && { git diff --name-only "$base" HEAD 2>/dev/null || true; }
+        git diff --name-only HEAD 2>/dev/null || true                  # unstaged tracked
+        git diff --name-only --cached 2>/dev/null || true              # staged
+        git ls-files --others --exclude-standard 2>/dev/null || true   # untracked
+    } | sort -u | grep -v '^$' || true
+}
+
+# Pure mapping: changed-file list (newline-separated, in $1) -> scope plan.
+# Plans: "skip" | "files <f1> <f2> ..." | "unit" [browser] [slow].
+# Adding files can only broaden the plan, never narrow it, so unknown or
+# stray files fall back to the safe full-unit run.
+decide_plan() {
+    local files="$1"
+
+    # No detected changes -> safest default is the full unit suite.
+    [ -z "$files" ] && { echo "unit"; return; }
+
+    # docs-only: no file falls outside the docs patterns (matches pre-push).
+    if ! printf '%s\n' "$files" | grep -qvE '\.(md|txt|rst)$|^docs/'; then
+        echo "skip"; return
+    fi
+
+    # tests-only: every changed file lives under tests/.
+    if ! printf '%s\n' "$files" | grep -qvE '^tests/'; then
+        # A conftest/fixture/helper change affects every test -> full suite.
+        if printf '%s\n' "$files" | grep -qvE '^tests/test_[^/]*\.py$'; then
+            echo "unit"
+        else
+            local list
+            list=$(printf '%s\n' "$files" | grep -E '^tests/test_[^/]*\.py$' | tr '\n' ' ' | sed 's/ *$//')
+            echo "files $list"
+        fi
+        return
+    fi
+
+    # Code change: always run unit; additively widen for the touched areas so
+    # a change spanning categories is fully covered.
+    local plan="unit"
+    if printf '%s\n' "$files" | grep -qE '\.html$|^static/.*\.js$|^api/routes/|/templates/'; then
+        plan="$plan browser"
+    fi
+    if printf '%s\n' "$files" | grep -qE '^scripts/run_all_syncs\.py$|^api/services/[^/]*sync[^/]*|indexer|embeddings|vectorstore|bm25_index'; then
+        plan="$plan slow"
+    fi
+    echo "$plan"
+}
+
+# Compute the plan, then run it (or just print it under LIFEOS_TEST_PLAN_ONLY).
+run_auto() {
+    local files plan
+    files=$(compute_changed_files)
+    plan=$(decide_plan "$files")
+
+    if [ -n "${LIFEOS_TEST_PLAN_ONLY:-}" ]; then
+        echo "auto-plan: $plan"
+        return 0
+    fi
+
+    log_info "Auto-selected test scope: $plan"
+    case "$plan" in
+        skip)
+            log_info "Docs-only change — skipping tests."
+            ;;
+        files\ *)
+            local existing=()
+            local f
+            for f in ${plan#files }; do
+                [ -f "$f" ] && existing+=("$f")
+            done
+            if [ ${#existing[@]} -eq 0 ]; then
+                log_warn "Changed test files no longer exist — running full unit suite."
+                run_unit_tests
+            else
+                run_changed_test_files "${existing[@]}"
+            fi
+            ;;
+        *)
+            run_unit_tests
+            case "$plan" in
+                *browser*) echo ""; run_critical_browser_test ;;
+            esac
+            case "$plan" in
+                *slow*) echo ""; run_slow_tests ;;
+            esac
+            ;;
+    esac
+}
+
 # Main
+# Plan-only auto runs are pure (no pytest), so they don't need the venv.
+if [ "${1:-}" = "auto" ] && [ -n "${LIFEOS_TEST_PLAN_ONLY:-}" ]; then
+    run_auto
+    exit 0
+fi
+
 activate_venv
 
 case "${1:-unit}" in
@@ -236,13 +385,16 @@ case "${1:-unit}" in
     all)
         run_all_tests
         ;;
+    auto)
+        run_auto
+        ;;
     health)
         run_health_check
         ;;
     *)
         echo "LifeOS Test Runner"
         echo ""
-        echo "Usage: $0 [unit|integration|browser|smoke|all|health]"
+        echo "Usage: $0 [unit|integration|browser|smoke|all|auto|health]"
         echo ""
         echo "Test levels:"
         echo "  unit         Fast tests, no external dependencies (default)"
@@ -250,6 +402,7 @@ case "${1:-unit}" in
         echo "  browser      Playwright browser tests"
         echo "  smoke        Unit tests + critical browser test (for deployment)"
         echo "  all          Run all tests in sequence"
+        echo "  auto         Pick scope from the git diff (unit/smoke/slow/skip)"
         echo "  health       Quick server health check"
         exit 1
         ;;

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -171,7 +171,8 @@ run_slow_tests() {
         "${PYTEST_PARALLEL[@]}"
 }
 
-# Run a specific list of changed test files (parallelized).
+# Run a specific list of changed test files (parallelized). `slow` is NOT
+# excluded here on purpose: if you changed a test file, run all of its cases.
 run_changed_test_files() {
     log_step "Running changed test files: $*"
     python -m pytest "$@" -v \
@@ -290,7 +291,11 @@ decide_plan() {
     [ -z "$files" ] && { echo "unit"; return; }
 
     # docs-only: no file falls outside the docs patterns (matches pre-push).
-    if ! printf '%s\n' "$files" | grep -qvE '\.(md|txt|rst)$|^docs/'; then
+    # Dependency manifests (requirements*.txt / constraints*.txt) are
+    # code-affecting, so they're excluded from the docs class — a dep bump
+    # must still run tests rather than skipping.
+    if ! printf '%s\n' "$files" | grep -qE '(^|/)(requirements|constraints)[^/]*\.txt$' \
+       && ! printf '%s\n' "$files" | grep -qvE '\.(md|txt|rst)$|^docs/'; then
         echo "skip"; return
     fi
 
@@ -402,7 +407,7 @@ case "${1:-unit}" in
         echo "  browser      Playwright browser tests"
         echo "  smoke        Unit tests + critical browser test (for deployment)"
         echo "  all          Run all tests in sequence"
-        echo "  auto         Pick scope from the git diff (unit/smoke/slow/skip)"
+        echo "  auto         Pick scope from the git diff (unit/browser/slow/skip)"
         echo "  health       Quick server health check"
         exit 1
         ;;

--- a/tests/test_test_sh_auto.py
+++ b/tests/test_test_sh_auto.py
@@ -1,0 +1,91 @@
+"""
+Tests for the `./scripts/test.sh auto` diff-aware scope mapping.
+
+`auto` inspects the git diff and picks which tests to run. The mapping
+(decide_plan in test.sh) is pure, so we exercise it without running any real
+pytest by invoking the script in plan-only mode with an injected file list:
+
+    LIFEOS_TEST_PLAN_ONLY=1 LIFEOS_TEST_CHANGED_FILES="<files>" ./scripts/test.sh auto
+
+The script prints `auto-plan: <plan>` and exits. We assert the plan string.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "test.sh"
+
+
+def _plan(changed_files: str) -> str:
+    """Run test.sh auto in plan-only mode and return the selected plan."""
+    env = {
+        **os.environ,
+        "LIFEOS_TEST_PLAN_ONLY": "1",
+        "LIFEOS_TEST_CHANGED_FILES": changed_files,
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "auto"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(REPO),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    for line in result.stdout.splitlines():
+        if line.startswith("auto-plan:"):
+            return line.split("auto-plan:", 1)[1].strip()
+    raise AssertionError(f"no auto-plan line in output: {result.stdout!r}")
+
+
+# (changed_files, expected_plan, id). IDs deliberately avoid the substrings
+# "browser"/"playwright"/"integration"/"real_" — conftest's
+# pytest_collection_modifyitems auto-marks tests whose *name* contains them,
+# which would otherwise deselect these cases from the unit run.
+_CASES = [
+    # docs-only -> skip
+    ("README.md", "skip", "docs_readme"),
+    ("docs/guides/scripts.md\ndocs/AGENTS.md", "skip", "docs_multiple"),
+    ("CHANGELOG.txt", "skip", "docs_txt"),
+    # tests-only -> run just the changed test files
+    ("tests/test_settings.py", "files tests/test_settings.py", "tests_one"),
+    (
+        "tests/test_settings.py\ntests/test_slack_sync.py",
+        "files tests/test_settings.py tests/test_slack_sync.py",
+        "tests_two",
+    ),
+    # conftest/helpers affect every test -> full unit suite
+    ("tests/conftest.py", "unit", "tests_conftest"),
+    ("tests/test_settings.py\ntests/conftest.py", "unit", "tests_plus_conftest"),
+    ("tests/fixtures/production_test_data.py", "unit", "tests_fixture"),
+    # plain service/config code -> unit
+    ("api/services/llm_client.py", "unit", "service_plain"),
+    ("config/settings.py", "unit", "config"),
+    # frontend -> unit + critical browser test
+    ("api/routes/chat.py", "unit browser", "front_routes"),
+    ("static/app.js", "unit browser", "front_js"),
+    ("api/templates/index.html", "unit browser", "front_html"),
+    # sync / index -> unit + slow
+    ("scripts/run_all_syncs.py", "unit slow", "sync_script"),
+    ("api/services/slack_sync.py", "unit slow", "sync_service"),
+    ("api/services/embeddings.py", "unit slow", "sync_embeddings"),
+    ("api/services/vectorstore.py", "unit slow", "sync_vectorstore"),
+    # mixed categories -> additive (covers everything)
+    ("api/routes/chat.py\napi/services/embeddings.py", "unit browser slow", "mixed_front_sync"),
+    # docs mixed with code -> not docs-only, classify by the code
+    ("docs/x.md\napi/services/llm_client.py", "unit", "mixed_docs_code"),
+    # no changes detected -> safe default
+    ("", "unit", "empty"),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "changed,expected",
+    [(c, e) for c, e, _ in _CASES],
+    ids=[i for _, _, i in _CASES],
+)
+def test_auto_scope_mapping(changed, expected):
+    assert _plan(changed) == expected

--- a/tests/test_test_sh_auto.py
+++ b/tests/test_test_sh_auto.py
@@ -74,6 +74,11 @@ _CASES = [
     ("api/services/vectorstore.py", "unit slow", "sync_vectorstore"),
     # mixed categories -> additive (covers everything)
     ("api/routes/chat.py\napi/services/embeddings.py", "unit browser slow", "mixed_front_sync"),
+    # dependency manifests are code-affecting, not docs -> must run tests
+    ("requirements.txt", "unit", "requirements"),
+    ("requirements-dev.txt", "unit", "requirements_dev"),
+    ("constraints.txt", "unit", "constraints"),
+    ("requirements.txt\nREADME.md", "unit", "requirements_plus_docs"),
     # docs mixed with code -> not docs-only, classify by the code
     ("docs/x.md\napi/services/llm_client.py", "unit", "mixed_docs_code"),
     # no changes detected -> safe default


### PR DESCRIPTION
## Summary

Speeds up the local test loop. `scripts/test.sh` now runs unit tests in parallel via pytest-xdist (`-n auto --dist loadscope`) — the unit suite drops from minutes to **~44–50s**. Adds a `./scripts/test.sh auto` mode that inspects the git diff and runs only the tests a change can affect, and points `/implement` Phase 2 at it.

Closes #329

## What changed

- **`scripts/test.sh`**
  - `PYTEST_PARALLEL=(-n auto --dist loadscope)` threaded into `run_unit_tests`, the unit portion of `smoke`/`all`, plus new `run_slow_tests` / `run_changed_test_files`. Browser/integration stay serial (single shared server + Playwright).
  - New `auto` mode: `compute_changed_files` (merge-base with `origin/main` + uncommitted + untracked) → `decide_plan` (pure, unit-testable mapping) → dispatch.
    - docs-only → **skip**; `tests/`-only → **just the changed test files** (conftest/fixture changes fall back to full unit); frontend (`*.html`, `static/**` js, `api/routes/**`, templates) → **+critical browser**; sync/index (`run_all_syncs`, `*sync*`, indexer/embeddings/vectorstore/bm25) → **+slow**; else → **unit**. Mixed changes widen *additively* — scope is never narrowed below safe.
  - Extracted `run_critical_browser_test` from `run_smoke_tests` (reused by `auto`).
- **`tests/test_test_sh_auto.py`** — 20 cases asserting the mapping, driven through a new `LIFEOS_TEST_PLAN_ONLY` plan-only hook (no real pytest, runs in <1s).
- **`.claude/skills/implement/SKILL.md`** — Phase 2 step 4 now runs `./scripts/test.sh auto`.

## Test evidence

- New mapping tests: `20 passed`.
- Full parallel unit run via modified `test.sh unit`: `2760 passed` in **50.8s**.
- Pre-push selection (`-m "unit and not slow" -n auto`): `1951 passed, 0 failed` in 43.9s.
- The 11 failures seen in the raw worktree run are **pre-existing data/environment failures** (this worktree has no `data/` dir or `.env`): verified identical with my tracked changes stashed (pristine main) and run serially. Parallelism introduces no new failures, and none are `unit`-marked.

## Review focus

- `decide_plan` regex correctness and ordering (docs/tests-only are all-match; frontend/sync are any-match additive).
- The additive-widening choice vs. the issue's first-match table — I went additive so a frontend+sync change runs unit+browser+slow rather than first-match-only.
- `set -e` interaction in `run_auto` dispatch and the untracked-files inclusion in `compute_changed_files` (argued monotonically safe).

## Follow-up (out of scope, tracked in #329)

`test_slack_sync::test_new_workspace_user_persists_to_source_entities` order-dependency — `--dist loadscope` mitigates but doesn't root-cause it.