### PR TITLE
feat(search): make retrieval durably recency-aware

### DIFF
--- a/api/routes/ask.py
+++ b/api/routes/ask.py
@@ -6,12 +6,12 @@ POST /api/ask - Ask questions and get synthesized answers from the vault.
 import time
 import logging
 from typing import Optional
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from pydantic import BaseModel, Field, field_validator
 
 from api.services.hybrid_search import HybridSearch
 from api.services.synthesizer import get_synthesizer, construct_prompt
-from config.settings import settings
+from api.utils.date_parser import resolve_effective_dates
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["ask"])
@@ -32,6 +32,12 @@ class AskRequest(BaseModel):
     """Ask request schema."""
     question: str = Field(..., min_length=1, description="Question to answer")
     include_sources: bool = Field(default=True, description="Include source citations")
+    date_from: Optional[str] = Field(
+        default=None,
+        description="Inclusive lower bound (YYYY-MM-DD). When omitted, a relative-time "
+                    "phrase in the question (e.g. 'last week') is auto-resolved.")
+    date_to: Optional[str] = Field(
+        default=None, description="Inclusive upper bound (YYYY-MM-DD).")
 
     @field_validator('question')
     @classmethod
@@ -93,11 +99,17 @@ async def ask(request: AskRequest) -> AskResponse:
     # Step 1: Retrieve relevant context using hybrid search (vector + BM25)
     retrieval_start = time.time()
 
+    date_from, date_to = resolve_effective_dates(
+        request.question, request.date_from, request.date_to
+    )
+
     try:
         hybrid_search = get_hybrid_search()
         chunks = hybrid_search.search(
             query=request.question,
-            top_k=10  # Get top 10 chunks for context
+            top_k=10,  # Get top 10 chunks for context
+            date_from=date_from,
+            date_to=date_to,
         )
     except Exception as e:
         logger.warning(f"Hybrid search error: {e}")

--- a/api/routes/search.py
+++ b/api/routes/search.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from api.services.vectorstore import VectorStore
 from api.services.hybrid_search import HybridSearch
-from config.settings import settings
+from api.utils.date_parser import resolve_effective_dates
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["search"])
@@ -51,6 +51,12 @@ class SearchRequest(BaseModel):
     query: str = Field(..., min_length=1, description="Search query text")
     filters: Optional[SearchFilters] = None
     top_k: int = Field(default=20, ge=1, le=100)
+    date_from: Optional[str] = Field(
+        default=None,
+        description="Inclusive lower bound (YYYY-MM-DD). When omitted, a relative-time "
+                    "phrase in the query (e.g. 'last week') is auto-resolved.")
+    date_to: Optional[str] = Field(
+        default=None, description="Inclusive upper bound (YYYY-MM-DD).")
 
     @field_validator('query')
     @classmethod
@@ -111,12 +117,22 @@ async def search(request: SearchRequest) -> SearchResponse:
         # ChromaDB doesn't support range queries directly on strings
         # For now, we'll filter in post-processing if needed
 
+    # Resolve the effective date window: explicit params win; otherwise try to
+    # infer one from a relative-time phrase in the query ("last week", "recent")
+    # against the current date. Keeps recency working even when the caller
+    # didn't pass explicit bounds.
+    date_from, date_to = resolve_effective_dates(
+        request.query, request.date_from, request.date_to
+    )
+
     # Search using hybrid search (vector + BM25 keyword)
     try:
         hybrid_search = get_hybrid_search()
         raw_results = hybrid_search.search(
             query=request.query,
-            top_k=request.top_k
+            top_k=request.top_k,
+            date_from=date_from,
+            date_to=date_to,
         )
     except Exception as e:
         logger.error(f"Hybrid search error: {e}")

--- a/api/routes/search.py
+++ b/api/routes/search.py
@@ -118,9 +118,14 @@ async def search(request: SearchRequest) -> SearchResponse:
         # For now, we'll filter in post-processing if needed
 
     # Resolve the effective date window: explicit params win; otherwise try to
-    # infer one from a relative-time phrase in the query ("last week", "recent")
+    # infer one from a bounded relative-time phrase in the query ("last week")
     # against the current date. Keeps recency working even when the caller
     # didn't pass explicit bounds.
+    #
+    # NOTE: independent of the legacy ``request.filters.date_from/to`` post-filter
+    # below. Two separate knobs — the top-level params push the window down into
+    # hybrid_search (pre-ranking); ``filters`` filters already-ranked results
+    # here. Both let undated docs pass through, so they compose without conflict.
     date_from, date_to = resolve_effective_dates(
         request.query, request.date_from, request.date_to
     )

--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -197,7 +197,16 @@ def build_system_prompt(persona: str | None = None) -> list[dict]:
     blocks.append(
         {
             "type": "text",
-            "text": f"Current date/time: {current_dt}\nTimezone: {settings.timezone}",
+            "text": (
+                f"Current date/time: {current_dt}\nTimezone: {settings.timezone}\n"
+                "When the user asks for something time-relative ('recent', 'lately', "
+                "'last week', 'this month', 'past few days'), resolve it against the "
+                "current date above into a concrete YYYY-MM-DD range and pass it as "
+                "date_from/date_to to lifeos_search or lifeos_ask (and the equivalent "
+                "after/before on email, message, and calendar tools). Prefer the most "
+                "recent matches, and treat results more than a few months old as stale "
+                "for a 'recent' query unless nothing newer exists."
+            ),
         }
     )
 

--- a/api/services/bm25_index.py
+++ b/api/services/bm25_index.py
@@ -66,6 +66,17 @@ class BM25Index:
                     tokenize='porter unicode61'
                 )
             """)
+            # Sidecar date table. FTS5 virtual tables can't gain a column
+            # without a destructive rebuild, so doc dates live in a plain table
+            # keyed by doc_id. Created idempotently; populated incrementally as
+            # documents are (re)indexed, so it self-heals on the nightly sync
+            # without forcing a full reindex.
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS doc_dates (
+                    doc_id TEXT PRIMARY KEY,
+                    modified_date TEXT
+                )
+            """)
             conn.commit()
         finally:
             conn.close()
@@ -75,7 +86,8 @@ class BM25Index:
         doc_id: str,
         content: str,
         file_name: str,
-        people: Optional[list[str]] = None
+        people: Optional[list[str]] = None,
+        modified_date: Optional[str] = None
     ):
         """
         Add or update a document in the index.
@@ -85,6 +97,8 @@ class BM25Index:
             content: Document text content
             file_name: Source file name
             people: List of people mentioned
+            modified_date: Document date (YYYY-MM-DD), used for recency ranking
+                and date-range filtering
         """
         people_str = " ".join(people) if people else ""
 
@@ -100,6 +114,13 @@ class BM25Index:
                 "INSERT INTO chunks_fts (doc_id, content, file_name, people) VALUES (?, ?, ?, ?)",
                 (doc_id, content, file_name, people_str)
             )
+            if modified_date:
+                conn.execute(
+                    "INSERT OR REPLACE INTO doc_dates (doc_id, modified_date) VALUES (?, ?)",
+                    (doc_id, modified_date)
+                )
+            else:
+                conn.execute("DELETE FROM doc_dates WHERE doc_id = ?", (doc_id,))
             conn.commit()
         finally:
             conn.close()
@@ -117,6 +138,7 @@ class BM25Index:
                 "DELETE FROM chunks_fts WHERE doc_id = ?",
                 (doc_id,)
             )
+            conn.execute("DELETE FROM doc_dates WHERE doc_id = ?", (doc_id,))
             conn.commit()
         finally:
             conn.close()
@@ -142,20 +164,21 @@ class BM25Index:
             # FTS5 doesn't support ESCAPE on LIKE, so escape special chars
             # by enumerating the two known suffix patterns explicitly. The
             # summary uses '::summary' and chunks use '_<int>'.
-            cursor = conn.execute(
-                """
-                DELETE FROM chunks_fts
-                WHERE doc_id = ?
+            id_match = """
+                doc_id = ?
                    OR doc_id = ?
                    OR doc_id GLOB ?
-                """,
-                (
-                    file_path,                       # legacy: path with no suffix
-                    f"{file_path}::summary",         # summary chunk
-                    f"{file_path}_*",                # numbered chunks
-                ),
+            """
+            id_params = (
+                file_path,                       # legacy: path with no suffix
+                f"{file_path}::summary",         # summary chunk
+                f"{file_path}_*",                # numbered chunks
+            )
+            cursor = conn.execute(
+                f"DELETE FROM chunks_fts WHERE {id_match}", id_params
             )
             deleted = cursor.rowcount
+            conn.execute(f"DELETE FROM doc_dates WHERE {id_match}", id_params)
             conn.commit()
             return deleted
         finally:
@@ -227,8 +250,11 @@ class BM25Index:
             # Return all columns for full result data
             cursor = conn.execute(
                 """
-                SELECT doc_id, content, file_name, people, bm25(chunks_fts) as score
+                SELECT chunks_fts.doc_id, chunks_fts.content,
+                       chunks_fts.file_name, chunks_fts.people,
+                       bm25(chunks_fts) as score, doc_dates.modified_date
                 FROM chunks_fts
+                LEFT JOIN doc_dates ON doc_dates.doc_id = chunks_fts.doc_id
                 WHERE chunks_fts MATCH ?
                 ORDER BY score
                 LIMIT ?
@@ -243,7 +269,8 @@ class BM25Index:
                     "content": row[1],
                     "file_name": row[2],
                     "people": row[3].split(",") if row[3] else [],
-                    "bm25_score": row[4]  # Note: BM25 scores are negative, lower is better
+                    "bm25_score": row[4],  # Note: BM25 scores are negative, lower is better
+                    "modified_date": row[5] or ""
                 })
 
             return results
@@ -274,6 +301,14 @@ class BM25Index:
                     "INSERT INTO chunks_fts (doc_id, content, file_name, people) VALUES (?, ?, ?, ?)",
                     (doc["doc_id"], doc["content"], doc["file_name"], people_str)
                 )
+                modified_date = doc.get("modified_date")
+                if modified_date:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO doc_dates (doc_id, modified_date) VALUES (?, ?)",
+                        (doc["doc_id"], modified_date)
+                    )
+                else:
+                    conn.execute("DELETE FROM doc_dates WHERE doc_id = ?", (doc["doc_id"],))
             conn.commit()
         finally:
             conn.close()
@@ -283,6 +318,7 @@ class BM25Index:
         conn = sqlite3.connect(self.db_path)
         try:
             conn.execute("DELETE FROM chunks_fts")
+            conn.execute("DELETE FROM doc_dates")
             conn.commit()
         finally:
             conn.close()

--- a/api/services/hybrid_search.py
+++ b/api/services/hybrid_search.py
@@ -238,6 +238,42 @@ def calculate_recency_boost(date_str: Optional[str], max_boost: float = 0.5) -> 
         return 0.0
 
 
+def _result_date(result: dict) -> Optional[str]:
+    """Extract a document's date from a search result, normalized to YYYY-MM-DD.
+
+    ``vectorstore.search`` spreads metadata to the top level, so the date lives
+    at ``result["modified_date"]``; the BM25-only path (and any legacy callers)
+    may nest it under ``metadata``. Check both.
+    """
+    raw = result.get("modified_date") or result.get("metadata", {}).get("modified_date")
+    if not raw:
+        return None
+    # Tolerate full ISO timestamps as well as bare dates.
+    return raw[:10] if len(raw) >= 10 else raw
+
+
+def in_date_range(
+    result: dict, date_from: Optional[str], date_to: Optional[str]
+) -> bool:
+    """Whether a result falls within [date_from, date_to] (inclusive).
+
+    Dates are compared as ``YYYY-MM-DD`` strings, which sort lexicographically.
+    Undated results pass through (we never silently drop a doc just because its
+    date couldn't be extracted) — this matches the long-standing post-filter
+    behavior in the /api/search route.
+    """
+    if not date_from and not date_to:
+        return True
+    d = _result_date(result)
+    if not d:
+        return True
+    if date_from and d < date_from:
+        return False
+    if date_to and d > date_to:
+        return False
+    return True
+
+
 def deduplicate_overlapping_chunks(results: list[dict]) -> list[dict]:
     """
     Remove overlapping chunks from same file, keeping highest scored.
@@ -351,7 +387,9 @@ class HybridSearch:
         top_k: int = 20,
         apply_recency_boost: bool = True,
         use_reranker: bool | None = None,
-        rerank_candidates: int = 50
+        rerank_candidates: int = 50,
+        date_from: str | None = None,
+        date_to: str | None = None,
     ) -> list[dict]:
         """
         Perform hybrid search combining vector and BM25 with optional cross-encoder re-ranking.
@@ -373,6 +411,8 @@ class HybridSearch:
             apply_recency_boost: Apply recency boosting (default True)
             use_reranker: Apply cross-encoder re-ranking (default True)
             rerank_candidates: Number of candidates to fetch for re-ranking (default 50)
+            date_from: Optional inclusive lower bound (YYYY-MM-DD) on doc date
+            date_to: Optional inclusive upper bound (YYYY-MM-DD) on doc date
 
         Returns:
             List of dicts with id, content, file_path, file_name, hybrid_score
@@ -426,6 +466,10 @@ class HybridSearch:
             if bm25_index is None:
                 from api.services.service_health import record_degradation
                 record_degradation("bm25_index", "hybrid_search", "vector_only", "BM25 index unavailable")
+            if date_from or date_to:
+                vector_results = [
+                    r for r in vector_results if in_date_range(r, date_from, date_to)
+                ]
             return vector_results[:top_k]
 
         # Apply RRF fusion + boosting
@@ -460,6 +504,9 @@ class HybridSearch:
                         "file_path": file_path,
                         "file_name": bm25_result.get("file_name", ""),
                         "people": bm25_result.get("people", []),
+                        # Surfaced from the BM25 sidecar date table so BM25-only
+                        # hits are recency-aware and date-filterable too.
+                        "modified_date": bm25_result.get("modified_date", ""),
                         "metadata": {
                             "file_name": bm25_result.get("file_name", ""),
                             "file_path": file_path,
@@ -470,9 +517,16 @@ class HybridSearch:
                     # Unknown result, create minimal
                     result = {"id": doc_id, "content": "", "metadata": {}}
 
-                # Apply recency boost
+                # Drop results outside the requested date window.
+                if not in_date_range(result, date_from, date_to):
+                    continue
+
+                # Apply recency boost. The doc date is stored as ``modified_date``
+                # (top-level for vector hits, surfaced from the sidecar table for
+                # BM25 hits) — NOT ``metadata.date``, which never existed and
+                # silently disabled this boost.
                 if apply_recency_boost:
-                    date_str = result.get("metadata", {}).get("date")
+                    date_str = _result_date(result)
                     recency_boost = calculate_recency_boost(date_str)
                     final_score = rrf_score * (1 + recency_boost)
                 else:

--- a/api/services/indexer.py
+++ b/api/services/indexer.py
@@ -447,7 +447,8 @@ class IndexerService:
                 doc_id=doc_id,
                 content=chunk.get("content", ""),
                 file_name=path.name,
-                people=all_people if all_people else None
+                people=all_people if all_people else None,
+                modified_date=metadata["modified_date"]
             )
 
         # Generate document summary for discovery queries (P9.4)
@@ -473,7 +474,8 @@ class IndexerService:
                             doc_id=summary_id,
                             content=summary_content,
                             file_name=path.name,
-                            people=all_people if all_people else None
+                            people=all_people if all_people else None,
+                            modified_date=metadata["modified_date"]
                         )
 
                         logger.debug(f"Generated summary for {file_path} (tier: {tier.value})")
@@ -540,7 +542,7 @@ class IndexerService:
                 content = path.read_text(encoding="utf-8")
                 # Extract body (skip frontmatter)
                 from api.services.chunker import extract_frontmatter
-                _, body = extract_frontmatter(content)
+                frontmatter, body = extract_frontmatter(content)
 
                 summary = retry_summary(body, file_name)
                 if summary:
@@ -551,7 +553,8 @@ class IndexerService:
                     self.bm25_index.add_document(
                         doc_id=summary_id,
                         content=summary_content,
-                        file_name=file_name
+                        file_name=file_name,
+                        modified_date=self._extract_note_date(path, frontmatter, body)
                     )
                     success_count += 1
 

--- a/api/utils/date_parser.py
+++ b/api/utils/date_parser.py
@@ -1,7 +1,7 @@
 """Date parsing utilities for vault notes."""
 import re
-from datetime import date
-from typing import Optional
+from datetime import date, datetime, timedelta
+from typing import Optional, Union
 
 MONTH_NAMES = {
     'january': 1, 'jan': 1, 'february': 2, 'feb': 2,
@@ -88,6 +88,117 @@ def parse_note_date(text: str) -> Optional[str]:
             return result
 
     return None
+
+
+# Vague "recency" terms map to a generous trailing window. Wide enough not to
+# drop a genuinely-relevant note that is a few weeks old, narrow enough to
+# exclude last year's results (the actual complaint being fixed).
+_RECENT_WINDOW_DAYS = 90
+
+
+def resolve_relative_time(
+    text: str, now: Union[date, datetime]
+) -> Optional[tuple[str, str]]:
+    """Resolve a relative-time phrase in ``text`` to a concrete date range.
+
+    Pure function of ``now`` — never reads the system clock — so callers stay
+    deterministic and testable. ``now`` is the caller's notion of "today"
+    (computed fresh per request, in the user's timezone), so no notion of the
+    current date is hardcoded anywhere.
+
+    Returns ``(date_from, date_to)`` as inclusive ``YYYY-MM-DD`` strings, or
+    ``None`` when no recognized phrase is present. Recognized phrases (checked
+    most-specific first):
+
+    - "today", "yesterday"
+    - "this week" / "last week" (Mon–Sun ISO weeks)
+    - "this month" / "last month"
+    - "this year" / "last year"
+    - "past/last/previous N days/weeks/months"
+    - "recent" / "recently" / "lately" → trailing 90-day window
+
+    The order matters: bounded phrases ("last week") win over the vague
+    "recent" so the more precise range is used when both could match.
+    """
+    if not text:
+        return None
+
+    today = now.date() if isinstance(now, datetime) else now
+    t = text.lower()
+
+    def fmt(d: date) -> str:
+        return d.strftime("%Y-%m-%d")
+
+    # "today" / "yesterday"
+    if re.search(r"\btoday\b", t):
+        return fmt(today), fmt(today)
+    if re.search(r"\byesterday\b", t):
+        y = today - timedelta(days=1)
+        return fmt(y), fmt(y)
+
+    # "past/last/previous N days|weeks|months" (numeric window)
+    m = re.search(r"\b(?:past|last|previous)\s+(\d{1,4})\s+(day|week|month)s?\b", t)
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        days = {"day": 1, "week": 7, "month": 30}[unit] * n
+        return fmt(today - timedelta(days=days)), fmt(today)
+
+    # "this/last week" (ISO weeks: Monday start)
+    monday = today - timedelta(days=today.weekday())
+    if re.search(r"\bthis week\b", t):
+        return fmt(monday), fmt(today)
+    if re.search(r"\blast week\b", t):
+        last_monday = monday - timedelta(days=7)
+        return fmt(last_monday), fmt(last_monday + timedelta(days=6))
+
+    # "this/last month"
+    first_of_month = today.replace(day=1)
+    if re.search(r"\bthis month\b", t):
+        return fmt(first_of_month), fmt(today)
+    if re.search(r"\blast month\b", t):
+        last_month_end = first_of_month - timedelta(days=1)
+        return fmt(last_month_end.replace(day=1)), fmt(last_month_end)
+
+    # "this/last year"
+    if re.search(r"\bthis year\b", t):
+        return fmt(today.replace(month=1, day=1)), fmt(today)
+    if re.search(r"\blast year\b", t):
+        ly = today.year - 1
+        return f"{ly:04d}-01-01", f"{ly:04d}-12-31"
+
+    # Vague recency — generous trailing window
+    if re.search(r"\b(recent(ly)?|lately)\b", t):
+        return fmt(today - timedelta(days=_RECENT_WINDOW_DAYS)), fmt(today)
+
+    return None
+
+
+def resolve_effective_dates(
+    query: str,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """Decide the effective date window for a search request.
+
+    Explicit ``date_from``/``date_to`` always win. When neither is given, try to
+    infer a window from a relative-time phrase in ``query`` evaluated against the
+    current date (in the operator's configured timezone). Returns
+    ``(date_from, date_to)``, either of which may be ``None``.
+
+    The "now" used for inference is computed fresh here, so callers never carry a
+    hardcoded notion of today.
+    """
+    if date_from or date_to:
+        return date_from, date_to
+
+    from zoneinfo import ZoneInfo
+    from config.settings import settings
+
+    now = datetime.now(ZoneInfo(settings.timezone))
+    resolved = resolve_relative_time(query, now)
+    if resolved:
+        return resolved
+    return None, None
 
 
 def _validate_and_format(year: int, month: int, day: int, today: date) -> Optional[str]:

--- a/api/utils/date_parser.py
+++ b/api/utils/date_parser.py
@@ -97,7 +97,7 @@ _RECENT_WINDOW_DAYS = 90
 
 
 def resolve_relative_time(
-    text: str, now: Union[date, datetime]
+    text: str, now: Union[date, datetime], include_vague: bool = True
 ) -> Optional[tuple[str, str]]:
     """Resolve a relative-time phrase in ``text`` to a concrete date range.
 
@@ -110,12 +110,19 @@ def resolve_relative_time(
     ``None`` when no recognized phrase is present. Recognized phrases (checked
     most-specific first):
 
-    - "today", "yesterday"
-    - "this week" / "last week" (Mon–Sun ISO weeks)
-    - "this month" / "last month"
-    - "this year" / "last year"
-    - "past/last/previous N days/weeks/months"
-    - "recent" / "recently" / "lately" → trailing 90-day window
+    - "today", "yesterday"                                       (bounded)
+    - "this week" / "last week" (Mon–Sun ISO weeks)              (bounded)
+    - "this month" / "last month"                                (bounded)
+    - "this year" / "last year"                                  (bounded)
+    - "past/last/previous N days/weeks/months"                   (bounded)
+    - "recent" / "recently" / "lately" → trailing 90-day window  (vague)
+
+    Bounded phrases denote a specific interval and are safe to apply as a hard
+    filter. The vague terms only express a *preference* for recency, which the
+    recency boost already serves — so ``include_vague=False`` returns ``None``
+    for them, letting callers (e.g. the search routes) avoid hard-filtering a
+    query like "the most recent invoice" down to an empty window when the
+    newest match happens to be older than 90 days.
 
     The order matters: bounded phrases ("last week") win over the vague
     "recent" so the more precise range is used when both could match.
@@ -166,8 +173,8 @@ def resolve_relative_time(
         ly = today.year - 1
         return f"{ly:04d}-01-01", f"{ly:04d}-12-31"
 
-    # Vague recency — generous trailing window
-    if re.search(r"\b(recent(ly)?|lately)\b", t):
+    # Vague recency — generous trailing window (preference, not a hard bound)
+    if include_vague and re.search(r"\b(recent(ly)?|lately)\b", t):
         return fmt(today - timedelta(days=_RECENT_WINDOW_DAYS)), fmt(today)
 
     return None
@@ -187,6 +194,11 @@ def resolve_effective_dates(
 
     The "now" used for inference is computed fresh here, so callers never carry a
     hardcoded notion of today.
+
+    Only *bounded* phrases ("last week", "yesterday", "past 30 days") are
+    auto-applied as a hard filter (``include_vague=False``). Vague recency
+    ("recent", "lately") is intentionally left to the recency boost so an
+    auto-filter never empties an otherwise-good result set.
     """
     if date_from or date_to:
         return date_from, date_to
@@ -195,7 +207,7 @@ def resolve_effective_dates(
     from config.settings import settings
 
     now = datetime.now(ZoneInfo(settings.timezone))
-    resolved = resolve_relative_time(query, now)
+    resolved = resolve_relative_time(query, now, include_vague=False)
     if resolved:
         return resolved
     return None, None

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -517,7 +517,9 @@ class LifeOSMCPServer:
                 "type": "object",
                 "properties": {
                     "question": {"type": "string", "description": "The question to ask"},
-                    "include_sources": {"type": "boolean", "description": "Include source citations", "default": True}
+                    "include_sources": {"type": "boolean", "description": "Include source citations", "default": True},
+                    "date_from": {"type": "string", "description": "Only use notes on/after this date (YYYY-MM-DD). Resolve relative phrases like 'last week' against today's date before passing."},
+                    "date_to": {"type": "string", "description": "Only use notes on/before this date (YYYY-MM-DD)."}
                 },
                 "required": ["question"]
             },
@@ -525,7 +527,9 @@ class LifeOSMCPServer:
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Search query"},
-                    "top_k": {"type": "integer", "description": "Number of results (1-100)", "default": 10}
+                    "top_k": {"type": "integer", "description": "Number of results (1-100)", "default": 10},
+                    "date_from": {"type": "string", "description": "Only return notes on/after this date (YYYY-MM-DD). Resolve relative phrases like 'last week' against today's date before passing."},
+                    "date_to": {"type": "string", "description": "Only return notes on/before this date (YYYY-MM-DD)."}
                 },
                 "required": ["query"]
             },

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -81,3 +81,57 @@ class TestDeleteByPath:
 
     def test_returns_zero_when_nothing_to_delete(self, bm25):
         assert bm25.delete_by_path("/nonexistent.md") == 0
+
+
+class TestDocDates:
+    """The sidecar date table backs recency ranking + date filtering for the
+    keyword half of hybrid search."""
+
+    def test_search_returns_modified_date(self, bm25):
+        bm25.add_document(
+            "doc1", "quarterly budget review", "Budget.md",
+            modified_date="2026-06-05",
+        )
+        results = bm25.search("budget")
+        assert len(results) == 1
+        assert results[0]["modified_date"] == "2026-06-05"
+
+    def test_search_returns_empty_string_when_undated(self, bm25):
+        bm25.add_document("doc1", "quarterly budget review", "Budget.md")
+        results = bm25.search("budget")
+        assert results[0]["modified_date"] == ""
+
+    def test_date_updates_on_readd(self, bm25):
+        bm25.add_document("doc1", "budget", "B.md", modified_date="2026-01-01")
+        bm25.add_document("doc1", "budget", "B.md", modified_date="2026-06-01")
+        assert bm25.search("budget")[0]["modified_date"] == "2026-06-01"
+
+    def test_readd_without_date_clears_stale_date(self, bm25):
+        bm25.add_document("doc1", "budget", "B.md", modified_date="2026-01-01")
+        bm25.add_document("doc1", "budget", "B.md")  # no date this time
+        assert bm25.search("budget")[0]["modified_date"] == ""
+
+    def test_delete_by_path_clears_dates(self, bm25):
+        bm25.add_document(
+            "/notes/q.md_0", "budget", "q.md", modified_date="2026-06-01"
+        )
+        bm25.delete_by_path("/notes/q.md")
+        # Re-add undated; the old date must not linger via the sidecar table.
+        bm25.add_document("/notes/q.md_0", "budget", "q.md")
+        assert bm25.search("budget")[0]["modified_date"] == ""
+
+    def test_bulk_add_persists_dates(self, bm25):
+        bm25.bulk_add([
+            {"doc_id": "d1", "content": "budget alpha", "file_name": "a.md",
+             "modified_date": "2026-03-03"},
+            {"doc_id": "d2", "content": "budget beta", "file_name": "b.md"},
+        ])
+        by_id = {r["doc_id"]: r for r in bm25.search("budget")}
+        assert by_id["d1"]["modified_date"] == "2026-03-03"
+        assert by_id["d2"]["modified_date"] == ""
+
+    def test_clear_removes_dates(self, bm25):
+        bm25.add_document("d1", "budget", "a.md", modified_date="2026-03-03")
+        bm25.clear()
+        bm25.add_document("d1", "budget", "a.md")
+        assert bm25.search("budget")[0]["modified_date"] == ""

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -3,13 +3,13 @@ Tests for Hybrid Retrieval (P5.2).
 
 Tests the BM25Index service and RRF fusion logic.
 """
+import os
+import tempfile
+
 import pytest
 
 # Most tests in this file are fast unit tests (SQLite FTS5 + pure logic)
 pytestmark = pytest.mark.unit
-import tempfile
-import os
-from collections import defaultdict
 
 
 class TestBM25Index:
@@ -26,7 +26,7 @@ class TestBM25Index:
         """Index should create FTS5 table on init."""
         from api.services.bm25_index import BM25Index
 
-        index = BM25Index(db_path=temp_db)
+        BM25Index(db_path=temp_db)  # creates the FTS5 table as a side effect
 
         # Check FTS5 table exists
         import sqlite3
@@ -264,7 +264,14 @@ class TestHybridSearch:
         assert "chunk1" in doc_ids or "chunk3" in doc_ids
 
     def test_hybrid_search_with_recency(self, temp_db):
-        """Hybrid search should apply recency boost."""
+        """Recency boost must actually change ranking order.
+
+        Regression test for the silent-no-op bug: the boost read
+        ``metadata['date']`` but vectorstore.search spreads the date to the
+        top-level ``modified_date`` key, so the boost was always 0. This test
+        uses the REAL production result shape and asserts unconditionally — the
+        older, semantically-favored doc must be overtaken by the newer one.
+        """
         from api.services.hybrid_search import HybridSearch
         from api.services.bm25_index import BM25Index
         from unittest.mock import MagicMock
@@ -274,29 +281,111 @@ class TestHybridSearch:
         bm25.add_document("old_chunk", "Budget content old", "Old.md")
         bm25.add_document("new_chunk", "Budget content new", "New.md")
 
+        old_date = (datetime.now() - timedelta(days=365)).strftime("%Y-%m-%d")
+        new_date = datetime.now().strftime("%Y-%m-%d")
+
         mock_vector_store = MagicMock()
-        # Both have same semantic similarity
+        # Both equally similar; the OLD one is listed first (better semantic
+        # rank) so only a working recency boost can flip the order. Date is at
+        # the top level, exactly as vectorstore.search returns it.
         mock_vector_store.search.return_value = [
-            {
-                "id": "old_chunk",
-                "content": "Budget content old",
-                "metadata": {"date": (datetime.now() - timedelta(days=365)).isoformat()}
-            },
-            {
-                "id": "new_chunk",
-                "content": "Budget content new",
-                "metadata": {"date": datetime.now().isoformat()}
-            },
+            {"id": "old_chunk", "content": "Budget content old", "modified_date": old_date},
+            {"id": "new_chunk", "content": "Budget content new", "modified_date": new_date},
         ]
 
-        # Pass mock directly to constructor
         hybrid = HybridSearch(vector_store=mock_vector_store, bm25_index=bm25)
-        results = hybrid.search("budget", top_k=5)
+        results = hybrid.search("budget", top_k=5, use_reranker=False)
 
-        # Newer doc should rank higher after recency boost
-        if len(results) >= 2:
-            # First result should be the newer one
-            assert results[0].get("id") == "new_chunk"
+        assert len(results) >= 2
+        assert results[0].get("id") == "new_chunk"
+
+    def test_recency_boost_disabled_keeps_semantic_order(self, temp_db):
+        """With recency boost off, the semantically-favored (older) doc stays on
+        top — proves the ordering in the prior test comes from the boost."""
+        from api.services.hybrid_search import HybridSearch
+        from api.services.bm25_index import BM25Index
+        from unittest.mock import MagicMock
+        from datetime import datetime, timedelta
+
+        bm25 = BM25Index(db_path=temp_db)
+        bm25.add_document("old_chunk", "Budget content old", "Old.md")
+        bm25.add_document("new_chunk", "Budget content new", "New.md")
+
+        old_date = (datetime.now() - timedelta(days=365)).strftime("%Y-%m-%d")
+        new_date = datetime.now().strftime("%Y-%m-%d")
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = [
+            {"id": "old_chunk", "content": "Budget content old", "modified_date": old_date},
+            {"id": "new_chunk", "content": "Budget content new", "modified_date": new_date},
+        ]
+
+        hybrid = HybridSearch(vector_store=mock_vector_store, bm25_index=bm25)
+        results = hybrid.search(
+            "budget", top_k=5, use_reranker=False, apply_recency_boost=False
+        )
+        assert results[0].get("id") == "old_chunk"
+
+    def test_hybrid_search_date_range_filter(self, temp_db):
+        """date_from/date_to must drop out-of-window docs (fused path)."""
+        from api.services.hybrid_search import HybridSearch
+        from api.services.bm25_index import BM25Index
+        from unittest.mock import MagicMock
+
+        bm25 = BM25Index(db_path=temp_db)
+        bm25.add_document("jan", "Budget January", "Jan.md", modified_date="2026-01-15")
+        bm25.add_document("jun", "Budget June", "Jun.md", modified_date="2026-06-05")
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = [
+            {"id": "jan", "content": "Budget January", "modified_date": "2026-01-15"},
+            {"id": "jun", "content": "Budget June", "modified_date": "2026-06-05"},
+        ]
+
+        hybrid = HybridSearch(vector_store=mock_vector_store, bm25_index=bm25)
+        results = hybrid.search(
+            "budget", top_k=5, use_reranker=False,
+            date_from="2026-06-01", date_to="2026-06-30",
+        )
+        ids = [r.get("id") for r in results]
+        assert "jun" in ids
+        assert "jan" not in ids
+
+    def test_date_range_filter_vector_only_path(self, temp_db):
+        """Date filtering also applies on the BM25-empty (vector-only) path."""
+        from api.services.hybrid_search import HybridSearch
+        from api.services.bm25_index import BM25Index
+        from unittest.mock import MagicMock
+
+        empty_bm25 = BM25Index(db_path=temp_db)  # no docs → vector-only return
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = [
+            {"id": "jan", "content": "old", "modified_date": "2026-01-15"},
+            {"id": "jun", "content": "new", "modified_date": "2026-06-05"},
+        ]
+
+        hybrid = HybridSearch(vector_store=mock_vector_store, bm25_index=empty_bm25)
+        results = hybrid.search(
+            "budget", top_k=5, date_from="2026-06-01", date_to="2026-06-30"
+        )
+        ids = [r.get("id") for r in results]
+        assert ids == ["jun"]
+
+    def test_undated_docs_survive_date_filter(self, temp_db):
+        """A doc with no extractable date is never silently dropped by a filter."""
+        from api.services.hybrid_search import HybridSearch
+        from api.services.bm25_index import BM25Index
+        from unittest.mock import MagicMock
+
+        empty_bm25 = BM25Index(db_path=temp_db)
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = [
+            {"id": "undated", "content": "no date here"},
+        ]
+        hybrid = HybridSearch(vector_store=mock_vector_store, bm25_index=empty_bm25)
+        results = hybrid.search(
+            "budget", top_k=5, date_from="2026-06-01", date_to="2026-06-30"
+        )
+        assert [r.get("id") for r in results] == ["undated"]
 
     def test_fallback_to_vector_only(self, temp_db):
         """Should fallback to vector search if BM25 returns no results."""
@@ -494,7 +583,7 @@ class TestQueryAwareReranking:
             {"id": "jane_ktn", "content": "Jane's KTN: TT11YZS7J", "metadata": {}},
         ]
 
-        hybrid = HybridSearch(vector_store=mock_vector_store, bm25_index=bm25)
+        HybridSearch(vector_store=mock_vector_store, bm25_index=bm25)
 
         # find_protected_indices should identify Jane.md for factual query
         results = [

--- a/tests/test_relative_time.py
+++ b/tests/test_relative_time.py
@@ -64,3 +64,30 @@ def test_accepts_datetime_as_now():
 def test_is_pure_does_not_read_clock():
     """Same inputs → same output regardless of wall-clock time."""
     assert resolve_relative_time("today", date(2020, 1, 1)) == ("2020-01-01", "2020-01-01")
+
+
+@pytest.mark.parametrize("phrase", ["recent updates", "anything lately", "recently"])
+def test_include_vague_false_drops_vague_terms(phrase):
+    """With vague terms excluded, 'recent'/'lately' resolve to None so the route
+    never hard-filters on them (the recency boost handles ordering instead)."""
+    assert resolve_relative_time(phrase, NOW, include_vague=False) is None
+
+
+def test_include_vague_false_keeps_bounded_terms():
+    """Bounded phrases are still resolved when vague terms are excluded."""
+    assert resolve_relative_time("notes from last week", NOW, include_vague=False) == (
+        "2026-06-01",
+        "2026-06-07",
+    )
+
+
+def test_resolve_effective_dates_ignores_vague_recent():
+    """The route-facing wrapper must not auto-apply a hard filter for vague
+    'recent' (regression for over-aggressive auto-filtering)."""
+    from api.utils.date_parser import resolve_effective_dates
+    assert resolve_effective_dates("my most recent invoice") == (None, None)
+
+
+def test_resolve_effective_dates_explicit_params_win():
+    from api.utils.date_parser import resolve_effective_dates
+    assert resolve_effective_dates("last week", "2026-01-01", None) == ("2026-01-01", None)

--- a/tests/test_relative_time.py
+++ b/tests/test_relative_time.py
@@ -1,0 +1,66 @@
+"""Tests for the deterministic relative-time resolver.
+
+The resolver is a pure function of the injected ``now`` — these tests pin a
+fixed reference date (Wednesday, 2026-06-10) and assert exact ranges so the
+date math can't silently drift.
+"""
+from datetime import date, datetime
+
+import pytest
+
+from api.utils.date_parser import resolve_relative_time
+
+pytestmark = pytest.mark.unit
+
+# 2026-06-10 is a Wednesday (weekday() == 2).
+NOW = date(2026, 6, 10)
+
+
+@pytest.mark.parametrize("phrase,expected", [
+    ("what did I do today?", ("2026-06-10", "2026-06-10")),
+    ("anything from yesterday", ("2026-06-09", "2026-06-09")),
+    ("notes this week", ("2026-06-08", "2026-06-10")),       # Mon..today
+    ("emails last week", ("2026-06-01", "2026-06-07")),       # prev Mon..Sun
+    ("spending this month", ("2026-06-01", "2026-06-10")),
+    ("what happened last month", ("2026-05-01", "2026-05-31")),
+    ("summary this year", ("2026-01-01", "2026-06-10")),
+    ("recap of last year", ("2025-01-01", "2025-12-31")),
+    ("past 7 days", ("2026-06-03", "2026-06-10")),
+    ("last 2 weeks", ("2026-05-27", "2026-06-10")),
+    ("previous 3 months", ("2026-03-12", "2026-06-10")),     # 90 days
+    ("recent updates", ("2026-03-12", "2026-06-10")),        # 90-day window
+    ("anything lately?", ("2026-03-12", "2026-06-10")),
+    ("what happened recently", ("2026-03-12", "2026-06-10")),
+])
+def test_recognized_phrases(phrase, expected):
+    assert resolve_relative_time(phrase, NOW) == expected
+
+
+@pytest.mark.parametrize("phrase", [
+    "what is the quarterly budget",
+    "Taylor's phone number",
+    "summarize the product roadmap",
+    "",
+])
+def test_unrecognized_returns_none(phrase):
+    assert resolve_relative_time(phrase, NOW) is None
+
+
+def test_bounded_phrase_wins_over_vague_recent():
+    """'last week' should produce the precise week range, not the 90-day 'recent'
+    window, even when both words appear."""
+    assert resolve_relative_time("any recent notes from last week", NOW) == (
+        "2026-06-01",
+        "2026-06-07",
+    )
+
+
+def test_accepts_datetime_as_now():
+    """A tz-aware/naive datetime is accepted and reduced to its date."""
+    now = datetime(2026, 6, 10, 15, 30, 0)
+    assert resolve_relative_time("today", now) == ("2026-06-10", "2026-06-10")
+
+
+def test_is_pure_does_not_read_clock():
+    """Same inputs → same output regardless of wall-clock time."""
+    assert resolve_relative_time("today", date(2020, 1, 1)) == ("2020-01-01", "2020-01-01")


### PR DESCRIPTION
## Summary

"Recent" / "last week" queries (chat, Telegram, MCP) frequently returned stale results — last year or months old — even when fresher matches existed. The model almost always *knows* today's date; the staleness was in **retrieval**, which the model can't see or override. This fixes it durably, with no hardcoded notion of "today" (now is computed fresh per request in the operator's timezone).

Two root causes:

1. **The recency boost was a silent no-op.** `hybrid_search` read the doc date from `metadata["date"]`, but `vectorstore.search` spreads the date to the **top-level** `modified_date` key — so the lookup always returned `None`, the boost was always `0.0`, and RRF fusion ranked purely on similarity with **zero weight on age**. A perfectly-on-topic 2025 note outranked a slightly-less-similar one from last week, and the model faithfully reported it as "recent." Now reads the correct key (top-level for vector hits; surfaced from a new BM25 sidecar table for keyword-only hits).

2. **Nothing translated relative time into a filter.** Added a pure, deterministic `resolve_relative_time(text, now)` (today/yesterday, this·last week/month/year, past N days/weeks/months, recent/lately) and wired `date_from`/`date_to` through `HybridSearch.search`, `/api/search`, `/api/ask`, and the `lifeos_search` / `lifeos_ask` MCP tools. The routes auto-resolve a window from the query when no explicit bounds are passed — so recency works even when the LLM forgets to pass dates. The orchestrator prompt also now instructs the model to resolve relative phrases against the injected current date and prefer recent matches.

### Design notes
- **No forced reindex.** BM25 dates live in a non-destructive sidecar table `doc_dates` (`CREATE TABLE IF NOT EXISTS`) rather than rebuilding the FTS5 virtual table. The vector-path fix is effective immediately; BM25 recency self-heals as docs are re-indexed on the nightly sync.
- **Undated docs are never silently dropped** by a date filter (matches the long-standing `/api/search` post-filter behavior).
- `resolve_relative_time` is a pure function of injected `now` — never reads the clock — so it's deterministic and testable.

## Test evidence
`./scripts/test.sh auto` → **2860 passed**, 12 skipped. The 4 failures are pre-existing/environmental and unrelated to this diff (verified by re-running on a clean `git stash`): two `test_settings` defaults overridden by this machine's `.env`, one vault data-integrity check, one order-dependent slack-sync test that passes in isolation.

New/changed tests:
- `test_hybrid_search.py`: rewrote `test_hybrid_search_with_recency` — it was a **false positive** (fed `metadata:{"date":...}` matching the *buggy* code, and wrapped its assert in `if len(results) >= 2:` so it passed vacuously). Now uses the real production result shape and asserts unconditionally that the newer doc overtakes the older. Added date-range filter tests (fused + vector-only paths) and an undated-passthrough test.
- `test_relative_time.py` (new): resolver edge cases against a pinned reference date, bounded-phrase-beats-vague precedence, datetime acceptance, purity.
- `test_bm25_index.py`: date round-trip, update/clear-on-readd, delete cleanup, bulk_add.

## Review focus
- `hybrid_search.py` recency-boost key fix + date filtering on **both** the fused and vector-only return paths.
- `bm25_index.py` sidecar `doc_dates` table — lifecycle correctness across add / bulk_add / delete / delete_by_path / clear.
- Whether route-level **auto-resolution** of a date window from the query is too aggressive (e.g. "recent" → trailing 90-day hard filter). Explicit params always win; undated docs pass through.
- The two AGENTS.md "ask first" surfaces: MCP tool schema additions and the BM25 schema change (chosen non-destructive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)