### PR TITLE
fix(orchestrator): verify current facts before negative claims

### DIFF
--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -93,6 +93,10 @@ Don't use tools for general knowledge, definitions, coding help, math, or anythi
 
 **Never say you "can't access" live data, "can't browse the web", or reference a "knowledge cutoff."** You have web search — use it.
 
+**Never assert from memory that something "hasn't been released / announced / happened yet," doesn't exist, or isn't available — call search_web first and let the results decide.** Your training data is stale, so a negative claim about the current world (a schedule, a price, a roster, a release) is exactly the kind of thing you get wrong. Only state that something isn't available *after* a web search comes up empty, and say you searched.
+
+**If {name} pushes back or says "do research" / "you're wrong" / "look it up," you MUST call search_web before replying — do not repeat your previous claim, and never say "my research confirms" unless you actually ran a search in this turn.**
+
 ## How to use tools
 
 - **NEVER output text between tool rounds.** The user sees everything you write. Only output text AFTER your final tool round, as the complete answer. No "Let me search...", no "I found X, let me look further...", no mid-search commentary.


### PR DESCRIPTION
## Summary

Reviving a `/tune` commit (from 2026-06-02) that was pushed but never PR'd. Adds two lines to the orchestrator system prompt so it stops confidently asserting that something "doesn't exist / hasn't been released / isn't available" from stale training data:

1. Never make a negative claim about the current world (a release, price, schedule, roster) from memory — call `search_web` first; only say it's unavailable *after* an empty search, and say you searched.
2. On user pushback ("you're wrong" / "do research" / "look it up"), you MUST `search_web` before replying — don't repeat the prior claim, and never say "my research confirms" without an actual search this turn.

Rebased onto current `main`; the change is the only diff (+4 lines in `api/services/agent_system_prompt.py`).

## Test evidence

Rebased cleanly. `tests/test_agent_system_prompt.py` — 9 passed; ruff clean; pre-push unit suite green (60). Prompt-only change, no logic touched.

## Review focus

- The new guidance is additive and consistent with the adjacent "you have web search, don't claim a knowledge cutoff" line — confirm no contradiction with other prompt sections.