### PR TITLE
feat(agent-worker): always write an Agent Output note on task completion

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -24,9 +24,13 @@ import signal
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
+
+if TYPE_CHECKING:
+    from datetime import datetime
+    from pathlib import Path
 
 from api.services.agent_worker.preflight import (
     ROUTE_ASK,
@@ -2129,7 +2133,9 @@ class Worker:
                 # fire still maps to the same file.
                 sched_name = self._resolve_schedule_name(schedule_id)
                 slug = _slugify(sched_name) if sched_name else ""
-                filename = f"{slug}.md" if slug else f"recurring-{schedule_id}.md"
+                # Append the schedule id so two distinct schedules that share a
+                # human name don't interleave into the same note.
+                filename = f"{slug}-{schedule_id}.md" if slug else f"recurring-{schedule_id}.md"
                 file_path = target_dir / filename
                 content = self._recurring_content(
                     file_path, schedule_id, sched_name or title, now, final_text,
@@ -2162,7 +2168,8 @@ class Worker:
         return (rel_path, obsidian_url)
 
     def _recurring_content(
-        self, file_path, schedule_id: str, label: str, now, final_text: str,
+        self, file_path: Path, schedule_id: str, label: str,
+        now: datetime, final_text: str,
     ) -> str:
         """Build the new contents for a recurring schedule's shared note by
         prepending this fire above any existing runs, newest first. Frontmatter

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import signal
 import threading
 import time
@@ -61,6 +62,30 @@ logger = logging.getLogger(__name__)
 # (init-failed MCPs). Above this we spill the body to a vault note and
 # put just a 1-line preview + obsidian:// link in the Telegram message.
 _INLINE_SUMMARY_MAX_CHARS = 2000
+
+# A recurring (cron) schedule stamps its handed-off #agent task with a
+# `sched-<id>` tag (see scheduler_store._hand_off_to_agent). The worker reads
+# it on completion to append every fire's output to one shared note per
+# schedule instead of a new note per fire.
+_SCHED_TAG_RE = re.compile(r"^sched-(\w+)$")
+
+
+def _slugify(text: str) -> str:
+    """Lowercase, hyphenated, filesystem-safe slug capped at 60 chars.
+    Returns '' for empty/symbol-only input."""
+    return re.sub(r"[^A-Za-z0-9]+", "-", text or "").strip("-").lower()[:60]
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Split a leading `---\\n...\\n---` YAML frontmatter block from the body.
+    Returns (frontmatter_with_delimiters, body). When there's no frontmatter,
+    returns ('', text) so the whole document is treated as body."""
+    if not text.startswith("---"):
+        return "", text
+    m = re.match(r"^---\n.*?\n---\n?", text, re.DOTALL)
+    if not m:
+        return "", text
+    return text[: m.end()], text[m.end():]
 
 
 def _worker_label(routing: str | None) -> str:
@@ -1709,21 +1734,32 @@ class Worker:
                     f"(agent idled without a final text reply — check transcript at "
                     f"`data/agent_transcripts/{session.session_id}.jsonl` for tool-use detail)"
                 )
-        elif len(final_text) <= _INLINE_SUMMARY_MAX_CHARS:
-            result_blurb = final_text
         else:
-            # Spill the full body to a vault note and link to it instead of
-            # truncating mid-answer. The agent's system prompts now ask the
-            # agent itself to create artifacts for long outputs, but the
-            # operator-facing UX shouldn't depend on the agent following
-            # that guidance: any over-length response gets spilled here.
-            spillover = self._spill_to_vault(session, task, final_text)
-            if spillover is None:
-                # Vault not configured or write failed — preserve the old
-                # behavior so the operator still gets *something* readable.
+            # Every completed task now lands a durable note in the vault's
+            # Agent Output folder — one-off tasks get a new note, recurring
+            # (cron-scheduled) tasks append to one shared note per schedule.
+            # The agent's system prompts also ask it to create artifacts for
+            # long outputs, but the operator-facing record shouldn't depend on
+            # the agent following that guidance: the worker always writes.
+            written = self._write_agent_output(session, task, final_text)
+            if len(final_text) <= _INLINE_SUMMARY_MAX_CHARS:
+                # Short answer: show it inline. Append a pointer to the saved
+                # note when the write succeeded (vault may be unconfigured).
+                result_blurb = final_text
+                if written is not None:
+                    rel_path, obsidian_url = written
+                    result_blurb += (
+                        f"\n\nSaved to vault: `{rel_path}`\n"
+                        f"[Open in Obsidian]({obsidian_url})"
+                    )
+            elif written is None:
+                # Over-length but vault not configured / write failed —
+                # preserve the old behavior so the operator still gets
+                # *something* readable instead of an empty message.
                 result_blurb = final_text[:_INLINE_SUMMARY_MAX_CHARS] + "…"
             else:
-                rel_path, obsidian_url = spillover
+                # Over-length: link to the note instead of truncating mid-answer.
+                rel_path, obsidian_url = written
                 preview = final_text.split("\n\n", 1)[0].strip()
                 if len(preview) > 400:
                     preview = preview[:400].rsplit(" ", 1)[0] + "…"
@@ -2027,22 +2063,48 @@ class Worker:
         })
         return True
 
-    def _spill_to_vault(
+    def _schedule_id_from_task(self, task: dict[str, Any]) -> str | None:
+        """Return the recurring schedule's id when the task carries a
+        `sched-<id>` tag (stamped by scheduler_store._hand_off_to_agent for
+        cron schedules), else None. Presence of the tag is the sole signal
+        that a completion belongs to a recurring schedule."""
+        for tag in task.get("tags") or []:
+            m = _SCHED_TAG_RE.match(str(tag).lstrip("#"))
+            if m:
+                return m.group(1)
+        return None
+
+    def _resolve_schedule_name(self, schedule_id: str) -> str | None:
+        """Look up a schedule's human name via the API so the recurring note
+        can be titled readably. Returns None on 404 / any error — the caller
+        falls back to a stable id-based filename so grouping still works."""
+        try:
+            resp = self._http.get(f"{self.api_base}/api/scheduler/{schedule_id}")
+            if resp.status_code != 200:
+                return None
+            name = (resp.json() or {}).get("name") or ""
+            return name.strip() or None
+        except Exception as exc:
+            logger.warning("resolve_schedule_name %s failed: %s", schedule_id, exc)
+            return None
+
+    def _write_agent_output(
         self, session: Session, task: dict[str, Any], final_text: str,
     ) -> tuple[str, str] | None:
-        """Write the agent's full response to a vault Markdown file and
-        return (vault-relative path, obsidian:// URL). Returns None when
-        the vault path is unset or the write fails — caller falls back to
-        a truncated inline summary so the operator never loses content
-        entirely.
+        """Write the agent's final answer to a Markdown note in the vault's
+        Agent Output folder and return (vault-relative path, obsidian:// URL).
+        Returns None when the vault path is unset or the write fails — the
+        caller keeps the inline summary so the operator never loses content.
 
-        File layout: `<vault>/<LIFEOS_AGENT_OUTPUT_DIR>/<YYYY-MM-DD>-<slug>.md`.
-        The output dir is operator-configurable via `LIFEOS_AGENT_OUTPUT_DIR`
-        (default `LifeOS/Tasks/Agent Output`) so spillover and the local
-        executor's direct vault writes land in the same place.
+        Two layouts, both under `<vault>/<LIFEOS_AGENT_OUTPUT_DIR>`
+        (operator-configurable via `LIFEOS_AGENT_OUTPUT_DIR`, default
+        `LifeOS/Tasks/Agent Output`):
+        - One-off task → a new note `<YYYY-MM-DD>-<slug>-<sid>.md`.
+        - Recurring (cron) task → one shared note per schedule
+          (`<schedule-slug>.md`); each fire is prepended under a dated heading,
+          newest on top, with frontmatter kept at the file head.
         """
         from datetime import datetime
-        import re
 
         vault_root = settings.vault_path
         if not vault_root:
@@ -2053,34 +2115,88 @@ class Worker:
             return None
 
         title = (task.get("description") or session.task_id).strip()
-        slug = re.sub(r"[^A-Za-z0-9]+", "-", title).strip("-").lower()[:60] or session.task_id
-        today = datetime.now().astimezone().strftime("%Y-%m-%d")
-        filename = f"{today}-{slug}.md"
+        now = datetime.now().astimezone()
+        today = now.strftime("%Y-%m-%d")
         folder = settings.agent_output_dir
+        schedule_id = self._schedule_id_from_task(task)
 
         try:
             target_dir = vault_root / folder
             target_dir.mkdir(parents=True, exist_ok=True)
-            file_path = target_dir / filename
-            # Frontmatter gives Obsidian / Dataview something to query on
-            # without changing how the body renders.
-            frontmatter = (
-                "---\n"
-                f"task: {title}\n"
-                f"session_id: {session.session_id}\n"
-                f"routing: {session.routing or 'unknown'}\n"
-                f"created: {today}\n"
-                "source: agent-worker\n"
-                "---\n\n"
-            )
-            file_path.write_text(frontmatter + final_text, encoding="utf-8")
+            if schedule_id:
+                # One shared note per schedule, titled by the schedule's human
+                # name when resolvable, else a stable id-keyed fallback so every
+                # fire still maps to the same file.
+                sched_name = self._resolve_schedule_name(schedule_id)
+                slug = _slugify(sched_name) if sched_name else ""
+                filename = f"{slug}.md" if slug else f"recurring-{schedule_id}.md"
+                file_path = target_dir / filename
+                content = self._recurring_content(
+                    file_path, schedule_id, sched_name or title, now, final_text,
+                )
+            else:
+                # Suffix with a short session id so two same-day tasks with
+                # the same slug don't clobber each other now that every
+                # completion writes a note.
+                slug = _slugify(title) or session.task_id
+                sid = session.session_id[-6:]
+                filename = f"{today}-{slug}-{sid}.md"
+                file_path = target_dir / filename
+                frontmatter = (
+                    "---\n"
+                    f"task: {title}\n"
+                    f"session_id: {session.session_id}\n"
+                    f"routing: {session.routing or 'unknown'}\n"
+                    f"created: {today}\n"
+                    "source: agent-worker\n"
+                    "---\n\n"
+                )
+                content = frontmatter + final_text
+            file_path.write_text(content, encoding="utf-8")
         except Exception as exc:
-            logger.warning("vault spillover write failed for %s: %s", session.task_id, exc)
+            logger.warning("agent output write failed for %s: %s", session.task_id, exc)
             return None
 
         rel_path = f"{folder}/{filename}"
         obsidian_url = build_obsidian_link(str(file_path), str(vault_root))
         return (rel_path, obsidian_url)
+
+    def _recurring_content(
+        self, file_path, schedule_id: str, label: str, now, final_text: str,
+    ) -> str:
+        """Build the new contents for a recurring schedule's shared note by
+        prepending this fire above any existing runs, newest first. Frontmatter
+        stays at the file head: `created` is preserved from the first run,
+        `updated` is bumped to today."""
+        today = now.strftime("%Y-%m-%d")
+        stamp = now.strftime("%Y-%m-%d %H:%M")
+        run_block = f"## {stamp}\n\n{final_text}\n\n---\n"
+
+        created = today
+        existing_body = ""
+        if file_path.exists():
+            try:
+                existing = file_path.read_text(encoding="utf-8")
+            except Exception:
+                existing = ""
+            fm, existing_body = _split_frontmatter(existing)
+            existing_body = existing_body.lstrip("\n")
+            # Keep the original creation date across fires.
+            m = re.search(r"^created:\s*(.+)$", fm, re.M)
+            if m:
+                created = m.group(1).strip()
+
+        frontmatter = (
+            "---\n"
+            f"schedule: {label}\n"
+            f"schedule_id: {schedule_id}\n"
+            f"created: {created}\n"
+            f"updated: {today}\n"
+            "source: agent-worker-recurring\n"
+            "---\n\n"
+        )
+        body = run_block + ("\n" + existing_body if existing_body else "")
+        return frontmatter + body
 
     def _mark_failed(self, session: Session, task: dict[str, Any], reason: str) -> None:
         title = task.get("description", session.task_id)

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -990,11 +990,19 @@ class SchedulerScheduler:
         The schedule's executor tag (``local`` / ``cloud`` / ``cloud-haiku`` /
         ``cloud-sonnet``) is passed straight through as a task tag — the agent
         worker's preflight routes on it, so no new execution path is needed.
+
+        For ``cron`` (recurring) schedules we also stamp a ``sched-<id>`` tag.
+        The worker reads it on completion to recognise the task as a recurring
+        fire and append its output to one shared note per schedule, rather than
+        a new note per fire. One-time (``once``) schedules get no such tag — each
+        is a stand-alone task that produces its own note.
         """
         from api.services.task_manager import get_task_manager
         tags = ["agent"]
         if entry.executor:
             tags.append(entry.executor.lstrip("#"))
+        if entry.schedule_type == "cron":
+            tags.append(f"sched-{entry.id}")
         task = get_task_manager().create(
             description=entry.message_content or entry.name,
             tags=tags,

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -93,7 +93,7 @@ The HTTP MCP transport exposes LifeOS tools to remote agents (primarily Anthropi
 | `LIFEOS_AGENT_DAILY_CAP_DOLLARS` | float | `100.00` | Global daily $-cap. When crossed, the worker stops claiming new tasks until next local midnight. Set to `0` to pause new claims entirely. |
 | `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` | int | `72` | How long to wait for a Telegram clarification before abandoning the task. |
 | `LIFEOS_AGENT_COST_CONFIRM_THRESHOLD_DOLLARS` | float | varies | Threshold above which preflight requires Telegram confirmation before running a task. |
-| `LIFEOS_AGENT_OUTPUT_DIR` | path | varies | Directory for worker-written task outputs. |
+| `LIFEOS_AGENT_OUTPUT_DIR` | path | `LifeOS/Tasks/Agent Output` | Vault-relative folder where the worker writes an Agent Output note on every successful task completion (one note per one-off task; one shared, prepended note per recurring cron schedule). |
 | `LIFEOS_AGENT_PREFLIGHT_MODEL` | str | `claude-haiku-4-5` | Model used for preflight (budget parsing, routing, ambiguity, sanity). |
 | `LIFEOS_AGENT_MANAGED_MODEL` | str | `claude-sonnet-4-6` | Informational — actual model lives in the Anthropic Console preset. |
 | `LIFEOS_AGENT_MANAGED_MODEL_FOR_TESTS` | str | — | Override for test runs. |

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Scheduler
-> **Last Updated:** 2026-05-29
+> **Last Updated:** 2026-06-21
 > **Audience:** Operators
 
 The Scheduler runs work on a timer. A **schedule** binds a **trigger** (one-off
@@ -68,6 +68,13 @@ and the executor tag (`#local` / `#cloud` / `#cloud-haiku` / `#cloud-sonnet`).
 The existing [agent worker](../specs/product/agent-worker.md) discovers the
 task and routes it via preflight. Progress is reported through the worker's own
 channel, not the scheduler.
+
+For **cron** (recurring) schedules the hand-off also stamps a `#sched-<id>` tag
+on the task. The worker reads it on completion and appends every fire's output
+to **one shared Agent Output note per schedule** (`LifeOS/Tasks/Agent Output/<schedule-slug>-<id>.md`),
+newest run on top under a dated heading — rather than a new note per fire. A
+one-time (`once`) agent schedule gets no such tag and produces its own one-off
+note like any other `#agent` task.
 
 ```markdown
 - [ ] Weekly Review [cron:: 0 9 * * 6] [action:: agent] #cloud <!-- id:d4e5f6 -->

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-06-03
+> **Last Updated:** 2026-06-21
 
 LifeOS includes an external **agent worker** that picks up tasks you've tagged `#agent` and completes them autonomously — running locally on a self-hosted LLM or on Anthropic's Managed Agents cloud, with budget caps you can specify in the task title and full audit transcripts on every run. When the agent finishes (or gets stuck), it notifies you on Telegram. If it has a question mid-run, it asks via Telegram and waits for your reply.
 
@@ -39,7 +39,7 @@ Within a poll cycle (default 60s), the worker:
 2. Atomically swaps the tag to `#agent-running` (so two workers can't claim the same task)
 3. Routes the task — to your local Gemma model or to Claude on Managed Agents — depending on tags, title cues, or capability inference
 4. Lets the agent execute: tool calls, MCP servers, web search, file I/O, the full kit
-5. On completion: marks the task done in your vault, swaps the tag to `#agent-completed`, and sends you a one-paragraph Telegram summary with the actual result
+5. On completion: marks the task done in your vault, swaps the tag to `#agent-completed`, writes the full result to an Agent Output note (`LifeOS/Tasks/Agent Output/`), and sends you a one-paragraph Telegram summary with the actual result (linking the note)
 
 Cost for that task: usually under $0.10 on Claude Sonnet 4.6, free on local Gemma. The full transcript (every tool call, every model turn) lands in `data/agent_transcripts/<session_id>.jsonl` for later review.
 

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-06-03
+> **Last Updated:** 2026-06-21
 
 Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
 
@@ -23,8 +23,9 @@ Engineering view of the agent worker — the stand-alone process that consumes `
 11. [Restart resumability](#restart-resumability)
 12. [Telegram clarification flow](#telegram-clarification-flow)
 13. [Transcripts](#transcripts)
-14. [Configuration surface](#configuration-surface)
-15. [Related Documents](#related-documents)
+14. [Agent Output notes](#agent-output-notes)
+15. [Configuration surface](#configuration-surface)
+16. [Related Documents](#related-documents)
 
 ---
 
@@ -66,7 +67,7 @@ All code lives in `api/services/agent_worker/`:
 
 | File | Responsibility |
 |---|---|
-| `worker.py` | Main poll loop, claim/dispatch, startup resume, signal handling, Telegram delivery, completion summaries |
+| `worker.py` | Main poll loop, claim/dispatch, startup resume, signal handling, Telegram delivery, completion summaries, Agent Output notes |
 | `preflight.py` | Haiku-based classifier (budget parsing, routing, ambiguity, sanity) |
 | `local_executor.py` | Agent loop against a local LLM (llama-server / Gemma 4 by default) |
 | `managed_executor.py` | Lifecycle wrapper around a Managed Agents session — `start()` → `poll()` → `_finalize_remote()` |
@@ -112,6 +113,7 @@ poll → spend tracker check (`can_start_task(default_budget)`)
              ask    → Telegram clarification, park at #agent-blocked
          on terminal outcome:
              COMPLETED → mark task done in vault + swap to #agent-completed
+                         + write Agent Output note (one-off, or prepend for recurring)
              FAILED / BUDGET_EXCEEDED → swap to matching tag
              BLOCKED → Telegram clarification + leave for human
              YIELDED → leave for sleeps loop to wake at wake_at
@@ -344,6 +346,19 @@ Every session has an append-only JSONL transcript at `data/agent_transcripts/<se
 ```
 
 Transcripts are append-only and survive worker restarts. They're the audit trail of choice — Telegram summaries point at them when a task lands at `#agent-failed` or produces an unexpectedly empty completion.
+
+---
+
+## Agent Output notes
+
+On every successful completion (root sessions only — not spawned children or operator root-spawns), `_completion_summary` calls `_write_agent_output` to persist the agent's final text as a Markdown note under `settings.agent_output_dir` (`LIFEOS_AGENT_OUTPUT_DIR`, default `LifeOS/Tasks/Agent Output`). This is unconditional now — it supersedes the old "spill to vault only when the reply exceeds 2000 chars" behavior — so short answers also get a durable note. Failed / blocked / budget-exceeded outcomes write nothing; an empty final text writes nothing.
+
+Two layouts:
+
+- **One-off task** → a new note `<YYYY-MM-DD>-<slug>-<sid>.md` (the trailing 6-char session id prevents same-day/same-slug clobbering), with `task` / `session_id` / `routing` / `created` / `source: agent-worker` frontmatter.
+- **Recurring (cron) schedule** → one shared note per schedule. The scheduler stamps the handed-off `#agent` task with a `sched-<id>` tag (see [scheduler.md](scheduler.md)); `_schedule_id_from_task` reads it on completion, resolves the schedule's name via `GET /api/scheduler/{id}` for a readable filename `<schedule-slug>-<id>.md` (falling back to `recurring-<id>.md`), and `_recurring_content` prepends this fire above prior runs under a `## YYYY-MM-DD HH:MM` heading — newest first, frontmatter `created` preserved and `updated` bumped.
+
+The Telegram summary links the note; over-length replies show a preview + link instead of the full body. When the vault path is unset or the write fails the worker keeps the inline summary so the operator never loses content.
 
 ---
 

--- a/tests/test_agent_output_write.py
+++ b/tests/test_agent_output_write.py
@@ -111,7 +111,9 @@ def test_recurring_first_run_creates_named_file(worker_and_vault, monkeypatch):
     res = w._write_agent_output(_session(), task, "First run body.")
 
     assert res is not None
-    f = _out_dir(vault) / "weekly-review.md"
+    # Filename is <schedule-slug>-<id>.md so distinct schedules sharing a name
+    # never collide.
+    f = _out_dir(vault) / "weekly-review-ab12cd34.md"
     assert f.exists()
     text = f.read_text(encoding="utf-8")
     assert "schedule_id: ab12cd34" in text
@@ -135,9 +137,11 @@ def test_recurring_second_run_prepends_newest_on_top(worker_and_vault, monkeypat
     assert "OLDER run body." in text
     assert "NEWER run body." in text
     assert text.index("NEWER run body.") < text.index("OLDER run body.")
-    # Exactly one frontmatter block and two dated run headings.
+    # Exactly one frontmatter block and two dated run headings, each closed by
+    # its own `---` rule (criterion #4: prior runs sit below the rule).
     assert text.count("source: agent-worker-recurring") == 1
     assert len(re.findall(r"^## ", text, re.M)) == 2
+    assert len(re.findall(r"^---$", _split_frontmatter(text)[1], re.M)) == 2
 
 
 def test_recurring_preserves_created_date_bumps_updated(worker_and_vault, monkeypatch):
@@ -147,7 +151,7 @@ def test_recurring_preserves_created_date_bumps_updated(worker_and_vault, monkey
     out = _out_dir(vault)
     out.mkdir(parents=True, exist_ok=True)
     # Seed an existing note from an earlier run with an old created date.
-    (out / "weekly-review.md").write_text(
+    (out / "weekly-review-ab12cd34.md").write_text(
         "---\n"
         "schedule: Weekly Review\n"
         "schedule_id: ab12cd34\n"
@@ -162,7 +166,7 @@ def test_recurring_preserves_created_date_bumps_updated(worker_and_vault, monkey
 
     w._write_agent_output(_session(), task, "fresh run")
 
-    text = (out / "weekly-review.md").read_text(encoding="utf-8")
+    text = (out / "weekly-review-ab12cd34.md").read_text(encoding="utf-8")
     fm, _body = _split_frontmatter(text)
     assert "created: 2020-01-01" in fm
     assert "updated: 2020-01-01" not in fm  # bumped to today

--- a/tests/test_agent_output_write.py
+++ b/tests/test_agent_output_write.py
@@ -1,0 +1,210 @@
+"""Tests for the worker's always-write Agent Output behavior.
+
+Every completed root #agent task lands a Markdown note in the vault's Agent
+Output folder. One-off tasks get a new dated note; recurring (cron-scheduled)
+tasks — recognised by a `sched-<id>` tag — append each fire to one shared note
+per schedule, newest run on top.
+
+These exercise `Worker._write_agent_output` directly (no poll loop), building a
+bare Worker via __new__ since the method only needs settings + the schedule-name
+resolver, which we stub.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from api.services.agent_worker.session_store import Session
+from api.services.agent_worker.worker import (
+    Worker,
+    _slugify,
+    _split_frontmatter,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _session(session_id="sess_abcdef123456", task_id="t1", routing="local"):
+    return Session(
+        task_id=task_id,
+        session_id=session_id,
+        status="completed",
+        started_at=0,
+        last_activity_at=0,
+        routing=routing,
+    )
+
+
+@pytest.fixture
+def worker_and_vault(tmp_path, monkeypatch):
+    from config.settings import settings
+
+    vault = tmp_path / "vault"
+    monkeypatch.setattr(settings, "vault_path", vault)
+    monkeypatch.setattr(settings, "agent_output_dir", "Agent Output")
+    return Worker.__new__(Worker), vault
+
+
+def _out_dir(vault):
+    return vault / "Agent Output"
+
+
+# ---------------------------------------------------------------------------
+# One-off tasks
+# ---------------------------------------------------------------------------
+
+def test_one_off_writes_new_dated_file(worker_and_vault):
+    w, vault = worker_and_vault
+    task = {"id": "t1", "description": "Summarize my inbox", "tags": ["agent", "local"]}
+
+    res = w._write_agent_output(_session(), task, "Here is the summary.")
+
+    assert res is not None
+    rel_path, url = res
+    files = list(_out_dir(vault).glob("*.md"))
+    assert len(files) == 1
+    f = files[0]
+    assert re.match(r"\d{4}-\d{2}-\d{2}-summarize-my-inbox-\w+\.md$", f.name)
+    text = f.read_text(encoding="utf-8")
+    assert "source: agent-worker" in text
+    assert "Here is the summary." in text
+    assert rel_path == f"Agent Output/{f.name}"
+    assert url.startswith("obsidian://")
+
+
+def test_one_off_same_slug_same_day_does_not_clobber(worker_and_vault):
+    """Two one-off tasks with the same description on the same day must not
+    overwrite each other — the session-id suffix keeps them distinct."""
+    w, vault = worker_and_vault
+    task = {"id": "t1", "description": "Daily digest", "tags": ["agent"]}
+
+    w._write_agent_output(_session(session_id="sess_aaaaaa111111"), task, "run A")
+    w._write_agent_output(_session(session_id="sess_bbbbbb222222"), task, "run B")
+
+    files = sorted(p.name for p in _out_dir(vault).glob("*.md"))
+    assert len(files) == 2
+
+
+def test_returns_none_when_vault_unset(worker_and_vault, monkeypatch):
+    w, vault = worker_and_vault
+    from config.settings import settings
+
+    monkeypatch.setattr(settings, "vault_path", None)
+    res = w._write_agent_output(_session(), {"id": "t1", "description": "x"}, "body")
+    assert res is None
+
+
+# ---------------------------------------------------------------------------
+# Recurring (cron) tasks
+# ---------------------------------------------------------------------------
+
+def test_recurring_first_run_creates_named_file(worker_and_vault, monkeypatch):
+    w, vault = worker_and_vault
+    monkeypatch.setattr(w, "_resolve_schedule_name", lambda sid: "Weekly Review")
+    task = {
+        "id": "t1",
+        "description": "Draft my weekly review",
+        "tags": ["agent", "cloud", "sched-ab12cd34"],
+    }
+
+    res = w._write_agent_output(_session(), task, "First run body.")
+
+    assert res is not None
+    f = _out_dir(vault) / "weekly-review.md"
+    assert f.exists()
+    text = f.read_text(encoding="utf-8")
+    assert "schedule_id: ab12cd34" in text
+    assert "source: agent-worker-recurring" in text
+    assert "First run body." in text
+    assert len(re.findall(r"^## ", text, re.M)) == 1
+
+
+def test_recurring_second_run_prepends_newest_on_top(worker_and_vault, monkeypatch):
+    w, vault = worker_and_vault
+    monkeypatch.setattr(w, "_resolve_schedule_name", lambda sid: "Weekly Review")
+    task = {"id": "t1", "description": "Draft my weekly review", "tags": ["sched-ab12cd34", "agent"]}
+
+    w._write_agent_output(_session(session_id="sess_run1_000000"), task, "OLDER run body.")
+    w._write_agent_output(_session(session_id="sess_run2_000000"), task, "NEWER run body.")
+
+    files = list(_out_dir(vault).glob("*.md"))
+    assert len(files) == 1, "all fires of one schedule share a single note"
+    text = files[0].read_text(encoding="utf-8")
+    # Both runs present, newest above oldest.
+    assert "OLDER run body." in text
+    assert "NEWER run body." in text
+    assert text.index("NEWER run body.") < text.index("OLDER run body.")
+    # Exactly one frontmatter block and two dated run headings.
+    assert text.count("source: agent-worker-recurring") == 1
+    assert len(re.findall(r"^## ", text, re.M)) == 2
+
+
+def test_recurring_preserves_created_date_bumps_updated(worker_and_vault, monkeypatch):
+    """A new fire keeps the note's original `created` date and bumps `updated`."""
+    w, vault = worker_and_vault
+    monkeypatch.setattr(w, "_resolve_schedule_name", lambda sid: "Weekly Review")
+    out = _out_dir(vault)
+    out.mkdir(parents=True, exist_ok=True)
+    # Seed an existing note from an earlier run with an old created date.
+    (out / "weekly-review.md").write_text(
+        "---\n"
+        "schedule: Weekly Review\n"
+        "schedule_id: ab12cd34\n"
+        "created: 2020-01-01\n"
+        "updated: 2020-01-01\n"
+        "source: agent-worker-recurring\n"
+        "---\n\n"
+        "## 2020-01-01 09:00\n\nancient run\n\n---\n",
+        encoding="utf-8",
+    )
+    task = {"id": "t1", "description": "Draft my weekly review", "tags": ["sched-ab12cd34"]}
+
+    w._write_agent_output(_session(), task, "fresh run")
+
+    text = (out / "weekly-review.md").read_text(encoding="utf-8")
+    fm, _body = _split_frontmatter(text)
+    assert "created: 2020-01-01" in fm
+    assert "updated: 2020-01-01" not in fm  # bumped to today
+    assert re.search(r"^updated: \d{4}-\d{2}-\d{2}$", fm, re.M)
+    assert "ancient run" in text  # prior run retained
+
+
+def test_recurring_name_resolution_failure_uses_id_filename(worker_and_vault, monkeypatch):
+    """When the schedule name can't be resolved (deleted schedule / API error),
+    fall back to a stable id-keyed filename so fires still group together."""
+    w, vault = worker_and_vault
+    monkeypatch.setattr(w, "_resolve_schedule_name", lambda sid: None)
+    task = {"id": "t1", "description": "Nightly thing", "tags": ["sched-zz99zz99", "agent"]}
+
+    res = w._write_agent_output(_session(), task, "body")
+
+    assert res is not None
+    assert (_out_dir(vault) / "recurring-zz99zz99.md").exists()
+
+
+def test_schedule_id_from_task_detects_tag(worker_and_vault):
+    w, _ = worker_and_vault
+    assert w._schedule_id_from_task({"tags": ["agent", "sched-ab12cd34"]}) == "ab12cd34"
+    assert w._schedule_id_from_task({"tags": ["#sched-ab12cd34"]}) == "ab12cd34"
+    assert w._schedule_id_from_task({"tags": ["agent", "local"]}) is None
+    assert w._schedule_id_from_task({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_split_frontmatter_roundtrip():
+    doc = "---\nschedule: X\nupdated: 2026-06-21\n---\n\n## 2026-06-21 09:00\n\nbody\n"
+    fm, body = _split_frontmatter(doc)
+    assert fm.startswith("---\n") and fm.rstrip().endswith("---")
+    assert body.lstrip("\n").startswith("## 2026-06-21 09:00")
+    # No frontmatter → everything is body.
+    assert _split_frontmatter("## just a heading\n") == ("", "## just a heading\n")
+
+
+def test_slugify():
+    assert _slugify("Draft my Weekly Review!") == "draft-my-weekly-review"
+    assert _slugify("   ") == ""
+    assert len(_slugify("x" * 200)) == 60

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -1180,6 +1180,26 @@ def test_completion_inline_summary_kept_when_under_cap(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_failed_task_writes_no_agent_output(tmp_path: Path):
+    """Only successful completions write a note. A FAILED outcome notifies via
+    Telegram but leaves the Agent Output folder untouched (criterion #6)."""
+    from config.settings import settings as _settings
+
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_FAILED, reason="boom"))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent and "failed" in sent[0].lower()
+    out_dir = _settings.vault_path / _settings.agent_output_dir
+    assert not out_dir.exists() or not list(out_dir.glob("*.md"))
+
+
+@pytest.mark.unit
 def test_completion_spills_to_vault_when_over_cap(tmp_path: Path, monkeypatch):
     """When final_text is >2000 chars, the worker writes the full body
     to the vault and replaces the inline blob with a short preview +

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -37,6 +37,15 @@ from api.services.agent_worker.worker import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _redirect_agent_output(tmp_path, monkeypatch):
+    """Every completed task now writes a note to the vault's Agent Output
+    folder. Redirect the vault to a throwaway tmp dir so these worker tests
+    write there instead of the repo's ./vault default."""
+    from config.settings import settings as _settings
+    monkeypatch.setattr(_settings, "vault_path", tmp_path / "vault", raising=False)
+
+
 # ---------------------------------------------------------------------------
 # Fake API
 # ---------------------------------------------------------------------------
@@ -1145,7 +1154,9 @@ def test_completion_label_says_local_for_local_routing(tmp_path: Path):
 
 @pytest.mark.unit
 def test_completion_inline_summary_kept_when_under_cap(tmp_path: Path):
-    """A short final_text is delivered inline — no spillover to vault."""
+    """A short final_text is delivered inline (not replaced by a preview), and
+    every completion now also lands a note in the vault — so the message carries
+    the full body plus a 'Saved to vault' pointer + obsidian:// link."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "summarize", "status": "todo", "tags": ["agent", "local"]},
     ])
@@ -1160,9 +1171,12 @@ def test_completion_inline_summary_kept_when_under_cap(tmp_path: Path):
     w.tick()
     sent = w._sent_telegram  # type: ignore[attr-defined]
     assert sent
+    # Full body inline — short answers are not truncated to a preview.
     assert short_text.strip() in sent[0]
     assert "Full answer saved to vault" not in sent[0]
-    assert "obsidian://" not in sent[0]
+    # Always-write: short completions still get a saved-note pointer.
+    assert "Saved to vault:" in sent[0]
+    assert "obsidian://" in sent[0]
 
 
 @pytest.mark.unit

--- a/tests/test_scheduler_store.py
+++ b/tests/test_scheduler_store.py
@@ -522,7 +522,9 @@ class TestActionDispatch:
         fake_tm.create.assert_called_once()
         kwargs = fake_tm.create.call_args.kwargs
         assert kwargs["description"] == "Draft my weekly review"
-        assert kwargs["tags"] == ["agent", "cloud"]
+        # Cron (recurring) schedules carry a sched-<id> tag so the worker
+        # appends each fire's output to one shared note per schedule.
+        assert kwargs["tags"] == ["agent", "cloud", f"sched-{entry.id}"]
         # No Telegram for an agent hand-off; the worker reports through its channel.
         mock_send.assert_not_called()
         refreshed = scheduler.store.get(entry.id)
@@ -537,6 +539,21 @@ class TestActionDispatch:
         )
         fake_tm = MagicMock()
         fake_tm.create.return_value = MagicMock(id="t1")
+        with patch("api.services.task_manager.get_task_manager", return_value=fake_tm):
+            await scheduler._fire_entry(entry)
+        assert fake_tm.create.call_args.kwargs["tags"] == ["agent", "local", f"sched-{entry.id}"]
+
+    @pytest.mark.asyncio
+    async def test_once_agent_action_has_no_sched_tag(self, scheduler):
+        """One-time schedules are stand-alone; they get no sched-<id> tag, so
+        the worker treats each as a one-off task with its own output note."""
+        entry = scheduler.store.create(
+            name="One shot", schedule_type="once",
+            schedule_value="2999-01-01T09:00:00",
+            action="agent", executor="local", message_content="do it once",
+        )
+        fake_tm = MagicMock()
+        fake_tm.create.return_value = MagicMock(id="t9")
         with patch("api.services.task_manager.get_task_manager", return_value=fake_tm):
             await scheduler._fire_entry(entry)
         assert fake_tm.create.call_args.kwargs["tags"] == ["agent", "local"]


### PR DESCRIPTION
## Summary

Every successfully completed root `#agent` task now lands a Markdown note in the vault's Agent Output folder (`LifeOS/Tasks/Agent Output`), regardless of reply length — previously a note was only written as spillover for replies >2000 chars.

- **One-off tasks** → a new dated note `<YYYY-MM-DD>-<slug>-<sid>.md`. The short session-id suffix prevents same-day/same-slug clobbering now that every task writes.
- **Recurring (cron) scheduler agent tasks** → all fires append to **one shared note per schedule** (`<schedule-slug>.md`), newest run on top under a `## YYYY-MM-DD HH:MM` heading, with frontmatter `created` preserved and `updated` bumped.

The schedule→task link rides on a `sched-<id>` tag stamped by the scheduler handoff for **cron schedules only** (`once` schedules stay one-off). On completion the worker reads the tag, resolves the schedule's human name via `GET /api/scheduler/{id}` for a readable filename (falling back to `recurring-<id>.md` on 404/error), and prepends the run. `_spill_to_vault` is generalized into `_write_agent_output`, now always invoked from `_completion_summary`.

No DB schema change, no new API endpoint, no new dependency, no MCP/HTTP contract change.

Closes #350

## Test evidence

- New `tests/test_agent_output_write.py` (10 tests): one-off dated file; no same-day clobber; vault-unset → None; recurring first run creates `<name-slug>.md`; second run prepends newest-on-top; `created` preserved + `updated` bumped; name-resolution failure → `recurring-<id>.md`; tag detection; `_split_frontmatter`/`_slugify` helpers.
- Updated `tests/test_scheduler_store.py` (cron handoff now expects `sched-<id>`; added `once`-gets-no-tag case) and `tests/test_agent_worker_loop.py` (autouse vault redirect; inline-summary test now expects the always-write pointer).
- `./scripts/test.sh auto` + pre-push full unit suite: **2051 passed, 8 skipped**. The 14 unrelated failures in the broad run (CRM data-integrity, meeting-prep, settings/me-page config defaults) were verified pre-existing on the clean base with this branch stashed.

## Review focus

- `_write_agent_output` recurring branch in `api/services/agent_worker/worker.py` — frontmatter `created` preservation across fires and the prepend ordering in `_recurring_content` / `_split_frontmatter`.
- `_hand_off_to_agent` in `api/services/scheduler_store.py` — that only `cron` schedules get the `sched-<id>` tag, and that the extra tag is inert to preflight routing.