### PR TITLE
fix(imessage): make date-filtered message history work in chat

### DIFF
--- a/api/routes/imessage.py
+++ b/api/routes/imessage.py
@@ -113,27 +113,6 @@ async def search_messages(
     try:
         store = get_imessage_store()
 
-        # Parse dates if provided
-        start_date = None
-        end_date = None
-        if after:
-            try:
-                start_date = datetime.fromisoformat(after.replace('Z', '+00:00'))
-                if start_date.tzinfo is None:
-                    start_date = start_date.replace(tzinfo=timezone.utc)
-            except ValueError:
-                # Try date-only format
-                start_date = datetime.strptime(after, "%Y-%m-%d").replace(tzinfo=timezone.utc)
-
-        if before:
-            try:
-                end_date = datetime.fromisoformat(before.replace('Z', '+00:00'))
-                if end_date.tzinfo is None:
-                    end_date = end_date.replace(tzinfo=timezone.utc)
-            except ValueError:
-                # Try date-only format
-                end_date = datetime.strptime(before, "%Y-%m-%d").replace(tzinfo=timezone.utc)
-
         # Validate direction
         if direction and direction not in ("sent", "received"):
             raise HTTPException(
@@ -151,12 +130,14 @@ async def search_messages(
                     detail=f"Could not resolve person '{entity_id}'. Use lifeos_people_search first to find the correct entity ID."
                 )
 
+        # Date bounds are normalized inside query_messages (date-only values are
+        # expanded to whole local days), so pass the raw strings through.
         messages = store.query_messages(
             entity_id=resolved_entity_id,
             phone=phone,
             search_term=q,
-            start_date=start_date,
-            end_date=end_date,
+            start_date=after,
+            end_date=before,
             direction=direction,
             limit=max_results,
         )

--- a/api/services/imessage.py
+++ b/api/services/imessage.py
@@ -15,10 +15,55 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from api.services.phone_utils import normalize_phone
+from config.settings import settings
 
 logger = logging.getLogger(__name__)
+
+LOCAL_TZ = ZoneInfo(settings.timezone)
+
+
+def _normalize_date_bound(value, *, end: bool) -> Optional[str]:
+    """Coerce a date bound into a UTC ISO-8601 string for timestamp comparison.
+
+    Accepts a ``datetime``, a ``YYYY-MM-DD`` string, or a full ISO datetime
+    string. The chat orchestrator passes bounds as strings, so this is what
+    keeps a date-filtered ``query_messages`` from crashing on ``str.isoformat``.
+
+    Date-only values are expanded to the start (``00:00:00``) or end
+    (``23:59:59.999999``) of that day in the configured local timezone, so a
+    single-day query (``start_date == end_date``, e.g. "yesterday" or "on
+    June 30") covers the whole local day instead of collapsing to midnight.
+    Stored timestamps are UTC, so the result is converted to UTC for correct
+    lexicographic comparison. Unparseable values are ignored (returns ``None``)
+    so a malformed date can never crash or silently empty the query.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        s = str(value).strip()
+        if not s:
+            return None
+        is_date_only = len(s) == 10 and s[4] == "-" and s[7] == "-"
+        try:
+            if is_date_only:
+                dt = datetime.strptime(s, "%Y-%m-%d")
+                if end:
+                    dt = dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+            else:
+                dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        except ValueError:
+            logger.warning("Ignoring unparseable date bound: %r", value)
+            return None
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=LOCAL_TZ)
+    return dt.astimezone(timezone.utc).isoformat()
 
 # Apple's epoch starts at 2001-01-01 00:00:00 UTC
 # Dates are stored in nanoseconds
@@ -343,8 +388,8 @@ class IMessageStore:
         except sqlite3.OperationalError as e:
             if "unable to open database" in str(e).lower():
                 raise PermissionError(
-                    f"Cannot access iMessage database. "
-                    f"Grant Full Disk Access to Terminal/IDE in System Preferences."
+                    "Cannot access iMessage database. "
+                    "Grant Full Disk Access to Terminal/IDE in System Preferences."
                 ) from e
             raise
 
@@ -592,8 +637,8 @@ class IMessageStore:
         entity_id: Optional[str] = None,
         phone: Optional[str] = None,
         search_term: Optional[str] = None,
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
+        start_date: Optional[str | datetime] = None,
+        end_date: Optional[str | datetime] = None,
         direction: Optional[str] = None,  # "sent", "received", or None for both
         limit: int = 100,
     ) -> list[IMessageRecord]:
@@ -635,13 +680,15 @@ class IMessageStore:
             sql += " AND text LIKE ?"
             params.append(f"%{search_term}%")
 
-        if start_date:
+        start_bound = _normalize_date_bound(start_date, end=False)
+        if start_bound:
             sql += " AND timestamp >= ?"
-            params.append(start_date.isoformat())
+            params.append(start_bound)
 
-        if end_date:
+        end_bound = _normalize_date_bound(end_date, end=True)
+        if end_bound:
             sql += " AND timestamp <= ?"
-            params.append(end_date.isoformat())
+            params.append(end_bound)
 
         if direction == "sent":
             sql += " AND is_from_me = 1"
@@ -780,8 +827,6 @@ class IMessageStore:
         Returns:
             List of dicts with contact info and message counts
         """
-        cutoff = datetime.now(timezone.utc).isoformat()
-
         with sqlite3.connect(self.storage_path) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.execute(
@@ -964,7 +1009,7 @@ def sync_and_join_imessages() -> dict:
     }
 
 
-def resolve_entity_id(entity_id: str) -> Optional[str]:
+def resolve_entity_id(entity_id: str) -> Optional[str]:  # noqa: F811 - pre-existing duplicate of the definition above; this entity_resolver-based one wins. Flagged as follow-up.
     """If entity_id isn't a UUID, try resolving it as a person name."""
     try:
         uuid_mod.UUID(entity_id)
@@ -983,8 +1028,8 @@ def resolve_entity_id(entity_id: str) -> Optional[str]:
 def query_person_messages(
     entity_id: str,
     search_term: Optional[str] = None,
-    start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None,
+    start_date: Optional[str | datetime] = None,
+    end_date: Optional[str | datetime] = None,
     limit: int = 100,
 ) -> dict:
     """

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -3,7 +3,7 @@ Tests for iMessage integration.
 """
 import pytest
 import tempfile
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 from api.services.imessage import (
@@ -12,7 +12,6 @@ from api.services.imessage import (
     apple_timestamp_to_datetime,
     datetime_to_apple_timestamp,
     extract_text_from_attributed_body,
-    get_imessage_store,
 )
 
 
@@ -194,6 +193,68 @@ class TestIMessageStore:
         # Verify cleared
         assert temp_store.get_statistics()["total_messages"] == 0
         assert temp_store._get_last_synced_rowid() == 0
+
+
+class TestQueryMessagesDateFilters:
+    """Regression tests for date-bound handling in query_messages.
+
+    Guards the orchestrator's get_message_history path, which passes date
+    bounds as 'YYYY-MM-DD' strings (previously crashed on str.isoformat) and
+    issues single-day queries for 'yesterday'/'on <date>' (previously returned
+    nothing because a date-only end collapsed to midnight). Timestamps are at
+    11:00/13:00 UTC so the target day resolves correctly for any realistic
+    local timezone.
+    """
+
+    @pytest.fixture
+    def store_with_dated_msgs(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            store = IMessageStore(f.name)
+            batch = [
+                (1, "day before", "2024-06-14T12:00:00+00:00", 1, "+15550000001", "+15550000001", "iMessage"),
+                (2, "target morning", "2024-06-15T11:00:00+00:00", 0, "+15550000001", "+15550000001", "iMessage"),
+                (3, "target afternoon", "2024-06-15T13:00:00+00:00", 1, "+15550000001", "+15550000001", "iMessage"),
+                (4, "day after", "2024-06-16T12:00:00+00:00", 0, "+15550000001", "+15550000001", "iMessage"),
+            ]
+            store._insert_batch(batch)
+            store.update_entity_mappings({"+15550000001": "entity-date"})
+            yield store
+            Path(f.name).unlink(missing_ok=True)
+
+    def test_string_bounds_do_not_crash(self, store_with_dated_msgs):
+        # Regression: string bounds previously raised AttributeError on .isoformat()
+        msgs = store_with_dated_msgs.query_messages(
+            entity_id="entity-date", start_date="2024-06-01", end_date="2024-06-30"
+        )
+        assert len(msgs) == 4
+
+    def test_single_day_string_is_inclusive(self, store_with_dated_msgs):
+        # 'on 2024-06-15' / 'yesterday': start == end, date-only -> whole local day
+        msgs = store_with_dated_msgs.query_messages(
+            entity_id="entity-date", start_date="2024-06-15", end_date="2024-06-15"
+        )
+        assert {m.text for m in msgs} == {"target morning", "target afternoon"}
+
+    def test_date_only_start_excludes_earlier(self, store_with_dated_msgs):
+        msgs = store_with_dated_msgs.query_messages(
+            entity_id="entity-date", start_date="2024-06-15"
+        )
+        assert {m.text for m in msgs} == {"target morning", "target afternoon", "day after"}
+
+    def test_datetime_bounds_still_work(self, store_with_dated_msgs):
+        msgs = store_with_dated_msgs.query_messages(
+            entity_id="entity-date",
+            start_date=datetime(2024, 6, 15, tzinfo=timezone.utc),
+            end_date=datetime(2024, 6, 15, 23, 59, 59, tzinfo=timezone.utc),
+        )
+        assert {m.text for m in msgs} == {"target morning", "target afternoon"}
+
+    def test_unparseable_bound_is_ignored_not_emptying(self, store_with_dated_msgs):
+        # A malformed date must not crash and must not silently drop every row.
+        msgs = store_with_dated_msgs.query_messages(
+            entity_id="entity-date", start_date="not-a-date"
+        )
+        assert len(msgs) == 4
 
 
 class TestIMessageRecord:


### PR DESCRIPTION
## Problem

A `/chat` query — *"summarize my texts with Tay on June 30 2023"* — returned **"I'm unable to retrieve your iMessage messages... due to a technical error."** Investigation showed the orchestrator's `get_message_history` tool was **crashing on every call**, not just date-scoped ones.

### Root cause (two bugs)

1. **Crash on string dates.** The orchestrator passes date bounds as `'YYYY-MM-DD'` strings, and the tool handler injects a default `start_date` string when none is given. `query_messages` called `start_date.isoformat()` — a `datetime`-only method — raising `AttributeError: 'str' object has no attribute 'isoformat'`. The agentic loop caught the error and silently fell back to `person_info` data, so the user saw wrong answers or "can't reach the tool." Present since the initial release.

2. **Whole-day exclusion.** Once the crash is fixed, a date-only end bound (`"2026-06-16"`) compares as midnight, so `timestamp <= "2026-06-16"` excludes everything *on* that day. Single-day queries ("yesterday", "on June 30") and date-only ranges returned **zero** messages.

Both bugs also affected the REST route `/api/imessage/search` (used by the MCP `lifeos_imessage_search` tool and the CRM UI) for the single-day case.

## Fix

A single `_normalize_date_bound()` helper in `query_messages`:
- accepts **str or datetime** bounds,
- expands **date-only** values to the start/end of that day **in the configured local timezone** (so "yesterday" means your local day, not a UTC slice),
- converts to UTC for correct comparison against stored timestamps,
- **ignores unparseable bounds** instead of crashing or silently emptying results.

The REST route now passes raw date strings through this same path (removing its duplicate, buggy parsing), so MCP/CRM get the identical fix.

## Verification

- **Original failing query now works** end-to-end through `/chat`: resolves the person → calls `get_message_history(start_date="2023-06-30")` → returns a correct same-day summary.
- REST single-day `after=2023-06-30&before=2023-06-30` now returns the full **local (ET) day** of messages (was 0); malformed dates return HTTP 200, not 500.
- New regression tests: crash-on-strings, single-day inclusivity, date-only start bound, datetime bounds still work, malformed input ignored.
- Full unit suite: **2872 passed**; the 5 failures are pre-existing and unrelated (settings defaults / vault-state / a slack-sync ordering flake — all fail without this change too).

## Scope notes / not in this PR
- **Calendar** date parsing is guarded by try/except (degrades softly) and **Monarch** passes strings to a client that expects `YYYY-MM-DD` strings — neither is a bug, left untouched.
- A **pre-existing duplicate `resolve_entity_id` definition** in `imessage.py` (the second, `entity_resolver`-based one shadows the first, `people_aggregator`-based one) is silenced with a targeted `# noqa: F811` and left for a separate follow-up rather than changed here.
- Incidental pre-existing ruff debt in the two touched files (unused f-string prefixes, an unused local, unused test imports) was cleared so the lint hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)