### PR TITLE
feat: "doctor" self-repair Telegram bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -293,6 +293,15 @@ LIFEOS_RELATIONSHIP_FOLDER=Relationship
 # TELEGRAM_THERAPIST_BOT_TOKEN=
 # TELEGRAM_THERAPIST_CHAT_ID=
 
+# Doctor bot (optional) — the self-repair surface. Unlike fitness/therapist
+# (pure chat), the doctor drives Claude Code: report a LifeOS problem and it
+# clarifies, files a GitHub issue, asks to implement, then on approval ships the
+# fix (worktree → /implement → PR → merge → restart) and reports back. Requires
+# Claude Code authenticated on the server and `gh` authed for issues/PRs. Leave
+# unset to not run it. See docs/guides/doctor-bot.md.
+# TELEGRAM_DOCTOR_BOT_TOKEN=
+# TELEGRAM_DOCTOR_CHAT_ID=
+
 # Mirror the fitness workout log into a Google Sheet (optional; off if unset).
 # The Sheet must be owned by / shared with your personal Google account, and the
 # OAuth token needs the read-write Sheets scope (auth/spreadsheets) — re-run the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMe
 | What does `#agent` do? | [specs/product/agent-worker.md](docs/specs/product/agent-worker.md) |
 | How does the agent worker work internally? | [specs/technical/agent-worker.md](docs/specs/technical/agent-worker.md) |
 | How do I set up the agent worker? | [guides/agent-worker-setup.md](docs/guides/agent-worker-setup.md) |
+| How does the doctor self-repair bot work? | [guides/doctor-bot.md](docs/guides/doctor-bot.md) |
 | How do schedules (triggers + actions) work? | [guides/scheduler.md](docs/guides/scheduler.md) |
 | How do I import Apple Health/Fitness data? | [guides/apple-health.md](docs/guides/apple-health.md) |
 | What does `/agents` show? | [specs/product/agent-viz.md](docs/specs/product/agent-viz.md) |

--- a/api/services/agent_worker/claude_code_spawn.py
+++ b/api/services/agent_worker/claude_code_spawn.py
@@ -62,8 +62,13 @@ def spawn_claude_code_session(
     working_dir: str | None = None,
     plan_mode: bool = False,
     chat_id: str | None = None,
+    bot: str | None = None,
 ) -> dict:
     """Create a parentless ``routing='claude_code'`` session.
+
+    ``bot`` tags the session with the Telegram bot that owns its operator-facing
+    notices (NULL = primary). An orchestration bot like the doctor passes its
+    name so the worker routes [NOTIFY]/[CLARIFY]/completion back to that bot.
 
     Returns ``{"ok": True, "session_id", "task_id"}`` on success, or
     ``{"ok": False, "error"}`` when ``prompt`` is empty.
@@ -86,6 +91,7 @@ def spawn_claude_code_session(
         "working_dir": working_dir,
         "plan_mode": bool(plan_mode),
         "chat_id": chat_id,
+        "bot": bot,
     }
     # See operator_spawn for the rationale on enqueueing the prompt before
     # the session row exists.
@@ -99,6 +105,7 @@ def spawn_claude_code_session(
         expected_output="text",
         parent_session_id=None,
         origin="operator",
+        bot=bot,
     )
 
     logger.info(
@@ -121,12 +128,13 @@ def parse_claude_code_spawn_payload(content: str) -> dict:
     try:
         data = json.loads(content)
     except (TypeError, ValueError, json.JSONDecodeError):
-        return {"prompt": content or "", "working_dir": None, "plan_mode": False, "chat_id": None}
+        return {"prompt": content or "", "working_dir": None, "plan_mode": False, "chat_id": None, "bot": None}
     if not isinstance(data, dict) or "prompt" not in data:
-        return {"prompt": content or "", "working_dir": None, "plan_mode": False, "chat_id": None}
+        return {"prompt": content or "", "working_dir": None, "plan_mode": False, "chat_id": None, "bot": None}
     return {
         "prompt": str(data.get("prompt") or ""),
         "working_dir": data.get("working_dir"),
         "plan_mode": bool(data.get("plan_mode")),
         "chat_id": data.get("chat_id"),
+        "bot": data.get("bot"),
     }

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -83,6 +83,12 @@ class Session:
     # NB: codex sessions reuse this column too (CodexExecutor stores the
     # codex thread id here); routing disambiguates.
     claude_code_session_id: str | None = None
+    # Telegram bot identity that owns this session's operator-facing messages.
+    # NULL = primary bot (the default for every legacy / non-doctor session).
+    # An orchestration bot (e.g. "doctor") tags its spawned sessions so the
+    # worker routes [NOTIFY]/[CLARIFY]/completion notices back to that bot, not
+    # the primary. See api/services/telegram.py and config/telegram_bots.json.
+    bot: str | None = None
 
 
 _SCHEMA = """
@@ -108,7 +114,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     managed_agent_session_id  TEXT,
     preset_class              TEXT,
     origin                    TEXT,  -- NULL/"agent" = #agent task; "operator" = root-spawned (#235)
-    claude_code_session_id    TEXT   -- Claude Code (or Codex) CLI session UUID for routing="claude_code"/"codex"
+    claude_code_session_id    TEXT,  -- Claude Code (or Codex) CLI session UUID for routing="claude_code"/"codex"
+    bot                       TEXT   -- Telegram bot that owns this session's notices; NULL = primary (#348)
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -160,7 +167,11 @@ CREATE TABLE IF NOT EXISTS pending_questions (
     -- on any chunk, so `deposit_answer` matches membership in this list (not
     -- just the first chunk in `sent_message_id`). NULL for legacy rows, which
     -- still match via `sent_message_id`.
-    sent_message_ids  TEXT
+    sent_message_ids  TEXT,
+    -- Telegram bot that sent this question. NULL = primary. Reply matching is
+    -- scoped by bot so a doctor-bot reply can't collide with a primary-bot
+    -- question that happens to share a numeric message id (#348).
+    bot               TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_pq_message_id ON pending_questions(sent_message_id);
 CREATE INDEX IF NOT EXISTS idx_pq_open ON pending_questions(answered_at, processed, timed_out);
@@ -275,6 +286,10 @@ class SessionStore:
                 conn.execute(
                     "ALTER TABLE pending_questions ADD COLUMN sent_message_ids TEXT"
                 )
+            # Idempotent migration for `pending_questions.bot` (#348) — scopes
+            # reply matching to the sending bot. Legacy rows stay NULL = primary.
+            if "bot" not in pq_cols:
+                conn.execute("ALTER TABLE pending_questions ADD COLUMN bot TEXT")
             # Idempotent migration for the prompt-cache token buckets on
             # `sessions`. Old rows stay at zero — we don't backfill historical
             # sessions, the raw event payloads in transcripts still have the
@@ -303,6 +318,8 @@ class SessionStore:
             # Idempotent migration for the Claude Code CLI session UUID.
             # Set for routing="claude_code" (Claude Code) and "codex" sessions;
             # NULL for everything else.
+            if "bot" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN bot TEXT")
             if "claude_code_session_id" not in sess_cols:
                 conn.execute("ALTER TABLE sessions ADD COLUMN claude_code_session_id TEXT")
                 # Migrate data from the legacy column if it existed (pre-rename
@@ -367,6 +384,7 @@ class SessionStore:
         root_session_id: str | None = None,
         spawn_depth: int = 0,
         origin: str | None = None,
+        bot: str | None = None,
     ) -> Session:
         """Insert a new session row. Raises sqlite3.IntegrityError if `task_id`
         already has a row — the caller should treat that as a lost-race signal.
@@ -388,15 +406,15 @@ class SessionStore:
                     task_id, session_id, status, routing, budget_json,
                     started_at, last_activity_at,
                     expected_output, parent_session_id,
-                    root_session_id, spawn_depth, origin
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    root_session_id, spawn_depth, origin, bot
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     task_id, sid, status, routing,
                     json.dumps(budget) if budget else None,
                     now, now,
                     expected_output, parent_session_id,
-                    root_sid, spawn_depth, origin,
+                    root_sid, spawn_depth, origin, bot,
                 ),
             )
         return Session(
@@ -412,6 +430,7 @@ class SessionStore:
             root_session_id=root_sid,
             spawn_depth=spawn_depth,
             origin=origin,
+            bot=bot,
         )
 
     def get(self, task_id: str) -> Session | None:
@@ -954,12 +973,15 @@ class SessionStore:
         sent_message_id: int,
         kind: str = "clarification",
         sent_message_ids: list[int] | None = None,
+        bot: str | None = None,
     ) -> int:
         """Record a pending question / follow-up keyed by Telegram message id.
 
         `sent_message_id` is the first (matchable) chunk id; `sent_message_ids`
         is the full chunk list for a split notification (defaults to just the
         first chunk). `deposit_answer` matches a reply to any chunk in the list.
+        `bot` is the Telegram bot that sent the message (NULL = primary); reply
+        matching is scoped by it so bots can't collide on numeric ids (#348).
         """
         ids = sent_message_ids or [int(sent_message_id)]
         with self._connect() as conn:
@@ -967,12 +989,12 @@ class SessionStore:
                 """
                 INSERT INTO pending_questions (
                     session_id, task_id, question, sent_message_id, sent_at,
-                    kind, sent_message_ids
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    kind, sent_message_ids, bot
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_id, task_id, question, int(sent_message_id), _now(),
-                    kind, json.dumps([int(i) for i in ids]),
+                    kind, json.dumps([int(i) for i in ids]), bot,
                 ),
             )
         return cur.lastrowid
@@ -1004,23 +1026,38 @@ class SessionStore:
             sent_message_ids=sent_message_ids,
         )
 
-    def deposit_answer(self, sent_message_id: int, answer: str) -> bool:
+    @staticmethod
+    def _bot_scope_clause(bot: str | None) -> tuple[str, list]:
+        """SQL fragment + params that scope a pending_questions lookup to `bot`.
+
+        ``bot=None`` → no scoping (legacy behavior). ``bot="primary"`` matches
+        both explicit 'primary' rows and legacy NULL-bot rows; any other name
+        matches only its own rows (#348).
+        """
+        if bot is None:
+            return "", []
+        return " AND (bot = ? OR (bot IS NULL AND ? = 'primary'))", [bot, bot]
+
+    def deposit_answer(self, sent_message_id: int, answer: str, bot: str | None = None) -> bool:
         """Record an answer for an open question, keyed by Telegram message_id.
 
         Matches a reply landing on any chunk of a split notification: the id is
         checked against both the primary `sent_message_id` and membership in the
-        `sent_message_ids` JSON list. Returns True if a matching open question
-        was found and updated; False otherwise (so the listener can fall through
-        to the chat pipeline).
+        `sent_message_ids` JSON list. When `bot` is given, the match is scoped to
+        that bot (see :meth:`_bot_scope_clause`). Returns True if a matching open
+        question was found and updated; False otherwise (so the listener can fall
+        through to the chat pipeline).
         """
+        bot_clause, bot_params = self._bot_scope_clause(bot)
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT id FROM pending_questions "
                 "WHERE answered_at IS NULL AND timed_out = 0 "
                 "AND (sent_message_id = ? OR (sent_message_ids IS NOT NULL "
-                "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?))) "
-                "ORDER BY id ASC LIMIT 1",
-                (int(sent_message_id), int(sent_message_id)),
+                "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?)))"
+                + bot_clause +
+                " ORDER BY id ASC LIMIT 1",
+                (int(sent_message_id), int(sent_message_id), *bot_params),
             ).fetchone()
             if not row:
                 return False
@@ -1091,22 +1128,27 @@ class SessionStore:
             ).fetchone()
         return dict(row) if row else None
 
-    def get_open_question_by_message_id(self, sent_message_id: int) -> dict | None:
+    def get_open_question_by_message_id(
+        self, sent_message_id: int, bot: str | None = None
+    ) -> dict | None:
         """Return the open (unanswered, not-timed-out) question a reply to
         `sent_message_id` matches — on any chunk — or None.
 
         Read-only sibling of `deposit_answer`: lets a caller inspect the matched
         row's `kind` before recording an answer (e.g. so the Telegram listener
-        can recognize a ``routing='code'`` follow-up).
+        can recognize a ``routing='code'`` follow-up). When `bot` is given, the
+        match is scoped to that bot (see :meth:`_bot_scope_clause`).
         """
+        bot_clause, bot_params = self._bot_scope_clause(bot)
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT * FROM pending_questions "
                 "WHERE answered_at IS NULL AND timed_out = 0 "
                 "AND (sent_message_id = ? OR (sent_message_ids IS NOT NULL "
-                "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?))) "
-                "ORDER BY id ASC LIMIT 1",
-                (int(sent_message_id), int(sent_message_id)),
+                "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?)))"
+                + bot_clause +
+                " ORDER BY id ASC LIMIT 1",
+                (int(sent_message_id), int(sent_message_id), *bot_params),
             ).fetchone()
         return dict(row) if row else None
 
@@ -1194,4 +1236,5 @@ class SessionStore:
             claude_code_session_id=(
                 row["claude_code_session_id"] if "claude_code_session_id" in row.keys() else None
             ),
+            bot=(row["bot"] if "bot" in row.keys() else None),
         )

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1327,8 +1327,11 @@ class Worker:
             transcript_store=self.transcript_store,
             notification_callback=notify,
         )
-        self._claude_code_executors[key] = executor
-        return executor
+        # CLI dispatch runs on a thread pool, so two same-bot sessions can reach
+        # here concurrently. The executor is cheap and stateless (per-session
+        # state lives in SessionStore), so the race is benign — setdefault just
+        # makes both callers return the same cached instance (#354 review).
+        return self._claude_code_executors.setdefault(key, executor)
 
     def _dispatch_codex_session(self, session, pending: list[dict]) -> None:
         """Drive one ``routing='codex'`` session through ``CodexExecutor``.

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -192,9 +192,9 @@ class Worker:
         # production wiring is explicit in `main()`. The previous default
         # — auto-importing the real Telegram module — leaked a test stub
         # message to a real operator chat once; never again.
-        def _noop_telegram(text, chat_id=None):
+        def _noop_telegram(text, chat_id=None, bot=None):
             return False
-        def _noop_with_id(text):
+        def _noop_with_id(text, chat_id=None, bot=None):
             return []
         self._telegram_send = telegram_send if telegram_send is not None else _noop_telegram
         self._telegram_send_with_id = (
@@ -206,6 +206,11 @@ class Worker:
         self._local_executor = local_executor  # lazily instantiated on first use
         self._managed_executor = managed_executor  # lazily instantiated on first claude task
         self._claude_code_executor = claude_code_executor  # lazily instantiated on first /claude task
+        # Per-bot ClaudeCodeExecutor cache (#348). An orchestration bot (doctor)
+        # needs its [NOTIFY]/[CLARIFY] notices routed to its own Telegram bot, so
+        # each bot gets an executor whose notification_callback is bound to that
+        # bot. Bypassed entirely when a test injects `_claude_code_executor`.
+        self._claude_code_executors: dict[str, object] = {}
         self._codex_executor = codex_executor  # lazily instantiated on first /codex task
         # Spawned CLI children (claude_code/codex) are long-running subprocesses.
         # Running them off the tick keeps the poll loop free to claim new tasks
@@ -1173,8 +1178,20 @@ class Worker:
         )
         from api.services.agent_worker.claude_code_spawn import parse_claude_code_spawn_payload
 
-        claude_code = self._get_claude_code_executor()
+        # The owning bot (NULL = primary) routes every operator-facing notice for
+        # this session — the streaming [NOTIFY]/[CLARIFY] (via the executor's
+        # callback) and the worker-sent block/completion/failure messages below.
+        bot = session.bot
+        claude_code = self._get_claude_code_executor(bot)
         sid = session.session_id
+
+        # Only thread `bot` when set so the primary path's send signature is
+        # byte-identical to before this change (#348). bot=None → primary.
+        def _send(text):
+            return self._telegram_send(text, bot=bot) if bot else self._telegram_send(text)
+
+        def _send_with_id(text):
+            return self._telegram_send_with_id(text, bot=bot) if bot else self._telegram_send_with_id(text)
 
         # Build the task dict + resume message from drained pending messages.
         # Fresh spawns carry the JSON payload produced by spawn_claude_code_session;
@@ -1222,7 +1239,7 @@ class Worker:
             else:
                 prompt = "Awaiting your reply to continue."
             try:
-                sent_ids = self._telegram_send_with_id(prompt) or []
+                sent_ids = _send_with_id(prompt) or []
             except Exception as exc:
                 logger.warning("code blocked reply prompt send failed: %s", exc)
                 sent_ids = []
@@ -1230,7 +1247,8 @@ class Worker:
                 # kind='followup' so _resume_as_followup picks the reply up
                 # alongside agent threads (unified routing model, #248). The
                 # session.routing == 'code' tells _resume_as_followup which
-                # executor branch to take.
+                # executor branch to take. `bot` scopes the reply match so a
+                # doctor reply can't collide with a primary question (#348).
                 self.session_store.create_pending_question(
                     session_id=sid,
                     task_id=session.task_id,
@@ -1238,6 +1256,7 @@ class Worker:
                     sent_message_id=sent_ids[0],
                     sent_message_ids=sent_ids,
                     kind="followup",
+                    bot=bot,
                 )
                 self.transcript_store.append(sid, "code_block_prompt_registered", {
                     "reason": outcome.reason, "message_ids": sent_ids,
@@ -1252,7 +1271,7 @@ class Worker:
             body = outcome.final_text.strip() if outcome.final_text else ""
             if body:
                 try:
-                    sent_ids = self._telegram_send_with_id(body) or []
+                    sent_ids = _send_with_id(body) or []
                 except Exception as exc:
                     logger.warning("code completion send failed: %s", exc)
                     sent_ids = []
@@ -1264,6 +1283,7 @@ class Worker:
                         sent_message_id=sent_ids[0],
                         sent_message_ids=sent_ids,
                         kind="followup",
+                        bot=bot,
                     )
             self.transcript_store.append(sid, "code_handled_completion", {
                 "final_chars": len(body),
@@ -1277,27 +1297,38 @@ class Worker:
         # operator-spawned /claude sessions have no vault row and are no-ops.
         label = "Code session"
         if outcome.status == STATUS_BUDGET_EXCEEDED:
-            self._telegram_send(f"⚠️ {label} hit its budget ({outcome.reason}).")
+            _send(f"⚠️ {label} hit its budget ({outcome.reason}).")
         elif outcome.status == STATUS_FAILED:
-            self._telegram_send(f"⚠️ {label} failed: {outcome.reason}.")
+            _send(f"⚠️ {label} failed: {outcome.reason}.")
         self._reconcile_vault_terminal(session, outcome.status)
 
-    def _get_claude_code_executor(self):
+    def _get_claude_code_executor(self, bot: str | None = None):
         """Lazy-construct the ClaudeCodeExecutor for /claude sessions.
 
-        Tests inject one via the constructor; production builds default
-        a ClaudeCodeExecutor wired to the worker's Telegram sender so [NOTIFY]
-        bodies stream live during the subprocess run.
+        Tests inject one via the constructor (returned for every bot). Production
+        builds one executor per owning bot, each wired to a notification callback
+        bound to that bot so [NOTIFY]/[CLARIFY] bodies stream live to the right
+        Telegram surface — the doctor bot's notices go to the doctor bot, not the
+        primary (#348). ``bot=None`` is the primary.
         """
         if self._claude_code_executor is not None:
             return self._claude_code_executor
+        key = bot or "primary"
+        cached = self._claude_code_executors.get(key)
+        if cached is not None:
+            return cached
         from api.services.agent_worker.claude_code_executor import ClaudeCodeExecutor
-        self._claude_code_executor = ClaudeCodeExecutor(
+        # Primary keeps the original callback (byte-identical to pre-#348). An
+        # orchestration bot gets a callback bound to its bot so streaming
+        # [NOTIFY]/[CLARIFY] bodies land on its Telegram surface.
+        notify = (lambda text: self._telegram_send(text, bot=bot)) if bot else self._telegram_send
+        executor = ClaudeCodeExecutor(
             session_store=self.session_store,
             transcript_store=self.transcript_store,
-            notification_callback=self._telegram_send,
+            notification_callback=notify,
         )
-        return self._claude_code_executor
+        self._claude_code_executors[key] = executor
+        return executor
 
     def _dispatch_codex_session(self, session, pending: list[dict]) -> None:
         """Drive one ``routing='codex'`` session through ``CodexExecutor``.

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -458,7 +458,7 @@ class TelegramBotListener:
         # Bots that own Claude Code session reply threads: the primary, plus any
         # orchestration bot (e.g. doctor). These run the agent/Claude-Code reply
         # hooks — scoped to their own bot — instead of being pure chat (#348).
-        self._owns_agent_sessions = self._is_primary or getattr(self._bot, "orchestrates", False)
+        self._owns_agent_sessions = self._is_primary or self._bot.orchestrates
         self._token = self._bot.token
         self._chat_id = self._bot.chat_id
         self._persona = self._bot.persona

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -455,6 +455,10 @@ class TelegramBotListener:
         # get their own offset file so concurrent pollers don't clobber each other.
         self._bot = bot or settings.telegram_primary_bot
         self._is_primary = self._bot.name == "primary"
+        # Bots that own Claude Code session reply threads: the primary, plus any
+        # orchestration bot (e.g. doctor). These run the agent/Claude-Code reply
+        # hooks — scoped to their own bot — instead of being pure chat (#348).
+        self._owns_agent_sessions = self._is_primary or getattr(self._bot, "orchestrates", False)
         self._token = self._bot.token
         self._chat_id = self._bot.chat_id
         self._persona = self._bot.persona
@@ -583,7 +587,7 @@ class TelegramBotListener:
         try:
             from api.services.agent_worker.session_store import SessionStore
             store = SessionStore()
-            return store.deposit_answer(reply_to_message_id, text)
+            return store.deposit_answer(reply_to_message_id, text, bot=self._bot.name)
         except Exception as exc:
             logger.warning(f"agent-worker deposit_answer failed: {exc}")
             return False
@@ -657,6 +661,51 @@ class TelegramBotListener:
             chat_id=chat_id,
         )
 
+    async def _handle_orchestration_message(self, text: str, chat_id: str):
+        """Spawn a Claude Code session for an orchestration bot (e.g. doctor).
+
+        The bot's persona is the orchestration contract; the user's message is
+        the problem report. The session is tagged with this bot's name so the
+        worker routes every [NOTIFY]/[CLARIFY]/completion notice back to this
+        bot, and a threaded reply (handled by the resume hook) continues it.
+        Working dir is the canonical LifeOS checkout, not whatever worktree the
+        operator happens to be in.
+        """
+        import os
+        from api.services.agent_worker.claude_code_spawn import spawn_claude_code_session
+        from api.services.agent_worker.session_store import SessionStore
+
+        working_dir = os.path.expanduser(os.path.join(str(settings.code_dir), "LifeOS"))
+        prompt = (
+            f"{self._persona}\n\n"
+            f"---\n\n"
+            f"The user just sent this report via the {self._bot.name} bot:\n\n{text}"
+        )
+        await send_message_async(
+            "🩺 On it — taking a look now. I'll follow up here as I go.",
+            chat_id=chat_id,
+        )
+        try:
+            result = await asyncio.to_thread(
+                spawn_claude_code_session,
+                SessionStore(),
+                prompt,
+                working_dir=working_dir,
+                plan_mode=False,
+                chat_id=chat_id,
+                bot=self._bot.name,
+            )
+        except Exception as exc:
+            logger.warning(f"orchestration spawn failed: {exc}")
+            await send_message_async(
+                f"Couldn't start the session: {str(exc)[:200]}", chat_id=chat_id,
+            )
+            return
+        if not result.get("ok"):
+            await send_message_async(
+                f"Couldn't start the session: {result.get('error')}", chat_id=chat_id,
+            )
+
     async def _handle_update(self, update: dict):
         """Process a single Telegram update."""
         # Route every outbound send during this update through this bot's token.
@@ -689,12 +738,13 @@ class TelegramBotListener:
         # Agent-worker clarification hook (Issue F). If this message is a
         # reply-thread to a previously-sent clarification question, deposit
         # the answer and short-circuit — don't route to the chat pipeline.
-        # Only the primary bot owns these agent/Claude-Code reply threads:
-        # Telegram message_ids are unique per chat (per bot), so a specialized
-        # bot must not match a reply against the shared follow-up table or it
-        # could collide with the primary's ids. Specialized bots are pure chat.
+        # Only bots that own agent/Claude-Code reply threads run this — the
+        # primary and any orchestration bot (doctor). The lookup is scoped to
+        # this bot (#348): Telegram message_ids are unique per chat (per bot),
+        # so without scoping a specialized bot could collide with the primary's
+        # ids in the shared follow-up table. Pure-chat specialized bots skip it.
         reply_to = message.get("reply_to_message")
-        if self._is_primary and reply_to and reply_to.get("message_id"):
+        if self._owns_agent_sessions and reply_to and reply_to.get("message_id"):
             reply_to_id = int(reply_to["message_id"])
             # A reply to a /claude completion resumes that Claude Code session
             # (#237) — checked before the agent-worker deposit since both use
@@ -721,6 +771,14 @@ class TelegramBotListener:
         # plain non-threaded message is always a fresh chat query, never
         # an implicit follow-up — so unrelated questions never get
         # silently swallowed into a finished agent or /claude thread.
+
+        # Orchestration bots (e.g. doctor) drive a Claude Code session instead
+        # of the chat pipeline. A threaded reply to one of its messages is
+        # already handled above (resume hook); a fresh message starts a new
+        # repair session whose clarify/implement gates round-trip on this bot.
+        if self._bot.orchestrates:
+            await self._handle_orchestration_message(text, chat_id)
+            return
 
         # Threaded-reply context for specialized bots: when the user replies to
         # one of the bot's own messages (e.g. correcting a "Logged: …" line), pass
@@ -902,7 +960,7 @@ class TelegramBotListener:
         try:
             from api.services.agent_worker.session_store import SessionStore
             store = SessionStore()
-            q = store.get_open_question_by_message_id(reply_to_message_id)
+            q = store.get_open_question_by_message_id(reply_to_message_id, bot=self._bot.name)
         except Exception as exc:
             logger.warning(f"cli reply lookup failed: {exc}")
             return False
@@ -914,7 +972,7 @@ class TelegramBotListener:
         session = store.get_by_session_id(session_id)
         if not session or session.routing not in ("claude_code", "codex"):
             return False
-        store.deposit_answer(reply_to_message_id, text)
+        store.deposit_answer(reply_to_message_id, text, bot=self._bot.name)
         label = "Codex" if session.routing == "codex" else "Claude Code"
         await send_message_async(f"Resuming {label} session...", chat_id=chat_id)
         return True

--- a/config/personas/doctor.md
+++ b/config/personas/doctor.md
@@ -1,0 +1,34 @@
+You are operating as the **doctor bot** — LifeOS's self-repair surface. The user messages you from Telegram when they notice LifeOS itself misbehaving or missing a capability. Your job is to turn that observation into a shipped fix: clarify what's wrong, file a GitHub issue, get the user's go-ahead, then implement → PR → merge → restart → confirm. You are running as a headless Claude Code session in the canonical LifeOS checkout (`~/Code/LifeOS`) with full shell, git, `gh`, and filesystem access, plus the project's `/draft-issue` and `/implement` skills.
+
+The user only sees messages you wrap in `[NOTIFY]` (statements) or `[CLARIFY]` (questions that pause you for a reply). Everything else is invisible to them. Keep these messages short and concrete — the user is on their phone.
+
+## The pipeline — run it in order
+
+**1. Clarify intent.** Read the report. If what's broken and what "fixed" looks like are already clear, skip ahead. If not, ask the *minimum* questions needed via `[CLARIFY]` (then stop and wait for the reply). Don't interrogate — one or two sharp questions, not a form. Investigate the codebase yourself first; only ask what you genuinely can't determine.
+
+**2. Draft the issue.** Once intent is clear, run the `/draft-issue` skill with a crisp description of the problem and the fix direction. It creates a GitHub issue. Capture the issue number and URL.
+
+**3. Surface it + gate.** Send the issue as a `[NOTIFY]` with a clickable link, e.g. `[NOTIFY] Filed #123: <title> — https://github.com/<owner>/<repo>/issues/123`. Then ask the gate as a `[CLARIFY]`: `Implement this now? Reply yes to ship it, or no to leave it as an issue.` Stop and wait.
+
+**4. On "no" (or anything that isn't approval):** `[NOTIFY] Left it as issue #123 for later.` Stop. Done.
+
+**5. On "yes" — implement, autonomously, end to end:**
+   a. Create an **isolated git worktree off `origin/main`** so you never disturb the canonical checkout (other agents share it). Something like: `git -C ~/Code/LifeOS fetch origin && git -C ~/Code/LifeOS worktree add -b doctor/issue-123 ~/Code/LifeOS/.worktrees/doctor-issue-123 origin/main`. Do all implementation work inside that worktree.
+   b. Run the `/implement` skill against the issue (`/implement 123`) **from inside the worktree**. It plans, writes tests, runs the suite, opens a PR, runs adversarial review, and merges. You are explicitly authorized to make multi-file changes here — the "keep changes small / stop at 4+ files" guidance in your base instructions is about unbounded scope creep and does **not** override an approved `/implement` run.
+   c. After the PR is merged, bring the canonical checkout to the merged code **before** restarting: `git -C ~/Code/LifeOS checkout main && git -C ~/Code/LifeOS pull`. Then clean up the worktree (`git -C ~/Code/LifeOS worktree remove .worktrees/doctor-issue-123`).
+   d. Restart the server so the change takes effect: `cd ~/Code/LifeOS && ./scripts/server.sh restart` (this picks up Python changes; the server does not auto-reload).
+   e. `[NOTIFY] Shipped: PR #<n> merged, repo on main, server restarted. Issue #123 closed.`
+
+## Autonomy
+
+Full-auto through merge. There is exactly **one** human gate: the "implement?" question in step 3. Once the user says yes, do not ask for further approval to branch, commit, push, or merge — `/implement`'s own adversarial review is the quality bar. The single exception is `/implement`'s escalation: if it reports unresolved Action-Required findings after 3 review rounds, do **not** merge — `[NOTIFY]` the escalation details and stop, leaving the PR open for a human.
+
+## Edge cases
+
+- **Restarting the agent worker:** you are running *inside* the `lifeos-agent-worker` process. Restarting `lifeos-api` is safe and is the usual need. If — and only if — your change touched agent-worker code (`api/services/agent_worker/`), the worker must also restart, which would kill you mid-run: send the "Shipped" `[NOTIFY]` **first**, then trigger the worker restart detached (e.g. `sudo systemctl restart lifeos-agent-worker` via `nohup ... &` / `systemd-run`) so your final message isn't lost.
+- **`gh` not authenticated / no remote:** if `/draft-issue` or `/implement` fails because GitHub isn't reachable, `[NOTIFY]` the specific problem (e.g. "gh isn't authenticated — run `gh auth login` on the server") instead of failing silently.
+- **Tests fail for reasons unrelated to the change, or the task turns out to need a human decision:** `[NOTIFY]` what you found and stop — don't force a merge.
+
+## Tone
+
+Terse, factual, a little clinical. No filler, no cheerleading. Lead with the status. You're a competent on-call engineer reporting in, not a chatbot.

--- a/config/settings.py
+++ b/config/settings.py
@@ -25,12 +25,16 @@ class TelegramBotConfig:
 
     ``name`` doubles as the per-bot state-file suffix, so it must be filesystem
     safe. ``persona`` is a system-prompt preamble injected for this bot's chats
-    (empty for the primary bot).
+    (empty for the primary bot). ``orchestrates`` marks a bot that drives Claude
+    Code sessions (e.g. the doctor self-repair bot) instead of being pure chat —
+    such a bot owns its own agent-session reply threads rather than redirecting
+    coding tasks to the primary bot.
     """
     name: str
     token: str
     chat_id: str
     persona: str = ""
+    orchestrates: bool = False
 
 
 class Settings(BaseSettings):
@@ -747,7 +751,10 @@ class Settings(BaseSettings):
                 except OSError as e:
                     logger.warning(f"Telegram bot '{name}': could not read persona file {persona_file}: {e}")
             seen.add(name)
-            bots.append(TelegramBotConfig(name=name, token=token, chat_id=chat_id, persona=persona))
+            bots.append(TelegramBotConfig(
+                name=name, token=token, chat_id=chat_id, persona=persona,
+                orchestrates=bool(entry.get("orchestrates", False)),
+            ))
         return bots
 
     @property

--- a/config/telegram_bots.json
+++ b/config/telegram_bots.json
@@ -10,5 +10,12 @@
     "token_env": "TELEGRAM_THERAPIST_BOT_TOKEN",
     "chat_id_env": "TELEGRAM_THERAPIST_CHAT_ID",
     "persona_file": "config/personas/therapist.md"
+  },
+  {
+    "name": "doctor",
+    "token_env": "TELEGRAM_DOCTOR_BOT_TOKEN",
+    "chat_id_env": "TELEGRAM_DOCTOR_CHAT_ID",
+    "persona_file": "config/personas/doctor.md",
+    "orchestrates": true
   }
 ]

--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -14,6 +14,7 @@ This directory contains operational guides — how to set up, configure, and run
 - `apple-health.md` — Apple Health/Fitness ingestion (HealthBridge app + iOS Shortcut fallback)
 - `troubleshooting.md` — Common issues and solutions
 - `claude-code-orchestration.md` — Claude Code multi-agent orchestration patterns
+- `doctor-bot.md` — Self-repair Telegram bot: report a problem → issue → implement → ship
 - `agent-worker-setup.md` — External agent worker prerequisites (Gemma swap, MCP HTTP transport, Cloudflare Tunnel, bearer token)
 - `agents-go-to.md` — /agents "Go To" wezterm pane setup (SessionStart hook + FD probe)
 

--- a/docs/guides/claude-code-orchestration.md
+++ b/docs/guides/claude-code-orchestration.md
@@ -212,4 +212,5 @@ If Claude is working in the wrong directory, make your task description more exp
 - [Claude Code Orchestration — Technical](../specs/technical/claude-code-orchestration.md) -- Implementation: subprocess, stream parsing, system prompt, cancellation
 - [Configuration](configuration.md) -- `LIFEOS_CLAUDE_*` env vars
 - [MCP Tools](../specs/product/mcp-tools.md) -- MCP tools available to Claude Code sessions
+- [Doctor Bot](doctor-bot.md) -- The self-repair bot, which drives a Claude Code session per the same orchestration machinery
 - [Scripts Reference](scripts.md) -- All LifeOS scripts with usage examples

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -253,6 +253,14 @@ When both are set, Telegram becomes a conversational client (full chat pipeline)
 
 Natural-language messages run through the chat pipeline (search, synthesis, tools).
 
+**Specialized bots** (optional) are separate `@BotFather` bots registered in [`config/telegram_bots.json`](../../config/telegram_bots.json), each with a persona in `config/personas/`. Leave a bot's token unset to not run it. `*_CHAT_ID` is optional and defaults to `TELEGRAM_CHAT_ID`.
+
+| Variable | Bot | Kind |
+|---|---|---|
+| `TELEGRAM_FITNESS_BOT_TOKEN` / `TELEGRAM_FITNESS_CHAT_ID` | `fitness` | Pure chat — clinical training/nutrition logging surface. |
+| `TELEGRAM_THERAPIST_BOT_TOKEN` / `TELEGRAM_THERAPIST_CHAT_ID` | `therapist` | Pure chat — advice-oriented surface grounded in therapy notes. |
+| `TELEGRAM_DOCTOR_BOT_TOKEN` / `TELEGRAM_DOCTOR_CHAT_ID` | `doctor` | **Orchestration** — self-repair surface that files an issue and ships a fix. See [doctor-bot.md](doctor-bot.md). |
+
 ### Monarch Money
 
 | Variable | Type | Default | Sets |
@@ -325,6 +333,7 @@ LIFEOS_ALERT_EMAIL=you@example.com
 - [First Run](first-run.md) — Post-install verification.
 - [Agent Worker Setup](agent-worker-setup.md) — Operator setup for the `#agent` worker; references many of the `LIFEOS_AGENT_*` vars above in operator-flow context.
 - [Claude Code Orchestration](claude-code-orchestration.md) — `/claude` setup; references the `LIFEOS_CLAUDE_*` vars in operator-flow context.
+- [Doctor Bot](doctor-bot.md) — The self-repair orchestration bot; setup of its `TELEGRAM_DOCTOR_*` vars and the repair flow.
 - [ADR-009: LIFEOS_LLM_BACKEND toggle](../adr/009-llm-backend-toggle.md) — Why the synthesis backend is operator-configurable.
 - [ADR-012: Embedding Pipeline](../adr/012-embedding-pipeline.md) — Why `LIFEOS_EMBEDDING_MODEL` is overridable; the OOM-protection knobs.
 - [`config/settings.py`](../../config/settings.py) — The source of truth; this guide should track it.

--- a/docs/guides/doctor-bot.md
+++ b/docs/guides/doctor-bot.md
@@ -1,0 +1,58 @@
+# Doctor Bot — Self-Repair Surface
+
+**Status:** Complete
+**Last Updated:** 2026-06-21
+**Audience:** Operator
+
+The **doctor** bot is a dedicated `@BotFather` Telegram bot whose only job is fixing LifeOS itself. You message it when you notice LifeOS misbehaving or missing something; it clarifies what you mean, files a GitHub issue, asks whether to implement, and — on your go-ahead — ships the fix end to end and reports back.
+
+Unlike the `fitness` and `therapist` bots (pure chat surfaces), the doctor **orchestrates**: each message drives a real Claude Code session, and that session's progress, questions, and completion all come back on the doctor bot.
+
+## The flow
+
+1. **You report a problem** (a fresh message to the doctor bot), e.g. _"the calendar tool returns last week's events when I ask for this week."_
+2. **Clarify.** The doctor asks questions only if intent is unclear; otherwise it proceeds.
+3. **Issue.** It runs `/draft-issue` and replies with a clickable GitHub issue link.
+4. **Gate.** It asks _"Implement this now?"_ — reply **yes** to ship, **no** to leave it as an issue. This is the single human gate.
+5. **Ship.** On **yes** it creates a worktree off `origin/main`, runs `/implement` (plan → tests → PR → adversarial review → merge), brings the canonical checkout to merged `main`, restarts the server, and confirms: _"Shipped: PR #N merged, server restarted."_
+
+Continue any step by **replying to the doctor's message** (swipe-to-reply in Telegram). A fresh, non-threaded message starts a **new** repair.
+
+## Setup
+
+1. **Create the bot.** In Telegram, message `@BotFather` → `/newbot`, name it (e.g. "LifeOS Doctor"), and copy the token.
+2. **Set the token** in `.env`:
+   ```bash
+   TELEGRAM_DOCTOR_BOT_TOKEN=<token-from-botfather>
+   # TELEGRAM_DOCTOR_CHAT_ID=   # optional; defaults to TELEGRAM_CHAT_ID
+   ```
+   The bot is registered in [`config/telegram_bots.json`](../../config/telegram_bots.json) and its behavior lives in [`config/personas/doctor.md`](../../config/personas/doctor.md). Leave the token unset to not run it.
+3. **Prerequisites on the server:**
+   - **Claude Code** installed and authenticated (`claude setup-token`) — same requirement as `/claude`. See [Claude Code Orchestration](claude-code-orchestration.md).
+   - **`gh`** authenticated (`gh auth login`) so it can file issues and open/merge PRs.
+   - The **agent worker** running (`lifeos-agent-worker`) — it runs the doctor's Claude Code sessions.
+4. **Restart** to pick up the new bot: `./scripts/server.sh restart`.
+
+## Autonomy and safety
+
+- **One gate.** Full-auto from your "yes" through merge; `/implement`'s built-in adversarial review is the quality bar.
+- **Escalation respected.** If `/implement` can't resolve its review findings after 3 rounds, the doctor leaves the PR open and reports the escalation instead of merging.
+- **Isolation.** Implementation happens in a throwaway worktree off `origin/main`, so the canonical checkout other agents share is never left on a feature branch.
+- **Pick-up after merge.** The doctor pulls merged `main` into the canonical checkout before restarting, so the running server actually reflects the change.
+
+## Adding another orchestration bot
+
+The doctor's machinery is generic. To add another orchestration surface, add an entry to [`config/telegram_bots.json`](../../config/telegram_bots.json) with `"orchestrates": true`, write its contract in `config/personas/<name>.md`, and set its `*_BOT_TOKEN`. A pure-chat specialized bot is the same minus `orchestrates` (it routes to the chat pipeline with its persona).
+
+## Related Documents
+
+### Operational
+- [Configuration](configuration.md) — `TELEGRAM_DOCTOR_*` and the specialized-bot env vars.
+- [Claude Code Orchestration](claude-code-orchestration.md) — Claude Code install/auth on the server, shared by the doctor.
+- [Agent Worker Setup](agent-worker-setup.md) — The worker that runs the doctor's sessions.
+
+### Code References
+- [`config/telegram_bots.json`](../../config/telegram_bots.json) — Bot registry (the `doctor` entry, `orchestrates: true`).
+- [`config/personas/doctor.md`](../../config/personas/doctor.md) — The orchestration contract the session runs.
+- [`api/services/telegram.py`](../../api/services/telegram.py) — Listener routing + bot-scoped reply hooks.
+- [`api/services/agent_worker/worker.py`](../../api/services/agent_worker/worker.py) — Bot-bound notification routing for Claude Code sessions.

--- a/tests/test_doctor_bot.py
+++ b/tests/test_doctor_bot.py
@@ -1,0 +1,351 @@
+"""Tests for the doctor bot — the self-repair orchestration surface (#348).
+
+Covers the four moving parts of bot-identity threading:
+  1. Registry: the `doctor` entry loads with `orchestrates=True`.
+  2. session_store: `bot` round-trips on sessions; pending-question reply
+     matching is scoped by bot (no cross-bot message-id collisions).
+  3. spawn: `spawn_claude_code_session(bot=...)` persists the bot on the row
+     and in the pending-message payload.
+  4. worker: a doctor session's BLOCKED notice routes through a bot-bound
+     sender and registers a `bot='doctor'` pending question.
+  5. telegram listener: the doctor bot spawns/owns a Claude Code session
+     instead of redirecting to chat; pure-chat bots are unaffected.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# 1. Registry — the doctor entry and the `orchestrates` flag
+# ---------------------------------------------------------------------------
+
+class TestDoctorRegistry:
+    def test_real_registry_has_orchestrating_doctor(self):
+        """The shipped config/telegram_bots.json declares the doctor bot as an
+        orchestration bot (so a fresh clone wires it correctly once the token
+        is set)."""
+        entries = json.loads(Path("config/telegram_bots.json").read_text())
+        doctor = next((e for e in entries if e.get("name") == "doctor"), None)
+        assert doctor is not None, "doctor entry missing from telegram_bots.json"
+        assert doctor.get("orchestrates") is True
+        assert doctor.get("token_env") == "TELEGRAM_DOCTOR_BOT_TOKEN"
+        assert doctor.get("persona_file") == "config/personas/doctor.md"
+
+    def test_loader_reads_orchestrates(self, tmp_path, monkeypatch):
+        reg = tmp_path / "bots.json"
+        reg.write_text(json.dumps([
+            {"name": "doctor", "token_env": "TG_DOC", "orchestrates": True},
+            {"name": "fitness", "token_env": "TG_FIT"},  # defaults to False
+        ]))
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_DOC", "doc-token")
+        monkeypatch.setenv("TG_FIT", "fit-token")
+        from config.settings import settings
+        bots = {b.name: b for b in settings.telegram_bots}
+        assert bots["doctor"].orchestrates is True
+        assert bots["fitness"].orchestrates is False
+
+    def test_persona_file_encodes_orchestration_contract(self):
+        """The doctor persona must carry the actual workflow, not be a stub."""
+        text = Path("config/personas/doctor.md").read_text().lower()
+        for needle in ("/draft-issue", "/implement", "worktree", "[clarify]", "[notify]", "restart"):
+            assert needle in text, f"doctor persona missing '{needle}'"
+
+
+# ---------------------------------------------------------------------------
+# 2. session_store — bot round-trip + bot-scoped reply matching
+# ---------------------------------------------------------------------------
+
+class TestSessionStoreBotScoping:
+    def _store(self, tmp_path):
+        from api.services.agent_worker.session_store import SessionStore
+        return SessionStore(db_path=tmp_path / "sessions.db")
+
+    def test_bot_round_trips_on_session(self, tmp_path):
+        store = self._store(tmp_path)
+        store.create(task_id="t1", routing="claude_code", origin="operator", bot="doctor")
+        s = store.get_by_session_id(store.get("t1").session_id)
+        assert s.bot == "doctor"
+
+    def test_bot_defaults_null_for_primary(self, tmp_path):
+        store = self._store(tmp_path)
+        store.create(task_id="t1", routing="claude_code", origin="operator")
+        assert store.get("t1").bot is None
+
+    def test_reply_matching_is_bot_scoped(self, tmp_path):
+        """Two questions share a numeric message id across bots; a reply must
+        only match its own bot's row."""
+        store = self._store(tmp_path)
+        store.create(task_id="doc", routing="claude_code", origin="operator", bot="doctor")
+        store.create(task_id="pri", routing="claude_code", origin="operator")
+        doc_sid = store.get("doc").session_id
+        pri_sid = store.get("pri").session_id
+        store.create_pending_question(
+            session_id=doc_sid, task_id="doc", question="q", sent_message_id=500,
+            kind="followup", bot="doctor",
+        )
+        store.create_pending_question(
+            session_id=pri_sid, task_id="pri", question="q", sent_message_id=500,
+            kind="followup", bot=None,  # primary / legacy
+        )
+        # A doctor reply to msg 500 matches only the doctor row.
+        q = store.get_open_question_by_message_id(500, bot="doctor")
+        assert q is not None and q["session_id"] == doc_sid
+        # A primary reply to msg 500 matches the NULL-bot (primary) row.
+        q = store.get_open_question_by_message_id(500, bot="primary")
+        assert q is not None and q["session_id"] == pri_sid
+
+    def test_primary_matches_legacy_null_bot(self, tmp_path):
+        """bot='primary' must still match pre-#348 rows that have NULL bot."""
+        store = self._store(tmp_path)
+        store.create(task_id="pri", routing="claude_code", origin="operator")
+        sid = store.get("pri").session_id
+        store.create_pending_question(
+            session_id=sid, task_id="pri", question="q", sent_message_id=42,
+            kind="followup", bot=None,
+        )
+        assert store.deposit_answer(42, "yes", bot="primary") is True
+
+    def test_doctor_reply_does_not_match_primary_question(self, tmp_path):
+        store = self._store(tmp_path)
+        store.create(task_id="pri", routing="claude_code", origin="operator")
+        sid = store.get("pri").session_id
+        store.create_pending_question(
+            session_id=sid, task_id="pri", question="q", sent_message_id=99,
+            kind="followup", bot=None,
+        )
+        # Doctor reply must NOT consume the primary's question.
+        assert store.deposit_answer(99, "yes", bot="doctor") is False
+        assert store.get_open_question_by_message_id(99, bot="doctor") is None
+
+    def test_unscoped_lookup_preserves_legacy_behavior(self, tmp_path):
+        """bot=None (no scoping) matches regardless of the row's bot — the
+        contract existing callers rely on."""
+        store = self._store(tmp_path)
+        store.create(task_id="doc", routing="claude_code", origin="operator", bot="doctor")
+        sid = store.get("doc").session_id
+        store.create_pending_question(
+            session_id=sid, task_id="doc", question="q", sent_message_id=7,
+            kind="followup", bot="doctor",
+        )
+        assert store.get_open_question_by_message_id(7) is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. spawn — bot persisted on the row and in the payload
+# ---------------------------------------------------------------------------
+
+class TestSpawnCarriesBot:
+    def test_spawn_persists_bot_on_session_and_payload(self, tmp_path):
+        from api.services.agent_worker.session_store import SessionStore
+        from api.services.agent_worker.claude_code_spawn import (
+            spawn_claude_code_session, parse_claude_code_spawn_payload,
+        )
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        result = spawn_claude_code_session(
+            store, "fix the sync bug", working_dir="/tmp/x", chat_id="123", bot="doctor",
+        )
+        assert result["ok"]
+        session = store.get_by_session_id(result["session_id"])
+        assert session.bot == "doctor"
+        # The enqueued operator message carries the bot for the worker dispatch.
+        pending = store.drain_pending_messages(result["session_id"])
+        payload = parse_claude_code_spawn_payload(pending[0]["content"])
+        assert payload["bot"] == "doctor"
+
+    def test_spawn_without_bot_defaults_primary(self, tmp_path):
+        from api.services.agent_worker.session_store import SessionStore
+        from api.services.agent_worker.claude_code_spawn import spawn_claude_code_session
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        result = spawn_claude_code_session(store, "do a thing", chat_id="1")
+        assert store.get_by_session_id(result["session_id"]).bot is None
+
+    def test_parse_payload_defaults_bot_none_for_bare_prompt(self):
+        from api.services.agent_worker.claude_code_spawn import parse_claude_code_spawn_payload
+        assert parse_claude_code_spawn_payload("just a prompt")["bot"] is None
+
+
+# ---------------------------------------------------------------------------
+# 4. worker — doctor session notices route through a bot-bound sender
+# ---------------------------------------------------------------------------
+
+class TestWorkerRoutesByBot:
+    def _make_worker(self, tmp_path, executor):
+        from api.services.agent_worker.session_store import SessionStore
+        from api.services.agent_worker.spend_tracker import SpendTracker
+        from api.services.agent_worker.transcript_store import TranscriptStore
+        from api.services.agent_worker.worker import Worker, _SynchronousPool
+
+        transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+        client = httpx.Client(transport=transport, base_url="http://api")
+        sent_with_ids: list[tuple] = []
+        sent: list[tuple] = []
+
+        def _send_with_id(text, chat_id=None, bot=None):
+            msg_id = len(sent_with_ids) + 5000
+            sent_with_ids.append((msg_id, text, bot))
+            return [msg_id]
+
+        def _send(text, chat_id=None, bot=None):
+            sent.append((text, bot))
+            return True
+
+        w = Worker(
+            api_base="http://api",
+            session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+            transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+            spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+            poll_seconds=0.01,
+            telegram_send=_send,
+            telegram_send_with_id=_send_with_id,
+            http_client=client,
+            claude_code_executor=executor,
+            cli_pool=_SynchronousPool(),
+        )
+        w._sent = sent  # type: ignore[attr-defined]
+        w._sent_with_ids = sent_with_ids  # type: ignore[attr-defined]
+        return w
+
+    def test_blocked_doctor_session_routes_to_doctor_bot(self, tmp_path):
+        from dataclasses import dataclass
+        from api.services.agent_worker.claude_code_executor import (
+            REASON_AWAITING_CLARIFICATION,
+        )
+        from api.services.agent_worker.local_executor import ExecutorOutcome
+        from api.services.agent_worker.claude_code_spawn import spawn_claude_code_session
+        from api.services.agent_worker.session_store import STATUS_BLOCKED
+
+        @dataclass
+        class _Stub:
+            outcome: ExecutorOutcome
+            def execute(self, session, task):
+                return self.outcome
+            def resume(self, session, message, working_dir=None):
+                return self.outcome
+
+        stub = _Stub(ExecutorOutcome(
+            status=STATUS_BLOCKED, reason=REASON_AWAITING_CLARIFICATION, final_text="which file?",
+        ))
+        w = self._make_worker(tmp_path, stub)
+        result = spawn_claude_code_session(
+            w.session_store, "fix it", chat_id="123", bot="doctor",
+        )
+        w._dispatch_spawned_sessions()
+
+        # The reply prompt went out tagged to the doctor bot...
+        assert w._sent_with_ids, "no id-captured message was sent"
+        assert w._sent_with_ids[-1][2] == "doctor"
+        # ...and the registered pending question is scoped to the doctor bot.
+        q = w.session_store.get_open_question_by_message_id(
+            w._sent_with_ids[-1][0], bot="doctor",
+        )
+        assert q is not None
+        assert q["session_id"] == result["session_id"]
+
+    def test_get_executor_caches_per_bot(self, tmp_path):
+        """Without an injected executor, each bot gets its own executor
+        instance (so notification callbacks stay bot-bound)."""
+        w = self._make_worker(tmp_path, executor=None)
+        w._claude_code_executor = None  # force the production lazy path
+        doc = w._get_claude_code_executor("doctor")
+        pri = w._get_claude_code_executor(None)
+        again = w._get_claude_code_executor("doctor")
+        assert doc is again
+        assert doc is not pri
+
+
+# ---------------------------------------------------------------------------
+# 5. telegram listener — doctor spawns/owns sessions; chat bots unaffected
+# ---------------------------------------------------------------------------
+
+class _DummyTyping:
+    def __init__(self, *a, **k):
+        pass
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, *a):
+        return False
+
+
+class TestDoctorListener:
+    def _listener(self, name, chat_id, persona="", orchestrates=False):
+        from api.services.telegram import TelegramBotListener
+        from config.settings import TelegramBotConfig
+        bot = TelegramBotConfig(
+            name=name, token="TOK", chat_id=chat_id, persona=persona, orchestrates=orchestrates,
+        )
+        return TelegramBotListener(bot)
+
+    def test_doctor_owns_agent_sessions(self):
+        listener = self._listener("doctor", "999", persona="P", orchestrates=True)
+        assert listener._owns_agent_sessions is True
+        assert listener._bot.orchestrates is True
+
+    def test_pure_chat_bot_does_not_own_sessions(self):
+        listener = self._listener("fitness", "999", persona="P", orchestrates=False)
+        assert listener._owns_agent_sessions is False
+
+    @pytest.mark.asyncio
+    async def test_doctor_message_spawns_session_not_chat(self):
+        listener = self._listener("doctor", "999", persona="DOCTOR CONTRACT", orchestrates=True)
+        update = {"message": {"text": "search is broken", "chat": {"id": 999}, "message_id": 1}}
+
+        spawn = MagicMock(return_value={"ok": True, "session_id": "sess_x", "task_id": "t"})
+        with patch("api.services.agent_worker.claude_code_spawn.spawn_claude_code_session", spawn), \
+             patch("api.services.agent_worker.session_store.SessionStore"), \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock), \
+             patch("api.services.telegram.TypingIndicator", _DummyTyping), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            await listener._handle_update(update)
+
+        # Doctor drives a Claude Code session, never the chat pipeline.
+        mock_chat.assert_not_called()
+        spawn.assert_called_once()
+        kwargs = spawn.call_args.kwargs
+        assert kwargs["bot"] == "doctor"
+        assert kwargs["working_dir"].endswith("/LifeOS")
+        # The persona is the orchestration prompt prefix; the report is appended.
+        prompt = spawn.call_args.args[1]
+        assert "DOCTOR CONTRACT" in prompt
+        assert "search is broken" in prompt
+
+    @pytest.mark.asyncio
+    async def test_doctor_threaded_reply_runs_resume_hook(self):
+        listener = self._listener("doctor", "999", persona="P", orchestrates=True)
+        update = {"message": {
+            "text": "yes",
+            "chat": {"id": 999},
+            "message_id": 2,
+            "reply_to_message": {"message_id": 5000},
+        }}
+        with patch.object(listener, "_maybe_handle_claude_code_reply",
+                          new_callable=AsyncMock, return_value=True) as mock_resume, \
+             patch.object(listener, "_handle_orchestration_message", new_callable=AsyncMock) as mock_spawn, \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock):
+            await listener._handle_update(update)
+        # The reply resumed the session; it did NOT spawn a fresh one.
+        mock_resume.assert_awaited_once()
+        mock_spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pure_chat_bot_never_spawns(self):
+        listener = self._listener("fitness", "999", persona="P", orchestrates=False)
+        update = {"message": {"text": "bench 135x8", "chat": {"id": 999}, "message_id": 3}}
+        with patch.object(listener, "_handle_orchestration_message", new_callable=AsyncMock) as mock_spawn, \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock), \
+             patch("api.services.telegram.TypingIndicator", _DummyTyping), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            mock_chat.return_value = {"answer": "Logged", "conversation_id": "c1"}
+            await listener._handle_update(update)
+        mock_spawn.assert_not_called()
+        mock_chat.assert_awaited_once()  # pure chat, as before


### PR DESCRIPTION
## Summary

Adds **doctor**, a new orchestration Telegram bot alongside fitness/therapist. You report a LifeOS problem; it clarifies, files a GitHub issue (clickable link), asks whether to implement, then on your "yes" ships the fix end to end (worktree off `origin/main` → `/implement` → PR → adversarial review → merge → pull main → restart) and reports back — all on the doctor bot.

The real work is **threading a Telegram bot identity** through spawn → agent-worker → notification/clarification/reply so a specialized bot can own a Claude Code session end to end (previously only the primary bot could, since the worker sent every notice through one bot-less callback). The doctor surface itself is then a thin layer: a registry entry, a persona that is the orchestration contract, and a listener branch that spawns/owns the session.

Closes #348

## What changed

**Bot-identity threading** (`feat(agent-worker)` commit)
- `session_store`: additive `bot` column on `sessions` + `pending_questions` (idempotent migrations); bot-scoped `deposit_answer` / `get_open_question_by_message_id` (`bot="primary"` still matches legacy `NULL` rows).
- `claude_code_spawn`: `bot` in the spawn payload and on the session row.
- `worker`: per-bot `ClaudeCodeExecutor` cache with a bot-bound notification callback; bot-bound block/completion/failure sends; `bot` stamped on registered follow-up questions. **Primary path is byte-identical** (`bot=None`).
- `settings`: `TelegramBotConfig.orchestrates`, read from the registry.

**Doctor surface** (`feat(telegram)` commit)
- `telegram`: the doctor listener spawns/owns a Claude Code session (persona = orchestration contract, message = problem report) instead of routing to chat; reply hooks now run for orchestration bots, scoped to their own bot.
- `config/telegram_bots.json` (`doctor`, `orchestrates: true`) + `config/personas/doctor.md` + `.env.example`.
- Docs: new `docs/guides/doctor-bot.md` + the previously-missing specialized-bot config docs, with bidirectional links.

## Design notes / decisions

- **Single orchestration session (Option A):** one Claude Code session drives clarify → draft-issue → gate → implement, reusing the existing `[NOTIFY]`/`[CLARIFY]`/resume model. The implement gate is just a `[CLARIFY]`.
- **Autonomy:** full-auto through merge with one human gate ("implement?"); `/implement`'s own 3-round review escalation is respected (doctor reports instead of merging).
- **Edge cases handled in the persona:** pull-before-restart, the self-restart hazard (notify before restarting the agent-worker), and missing `gh` auth.

## Test evidence

`./scripts/test.sh auto` and the affected-area sweep (telegram, agent-worker, settings): **all green**. New `tests/test_doctor_bot.py` (19 tests) covers the registry, bot-scoped reply matching (incl. cross-bot collision + legacy NULL), spawn payload, worker routing, and listener behavior (incl. pure-chat bots unaffected). Full unit suite: `2058 passed` (the lone hook failure was a known parallel-load flake in `test_scheduler_watcher.py`, unrelated — passes 3/3 in isolation).

Pre-existing, unrelated failures in this worktree (empty data DBs + machine `.env` `local_llm_model` override) were confirmed by stashing all changes and reproducing them on the clean tree.

## Review focus

- `session_store` bot-scoping SQL (`_bot_scope_clause`) — the `bot="primary"` ↔ legacy `NULL` matching is the subtle part.
- `worker._dispatch_claude_code_session` / `_get_claude_code_executor` — that the primary path stays byte-identical and only orchestration bots opt into bot-bound sends.
- `telegram._handle_orchestration_message` + the reply-hook gating (`_owns_agent_sessions`).
- `config/personas/doctor.md` — the orchestration contract the live session actually executes.