### PR TITLE
feat(agent-worker): Haiku tier + one message for delegated tasks

### DIFF
--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -456,6 +456,10 @@ class ClaudeCodeExecutor:
                 "cost_usd": state.cost_usd,
                 "notifications_sent": state.notifications_sent,
                 "final_chars": len(final_text),
+                # Persist the text itself so a parent that spawned this session
+                # can read it via _child_final_text — for children the bodies
+                # never streamed to Telegram, so this is their only path out (#349).
+                "final_text": final_text,
             })
             return ExecutorOutcome(
                 status=STATUS_COMPLETED,

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -151,6 +151,13 @@ class _RunState:
     pending_clarification: str = ""   # Last [CLARIFY] body
     plan_text: str = ""               # Accumulated [NOTIFY] when plan_mode
     plan_mode: bool = False
+    # True when this session was spawned by another agent (has a parent). Child
+    # sessions report back to their parent, not the operator: their [NOTIFY]
+    # bodies and heartbeats are NOT streamed to Telegram (#349). Instead the
+    # bodies accumulate in `notify_bodies` and get folded into final_text so the
+    # parent — which only reads final_text — still receives the substance.
+    is_child: bool = False
+    notify_bodies: list[str] = field(default_factory=list)
     awaiting_approval: bool = False   # plan-mode result event reached
     awaiting_clarification: bool = False
     cost_usd: float = 0.0
@@ -281,7 +288,13 @@ class ClaudeCodeExecutor:
     # Internal lifecycle
     # ------------------------------------------------------------------
 
-    def _build_command(self, prompt: str, resume_session_id: Optional[str], session_id: str = "") -> list[str]:
+    def _build_command(
+        self,
+        prompt: str,
+        resume_session_id: Optional[str],
+        session_id: str = "",
+        model: str = "opus",
+    ) -> list[str]:
         platform_desc = (
             "Linux server running Ubuntu"
             if platform.system() == "Linux"
@@ -292,7 +305,7 @@ class ClaudeCodeExecutor:
             "-p", prompt,
             "--output-format", "stream-json",
             "--verbose",
-            "--model", "opus",
+            "--model", model,
             "--max-turns", str(settings.claude_max_turns),
             "--dangerously-skip-permissions",
             "--chrome",
@@ -316,6 +329,24 @@ class ClaudeCodeExecutor:
         already inside a session and refuse to run."""
         return {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE")}
 
+    @staticmethod
+    def _effective_final_text(state: _RunState) -> str:
+        """Text handed back to the worker as the session's result.
+
+        For child sessions (#349) the [NOTIFY] bodies never streamed to the
+        operator, so fold them into final_text — the parent only reads
+        final_text and would otherwise lose everything the child reported.
+        Operator sessions return final_text unchanged (their notifies already
+        streamed live, and are deliberately stripped to avoid repetition).
+        """
+        if not state.is_child or not state.notify_bodies:
+            return state.final_text
+        parts = list(state.notify_bodies)
+        prose = (state.final_text or "").strip()
+        if prose and prose not in parts:
+            parts.append(prose)
+        return "\n\n".join(parts).strip()
+
     def _run(
         self,
         *,
@@ -326,7 +357,10 @@ class ClaudeCodeExecutor:
         plan_mode: bool,
     ) -> ExecutorOutcome:
         sid = session.session_id
-        cmd = self._build_command(prompt, resume_session_id, session_id=sid)
+        cmd = self._build_command(
+            prompt, resume_session_id, session_id=sid,
+            model=session.claude_code_model or "opus",
+        )
 
         self.transcript_store.append(sid, "claude_code_spawn", {
             "resume": bool(resume_session_id),
@@ -355,7 +389,7 @@ class ClaudeCodeExecutor:
         # observer sees the correct status.
         self.session_store.update_status(session.task_id, STATUS_RUNNING)
 
-        state = _RunState(plan_mode=plan_mode)
+        state = _RunState(plan_mode=plan_mode, is_child=bool(session.parent_session_id))
         timed_out = threading.Event()
         stop_heartbeat = threading.Event()
 
@@ -416,15 +450,16 @@ class ClaudeCodeExecutor:
             )
 
         if proc.returncode == 0 or state.terminal:
+            final_text = self._effective_final_text(state)
             self.session_store.update_status(session.task_id, STATUS_COMPLETED)
             self.transcript_store.append(sid, "claude_code_completed", {
                 "cost_usd": state.cost_usd,
                 "notifications_sent": state.notifications_sent,
-                "final_chars": len(state.final_text),
+                "final_chars": len(final_text),
             })
             return ExecutorOutcome(
                 status=STATUS_COMPLETED,
-                final_text=state.final_text,
+                final_text=final_text,
             )
 
         # Subprocess exited non-zero without a terminal event — surface the
@@ -529,10 +564,14 @@ class ClaudeCodeExecutor:
                         continue
                     state.notifications_sent += 1
                     state.last_notify_at = time.time()
-                    try:
-                        self._notify(body)
-                    except Exception as exc:  # pragma: no cover — defensive
-                        logger.warning("notification callback raised: %s", exc)
+                    state.notify_bodies.append(body)
+                    # Child sessions don't stream to the operator — their bodies
+                    # are folded into final_text for the parent instead (#349).
+                    if not state.is_child:
+                        try:
+                            self._notify(body)
+                        except Exception as exc:  # pragma: no cover — defensive
+                            logger.warning("notification callback raised: %s", exc)
                     self.transcript_store.append(sid, "claude_code_notify", {
                         "body": body, "body_chars": len(body),
                     })
@@ -607,6 +646,11 @@ class ClaudeCodeExecutor:
                 return
             now = time.time()
             if now - state.last_notify_at < self._heartbeat_interval:
+                continue
+            # Child sessions stay silent to the operator — the parent reports
+            # progress on their behalf (#349).
+            if state.is_child:
+                state.last_notify_at = now
                 continue
             elapsed = int(now - state.started_at)
             minutes = elapsed // 60

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -139,10 +139,11 @@ def _with_caller(props: dict, required: list[str]) -> dict:
 INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
         "name": "lifeos_agent_spawn",
-        "description": "Spawn a child agent session that runs in parallel. Returns immediately with a `child_session_id` you can monitor with `lifeos_agent_check` or wait on with `lifeos_agent_yield_until`. Budget is drawn from your remaining lineage budget. Use `claude_code` to delegate work that needs a real browser / GUI automation — its `--chrome` browser works headless, unlike Codex's (whose computer use is a desktop-app-only feature, unavailable here).",
+        "description": "Spawn a child agent session that runs in parallel. Returns immediately with a `child_session_id` you can monitor with `lifeos_agent_check` or wait on with `lifeos_agent_yield_until`. Budget is drawn from your remaining lineage budget. Use `claude_code` to delegate work that needs a real browser / GUI automation — its `--chrome` browser works headless, unlike Codex's (whose computer use is a desktop-app-only feature, unavailable here). For `claude_code` children, pick `tier` by task difficulty: `haiku` for simple lookups / quick web research, `sonnet` for moderate work, `opus` (default) for hard reasoning.",
         "input_schema": _with_caller({
             "prompt": {"type": "string", "description": "Task description for the child agent"},
             "model": {"type": "string", "enum": ["claude", "local", "claude_code", "codex"], "description": "Which executor to run the child on. claude=Managed Agents (cloud API), local=Gemma, claude_code=Claude Code CLI (has a working --chrome browser), codex=Codex CLI (code/general tasks; no browser in headless mode)."},
+            "tier": {"type": "string", "enum": ["haiku", "sonnet", "opus"], "description": "For model=claude_code only: which Claude tier the child CLI runs. Use 'haiku' for simple lookups/quick research, 'sonnet' for moderate tasks, 'opus' (default) for hard reasoning. Ignored for other engines."},
             "max_dollars": {"type": "number", "description": "Optional per-child dollar budget"},
             "max_tokens": {"type": "integer", "description": "Optional per-child token budget"},
             "wall_seconds": {"type": "integer", "description": "Optional per-child wall-clock budget"},
@@ -225,6 +226,15 @@ def spawn(ctx: InterAgentContext, args: dict) -> dict:
             "model must be one of 'claude', 'local', 'claude_code', 'codex'",
             code="invalid_arg",
         )
+    # Optional Claude tier for claude_code children (#349). Ignored for other
+    # engines so the caller can pass it uniformly without an error.
+    tier = (args.get("tier") or "").strip().lower() or None
+    if tier and tier not in ("haiku", "sonnet", "opus"):
+        return _err(
+            "tier must be one of 'haiku', 'sonnet', 'opus'",
+            code="invalid_arg",
+        )
+    claude_code_model = tier if model == "claude_code" else None
 
     caller = ctx.session_store.get_by_session_id(ctx.caller_session_id)
     if caller is None:
@@ -307,6 +317,7 @@ def spawn(ctx: InterAgentContext, args: dict) -> dict:
         parent_session_id=caller.session_id,
         root_session_id=root,
         spawn_depth=new_depth,
+        claude_code_model=claude_code_model,
     )
     # The prompt becomes the child's task description (used by the executor's
     # _seed_conversation) so the system prompt + inter-agent guidance run as
@@ -318,6 +329,7 @@ def spawn(ctx: InterAgentContext, args: dict) -> dict:
         "root_session_id": root,
         "spawn_depth": new_depth,
         "model": model,
+        "tier": claude_code_model,
         "prompt_chars": len(prompt),
     })
     ctx.transcript_store.append(caller.session_id, "spawned_child", {

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -83,6 +83,11 @@ class Session:
     # NB: codex sessions reuse this column too (CodexExecutor stores the
     # codex thread id here); routing disambiguates.
     claude_code_session_id: str | None = None
+    # Claude tier the Claude Code CLI runs for routing="claude_code" sessions
+    # ("haiku" / "sonnet" / "opus"). Set by lifeos_agent_spawn's `tier` arg so
+    # the worker can escalate simple delegated work to a cheaper model. NULL
+    # falls back to the CLI default ("opus").
+    claude_code_model: str | None = None
 
 
 _SCHEMA = """
@@ -108,7 +113,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     managed_agent_session_id  TEXT,
     preset_class              TEXT,
     origin                    TEXT,  -- NULL/"agent" = #agent task; "operator" = root-spawned (#235)
-    claude_code_session_id    TEXT   -- Claude Code (or Codex) CLI session UUID for routing="claude_code"/"codex"
+    claude_code_session_id    TEXT,  -- Claude Code (or Codex) CLI session UUID for routing="claude_code"/"codex"
+    claude_code_model         TEXT   -- Claude tier for routing="claude_code" (haiku/sonnet/opus); NULL = CLI default (opus)
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -312,6 +318,10 @@ class SessionStore:
                         "UPDATE sessions SET claude_code_session_id = code_session_id "
                         "WHERE claude_code_session_id IS NULL AND code_session_id IS NOT NULL"
                     )
+            # Idempotent migration for the per-session Claude Code tier (#349).
+            # Old rows stay NULL → the CLI default ("opus").
+            if "claude_code_model" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN claude_code_model TEXT")
             # Migrate legacy routing tag: 'code' was the pre-rename name for
             # what is now 'claude_code'. Idempotent — only flips rows that
             # still carry the old value.
@@ -367,6 +377,7 @@ class SessionStore:
         root_session_id: str | None = None,
         spawn_depth: int = 0,
         origin: str | None = None,
+        claude_code_model: str | None = None,
     ) -> Session:
         """Insert a new session row. Raises sqlite3.IntegrityError if `task_id`
         already has a row — the caller should treat that as a lost-race signal.
@@ -388,15 +399,15 @@ class SessionStore:
                     task_id, session_id, status, routing, budget_json,
                     started_at, last_activity_at,
                     expected_output, parent_session_id,
-                    root_session_id, spawn_depth, origin
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    root_session_id, spawn_depth, origin, claude_code_model
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     task_id, sid, status, routing,
                     json.dumps(budget) if budget else None,
                     now, now,
                     expected_output, parent_session_id,
-                    root_sid, spawn_depth, origin,
+                    root_sid, spawn_depth, origin, claude_code_model,
                 ),
             )
         return Session(
@@ -412,6 +423,7 @@ class SessionStore:
             root_session_id=root_sid,
             spawn_depth=spawn_depth,
             origin=origin,
+            claude_code_model=claude_code_model,
         )
 
     def get(self, task_id: str) -> Session | None:
@@ -1193,5 +1205,8 @@ class SessionStore:
             origin=(row["origin"] if "origin" in row.keys() else None),
             claude_code_session_id=(
                 row["claude_code_session_id"] if "claude_code_session_id" in row.keys() else None
+            ),
+            claude_code_model=(
+                row["claude_code_model"] if "claude_code_model" in row.keys() else None
             ),
         )

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -75,6 +75,16 @@ def _worker_label(routing: str | None) -> str:
     return "Agent worker"
 
 
+# Friendly names for the engine a child session ran on, used in the escalation
+# flag (#349) so the operator sees where delegated work actually executed.
+_ENGINE_LABELS = {
+    "claude_code": "Claude Code",
+    "codex": "Codex",
+    "claude": "cloud Claude",
+    "local": "local Gemma",
+}
+
+
 def _format_token_buckets(
     tokens_in: int,
     cache_creation: int,
@@ -1666,6 +1676,26 @@ class Worker:
 
         logger.warning("unhandled outcome status %r for %s", outcome.status, session.task_id)
 
+    def _escalation_note(self, session: Session) -> str:
+        """One-line flag naming the engine(s) a session delegated work to (#349).
+
+        Empty when the session spawned no children. When it did, the operator
+        gets a single completion message (the children stayed silent), so this
+        tells them the work was escalated and where it ran — e.g.
+        "⤴️ Escalated to Claude Code (haiku)".
+        """
+        children = self.session_store.list_sessions(parent_session_id=session.session_id)
+        if not children:
+            return ""
+        labels: list[str] = []
+        for child in children:
+            engine = _ENGINE_LABELS.get(child.routing, child.routing or "agent")
+            if child.routing == "claude_code":
+                engine = f"{engine} ({child.claude_code_model or 'opus'})"
+            if engine not in labels:
+                labels.append(engine)
+        return "⤴️ Escalated to " + ", ".join(labels)
+
     def _completion_summary(self, session: Session, task: dict[str, Any], outcome) -> str:
         refreshed = self.session_store.get(session.task_id) or session
         # Use active seconds (excludes sleeps) so the figure reflects real
@@ -1745,10 +1775,13 @@ class Worker:
         if init_failed:
             footer = f"\n\nNote: {len(init_failed)} MCP server(s) unavailable this session: {', '.join(init_failed)}"
 
+        escalation = self._escalation_note(session)
+        escalation_line = f"\n{escalation}" if escalation else ""
+
         return (
             f"✅ {label}: completed '{title}' "
             f"({expected}) — {tokens_summary}, ${refreshed.total_dollars:.2f}, "
-            f"{active_s}s active.\n\n{result_blurb}{footer}"
+            f"{active_s}s active.{escalation_line}\n\n{result_blurb}{footer}"
         )
 
     def _recover_result_from_transcript(self, session_id: str) -> str:

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1259,8 +1259,12 @@ class Worker:
             # capture so a threaded reply can resume the session via
             # _resume_as_followup. [NOTIFY] bodies that already streamed
             # during execution are stripped from final_text by the executor.
+            # Spawned children (have a parent) stay silent to the operator —
+            # the parent relays their findings in its own single completion
+            # message (#349); the child's final_text reaches the parent via
+            # _child_final_text instead.
             body = outcome.final_text.strip() if outcome.final_text else ""
-            if body:
+            if body and not session.parent_session_id:
                 try:
                     sent_ids = self._telegram_send_with_id(body) or []
                 except Exception as exc:
@@ -1986,14 +1990,14 @@ class Worker:
             cached = None
         if cached:
             return cached
-        # Fallback: scan the transcript for a `completed` or `managed_completed`
-        # event with non-empty `final_text`.
+        # Fallback: scan the transcript for a `completed`, `managed_completed`,
+        # or `claude_code_completed` event with non-empty `final_text`.
         path = self.transcript_store.dir / f"{child.session_id}.jsonl"
         last_text = ""
         for d in _iter_transcript(path):
             kind = d.get("kind", "")
             payload = d.get("payload", {}) or {}
-            if kind in ("completed", "managed_completed"):
+            if kind in ("completed", "managed_completed", "claude_code_completed"):
                 ft = payload.get("final_text") or ""
                 if ft:
                     last_text = ft

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-06-03
+> **Last Updated:** 2026-06-21
 
 Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
 
@@ -256,7 +256,7 @@ Local agents can spawn child sessions and coordinate via the `lifeos_agent_*` to
 
 | Tool | Purpose |
 |---|---|
-| `lifeos_agent_spawn` | Create a new agent session (local or claude). Returns `session_id`. |
+| `lifeos_agent_spawn` | Create a new agent session (local or claude). Returns `session_id`. Optional `tier` (`haiku`/`sonnet`/`opus`) picks the Claude Code child's CLI model — see [Delegation tier + single-message (#349)](#delegation-tier--single-message-349). |
 | `lifeos_agent_send` | Post a message to a child session's queue. |
 | `lifeos_agent_check` | Poll a child's current state. |
 | `lifeos_agent_yield_until` | Pause the caller until specific children reach terminal state — preferred over polling (no idle billing). |
@@ -280,6 +280,13 @@ Lineage budgets: every session tracks `root_session_id` + `spawn_depth`. Budget 
 ### Off-tick CLI dispatch (#299)
 
 Spawned `claude_code` / `codex` children are long-running subprocesses. `_dispatch_spawned_sessions` runs them on a bounded `ThreadPoolExecutor` (`_cli_pool`, sized `2 × agent_max_concurrent_managed`) via `_submit_cli_dispatch`, rather than inline — so one delegated child can't park the poll loop and starve new `#agent` claims or sibling dispatch. An `_cli_inflight` set (lock-guarded) prevents a re-scan from re-submitting a child in the window before its executor flips the row `CLAIMED→RUNNING`; for CLI routes the guard is checked *before* draining pending messages so a skipped re-scan can't discard them. Per-routing concurrency stays bounded at `lifeos_agent_spawn` time (`count_active_by_routing`), independent of dispatch timing. The `local` route stays inline (in-process, GPU-bound, cap 1). `stop()` calls `shutdown(wait=False, cancel_futures=True)`; children still running are reconciled by `resume_pending()` on restart. Tests inject a `_SynchronousPool` for deterministic dispatch.
+
+### Delegation tier + single-message (#349)
+
+When an agent delegates to a `claude_code` child, two behaviors keep the cost down and the operator's inbox clean:
+
+- **Tier.** `lifeos_agent_spawn`'s optional `tier` (`haiku` / `sonnet` / `opus`, default `opus`) is persisted on the child's `sessions.claude_code_model` column (additive migration; NULL → CLI default) and threaded into `_build_command` as `--model`, so the worker can run a simple lookup on Haiku instead of Opus. Ignored for non-`claude_code` engines.
+- **One operator message.** A spawned child (`parent_session_id` set) stays silent to the operator: `ClaudeCodeExecutor` suppresses live `[NOTIFY]`/heartbeat streaming and instead folds the notify bodies into `final_text` (`_effective_final_text`), and `_dispatch_claude_code_session` skips the terminal Telegram send for children. The child's `final_text` is persisted in its `claude_code_completed` transcript event, where the parent reads it via `_child_final_text` — so the parent's single completion message carries the child's findings. That message is flagged by `_escalation_note` with the engine + tier, e.g. `⤴️ Escalated to Claude Code (haiku)`. Operator `/claude` sessions (no parent) stream and send as before.
 
 ---
 

--- a/tests/test_agent_worker_claude_code_dispatch.py
+++ b/tests/test_agent_worker_claude_code_dispatch.py
@@ -94,6 +94,81 @@ def _recording_worker(tmp_path: Path, claude_code_executor):
     return worker, calls
 
 
+def _capturing_worker(tmp_path: Path, claude_code_executor):
+    """Worker whose Telegram senders record every message, so a test can assert
+    the exact operator-facing message count (#349)."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    sent: list[str] = []
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+    worker = Worker(
+        api_base="http://api",
+        session_store=store,
+        transcript_store=transcripts,
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        telegram_send_with_id=lambda text: sent.append(text) or [1],
+        http_client=client,
+        claude_code_executor=claude_code_executor,
+        cli_pool=_SynchronousPool(),
+    )
+    return worker, store, transcripts, sent
+
+
+def test_spawned_child_completion_does_not_telegram_operator(tmp_path: Path):
+    """A spawned claude_code child (has a parent) must NOT send its completion
+    text to the operator — the parent relays it in one message (#349)."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="Match 1: A vs B at noon.")
+    )
+    worker, store, _, sent = _capturing_worker(tmp_path, claude_code_executor=stub)
+    parent = store.create(task_id="parent-1", routing="local")
+    child = store.create(
+        task_id="child-1", routing="claude_code", parent_session_id=parent.session_id,
+    )
+    store.enqueue_message(child.session_id, "agent", "list today's matches")
+
+    worker._dispatch_claude_code_session(child, [{"content": "list today's matches"}])
+
+    assert sent == []  # nothing reached the operator
+
+
+def test_operator_claude_session_still_telegrams_on_completion(tmp_path: Path):
+    """Contrast: an operator /claude session (no parent) still surfaces its
+    final text to the operator."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="All done.")
+    )
+    worker, store, _, sent = _capturing_worker(tmp_path, claude_code_executor=stub)
+    session = store.create(task_id="op-1", routing="claude_code", origin="operator")
+    store.enqueue_message(session.session_id, "operator", "do a thing")
+
+    worker._dispatch_claude_code_session(session, [{"content": "do a thing"}])
+
+    assert any("All done." in s for s in sent)
+
+
+def test_child_final_text_reads_claude_code_completed_event(tmp_path: Path):
+    """The parent pulls a claude_code child's final_text from the
+    claude_code_completed transcript event — the child's only path out now that
+    it stays silent to the operator (#349)."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="")
+    )
+    worker, store, transcripts, _ = _capturing_worker(tmp_path, claude_code_executor=stub)
+    parent = store.create(task_id="parent-1", routing="local")
+    child = store.create(
+        task_id="child-1", routing="claude_code", parent_session_id=parent.session_id,
+    )
+    transcripts.append(child.session_id, "claude_code_completed", {
+        "final_chars": 23, "final_text": "Match 1: A vs B at noon.",
+    })
+
+    assert "Match 1: A vs B at noon." in worker._child_final_text(child)
+
+
 def test_vault_claude_task_marked_complete_on_finish(tmp_path: Path):
     """A vault-routed ``#agent #claude`` task (origin != 'operator', no parent)
     must be reconciled in the vault when the Claude Code session completes:

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -130,6 +130,19 @@ def _seed_session(store: SessionStore, *, task_id: str = "task-1"):
     )
 
 
+def _seed_child_session(
+    store: SessionStore, *, task_id: str = "child-1", claude_code_model: str | None = None,
+):
+    """A claude_code session spawned by another agent — has a parent, so it
+    reports back to that parent rather than streaming to the operator (#349)."""
+    return store.create(
+        task_id=task_id,
+        routing="claude_code",
+        parent_session_id="sess_parent",
+        claude_code_model=claude_code_model,
+    )
+
+
 def _read_transcript(transcripts: TranscriptStore, session_id: str) -> list[dict]:
     return transcripts.read(session_id)
 
@@ -210,6 +223,77 @@ def test_assistant_narrative_outside_notify_is_kept_as_final_text(tmp_path: Path
     assert "Found a typo." in outcome.final_text
     assert "NOTIFY" not in outcome.final_text
     assert notifications == ["Fixed it."]
+
+
+def test_child_notify_not_streamed_and_folded_into_final_text(tmp_path: Path):
+    """A spawned child (#349) must NOT stream [NOTIFY] to the operator. Instead
+    the bodies are folded into final_text so the parent — which only reads
+    final_text — still receives the substance the child reported."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] Match 1: A vs B."}]},
+        },
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] Match 2: C vs D."}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.05, "result": ""},
+    ]
+    notifications: list[str] = []
+    executor, store, transcripts = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events), notifications=notifications,
+    )
+    session = _seed_child_session(store)
+
+    outcome = executor.execute(session, {"description": "list today's matches"})
+
+    assert outcome.status == STATUS_COMPLETED
+    # Nothing streamed to the operator's Telegram.
+    assert notifications == []
+    # Both bodies are present in the text the parent receives.
+    assert "Match 1: A vs B." in outcome.final_text
+    assert "Match 2: C vs D." in outcome.final_text
+    # Audit trail still records the bodies as transcript events.
+    kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
+    assert kinds.count("claude_code_notify") == 2
+
+
+def test_build_command_uses_session_model_tier(tmp_path: Path):
+    """A child seeded with claude_code_model='haiku' runs the CLI with
+    --model haiku; the default (None) falls back to opus (#349)."""
+    captured: dict = {}
+
+    def _spawn_capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc([
+            {"type": "system", "subtype": "init", "session_id": "cli-1"},
+            {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "ok"},
+        ])
+
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_capture)
+    session = _seed_child_session(store, claude_code_model="haiku")
+    executor.execute(session, {"description": "simple lookup"})
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("--model") + 1] == "haiku"
+
+
+def test_build_command_defaults_to_opus(tmp_path: Path):
+    captured: dict = {}
+
+    def _spawn_capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc([
+            {"type": "system", "subtype": "init", "session_id": "cli-1"},
+            {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "ok"},
+        ])
+
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_capture)
+    session = _seed_session(store)  # operator session, no tier set
+    executor.execute(session, {"description": "anything"})
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("--model") + 1] == "opus"
 
 
 def test_tool_use_records_transcript_event(tmp_path: Path):

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -256,8 +256,15 @@ def test_child_notify_not_streamed_and_folded_into_final_text(tmp_path: Path):
     assert "Match 1: A vs B." in outcome.final_text
     assert "Match 2: C vs D." in outcome.final_text
     # Audit trail still records the bodies as transcript events.
-    kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
+    events = _read_transcript(transcripts, session.session_id)
+    kinds = [e["kind"] for e in events]
     assert kinds.count("claude_code_notify") == 2
+    # The completion event persists the folded text so the parent can read it
+    # via _child_final_text (the child never streamed it to Telegram).
+    completed = [e for e in events if e["kind"] == "claude_code_completed"]
+    assert completed
+    persisted = completed[0]["payload"]["final_text"]
+    assert "Match 1: A vs B." in persisted and "Match 2: C vs D." in persisted
 
 
 def test_build_command_uses_session_model_tier(tmp_path: Path):

--- a/tests/test_agent_worker_inter_agent.py
+++ b/tests/test_agent_worker_inter_agent.py
@@ -120,6 +120,51 @@ def test_spawn_cli_child_for_capability_fallback(ctx, store, parent, model):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("tier", ["haiku", "sonnet", "opus"])
+def test_spawn_claude_code_tier_persisted(ctx, store, tier):
+    """A claude_code child's `tier` arg lands on the session as
+    claude_code_model so the executor runs the CLI with that --model (#349)."""
+    result = dispatch(ctx, "lifeos_agent_spawn", {
+        "prompt": "look up today's matches", "model": "claude_code", "tier": tier,
+    })
+    assert result["ok"]
+    child = store.get_by_session_id(result["child_session_id"])
+    assert child.claude_code_model == tier
+
+
+@pytest.mark.unit
+def test_spawn_claude_code_default_tier_is_none(ctx, store):
+    """No tier → claude_code_model NULL → the executor falls back to opus."""
+    result = dispatch(ctx, "lifeos_agent_spawn", {
+        "prompt": "hard reasoning task", "model": "claude_code",
+    })
+    assert result["ok"]
+    child = store.get_by_session_id(result["child_session_id"])
+    assert child.claude_code_model is None
+
+
+@pytest.mark.unit
+def test_spawn_rejects_invalid_tier(ctx):
+    result = dispatch(ctx, "lifeos_agent_spawn", {
+        "prompt": "x", "model": "claude_code", "tier": "ultra",
+    })
+    assert not result["ok"]
+    assert result["error"] == "invalid_arg"
+
+
+@pytest.mark.unit
+def test_spawn_tier_ignored_for_non_claude_code(ctx, store):
+    """tier is a claude_code-only knob — a valid tier on a local child is
+    silently dropped rather than erroring, so callers can pass it uniformly."""
+    result = dispatch(ctx, "lifeos_agent_spawn", {
+        "prompt": "x", "model": "local", "tier": "haiku",
+    })
+    assert result["ok"]
+    child = store.get_by_session_id(result["child_session_id"])
+    assert child.claude_code_model is None
+
+
+@pytest.mark.unit
 def test_spawn_cli_child_skips_dollar_ceiling(store, transcript):
     """CLI routes are subscription-billed, so a CLI child spawns even when the
     parent has no remaining per-token dollar budget."""

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -496,6 +496,46 @@ def test_completion_summary_renders_four_bucket_breakdown(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_completion_summary_flags_escalation_to_child_engine(tmp_path: Path):
+    """When a session delegated work to a claude_code child, the single
+    completion message names the engine + tier so the operator knows the task
+    was escalated and where it ran (#349)."""
+    api = FakeApi(tasks=[])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="Here are today's matches: A vs B at noon.",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    parent = w.session_store.create(task_id="t1", routing="local", expected_output="text")
+    w.session_store.create(
+        task_id="spawn_child", routing="claude_code",
+        parent_session_id=parent.session_id, claude_code_model="haiku",
+    )
+    msg = w._completion_summary(parent, {"id": "t1", "description": "world cup"},
+                                executor.outcome)
+    assert "⤴️ Escalated to Claude Code (haiku)" in msg
+    # The single message still carries the actual result.
+    assert "Here are today's matches" in msg
+
+
+@pytest.mark.unit
+def test_completion_summary_no_escalation_line_without_children(tmp_path: Path):
+    """A session that ran solo (spawned no children) gets no escalation flag."""
+    api = FakeApi(tasks=[])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="Done.",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    sess = w.session_store.create(task_id="t1", routing="local", expected_output="text")
+    msg = w._completion_summary(sess, {"id": "t1", "description": "simple task"},
+                                executor.outcome)
+    assert "Escalated" not in msg
+
+
+@pytest.mark.unit
 def test_completion_summary_includes_init_failed_mcps_footer(tmp_path: Path):
     """When the managed executor reports MCPs that failed to initialize,
     the completion summary appends a "Note: N MCP server(s) unavailable"


### PR DESCRIPTION
## Summary

A `#local` task that delegates to a Claude Code child via `lifeos_agent_spawn` used to produce **two** operator Telegram messages — the child's live `[NOTIFY]` stream and the parent's completion summary — and the child could only run on Opus. This makes the delegated child cheap-tier-selectable and collapses the output to one flagged message.

Three changes:
1. **Haiku tier** — `claude_code_executor` builds `--model` from `session.claude_code_model` (default `opus`); `lifeos_agent_spawn` gains a `tier` arg (`haiku`/`sonnet`/`opus`) persisted to a new nullable `claude_code_model` session column. The tool description steers the worker to pick `haiku` for simple lookups, `opus` for hard reasoning.
2. **One message on delegation** — a spawned child (`parent_session_id` set) no longer streams `[NOTIFY]`/heartbeats to the operator; its notify bodies are folded into `final_text` so the parent (which only reads `final_text`) still gets the substance. Operator `/claude` sessions stream as before.
3. **Escalation flag** — when a session spawned children, its completion message names the engine + tier, e.g. `⤴️ Escalated to Claude Code (haiku)`.

Closes #349

## Test evidence

`pytest tests/ -m unit` → **2059 passed, 8 skipped**. New/changed coverage:
- `test_agent_worker_inter_agent.py` — tier persisted to `claude_code_model`; invalid tier rejected; tier ignored for non-claude_code; default tier NULL.
- `test_agent_worker_claude_code_executor.py` — child `[NOTIFY]` folded into `final_text` and **not** streamed; `--model` reflects the session tier (haiku) / defaults to opus.
- `test_agent_worker_loop.py` — completion message shows the escalation flag; no flag when the session ran solo.

## Review focus

- `claude_code_executor._effective_final_text` — folding `notify_bodies` into the child's `final_text` (correctness of what the parent receives).
- `is_child` gating of `[NOTIFY]` + heartbeats — that operator `/claude` sessions are unaffected (they have no `parent_session_id`).
- New `claude_code_model` column: additive migration + `_row_to_session` guard, consistent with the existing pattern.
- `_escalation_note` runs one `list_sessions(parent_session_id=...)` query per completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)