### PR TITLE
feat(fitness): Apple Health ingest endpoint (#333 server side)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -304,6 +304,9 @@ LIFEOS_RELATIONSHIP_FOLDER=Relationship
 # (see docs/guides/apple-health.md). Default: data/apple-imports/health.json.
 # Point at a synced location (e.g. ~/Code/Sync/health/health.json) for automation.
 # LIFEOS_HEALTH_EXPORT_PATH=
+# Bearer token for the HealthBridge app's POST delivery (POST /api/fitness/health/ingest).
+# Empty disables that endpoint. Generate with: openssl rand -hex 32
+# LIFEOS_HEALTH_INGEST_TOKEN=
 
 # =============================================================================
 # FINANCIAL DATA (optional)

--- a/api/main.py
+++ b/api/main.py
@@ -32,7 +32,7 @@ from fastapi.exceptions import RequestValidationError
 from pathlib import Path
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, jobs, perf, agents, vault
+from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, jobs, perf, agents, vault, fitness
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -217,6 +217,7 @@ app.include_router(jobs.router)
 app.include_router(perf.router)
 app.include_router(agents.router)
 app.include_router(vault.router)
+app.include_router(fitness.router)
 
 # Serve static files
 web_dir = Path(__file__).parent.parent / "web"

--- a/api/routes/fitness.py
+++ b/api/routes/fitness.py
@@ -1,0 +1,56 @@
+"""
+Fitness API routes.
+
+Currently just the authenticated Apple Health ingest endpoint (#333) — the
+on-device HealthBridge app POSTs its payload here over Tailscale, and it lands
+in fitness.db via the same ingest core the nightly file importer uses.
+"""
+import hmac
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/fitness", tags=["fitness"])
+
+
+class HealthIngestRequest(BaseModel):
+    """Apple Health payload — matches the health.json schema (see #333 / guide)."""
+    workouts: list[dict] = Field(default_factory=list)
+    metrics: list[dict] = Field(default_factory=list)
+
+
+def _check_ingest_auth(request: Request) -> None:
+    """Bearer-token gate. Disabled (503) until LIFEOS_HEALTH_INGEST_TOKEN is set —
+    a dedicated token, separate from the MCP transport's bearer."""
+    expected = settings.health_ingest_token
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="Health ingest disabled: set LIFEOS_HEALTH_INGEST_TOKEN to enable.",
+        )
+    header = request.headers.get("authorization", "")
+    scheme, _, token = header.partition(" ")
+    token = token.strip()
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    if not hmac.compare_digest(token, expected):
+        raise HTTPException(status_code=401, detail="invalid bearer token")
+
+
+@router.post("/health/ingest")
+async def health_ingest(payload: HealthIngestRequest, request: Request):
+    """Ingest an Apple Health payload into the fitness store.
+
+    Idempotent — workouts dedupe on the HKWorkout uuid, metrics on (type, start).
+    Returns created/skipped counts.
+    """
+    _check_ingest_auth(request)
+    from api.services.health_import import ingest_health
+    result = ingest_health(payload.model_dump())
+    logger.info(f"Health ingest: {result}")
+    return result

--- a/api/routes/fitness.py
+++ b/api/routes/fitness.py
@@ -9,13 +9,17 @@ import hmac
 import logging
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/fitness", tags=["fitness"])
+
+# Upper bound on items per ingest. Generous enough for a multi-year one-shot
+# backfill; rejects absurd payloads (the endpoint takes on-demand POSTs).
+_MAX_INGEST_ITEMS = 100_000
 
 
 class HealthIngestRequest(BaseModel):
@@ -43,13 +47,30 @@ def _check_ingest_auth(request: Request) -> None:
 
 
 @router.post("/health/ingest")
-async def health_ingest(payload: HealthIngestRequest, request: Request):
+async def health_ingest(request: Request):
     """Ingest an Apple Health payload into the fitness store.
 
     Idempotent — workouts dedupe on the HKWorkout uuid, metrics on (type, start).
-    Returns created/skipped counts.
+    Returns created/skipped counts. Authenticates BEFORE parsing the body so an
+    unauthenticated caller can't probe validation behavior.
     """
     _check_ingest_auth(request)
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+    try:
+        payload = HealthIngestRequest.model_validate(body)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors())
+
+    total = len(payload.workouts) + len(payload.metrics)
+    if total > _MAX_INGEST_ITEMS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"payload too large: {total} items (max {_MAX_INGEST_ITEMS})",
+        )
+
     from api.services.health_import import ingest_health
     result = ingest_health(payload.model_dump())
     logger.info(f"Health ingest: {result}")

--- a/api/services/health_import.py
+++ b/api/services/health_import.py
@@ -1,0 +1,154 @@
+"""
+Apple Health ingest core (issue #333).
+
+Shared by both delivery paths: the file importer (`scripts/apple_data_import.py`,
+nightly `apple_import` step) and the authenticated `POST /api/fitness/health/ingest`
+endpoint. Both hand a parsed payload dict to `ingest_health()`.
+
+Writes into the self-data fitness store (ADR-013): Apple workouts →
+workout_sessions(source=apple_health), metrics → health_metrics(source=apple_health).
+Idempotent — workouts dedupe on the HKWorkout uuid, metrics on (type, start).
+"""
+import logging
+import re
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# Apple HKWorkoutActivityType (or a friendly label) → our session kind.
+_HEALTH_KIND_MAP = {
+    "running": "cardio", "walking": "cardio", "cycling": "cardio",
+    "swimming": "cardio", "rowing": "cardio", "elliptical": "cardio",
+    "hiking": "cardio", "highintensityintervaltraining": "cardio",
+    "functionalstrengthtraining": "strength", "traditionalstrengthtraining": "strength",
+    "strengthtraining": "strength", "weighttraining": "strength", "weightlifting": "strength",
+    "yoga": "mobility", "coretraining": "mobility", "flexibility": "mobility",
+}
+
+
+def _to_utc_iso(ts: str | None) -> str:
+    """Normalize an ISO8601 timestamp (offset or trailing Z) to UTC ISO.
+
+    Returns "" for missing or unparseable input so callers can treat it as "no
+    usable timestamp" — important for metric dedup, which needs a stable key.
+    """
+    if not ts:
+        return ""
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat()
+    except (ValueError, TypeError):
+        return ""
+
+
+def _local_date(utc_iso: str) -> str | None:
+    """Local calendar date (YYYY-MM-DD) for a UTC ISO timestamp, in the configured
+    timezone — so an evening workout buckets on the right day and matches manual
+    logging's notion of 'today'. None if not parseable."""
+    if not utc_iso:
+        return None
+    try:
+        return datetime.fromisoformat(utc_iso).astimezone(ZoneInfo(settings.timezone)).date().isoformat()
+    except (ValueError, TypeError):
+        return None
+
+
+def _health_kind(workout_type: str | None) -> str:
+    if not workout_type:
+        return "cardio"
+    key = re.sub(r"[^a-z]", "", workout_type.lower()).replace("hkworkoutactivitytype", "")
+    return _HEALTH_KIND_MAP.get(key, "cardio")
+
+
+def _workout_summary(w: dict) -> str:
+    """One-line human summary for an Apple workout, e.g. '10.0 km · 55 min · 145 bpm'."""
+    parts = []
+    dist = w.get("distance_m")
+    if dist:
+        parts.append(f"{dist / 1000:.1f} km")
+    dur = w.get("duration_s")
+    if dur:
+        parts.append(f"{int(dur // 60)} min")
+    energy = w.get("energy_kcal")
+    if energy:
+        parts.append(f"{int(energy)} kcal")
+    hr = w.get("avg_hr")
+    if hr:
+        parts.append(f"{int(hr)} bpm")
+    return " · ".join(parts)
+
+
+def ingest_health(data: dict, dry_run: bool = False) -> dict:
+    """Upsert a parsed Apple Health payload into the fitness store.
+
+    `data` is `{"workouts": [...], "metrics": [...]}`. Idempotent and safe to
+    re-run; returns created/skipped counts.
+    """
+    from api.services.fitness_store import get_fitness_store
+    store = get_fitness_store()
+
+    w_created = w_skipped = m_created = m_skipped = 0
+
+    for w in data.get("workouts") or []:
+        ref = (w.get("uuid") or "").strip()
+        if not ref:
+            continue
+        if store.has_workout_ref(ref):
+            w_skipped += 1
+            continue
+        if dry_run:
+            w_created += 1
+            continue
+        start = _to_utc_iso(w.get("start"))
+        store.add_session(
+            sets=[],
+            date=_local_date(start),   # local calendar day; None → store uses today
+            kind=_health_kind(w.get("type")),
+            source="apple_health",
+            title=w.get("type", "") or "Workout",
+            notes=_workout_summary(w),
+            raw_ref=ref,
+        )
+        w_created += 1
+
+    for m in data.get("metrics") or []:
+        mtype = (m.get("type") or "").strip()
+        value = m.get("value")
+        if not mtype or value is None:
+            continue
+        start = _to_utc_iso(m.get("start"))
+        if not start:
+            # Without a stable timestamp the metric can't be deduped (log_metric
+            # would substitute now()), so it would duplicate on every re-import.
+            m_skipped += 1
+            continue
+        if store.has_metric(mtype, start):
+            m_skipped += 1
+            continue
+        if dry_run:
+            m_created += 1
+            continue
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            continue
+        store.log_metric(
+            mtype, value, unit=m.get("unit", ""),
+            start_at=start, end_at=_to_utc_iso(m.get("end")), source="apple_health",
+        )
+        m_created += 1
+
+    logger.info(
+        f"Apple Health: workouts +{w_created} (skip {w_skipped}), "
+        f"metrics +{m_created} (skip {m_skipped})"
+    )
+    return {
+        "status": "ok",
+        "workouts_created": w_created, "workouts_skipped": w_skipped,
+        "metrics_created": m_created, "metrics_skipped": m_skipped,
+    }

--- a/config/settings.py
+++ b/config/settings.py
@@ -626,6 +626,13 @@ class Settings(BaseSettings):
         description="Path to the Apple Health export JSON written by the iOS Shortcut "
                     "(e.g. a synced ~/Code/Sync/health/health.json). Imported nightly."
     )
+    health_ingest_token: str = Field(
+        default="",
+        alias="LIFEOS_HEALTH_INGEST_TOKEN",
+        description="Bearer token for POST /api/fitness/health/ingest (the HealthBridge "
+                    "app's POST delivery mode). Empty disables the endpoint (503). "
+                    "Generate with `openssl rand -hex 32`."
+    )
 
     # Monarch Money
     monarch_email: str = Field(

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -718,79 +718,13 @@ def import_whatsapp(dry_run: bool = False, manifest: dict | None = None) -> dict
 # that emits health.json into a synced path (see docs/guides/apple-health.md).
 # ---------------------------------------------------------------------------
 
-# Apple HKWorkoutActivityType (or a friendly label) → our session kind.
-_HEALTH_KIND_MAP = {
-    "running": "cardio", "walking": "cardio", "cycling": "cardio",
-    "swimming": "cardio", "rowing": "cardio", "elliptical": "cardio",
-    "hiking": "cardio", "highintensityintervaltraining": "cardio",
-    "functionalstrengthtraining": "strength", "traditionalstrengthtraining": "strength",
-    "strengthtraining": "strength", "weighttraining": "strength", "weightlifting": "strength",
-    "yoga": "mobility", "coretraining": "mobility", "flexibility": "mobility",
-}
-
-
-def _to_utc_iso(ts: str | None) -> str:
-    """Normalize an ISO8601 timestamp (offset or trailing Z) to UTC ISO.
-
-    Returns "" for missing or unparseable input so callers can treat it as "no
-    usable timestamp" — important for metric dedup, which needs a stable key.
-    """
-    if not ts:
-        return ""
-    try:
-        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.astimezone(timezone.utc).isoformat()
-    except (ValueError, TypeError):
-        return ""
-
-
-def _local_date(utc_iso: str) -> str | None:
-    """Local calendar date (YYYY-MM-DD) for a UTC ISO timestamp, in the configured
-    timezone — so an evening workout buckets on the right day and matches manual
-    logging's notion of 'today'. None if not parseable."""
-    if not utc_iso:
-        return None
-    try:
-        from zoneinfo import ZoneInfo
-        from config.settings import settings
-        return datetime.fromisoformat(utc_iso).astimezone(ZoneInfo(settings.timezone)).date().isoformat()
-    except (ValueError, TypeError):
-        return None
-
-
-def _health_kind(workout_type: str | None) -> str:
-    if not workout_type:
-        return "cardio"
-    key = re.sub(r"[^a-z]", "", workout_type.lower()).replace("hkworkoutactivitytype", "")
-    return _HEALTH_KIND_MAP.get(key, "cardio")
-
-
-def _workout_summary(w: dict) -> str:
-    """One-line human summary for an Apple workout, e.g. '10.0 km · 55 min · 145 bpm'."""
-    parts = []
-    dist = w.get("distance_m")
-    if dist:
-        parts.append(f"{dist / 1000:.1f} km")
-    dur = w.get("duration_s")
-    if dur:
-        parts.append(f"{int(dur // 60)} min")
-    energy = w.get("energy_kcal")
-    if energy:
-        parts.append(f"{int(energy)} kcal")
-    hr = w.get("avg_hr")
-    if hr:
-        parts.append(f"{int(hr)} bpm")
-    return " · ".join(parts)
-
-
 def import_health(dry_run: bool = False) -> dict:
-    """Import Apple Health export (health.json) into the fitness store.
+    """Import the Apple Health export (health.json) into the fitness store.
 
-    Workouts → workout_sessions(source=apple_health); metrics → health_metrics.
-    Idempotent: workouts dedupe on the Apple UUID, metrics on (type, start_at).
-    Absent file → skipped (a fresh clone / no-iPhone setup is unaffected).
+    Reads the file at LIFEOS_HEALTH_EXPORT_PATH and delegates to the shared
+    ingest core (api.services.health_import.ingest_health) — the same core the
+    POST /api/fitness/health/ingest endpoint uses (#333). Absent file → skipped
+    (a fresh clone / no-iPhone setup is unaffected).
     """
     from config.settings import settings
     path = Path(settings.health_export_path)
@@ -805,69 +739,8 @@ def import_health(dry_run: bool = False) -> dict:
     except (json.JSONDecodeError, OSError) as e:
         return {"status": "error", "error": f"could not read {path}: {e}"}
 
-    from api.services.fitness_store import get_fitness_store
-    store = get_fitness_store()
-
-    w_created = w_skipped = m_created = m_skipped = 0
-
-    for w in data.get("workouts", []):
-        ref = (w.get("uuid") or "").strip()
-        if not ref:
-            continue
-        if store.has_workout_ref(ref):
-            w_skipped += 1
-            continue
-        if dry_run:
-            w_created += 1
-            continue
-        start = _to_utc_iso(w.get("start"))
-        store.add_session(
-            sets=[],
-            date=_local_date(start),   # local calendar day; None → store uses today
-            kind=_health_kind(w.get("type")),
-            source="apple_health",
-            title=w.get("type", "") or "Workout",
-            notes=_workout_summary(w),
-            raw_ref=ref,
-        )
-        w_created += 1
-
-    for m in data.get("metrics", []):
-        mtype = (m.get("type") or "").strip()
-        value = m.get("value")
-        if not mtype or value is None:
-            continue
-        start = _to_utc_iso(m.get("start"))
-        if not start:
-            # Without a stable timestamp the metric can't be deduped (log_metric
-            # would substitute now()), so it would duplicate on every re-import.
-            m_skipped += 1
-            continue
-        if store.has_metric(mtype, start):
-            m_skipped += 1
-            continue
-        if dry_run:
-            m_created += 1
-            continue
-        try:
-            value = float(value)
-        except (TypeError, ValueError):
-            continue
-        store.log_metric(
-            mtype, value, unit=m.get("unit", ""),
-            start_at=start, end_at=_to_utc_iso(m.get("end")), source="apple_health",
-        )
-        m_created += 1
-
-    logger.info(
-        f"Apple Health: workouts +{w_created} (skip {w_skipped}), "
-        f"metrics +{m_created} (skip {m_skipped})"
-    )
-    return {
-        "status": "ok",
-        "workouts_created": w_created, "workouts_skipped": w_skipped,
-        "metrics_created": m_created, "metrics_skipped": m_skipped,
-    }
+    from api.services.health_import import ingest_health
+    return ingest_health(data, dry_run=dry_run)
 
 
 def main():

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -265,8 +265,11 @@ run_health_check() {
 # Print the changed files (one per line) for the current branch: everything
 # since the merge-base with origin/main, plus uncommitted and untracked work.
 # Overridable via LIFEOS_TEST_CHANGED_FILES (newline-separated) for testing.
+# Use ${VAR+x} (set, even if empty) — NOT ${VAR:-} (non-empty) — so an explicit
+# empty override ("no changes") is honored instead of falling back to the git
+# diff. Without this the 'empty' case picks up the working tree's real changes.
 compute_changed_files() {
-    if [ -n "${LIFEOS_TEST_CHANGED_FILES:-}" ]; then
+    if [ -n "${LIFEOS_TEST_CHANGED_FILES+x}" ]; then
         printf '%s\n' "$LIFEOS_TEST_CHANGED_FILES" | grep -v '^$' || true
         return
     fi

--- a/tests/test_apple_health_import.py
+++ b/tests/test_apple_health_import.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 import pytest
 
-from scripts.apple_data_import import import_health, _to_utc_iso, _health_kind, _workout_summary
+from scripts.apple_data_import import import_health
+from api.services.health_import import _to_utc_iso, _health_kind, _workout_summary
 from api.services.fitness_store import FitnessStore
 
 pytestmark = pytest.mark.unit

--- a/tests/test_health_ingest_endpoint.py
+++ b/tests/test_health_ingest_endpoint.py
@@ -1,0 +1,99 @@
+"""
+Tests for the authenticated Apple Health ingest endpoint and service (#333).
+
+POST /api/fitness/health/ingest shares the ingest core with the file importer;
+this covers the bearer-auth gate and that a posted payload lands in fitness.db.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.services.fitness_store as fs
+from api.services.fitness_store import FitnessStore
+from api.services.health_import import ingest_health
+from api.routes import fitness as fitness_route
+
+pytestmark = pytest.mark.unit
+
+
+def _payload():
+    return {
+        "workouts": [{"uuid": "W1", "type": "Running", "start": "2026-06-07T08:00:00Z", "duration_s": 600}],
+        "metrics": [{"type": "body_weight", "value": 178.4, "unit": "lb", "start": "2026-06-07T07:00:00Z"}],
+    }
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    store = FitnessStore(db_path=str(tmp_path / "fitness.db"))
+    monkeypatch.setattr(fs, "_store_instance", store)  # get_fitness_store() → this
+    app = FastAPI()
+    app.include_router(fitness_route.router)
+    client = TestClient(app)
+    return client, store, monkeypatch
+
+
+# -- service core --
+
+class TestIngestService:
+    def test_ingest_payload_lands_rows(self, env):
+        _, store, _ = env
+        result = ingest_health(_payload())
+        assert result["workouts_created"] == 1
+        assert result["metrics_created"] == 1
+        assert len(store.list_sessions()) == 1
+        assert store.latest_metric("body_weight").value == 178.4
+
+    def test_ingest_idempotent(self, env):
+        _, store, _ = env
+        ingest_health(_payload())
+        second = ingest_health(_payload())
+        assert second["workouts_created"] == 0 and second["workouts_skipped"] == 1
+        assert second["metrics_created"] == 0 and second["metrics_skipped"] == 1
+
+
+# -- endpoint auth --
+
+class TestIngestEndpoint:
+    def test_disabled_without_token(self, env):
+        client, _, monkeypatch = env
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "")
+        resp = client.post("/api/fitness/health/ingest", json=_payload())
+        assert resp.status_code == 503
+
+    def test_missing_bearer_rejected(self, env):
+        client, _, monkeypatch = env
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "secret-token")
+        resp = client.post("/api/fitness/health/ingest", json=_payload())
+        assert resp.status_code == 401
+
+    def test_wrong_token_rejected(self, env):
+        client, _, monkeypatch = env
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "secret-token")
+        resp = client.post(
+            "/api/fitness/health/ingest", json=_payload(),
+            headers={"Authorization": "Bearer wrong"},
+        )
+        assert resp.status_code == 401
+
+    def test_valid_token_ingests(self, env):
+        client, store, monkeypatch = env
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "secret-token")
+        resp = client.post(
+            "/api/fitness/health/ingest", json=_payload(),
+            headers={"Authorization": "Bearer secret-token"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["workouts_created"] == 1 and body["metrics_created"] == 1
+        assert len(store.list_sessions()) == 1
+
+    def test_empty_payload_ok(self, env):
+        client, _, monkeypatch = env
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "secret-token")
+        resp = client.post(
+            "/api/fitness/health/ingest", json={},
+            headers={"Authorization": "Bearer secret-token"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["workouts_created"] == 0

--- a/tests/test_health_ingest_endpoint.py
+++ b/tests/test_health_ingest_endpoint.py
@@ -97,3 +97,35 @@ class TestIngestEndpoint:
         )
         assert resp.status_code == 200
         assert resp.json()["workouts_created"] == 0
+
+    def test_auth_runs_before_body_validation(self, env):
+        # Unauthenticated + malformed body must hit the auth gate (503/401), not
+        # leak field-level validation (422).
+        client, _, monkeypatch = env
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "")
+        resp = client.post("/api/fitness/health/ingest", json={"workouts": "not-a-list"})
+        assert resp.status_code == 503  # disabled gate fires before parsing
+
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "secret-token")
+        resp = client.post("/api/fitness/health/ingest", json={"workouts": "not-a-list"})
+        assert resp.status_code == 401  # missing bearer fires before parsing
+
+    def test_malformed_body_with_auth_is_422(self, env):
+        client, _, monkeypatch = env
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "secret-token")
+        resp = client.post(
+            "/api/fitness/health/ingest", json={"workouts": "not-a-list"},
+            headers={"Authorization": "Bearer secret-token"},
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_payload_rejected(self, env):
+        client, _, monkeypatch = env
+        monkeypatch.setattr(fitness_route.settings, "health_ingest_token", "secret-token")
+        monkeypatch.setattr(fitness_route, "_MAX_INGEST_ITEMS", 3)
+        resp = client.post(
+            "/api/fitness/health/ingest",
+            json={"metrics": [{"type": "body_weight", "value": 1, "start": f"2026-06-0{i}T00:00:00Z"} for i in range(1, 6)]},
+            headers={"Authorization": "Bearer secret-token"},
+        )
+        assert resp.status_code == 413


### PR DESCRIPTION
## Summary

Server half of #333: an authenticated `POST /api/fitness/health/ingest` so the on-device HealthBridge app has a delivery target, sharing **one ingest code path** with the nightly file importer.

Relates to #333 (the Swift app + on-device build are the follow-up PR; this issue stays open until that's deployed).

## What's included

- **`api/services/health_import.py` (new)** — `ingest_health(data)`: the parse+upsert core (+ timestamp/kind/summary helpers), extracted from the import script so both a route and the script call it (clean layering — a FastAPI route shouldn't import a private fn from `scripts/`).
- **`scripts/apple_data_import.py`** — `import_health()` now just reads the file and delegates to `ingest_health()`. Behavior unchanged; existing tests pass through the delegation.
- **`api/routes/fitness.py` (new)** — `POST /api/fitness/health/ingest`: bearer-auth via a **dedicated** `LIFEOS_HEALTH_INGEST_TOKEN` (`hmac.compare_digest`; **503 when unset** so it's off by default), hands the body to `ingest_health`, returns counts. Registered in `main.py`.
- **settings + `.env.example`** — `LIFEOS_HEALTH_INGEST_TOKEN`.

Idempotent (workout `uuid`; metric `(type, start)`); empty/absent payloads are safe.

## Also fixes a repo-wide push-gate bug (separate commit)

While adding `api/routes/fitness.py` I hit `test_auto_scope_mapping[empty]` failing in the **pre-push hook** — blocking *all* local pushes. Root cause in #331's `scripts/test.sh`: `compute_changed_files` used `${VAR:-}` (truthy only when non-empty), so the test's explicit `LIFEOS_TEST_CHANGED_FILES=""` ("no changes") fell through to the real git diff and picked up the working tree. Fixed with `${VAR+x}` (honors a set-but-empty override). Isolated in its own commit.

## Test evidence

`./scripts/test.sh auto` — **2818 passed** (after the fix), 12 skipped. The 5 failures are the known pre-existing/environmental set. New: `tests/test_health_ingest_endpoint.py` (7 — auth gate 503/401/200, idempotent ingest, empty payload) + `tests/test_test_sh_auto.py` now fully green (24, incl. `[empty]`). Existing `test_apple_health_import.py` (11) still green through the refactor.

## Review focus

- The service extraction (`import_health` → `ingest_health`) — behavior parity with the old inline version.
- The bearer-auth gate (503-when-unset, hmac compare).
- The `test.sh` `${VAR+x}` fix — correct shell semantics for set-but-empty.