### PR TITLE
refactor(google-auth): remove shadowed duplicate account helpers

### DIFF
--- a/api/services/google_auth.py
+++ b/api/services/google_auth.py
@@ -218,16 +218,6 @@ class GoogleAuthService:
             return False
 
 
-def resolve_account(account: str) -> GoogleAccount:  # noqa: F811 (pre-existing duplicate; see PR #327 note)
-    """Resolve a string account name ('personal'/'work') to a GoogleAccount enum."""
-    return GoogleAccount.PERSONAL if account == "personal" else GoogleAccount.WORK
-
-
-def get_configured_accounts() -> list[GoogleAccount]:  # noqa: F811 (pre-existing duplicate; see PR #327 note)
-    """Return the list of configured Google account types."""
-    return [GoogleAccount.WORK, GoogleAccount.PERSONAL]
-
-
 # Singleton instances for each account
 _auth_services: dict[GoogleAccount, GoogleAuthService] = {}
 

--- a/tests/test_google_auth_accounts.py
+++ b/tests/test_google_auth_accounts.py
@@ -1,0 +1,50 @@
+"""
+Tests for google_auth account helpers (issue #330).
+
+Locks in the WORK2-aware behavior of resolve_account / get_configured_accounts
+that was previously dead — shadowed by simpler duplicate definitions. Guards
+against the duplicates (or a re-simplification) coming back.
+"""
+import pytest
+
+from api.services.google_auth import resolve_account, get_configured_accounts, GoogleAccount
+
+pytestmark = pytest.mark.unit
+
+
+class TestResolveAccount:
+    def test_personal(self):
+        assert resolve_account("personal") == GoogleAccount.PERSONAL
+
+    def test_work(self):
+        assert resolve_account("work") == GoogleAccount.WORK
+
+    def test_work2_is_not_collapsed_to_work(self):
+        # The bug fixed in #330: the shadowing duplicate mapped anything != "personal"
+        # to WORK, losing WORK2.
+        assert resolve_account("work2") == GoogleAccount.WORK2
+
+    def test_unknown_defaults_to_personal(self):
+        assert resolve_account("nonsense") == GoogleAccount.PERSONAL
+
+
+class TestGetConfiguredAccounts:
+    def test_personal_always_present(self):
+        assert GoogleAccount.PERSONAL in get_configured_accounts()
+
+    def test_detects_credential_files_including_work2(self, tmp_path, monkeypatch):
+        # get_configured_accounts reads ./config relative to cwd.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / "credentials-work2.json").write_text("{}")
+
+        accounts = get_configured_accounts()
+        assert GoogleAccount.PERSONAL in accounts   # always
+        assert GoogleAccount.WORK2 in accounts      # credential file present
+        assert GoogleAccount.WORK not in accounts   # no work credential file here
+
+    def test_no_extra_accounts_without_credentials(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config").mkdir()
+        accounts = get_configured_accounts()
+        assert accounts == [GoogleAccount.PERSONAL]


### PR DESCRIPTION
## Summary

`resolve_account` / `get_configured_accounts` were each **defined twice** in `google_auth.py`. Python used the simpler later copies, so the richer earlier versions (WORK2-aware, credential-file-detecting) were dead code. This removes the later duplicates so the intended behavior is live, and drops the `# noqa: F811` markers added in #327.

Closes #330

## Behavior change (intended)

- `resolve_account("work2")` → `WORK2` (was incorrectly `WORK`).
- `get_configured_accounts()` → reflects which `config/credentials-*.json` files actually exist, including WORK2 (was a hardcoded `[WORK, PERSONAL]`).

On a machine with only personal+work credentials the live account *set* is unchanged (just ordering); the fix matters when WORK2 is configured or work credentials are absent.

## Test evidence

`./scripts/test.sh` — **2811 passed**, 12 skipped (the 5 failures are the known pre-existing/environmental set, verified on `main` throughout this batch). No caller across calendar/gmail/drive/scheduler/agent_tools regressed. New `tests/test_google_auth_accounts.py` (7) locks in the WORK2-aware behavior and guards against re-shadowing. Ruff clean (F811 gone).

## Review focus

- The behavior change is desirable (the richer versions were the intended ones) — confirm no caller relied on the buggy hardcoded `[WORK, PERSONAL]`.
- Test isolation: `get_configured_accounts` tests `chdir` to a tmp dir with a fake `config/`.