### PR TITLE
docs: document whisper-relay HTTP client contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,12 @@
 
 > **Audience:** All AI coding agents (Claude Code, Cursor, Copilot, etc.)
 > **Status:** Complete
-> **Last Updated:** 2026-03-04
+> **Last Updated:** 2026-06-18
 
 LifeOS is a self-hosted personal AI assistant with two halves:
 
 1. **A context layer** — indexes personal data (notes, emails, messages, photos, calendar, contacts, financial data) into a unified semantically-searchable corpus with cross-source entity resolution.
-2. **An agentic layer** — an agent worker plus chat/Telegram/MCP surfaces that autonomously complete multi-step tasks against that context (drafting, scheduling, researching, prepping) and report progress as they work.
+2. **An agentic layer** — an agent worker plus chat/Telegram/MCP/**voice (whisper-relay)** surfaces that autonomously complete multi-step tasks against that context (drafting, scheduling, researching, prepping) and report progress as they work.
 
 Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMessage, phone calls, and contacts.
 
@@ -21,6 +21,7 @@ Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMe
 - **Sync phases**: Seven-phase nightly pipeline — Collection → Entity Processing → Relationship Building → Indexing → Content Sync → Entity Cleanup → Consistency Verification.
 - **Agentic chat**: Orchestrator LLM autonomously calls 15+ tools (search, calendar, email, tasks, etc.) across multiple rounds to answer queries.
 - **Agent worker**: Autonomous executor for `#agent`-tagged tasks (or work delegated from chat/Telegram). Runs long, multi-step sessions with the full MCP tool catalog, reports progress through the originating channel, and can route to local Gemma or cloud Claude via Managed Agents. See [specs/product/agent-worker.md](docs/specs/product/agent-worker.md).
+- **HTTP client surfaces**: Web chat, Telegram, and whisper-relay share a stable HTTP contract — see [specs/technical/client-surfaces.md](docs/specs/technical/client-surfaces.md) before changing chat or conversation APIs.
 
 ## Tech Stack
 
@@ -57,6 +58,7 @@ Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMe
 |----------|----------|
 | How is data modeled? | [specs/product/data-model.md](docs/specs/product/data-model.md) |
 | What API endpoints exist? | [specs/product/api-reference.md](docs/specs/product/api-reference.md) |
+| What must not break for external chat clients? | [specs/technical/client-surfaces.md](docs/specs/technical/client-surfaces.md) |
 | How does the sync pipeline work? | [specs/technical/data-and-sync.md](docs/specs/technical/data-and-sync.md) |
 | What does the code structure look like? | [specs/technical/architecture.md](docs/specs/technical/architecture.md) |
 | How does hybrid search work internally? | [specs/technical/search-indexing.md](docs/specs/technical/search-indexing.md) |
@@ -187,6 +189,7 @@ Quick-reference guardrails for all contributors. These complement the Developmen
 | **Ask first** | Public API changes (new or modified endpoints) |
 | **Ask first** | Changes to sync pipeline phases or cron jobs |
 | **Ask first** | Changes to MCP tool definitions |
+| **Ask first** | Breaking changes to HTTP client contract — see [client-surfaces.md](docs/specs/technical/client-surfaces.md) |
 | **Never** | Commit secrets, credentials, or API keys |
 | **Never** | Force push to main |
 | **Never** | Skip pre-commit hooks (`--no-verify`) |
@@ -427,6 +430,7 @@ Services are tracked on-use, not by polling. Degradation events (fallback usage)
 3. **Committing without testing** → Use `./scripts/deploy.sh`
 4. **Starting server on localhost only** → Must use 0.0.0.0 for Tailscale
 5. **Overfitting to specific test cases** → Consider effects on the full system
+6. **Breaking external chat clients** → See [client-surfaces.md](docs/specs/technical/client-surfaces.md) before editing chat/conversation routes or web SSE handling
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,4 @@ curl http://localhost:8000/health/full | jq   # Health check
 9. **Over-documenting routine changes** → Not every change needs a docs update. Write what helps the next reader understand current state.
 10. **Deleting or modifying a failing test to unblock a commit** → See AGENTS.md § "Tests Are Sacred" for the full decision framework.
 11. **Committing without running the test suite** → Run `./scripts/test.sh` before every commit. No exceptions.
+12. **Breaking external chat clients** → See [client-surfaces.md](docs/specs/technical/client-surfaces.md) before editing chat/conversation routes or web SSE handling.

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** API Gateway
-**Last Updated:** 2026-05-27
+**Last Updated:** 2026-06-18
 
 Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two adjacent catalogs split out for size:
 
@@ -39,6 +39,8 @@ Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two
 
 **Authentication:** None (Tailscale-only access)
 
+**External HTTP clients:** See [Client Surfaces](../technical/client-surfaces.md) for consumers (web, Telegram, whisper-relay) and breaking-change policy.
+
 **OpenAPI Spec:** `GET /openapi.json`
 
 ---
@@ -65,10 +67,15 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 | `routing` | `sources`, `reasoning`, `latency_ms` | Which pipeline path was selected |
 | `status` | `message` | Tool execution status (e.g. "Searching notes...") |
 | `content` | `content` | Streamed response text chunk |
+| `self_correction` | — | Model retrying; consumers should clear buffered text |
+| `conversation_id` | `conversation_id` | Assigned or confirmed thread id (required for multi-turn clients) |
 | `sources` | `sources` | Data sources used (vault, calendar, gmail, etc.) |
-| `claude_intent` | `task` | Query requires Claude Code (terminal/filesystem) |
+| `claude_intent` | `task`, `engine` (`claude_code` \| `codex`) | CLI engine handoff; HTTP clients POST `/api/chat/handoff` |
+| `error` | `message` | Fatal error for this turn |
 | `usage` | `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `cost_usd` | Token usage and cost |
-| `done` | — | Stream complete |
+| `done` | — | Stream complete (optional; HTTP stream close also finalizes) |
+
+**Wire format:** lines `data: {json}\n`. Clients may ignore `routing`, `sources`, `usage`, and `done` if they handle stream close.
 
 **Pipeline routing (in order of priority):**
 1. **Ambiguous task/reminder** — asks user for clarification (task vs reminder vs both).
@@ -100,6 +107,34 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 | `search_memories` | Search previously saved memories |
 
 **Prompt caching (Anthropic backend only):** System prompt and tool definitions use Anthropic `cache_control` breakpoints. Cache reads cost 0.1x input price; repeated queries within 5 minutes hit the cache.
+
+### POST /api/chat/handoff
+
+Spawn a CLI engine worker session when the orchestrator emits `claude_intent` on the SSE stream. HTTP clients call this endpoint; Telegram spawns in-process instead.
+
+**Request:**
+```json
+{
+  "engine": "claude_code",
+  "task": "refactor the parser",
+  "conversation_id": "optional-uuid"
+}
+```
+
+- `engine` — `"claude_code"` or `"codex"` only
+- `task` — non-empty task description forwarded to the worker
+- `conversation_id` — optional; when set, an assistant acknowledgment is appended to the thread
+
+**Response (200):**
+```json
+{
+  "ok": true,
+  "engine": "claude_code",
+  "session_id": "sess_abc123",
+  "working_dir": "/path/to/repo",
+  "message": "Handed off to Claude Code — running in the background..."
+}
+```
 
 ### POST /api/search
 
@@ -383,7 +418,22 @@ Search memories by keyword.
 
 ### GET /api/conversations
 
-List all conversations.
+List all conversations (most recent first, up to 50).
+
+**Response:**
+```json
+{
+  "conversations": [
+    {
+      "id": "conv-uuid",
+      "title": "Budget planning",
+      "created_at": "2026-06-01T12:00:00",
+      "updated_at": "2026-06-01T12:05:00",
+      "message_count": 4
+    }
+  ]
+}
+```
 
 ### POST /api/conversations
 
@@ -392,6 +442,28 @@ Create new conversation.
 ### GET /api/conversations/{id}
 
 Get conversation with messages.
+
+**Response:**
+```json
+{
+  "id": "conv-uuid",
+  "title": "Budget planning",
+  "created_at": "2026-06-01T12:00:00",
+  "updated_at": "2026-06-01T12:05:00",
+  "messages": [
+    {
+      "id": "msg-uuid",
+      "role": "user",
+      "content": "What did we discuss last week?",
+      "created_at": "2026-06-01T12:00:00",
+      "sources": null,
+      "routing": null
+    }
+  ]
+}
+```
+
+`role` is `user` or `assistant`.
 
 ### DELETE /api/conversations/{id}
 
@@ -707,5 +779,6 @@ Get usage summary with stats for 24h, 7d, 30d, and all-time. Includes daily cost
 - [mcp-tools.md](mcp-tools.md) — MCP tool catalog (the canonical home — was previously duplicated here)
 - [Data & Sync](../technical/data-and-sync.md) — Data sources and sync pipeline
 - [Chat UI](chat-ui.md) — Chat interface product spec
+- [Client Surfaces](../technical/client-surfaces.md) — HTTP consumers and breaking-change policy
 - [CRM UI](crm-ui.md) — CRM index pointing at the four product sub-specs
 - [Configuration](../../guides/configuration.md) — Env vars referenced by several endpoints (LIFEOS_USER_NAME, LIFEOS_WORK_DOMAIN, etc.)

--- a/docs/specs/product/chat-ui.md
+++ b/docs/specs/product/chat-ui.md
@@ -225,5 +225,6 @@ See [Frontend Architecture](../technical/frontend.md) for:
 ## Related Documents
 
 - [API Reference](api-reference.md) -- API endpoint contracts
+- [Client Surfaces](../technical/client-surfaces.md) -- HTTP consumers and breaking-change policy
 - [Frontend](../technical/frontend.md) -- UI implementation details
 - [MCP Tools](mcp-tools.md) -- MCP tool specifications

--- a/docs/specs/standards/testing-standards.md
+++ b/docs/specs/standards/testing-standards.md
@@ -1,7 +1,7 @@
 # Testing Standards
 
 > **Status:** Complete
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-06-18
 > **Audience:** All developers and AI agents
 
 Testing patterns and conventions for the LifeOS codebase.
@@ -154,6 +154,15 @@ Option (a) is the default. Options (b) and (c) require explicit justification in
 - Rewrite a test you don't fully understand.
 - Weaken assertions (e.g., changing `assertEqual` to `assertIn`) without justification.
 
+## HTTP client contract tests
+
+When changing chat or conversation APIs, run the tests in [Client Surfaces](../technical/client-surfaces.md#before-changing-chat-or-conversation-apis) and update them if shapes change.
+
+| Test file | Endpoints |
+|-----------|-----------|
+| `tests/test_chat_api.py` | ask/stream, handoff |
+| `tests/test_conversations_api.py` | conversation list/detail |
+
 ## Benchmark Tests
 
 `test_perf_benchmark.py` runs queries against a **live server**, collects perf traces, and validates answer quality. It is not part of the unit test suite.
@@ -178,5 +187,6 @@ There is no enforced coverage threshold. The project relies on targeted tests fo
 ## Related Documents
 
 - [specs/technical/architecture.md](../technical/architecture.md) -- system architecture and code structure
+- [Client Surfaces](../technical/client-surfaces.md) -- HTTP consumers and breaking-change policy
 - [AGENTS.md](../../../AGENTS.md) -- development workflow and agent instructions
 - [Python Conventions](python-conventions.md) -- coding style and module patterns

--- a/docs/specs/technical/AGENTS.md
+++ b/docs/specs/technical/AGENTS.md
@@ -5,6 +5,7 @@ This directory contains technical specifications — how the system is built fro
 - `agent-viz.md` — Implementation of the `/agents` page (SSE feed, JSONL ingest, D3 graph, status inference)
 - `agent-worker.md` — Agent worker internals (session lifecycle, executor split, MCP transport, budget enforcement)
 - `architecture.md` — Top-level code structure, module boundaries, request flow
+- `client-surfaces.md` — HTTP consumers, whisper-relay integration, breaking-change policy
 - `claude-code-orchestration.md` — Implementation of the Claude Code orchestration surface (skill discovery, MCP server wiring)
 - `data-and-sync.md` — Seven-phase nightly sync pipeline; per-phase responsibilities and failure modes
 - `frontend.md` — Vanilla HTML/JS architecture (no build step), shared components, page conventions

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -301,6 +301,7 @@ Tests are in `tests/` with naming convention `test_*.py`.
 ## Related Documents
 
 - [Data & Sync](data-and-sync.md) -- Data sources and sync pipeline
+- [Client Surfaces](client-surfaces.md) -- HTTP consumers and breaking-change policy
 - [Frontend](frontend.md) -- UI components and patterns
 - [API Reference](../product/api-reference.md) -- API endpoint contracts
 - [ADR-001: Python/FastAPI](../../adr/001-python-fastapi.md) -- Why Python/FastAPI was chosen

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -1,0 +1,61 @@
+# HTTP Client Surfaces
+
+> **Status:** Complete
+> **Owner:** Platform
+> **Last Updated:** 2026-06-18
+
+LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that submit text and consume SSE without importing LifeOS Python modules. Endpoint and event **shapes** are defined in [api-reference.md](../product/api-reference.md); this doc covers **who consumes them**, **whisper-relay integration**, and **breaking-change policy**.
+
+---
+
+## Surfaces
+
+| Surface | Transport | Chat/conversation endpoints |
+|---------|-----------|----------------------------|
+| Web chat | Browser → FastAPI | ask/stream, handoff, conversation CRUD — `web/index.html` |
+| Telegram | In-process `chat_via_api` | Same SSE as ask/stream; handoffs spawn in-process — `api/services/telegram.py` |
+| **whisper-relay** | Separate app → HTTP | ask/stream, handoff, `GET /api/conversations`, `GET /api/conversations/{id}` — see below |
+| MCP / Managed Agents | stdio or HTTP MCP | Tool catalog only — `mcp_server.py` |
+
+---
+
+## whisper-relay
+
+Voice transport in the same GitHub org as LifeOS: [github.com/nbramia/whisper-relay](https://github.com/nbramia/whisper-relay). Local checkout: `~/Code/whisper-relay` (review the consumer implementation in `src/voice_gateway/adapters/lifeos.py` when changing chat or conversation APIs).
+
+Connects to LifeOS at `LIFEOS_BASE_URL` (default `http://127.0.0.1:8000`), 300s timeout on ask/stream, no auth headers — same trust model as web chat on localhost/Tailscale.
+
+**Endpoints used** (request/response shapes: [api-reference.md](../product/api-reference.md)): `POST /api/ask/stream`, `POST /api/chat/handoff`, `GET /api/conversations`, `GET /api/conversations/{id}`.
+
+**Consumer-specific behavior** (LifeOS API unchanged; how whisper-relay interprets it):
+
+- Speaks `status` events immediately during long tool rounds.
+- On `claude_intent`, POSTs handoff after the SSE stream ends; **replaces** accumulated `content` with the handoff confirmation (does not append).
+- Reads handoff `message`, then `ack`, then a generic phrase using `session_id`; non-200 handoff still completes the turn with a spoken failure message.
+- Proxies conversation list/detail to its mobile UI (`/api/voice/conversations*`). No `channel` or modality field — voice text is identical to typed chat at the API layer.
+- Cancel = close the SSE connection (LifeOS has no cancel endpoint).
+
+Upstream mirror of this integration: `whisper-relay/docs/adr/002-upstream-integration-boundaries.md`.
+
+---
+
+## Before changing chat or conversation APIs
+
+1. Read [api-reference.md](../product/api-reference.md) § Chat and Conversations endpoints.
+2. Compare `web/index.html`, `api/services/telegram.py`, and `~/Code/whisper-relay/src/voice_gateway/adapters/lifeos.py`.
+3. Run contract tests listed in [testing-standards.md](../standards/testing-standards.md#http-client-contract-tests).
+4. Treat removals or renames of public fields/events as a **breaking change** — update whisper-relay in the same release or maintain backward compatibility.
+
+---
+
+## Related Documents
+
+### Specifications
+- [API Reference](../product/api-reference.md) — Canonical endpoint and SSE shapes
+- [Chat UI](../product/chat-ui.md) — Web chat product behavior
+- [Architecture](architecture.md) — Code layout for chat routes and services
+- [Testing Standards](../standards/testing-standards.md) — Contract regression tests
+
+### Code References
+- [Chat route](../../api/routes/chat.py) — SSE emission and handoff handler
+- [Conversations route](../../api/routes/conversations.py) — List/detail handlers


### PR DESCRIPTION
## Summary
- Add `docs/specs/technical/client-surfaces.md` as the single source of truth for HTTP consumer integration (web, Telegram, whisper-relay) and breaking-change policy
- Extend `api-reference.md` with handoff and conversation response shapes; other docs link in without duplicating contract nuance
- Point agents at contract tests and whisper-relay repo (`~/Code/whisper-relay`, same GitHub org)

## Test plan
- [x] Docs-only change — no code or runtime behavior affected
- [ ] Review cross-links resolve (client-surfaces ↔ api-reference ↔ AGENTS.md)
- [ ] Confirm whisper-relay consumer behavior in `client-surfaces.md` matches `whisper-relay/src/voice_gateway/adapters/lifeos.py`


Made with [Cursor](https://cursor.com)