### PR TITLE
feat(codex): install native Codex skills alongside converted portable skills

### DIFF
--- a/.agents/skills/address-review/SKILL.md
+++ b/.agents/skills/address-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: address-review
+description: Address PR review feedback and verify independently
+argument-hint: <pr-number>
+---
+
+# Address Review Feedback
+
+Address review comments on PR #$ARGUMENTS. Be adversarial about the feedback itself — verify that suggestions are correct before applying them.
+
+## PR Context
+
+- PR metadata: !`gh pr view $ARGUMENTS`
+- Inline review comments: !`gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments --jq '.[] | "---\n\(.path):\(.line // .original_line)\n\(.body)\n"'`
+- PR conversation comments: !`gh pr view $ARGUMENTS --comments`
+
+## Instructions
+
+### Step 1: Gather All Feedback
+
+Read every review comment above. Categorize each piece of feedback:
+
+- **Action Required** — Reviewer flagged as blocking merge
+- **Recommended** — Reviewer suggested addressing before merge
+- **Minor** — Nits, style suggestions
+
+### Step 2: Independently Verify Each Finding
+
+**Do not blindly apply suggestions.** For each piece of feedback:
+
+1. **Read the code in question** — Use Glob/Grep/Read to find the relevant file and understand the full context, not just the diff snippet.
+2. **Assess whether the feedback is correct** — Reviewers (including agent reviewers) can be wrong. Check:
+   - Does the suggested change actually fix the issue identified?
+   - Could the suggestion introduce a new bug or regression?
+   - Is the reviewer missing context that makes the current code correct?
+   - Does the suggestion align with project conventions (`AGENTS.md`)?
+3. **For test-related feedback** — Run the tests yourself on the Mac Mini (`./scripts/test.sh`). Do not trust "tests pass" claims from anyone. Agents are cheap; broken merges are expensive.
+4. **For security feedback** — Take it seriously by default. Security suggestions should be applied unless you can clearly demonstrate they're wrong.
+
+### Step 3: Respond to Each Finding
+
+For each piece of feedback, take one of these actions:
+
+**Apply** — The feedback is correct. Make the change.
+- Edit the code
+- Run the full test suite to confirm the fix doesn't break anything
+- Note what was changed
+
+**Partially apply** — The core insight is right but the suggested fix isn't quite right.
+- Implement a better fix that addresses the underlying concern
+- Explain why you deviated from the exact suggestion
+
+**Reject with justification** — The feedback is incorrect or doesn't apply.
+- Explain clearly why the current code is correct
+- Reference specs, ADRs, or project conventions to support your reasoning
+- Never reject feedback without a concrete justification
+
+**Escalate** — You're unsure whether the feedback is valid.
+- Flag it to the human with the evidence for and against
+- Do not guess or silently skip
+
+### Step 4: Run Full Verification
+
+After addressing all feedback:
+
+1. **Run the full test suite** — Every test must pass. No exceptions.
+2. **Spot-check your changes** — Read through your own diff. Did you introduce any new issues while fixing the review feedback?
+3. **Check sizing** — If the fixes significantly expanded the PR, flag whether it should be split.
+
+### Step 5: Commit and Push
+
+- Commit fixes with clear messages linking to the review feedback: `fix: Address review — <description>`
+- Keep fix commits separate from each other when they address unrelated feedback (easier to review the re-review)
+- Push to the PR branch
+
+### Step 6: Post Summary and Re-request Review
+
+Post a comment on the PR summarizing how each finding was addressed, then re-request review from the original reviewer(s):
+
+```
+gh pr comment $ARGUMENTS --body "<summary>"
+
+# Re-request review from original reviewer(s)
+gh pr view $ARGUMENTS --json reviews,reviewRequests \
+  --jq '([.reviews[].author.login] + [.reviewRequests[].login]) | unique | .[]' \
+  | while read reviewer; do gh pr edit $ARGUMENTS --add-reviewer "$reviewer"; done
+```
+
+Use this format for the summary:
+
+```markdown
+## Review Feedback Addressed
+
+| # | Finding | Action | Details |
+|---|---------|--------|---------|
+| 1 | <brief description> | Applied / Partially applied / Rejected | <what was done and why> |
+| 2 | ... | ... | ... |
+
+**Tests:** `./scripts/test.sh` — all passing
+**New commits:** <list of fix commits>
+```
+
+For any rejected findings, provide the full justification in the Details column so the reviewer can evaluate your reasoning.

--- a/.agents/skills/catchup/SKILL.md
+++ b/.agents/skills/catchup/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: catchup
+description: Synthesize recent PR activity into a cross-PR net-effects briefing
+argument-hint: [hours] [me|others]
+---
+
+# Catchup: Recent PR Synthesis
+
+Arguments: `$ARGUMENTS`
+
+Parameters (order-independent, all optional):
+- **hours** — numeric, defaults to 24
+- **author filter** — `me` (only your PRs), `others` (everyone except you), or omit for all
+
+## PR Data
+
+Merged PRs in the window:
+
+!`A="${ARGUMENTS:-}"; H=$(echo "$A" | grep -oE '[0-9]+' | head -1); H=${H:-24}; F=$(echo "$A" | grep -oiE '\b(me|others)\b' | head -1 | tr A-Z a-z); case "$F" in me) AF="author:@me";; others) AF="-author:@me";; *) AF="";; esac; gh pr list --state=merged --search="merged:>=$(date -u -v-${H}H +%Y-%m-%dT%H:%M:%S)Z ${AF}" --json number,title,author,mergedAt,body,additions,deletions,changedFiles --limit 50 2>/dev/null || echo "GH_ERROR"`
+
+Open/changed PRs in the window (created or updated):
+
+!`A="${ARGUMENTS:-}"; H=$(echo "$A" | grep -oE '[0-9]+' | head -1); H=${H:-24}; F=$(echo "$A" | grep -oiE '\b(me|others)\b' | head -1 | tr A-Z a-z); case "$F" in me) AF="author:@me";; others) AF="-author:@me";; *) AF="";; esac; gh pr list --state=open --search="updated:>=$(date -u -v-${H}H +%Y-%m-%dT%H:%M:%S)Z ${AF}" --json number,title,author,createdAt,updatedAt,body,additions,deletions,changedFiles,labels --limit 50 2>/dev/null || echo "GH_ERROR"`
+
+Git stats for the window:
+
+!`A="${ARGUMENTS:-}"; H=$(echo "$A" | grep -oE '[0-9]+' | head -1); H=${H:-24}; SINCE=$(date -u -v-${H}H +%Y-%m-%dT%H:%M:%S); COMMITS=$(git log --since="$SINCE" --oneline origin/main 2>/dev/null | wc -l | tr -d ' '); STATS=$(git log --since="$SINCE" --shortstat origin/main 2>/dev/null | grep "insertion\|deletion" | awk '{for(i=1;i<=NF;i++){if($i~/insertion/)ins+=$(i-1);if($i~/deletion/)del+=$(i-1)}} END {printf "%d added, %d removed", ins+0, del+0}'); echo "commits=$COMMITS $STATS"`
+
+Project context for understanding what changed:
+
+!`cat AGENTS.md`
+
+## Instructions
+
+You are producing a **net-effects briefing** — not a PR-by-PR changelog. The reader wants to understand what's different about the codebase now compared to N hours ago.
+
+Check the arguments above to determine the author filter. If `others` was specified, note in your briefing header that this covers changes by other contributors (not the person running the skill). If `me` was specified, note it covers only the runner's own changes. If no filter, cover all contributors.
+
+### Step 1: Triage
+
+If either PR list shows `GH_ERROR`, report that `gh` failed (likely auth or network) and stop.
+
+Scan both PR lists. If there are zero PRs in both lists, say so and stop.
+
+Group PRs into two buckets:
+- **Landed** — merged in the window
+- **In flight** — open PRs created or updated in the window
+
+### Step 2: Understand the changes
+
+For each merged PR, read its description carefully. Extract:
+- What area of the codebase it touches
+- What capability it adds, changes, or removes
+- Whether it introduces schema/migration changes, API surface changes, new dependencies, or test infrastructure changes
+
+If a PR description is too terse to understand the scope, fetch the diff summary:
+```
+gh pr diff <number> --stat
+```
+
+For particularly important or large PRs, fetch the full diff to understand the actual changes:
+```
+gh pr diff <number>
+```
+
+Use your judgment — not every PR needs a full diff read. Focus effort on PRs with large insertion counts, schema changes, or architectural implications.
+
+### Step 3: Write the briefing
+
+Produce the following sections. Use concise, direct language. No filler.
+
+---
+
+#### By the Numbers
+
+A compact stats line at the top of the briefing. Use the git stats and PR data provided above to produce a single line like:
+
+> **12 commits, 6 PRs merged, +4,713 / -128 lines**
+
+Include: commit count, merged PR count, lines added/removed. If an author filter is active, note it (e.g., "by @user" or "by others").
+
+#### Landed
+
+*Group changes by theme/area, not by PR.* Merge related PRs into a single narrative. For each theme:
+- What changed (capabilities added, removed, or modified)
+- Relevant stats if notable (e.g., "new sync phase", "15 new API tests")
+- Which PRs contributed and who authored them (parenthetical references, e.g., "#23, #24 — @user")
+
+Themes should be whatever emerges naturally from the changes — examples: "Sync pipeline", "Search & indexing", "CRM / entity resolution", "API endpoints", "MCP tools", "Documentation", "Tooling", "Test coverage". Don't force categories that don't exist.
+
+#### System Impact
+
+For each theme above, explain in plain language **how the system's behavior or capabilities changed at a high level**. Write this for someone who hasn't looked at the code — they want to know what the system can do now that it couldn't before, what works differently, or what's more reliable/faster/safer.
+
+Examples of the right level of abstraction:
+- "The nightly sync pipeline now halts on critical failures instead of continuing with stale data. If ChromaDB goes down mid-sync, downstream phases won't run with incomplete indexes."
+- "Hybrid search now weights BM25 keyword matches more heavily for short queries, improving precision on exact-name lookups without degrading semantic recall for longer questions."
+- "The CRM person timeline now includes iMessage and WhatsApp data alongside email and calendar, giving a unified interaction history per person."
+
+Avoid restating the "what changed" section — focus on the **so what**.
+
+#### In Flight
+
+For each open PR updated in the window:
+- Title and author
+- What it's adding/changing
+- Current state (draft? review requested? CI passing?)
+
+If there are no open PRs, omit this section.
+
+#### Review Attention
+
+Optional section — include only if warranted. Flag items like:
+- Unusually large PRs that may not have received proportional review depth
+- Architectural decisions that are now load-bearing and hard to reverse
+- Areas with complex logic that could benefit from a closer look
+- Cross-cutting changes that affect many files
+- New dependencies introduced
+
+If nothing warrants attention, omit this section entirely.
+
+---
+
+### Formatting rules
+
+- Use markdown headers and bullets
+- Reference PR numbers as `#N` (GitHub will auto-link them)
+- Don't include full PR descriptions — synthesize
+- Keep the total output scannable — aim for a briefing someone can read in 2-3 minutes
+- Don't editorialize on code quality or contributor velocity
+
+## Escalation
+
+Stop and tell the user when:
+- `gh` commands fail (auth, network, or unexpected errors)
+- Either PR list returns exactly 50 results (the limit cap) — suggest a shorter time window
+- The date command fails (this skill uses macOS `date -v` syntax; it won't work on Linux)

--- a/.agents/skills/draft-issue/SKILL.md
+++ b/.agents/skills/draft-issue/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: draft-issue
+description: >
+  Draft and create a GitHub issue from a description, investigation, or conversation context.
+  Use when a problem is too large for a quick fix, when you want to propose a change for later,
+  or when the user asks to "file an issue", "create an issue", "draft an issue", "open a ticket",
+  or "log this for later". Also useful when another skill (like tune) determines a
+  change is too large and needs to be tracked as an issue instead.
+argument-hint: <issue description or context>
+---
+
+# Draft Issue
+
+Create a GitHub issue for: **$ARGUMENTS**
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -5`
+- Open issues: !`gh issue list --state=open --json number,title --limit=10 --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null || echo "GH_ERROR"`
+
+## Instructions
+
+### Step 1: Understand the ask
+
+Parse `$ARGUMENTS` to determine what the issue should cover. The input could be:
+- A direct description ("add rate limiting to the search endpoint")
+- A problem statement ("the sync pipeline sometimes misses new contacts")
+- A reference to something discovered during other work ("tune found this needs a larger refactor")
+- A conversation context where the user said "file an issue for this"
+
+If the description is too vague to write a useful issue, ask one clarifying question.
+
+### Step 2: Research (if needed)
+
+If the issue relates to specific code or behavior, quickly investigate:
+- Read relevant files to understand the current state
+- Check if a similar issue already exists (use the open issues list above)
+- Identify which files/modules would be affected
+
+Skip this if the user already provided enough detail.
+
+### Step 3: Write and create the issue
+
+Create the issue with a clear structure:
+
+```bash
+gh issue create \
+  --title "<type>: <imperative summary>" \
+  --label "<label>" \
+  --body "$(cat <<'EOF'
+## Problem
+
+<What's wrong or what's missing — 2-3 sentences>
+
+## Context
+
+<How this was discovered, why it matters, any relevant background>
+
+## Suggested approach
+
+<High-level direction — not a full spec, just enough to orient whoever picks it up>
+
+## Files involved
+
+<List of files/modules likely affected>
+
+## Acceptance criteria
+
+- [ ] <Verifiable condition 1>
+- [ ] <Verifiable condition 2>
+EOF
+)"
+```
+
+**Title format:** Use the same `<type>: <summary>` convention as commits (feat, fix, refactor, docs, etc.). Keep it under 70 characters.
+
+**Labels:** Use existing labels. Common ones: `bug`, `enhancement`, `documentation`. Check what's available with `gh label list` if unsure.
+
+**Body guidelines:**
+- Problem section should be understandable by someone with no context
+- Suggested approach should be directional, not prescriptive
+- Acceptance criteria should be objectively verifiable
+- Don't include implementation details unless they're critical constraints
+- Use synthetic data in any examples
+
+### Step 4: Report
+
+Tell the user:
+- The issue number and URL
+- A one-line summary of what was filed
+
+Keep it brief — the user can read the full issue on GitHub.

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: implement
+description: "Full Codex implementation lifecycle for GitHub issues, pull requests, or freeform coding tasks: understand scope, plan, create a branch, write tests, implement changes, run verification, create a PR, perform adversarial review/address rounds, merge, and update linked issues. Use when the user invokes $implement, asks to implement an issue such as '#123', says 'implement this', asks for end-to-end delivery from task to PR/merge, or wants the former Claude /implement workflow in Codex."
+---
+
+# Implement
+
+Run the full implementation lifecycle for the request you were given.
+
+## Core Rules
+
+- Use the repo's `AGENTS.md` and nested guidance as binding instructions.
+- Use `update_plan` when available. If it is unavailable, maintain a concise visible checklist in normal messages.
+- Keep exactly one plan item `in_progress` at a time and update status as phases complete.
+- Keep changes surgical. Do not refactor adjacent code unless needed for the task.
+- Prefer tests that fail before implementation and pass after it.
+- Never skip, weaken, delete, or mark failing tests as skipped just to pass.
+- Do not overwrite or revert user changes. Work with a dirty tree carefully.
+- If the task requires a public API change, database schema change, sync-phase change, MCP tool definition change, or new dependency, follow the repo's "Ask first" boundary before editing.
+
+## Entry Point
+
+Identify the target before planning:
+
+1. Run `git branch --show-current` and `git log --oneline -5`.
+2. If the leading token of the user's request is a number or starts with `#`, treat it as a GitHub issue. Fetch it with `gh issue view <number> --comments`.
+3. Otherwise, check for a PR on the current branch:
+   `gh pr list --head "$(git branch --show-current)" --json number,title,body --jq '.[0]'`.
+   If the PR matches the user's request, treat it as the target PR.
+4. Otherwise, treat the request as a freeform task.
+
+Parse trailing modifiers:
+
+| Modifier | Effect |
+| --- | --- |
+| none | Run all phases. |
+| `quick` or `no-review` | Skip the adversarial review/address loop. |
+| `no-plan` | Skip the initial planning phase only when the target is already precise. |
+| `review-only` | Run only the review/address loop for the target PR. |
+| `no-merge` | Stop after PR creation/review and leave merge to the user. |
+
+When in doubt, run more of the lifecycle, not less.
+
+## Phase 1: Understand And Plan
+
+Skip only for `no-plan` or `review-only`.
+
+1. Explore relevant files with `rg`, `rg --files`, and targeted reads.
+2. Read any referenced specs, ADRs, issue comments, or failing test output.
+3. Define concrete acceptance criteria.
+4. Identify the test cases that prove the criteria.
+5. Plan the smallest viable implementation: files to edit, tests to add/update, and verification commands.
+6. Present the plan briefly if the task is substantial or if tradeoffs matter.
+
+Update the plan with granular items before editing.
+
+## Phase 2: Implement
+
+Skip for `review-only`.
+
+1. Create a branch if currently on `main` or another non-feature branch:
+   `<type>/<short-description>`, lowercase and hyphen-separated.
+2. Write focused tests first when practical.
+3. Implement production changes.
+4. Run targeted tests as soon as the changed area is testable.
+5. Run the repo's normal verifier before PR creation. For LifeOS, prefer:
+   `./scripts/test.sh auto`
+6. Read the diff yourself:
+   - `git diff --stat`
+   - `git diff`
+   - touched files directly if needed
+7. Fix unused imports, style mismatches, missing docs, or behavior gaps that trace to the task.
+
+If Python files changed in LifeOS, restart through `./scripts/server.sh restart` when the task requires a running server or manual API verification. Never run `uvicorn` directly.
+
+## Phase 3: Create PR
+
+Skip for `review-only` when the target PR already exists.
+
+1. Commit with `<type>: <summary>`.
+2. Push the branch.
+3. Create the PR:
+
+```bash
+gh pr create --title "<type>: <imperative summary>" --body "$(cat <<'EOF'
+## Summary
+<1-3 sentences: what changed and why>
+
+<Closes #N / Relates to #N if applicable>
+
+## Test evidence
+<commands and result summary>
+
+## Review focus
+<areas where reviewer attention is useful>
+EOF
+)"
+```
+
+4. If the target was a GitHub issue, comment on it:
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+## In Progress
+
+Implementation PR created: #<pr-number> — <PR title>
+Entering review/verification phase.
+EOF
+)"
+```
+
+## Phase 4: Review And Address Loop
+
+Skip for `quick` or `no-review`. Run for existing PRs by default.
+
+Default to one round. Run at most three rounds.
+
+### 4A. Review
+
+Use a Codex subagent only when the user or current session policy explicitly allows subagents/delegation. Otherwise, perform the same adversarial review yourself in the main context.
+
+For a subagent review, ask for a bounded PR review:
+
+```text
+Review PR #<number> adversarially. Read the PR description, linked issue/specs, and diff.
+Prioritize correctness bugs, regressions, privacy/security risks, missing tests, and repo-standard violations.
+Return findings only, grouped as Action Required, Recommended, Minor, then a brief summary.
+Use file:line references.
+```
+
+For local review, fetch and inspect:
+
+```bash
+gh pr view <number> --json number,title,body,comments,reviews
+gh pr diff <number> --name-only
+gh pr diff <number>
+```
+
+### 4B. Referee Findings
+
+Evaluate every finding before acting:
+
+| Decision | Use when |
+| --- | --- |
+| Accept | You verified the finding is valid. |
+| Downgrade | The concern is real but severity is overstated. |
+| Reject | The finding is incorrect, irrelevant, unsupported, or out of scope. |
+
+Accept Action Required and security findings by default unless the code clearly proves them wrong.
+
+Post referee decisions to the PR:
+
+```bash
+gh pr comment <number> --body "$(cat <<'EOF'
+## Review Round <N> — Referee Decisions
+
+| # | Finding | Reviewer Severity | Decision | Reasoning |
+|---|---------|-------------------|----------|-----------|
+| 1 | <brief description> | Action Required / Recommended / Minor | Accept / Downgrade / Reject | <why> |
+
+**Findings forwarded to addresser:** <count>
+EOF
+)"
+```
+
+If no findings survive, post:
+
+```bash
+gh pr comment <number> --body "Review Round <N>: no actionable findings — review loop complete."
+```
+
+### 4C. Address
+
+Address accepted and downgraded findings either yourself or with a Codex worker subagent when allowed and when the write scope is clear.
+
+Rules:
+
+- Read the relevant code before changing it.
+- Keep fixes scoped to forwarded findings.
+- Add or adjust tests when a finding exposes untested behavior.
+- Run targeted tests and then the repo verifier again.
+- Commit fixes separately when they address unrelated findings.
+- Push to the PR branch.
+- Comment with what changed and the test evidence.
+
+### 4D. Self-Verify Continuation
+
+After addressing, inspect the new diff yourself. Spawn or perform another review round only if there is concrete reason:
+
+- A forwarded finding is not fixed.
+- A fix introduced a new touched area not previously reviewed.
+- A change does not trace to the task or review findings.
+- Tests changed in a way that weakens coverage.
+
+Stop after round 3. If unresolved Action Required findings remain, comment on the PR with an escalation summary and report that human review is needed.
+
+## Phase 5: Merge And Finalize
+
+Skip for `no-merge`.
+
+1. Run the final verifier. In LifeOS, use `./scripts/test.sh auto` unless a broader suite is warranted.
+2. Use the native `$pr-check` skill if installed, or manually verify PR standards.
+3. Use the native `$merge-pr` skill if installed. It should validate, merge, delete the branch, and update linked issues.
+4. If `$merge-pr` is not available, run the equivalent non-interactive GitHub flow:
+   - Confirm tests passed.
+   - Confirm PR has no unresolved required checks or blocking comments.
+   - Squash merge with `gh pr merge --squash --delete-branch`.
+   - Comment on linked issues with the merged PR and outcome.
+5. Report the PR/merge result and test evidence to the user.
+
+## Output Shape
+
+During work, keep user updates short and concrete.
+
+Final response:
+
+- State what changed.
+- Link the PR or merged commit.
+- Summarize verification.
+- Mention any skipped phase, failed command, or residual risk.

--- a/.agents/skills/implement/agents/openai.yaml
+++ b/.agents/skills/implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Implement"
+  short_description: "Issue-to-PR implementation loop"
+  default_prompt: "Use $implement to implement this issue end to end."

--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: merge-pr
+description: Merge a PR and update upstream GitHub issues with progress
+argument-hint: <pr-number>
+---
+
+# Merge PR and Update Issues
+
+Merge PR #$ARGUMENTS and update all linked GitHub issues with what was delivered.
+
+## PR Context
+
+- PR metadata: !`gh pr view $ARGUMENTS --json number,title,body,state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRefName,baseRefName,additions,deletions,changedFiles`
+- PR checks: !`gh pr checks $ARGUMENTS 2>/dev/null || echo "NO_CHECKS"`
+
+## Instructions
+
+### Step 1: Validate Readiness
+
+Check that the PR is safe to merge. For each check, determine pass/fail:
+
+1. **State** — PR must be `OPEN`. If already merged or closed, report and stop.
+2. **Merge conflicts** — `mergeable` must not be `CONFLICTING`. If conflicts exist, report and stop.
+3. **CI status** — All status checks must pass. If any check is failing, report which ones and stop.
+4. **PR standards** — Read `.Codex/skills/pr-check/SKILL.md` and execute its validation checks against the PR. All checks must pass (WARN is acceptable, FAIL is not). Fix any failures if possible; otherwise report what needs to be fixed and stop.
+5. **Review decision** — Check `reviewDecision` from the PR metadata. If `CHANGES_REQUESTED`, stop and report. If `REVIEW_REQUIRED` or empty/null (no reviews submitted), escalate to the user. Only proceed if `APPROVED` or if the user explicitly confirms.
+
+**If validation fails**, stop and report exactly what needs to be fixed. Do not merge.
+
+**If validation requires human judgment** (e.g., a check is flaky, the PR has unresolved conversations), stop and consult the user with the evidence.
+
+### Step 2: Merge
+
+Squash-merge the PR and delete the remote branch:
+
+```
+gh pr merge $ARGUMENTS --squash --delete-branch
+```
+
+If the merge fails, report the error and stop.
+
+**Normalize commit timestamp** (privacy: hides work schedule):
+
+After the merge succeeds, pull the merge commit and normalize its timestamp to 12:00 UTC on the same date. This matches the post-commit hook behavior, which doesn't run for GitHub-side merges.
+
+```bash
+git checkout main && git pull origin main
+NORM_DATE="$(date -u -d "$(git log -1 --format='%ad' --date=short) 12:00" '+%Y-%m-%dT12:00:00+00:00')"
+GIT_AUTHOR_DATE="$NORM_DATE" GIT_COMMITTER_DATE="$NORM_DATE" \
+    git commit --amend --no-edit --no-verify --date="$NORM_DATE"
+git push --force-with-lease origin main
+```
+
+If the force-push fails (e.g., another commit landed), warn the user but do not retry. The merge itself already succeeded.
+
+### Step 3: Update Linked Issues
+
+1. **Extract issue references** from the PR title and description. Look for:
+   - **Closing references:** `Closes #N`, `Fixes #N`, `Resolves #N` (case-insensitive) — the PR fully addresses the issue
+   - **Partial references:** `Relates to #N`, `Part of #N` — the PR partially addresses or relates to the issue
+
+2. **For each referenced issue**, fetch the issue with `gh issue view <N> --json state,title` and post an update:
+
+   **For closing references** (issue should be auto-closed by GitHub):
+   ```
+   gh issue comment <N> --body "$(cat <<'EOF'
+   ## Delivered
+
+   **PR:** #<pr-number> — <PR title>
+
+   ### Changes delivered
+   - <bullet summary extracted from PR description and diff>
+
+   This PR fully addresses this issue.
+   EOF
+   )"
+   ```
+
+   **For partial references:**
+   ```
+   gh issue comment <N> --body "$(cat <<'EOF'
+   ## Progress Update
+
+   **PR:** #<pr-number> — <PR title>
+
+   ### Changes delivered
+   - <bullet summary extracted from PR description>
+
+   ### Remaining work
+   <What this issue still needs, based on reading the issue body vs. what was delivered. If unclear, state "See issue description for remaining scope.">
+   EOF
+   )"
+   ```
+
+3. **If no issues are referenced**, skip this step.
+
+### Step 4: Report
+
+Output a summary:
+
+```
+## Merge Complete
+
+**PR:** #<number> — <title>
+**Merged to:** <base branch>
+**Issues updated:** <list of issue numbers, or "none">
+
+### Changes
+- <bullet summary>
+```
+
+## Escalation
+
+Stop and consult the user when:
+
+- PR has failing CI checks that may be flaky (unclear if real failure)
+- PR has unresolved review conversations
+- Merge fails for an unexpected reason
+- An issue referenced by the PR is already closed and the update seems redundant
+- Any situation requiring human judgment about whether to proceed

--- a/.agents/skills/mine-for-ideas/SKILL.md
+++ b/.agents/skills/mine-for-ideas/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: mine-for-ideas
+description: Analyze an open-source repo and surface ideas/patterns LifeOS could learn from
+argument-hint: <github-url> [context/guidance]
+---
+
+# Mine for Ideas: Open-Source Intelligence
+
+Arguments: `$ARGUMENTS`
+
+Parameters:
+- **github-url** (required) — Full GitHub URL to the repo, must be the first argument (e.g., `https://github.com/org/repo`)
+- **context** (optional) — Freetext guidance on what to focus on, what to compare, or what questions to answer. Everything after the URL is treated as context. Examples:
+  - `pay special attention to their entity resolution approach vs. ours`
+  - `how do they handle hybrid search? we use ChromaDB + FTS5 via RRF`
+  - `their sync pipeline looks interesting, especially incremental indexing`
+
+  If omitted, analyze the repo holistically for anything relevant to LifeOS.
+
+## LifeOS Context
+
+Project context for understanding what's relevant:
+
+!`cat AGENTS.md`
+
+## Instructions
+
+You are mining an open-source project for ideas, patterns, and approaches that could benefit LifeOS. This is **architectural intelligence** — you're comparing engineering worldviews, not listing features. The goal is to understand how another team solved problems we also face, identify where their thinking reveals blind spots in ours, and flag where adopting their approach would create new problems we'd need to solve.
+
+### Step 1: Parse arguments
+
+The arguments string starts with a GitHub URL, followed by optional freetext context. Parse them as:
+- **URL**: The first token matching `https://github.com/...`
+- **Context**: Everything after the URL — freetext guidance on what to focus on, compare, or answer
+
+If no URL is provided, stop and ask for one.
+
+Parse the owner/repo from the URL (e.g., `https://github.com/chroma-core/chroma` -> `chroma-core/chroma`).
+
+If context was provided, use it to guide exploration depth and focus areas. The context shapes which parts of the target repo to explore most deeply and which LifeOS specs to compare against. Weave it into the subagent prompts in Steps 2 and 3.
+
+### Step 2: Explore the target repo
+
+Use a thorough Explore subagent to analyze the target repository. The subagent should:
+
+1. **Read the README** via WebFetch (`https://github.com/{owner}/{repo}`)
+2. **Explore the repo structure** via the GitHub API:
+   ```
+   gh api repos/{owner}/{repo}/contents --jq '.[].name'
+   ```
+3. **Read key source files** — look for core modules, main abstractions, interesting patterns. Use:
+   ```
+   gh api repos/{owner}/{repo}/contents/{path} --jq '.content' | base64 -d
+   ```
+4. **Read documentation** if it exists (docs/, README, ARCHITECTURE.md, etc.)
+
+If the user provided context/guidance, use it to direct exploration — concentrate on the areas they called out, compare against the aspects they're curious about, and answer the questions they raised. Otherwise, explore broadly and identify what's most relevant to LifeOS.
+
+The subagent should extract:
+- Core architecture and design philosophy
+- Key abstractions and data structures — not just names, but *why* they're shaped that way
+- How they handle problems LifeOS also faces (entity resolution, hybrid search, sync pipelines, personal data indexing, agentic chat)
+- What their fundamental mental model is (batch vs live? pipeline vs service? mutable vs append-only? cloud vs local-first?)
+- Novel or creative patterns, especially ones that challenge our assumptions
+- Testing approaches worth noting
+
+### Step 3: Understand LifeOS's current approach
+
+Use a second subagent to read the relevant LifeOS specs and implementation for the same domain areas. Focus on:
+- Product specs in `docs/specs/product/`
+- Technical specs in `docs/specs/technical/`
+- ADRs in `docs/adr/`
+- Existing implementation in `api/` and `config/`
+
+The subagent should focus on understanding LifeOS's **architectural assumptions and constraints** — not just what the code looks like, but what invariants we've committed to (two-tier SourceEntity/PersonEntity model, hybrid search via RRF, local-only data, ChromaDB + FTS5, five-phase sync pipeline, agentic chat with tool calls, macOS-native integrations).
+
+### Step 4: Synthesize the comparison
+
+Run both subagents in parallel. Once both complete, produce the analysis below.
+
+**Important**: Run the exploration and LifeOS context subagents concurrently for efficiency.
+
+### Step 5: Write the analysis
+
+This analysis has two parts: **understanding** (what are the real differences?) and **judgment** (what should we do about them?). Both matter. Don't skip to recommendations without first building deep understanding.
+
+Produce the following sections. Be direct, specific, and opinionated. Write at the level of an architect who has internalized both systems.
+
+---
+
+#### Repo Overview
+
+2-3 sentences on what the repo does and its tech stack. Include stars/activity if notable.
+
+#### Fundamental Differences
+
+This is the most important section. For each major difference between their approach and ours (aim for 3-6):
+
+- **Bold title** — name the difference as an architectural choice, not a feature (e.g., "Cloud-native vector ops vs. local ChromaDB", not "They use Pinecone")
+- **Their approach**: What they do and *why* their system is shaped this way. Reference specific files, abstractions, or patterns. Explain the mental model, not just the mechanism.
+- **Our approach**: What LifeOS does (or plans to do) and why. Reference specific specs, ADRs, or code.
+- **Why the difference matters**: What does their choice enable that ours doesn't? What does ours enable that theirs doesn't? Be concrete — talk about specific scenarios, query patterns, or user experiences that differ.
+
+Don't flatten this into "pros and cons." Each difference reflects a tradeoff rooted in different system constraints. Name those constraints.
+
+#### Tradeoff Analysis
+
+For each difference above that initially looks appealing to adopt, stress-test it against LifeOS's constraints. This section is adversarial — it's where you identify what would **break or degrade** if we naively adopted an appealing pattern.
+
+Think about:
+- **Privacy**: Does this require sending personal data to external services? LifeOS is local-only by design (AGENTS.md § Privacy Is Non-Negotiable). Codex API is the only exception, used for discrete queries.
+- **Stability**: Would this make the system's behavior less predictable over time? Would entities or search results shift without user action?
+- **Performance**: Does this add query-time computation where we currently have pre-computed results? Does it conflict with "every operation should be delightfully fast"?
+- **Blast radius**: Can a small change cascade into large, unexpected effects? How does this interact with our two-tier data model (SourceEntity -> PersonEntity)?
+- **Simplicity**: Is the implementation complexity justified by the benefit, given LifeOS's current stage? (AGENTS.md § Simplicity First)
+- **macOS constraints**: Does this work within our macOS-native setup (FDA, launchd, Tailscale, no Docker)?
+
+Be specific. "This could cause instability" is not useful. "A new match rule between SourceEntity A and SourceEntity B could transitively merge two previously-separate PersonEntity clusters without user action, changing CRM results for both" is useful.
+
+#### What to Adopt (and How)
+
+For each idea worth adopting, explain the **adapted version** that works within LifeOS's constraints — not the original pattern, but the version that captures the insight while respecting our architectural invariants. Be concrete about:
+- What would change in the schema, spec, or code
+- What stays the same
+- What new problems the adoption creates and how to handle them
+
+#### What We're Doing Better
+
+Areas where LifeOS's approach is already stronger. Reinforces good decisions. Keep this short — 2-3 items max. Explain *why* our approach is better for our use case, not just that it's different.
+
+#### Net Recommendation
+
+A short synthesis (3-5 sentences). State the single biggest architectural insight, whether it warrants an ADR, spec change, or just awareness. If the answer is "nothing to adopt, but this validated our approach," say that.
+
+---
+
+### Quality bar
+
+The analysis should read like an architect's memo, not a feature comparison table. The reader should come away understanding:
+1. How the other project's team *thinks* about the problem (their mental model)
+2. Where their thinking reveals something we hadn't considered
+3. Whether and how to adapt their ideas without breaking our invariants
+4. What we're already doing right that we should protect
+
+Avoid:
+- Surface-level pattern-spotting ("they use X, we could use X too")
+- Listing features without analyzing tradeoffs
+- Generic praise or dismissal
+- Recommendations without concrete integration analysis
+
+### Step 6: Offer to create a GitHub issue
+
+After presenting the analysis, ask the user:
+
+> Would you like me to create a GitHub issue to track any of these ideas? I can create one tagged with the `idea` label containing the key findings and references.
+
+If the user says yes, ask which ideas to include (or all), then create the issue:
+
+```
+gh issue create \
+  --title "Idea: [concise title from net recommendation]" \
+  --label "idea" \
+  --body "$(cat <<'EOF'
+## Source
+
+[Repo Name](github-url) — brief description
+
+## Key Ideas
+
+[Selected ideas from the "What to Adopt" section, with the adapted-for-LifeOS version, not the raw pattern]
+
+## Tradeoffs & Risks
+
+[Key concerns from the tradeoff analysis that must be addressed]
+
+## Suggested Next Step
+
+[ADR, spec change, prototype, or just "keep in mind for when we build X"]
+
+## References
+
+- [Link to specific files/patterns in the source repo]
+- [Link to relevant LifeOS specs]
+
+---
+*Generated by `/mine-for-ideas`*
+EOF
+)"
+```
+
+Ensure the `idea` label exists first:
+```
+gh label create idea --description "Ideas mined from external projects" --color "0E8A16" 2>/dev/null || true
+```
+
+## Escalation
+
+Stop and tell the user when:
+- No GitHub URL provided in arguments
+- `gh` API calls fail (auth, rate limit, or network)
+- The repo is private or inaccessible
+- The repo is too large to meaningfully explore (>500 files in core dirs) — suggest a focus area

--- a/.agents/skills/pr-check/SKILL.md
+++ b/.agents/skills/pr-check/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pr-check
+description: Validate a PR against PR standards before requesting review
+argument-hint: [pr-number]
+---
+
+# PR Standards Check
+
+Pre-flight validation for PR quality.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- PR data: !`gh pr view $ARGUMENTS --json title,body,additions,deletions,changedFiles,commits,baseRefName,number 2>/dev/null || echo "NO_PR_FOUND"`
+- Commits since main: !`git log --oneline main..HEAD`
+
+## Instructions
+
+Validate the current PR against each standard below. If no PR number was provided and `NO_PR_FOUND` appears above, check only what can be validated locally (branch name, commits, diff size) and note that no PR exists yet.
+
+For each check, output one of:
+- **PASS** — Meets the standard
+- **WARN** — Minor deviation, note what's off
+- **FAIL** — Does not meet the standard, explain what needs to change
+
+### Checks
+
+**1. Branch Naming**
+Branch must match `<type>/<short-description>` where type is one of: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`. Must be lowercase, hyphen-separated. No issue numbers in the branch name.
+
+**2. PR Title**
+Must match `<type>: <imperative summary>`. Type prefix should match branch type. Under 72 characters. No period at the end. Imperative mood ("Add", "Fix"), not past tense ("Added", "Fixed").
+
+**3. PR Description — Summary**
+Must include 1-3 sentences explaining what the change does and why.
+
+**4. PR Description — Test Evidence**
+Must include how the change was verified: test output, manual steps, or "covered by existing tests."
+
+**5. PR Sizing**
+Check additions + deletions (excluding generated code, test fixtures, lock files if identifiable):
+- Under 400 lines → PASS
+- 400-600 lines → WARN ("consider splitting")
+- Over 600 lines → FAIL ("should be split")
+
+**6. Commit Messages**
+Each commit message should follow `<type>: <summary>` format. No "WIP", "fixup", or "wip" commits.
+
+**7. References**
+If the change relates to a GitHub issue, it should reference it with `Closes #N` or `Relates to #N`. WARN if no references found (not all PRs need them, but flag for awareness).
+
+**8. Secrets & Sensitive Data**
+This project is open-source. The diff MUST NOT contain any of the following. FAIL immediately if found:
+- **API keys, tokens, or secrets** — any string that looks like a bearer token, API key, bot token, OAuth secret, or password (check for patterns like `sk-`, `ghp_`, `bot[0-9]`, `xoxb-`, `Bearer `, long hex/base64 strings assigned to credential variables). Tokens in test mocks/fixtures using obviously fake values are OK.
+- **Hardcoded user-specific paths** — absolute paths referencing a specific user's home directory (e.g., `/Users/alice/`, `/home/username/`). Relative paths and `~/` are OK. Paths in AGENTS.md, AGENTS.md, and documentation that describe the project setup are exempt.
+- **Real personal names or emails** — real people's names, email addresses, phone numbers, or other PII in code or test fixtures. Synthetic/obviously fake data is OK (e.g., "John Doe", "test@example.com"). Names in git commit metadata, AGENTS.md, and AGENTS.md are exempt.
+- **Internal infrastructure details** — Tailscale IPs, internal hostnames, or private network addresses in code (their presence in AGENTS.md/AGENTS.md for developer setup is OK).
+
+To check, read the full diff: !`git diff main..HEAD -- ':!AGENTS.md' ':!AGENTS.md'`
+
+### Output Format
+
+```
+## PR Standards Check
+
+| # | Check | Result | Notes |
+|---|-------|--------|-------|
+| 1 | Branch naming | PASS/WARN/FAIL | ... |
+| 2 | PR title | PASS/WARN/FAIL | ... |
+| 3 | Summary | PASS/WARN/FAIL | ... |
+| 4 | Test evidence | PASS/WARN/FAIL | ... |
+| 5 | Sizing | PASS/WARN/FAIL | ... |
+| 6 | Commit messages | PASS/WARN/FAIL | ... |
+| 7 | References | PASS/WARN/FAIL | ... |
+| 8 | Secrets & sensitive data | PASS/WARN/FAIL | ... |
+
+**Result: X/8 passing, Y warnings, Z failures**
+```
+
+If there are failures, add a brief "Suggested Fixes" section listing what to change.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: review-pr
+description: Run adversarial PR review with specialist subagents
+argument-hint: <pr-number>
+---
+
+# Adversarial PR Review
+
+Review PR #$ARGUMENTS using specialist agents. Be adversarial — verify claims, don't trust assertions.
+
+## PR Context
+
+- PR metadata: !`gh pr view $ARGUMENTS`
+- PR diff: !`gh pr diff $ARGUMENTS`
+- PR comments: !`gh pr view $ARGUMENTS --comments`
+
+## Instructions
+
+### Step 1: Gather Context
+
+Before spawning any review agents, gather context yourself:
+
+1. Read the PR description above. Identify the **intent**, **test evidence**, and any **review focus** areas the author flagged.
+2. Check referenced issues or specs — if the description links to issues (`#N`) or spec documents, read them to understand what the PR is supposed to accomplish.
+3. Scan the diff file list. Identify which modules are touched. Does the scope match the stated intent, or are there unrelated changes?
+4. If the change touches architecture (new modules, new dependencies, schema changes), read related ADRs in `docs/adr/` to confirm alignment.
+5. If this is part of a stacked PR series, note the stack position and ensure you're reviewing in order.
+
+### Step 2: Verify Claims
+
+Do not trust the PR description at face value. Independently verify:
+
+- **Test evidence** — If the author says "all tests pass," check out the branch and run the tests yourself. Agent work is cheap; broken merges are expensive.
+- **Scope claims** — If the description says "only touches X," confirm via the diff that nothing else was changed.
+- **Spec conformance** — If the description says "implements spec Y," read the spec and verify the implementation actually matches.
+
+### Step 3: Select Specialist Agents
+
+Based on the change type, determine which specialists to spawn:
+
+- **Docs-only change** → Standards only
+- **Code change (typical)** → Correctness + Security + Standards
+- **New API endpoint** → Correctness + Security + Requirements + Standards
+- **Performance-sensitive path** → All five specialists
+
+### Step 4: Spawn Specialist Agents
+
+Use the Task tool to spawn the selected agents **in parallel**. Each agent should be a `general-purpose` subagent. Provide each agent with:
+
+- The full PR diff (copy it into the prompt)
+- The specific focus area and what to look for (see table below)
+- The relevant standards document(s) to check against
+- Instructions to categorize every finding by severity: **Action Required**, **Recommended**, or **Minor**
+
+| Agent | Focus | Reference Docs |
+|-------|-------|---------------|
+| Correctness | Logic bugs, edge cases, error handling gaps, race conditions | `AGENTS.md` (development principles) |
+| Security | AuthZ/AuthN, injection risks, secrets exposure, PII handling | `AGENTS.md` (privacy principles) |
+| Performance | Hot paths, N+1 queries, async bottlenecks, SQLite locking, connection pool exhaustion | `AGENTS.md` (tech stack), `docs/specs/technical/architecture.md` |
+| Requirements | Validates code against acceptance criteria and referenced specs | Referenced issues/specs from PR description |
+| Standards | Project conventions, naming, structure, test coverage, PR formatting | `AGENTS.md`, `.Codex/skills/pr-check/SKILL.md` |
+
+### Step 5: Consolidate Review
+
+After all specialist agents return findings:
+
+1. Merge all findings into a single list
+2. Deduplicate — if multiple agents flagged the same issue, keep the most detailed version
+3. Resolve conflicts — if agents disagree, note the disagreement and recommend the safer option
+4. Sort by severity: **Action Required** first, then **Recommended**, then **Minor**
+
+### Step 6: Post Review
+
+Format the consolidated review and post it as a GitHub PR review comment using:
+
+```
+gh pr review $ARGUMENTS --comment --body "<review content>"
+```
+
+Use this output format:
+
+```markdown
+## PR Review: <PR title>
+
+### Action Required
+- **[Agent]** Finding description with file:line references
+
+### Recommended
+- **[Agent]** Finding description with file:line references
+
+### Minor
+- **[Agent]** Finding description with file:line references
+
+### Summary
+<1-2 sentence overall assessment: merge-ready, needs changes, or needs discussion>
+```
+
+If there are no Action Required items, state that explicitly. If there are no findings at all in a category, omit that category.
+
+## Escalation
+
+Stop the review and flag the human directly (do not post as a PR comment) when encountering:
+
+- Ambiguous requirements or missing acceptance criteria
+- Failing tests where root cause is unclear
+- Architectural decisions that affect multiple modules
+- New third-party dependency introduction
+- Changes touching auth, crypto, or PII handling
+
+When escalating, provide: what you tried, evidence, options with tradeoffs, and your recommended path.
+
+## Anti-Patterns
+
+Do not fall into these traps during review:
+
+- **Blind trust** — Merging because "it passed CI" without understanding the changes
+- **Review theater** — Approving without reading or comprehending
+- **Skipping verification** — Trusting the author's claims about test results or scope
+- **Test modification** — Suggesting test changes to make them pass instead of fixing the code (see AGENTS.md § "Tests Are Sacred")

--- a/.agents/skills/stale/SKILL.md
+++ b/.agents/skills/stale/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: stale
+description: Housekeeping report — find stale PRs, orphan branches, stale issues, and stale plans
+argument-hint: [days]
+---
+
+# Stale: Housekeeping Report
+
+Arguments: `$ARGUMENTS`
+
+Parameters (all optional):
+- **days** — staleness threshold in days, defaults to 14
+
+## Repository Data
+
+Open PRs with metadata:
+
+!`gh pr list --state=open --json number,title,author,createdAt,updatedAt,isDraft,reviewDecision,headRefName,additions,deletions --limit 100 2>/dev/null || echo "GH_ERROR"`
+
+Open issues:
+
+!`gh issue list --state=open --json number,title,assignees,createdAt,updatedAt,labels --limit 100 2>/dev/null || echo "GH_ERROR"`
+
+Local branches with last commit date:
+
+!`git branch --format='%(refname:short) %(committerdate:iso8601)' 2>/dev/null | grep -v '^main$' | grep -v '^master$'`
+
+Branch-to-PR mapping:
+
+!`git branch --format='%(refname:short)' | grep -v '^main$' | grep -v '^master$' | while IFS= read -r b; do PR=$(gh pr list --head "$b" --state=open --json number --jq '.[0].number' 2>/dev/null); echo "$b -> ${PR:-none}"; done`
+
+Plan files (if docs/plans/ exists):
+
+!`if [ -d docs/plans ]; then find docs/plans -name '*.md' -not -path '*/archive/*' 2>/dev/null; else echo "NO_PLANS_DIR"; fi`
+
+Plan file contents (frontmatter only, for status/date checking):
+
+!`if [ -d docs/plans ]; then find docs/plans -name '*.md' -not -path '*/archive/*' 2>/dev/null | while IFS= read -r f; do echo "=== $f ==="; head -20 "$f" 2>/dev/null; echo; done; else echo "NO_PLANS_DIR"; fi`
+
+## Instructions
+
+You are producing a **housekeeping report** — identifying stale items that need cleanup, closure, or attention.
+
+### Step 1: Triage
+
+If any data block shows `GH_ERROR`, report that `gh` failed (likely auth or network) and stop.
+
+Parse the days threshold from arguments (default 14). An item is "stale" if it hasn't been updated in more than this many days.
+
+### Step 2: Analyze
+
+For each category, identify stale or orphaned items:
+
+**Stale PRs** — Open PRs where `updatedAt` is older than the threshold.
+
+**Orphan branches** — Local branches that have no open PR (mapped to `none` in the branch-to-PR data). For each orphan, check if it's been merged into main:
+```
+git branch --merged main
+```
+An orphan that's already merged into main is a safe delete candidate. An unmerged orphan needs investigation.
+
+**Stale issues** — Open issues where `updatedAt` is older than the threshold.
+
+**Stale plans** — Plan files in `docs/plans/` (not in `archive/`) that appear completed, have a past target date, or haven't been updated recently. Check frontmatter for `Status` and date fields.
+
+### Step 3: Write the report
+
+Produce the following sections:
+
+---
+
+#### Summary
+
+A single compact line:
+
+> **2 stale PRs, 3 orphan branches, 1 stale issue, 0 stale plans**
+
+#### Stale PRs
+
+A table for each stale PR:
+
+| PR | Title | Author | Age | Status | Suggested Action |
+|----|-------|--------|-----|--------|-----------------|
+
+Status should reflect: `DRAFT`, `AWAITING REVIEW`, `CHANGES REQUESTED`, `APPROVED`.
+Suggested actions: "Close — appears abandoned", "Ping author for update", "Needs rebase", "Review and merge — approved but stale", etc.
+
+If no stale PRs, say "None — all PRs are active."
+
+#### Orphan Branches
+
+List each orphan branch with:
+- Branch name
+- Last commit date
+- Whether it's merged into main
+- Suggested action: "Safe to delete (merged)" or "Investigate — unmerged and has no PR"
+
+If no orphan branches, say "None — all branches have open PRs."
+
+#### Stale Issues
+
+A table for each stale issue:
+
+| Issue | Title | Assignee | Age | Labels | Suggested Action |
+|-------|-------|----------|-----|--------|-----------------|
+
+Suggested actions: "Close — likely resolved", "Needs triage", "Reassign — assignee may be unavailable", etc.
+
+If no stale issues, say "None — all issues are active."
+
+#### Stale Plans
+
+List plan files that appear stale:
+- File path
+- Status from frontmatter (if present)
+- Why it's flagged (completed, past target date, no recent updates)
+- Suggested action: "Archive to docs/plans/archive/", "Update status", "Delete if superseded"
+
+If `docs/plans/` doesn't exist or has no stale plans, say "None."
+
+#### Quick Wins
+
+List exact commands the user can copy-paste to clean up safe-to-delete items. **Do not execute these — list them only.**
+
+Examples:
+```
+git branch -d feature/old-branch    # merged, safe to delete
+git push origin --delete feature/old-branch  # clean up remote
+gh pr close 42 --comment "Closing stale PR — superseded by #57"
+```
+
+If there are no quick wins, omit this section.
+
+---
+
+### Formatting rules
+
+- Use markdown tables for PRs and issues
+- Reference PR/issue numbers as `#N`
+- Show ages as "X days" (compute from current date vs `updatedAt` or commit date)
+- Keep it scannable — this is a cleanup checklist, not a deep analysis
+- Be specific in suggested actions — generic "review this" isn't helpful
+
+## Escalation
+
+Stop and tell the user when:
+- `gh` commands fail (auth, network, or unexpected errors)
+- Any list returns at its limit cap (100 results) — the repo may have more items than shown

--- a/.agents/skills/standup/SKILL.md
+++ b/.agents/skills/standup/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: standup
+description: Personal daily summary — what you shipped, what's in progress, what needs attention
+argument-hint: [hours]
+---
+
+# Standup: Personal Daily Summary
+
+Arguments: `$ARGUMENTS`
+
+Parameters (all optional):
+- **hours** — numeric, defaults to 24
+
+## My Data
+
+Merged PRs by me in the window:
+
+!`H=$(echo "${ARGUMENTS:-}" | grep -oE '[0-9]+' | head -1); H=${H:-24}; gh pr list --author=@me --state=merged --search="merged:>=$(date -u -d "${H} hours ago" +%Y-%m-%dT%H:%M:%S)Z" --json number,title,mergedAt,additions,deletions,changedFiles --limit 50 2>/dev/null || echo "GH_ERROR"`
+
+Open PRs by me with review status:
+
+!`gh pr list --author=@me --state=open --json number,title,createdAt,updatedAt,isDraft,reviewDecision,additions,deletions,changedFiles --limit 50 2>/dev/null || echo "GH_ERROR"`
+
+Issues assigned to me:
+
+!`gh issue list --assignee=@me --state=open --json number,title,createdAt,updatedAt,labels --limit 50 2>/dev/null || echo "GH_ERROR"`
+
+My commits on main in the window:
+
+!`H=$(echo "${ARGUMENTS:-}" | grep -oE '[0-9]+' | head -1); H=${H:-24}; EMAIL=$(git config user.email); git log --author="$EMAIL" --since="$(date -u -d "${H} hours ago" +%Y-%m-%dT%H:%M:%S)" --oneline origin/main 2>/dev/null || echo "No commits found"`
+
+My git stats for the window:
+
+!`H=$(echo "${ARGUMENTS:-}" | grep -oE '[0-9]+' | head -1); H=${H:-24}; EMAIL=$(git config user.email); SINCE=$(date -u -d "${H} hours ago" +%Y-%m-%dT%H:%M:%S); COMMITS=$(git log --author="$EMAIL" --since="$SINCE" --oneline origin/main 2>/dev/null | wc -l | tr -d ' '); STATS=$(git log --author="$EMAIL" --since="$SINCE" --shortstat origin/main 2>/dev/null | grep "insertion\|deletion" | awk '{for(i=1;i<=NF;i++){if($i~/insertion/)ins+=$(i-1);if($i~/deletion/)del+=$(i-1)}} END {printf "+%d / -%d lines", ins+0, del+0}'); echo "commits=$COMMITS $STATS"`
+
+## Instructions
+
+You are producing a **personal standup summary** — a quick status report of what *I* shipped, what's in progress, and what needs my attention.
+
+### Step 1: Triage
+
+If any data block shows `GH_ERROR`, report that `gh` failed (likely auth or network) and stop.
+
+Parse the hours parameter from the arguments (default 24). Note the time window in the output header.
+
+### Step 2: Write the standup
+
+Produce the following sections:
+
+---
+
+#### Stats
+
+A single compact line summarizing activity:
+
+> **3 commits, 1 PR merged, 2 PRs open, +713 / -28 lines (last 24h)**
+
+Derive values from the git stats and PR data above. Adjust the "(last Nh)" to match the actual window.
+
+#### Done
+
+List merged PRs and landed commits in the window. For each:
+- PR number and title
+- Brief description of what it accomplished (one line)
+
+If no merged PRs or commits, say "Nothing landed in this window."
+
+#### In Progress
+
+List open PRs by me. For each:
+- PR number and title
+- Status label derived from the data:
+  - `DRAFT` — if `isDraft` is true
+  - `CHANGES REQUESTED` — if `reviewDecision` is `CHANGES_REQUESTED`
+  - `APPROVED` — if `reviewDecision` is `APPROVED`
+  - `AWAITING REVIEW` — otherwise (not draft, no decision yet)
+- Lines changed (`+N / -M`)
+
+If no open PRs, say "No open PRs."
+
+#### Needs Attention
+
+Flag items that require action. Include only items that apply:
+- PRs with `CHANGES REQUESTED` status — need to address feedback
+- Stale open PRs (updated 7+ days ago) — need to push forward or close
+- Assigned issues — list with age and labels
+
+If nothing needs attention, omit this section entirely.
+
+---
+
+### Formatting rules
+
+- Use markdown headers and bullets
+- Reference PR numbers as `#N`
+- Reference issues as `#N`
+- Keep it scannable — this should take under 1 minute to read
+- Don't editorialize or add motivational commentary
+
+## Escalation
+
+Stop and tell the user when:
+- `gh` commands fail
+- Any PR list returns exactly 50 results — suggest a shorter time window

--- a/.agents/skills/tune/SKILL.md
+++ b/.agents/skills/tune/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: tune
+description: >
+  Tune LifeOS orchestrator behavior based on feedback about a bad response.
+  Use when the user describes a problem with how LifeOS answered a query — wrong sources,
+  too verbose, not persistent enough, poor tool selection, bad source integration,
+  missing detail, gave up too early, etc. Also covers Codex task execution issues
+  (scope, persistence, notification style). Makes a surgical prompt edit, branches, commits, and pushes.
+  Trigger on: "tune", "response-tuning", "fix the prompt", "tune the response",
+  "it didn't search enough", "too verbose", "improve the orchestrator", "the response was bad",
+  or any feedback about LifeOS chat/orchestrator quality.
+argument-hint: <feedback about what went wrong>
+---
+
+# Response Tuning
+
+Improve LifeOS orchestrator behavior based on this feedback: **$ARGUMENTS**
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -3`
+- Recent conversations: !`sqlite3 data/conversations.db "SELECT m.role, substr(m.content, 1, 200), m.created_at FROM messages m JOIN conversations c ON m.conversation_id = c.id ORDER BY m.created_at DESC LIMIT 10;" 2>/dev/null || echo "NO_CONVERSATION_DB"`
+- Recent perf traces: !`curl -s http://localhost:8000/api/perf/traces?limit=3 2>/dev/null | python3 -c "import sys,json; data=json.load(sys.stdin); [print(f'{t.get(\"question\",\"\")[:100]} | tools: {[s[\"name\"] for s in t.get(\"spans\",[]) if s[\"name\"].startswith(\"tool_\")]}') for t in data.get('traces',[])]" 2>/dev/null || echo "NO_PERF_DATA"`
+
+## How this works
+
+You are fixing the orchestrator's behavior — the instructions that tell LifeOS how to search,
+pick tools, integrate sources, and format responses. The user got a bad result and is telling
+you what went wrong so you can prevent it from happening again.
+
+The fix is almost always a targeted edit to an instruction in a system prompt. Think of it like
+tuning a knob — you're adjusting the model's tendencies, not rewriting the system.
+
+## Step 1: Diagnose
+
+Read the feedback and the recent conversation context above. Identify:
+
+1. **What went wrong** — Map the feedback to a specific failure mode:
+   - Didn't search enough sources → tool persistence / multi-tool patterns
+   - Too verbose / too terse → response format section
+   - Gave up without trying → give-up detection / self-correction
+   - Wrong tool chosen → tool descriptions / when-to-use guidance
+   - Poor source integration → synthesis instructions
+   - Didn't follow up on partial results → search persistence rules
+   - Bad Codex task execution → orchestrator scope/persistence/notification rules
+
+2. **Which file owns this behavior:**
+
+   | Behavior | File | Key section |
+   |----------|------|-------------|
+   | Chat tool selection & search strategy | `api/services/agent_system_prompt.py` | `_STATIC_PROMPT_TEMPLATE` |
+   | Chat response format & conciseness | `api/services/agent_system_prompt.py` | Response format section |
+   | Chat tool round limits | `api/services/agent_loop.py` | `max_tool_rounds` param |
+   | Give-up detection patterns | `api/services/agent_loop.py` | `_GIVE_UP_PATTERNS` |
+   | Self-correction nudge | `api/services/agent_loop.py` | `SELF_CORRECTION_NUDGE` |
+   | Codex task scope & persistence | `api/services/claude_orchestrator.py` | `_SYSTEM_PROMPT` |
+   | Codex notifications | `api/services/claude_orchestrator.py` | NOTIFICATIONS section |
+
+3. **Read the target file(s)** — Read the actual current content of the file you plan to edit.
+   Do not work from memory. The prompt may have changed since you last saw it.
+
+## Step 2: Assess scope
+
+This skill is for **small, surgical changes**. Before editing, ask yourself:
+
+- Am I changing fewer than ~20 lines of prompt text? → Proceed.
+- Am I adding/adjusting a single behavioral rule or instruction? → Proceed.
+- Am I tweaking a parameter (like max_tool_rounds)? → Proceed.
+- Would this require restructuring the prompt, adding new tools, or changing multiple
+  modules? → **Stop.** Use the `/draft-issue` skill to create a GitHub issue:
+
+  ```
+  Skill tool → skill: "draft-issue", args: "Orchestrator: <summary>. Feedback: <user feedback>. Root cause: <your diagnosis>. Files: <list>. Too large for a prompt tweak because <reason>."
+  ```
+
+  Then notify the user that an issue was created and stop.
+
+## Step 3: Edit
+
+Make the change. Guidelines:
+
+- **Match the existing style.** The prompts use a specific tone and structure — imperative,
+  concise, example-driven. Don't introduce a different voice.
+- **Be specific, not vague.** "Search at least 3 different sources" is better than
+  "Be more thorough." The model responds to concrete instructions.
+- **Explain why when it's not obvious.** A brief parenthetical like "(the user can't easily
+  follow up from their phone)" helps the model internalize the intent.
+- **Don't bloat the prompt.** If you're adding a new rule, check if an existing rule already
+  covers a similar case and can be strengthened instead. Every line in the prompt costs
+  attention — keep it lean.
+- **Don't weaken other behaviors.** Read the surrounding context to make sure your edit
+  doesn't contradict or undermine an existing instruction.
+- **Test your edit mentally.** Imagine the same query that produced the bad response going
+  through the updated prompt. Would the model now behave differently? If not, your edit
+  isn't targeted enough.
+
+## Step 4: Branch, commit, push
+
+```bash
+# Ensure we branch from main
+git checkout main
+git pull --ff-only
+
+# Create branch
+git checkout -b fix/response-tuning-<short-description>
+
+# Stage only the changed files
+git add <changed-files>
+
+# Commit
+git commit -m "fix: tune orchestrator — <what was adjusted>
+
+Feedback: <brief user feedback>
+Change: <one-line description of what was edited>"
+
+# Push
+git push -u origin fix/response-tuning-<short-description>
+```
+
+## Step 5: Notify
+
+Report back with:
+- What you diagnosed
+- What you changed (quote the before/after of the edited lines)
+- The branch name so the user can review
+
+Keep it to 3-5 sentences. The user is on their phone.
+
+## Related skills
+
+This skill delegates to other skills when needed:
+
+- **`/draft-issue`** — When Step 2 determines the change is too large for a prompt tweak,
+  use the Skill tool to invoke `draft-issue` with context about the problem and diagnosis.
+- **`/implement`** — If the user later asks to implement a filed issue, point them to
+  `/implement #<issue-number>`. Don't invoke it automatically from this skill.

--- a/api/services/agent_worker/codex_skill_sync.py
+++ b/api/services/agent_worker/codex_skill_sync.py
@@ -1,26 +1,29 @@
-"""Materialize engine-agnostic LifeOS skills into Codex's skill format.
+"""Materialize LifeOS skills into Codex's local skill format.
 
 LifeOS skills live in `.claude/skills/<name>/SKILL.md` and are authored in
 Claude Code's slash-command dialect: YAML frontmatter with `argument-hint`, a
 `$ARGUMENTS` placeholder, and `` !`cmd` `` bash-injection blocks in the Context
-section. Codex discovers skills only from `$CODEX_HOME/skills` (or
-`~/.codex/skills`) — there is no project-level `.codex/skills` — and its
-`SKILL.md` format is a plain prompt doc with no `$ARGUMENTS` / bash injection.
+section. The portable subset is converted into Codex's plain `SKILL.md` format
+and installed into `$CODEX_HOME/skills` (or `~/.codex/skills`) for local Codex
+sessions and the LifeOS Codex worker.
 
 This module converts the portable subset (no Claude subagent orchestration)
-to Codex's format and installs them. It is import-safe and side-effect-free
-until `install_skills()` is called, so the transform can be unit-tested without
-touching the filesystem.
+to Codex's format and installs them. It also installs native Codex skills
+checked into `.agents/skills/` without conversion. It is import-safe and
+side-effect-free until an install function is called, so transforms can be
+unit-tested without touching the filesystem.
 
 Only engine-agnostic skills are ported. The Claude-orchestration skills
-(`implement`, `review-pr`, `address-review`, `mine-for-ideas`) drive Claude's
-`Task`/`Skill` subagent loop and are deliberately left Claude-only; `tune`
-edits the LifeOS Claude-orchestrator internals and is also excluded.
+(`review-pr`, `address-review`, `mine-for-ideas`) drive Claude's `Task`/`Skill`
+subagent loop and are deliberately left Claude-only; `tune` edits the LifeOS
+Claude-orchestrator internals and is also excluded. `implement` has a separate
+native Codex rewrite under `.agents/skills/implement`.
 """
 from __future__ import annotations
 
 import os
 import re
+import shutil
 from pathlib import Path
 
 import yaml
@@ -39,6 +42,12 @@ PORTABLE_SKILLS = (
     "pr-check",
     "merge-pr",
     "remove-worktree",
+)
+
+# Native Codex skills authored directly in Codex's SKILL.md format under
+# `.agents/skills`. They are copied as-is so bundled resources/metadata survive.
+NATIVE_CODEX_SKILLS = (
+    "implement",
 )
 
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
@@ -120,5 +129,33 @@ def install_skills(
         dest_dir = codex_dir / name
         dest_dir.mkdir(parents=True, exist_ok=True)
         (dest_dir / "SKILL.md").write_text(converted, encoding="utf-8")
+        installed.append(name)
+    return installed
+
+
+def install_native_codex_skills(
+    native_skills_dir: Path | str,
+    codex_skills_dir: Path | str | None = None,
+    skills: tuple[str, ...] = NATIVE_CODEX_SKILLS,
+) -> list[str]:
+    """Copy native Codex skills into Codex's local skill directory.
+
+    Returns the list of skill names installed. Missing allowlisted sources are
+    skipped so older checkouts can still install the converted portable set.
+    Existing destination directories for these allowlisted skills are replaced
+    to avoid stale resources after a source-side edit removes files.
+    """
+    native_dir = Path(native_skills_dir)
+    codex_dir = Path(codex_skills_dir) if codex_skills_dir is not None else _codex_skills_dir()
+
+    installed: list[str] = []
+    for name in skills:
+        src_dir = native_dir / name
+        if not (src_dir / "SKILL.md").is_file():
+            continue
+        dest_dir = codex_dir / name
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
+        shutil.copytree(src_dir, dest_dir)
         installed.append(name)
     return installed

--- a/scripts/install_codex_skills.py
+++ b/scripts/install_codex_skills.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Install the portable LifeOS skills into Codex's skill directory.
+"""Install the LifeOS skills into Codex's local skill directory.
 
 Codex discovers skills from ``$CODEX_HOME/skills`` (or ``~/.codex/skills``) —
-machine-local, like the Codex MCP config. This script converts the
-engine-agnostic LifeOS skills from ``.claude/skills/`` into Codex's ``SKILL.md``
-format and writes them there, so ``#codex`` agents get the same workflow
-helpers as ``#claude`` (standup, catchup, pr-check, merge-pr, etc.).
+machine-local, like the Codex MCP config. This script converts portable LifeOS
+skills from ``.claude/skills/`` into Codex's ``SKILL.md`` format and also copies
+native Codex skills from ``.agents/skills/``. That gives ``#codex`` agents the
+same workflow helpers as ``#claude`` where portable, plus Codex-specific
+rewrites for workflows whose Claude version depends on Claude-only primitives.
 
 Re-run after editing the source skills. Idempotent.
 
@@ -20,7 +21,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from api.services.agent_worker.codex_skill_sync import install_skills  # noqa: E402
+from api.services.agent_worker.codex_skill_sync import (  # noqa: E402
+    install_native_codex_skills,
+    install_skills,
+)
 
 
 def main() -> int:
@@ -28,7 +32,9 @@ def main() -> int:
     if not claude_skills.is_dir():
         print(f"No skills source at {claude_skills}", file=sys.stderr)
         return 1
+    native_skills = REPO_ROOT / ".agents" / "skills"
     installed = install_skills(claude_skills)
+    installed.extend(install_native_codex_skills(native_skills))
     if not installed:
         print("No portable skills found to install.", file=sys.stderr)
         return 1

--- a/tests/test_codex_skill_sync.py
+++ b/tests/test_codex_skill_sync.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import pytest
 
 from api.services.agent_worker.codex_skill_sync import (
+    NATIVE_CODEX_SKILLS,
     PORTABLE_SKILLS,
+    install_native_codex_skills,
     install_skills,
     transform_skill,
 )
@@ -144,6 +146,32 @@ def test_install_skips_missing_sources(tmp_path: Path):
     assert installed == ["standup"]
 
 
+def test_install_native_codex_skills_copies_skill_directory(tmp_path: Path):
+    native_dir = tmp_path / "native_skills"
+    codex_dir = tmp_path / "codex_skills"
+    skill_dir = native_dir / "implement"
+    agents_dir = skill_dir / "agents"
+    agents_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: implement\ndescription: Native Codex lifecycle.\n---\nBody.\n",
+        encoding="utf-8",
+    )
+    (agents_dir / "openai.yaml").write_text(
+        'interface:\n  display_name: "Implement"\n',
+        encoding="utf-8",
+    )
+
+    installed = install_native_codex_skills(native_dir, codex_dir)
+
+    assert installed == ["implement"]
+    assert (codex_dir / "implement" / "SKILL.md").read_text(encoding="utf-8").endswith("Body.\n")
+    assert (codex_dir / "implement" / "agents" / "openai.yaml").is_file()
+
+
 def test_orchestration_skills_excluded_from_allowlist():
     for excluded in ("implement", "review-pr", "address-review", "tune", "mine-for-ideas"):
         assert excluded not in PORTABLE_SKILLS
+
+
+def test_native_codex_skills_include_implement_only():
+    assert NATIVE_CODEX_SKILLS == ("implement",)


### PR DESCRIPTION
## Summary

Extends the Codex skill-sync so `#codex` agents can run skills that have a native Codex rewrite, not just the portable skills converted from `.claude/skills/`.

- New `install_native_codex_skills()` in `codex_skill_sync.py` copies skills authored directly in Codex's `SKILL.md` format from `.agents/skills/` into `$CODEX_HOME/skills` **as-is** (preserving bundled `agents/*.yaml` resources and metadata), replacing any existing destination dir so a source-side file removal doesn't leave stale resources.
- `scripts/install_codex_skills.py` now runs this after the portable-skill conversion. Currently allowlisted native skill: `implement` (its Claude version depends on Claude-only `Task`/`Skill` subagent primitives, so it gets a dedicated Codex rewrite).
- Adds the native Codex skill sources under `.agents/skills/` — `implement` (with `agents/openai.yaml`) is wired via the allowlist; the remaining skills (address-review, catchup, draft-issue, merge-pr, mine-for-ideas, pr-check, review-pr, stale, standup, tune) are checked in as source for future allowlisting.
- Missing allowlisted sources are skipped, so older checkouts still install the portable subset cleanly.
- Docstrings updated; `implement` removed from the "left Claude-only" note since it now has a native Codex path.

## Test evidence

New unit tests in `test_codex_skill_sync.py` (use `tmp_path`, independent of the real `.agents/` dir):
- `test_install_native_codex_skills_copies_skill_directory` — copies `SKILL.md` + bundled `agents/openai.yaml`
- `test_native_codex_skills_include_implement_only` — allowlist guard

## Review focus

- The `shutil.rmtree` + `copytree` replace semantics for the destination dir.
- Allowlist (`NATIVE_CODEX_SKILLS`) vs the portable `PORTABLE_SKILLS` set — `implement` is intentionally native, excluded from portable.