### PR TITLE
feat(fitness): scale Apple Health ingest + daily-aggregate cumulative metrics

### DIFF
--- a/api/routes/fitness.py
+++ b/api/routes/fitness.py
@@ -18,8 +18,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/fitness", tags=["fitness"])
 
 # Upper bound on items per ingest. Generous enough for a multi-year one-shot
-# backfill; rejects absurd payloads (the endpoint takes on-demand POSTs).
-_MAX_INGEST_ITEMS = 100_000
+# backfill of high-frequency samples (heart rate, steps); rejects absurd
+# payloads (the endpoint takes on-demand POSTs).
+_MAX_INGEST_ITEMS = 1_000_000
 
 
 class HealthIngestRequest(BaseModel):

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -660,7 +660,9 @@ TOOL_DEFINITIONS = [
             "optionally for one `exercise` or `kind`.\n"
             "- 'log_metric': record a body metric, e.g. morning body weight "
             "(metric_type 'body_weight', value 178.4, unit 'lb').\n"
-            "- 'metrics': list a metric over time (e.g. body_weight trend).\n"
+            "- 'metrics': list a metric over time (e.g. body_weight trend). "
+            "Cumulative metrics ('steps', 'active_energy') are returned as daily "
+            "totals rather than raw intraday samples.\n"
             "- 'get_profile' / 'set_profile': read or set the training profile "
             "(keys: goals, injuries, equipment, experience, schedule, constraints, "
             "preferences).\n"
@@ -1532,11 +1534,27 @@ def _workout_metrics(inp: dict) -> str:
     if not metric_type:
         return "Error: 'metrics' needs a 'metric_type'."
     store = get_fitness_store()
-    rows = store.list_metrics(metric_type, start=inp.get("date_start"), end=inp.get("date_end"),
-                              limit=int(inp.get("limit", 100) or 100))
+    label = metric_type.replace("_", " ")
+    limit = int(inp.get("limit", 100) or 100)
+
+    # Cumulative metrics (steps, active energy) arrive from Apple Health as many
+    # intraday buckets — sum them to one daily total so the trend is readable.
+    if metric_type in _CUMULATIVE_METRICS:
+        days = store.daily_metric_totals(
+            metric_type, start=inp.get("date_start"), end=inp.get("date_end"), limit=limit,
+        )
+        if not days:
+            return f"No {label} recorded."
+        lines = [f"{label} (daily total):"]
+        for d in days:
+            unit = f" {d['unit']}" if d["unit"] else ""
+            lines.append(f"  {d['date']}: {_fmt_num(d['value'])}{unit}")
+        return "\n".join(lines)
+
+    rows = store.list_metrics(metric_type, start=inp.get("date_start"), end=inp.get("date_end"), limit=limit)
     if not rows:
-        return f"No {metric_type.replace('_', ' ')} recorded."
-    lines = [f"{metric_type.replace('_', ' ')}:"]
+        return f"No {label} recorded."
+    lines = [f"{label}:"]
     for m in rows:
         unit = f" {m.unit}" if m.unit else ""
         lines.append(f"  {m.start_at[:10]}: {_fmt_num(m.value)}{unit}")
@@ -1562,6 +1580,10 @@ def _workout_set_profile(inp: dict) -> str:
 
 # Recovery metrics worth citing for a readiness read (manual + Apple Health #323).
 _RECOVERY_METRICS = ("body_weight", "resting_hr", "hrv", "sleep_hours")
+
+# Cumulative metrics: Apple Health emits many intraday buckets per day, so the
+# meaningful view is a daily SUM, not the raw per-sample list (see #333).
+_CUMULATIVE_METRICS = frozenset({"steps", "active_energy"})
 
 
 def _workout_readiness(inp: dict) -> str:

--- a/api/services/fitness_store.py
+++ b/api/services/fitness_store.py
@@ -44,6 +44,17 @@ def _now_iso() -> str:
     return datetime.now(ZoneInfo(settings.timezone)).isoformat()
 
 
+def _local_day(utc_iso: str) -> Optional[str]:
+    """Local calendar day (YYYY-MM-DD) for a stored UTC ISO timestamp, in the
+    configured timezone — so daily rollups match the session day-bucketing."""
+    if not utc_iso:
+        return None
+    try:
+        return datetime.fromisoformat(utc_iso).astimezone(ZoneInfo(settings.timezone)).date().isoformat()
+    except (ValueError, TypeError):
+        return None
+
+
 @dataclass
 class WorkoutSet:
     exercise: str
@@ -432,6 +443,76 @@ class FitnessStore:
         return HealthMetric(id=metric_id, metric_type=metric_type, value=value, unit=unit,
                             start_at=start_at, end_at=end_at or "", source=source)
 
+    # -- bulk import (single-transaction; for large Apple Health backfills) --
+
+    def existing_workout_refs(self) -> set[str]:
+        """All non-empty provenance refs — one query for batch idempotent import."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            rows = conn.execute(
+                "SELECT raw_ref FROM workout_sessions WHERE raw_ref != ''"
+            ).fetchall()
+        finally:
+            conn.close()
+        return {r[0] for r in rows}
+
+    def existing_metric_keys(self) -> set[tuple[str, str]]:
+        """All (metric_type, start_at) pairs — one query for batch idempotent import."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            rows = conn.execute(
+                "SELECT metric_type, start_at FROM health_metrics"
+            ).fetchall()
+        finally:
+            conn.close()
+        return {(r[0], r[1]) for r in rows}
+
+    def bulk_insert_sessions(self, sessions: list[dict]) -> None:
+        """Insert workout sessions (no sets) in a single transaction. Each dict
+        needs date, kind, source, title, notes, raw_ref; id/timestamps generated.
+        Caller is responsible for dedup (see existing_workout_refs)."""
+        if not sessions:
+            return
+        now = _now_iso()
+        rows = [
+            (uuid.uuid4().hex[:12], s.get("date") or _today(), s.get("kind", ""),
+             s.get("source", "manual"), s.get("title", ""), s.get("notes", ""),
+             s.get("raw_ref", ""), now, now)
+            for s in sessions
+        ]
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.executemany(
+                "INSERT INTO workout_sessions (id, date, kind, source, title, notes, raw_ref, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def bulk_insert_metrics(self, metrics: list[dict]) -> None:
+        """Insert health metrics in a single transaction. Each dict needs
+        metric_type, value, unit, start_at, end_at, source; id generated.
+        Caller is responsible for dedup (see existing_metric_keys)."""
+        if not metrics:
+            return
+        rows = [
+            (uuid.uuid4().hex[:12], m["metric_type"], m["value"], m.get("unit", ""),
+             m["start_at"], m.get("end_at"), m.get("source", "manual"))
+            for m in metrics
+        ]
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.executemany(
+                "INSERT INTO health_metrics (id, metric_type, value, unit, start_at, end_at, source) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
     def list_metrics(
         self, metric_type: str, start: Optional[str] = None, end: Optional[str] = None, limit: int = 100,
     ) -> list[HealthMetric]:
@@ -460,6 +541,38 @@ class FitnessStore:
     def latest_metric(self, metric_type: str) -> Optional[HealthMetric]:
         rows = self.list_metrics(metric_type, limit=1)
         return rows[0] if rows else None
+
+    def daily_metric_totals(
+        self, metric_type: str, start: Optional[str] = None, end: Optional[str] = None, limit: int = 100,
+    ) -> list[dict]:
+        """Daily rollup for a cumulative metric (e.g. steps, active_energy): the
+        sum of all samples within each local calendar day. Apple Health stores
+        these as many intraday buckets; this collapses them to one total per day.
+
+        start/end bound the local-day range (YYYY-MM-DD, inclusive). Returns a
+        newest-first list of {date, value, unit, samples}, capped at `limit` days.
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            rows = conn.execute(
+                "SELECT value, unit, start_at FROM health_metrics WHERE metric_type = ?",
+                (metric_type,),
+            ).fetchall()
+        finally:
+            conn.close()
+        buckets: dict[str, dict] = {}
+        for value, unit, start_at in rows:
+            day = _local_day(start_at)
+            if day is None or (start and day < start) or (end and day > end):
+                continue
+            b = buckets.get(day)
+            if b is None:
+                buckets[day] = {"date": day, "value": value, "unit": unit or "", "samples": 1}
+            else:
+                b["value"] += value
+                b["samples"] += 1
+        ordered = sorted(buckets.values(), key=lambda d: d["date"], reverse=True)
+        return ordered[:limit]
 
     # -- training profile --
 

--- a/api/services/health_import.py
+++ b/api/services/health_import.py
@@ -94,28 +94,36 @@ def ingest_health(data: dict, dry_run: bool = False) -> dict:
 
     w_created = w_skipped = m_created = m_skipped = 0
 
+    # Preload existing keys once, then dedup in-memory and insert in a single
+    # transaction per table. A multi-year backfill can be 100k+ rows; the old
+    # per-row connect+commit approach took minutes and timed out the request.
+    existing_refs = store.existing_workout_refs()
+    seen_refs: set[str] = set()
+    session_rows: list[dict] = []
     for w in data.get("workouts") or []:
         ref = (w.get("uuid") or "").strip()
         if not ref:
             continue
-        if store.has_workout_ref(ref):
+        if ref in existing_refs or ref in seen_refs:
             w_skipped += 1
             continue
+        seen_refs.add(ref)
+        w_created += 1
         if dry_run:
-            w_created += 1
             continue
         start = _to_utc_iso(w.get("start"))
-        store.add_session(
-            sets=[],
-            date=_local_date(start),   # local calendar day; None → store uses today
-            kind=_health_kind(w.get("type")),
-            source="apple_health",
-            title=w.get("type", "") or "Workout",
-            notes=_workout_summary(w),
-            raw_ref=ref,
-        )
-        w_created += 1
+        session_rows.append({
+            "date": _local_date(start),   # local calendar day; None → store uses today
+            "kind": _health_kind(w.get("type")),
+            "source": "apple_health",
+            "title": w.get("type", "") or "Workout",
+            "notes": _workout_summary(w),
+            "raw_ref": ref,
+        })
 
+    existing_metric_keys = store.existing_metric_keys()
+    seen_keys: set[tuple[str, str]] = set()
+    metric_rows: list[dict] = []
     for m in data.get("metrics") or []:
         mtype = (m.get("type") or "").strip()
         value = m.get("value")
@@ -123,25 +131,32 @@ def ingest_health(data: dict, dry_run: bool = False) -> dict:
             continue
         start = _to_utc_iso(m.get("start"))
         if not start:
-            # Without a stable timestamp the metric can't be deduped (log_metric
-            # would substitute now()), so it would duplicate on every re-import.
+            # Without a stable timestamp the metric can't be deduped (it would
+            # duplicate on every re-import), so skip it.
             m_skipped += 1
             continue
-        if store.has_metric(mtype, start):
+        key = (mtype, start)
+        if key in existing_metric_keys or key in seen_keys:
             m_skipped += 1
             continue
         if dry_run:
+            seen_keys.add(key)
             m_created += 1
             continue
         try:
             value = float(value)
         except (TypeError, ValueError):
             continue
-        store.log_metric(
-            mtype, value, unit=m.get("unit", ""),
-            start_at=start, end_at=_to_utc_iso(m.get("end")), source="apple_health",
-        )
+        seen_keys.add(key)
         m_created += 1
+        metric_rows.append({
+            "metric_type": mtype, "value": value, "unit": m.get("unit", ""),
+            "start_at": start, "end_at": _to_utc_iso(m.get("end")), "source": "apple_health",
+        })
+
+    if not dry_run:
+        store.bulk_insert_sessions(session_rows)
+        store.bulk_insert_metrics(metric_rows)
 
     logger.info(
         f"Apple Health: workouts +{w_created} (skip {w_skipped}), "

--- a/docs/guides/apple-health.md
+++ b/docs/guides/apple-health.md
@@ -101,6 +101,9 @@ Notes:
 - Suggested `metrics.type` values the fitness bot recognizes as recovery
   signals: `body_weight`, `resting_hr`, `hrv`, `sleep_hours`. Any other type is
   imported and queryable too.
+- Cumulative quantities (`steps`, `active_energy`) arrive as many intraday
+  samples; the fitness bot's `metrics` query returns them as **daily totals**
+  (summed per local calendar day), not raw buckets.
 
 ---
 

--- a/tests/test_agent_tools_workouts.py
+++ b/tests/test_agent_tools_workouts.py
@@ -88,6 +88,16 @@ class TestDispatch:
         out = _tool_manage_workouts({"action": "metrics", "metric_type": "body_weight"})
         assert "body weight" in out.lower()
 
+    def test_metrics_sums_cumulative_to_daily_total(self, temp_store):
+        # steps arrives as intraday buckets; the tool reports one daily total.
+        for h, v in ((10, 100), (12, 250), (14, 75)):
+            temp_store.log_metric("steps", v, unit="count", start_at=f"2026-06-07T{h}:00:00+00:00")
+        out = _tool_manage_workouts({"action": "metrics", "metric_type": "steps"})
+        assert "steps (daily total)" in out
+        assert "2026-06-07: 425 count" in out
+        # one summed line, not three raw buckets
+        assert out.count("2026-06-07:") == 1
+
     def test_history(self, temp_store):
         _tool_manage_workouts({"action": "log", "sets": [{"exercise": "squats", "reps": 5, "weight": 185}]})
         out = _tool_manage_workouts({"action": "history", "exercise": "squats"})

--- a/tests/test_apple_health_import.py
+++ b/tests/test_apple_health_import.py
@@ -144,6 +144,42 @@ def test_metric_without_start_is_skipped_not_duplicated(health_env):
     assert len(store.list_metrics("body_weight")) == 0  # never written, never duplicated
 
 
+def test_duplicate_rows_within_one_payload_are_deduped(health_env):
+    # The batch importer dedups in-memory, so duplicate uuids / (type, start)
+    # keys inside a single payload collapse to one row each.
+    store, export = health_env
+    _write(export, {
+        "workouts": [
+            {"uuid": "W1", "type": "Running", "start": "2026-06-07T08:00:00Z", "duration_s": 600},
+            {"uuid": "W1", "type": "Running", "start": "2026-06-07T08:00:00Z", "duration_s": 600},
+        ],
+        "metrics": [
+            {"type": "body_weight", "value": 178.0, "start": "2026-06-07T07:00:00Z"},
+            {"type": "body_weight", "value": 178.0, "start": "2026-06-07T07:00:00Z"},
+        ],
+    })
+    result = import_health()
+    assert result["workouts_created"] == 1 and result["workouts_skipped"] == 1
+    assert result["metrics_created"] == 1 and result["metrics_skipped"] == 1
+    assert len(store.list_sessions()) == 1
+    assert len(store.list_metrics("body_weight")) == 1
+
+
+def test_large_payload_ingests(health_env):
+    # Regression for the timeout: a backfill of many rows must import in a single
+    # transaction, not per-row connect+commit.
+    store, export = health_env
+    metrics = [
+        {"type": "heart_rate", "value": 60 + (i % 40), "unit": "bpm",
+         "start": f"2026-01-{1 + i // 1440:02d}T{(i // 60) % 24:02d}:{i % 60:02d}:00Z"}
+        for i in range(5000)
+    ]
+    _write(export, {"metrics": metrics})
+    result = import_health()
+    assert result["metrics_created"] == 5000
+    assert len(store.list_metrics("heart_rate", limit=10000)) == 5000
+
+
 def test_workout_date_is_local_not_utc(health_env, monkeypatch):
     # An evening-ET workout that crosses midnight UTC must bucket on the local
     # calendar day, matching manual logging.

--- a/tests/test_fitness_store.py
+++ b/tests/test_fitness_store.py
@@ -113,6 +113,29 @@ class TestMetrics:
         assert len(store.list_metrics("resting_hr")) == 1
 
 
+class TestDailyMetricTotals:
+    def test_sums_intraday_samples_per_day(self, store):
+        # Several midday buckets on one day (midday is tz-stable) collapse to one total.
+        for h, v in ((10, 10), (12, 20), (14, 30)):
+            store.log_metric("steps", v, unit="count", start_at=f"2026-06-07T{h}:00:00+00:00")
+        store.log_metric("steps", 5, unit="count", start_at="2026-06-08T12:00:00+00:00")
+        days = store.daily_metric_totals("steps")
+        assert days[0] == {"date": "2026-06-08", "value": 5, "unit": "count", "samples": 1}
+        assert days[1] == {"date": "2026-06-07", "value": 60, "unit": "count", "samples": 3}
+
+    def test_newest_first_and_day_limit(self, store):
+        for d in range(1, 6):
+            store.log_metric("steps", 100, start_at=f"2026-06-0{d}T12:00:00+00:00")
+        days = store.daily_metric_totals("steps", limit=2)
+        assert [r["date"] for r in days] == ["2026-06-05", "2026-06-04"]
+
+    def test_local_day_range_filter(self, store):
+        for d in (1, 2, 3):
+            store.log_metric("steps", 100, start_at=f"2026-06-0{d}T12:00:00+00:00")
+        days = store.daily_metric_totals("steps", start="2026-06-02", end="2026-06-02")
+        assert len(days) == 1 and days[0]["date"] == "2026-06-02"
+
+
 # -- profile --
 
 class TestProfile:


### PR DESCRIPTION
## Summary

The first real HealthBridge backfill (185k+ events) surfaced two ingest failures and one downstream data-shape gap. This fixes all three.

### Ingest — was rejecting, then timing out
- **Cap:** raised per-request limit `100_000 → 1_000_000` (a multi-year backfill of high-frequency samples easily exceeds 100k).
- **Throughput:** the old path opened a fresh SQLite connection and committed **per row** — ~370k connect+commit cycles for 185k metrics, which ran for minutes and timed out the client. Rewrote `ingest_health` to:
  - preload existing dedup keys in **one query each** (workout refs, metric `(type, start)` pairs),
  - dedup in-memory (now also collapses duplicates *within* a single payload),
  - insert via **one `executemany` transaction per table**.
  - Measured: **185k items ingest in ~1.2s**, idempotent re-ingest in ~0.4s.

### Query — cumulative metrics were unreadable
Apple Health emits `steps`/`active_energy` as many **intraday buckets** (e.g. 14 separate `steps` rows for one day). The `metrics` agent action listed raw buckets, so "steps today" returned a garbled per-bucket list and `latest_metric` returned a meaningless final bucket.
- Added `FitnessStore.daily_metric_totals` — sums samples per **local calendar day** (matching session day-bucketing).
- Routed the `manage_workouts` `metrics` action through it for cumulative types (`steps`, `active_energy`); point-in-time metrics (`body_weight`, `resting_hr`, `hrv`, `sleep_hours`) are unchanged.

## Verified against real synced data
- 184,689 real metrics + 109 sessions confirmed compatible with every consumer: readiness (all 4 recovery signals present & current), the Google Sheet mirror (sessions-only, no metric-volume risk), idempotent re-sync, and the `(metric_type, start_at)` index keeping queries fast.
- Daily aggregation confirmed correct on real data, including local-day reassignment of midnight-crossing samples.

## Tests
- 6 new tests (batch import, within-payload dedup, large-payload, daily rollup totals/limit/range). Full suite: 2,827 passed; the 5 failures are pre-existing and unrelated (settings LLM defaults, slack_sync, p91 vault data-integrity).

Related: #333 (HealthBridge app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)