### PR TITLE
feat(personas): HTTP persona discovery and persona_id for chat API

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -791,6 +791,35 @@ def find_task_by_topic(
 
 router = APIRouter(prefix="/api", tags=["chat"])
 
+
+class PersonaInfoResponse(BaseModel):
+    """A single HTTP-visible chat persona (no secrets)."""
+    id: str
+    label: str
+    capabilities: list[str] = []
+
+
+class PersonasResponse(BaseModel):
+    """Response for the persona discovery endpoint."""
+    personas: list[PersonaInfoResponse]
+
+
+@router.get("/personas", response_model=PersonasResponse)
+async def list_personas():
+    """List chat personas available to HTTP clients (web, voice/whisper-relay).
+
+    Returns the primary persona plus each configured specialized bot. Adding a
+    registry entry + its token env var surfaces a new persona after restart with
+    no code change. Only the primary advertises handoff/agent capabilities.
+    """
+    return PersonasResponse(
+        personas=[
+            PersonaInfoResponse(id=p.id, label=p.label, capabilities=p.capabilities)
+            for p in settings.list_http_personas()
+        ]
+    )
+
+
 # Attachment configuration
 ALLOWED_MEDIA_TYPES = {
     # Images - 5MB each
@@ -849,6 +878,11 @@ class AskStreamRequest(BaseModel):
     conversation_id: Optional[str] = None
     attachments: Optional[list[Attachment]] = None
     persona: Optional[str] = None
+    # HTTP clients (web, voice) select a persona by id; the server resolves it to
+    # the same preamble the matching Telegram bot uses. The raw `persona` field
+    # above is the internal Telegram path (full preamble text); the two are
+    # mutually exclusive (sending both is a 400 in the route handler).
+    persona_id: Optional[str] = None
 
     @field_validator("persona")
     @classmethod
@@ -981,6 +1015,27 @@ async def ask_stream(request: AskStreamRequest):
     if not request.question.strip():
         raise HTTPException(status_code=400, detail="Question cannot be empty")
 
+    # Resolve persona BEFORE the SSE stream opens so an invalid selection is a
+    # clean 400 rather than a mid-stream error. `persona` (raw preamble text) is
+    # the internal Telegram path; `persona_id` is the HTTP-client path resolved
+    # against the same registry. They are mutually exclusive.
+    persona_preamble = request.persona or ""
+    new_conversation_persona_id = "primary"
+    if request.persona_id is not None:
+        if request.persona is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Provide either persona_id or persona, not both",
+            )
+        resolved = settings.resolve_persona(request.persona_id)
+        if resolved is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown persona_id: {request.persona_id!r}",
+            )
+        persona_preamble = resolved
+        new_conversation_persona_id = request.persona_id
+
     async def generate():
         try:
             # Get or create conversation
@@ -988,8 +1043,9 @@ async def ask_stream(request: AskStreamRequest):
             conversation_id = request.conversation_id
 
             if not conversation_id:
-                # Create new conversation
-                conv = store.create_conversation()
+                # Create new conversation, tagged with the selected persona so
+                # persona-scoped listing (e.g. the voice sidebar) can filter it.
+                conv = store.create_conversation(persona_id=new_conversation_persona_id)
                 conversation_id = conv.id
                 # Generate title from question
                 title = generate_title(request.question)
@@ -1224,7 +1280,7 @@ async def ask_stream(request: AskStreamRequest):
                 model_tier=orchestrator_model,
                 max_tool_rounds=5,
                 model=orchestrator_model if escalated else "",
-                persona=request.persona or "",
+                persona=persona_preamble,
             ):
                 if event["type"] == "text":
                     yield f"data: {json.dumps({'type': 'content', 'content': event['content']})}\n\n"

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -13,7 +13,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from api.services.conversation_store import (
-    get_store, generate_title, format_conversation_history
+    get_store, generate_title
 )
 from api.services.hybrid_search import HybridSearch
 from api.services.synthesizer import construct_prompt, get_synthesizer
@@ -36,6 +36,7 @@ class ConversationResponse(BaseModel):
     created_at: str
     updated_at: str
     message_count: int
+    persona_id: str = "primary"
 
 
 class MessageResponse(BaseModel):
@@ -68,14 +69,16 @@ class AskRequest(BaseModel):
 
 
 @router.get("", response_model=ConversationListResponse)
-async def list_conversations():
+async def list_conversations(persona_id: str = "primary"):
     """
-    List all conversations sorted by most recent.
+    List conversations for a persona, sorted by most recent.
 
-    Returns up to 50 conversations with metadata.
+    Returns up to 50 conversations with metadata. ``persona_id`` defaults to
+    ``"primary"`` so web chat (which omits it) keeps seeing its own threads;
+    pass e.g. ``?persona_id=fitness`` to scope to a specialized persona.
     """
     store = get_store()
-    conversations = store.list_conversations()
+    conversations = store.list_conversations(persona_id=persona_id)
 
     return ConversationListResponse(
         conversations=[
@@ -84,7 +87,8 @@ async def list_conversations():
                 title=c.title,
                 created_at=c.created_at.isoformat(),
                 updated_at=c.updated_at.isoformat(),
-                message_count=c.message_count
+                message_count=c.message_count,
+                persona_id=c.persona_id,
             )
             for c in conversations
         ]

--- a/api/services/conversation_store.py
+++ b/api/services/conversation_store.py
@@ -7,7 +7,7 @@ import sqlite3
 import json
 import uuid
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -32,6 +32,7 @@ class Conversation:
     created_at: datetime
     updated_at: datetime
     message_count: int = 0
+    persona_id: str = "primary"
 
 
 @dataclass
@@ -72,10 +73,22 @@ class ConversationStore:
                 CREATE TABLE IF NOT EXISTS conversations (
                     id TEXT PRIMARY KEY,
                     title TEXT NOT NULL,
+                    persona_id TEXT NOT NULL DEFAULT 'primary',
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
             """)
+            # Additive migration for pre-existing databases (#351): tag each
+            # conversation with the persona that owns it. Existing rows backfill
+            # to 'primary' so web/Telegram history is unaffected.
+            existing_cols = {
+                row[1] for row in conn.execute("PRAGMA table_info(conversations)")
+            }
+            if "persona_id" not in existing_cols:
+                conn.execute(
+                    "ALTER TABLE conversations "
+                    "ADD COLUMN persona_id TEXT NOT NULL DEFAULT 'primary'"
+                )
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS messages (
                     id TEXT PRIMARY KEY,
@@ -97,12 +110,17 @@ class ConversationStore:
         finally:
             conn.close()
 
-    def create_conversation(self, title: Optional[str] = None) -> Conversation:
+    def create_conversation(
+        self,
+        title: Optional[str] = None,
+        persona_id: str = "primary",
+    ) -> Conversation:
         """
         Create a new conversation.
 
         Args:
             title: Optional title (default "New Conversation")
+            persona_id: Persona that owns the thread (default "primary")
 
         Returns:
             Created conversation
@@ -114,8 +132,9 @@ class ConversationStore:
         conn = sqlite3.connect(self.db_path)
         try:
             conn.execute(
-                "INSERT INTO conversations (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)",
-                (conv_id, title, now, now)
+                "INSERT INTO conversations (id, title, persona_id, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (conv_id, title, persona_id, now, now)
             )
             conn.commit()
         finally:
@@ -126,7 +145,8 @@ class ConversationStore:
             title=title,
             created_at=now,
             updated_at=now,
-            message_count=0
+            message_count=0,
+            persona_id=persona_id,
         )
 
     def get_conversation(self, conv_id: str) -> Optional[Conversation]:
@@ -144,7 +164,7 @@ class ConversationStore:
             cursor = conn.execute(
                 """
                 SELECT c.id, c.title, c.created_at, c.updated_at,
-                       COUNT(m.id) as message_count
+                       COUNT(m.id) as message_count, c.persona_id
                 FROM conversations c
                 LEFT JOIN messages m ON m.conversation_id = c.id
                 WHERE c.id = ?
@@ -162,34 +182,49 @@ class ConversationStore:
                 title=row[1],
                 created_at=datetime.fromisoformat(row[2]) if isinstance(row[2], str) else row[2],
                 updated_at=datetime.fromisoformat(row[3]) if isinstance(row[3], str) else row[3],
-                message_count=row[4]
+                message_count=row[4],
+                persona_id=row[5] or "primary",
             )
         finally:
             conn.close()
 
-    def list_conversations(self, limit: int = 50) -> list[Conversation]:
+    def list_conversations(
+        self,
+        limit: int = 50,
+        persona_id: Optional[str] = None,
+    ) -> list[Conversation]:
         """
-        List all conversations sorted by updated_at desc.
+        List conversations sorted by updated_at desc.
 
         Args:
             limit: Maximum number of conversations to return
+            persona_id: When set, return only threads owned by that persona.
+                When None, return all personas' threads.
 
         Returns:
             List of conversations
         """
+        where = ""
+        params: list = []
+        if persona_id is not None:
+            where = "WHERE c.persona_id = ?"
+            params.append(persona_id)
+        params.append(limit)
+
         conn = sqlite3.connect(self.db_path)
         try:
             cursor = conn.execute(
-                """
+                f"""
                 SELECT c.id, c.title, c.created_at, c.updated_at,
-                       COUNT(m.id) as message_count
+                       COUNT(m.id) as message_count, c.persona_id
                 FROM conversations c
                 LEFT JOIN messages m ON m.conversation_id = c.id
+                {where}
                 GROUP BY c.id
                 ORDER BY c.updated_at DESC
                 LIMIT ?
                 """,
-                (limit,)
+                params
             )
 
             conversations = []
@@ -199,7 +234,8 @@ class ConversationStore:
                     title=row[1],
                     created_at=datetime.fromisoformat(row[2]) if isinstance(row[2], str) else row[2],
                     updated_at=datetime.fromisoformat(row[3]) if isinstance(row[3], str) else row[3],
-                    message_count=row[4]
+                    message_count=row[4],
+                    persona_id=row[5] or "primary",
                 ))
 
             return conversations

--- a/config/settings.py
+++ b/config/settings.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from dotenv import dotenv_values
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -25,12 +25,29 @@ class TelegramBotConfig:
 
     ``name`` doubles as the per-bot state-file suffix, so it must be filesystem
     safe. ``persona`` is a system-prompt preamble injected for this bot's chats
-    (empty for the primary bot).
+    (empty for the primary bot). ``label`` is an optional human-friendly display
+    name surfaced to HTTP clients; when blank, callers fall back to the
+    capitalized ``name``.
     """
     name: str
     token: str
     chat_id: str
     persona: str = ""
+    label: str = ""
+
+
+# Capabilities advertised to HTTP clients for the primary persona only.
+# Specialized bots are pure chat (no /agent, no engine handoff), matching the
+# Telegram primary-only command surface.
+PRIMARY_PERSONA_CAPABILITIES = ("handoff", "agent")
+
+
+@dataclass(frozen=True)
+class PersonaInfo:
+    """An HTTP-visible chat persona (no secrets) for the discovery endpoint."""
+    id: str
+    label: str
+    capabilities: list = field(default_factory=list)
 
 
 class Settings(BaseSettings):
@@ -746,9 +763,50 @@ class Settings(BaseSettings):
                     persona = Path(persona_file).read_text().strip()
                 except OSError as e:
                     logger.warning(f"Telegram bot '{name}': could not read persona file {persona_file}: {e}")
+            label = (entry.get("label") or "").strip()
             seen.add(name)
-            bots.append(TelegramBotConfig(name=name, token=token, chat_id=chat_id, persona=persona))
+            bots.append(TelegramBotConfig(
+                name=name, token=token, chat_id=chat_id, persona=persona, label=label
+            ))
         return bots
+
+    def list_http_personas(self) -> list["PersonaInfo"]:
+        """Chat personas visible to HTTP clients (web, voice/whisper-relay).
+
+        Returns the primary persona plus every configured specialized bot from
+        the registry whose token env is set (``telegram_bots`` already drops the
+        unset ones). No secrets are exposed. Only the primary advertises
+        ``handoff``/``agent`` capabilities; specialized bots are pure chat.
+        Adding a registry entry + its token env var surfaces a new persona on
+        the next restart with no code change.
+        """
+        personas = [PersonaInfo(
+            id="primary",
+            label="LifeOS",
+            capabilities=list(PRIMARY_PERSONA_CAPABILITIES),
+        )]
+        for bot in self.telegram_bots:
+            personas.append(PersonaInfo(
+                id=bot.name,
+                label=bot.label or bot.name.capitalize(),
+                capabilities=[],
+            ))
+        return personas
+
+    def resolve_persona(self, persona_id: str) -> "str | None":
+        """Resolve a persona id to its system-prompt preamble for HTTP clients.
+
+        Same registry source as Telegram, so ``persona_id="fitness"`` yields the
+        exact preamble the fitness Telegram bot uses. ``"primary"`` resolves to
+        an empty preamble (the default, no persona). Returns ``None`` for an
+        unknown id so the caller can reject it with HTTP 400.
+        """
+        if persona_id == "primary":
+            return ""
+        for bot in self.telegram_bots:
+            if bot.name == persona_id:
+                return bot.persona
+        return None
 
     @property
     def photos_db_path(self) -> str:

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** API Gateway
-**Last Updated:** 2026-06-18
+**Last Updated:** 2026-06-21
 
 Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two adjacent catalogs split out for size:
 
@@ -56,9 +56,13 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 {
   "question": "What did we discuss in the product meeting?",
   "conversation_id": "optional-uuid",
-  "include_sources": true
+  "include_sources": true,
+  "persona_id": "fitness"
 }
 ```
+
+- `persona_id` (optional) — selects a chat persona by id (see [`GET /api/personas`](#get-apipersonas)). The server applies the same system-prompt preamble the matching Telegram bot uses. Unknown ids return **400**. Omit it for the default (`primary`) persona. A new conversation created in this call is tagged with the persona so it can be filtered later (see [`GET /api/conversations`](#get-apiconversations)).
+- `persona` (optional, internal) — raw preamble text used by the in-process Telegram client. Mutually exclusive with `persona_id` (sending both returns **400**); HTTP clients should use `persona_id`.
 
 **Response:** Server-Sent Events stream with event types:
 
@@ -107,6 +111,25 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 | `search_memories` | Search previously saved memories |
 
 **Prompt caching (Anthropic backend only):** System prompt and tool definitions use Anthropic `cache_control` breakpoints. Cache reads cost 0.1x input price; repeated queries within 5 minutes hit the cache.
+
+### GET /api/personas
+
+List chat personas available to HTTP clients (web chat, voice/whisper-relay). Returns the `primary` persona plus each configured specialized Telegram bot whose token env is set. No secrets are exposed. Adding a registry entry (`config/telegram_bots.json`) plus its token env var surfaces a new persona after restart — no code change.
+
+**Response:**
+```json
+{
+  "personas": [
+    { "id": "primary", "label": "LifeOS", "capabilities": ["handoff", "agent"] },
+    { "id": "fitness", "label": "Fitness", "capabilities": [] },
+    { "id": "therapist", "label": "Therapist", "capabilities": [] }
+  ]
+}
+```
+
+- `id` — pass as `persona_id` on [`POST /api/ask/stream`](#post-apiaskstream) and as the `persona_id` query param on [`GET /api/conversations`](#get-apiconversations).
+- `label` — display name; defaults to the capitalized id when the registry entry omits an explicit `label`.
+- `capabilities` — only `primary` advertises `["handoff", "agent"]` (CLI engine handoff and `/agent` spawns). Specialized personas are pure chat (`[]`).
 
 ### POST /api/chat/handoff
 
@@ -418,7 +441,10 @@ Search memories by keyword.
 
 ### GET /api/conversations
 
-List all conversations (most recent first, up to 50).
+List conversations for a persona (most recent first, up to 50).
+
+**Query params:**
+- `persona_id` (optional, default `"primary"`) — scope to a persona's threads (e.g. `?persona_id=fitness`). Omitting it returns the `primary` persona's threads, preserving web-chat behavior. Persona ids come from [`GET /api/personas`](#get-apipersonas).
 
 **Response:**
 ```json
@@ -429,11 +455,14 @@ List all conversations (most recent first, up to 50).
       "title": "Budget planning",
       "created_at": "2026-06-01T12:00:00",
       "updated_at": "2026-06-01T12:05:00",
-      "message_count": 4
+      "message_count": 4,
+      "persona_id": "primary"
     }
   ]
 }
 ```
+
+Conversations are tagged with `persona_id` when created via `POST /api/ask/stream` (default `primary`); rows created before this field existed backfill to `primary`.
 
 ### POST /api/conversations
 
@@ -441,7 +470,7 @@ Create new conversation.
 
 ### GET /api/conversations/{id}
 
-Get conversation with messages.
+Get conversation with messages. Access by id is **not** persona-scoped — any valid id resolves regardless of its persona.
 
 **Response:**
 ```json

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-06-18
+> **Last Updated:** 2026-06-21
 
 LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that submit text and consume SSE without importing LifeOS Python modules. Endpoint and event **shapes** are defined in [api-reference.md](../product/api-reference.md); this doc covers **who consumes them**, **whisper-relay integration**, and **breaking-change policy**.
 
@@ -25,7 +25,13 @@ Voice transport in the same GitHub org as LifeOS: [github.com/nbramia/whisper-re
 
 Connects to LifeOS at `LIFEOS_BASE_URL` (default `http://127.0.0.1:8000`), 300s timeout on ask/stream, no auth headers — same trust model as web chat on localhost/Tailscale.
 
-**Endpoints used** (request/response shapes: [api-reference.md](../product/api-reference.md)): `POST /api/ask/stream`, `POST /api/chat/handoff`, `GET /api/conversations`, `GET /api/conversations/{id}`.
+**Endpoints used** (request/response shapes: [api-reference.md](../product/api-reference.md)): `GET /api/personas`, `POST /api/ask/stream`, `POST /api/chat/handoff`, `GET /api/conversations`, `GET /api/conversations/{id}`.
+
+**Persona contract** (shared by web and voice; lets a thin client expose LifeOS's multi-bot personas without reading LifeOS config):
+
+- `GET /api/personas` lists selectable personas (`primary` + configured specialized bots). The client renders these as a picker; ids are stable, labels are display-only. Only `primary` carries `handoff`/`agent` capabilities — gate any handoff UI on that.
+- Send the chosen `persona_id` on `POST /api/ask/stream`. The server applies the matching persona preamble and tags a newly created conversation with that persona. Unknown ids and `persona`+`persona_id` together are **400** — surface as a turn-level failure, not a crash.
+- Scope the thread sidebar with `GET /api/conversations?persona_id=<id>`. Omitting the param shows the `primary` persona's threads (default web behavior). Conversation detail (`GET /api/conversations/{id}`) is not persona-scoped — fetch by id directly.
 
 **Consumer-specific behavior** (LifeOS API unchanged; how whisper-relay interprets it):
 

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -1,0 +1,297 @@
+"""
+Tests for HTTP persona discovery and persona_id chat scoping (issue #351).
+
+Covers the settings registry helpers (list_http_personas / resolve_persona),
+the GET /api/personas discovery endpoint, persona_id resolution + 400 handling
+on POST /api/ask/stream, and persona-scoped conversation storage/listing.
+"""
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _registry(tmp_path, entries):
+    """Write a telegram_bots.json registry and point settings at it."""
+    reg = tmp_path / "bots.json"
+    reg.write_text(json.dumps(entries))
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# settings.list_http_personas
+# ---------------------------------------------------------------------------
+
+class TestListHttpPersonas:
+    def test_primary_plus_configured_bots(self, tmp_path, monkeypatch):
+        persona_file = tmp_path / "fitness.md"
+        persona_file.write_text("FIT PERSONA")
+        reg = _registry(tmp_path, [
+            {"name": "fitness", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT", "tok")
+        from config.settings import settings
+
+        personas = settings.list_http_personas()
+        assert [p.id for p in personas] == ["primary", "fitness"]
+
+        primary = personas[0]
+        assert primary.label == "LifeOS"
+        assert primary.capabilities == ["handoff", "agent"]
+
+        fitness = personas[1]
+        assert fitness.label == "Fitness"  # capitalized default
+        assert fitness.capabilities == []  # specialized bots are pure chat
+
+    def test_unset_token_bot_omitted(self, tmp_path, monkeypatch):
+        reg = _registry(tmp_path, [
+            {"name": "fitness", "token_env": "TG_FIT"},
+            {"name": "therapist", "token_env": "TG_THER"},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT", "tok")
+        monkeypatch.delenv("TG_THER", raising=False)
+        from config.settings import settings
+
+        assert [p.id for p in settings.list_http_personas()] == ["primary", "fitness"]
+
+    def test_new_registry_entry_surfaces_without_code_change(self, tmp_path, monkeypatch):
+        # Acceptance: adding a registry entry + env var surfaces a new persona.
+        reg = _registry(tmp_path, [{"name": "doctor", "token_env": "TG_DOC"}])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_DOC", "tok")
+        from config.settings import settings
+
+        ids = [p.id for p in settings.list_http_personas()]
+        assert "doctor" in ids
+
+    def test_custom_label_from_registry(self, tmp_path, monkeypatch):
+        reg = _registry(tmp_path, [
+            {"name": "doctor", "token_env": "TG_DOC", "label": "Dr. LifeOS"},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_DOC", "tok")
+        from config.settings import settings
+
+        doctor = settings.list_http_personas()[1]
+        assert doctor.label == "Dr. LifeOS"
+
+
+# ---------------------------------------------------------------------------
+# settings.resolve_persona
+# ---------------------------------------------------------------------------
+
+class TestResolvePersona:
+    def test_primary_resolves_to_empty(self):
+        from config.settings import settings
+        assert settings.resolve_persona("primary") == ""
+
+    def test_unknown_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", tmp_path / "none.json")
+        from config.settings import settings
+        assert settings.resolve_persona("ghost") is None
+
+    def test_known_resolves_to_bot_preamble(self, tmp_path, monkeypatch):
+        persona_file = tmp_path / "fitness.md"
+        persona_file.write_text("FIT PERSONA")
+        reg = _registry(tmp_path, [
+            {"name": "fitness", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT", "tok")
+        from config.settings import settings
+
+        # Same preamble the fitness Telegram bot uses (single registry source).
+        assert settings.resolve_persona("fitness") == "FIT PERSONA"
+        assert settings.resolve_persona("fitness") == settings.telegram_bots[0].persona
+
+
+# ---------------------------------------------------------------------------
+# GET /api/personas
+# ---------------------------------------------------------------------------
+
+class TestPersonasEndpoint:
+    def test_discovery_endpoint(self, client, tmp_path, monkeypatch):
+        persona_file = tmp_path / "fitness.md"
+        persona_file.write_text("FIT PERSONA")
+        reg = _registry(tmp_path, [
+            {"name": "fitness", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT", "tok")
+
+        resp = client.get("/api/personas")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [p["id"] for p in data["personas"]] == ["primary", "fitness"]
+        assert data["personas"][0]["capabilities"] == ["handoff", "agent"]
+        assert data["personas"][1]["capabilities"] == []
+
+
+# ---------------------------------------------------------------------------
+# persona_id resolution on POST /api/ask/stream
+# ---------------------------------------------------------------------------
+
+class TestAskStreamPersonaId:
+    def test_unknown_persona_id_returns_400(self, client, tmp_path, monkeypatch):
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", tmp_path / "none.json")
+        resp = client.post("/api/ask/stream", json={"question": "hi", "persona_id": "ghost"})
+        assert resp.status_code == 400
+        assert "ghost" in resp.json()["detail"]
+
+    def test_persona_and_persona_id_conflict_returns_400(self, client):
+        resp = client.post(
+            "/api/ask/stream",
+            json={"question": "hi", "persona": "X", "persona_id": "primary"},
+        )
+        assert resp.status_code == 400
+
+    def test_persona_id_applies_resolved_preamble(self, client, tmp_path, monkeypatch):
+        # End-to-end: persona_id="fitness" threads the fitness preamble into the
+        # agent loop, identical to what the fitness Telegram bot sends.
+        persona_file = tmp_path / "fitness.md"
+        persona_file.write_text("FIT PERSONA")
+        reg = _registry(tmp_path, [
+            {"name": "fitness", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT", "tok")
+
+        captured = {}
+
+        async def fake_loop(**kwargs):
+            captured.update(kwargs)
+            yield {"type": "result", "result": SimpleNamespace(
+                total_input_tokens=0, total_output_tokens=0, total_cost_usd=0.0,
+                model="x", tool_calls_log=[], full_text="ok",
+            )}
+
+        def fake_resolve(history, question, model, escalation_model):
+            return model, False
+
+        mock_store = MagicMock()
+        mock_store.create_conversation.return_value = SimpleNamespace(id="c1")
+        mock_store.get_messages.return_value = []
+
+        with patch("api.routes.chat.get_store", return_value=mock_store), \
+             patch("api.routes.chat.classify_action_intent", return_value=None), \
+             patch("api.services.agent_loop.run_agent_loop", fake_loop), \
+             patch("api.services.agent_loop.resolve_orchestrator_model", fake_resolve):
+            resp = client.post(
+                "/api/ask/stream",
+                json={"question": "log my workout", "persona_id": "fitness"},
+            )
+            # Drain the SSE stream so generate() runs to completion.
+            _ = resp.text
+
+        assert resp.status_code == 200
+        assert captured.get("persona") == "FIT PERSONA"
+        # New conversation tagged with the selected persona.
+        assert mock_store.create_conversation.call_args.kwargs.get("persona_id") == "fitness"
+
+
+# ---------------------------------------------------------------------------
+# persona-scoped conversation storage + listing
+# ---------------------------------------------------------------------------
+
+class TestConversationPersonaScoping:
+    @pytest.fixture
+    def store(self):
+        from api.services.conversation_store import ConversationStore
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            yield ConversationStore(db_path=path)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_create_defaults_to_primary(self, store):
+        conv = store.create_conversation(title="t")
+        assert conv.persona_id == "primary"
+        assert store.get_conversation(conv.id).persona_id == "primary"
+
+    def test_create_with_persona_id(self, store):
+        conv = store.create_conversation(title="t", persona_id="fitness")
+        assert conv.persona_id == "fitness"
+        assert store.get_conversation(conv.id).persona_id == "fitness"
+
+    def test_list_filters_by_persona(self, store):
+        store.create_conversation(title="web", persona_id="primary")
+        store.create_conversation(title="fit", persona_id="fitness")
+        store.create_conversation(title="fit2", persona_id="fitness")
+
+        primary = store.list_conversations(persona_id="primary")
+        fitness = store.list_conversations(persona_id="fitness")
+        assert {c.title for c in primary} == {"web"}
+        assert {c.title for c in fitness} == {"fit", "fit2"}
+
+    def test_list_without_filter_returns_all(self, store):
+        store.create_conversation(title="web", persona_id="primary")
+        store.create_conversation(title="fit", persona_id="fitness")
+        assert len(store.list_conversations()) == 2
+
+    def test_migration_backfills_existing_rows(self):
+        # A pre-#351 conversations table (no persona_id column) must migrate and
+        # backfill existing rows to 'primary'.
+        import sqlite3
+        from api.services.conversation_store import ConversationStore
+
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            conn = sqlite3.connect(path)
+            conn.execute(
+                "CREATE TABLE conversations (id TEXT PRIMARY KEY, title TEXT NOT NULL, "
+                "created_at TIMESTAMP, updated_at TIMESTAMP)"
+            )
+            conn.execute(
+                "INSERT INTO conversations (id, title, created_at, updated_at) "
+                "VALUES ('old', 'legacy', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            )
+            conn.commit()
+            conn.close()
+
+            store = ConversationStore(db_path=path)  # triggers migration
+            conv = store.get_conversation("old")
+            assert conv is not None
+            assert conv.persona_id == "primary"
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/conversations?persona_id=<id>
+# ---------------------------------------------------------------------------
+
+class TestConversationsListPersonaParam:
+    def test_default_param_is_primary(self, client):
+        mock_store = MagicMock()
+        mock_store.list_conversations.return_value = []
+        with patch("api.routes.conversations.get_store", return_value=mock_store):
+            resp = client.get("/api/conversations")
+        assert resp.status_code == 200
+        assert mock_store.list_conversations.call_args.kwargs.get("persona_id") == "primary"
+
+    def test_explicit_persona_param_forwarded(self, client):
+        mock_store = MagicMock()
+        mock_store.list_conversations.return_value = []
+        with patch("api.routes.conversations.get_store", return_value=mock_store):
+            resp = client.get("/api/conversations?persona_id=fitness")
+        assert resp.status_code == 200
+        assert mock_store.list_conversations.call_args.kwargs.get("persona_id") == "fitness"


### PR DESCRIPTION
## Summary

Exposes LifeOS's configured chat personas to HTTP clients (web chat, voice/whisper-relay) so they can select a persona per turn instead of always hitting the primary path. Until now only Telegram could route to the fitness/therapist/doctor bots; this extends the same registry to the HTTP contract.

Closes #351

## What changed

- **`GET /api/personas`** — discovery endpoint returning `primary` plus each configured specialized bot whose token env is set. Built from the same registry as Telegram startup (`settings.list_http_personas()`), so adding a `config/telegram_bots.json` entry + its token env surfaces a new persona after restart with no code change. No secrets exposed; only `primary` advertises `handoff`/`agent` capabilities.
- **`persona_id` on `POST /api/ask/stream`** — resolved **before** the SSE stream opens (clean 400, not a mid-stream error) to the exact preamble the matching Telegram bot uses. Unknown id → 400; sending both `persona` and `persona_id` → 400. The internal Telegram `persona` (raw text) path is unchanged.
- **Conversation scoping** — additive `persona_id` column on `conversations` (existing rows backfill to `'primary'` via an idempotent `ALTER TABLE` migration), set on creation via ask/stream, and `GET /api/conversations?persona_id=<id>` filtering. The query param defaults to `primary`, so web chat (which omits it) sees no behavior change.
- **Docs** — `api-reference.md` (new endpoint + request/response fields) and `client-surfaces.md` (whisper-relay persona contract); dates bumped.
- Dropped two pre-existing unused imports (`dataclasses.field`, `format_conversation_history`) in the touched files to pass the pre-commit ruff gate.

## Design decisions

- **Conflict rule:** `persona` + `persona_id` together → 400 (explicit over silent precedence). The two surfaces are mutually exclusive in practice (Telegram sends `persona`, HTTP sends `persona_id`).
- **Detail access:** `GET /api/conversations/{id}` is intentionally **not** persona-scoped (unchanged shape) — documented in api-reference.md.
- **Schema change:** the `persona_id` column is additive and backward-compatible; flagged here per AGENTS.md "Ask first: DB schema changes" — it's exactly what the issue specifies.

## Test evidence

New `tests/test_persona_api.py` (18 tests): discovery helper, resolution (`primary`→`""`, known→preamble, unknown→`None`), `GET /api/personas`, ask/stream 400s (unknown id + conflict), end-to-end `persona_id`→`run_agent_loop` preamble + conversation tagging, persona-scoped store create/get/list, and the backfill migration.

- `tests/test_persona_api.py` — **18 passed**
- Related suites (conversation_store, conversations_api, telegram_multibot, chat_api) — **123 passed**
- Full pre-push unit selection (`-m "unit and not slow"`) — **2058 passed, 8 skipped**

## Review focus

- Persona resolution + the two 400 guards in `ask_stream` (executed before streaming).
- The `conversations` `persona_id` migration / backfill and the `list_conversations` filter (f-string interpolates only a fixed literal; the value is parameterized).
- Default-`primary` behavior on `GET /api/conversations` (no regression for web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Notes

- **MCP `lifeos_conversations_list`**: this tool calls `GET /api/conversations`, which now defaults to `persona_id="primary"`. Today every conversation is tagged `primary` (legacy backfill + web + all Telegram bots send raw `persona` text, never `persona_id`), so the effective output is unchanged; once an HTTP client starts sending `persona_id`, this tool will list only the primary persona's threads. The tool definition is unchanged.
