### PR TITLE
feat(fitness): Apple Health import via iOS Shortcut (server side)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,6 +300,11 @@ LIFEOS_RELATIONSHIP_FOLDER=Relationship
 # has no per-file write scope, so this grants read-write to ALL your Sheets.
 # LIFEOS_FITNESS_SHEET_ID=
 
+# Apple Health import: path to the health.json written by the iOS Shortcut
+# (see docs/guides/apple-health.md). Default: data/apple-imports/health.json.
+# Point at a synced location (e.g. ~/Code/Sync/health/health.json) for automation.
+# LIFEOS_HEALTH_EXPORT_PATH=
+
 # =============================================================================
 # FINANCIAL DATA (optional)
 # =============================================================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMe
 | How does the agent worker work internally? | [specs/technical/agent-worker.md](docs/specs/technical/agent-worker.md) |
 | How do I set up the agent worker? | [guides/agent-worker-setup.md](docs/guides/agent-worker-setup.md) |
 | How do schedules (triggers + actions) work? | [guides/scheduler.md](docs/guides/scheduler.md) |
+| How do I import Apple Health/Fitness data? | [guides/apple-health.md](docs/guides/apple-health.md) |
 | What does `/agents` show? | [specs/product/agent-viz.md](docs/specs/product/agent-viz.md) |
 | How does the `/agents` page work internally? | [specs/technical/agent-viz.md](docs/specs/technical/agent-viz.md) |
 | What does the CRM do (overview)? | [specs/product/crm-ui.md](docs/specs/product/crm-ui.md) |

--- a/api/services/fitness_store.py
+++ b/api/services/fitness_store.py
@@ -246,6 +246,33 @@ class FitnessStore:
             for r in rows
         ]
 
+    def has_workout_ref(self, raw_ref: str) -> bool:
+        """Whether a session with this provenance ref (e.g. an Apple workout UUID)
+        already exists — used for idempotent imports."""
+        if not raw_ref:
+            return False
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM workout_sessions WHERE raw_ref = ? LIMIT 1", (raw_ref,)
+            ).fetchone()
+        finally:
+            conn.close()
+        return row is not None
+
+    def has_metric(self, metric_type: str, start_at: str) -> bool:
+        """Whether a metric sample at this (type, start_at) already exists — used
+        for idempotent imports."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM health_metrics WHERE metric_type = ? AND start_at = ? LIMIT 1",
+                (metric_type, start_at),
+            ).fetchone()
+        finally:
+            conn.close()
+        return row is not None
+
     def get_latest_session(self) -> Optional[WorkoutSession]:
         conn = sqlite3.connect(self.db_path)
         try:

--- a/config/settings.py
+++ b/config/settings.py
@@ -620,6 +620,12 @@ class Settings(BaseSettings):
         alias="LIFEOS_FITNESS_SHEET_ID",
         description="Google Sheet ID to mirror the workout log into (optional; mirror is off if unset)"
     )
+    health_export_path: str = Field(
+        default="data/apple-imports/health.json",
+        alias="LIFEOS_HEALTH_EXPORT_PATH",
+        description="Path to the Apple Health export JSON written by the iOS Shortcut "
+                    "(e.g. a synced ~/Code/Sync/health/health.json). Imported nightly."
+    )
 
     # Monarch Money
     monarch_email: str = Field(

--- a/docs/adr/010-apple-data-agent.md
+++ b/docs/adr/010-apple-data-agent.md
@@ -114,6 +114,7 @@ Skip the export step entirely; have Linux read the Mac's `~/Library/` over a net
 
 ### Design Context
 - [ADR-007: Linux Migration](007-linux-migration.md) — Established the multi-machine pattern this ADR formalizes; the Mac's role change to "Apple Data Agent" was part of that decision but not given its own record
+- [ADR-014: Apple Health collection & import](014-apple-health-collection.md) — Parallels this pipeline for Health data; explains why the Mac-side reader doesn't extend to HealthKit (iOS-only data)
 
 ### Specifications
 - [Data & Sync](../specs/technical/data-and-sync.md) — Seven-phase nightly sync pipeline; phase 5 imports the Mac's export

--- a/docs/adr/013-fitness-store.md
+++ b/docs/adr/013-fitness-store.md
@@ -11,48 +11,83 @@ workouts from text, tracks body metrics (morning weight, resting HR), holds a
 training profile, and imports Apple Health/Fitness data. This data needs a home.
 
 The established data model is the two-tier `SourceEntity` → `PersonEntity`
-structure ([ADR-003](003-two-tier-data-model.md)) — built to resolve *people*
-across sources (an email, a phone, a Slack id all map to one person). Its
-fields are person-contact-centric (`observed_name`, `observed_email`,
-`observed_phone`, `canonical_person_id`).
+structure ([ADR-003](003-two-tier-data-model.md)), built to resolve *people*
+across sources. Its fields are person-contact-centric (`observed_name`,
+`observed_email`, `observed_phone`, `canonical_person_id`).
 
-Workout and health data is **not about other people** — it's the user's own
+Workout and health data is **not about other people** — it is the user's own
 time-series: sets/reps/loads, body weight, heart rate, sleep, Apple workouts.
-It's also high-volume (a year of HealthKit samples is tens of thousands of
-rows) and queried very differently (date-range scans, volume aggregation,
+It is also high-volume (a year of HealthKit samples is tens of thousands of
+rows) and queried differently (date-range scans, volume aggregation,
 trend-over-time) than person resolution.
 
 ## Decision
 
 Store fitness data in a **dedicated SQLite store, `data/fitness.db`**
-(`api/services/fitness_store.py`), separate from the CRM model:
+(`api/services/fitness_store.py`), separate from the CRM model. Tables:
+`workout_sessions`, `workout_sets`, `health_metrics`, `training_profile`, with a
+`source` column (`manual` | `apple_health`) unifying hand-logged and imported
+data. The store is self-referential — no `person_id`, no entity resolution.
+Raw health metrics are queried by direct SQL and are **never embedded into
+ChromaDB**; only human-readable workout *summaries* are candidates for semantic
+indexing. The orchestrator reaches it through the `manage_workouts` tool.
 
-- Tables: `workout_sessions`, `workout_sets`, `health_metrics`,
-  `training_profile`. A `source` column (`manual` | `apple_health`) unifies
-  hand-logged and imported data.
-- It is **self-referential** — there is no `person_id`; everything is the user's
-  own data. No entity resolution applies.
-- **Raw health metrics are never embedded into ChromaDB** (volume). They're
-  queried by direct SQL (date-range scans). Only human-readable workout
-  *summaries* are candidates for semantic indexing (deferred; see #323).
-- The orchestrator reaches it through the `manage_workouts` tool, not the
-  person-centric CRM tools.
+## Rationale
+
+The CRM model exists to answer "who is this and how do they connect to other
+people." Fitness data has no such question — it is single-subject time-series.
+Forcing it into `SourceEntity` would mean abusing person-contact fields for
+metric data, bloating the entity tables and the vector index with tens of
+thousands of low-value rows, and inheriting entity-resolution machinery that
+does nothing useful here. A purpose-built store keeps queries fast
+(date-range/aggregation) and keeps the CRM model clean.
+
+## Alternatives Considered
+
+### Extend `SourceEntity` with health fields
+
+Add `source_type="health_*"` rows and stuff metrics into the generic `metadata`
+JSON, pointing `canonical_person_id` at a "self" person.
+
+**Rejected because:** the dataclass is contact-centric (name/email/phone), the
+`metadata` blob is unindexed and unvalidated for metric queries, and a year of
+samples would bloat the shared entity tables. Entity resolution would run over
+data that has no person to resolve.
+
+### Index all health data into ChromaDB
+
+Treat each metric/workout as a document for semantic search.
+
+**Rejected because:** raw metrics are high-volume and numeric — semantic search
+over "step count = 8123" is useless and expensive. Direct SQL is the right
+query path; only workout summaries benefit from embedding.
 
 ## Consequences
 
-- **Pro:** Clean separation — the CRM model stays about people; fitness queries
-  are fast and purpose-built; high-volume health data doesn't bloat the entity
-  tables or the vector index.
-- **Pro:** Apple Health import ([ADR-014](014-apple-health-collection.md)) writes
-  into the same store with `source=apple_health`, so manual and device data sit
-  side by side.
-- **Con:** A second storage model to maintain. Mitigated by following the same
-  SQLite idioms as the other stores (`conversation_store.py`).
-- **Con:** Fitness data won't appear in person timelines or cross-source entity
-  views. That's intended — it isn't about other people.
+### Positive
+
+- Clean separation — the CRM model stays about people; fitness queries are fast
+  and purpose-built; high-volume data doesn't bloat the entity tables or vector
+  index.
+- Apple Health import ([ADR-014](014-apple-health-collection.md)) writes into the
+  same store with `source=apple_health`, so manual and device data sit together.
+- Follows the existing SQLite idioms (`conversation_store.py`), so it's familiar.
+
+### Negative
+
+- A second storage model to maintain alongside the CRM stores.
+- Fitness data won't appear in person timelines or cross-source entity views —
+  intended, since it isn't about other people, but a boundary to remember.
 
 ## Related Documents
 
-- [ADR-003 — Two-Tier Data Model](003-two-tier-data-model.md)
-- [ADR-014 — Apple Health collection & import](014-apple-health-collection.md)
-- [guides/apple-health.md](../guides/apple-health.md)
+### Design Context
+- [ADR-003: Two-Tier Data Model](003-two-tier-data-model.md) — The person-centric model this store deliberately sits outside of
+- [ADR-014: Apple Health collection & import](014-apple-health-collection.md) — Writes into this store with `source=apple_health`
+
+### Operational
+- [guides/apple-health.md](../guides/apple-health.md) — How Apple data lands in this store
+
+### Code References
+- [`api/services/fitness_store.py`](../../api/services/fitness_store.py) — The store
+- [`api/services/agent_tools.py`](../../api/services/agent_tools.py) — `manage_workouts` tool over it

--- a/docs/adr/013-fitness-store.md
+++ b/docs/adr/013-fitness-store.md
@@ -1,0 +1,58 @@
+# ADR-013: Self-Data Fitness Store (outside the two-tier CRM model)
+
+**Status:** Complete
+**Last Updated:** 2026-06-08
+**Decision:** Accepted
+
+## Context
+
+LifeOS gained a fitness capability (issues #320–#323): a Telegram bot logs
+workouts from text, tracks body metrics (morning weight, resting HR), holds a
+training profile, and imports Apple Health/Fitness data. This data needs a home.
+
+The established data model is the two-tier `SourceEntity` → `PersonEntity`
+structure ([ADR-003](003-two-tier-data-model.md)) — built to resolve *people*
+across sources (an email, a phone, a Slack id all map to one person). Its
+fields are person-contact-centric (`observed_name`, `observed_email`,
+`observed_phone`, `canonical_person_id`).
+
+Workout and health data is **not about other people** — it's the user's own
+time-series: sets/reps/loads, body weight, heart rate, sleep, Apple workouts.
+It's also high-volume (a year of HealthKit samples is tens of thousands of
+rows) and queried very differently (date-range scans, volume aggregation,
+trend-over-time) than person resolution.
+
+## Decision
+
+Store fitness data in a **dedicated SQLite store, `data/fitness.db`**
+(`api/services/fitness_store.py`), separate from the CRM model:
+
+- Tables: `workout_sessions`, `workout_sets`, `health_metrics`,
+  `training_profile`. A `source` column (`manual` | `apple_health`) unifies
+  hand-logged and imported data.
+- It is **self-referential** — there is no `person_id`; everything is the user's
+  own data. No entity resolution applies.
+- **Raw health metrics are never embedded into ChromaDB** (volume). They're
+  queried by direct SQL (date-range scans). Only human-readable workout
+  *summaries* are candidates for semantic indexing (deferred; see #323).
+- The orchestrator reaches it through the `manage_workouts` tool, not the
+  person-centric CRM tools.
+
+## Consequences
+
+- **Pro:** Clean separation — the CRM model stays about people; fitness queries
+  are fast and purpose-built; high-volume health data doesn't bloat the entity
+  tables or the vector index.
+- **Pro:** Apple Health import ([ADR-014](014-apple-health-collection.md)) writes
+  into the same store with `source=apple_health`, so manual and device data sit
+  side by side.
+- **Con:** A second storage model to maintain. Mitigated by following the same
+  SQLite idioms as the other stores (`conversation_store.py`).
+- **Con:** Fitness data won't appear in person timelines or cross-source entity
+  views. That's intended — it isn't about other people.
+
+## Related Documents
+
+- [ADR-003 — Two-Tier Data Model](003-two-tier-data-model.md)
+- [ADR-014 — Apple Health collection & import](014-apple-health-collection.md)
+- [guides/apple-health.md](../guides/apple-health.md)

--- a/docs/adr/014-apple-health-collection.md
+++ b/docs/adr/014-apple-health-collection.md
@@ -1,0 +1,59 @@
+# ADR-014: Apple Health Collection via iOS Shortcut
+
+**Status:** Complete
+**Last Updated:** 2026-06-08
+**Decision:** Accepted
+
+## Context
+
+LifeOS imports Apple Health/Fitness data into the fitness store
+([ADR-013](013-fitness-store.md)). The open question (issue #323) was **how to
+get the data off Apple devices.**
+
+The existing Apple Data Agent ([ADR-010](010-apple-data-agent.md)) runs on the
+Mac Mini and reads protected macOS databases (Messages, Contacts, CallHistory,
+Photos) under a Full Disk Access grant. The initial assumption was that Health
+would slot in the same way — a Swift HealthKit CLI on the Mini.
+
+That assumption is wrong: **macOS has no Health app, and a Mac does not hold the
+iPhone/Watch HealthKit store.** HealthKit data is iOS/watchOS-resident and does
+not sync to Macs for third-party reads. A Mac-side reader would find an empty
+store. The viable readers are all on iOS.
+
+## Decision
+
+Collect Apple Health data with an **iOS Shortcut** running on the iPhone:
+
+- The Shortcut reads HealthKit (workouts + selected quantity samples) and writes
+  a `health.json` (schema in [guides/apple-health.md](../guides/apple-health.md))
+  into a **synced folder** (the Syncthing `~/Code/Sync/` share, already mirrored
+  to the server). A daily iOS Automation runs it.
+- The **server-side import is collection-agnostic**: `import_health()` in
+  `scripts/apple_data_import.py` reads the JSON from
+  `LIFEOS_HEALTH_EXPORT_PATH` and upserts into `data/fitness.db`. It runs as one
+  of the sources in the existing nightly `apple_import` step.
+- **Idempotency:** workouts dedupe on the HKWorkout `uuid`, metrics on
+  `(type, start)`. Timestamps are normalized to UTC on import.
+- A manual **Health-app XML export** remains a fallback for one-time history
+  backfill (same import target).
+
+The originally-considered **Swift HealthKit CLI on the Mac Mini is rejected** —
+the Mini doesn't have the data.
+
+## Consequences
+
+- **Pro:** Works with Apple's actual data residency; no fragile attempt to read
+  iPhone data from a Mac. No new macOS/Swift build dependency.
+- **Pro:** The import is decoupled from collection — if Apple ever offers a
+  better export, only the producer changes; the importer is unchanged.
+- **Con:** The Shortcut is built and maintained on the phone (can't be authored
+  from the server), and HealthKit "Find Samples" actions are slow over long
+  ranges — mitigated by a small daily window plus idempotent overlap.
+- **Con:** Collection depends on the iOS Automation actually firing; a missed
+  day is self-healing on the next run (idempotent, windowed).
+
+## Related Documents
+
+- [ADR-010 — Apple Data Agent](010-apple-data-agent.md)
+- [ADR-013 — Self-data fitness store](013-fitness-store.md)
+- [guides/apple-health.md](../guides/apple-health.md)

--- a/docs/adr/014-apple-health-collection.md
+++ b/docs/adr/014-apple-health-collection.md
@@ -22,38 +22,69 @@ store. The viable readers are all on iOS.
 
 ## Decision
 
-Collect Apple Health data with an **iOS Shortcut** running on the iPhone:
+Collect Apple Health data with an **iOS Shortcut** on the iPhone. The Shortcut
+reads HealthKit and writes a `health.json` (schema in
+[guides/apple-health.md](../guides/apple-health.md)) into a synced folder (the
+Syncthing `~/Code/Sync/` share, already mirrored to the server); a daily iOS
+Automation runs it. The **server-side import is collection-agnostic**:
+`import_health()` in `scripts/apple_data_import.py` reads the JSON from
+`LIFEOS_HEALTH_EXPORT_PATH` and upserts into `data/fitness.db`, running as a
+source in the existing nightly `apple_import` step. Idempotency: workouts dedupe
+on the HKWorkout `uuid`, metrics on `(type, start)`; timestamps normalize to UTC.
 
-- The Shortcut reads HealthKit (workouts + selected quantity samples) and writes
-  a `health.json` (schema in [guides/apple-health.md](../guides/apple-health.md))
-  into a **synced folder** (the Syncthing `~/Code/Sync/` share, already mirrored
-  to the server). A daily iOS Automation runs it.
-- The **server-side import is collection-agnostic**: `import_health()` in
-  `scripts/apple_data_import.py` reads the JSON from
-  `LIFEOS_HEALTH_EXPORT_PATH` and upserts into `data/fitness.db`. It runs as one
-  of the sources in the existing nightly `apple_import` step.
-- **Idempotency:** workouts dedupe on the HKWorkout `uuid`, metrics on
-  `(type, start)`. Timestamps are normalized to UTC on import.
-- A manual **Health-app XML export** remains a fallback for one-time history
-  backfill (same import target).
+## Rationale
 
-The originally-considered **Swift HealthKit CLI on the Mac Mini is rejected** —
-the Mini doesn't have the data.
+Collection must run where the data actually lives — iOS. Decoupling collection
+(the Shortcut) from import (the server) means the producer can change without
+touching the importer, and the importer can be unit-tested against a fixture.
+Routing through the existing Sync share avoids any new transport. Idempotent,
+windowed imports make a missed automation run self-healing.
+
+## Alternatives Considered
+
+### Swift HealthKit CLI on the Mac Mini
+
+Mirror the existing Apple Data Agent — a compiled Swift binary reading
+`HKHealthStore` under the Mini's FDA grant.
+
+**Rejected because:** macOS does not hold the iPhone/Watch HealthKit store, so
+the CLI would read an empty store. This was the original plan and is the reason
+the issue was spiked before building.
+
+### Manual Health-app XML export only
+
+The iPhone Health app can export a full XML archive.
+
+**Rejected because:** it is manual and not automatable for ongoing sync. Kept as
+a **fallback for one-time history backfill** (same import target), not the
+primary path.
 
 ## Consequences
 
-- **Pro:** Works with Apple's actual data residency; no fragile attempt to read
-  iPhone data from a Mac. No new macOS/Swift build dependency.
-- **Pro:** The import is decoupled from collection — if Apple ever offers a
-  better export, only the producer changes; the importer is unchanged.
-- **Con:** The Shortcut is built and maintained on the phone (can't be authored
-  from the server), and HealthKit "Find Samples" actions are slow over long
-  ranges — mitigated by a small daily window plus idempotent overlap.
-- **Con:** Collection depends on the iOS Automation actually firing; a missed
-  day is self-healing on the next run (idempotent, windowed).
+### Positive
+
+- Works with Apple's actual data residency; no fragile attempt to read iPhone
+  data from a Mac, and no new macOS/Swift build dependency.
+- Import is decoupled from collection — a better future export only changes the
+  producer; the importer is unchanged and independently testable.
+
+### Negative
+
+- The Shortcut is built and maintained on the phone (can't be authored from the
+  server), and HealthKit "Find Samples" actions are slow over long ranges —
+  mitigated by a small daily window plus idempotent overlap.
+- Collection depends on the iOS Automation firing; a missed day self-heals on
+  the next windowed run.
 
 ## Related Documents
 
-- [ADR-010 — Apple Data Agent](010-apple-data-agent.md)
-- [ADR-013 — Self-data fitness store](013-fitness-store.md)
-- [guides/apple-health.md](../guides/apple-health.md)
+### Design Context
+- [ADR-010: Apple Data Agent](010-apple-data-agent.md) — The Mac-side pipeline this parallels; explains the FDA grant the rejected Swift-CLI alternative would have used
+- [ADR-013: Self-data fitness store](013-fitness-store.md) — Where imported data lands
+
+### Operational
+- [guides/apple-health.md](../guides/apple-health.md) — iOS Shortcut build steps + `health.json` schema
+
+### Code References
+- [`scripts/apple_data_import.py`](../../scripts/apple_data_import.py) — `import_health()`
+- [`tests/test_apple_health_import.py`](../../tests/test_apple_health_import.py) — Import coverage

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -14,6 +14,8 @@ This directory contains Architecture Decision Records (ADRs) — immutable recor
 - `010-apple-data-agent.md` — Mac as nightly source for iMessage, calls, and contacts
 - `011-external-agent-ingest.md` — Read-only direct-access ingest path for external agents
 - `012-embedding-pipeline.md` — GPU embedding pipeline with CPU fallback
+- `013-fitness-store.md` — Self-data fitness store, separate from the person-centric CRM model
+- `014-apple-health-collection.md` — Apple Health via an iOS Shortcut (a Mac has no HealthKit store)
 
 ## Key Principles
 

--- a/docs/guides/apple-health.md
+++ b/docs/guides/apple-health.md
@@ -1,0 +1,126 @@
+# Apple Health Import (iOS Shortcut → LifeOS)
+
+> **Audience:** Operators setting up Apple Health/Fitness ingestion
+> **Status:** Complete
+> **Last Updated:** 2026-06-08
+
+LifeOS imports Apple Health/Fitness data (workouts, body weight, resting heart
+rate, HRV, sleep, energy) into the fitness store so the fitness bot can
+cross-reference training with recovery.
+
+**Why a Shortcut and not a Mac job:** macOS has no Health app and a Mac does not
+hold the iPhone/Watch HealthKit store, so the data can only be read **on iOS**.
+An iOS Shortcut reads HealthKit and writes a `health.json` into a synced folder;
+the LifeOS server imports it nightly. See [ADR-014](../adr/014-apple-health-collection.md).
+
+The data lands in the **self-data fitness store** (`data/fitness.db`), not the
+person-centric CRM model — see [ADR-013](../adr/013-fitness-store.md).
+
+---
+
+## 1. Where the file goes
+
+The importer reads `LIFEOS_HEALTH_EXPORT_PATH` (default
+`data/apple-imports/health.json`). The simplest automated path is the Syncthing
+share that's already mirrored to every machine:
+
+1. Pick a synced location, e.g. `~/Code/Sync/health/health.json`.
+2. Set it in `.env` on the server:
+   ```
+   LIFEOS_HEALTH_EXPORT_PATH=/home/nathanramia/Code/Sync/health/health.json
+   ```
+   (No "mover" step needed — the Shortcut writes into the synced folder on the
+   phone via iCloud Drive/Working Copy, or you point the path at wherever your
+   sync tool lands the file.)
+
+---
+
+## 2. The `health.json` schema
+
+The Shortcut must emit this shape (extra keys are ignored):
+
+```json
+{
+  "generated_at": "2026-06-08T06:00:00-04:00",
+  "watermark": "2026-06-07T00:00:00-04:00",
+  "workouts": [
+    {
+      "uuid": "F1A2…",                 // HKWorkout UUID — REQUIRED, dedupe key
+      "type": "Running",               // workout type (friendly or HK identifier)
+      "start": "2026-06-07T08:00:00-04:00",
+      "end": "2026-06-07T08:55:00-04:00",
+      "duration_s": 3300,
+      "distance_m": 10000,             // optional
+      "energy_kcal": 620,              // optional
+      "avg_hr": 145                    // optional
+    }
+  ],
+  "metrics": [
+    { "type": "body_weight", "value": 178.4, "unit": "lb",
+      "start": "2026-06-07T07:00:00-04:00" },
+    { "type": "resting_hr", "value": 54, "unit": "bpm",
+      "start": "2026-06-07T07:00:00-04:00" },
+    { "type": "sleep_hours", "value": 7.2, "unit": "h",
+      "start": "2026-06-07T00:00:00-04:00", "end": "2026-06-07T07:00:00-04:00" }
+  ]
+}
+```
+
+Notes:
+- **`uuid` is required** on workouts — it's the idempotency key, so re-running
+  the Shortcut never duplicates a session. Metrics dedupe on `(type, start)`.
+- Timestamps may carry any offset or a trailing `Z`; the importer normalizes to
+  UTC.
+- Suggested `metrics.type` values the fitness bot recognizes as recovery
+  signals: `body_weight`, `resting_hr`, `hrv`, `sleep_hours`. Any other type is
+  imported and queryable too.
+
+---
+
+## 3. Building the iOS Shortcut (on the iPhone)
+
+> Built once on the phone. This can't be done from the Linux/Mac side.
+
+1. **Shortcuts app → +** (new shortcut). Name it "LifeOS Health Export".
+2. For each data type, add a **Find Health Samples** action, filter
+   **Start Date is in the last 1 day** (or since your watermark), then build a
+   dictionary entry per sample:
+   - **Workouts:** Find Workouts → for each, read UUID, type, start/end,
+     duration, distance, active energy, average heart rate.
+   - **Body weight / resting HR / HRV / sleep / energy:** Find Health Samples
+     for each quantity type → value, unit, start (+ end for sleep).
+3. Assemble a **Dictionary** matching the schema above (`workouts` and `metrics`
+   arrays), then **Get Text from Dictionary** (JSON).
+4. **Save File** → overwrite to your synced location (iCloud Drive folder that
+   maps to `~/Code/Sync/health/health.json`, or use the Working Copy/Syncthing
+   app's save target).
+5. **Automation:** Shortcuts → Automation → **Time of Day → 6:00 AM, daily** →
+   run "LifeOS Health Export". (Optionally also run it manually after a workout.)
+
+> Tip: HealthKit "Find Samples" actions can be slow over long ranges. Keep the
+> daily window small (last 1–2 days); the importer's idempotency means overlap
+> is harmless. For a one-time history backfill, run a wider window once.
+
+---
+
+## 4. Import & verify (server)
+
+The import runs automatically as part of the nightly **`apple_import`** sync
+step (it's one of the Apple import sources). To run it on demand:
+
+```bash
+~/.venvs/lifeos/bin/python scripts/apple_data_import.py --execute --source health
+```
+
+Expected output includes `workouts +N` / `metrics +N`. Then query via the
+fitness bot ("what's my body weight trend", "readiness") or directly — health
+metrics and Apple workouts live in `data/fitness.db` alongside your manual log.
+
+---
+
+## Related Documents
+
+- [ADR-013 — Self-data fitness store](../adr/013-fitness-store.md)
+- [ADR-014 — Apple Health collection & import](../adr/014-apple-health-collection.md)
+- [ADR-010 — Apple Data Agent](../adr/010-apple-data-agent.md)
+- [guides/scheduler.md](scheduler.md) — proactive check-ins (e.g. morning weight)

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -712,11 +712,146 @@ def import_whatsapp(dry_run: bool = False, manifest: dict | None = None) -> dict
     }
 
 
+# ---------------------------------------------------------------------------
+# Apple Health (#323) — written into the self-data fitness store, NOT the
+# person-centric SourceEntity model (see ADR-013). Source is an iOS Shortcut
+# that emits health.json into a synced path (see docs/guides/apple-health.md).
+# ---------------------------------------------------------------------------
+
+# Apple HKWorkoutActivityType (or a friendly label) → our session kind.
+_HEALTH_KIND_MAP = {
+    "running": "cardio", "walking": "cardio", "cycling": "cardio",
+    "swimming": "cardio", "rowing": "cardio", "elliptical": "cardio",
+    "hiking": "cardio", "highintensityintervaltraining": "cardio",
+    "functionalstrengthtraining": "strength", "traditionalstrengthtraining": "strength",
+    "yoga": "mobility", "coretraining": "mobility", "flexibility": "mobility",
+}
+
+
+def _to_utc_iso(ts: str | None) -> str:
+    """Normalize an ISO8601 timestamp (with offset or trailing Z) to UTC ISO."""
+    if not ts:
+        return ""
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat()
+    except (ValueError, TypeError):
+        return ts
+
+
+def _health_kind(workout_type: str | None) -> str:
+    if not workout_type:
+        return "cardio"
+    key = re.sub(r"[^a-z]", "", workout_type.lower()).replace("hkworkoutactivitytype", "")
+    return _HEALTH_KIND_MAP.get(key, "cardio")
+
+
+def _workout_summary(w: dict) -> str:
+    """One-line human summary for an Apple workout, e.g. '10.0 km · 55 min · 145 bpm'."""
+    parts = []
+    dist = w.get("distance_m")
+    if dist:
+        parts.append(f"{dist / 1000:.1f} km")
+    dur = w.get("duration_s")
+    if dur:
+        parts.append(f"{int(dur // 60)} min")
+    energy = w.get("energy_kcal")
+    if energy:
+        parts.append(f"{int(energy)} kcal")
+    hr = w.get("avg_hr")
+    if hr:
+        parts.append(f"{int(hr)} bpm")
+    return " · ".join(parts)
+
+
+def import_health(dry_run: bool = False) -> dict:
+    """Import Apple Health export (health.json) into the fitness store.
+
+    Workouts → workout_sessions(source=apple_health); metrics → health_metrics.
+    Idempotent: workouts dedupe on the Apple UUID, metrics on (type, start_at).
+    Absent file → skipped (a fresh clone / no-iPhone setup is unaffected).
+    """
+    from config.settings import settings
+    path = Path(settings.health_export_path)
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+    if not path.exists():
+        logger.info(f"No Apple Health export at {path} — skipping")
+        return {"status": "skipped", "reason": "no health.json"}
+
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        return {"status": "error", "error": f"could not read {path}: {e}"}
+
+    from api.services.fitness_store import get_fitness_store
+    store = get_fitness_store()
+
+    w_created = w_skipped = m_created = m_skipped = 0
+
+    for w in data.get("workouts", []):
+        ref = (w.get("uuid") or "").strip()
+        if not ref:
+            continue
+        if store.has_workout_ref(ref):
+            w_skipped += 1
+            continue
+        if dry_run:
+            w_created += 1
+            continue
+        start = _to_utc_iso(w.get("start"))
+        date = start[:10] if start else None
+        store.add_session(
+            sets=[],
+            date=date,
+            kind=_health_kind(w.get("type")),
+            source="apple_health",
+            title=w.get("type", "") or "Workout",
+            notes=_workout_summary(w),
+            raw_ref=ref,
+        )
+        w_created += 1
+
+    for m in data.get("metrics", []):
+        mtype = (m.get("type") or "").strip()
+        value = m.get("value")
+        if not mtype or value is None:
+            continue
+        start = _to_utc_iso(m.get("start"))
+        if store.has_metric(mtype, start):
+            m_skipped += 1
+            continue
+        if dry_run:
+            m_created += 1
+            continue
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            continue
+        store.log_metric(
+            mtype, value, unit=m.get("unit", ""),
+            start_at=start, end_at=_to_utc_iso(m.get("end")), source="apple_health",
+        )
+        m_created += 1
+
+    logger.info(
+        f"Apple Health: workouts +{w_created} (skip {w_skipped}), "
+        f"metrics +{m_created} (skip {m_skipped})"
+    )
+    return {
+        "status": "ok",
+        "workouts_created": w_created, "workouts_skipped": w_skipped,
+        "metrics_created": m_created, "metrics_skipped": m_skipped,
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Import Apple ecosystem data from Mac Mini exports")
     parser.add_argument("--execute", action="store_true", help="Actually import")
     parser.add_argument("--dry-run", action="store_true", help="Preview only")
-    parser.add_argument("--source", choices=["contacts", "imessage", "phone", "photos", "whatsapp"], help="Import single source")
+    parser.add_argument("--source", choices=["contacts", "imessage", "phone", "photos", "whatsapp", "health"], help="Import single source")
     args = parser.parse_args()
 
     if not args.execute and not args.dry_run:
@@ -746,6 +881,7 @@ def main():
         "phone": import_phone_calls,
         "photos": import_photos_faces,
         "whatsapp": _import_whatsapp_wrapper,
+        "health": import_health,
     }
 
     if args.source:

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -724,12 +724,17 @@ _HEALTH_KIND_MAP = {
     "swimming": "cardio", "rowing": "cardio", "elliptical": "cardio",
     "hiking": "cardio", "highintensityintervaltraining": "cardio",
     "functionalstrengthtraining": "strength", "traditionalstrengthtraining": "strength",
+    "strengthtraining": "strength", "weighttraining": "strength", "weightlifting": "strength",
     "yoga": "mobility", "coretraining": "mobility", "flexibility": "mobility",
 }
 
 
 def _to_utc_iso(ts: str | None) -> str:
-    """Normalize an ISO8601 timestamp (with offset or trailing Z) to UTC ISO."""
+    """Normalize an ISO8601 timestamp (offset or trailing Z) to UTC ISO.
+
+    Returns "" for missing or unparseable input so callers can treat it as "no
+    usable timestamp" — important for metric dedup, which needs a stable key.
+    """
     if not ts:
         return ""
     try:
@@ -738,7 +743,21 @@ def _to_utc_iso(ts: str | None) -> str:
             dt = dt.replace(tzinfo=timezone.utc)
         return dt.astimezone(timezone.utc).isoformat()
     except (ValueError, TypeError):
-        return ts
+        return ""
+
+
+def _local_date(utc_iso: str) -> str | None:
+    """Local calendar date (YYYY-MM-DD) for a UTC ISO timestamp, in the configured
+    timezone — so an evening workout buckets on the right day and matches manual
+    logging's notion of 'today'. None if not parseable."""
+    if not utc_iso:
+        return None
+    try:
+        from zoneinfo import ZoneInfo
+        from config.settings import settings
+        return datetime.fromisoformat(utc_iso).astimezone(ZoneInfo(settings.timezone)).date().isoformat()
+    except (ValueError, TypeError):
+        return None
 
 
 def _health_kind(workout_type: str | None) -> str:
@@ -802,10 +821,9 @@ def import_health(dry_run: bool = False) -> dict:
             w_created += 1
             continue
         start = _to_utc_iso(w.get("start"))
-        date = start[:10] if start else None
         store.add_session(
             sets=[],
-            date=date,
+            date=_local_date(start),   # local calendar day; None → store uses today
             kind=_health_kind(w.get("type")),
             source="apple_health",
             title=w.get("type", "") or "Workout",
@@ -820,6 +838,11 @@ def import_health(dry_run: bool = False) -> dict:
         if not mtype or value is None:
             continue
         start = _to_utc_iso(m.get("start"))
+        if not start:
+            # Without a stable timestamp the metric can't be deduped (log_metric
+            # would substitute now()), so it would duplicate on every re-import.
+            m_skipped += 1
+            continue
         if store.has_metric(mtype, start):
             m_skipped += 1
             continue

--- a/tests/test_apple_health_import.py
+++ b/tests/test_apple_health_import.py
@@ -1,0 +1,129 @@
+"""
+Tests for the Apple Health import (issue #323).
+
+The iOS Shortcut writes health.json; import_health upserts workouts into
+workout_sessions(source=apple_health) and metrics into health_metrics, both
+idempotently with UTC-normalized timestamps.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.apple_data_import import import_health, _to_utc_iso, _health_kind, _workout_summary
+from api.services.fitness_store import FitnessStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def health_env(tmp_path, monkeypatch):
+    """A temp fitness store + a temp health.json wired into the importer."""
+    store = FitnessStore(db_path=str(tmp_path / "fitness.db"))
+    monkeypatch.setattr("api.services.fitness_store.get_fitness_store", lambda: store)
+    export = tmp_path / "health.json"
+    import config.settings as cfg
+    monkeypatch.setattr(cfg.settings, "health_export_path", str(export))
+    return store, export
+
+
+def _write(export: Path, payload: dict):
+    export.write_text(json.dumps(payload))
+
+
+# -- helpers --
+
+def test_to_utc_iso_normalizes_offset_and_z():
+    assert _to_utc_iso("2026-06-07T08:00:00-04:00").startswith("2026-06-07T12:00:00+00:00")
+    assert _to_utc_iso("2026-06-07T12:00:00Z").startswith("2026-06-07T12:00:00+00:00")
+    assert _to_utc_iso("") == ""
+
+
+def test_health_kind_maps_apple_types():
+    assert _health_kind("HKWorkoutActivityTypeRunning") == "cardio"
+    assert _health_kind("functionalStrengthTraining") == "strength"
+    assert _health_kind("Yoga") == "mobility"
+    assert _health_kind("Pickleball") == "cardio"  # default
+    assert _health_kind(None) == "cardio"
+
+
+def test_workout_summary_formats():
+    s = _workout_summary({"distance_m": 10000, "duration_s": 3300, "avg_hr": 145})
+    assert "10.0 km" in s and "55 min" in s and "145 bpm" in s
+
+
+# -- import --
+
+def test_missing_file_skips(health_env):
+    store, export = health_env  # export not written
+    result = import_health()
+    assert result["status"] == "skipped"
+
+
+def test_imports_workouts_and_metrics(health_env):
+    store, export = health_env
+    _write(export, {
+        "workouts": [
+            {"uuid": "W1", "type": "HKWorkoutActivityTypeRunning",
+             "start": "2026-06-07T08:00:00-04:00", "end": "2026-06-07T08:55:00-04:00",
+             "duration_s": 3300, "distance_m": 10000, "avg_hr": 145},
+        ],
+        "metrics": [
+            {"type": "body_weight", "value": 178.4, "unit": "lb", "start": "2026-06-07T07:00:00-04:00"},
+            {"type": "resting_hr", "value": 54, "unit": "bpm", "start": "2026-06-07T07:00:00-04:00"},
+        ],
+    })
+    result = import_health()
+    assert result["status"] == "ok"
+    assert result["workouts_created"] == 1
+    assert result["metrics_created"] == 2
+
+    sessions = store.list_sessions()
+    assert len(sessions) == 1
+    assert sessions[0].source == "apple_health"
+    assert sessions[0].kind == "cardio"
+    assert sessions[0].date == "2026-06-07"
+    assert "10.0 km" in sessions[0].notes
+    assert store.latest_metric("body_weight").value == 178.4
+
+
+def test_idempotent_reimport(health_env):
+    store, export = health_env
+    payload = {
+        "workouts": [{"uuid": "W1", "type": "Running", "start": "2026-06-07T08:00:00Z", "duration_s": 600}],
+        "metrics": [{"type": "body_weight", "value": 178.0, "start": "2026-06-07T07:00:00Z"}],
+    }
+    _write(export, payload)
+    import_health()
+    second = import_health()
+    assert second["workouts_created"] == 0 and second["workouts_skipped"] == 1
+    assert second["metrics_created"] == 0 and second["metrics_skipped"] == 1
+    assert len(store.list_sessions()) == 1
+    assert len(store.list_metrics("body_weight")) == 1
+
+
+def test_metrics_stored_in_utc(health_env):
+    store, export = health_env
+    _write(export, {"metrics": [{"type": "body_weight", "value": 178.0, "start": "2026-06-07T07:00:00-04:00"}]})
+    import_health()
+    m = store.latest_metric("body_weight")
+    assert m.start_at.startswith("2026-06-07T11:00:00+00:00")  # -04:00 → UTC
+
+
+def test_bad_rows_skipped(health_env):
+    store, export = health_env
+    _write(export, {
+        "workouts": [{"type": "Running"}],                       # no uuid → skip
+        "metrics": [{"type": "body_weight"}, {"value": 5}],      # no value / no type → skip
+    })
+    result = import_health()
+    assert result["status"] == "ok"
+    assert result["workouts_created"] == 0
+    assert result["metrics_created"] == 0
+
+
+def test_malformed_json_errors_gracefully(health_env):
+    store, export = health_env
+    export.write_text("{not json")
+    result = import_health()
+    assert result["status"] == "error"

--- a/tests/test_apple_health_import.py
+++ b/tests/test_apple_health_import.py
@@ -37,11 +37,13 @@ def test_to_utc_iso_normalizes_offset_and_z():
     assert _to_utc_iso("2026-06-07T08:00:00-04:00").startswith("2026-06-07T12:00:00+00:00")
     assert _to_utc_iso("2026-06-07T12:00:00Z").startswith("2026-06-07T12:00:00+00:00")
     assert _to_utc_iso("") == ""
+    assert _to_utc_iso("not-a-date") == ""   # unparseable → "" (no false dedup key)
 
 
 def test_health_kind_maps_apple_types():
     assert _health_kind("HKWorkoutActivityTypeRunning") == "cardio"
     assert _health_kind("functionalStrengthTraining") == "strength"
+    assert _health_kind("Strength Training") == "strength"   # friendly label
     assert _health_kind("Yoga") == "mobility"
     assert _health_kind("Pickleball") == "cardio"  # default
     assert _health_kind(None) == "cardio"
@@ -127,3 +129,29 @@ def test_malformed_json_errors_gracefully(health_env):
     export.write_text("{not json")
     result = import_health()
     assert result["status"] == "error"
+
+
+def test_metric_without_start_is_skipped_not_duplicated(health_env):
+    # Regression: a metric with no parseable start has no stable dedup key, so it
+    # must be skipped — not written (and re-written on every import).
+    store, export = health_env
+    _write(export, {"metrics": [{"type": "body_weight", "value": 178.0}]})  # no start
+    first = import_health()
+    second = import_health()
+    assert first["metrics_created"] == 0 and first["metrics_skipped"] == 1
+    assert second["metrics_created"] == 0
+    assert len(store.list_metrics("body_weight")) == 0  # never written, never duplicated
+
+
+def test_workout_date_is_local_not_utc(health_env, monkeypatch):
+    # An evening-ET workout that crosses midnight UTC must bucket on the local
+    # calendar day, matching manual logging.
+    import config.settings as cfg
+    monkeypatch.setattr(cfg.settings, "timezone", "America/New_York")
+    store, export = health_env
+    _write(export, {"workouts": [
+        {"uuid": "W-eve", "type": "Running", "start": "2026-06-08T01:00:00Z", "duration_s": 600},
+        # 01:00 UTC Jun 8 == 21:00 ET Jun 7
+    ]})
+    import_health()
+    assert store.list_sessions()[0].date == "2026-06-07"


### PR DESCRIPTION
## Summary

Server-side pipeline to import Apple Health/Fitness data into the fitness store (#320's `fitness.db`). Collection is an **iOS Shortcut** built on the iPhone (macOS has no HealthKit store) that writes `health.json` into a synced folder; this PR imports it.

Closes #323

## What's included

- **`scripts/apple_data_import.py` → `import_health()`** — reads `LIFEOS_HEALTH_EXPORT_PATH`, upserts workouts → `workout_sessions(source=apple_health)` and metrics → `health_metrics(source=apple_health)`. **Idempotent** (workouts dedupe on HKWorkout UUID, metrics on `(type, start)`), **UTC-normalized** timestamps, graceful skip when the file is absent. Registered as an import source, so it runs in the existing nightly **`apple_import`** step (no `run_all_syncs` change needed) and via `--source health`.
- **`fitness_store.py`** — `has_workout_ref` / `has_metric` dedup helpers.
- **`LIFEOS_HEALTH_EXPORT_PATH`** setting (default `data/apple-imports/health.json`).
- **`docs/guides/apple-health.md`** — step-by-step iOS Shortcut build + the `health.json` schema (this is the reference for the part the user builds on their phone).
- **ADR-013** (self-data fitness store, outside the CRM model) + **ADR-014** (iOS-Shortcut collection; the Mac-side Swift CLI is explicitly rejected — a Mac has no HealthKit store).

## Scope / deferrals

- **iOS Shortcut** is built on the iPhone (out of scope for this machine) — fully documented in the guide.
- **ChromaDB summary-indexing** of Apple workouts deferred: the embedding model can't run in the import path (hardware constraint — it can't co-run with the LLM, which is why the sync pipeline indexes in a separate phase), and Apple workouts/metrics are already queryable via `manage_workouts` (list/history/summary/metrics). Tracked as a follow-up.

## Test evidence

Targeted (full suite batched with #330 at the end): `tests/test_apple_health_import.py` (9) — helpers (UTC normalize, kind map, summary), import of workouts+metrics, idempotent re-import, UTC storage, bad-row skipping, malformed-JSON handling. Plus `test_fitness_store.py` + existing `test_apple_pipeline.py` green (62 total). Ruff clean.

## Review focus

- Idempotency keys (`has_workout_ref` / `has_metric`) and UTC normalization (`_to_utc_iso`).
- `import_health` registration in the dispatch + the aggregate-stats loop gracefully skipping the non-CRM `health` source.
- The deferral of summary-indexing — is the reasoning sound, or should a minimal indexing path be in-scope?