### PR TITLE
feat(scheduler): full CRUD in manage_schedules + editable instructions in markdown

### DIFF
--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -29,7 +29,7 @@ from config.settings import settings
 logger = logging.getLogger(__name__)
 
 # Consolidated tools that use sub-action status messages
-_CONSOLIDATED_TOOLS = {"manage_tasks", "manage_reminders", "person_info"}
+_CONSOLIDATED_TOOLS = {"manage_tasks", "manage_reminders", "manage_schedules", "person_info"}
 
 # Patterns that indicate the model is giving up without trying tools
 _GIVE_UP_PATTERNS = re.compile(

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -366,21 +366,26 @@ TOOL_DEFINITIONS = [
     {
         "name": "manage_schedules",
         "description": (
-            "Manage schedules: create or list. A schedule binds a trigger "
-            "(once/cron) to an action (notify/prompt/endpoint/agent). Use "
-            "action='agent' to run autonomous work on a schedule."
+            "Manage schedules: create, list, update, or delete. A schedule binds "
+            "a trigger (once/cron) to an action (notify/prompt/endpoint/agent). Use "
+            "action='agent' to run autonomous work on a schedule. For update/delete, "
+            "pass schedule_id from a prior list; update changes only the fields you supply."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["create", "list"],
+                    "enum": ["create", "list", "update", "delete"],
                     "description": "Operation to perform.",
+                },
+                "schedule_id": {
+                    "type": "string",
+                    "description": "ID of the schedule to update or delete (from action='list').",
                 },
                 "name": {
                     "type": "string",
-                    "description": "Short schedule name/title (for create).",
+                    "description": "Short schedule name/title (for create; optional for update).",
                 },
                 "schedule_type": {
                     "type": "string",
@@ -404,6 +409,10 @@ TOOL_DEFINITIONS = [
                     "type": "string",
                     "enum": ["local", "cloud", "cloud-haiku", "cloud-sonnet"],
                     "description": "For schedule_action='agent': which executor the spawned #agent task targets.",
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable (true) or pause (false) the schedule (for update).",
                 },
             },
             "required": ["action"],
@@ -1262,12 +1271,52 @@ def _schedule_list(inp: dict) -> str:
     return "\n".join(lines)
 
 
+def _schedule_update(inp: dict) -> str:
+    from api.services.scheduler_store import get_scheduler_store
+    schedule_id = inp.get("schedule_id")
+    if not schedule_id:
+        return "Error: schedule_id is required for update (use action='list' to find it)."
+    # Only forward fields the caller actually supplied (partial update). The
+    # schedule's own action is passed as `schedule_action`, not `action`.
+    fields = {
+        key: inp[key]
+        for key in ("name", "schedule_type", "schedule_value", "message_content", "executor", "enabled")
+        if inp.get(key) is not None
+    }
+    if inp.get("schedule_action") is not None:
+        fields["action"] = inp["schedule_action"]
+    store = get_scheduler_store()
+    entry = store.update(schedule_id, **fields)
+    if entry is None:
+        return f"Error: No schedule found with id '{schedule_id}'."
+    label = f"{entry.action} (#{entry.executor})" if entry.action == "agent" and entry.executor else entry.action
+    return (f"Schedule updated: \"{entry.name}\" (id: {entry.id}, action: {label}, "
+            f"next: {entry.next_trigger_at})")
+
+
+def _schedule_delete(inp: dict) -> str:
+    from api.services.scheduler_store import get_scheduler_store
+    schedule_id = inp.get("schedule_id")
+    if not schedule_id:
+        return "Error: schedule_id is required for delete (use action='list' to find it)."
+    store = get_scheduler_store()
+    entry = store.get(schedule_id)
+    name = entry.name if entry else ""
+    if store.delete(schedule_id):
+        return f"Schedule deleted: \"{name}\" (id: {schedule_id})"
+    return f"Error: No schedule found with id '{schedule_id}'."
+
+
 def _tool_manage_schedules(inp: dict):
     action = inp["action"]
     if action == "create":
         return _schedule_create(inp)
     elif action == "list":
         return _schedule_list(inp)
+    elif action == "update":
+        return _schedule_update(inp)
+    elif action == "delete":
+        return _schedule_delete(inp)
     return f"Error: Unknown manage_schedules action '{action}'"
 
 
@@ -1823,6 +1872,8 @@ TOOL_STATUS_MESSAGES = {
     "manage_schedules": "Managing schedules...",
     "manage_schedules.create": "Setting schedule...",
     "manage_schedules.list": "Loading schedules...",
+    "manage_schedules.update": "Updating schedule...",
+    "manage_schedules.delete": "Removing schedule...",
     "manage_workouts": "Updating workout log...",
     "manage_workouts.log": "Logging workout...",
     "manage_workouts.update": "Correcting log...",

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -15,12 +15,14 @@ checkbox lines with stable ``<!-- id:xxxx -->`` IDs and Dataview-style
 and edited in Obsidian and a watcher reindexes on change.
 
 The markdown line carries the user-editable *definition* (enabled checkbox,
-name, trigger, timezone, action, message type, executor tag). The heavier
-payload (``message_content``, ``endpoint_config``) and computed
-``next_trigger_at`` live in a rebuildable index cache
-(``data/scheduler_index.json``) and are merged back by ID when markdown is
-reindexed. The cache is never the source of truth — it can be deleted and
-rebuilt from the vault.
+name, trigger, timezone, action, message type, executor tag). The
+human-editable instruction text (``message_content``) is written beneath the
+line as an indented ``> `` blockquote body, so it can be read and edited in
+Obsidian and round-trips back through reindexing. The structured
+``endpoint_config`` and computed ``next_trigger_at`` (plus run history) live in
+a rebuildable index cache (``data/scheduler_index.json``) and are merged back
+by ID when markdown is reindexed. The cache is never the source of truth — it
+can be deleted and rebuilt from the vault.
 """
 import asyncio
 import json
@@ -194,6 +196,9 @@ _INLINE_FIELD_RE = re.compile(r'\[(\w+)::\s*([^\]]*)\]')
 _TAG_RE = re.compile(r'#([\w-]+)')
 _ID_RE = re.compile(r'<!--\s*id:(\w+)\s*-->')
 _CHECKBOX_RE = re.compile(r'^- \[(.)\]\s+(.*)$')
+# Instruction-text body: an indented blockquote line beneath a schedule line.
+_BODY_LINE_RE = re.compile(r'^\s+>\s?(.*)$')
+_BODY_INDENT = "    "
 
 
 def _format_entry_line(entry: ScheduleEntry) -> str:
@@ -266,6 +271,52 @@ def _parse_entry_line(line: str) -> Optional[ScheduleEntry]:
         last_triggered_at=fields.get("last") or None,
         timezone=fields.get("tz", ""),
     )
+
+
+def _format_entry_block(entry: ScheduleEntry) -> list[str]:
+    """ScheduleEntry → its markdown checkbox line plus an indented ``> ``
+    blockquote body carrying the human-editable ``message_content`` (one line
+    per content line). Empty content emits no body lines.
+    """
+    lines = [_format_entry_line(entry)]
+    if entry.message_content:
+        for content_line in entry.message_content.split("\n"):
+            lines.append(f"{_BODY_INDENT}> {content_line}" if content_line else f"{_BODY_INDENT}>")
+    return lines
+
+
+def _iter_entry_blocks(lines: list[str]):
+    """Yield ``(start, end, entry)`` for each schedule block in ``lines``.
+
+    ``end`` is exclusive and includes any indented blockquote body lines that
+    immediately follow the checkbox line; the body is attached to the entry's
+    ``message_content``.
+    """
+    i, n = 0, len(lines)
+    while i < n:
+        entry = _parse_entry_line(lines[i])
+        if entry is None:
+            i += 1
+            continue
+        start, j, body = i, i + 1, []
+        while j < n:
+            m = _BODY_LINE_RE.match(lines[j])
+            if not m:
+                break
+            body.append(m.group(1))
+            j += 1
+        if body:
+            entry.message_content = "\n".join(body)
+        yield start, j, entry
+        i = j
+
+
+def _find_block_span(lines: list[str], entry_id: str) -> Optional[tuple[int, int]]:
+    """Return the ``(start, end)`` line span of the block for ``entry_id``."""
+    for start, end, entry in _iter_entry_blocks(lines):
+        if entry.id == entry_id:
+            return start, end
+    return None
 
 
 class SchedulerStore:
@@ -352,8 +403,8 @@ class SchedulerStore:
                 "---\ntype: scheduler\n---\n# Scheduler Inbox\n\n", encoding="utf-8"
             )
 
-    def _insert_line_at_top(self, line: str):
-        """Insert a schedule line above the first existing schedule line."""
+    def _insert_block_at_top(self, block: list[str]):
+        """Insert a schedule block above the first existing schedule line."""
         self._ensure_inbox()
         lines = self._read_inbox_lines()
         first_idx = next(
@@ -361,28 +412,29 @@ class SchedulerStore:
             None,
         )
         if first_idx is None:
-            lines.append(line)
+            lines.extend(block)
         else:
-            lines = lines[:first_idx] + [line] + lines[first_idx:]
+            lines = lines[:first_idx] + block + lines[first_idx:]
         self._write_inbox_lines(lines)
 
-    def _rewrite_line(self, entry: ScheduleEntry):
-        """Replace the markdown line for ``entry`` (by ID); append if absent."""
-        new_line = _format_entry_line(entry)
+    def _rewrite_block(self, entry: ScheduleEntry):
+        """Replace the markdown block for ``entry`` (by ID); insert if absent."""
+        block = _format_entry_block(entry)
         lines = self._read_inbox_lines()
-        for i, ln in enumerate(lines):
-            m = _ID_RE.search(ln)
-            if m and m.group(1) == entry.id:
-                lines[i] = new_line
-                self._write_inbox_lines(lines)
-                return
-        self._insert_line_at_top(new_line)
+        span = _find_block_span(lines, entry.id)
+        if span is None:
+            self._insert_block_at_top(block)
+            return
+        start, end = span
+        self._write_inbox_lines(lines[:start] + block + lines[end:])
 
-    def _remove_line(self, entry_id: str):
+    def _remove_block(self, entry_id: str):
         lines = self._read_inbox_lines()
-        kept = [ln for ln in lines if not (_ID_RE.search(ln) and _ID_RE.search(ln).group(1) == entry_id)]
-        if len(kept) != len(lines):
-            self._write_inbox_lines(kept)
+        span = _find_block_span(lines, entry_id)
+        if span is None:
+            return
+        start, end = span
+        self._write_inbox_lines(lines[:start] + lines[end:])
 
     # ------------------------------------------------------------------
     # CRUD
@@ -400,7 +452,7 @@ class SchedulerStore:
                 **kwargs,
             )
             entry.next_trigger_at = compute_next_trigger(entry)
-            self._insert_line_at_top(_format_entry_line(entry))
+            self._insert_block_at_top(_format_entry_block(entry))
             self._entries[entry.id] = entry
             self._save()
             logger.info(f"Created schedule: {entry.id} - {entry.name}")
@@ -426,7 +478,7 @@ class SchedulerStore:
                     setattr(entry, key, value)
             if any(k in kwargs for k in ("schedule_type", "schedule_value", "enabled", "timezone")):
                 entry.next_trigger_at = compute_next_trigger(entry) if entry.enabled else None
-            self._rewrite_line(entry)
+            self._rewrite_block(entry)
             self._save()
             return entry
 
@@ -434,7 +486,7 @@ class SchedulerStore:
         with self._lock:
             if entry_id in self._entries:
                 del self._entries[entry_id]
-                self._remove_line(entry_id)
+                self._remove_block(entry_id)
                 self._save()
                 return True
             return False
@@ -451,7 +503,7 @@ class SchedulerStore:
                 entry.next_trigger_at = None
             else:
                 entry.next_trigger_at = compute_next_trigger(entry)
-            self._rewrite_line(entry)
+            self._rewrite_block(entry)
             self._save()
 
     def record_run(self, entry_id: str, status: str, result: str = ""):
@@ -530,10 +582,7 @@ class SchedulerStore:
             except Exception as e:
                 logger.warning(f"Could not read {file_path}: {e}")
                 return
-            for line in lines:
-                entry = _parse_entry_line(line)
-                if not entry:
-                    continue
+            for _start, _end, entry in _iter_entry_blocks(lines):
                 self._merge_prior(entry, prior.get(entry.id))
                 entry.next_trigger_at = compute_next_trigger(entry) if entry.enabled else None
                 self._entries[entry.id] = entry
@@ -543,10 +592,7 @@ class SchedulerStore:
         """Full re-parse of Inbox.md into the cache."""
         prior = {eid: e for eid, e in self._entries.items()}
         self._entries.clear()
-        for line in self._read_inbox_lines():
-            entry = _parse_entry_line(line)
-            if not entry:
-                continue
+        for _start, _end, entry in _iter_entry_blocks(self._read_inbox_lines()):
             self._merge_prior(entry, prior.get(entry.id))
             entry.next_trigger_at = compute_next_trigger(entry) if entry.enabled else None
             self._entries[entry.id] = entry
@@ -555,7 +601,13 @@ class SchedulerStore:
 
     @staticmethod
     def _merge_prior(entry: ScheduleEntry, prior: Optional[ScheduleEntry]):
-        """Carry payload fields (not represented in markdown) forward by ID."""
+        """Carry cached fields forward by ID when markdown doesn't supply them.
+
+        ``message_content`` now lives in the markdown body, so markdown wins when
+        a body is present; the cache fallback only fills entries written before
+        bodies existed (lazy migration). ``endpoint_config`` and run history have
+        no markdown representation and are always carried from the cache.
+        """
         if not prior:
             return
         if not entry.message_content:

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -18,7 +18,10 @@ The markdown line carries the user-editable *definition* (enabled checkbox,
 name, trigger, timezone, action, message type, executor tag). The
 human-editable instruction text (``message_content``) is written beneath the
 line as an indented ``> `` blockquote body, so it can be read and edited in
-Obsidian and round-trips back through reindexing. The structured
+Obsidian and round-trips back through reindexing. Indented blockquote lines
+directly following a schedule line are reserved for this body — a standalone
+note placed there will be absorbed into the schedule's ``message_content`` on
+reindex. The structured
 ``endpoint_config`` and computed ``next_trigger_at`` (plus run history) live in
 a rebuildable index cache (``data/scheduler_index.json``) and are merged back
 by ID when markdown is reindexed. The cache is never the source of truth — it

--- a/tests/test_scheduler_api.py
+++ b/tests/test_scheduler_api.py
@@ -171,6 +171,95 @@ class TestManageSchedulesAgentTool:
         assert "\"N\"" in out
         assert "notify" in out
 
+    def test_update_schedule_tool(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore
+        from api.services import agent_tools
+
+        store = SchedulerStore(vault_path=tmp_path / "vault",
+                               index_path=tmp_path / "idx.json")
+        created = store.create(name="Old name", schedule_type="cron",
+                               schedule_value="0 9 * * *", action="prompt",
+                               message_content="old prompt")
+        with patch("api.services.scheduler_store.get_scheduler_store", return_value=store):
+            out = agent_tools._tool_manage_schedules({
+                "action": "update",
+                "schedule_id": created.id,
+                "name": "New name",
+                "message_content": "new prompt",
+                "enabled": False,
+            })
+        assert "Schedule updated" in out
+        refreshed = store.get(created.id)
+        assert refreshed.name == "New name"
+        assert refreshed.message_content == "new prompt"
+        assert refreshed.enabled is False
+
+    def test_update_only_changes_supplied_fields(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore
+        from api.services import agent_tools
+
+        store = SchedulerStore(vault_path=tmp_path / "vault",
+                               index_path=tmp_path / "idx.json")
+        created = store.create(name="Keep", schedule_type="cron",
+                               schedule_value="0 9 * * *", action="prompt",
+                               message_content="keep me")
+        with patch("api.services.scheduler_store.get_scheduler_store", return_value=store):
+            agent_tools._tool_manage_schedules({
+                "action": "update", "schedule_id": created.id,
+                "schedule_value": "0 10 * * *",
+            })
+        refreshed = store.get(created.id)
+        assert refreshed.schedule_value == "0 10 * * *"
+        assert refreshed.name == "Keep"
+        assert refreshed.message_content == "keep me"
+
+    def test_update_missing_id_errors(self, tmp_path):
+        from api.services import agent_tools
+        out = agent_tools._tool_manage_schedules({"action": "update", "name": "X"})
+        assert "Error" in out and "schedule_id" in out
+
+    def test_update_unknown_id_errors(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore
+        from api.services import agent_tools
+
+        store = SchedulerStore(vault_path=tmp_path / "vault",
+                               index_path=tmp_path / "idx.json")
+        with patch("api.services.scheduler_store.get_scheduler_store", return_value=store):
+            out = agent_tools._tool_manage_schedules({
+                "action": "update", "schedule_id": "nope", "name": "X"})
+        assert "Error" in out and "nope" in out
+
+    def test_delete_schedule_tool(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore
+        from api.services import agent_tools
+
+        store = SchedulerStore(vault_path=tmp_path / "vault",
+                               index_path=tmp_path / "idx.json")
+        created = store.create(name="Doomed", schedule_type="cron",
+                               schedule_value="0 9 * * *", action="notify",
+                               message_content="bye")
+        with patch("api.services.scheduler_store.get_scheduler_store", return_value=store):
+            out = agent_tools._tool_manage_schedules({
+                "action": "delete", "schedule_id": created.id})
+        assert "Schedule deleted" in out and "Doomed" in out
+        assert store.get(created.id) is None
+
+    def test_delete_missing_id_errors(self, tmp_path):
+        from api.services import agent_tools
+        out = agent_tools._tool_manage_schedules({"action": "delete"})
+        assert "Error" in out and "schedule_id" in out
+
+    def test_delete_unknown_id_errors(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore
+        from api.services import agent_tools
+
+        store = SchedulerStore(vault_path=tmp_path / "vault",
+                               index_path=tmp_path / "idx.json")
+        with patch("api.services.scheduler_store.get_scheduler_store", return_value=store):
+            out = agent_tools._tool_manage_schedules({
+                "action": "delete", "schedule_id": "ghost"})
+        assert "Error" in out and "ghost" in out
+
     def test_manage_reminders_alias_still_works(self, tmp_path):
         from api.services.scheduler_store import SchedulerStore
         from api.services import agent_tools

--- a/tests/test_scheduler_store.py
+++ b/tests/test_scheduler_store.py
@@ -135,11 +135,11 @@ class TestMarkdownSourceOfTruth:
         assert store.get(entry.id).enabled is False
 
     def test_reindex_preserves_message_content(self, store):
-        """message_content lives in the cache and is merged back by ID."""
+        """An edit to a definition field leaves the instruction body intact."""
         entry = store.create(name="Briefing", schedule_type="cron",
                              schedule_value="0 9 * * *", message_type="prompt",
                              message_content="What's on my calendar?")
-        # A pure markdown edit (no content field) must not wipe the payload.
+        # Editing only the cron field (body untouched) must not wipe the content.
         content = store.inbox_path.read_text(encoding="utf-8")
         patched = content.replace("[cron:: 0 9 * * *]", "[cron:: 30 9 * * *]")
         store.inbox_path.write_text(patched, encoding="utf-8")
@@ -148,6 +148,48 @@ class TestMarkdownSourceOfTruth:
         refreshed = store.get(entry.id)
         assert refreshed.schedule_value == "30 9 * * *"
         assert refreshed.message_content == "What's on my calendar?"
+
+    def test_create_writes_message_content_to_markdown(self, store):
+        """The instruction text is human-readable in Inbox.md, not just the cache."""
+        store.create(name="Briefing", schedule_type="cron", schedule_value="0 9 * * *",
+                     message_type="prompt", message_content="What's on my calendar?")
+        content = store.inbox_path.read_text(encoding="utf-8")
+        assert "> What's on my calendar?" in content
+
+    def test_external_edit_message_content_round_trips(self, store):
+        """Hand-editing the instruction body in markdown updates the cache on reindex."""
+        entry = store.create(name="Briefing", schedule_type="cron",
+                             schedule_value="0 9 * * *", message_type="prompt",
+                             message_content="old instruction")
+        content = store.inbox_path.read_text(encoding="utf-8")
+        patched = content.replace("> old instruction", "> new instruction")
+        assert patched != content  # sanity: the body line was present to edit
+        store.inbox_path.write_text(patched, encoding="utf-8")
+
+        store.reindex_file(str(store.inbox_path))
+        assert store.get(entry.id).message_content == "new instruction"
+
+    def test_multiline_message_content_round_trips(self, store, tmp_path):
+        """Multi-line instructions survive a full rebuild from markdown."""
+        multiline = "Line one.\n\nLine three after a blank."
+        store.create(name="Multi", schedule_type="cron", schedule_value="0 9 * * *",
+                     message_type="prompt", message_content=multiline)
+        # A fresh store rebuilds purely from the vault markdown.
+        store2 = SchedulerStore(
+            vault_path=tmp_path / "vault",
+            index_path=tmp_path / "scheduler_index_multi.json",
+        )
+        names = {e.name: e for e in store2.list_all()}
+        assert names["Multi"].message_content == multiline
+
+    def test_delete_removes_body_lines(self, store):
+        """Deleting a schedule removes its body block, not just the checkbox line."""
+        entry = store.create(name="Doomed", schedule_type="cron", schedule_value="0 9 * * *",
+                             message_type="prompt", message_content="erase me")
+        store.delete(entry.id)
+        content = store.inbox_path.read_text(encoding="utf-8")
+        assert "erase me" not in content
+        assert entry.id not in content
 
     def test_rebuild_index_from_markdown(self, store, tmp_path):
         store.create(name="Persist", schedule_type="cron", schedule_value="0 9 * * *",


### PR DESCRIPTION
## Summary

Closes #342. Two related scheduler gaps:

**Part 1 — `manage_schedules` chat tool CRUD.** The agentic chat tool only supported `create`/`list`. It now also supports `update` and `delete`, matching the full CRUD the MCP surface (`lifeos_schedule_*`) already exposed. `update` is a partial update (only the fields you pass change); both require `schedule_id` (from `list`) and return clear errors when it's missing or unknown. Also registers `manage_schedules` in `_CONSOLIDATED_TOOLS` so its per-action status labels actually fire (they were previously dead — `manage_schedules` wasn't in the set, so only the generic "Managing schedules..." ever showed).

**Part 2 — editable instructions in the vault markdown.** Previously `message_content` (the instruction/prompt text) lived only in the index cache (`data/scheduler_index.json`), so it never appeared in `Inbox.md` and couldn't be hand-edited. It now serializes beneath each schedule's checkbox line as an indented `> ` blockquote body, which is human-readable, multi-line-safe, and round-trips through reindexing. The line helpers became block-aware (insert/rewrite/remove + reindex parse over `(start, end, entry)` blocks).

### Migration note
`_merge_prior` keeps a cache fallback for `message_content`: schedules created before this change have no body in markdown, so they keep their cached content and migrate lazily — a body is written the next time the schedule is updated or fires. New schedules get a body immediately. `endpoint_config` and run history remain cache-only (no markdown representation). One consequence of the fallback: clearing a message by deleting its body alone won't take (the cache restores it); changing the text works as expected.

## Test evidence

Run against an up-to-date isolated checkout on the server venv (the local box has no venv; the on-box `~/Code/lifeos` is stale):

- `tests/test_scheduler_store.py tests/test_scheduler_api.py tests/test_scheduler_watcher.py` → **81 passed**
- Related modules (agent tools/loop, telegram routing, migrate-reminders, audit e2e, mcp exposure) → **237 passed**
- Full unit suite → **946 passed, 1 failed** — the one failure is `test_claude_code_ingest.py::test_live_process_cache_avoids_repeated_scans`, which errors at `import psutil` (dependency missing from that venv), unrelated to this change.

New tests: tool-level `update`/`delete` (happy path, partial update, missing/unknown id) and markdown body round-trip (write, external edit, multi-line rebuild, delete removes body).

## Review focus

- `scheduler_store._iter_entry_blocks` / `_find_block_span` and the block-aware rewrite/remove — correctness of body span detection (blank lines in content, content lines that look like checkboxes).
- The `_merge_prior` lazy-migration tradeoff (clearing-by-emptying-body limitation) — acceptable, or should markdown win unconditionally?
- `_schedule_update` field forwarding (`schedule_action` → `action`; `enabled=False` handling).