### PR TITLE
feat(chat): persona picker on /chat

### DIFF
--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-06-21
+> **Last Updated:** 2026-06-22
 
 LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that submit text and consume SSE without importing LifeOS Python modules. Endpoint and event **shapes** are defined in [api-reference.md](../product/api-reference.md); this doc covers **who consumes them**, **whisper-relay integration**, and **breaking-change policy**.
 
@@ -12,7 +12,7 @@ LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that subm
 
 | Surface | Transport | Chat/conversation endpoints |
 |---------|-----------|----------------------------|
-| Web chat | Browser → FastAPI | ask/stream, handoff, conversation CRUD — `web/index.html` |
+| Web chat | Browser → FastAPI | personas, ask/stream, handoff, conversation CRUD — `web/index.html` + `web/chat/` |
 | Telegram | In-process `chat_via_api` | Same SSE as ask/stream; handoffs spawn in-process — `api/services/telegram.py` |
 | **whisper-relay** | Separate app → HTTP | ask/stream, handoff, `GET /api/conversations`, `GET /api/conversations/{id}` — see below |
 | MCP / Managed Agents | stdio or HTTP MCP | Tool catalog only — `mcp_server.py` |
@@ -32,6 +32,8 @@ Connects to LifeOS at `LIFEOS_BASE_URL` (default `http://127.0.0.1:8000`), 300s 
 - `GET /api/personas` lists selectable personas (`primary` + configured specialized bots). The client renders these as a picker; ids are stable, labels are display-only. The `primary` persona and orchestrating bots (e.g. the doctor self-repair bot) carry `handoff`/`agent` capabilities — gate any handoff UI on a persona's `capabilities`, not on a hardcoded `primary` check.
 - Send the chosen `persona_id` on `POST /api/ask/stream`. The server applies the matching persona preamble and tags a newly created conversation with that persona. Unknown ids and `persona`+`persona_id` together are **400** — surface as a turn-level failure, not a crash.
 - Scope the thread sidebar with `GET /api/conversations?persona_id=<id>`. Omitting the param shows the `primary` persona's threads (default web behavior). Conversation detail (`GET /api/conversations/{id}`) is not persona-scoped — fetch by id directly.
+
+Web chat implements this contract in `web/chat/persona.js`: a header `<select>` populated from `/api/personas`, the selection persisted across refresh in `sessionStorage` (`lifeos:chat:persona_id`), capability-gated `claude_intent` handoff, and a persona-scoped sidebar. Switching persona starts a fresh, persona-scoped conversation.
 
 **Consumer-specific behavior** (LifeOS API unchanged; how whisper-relay interprets it):
 

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-06-22
+> **Last Updated:** 2026-06-21
 
 LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that submit text and consume SSE without importing LifeOS Python modules. Endpoint and event **shapes** are defined in [api-reference.md](../product/api-reference.md); this doc covers **who consumes them**, **whisper-relay integration**, and **breaking-change policy**.
 

--- a/web/chat/ask-stream.js
+++ b/web/chat/ask-stream.js
@@ -7,6 +7,7 @@ import { state, config, elements, endpoints, hooks } from './session.js';
 import { addMessage, updateMessage, setStatus } from './thread.js';
 import { clearAttachments } from './attachments.js';
 import { loadConversations } from './conversations.js';
+import { personaSupportsHandoff } from './persona.js';
 
 // Low-level SSE transport. Builds the request body, opens the stream, and calls
 // `on(data)` for each parsed `data:` event. If `on` returns `true`, processing
@@ -141,30 +142,33 @@ export async function sendMessage() {
           state.sessionCost += data.cost_usd || 0;
           elements.sessionCostEl.textContent = '$' + state.sessionCost.toFixed(3);
         } else if (data.type === 'claude_intent') {
-          // Engine handoff (#305b/c): the orchestrator
-          // delegated to a CLI worker. Spawn it via the
-          // handoff endpoint and reflect it in the thread.
-          const engine = data.engine || 'claude_code';
-          const label = engine === 'codex' ? 'Codex' : 'Claude Code';
-          fullContent = '🤝 Handing off to ' + label + '…';
-          updateMessage(msgId, fullContent);
-          fetch(endpoints.handoff, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              engine: engine,
-              task: data.task || '',
-              conversation_id: state.currentConversationId,
-            }),
-          }).then(r => r.json()).then(d => {
-            fullContent = (d && d.message)
-              ? d.message
-              : '⚠️ Handoff to ' + label + ' failed.';
+          // Engine handoff (#305b/c): the orchestrator delegated to a CLI
+          // worker. Gate it on the selected persona's advertised capabilities
+          // (#359) — only personas with the `handoff` capability may trigger
+          // it; for others, ignore the intent (no handoff UI).
+          if (personaSupportsHandoff()) {
+            const engine = data.engine || 'claude_code';
+            const label = engine === 'codex' ? 'Codex' : 'Claude Code';
+            fullContent = '🤝 Handing off to ' + label + '…';
             updateMessage(msgId, fullContent);
-          }).catch(() => {
-            fullContent = '⚠️ Handoff to ' + label + ' failed.';
-            updateMessage(msgId, fullContent);
-          });
+            fetch(endpoints.handoff, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                engine: engine,
+                task: data.task || '',
+                conversation_id: state.currentConversationId,
+              }),
+            }).then(r => r.json()).then(d => {
+              fullContent = (d && d.message)
+                ? d.message
+                : '⚠️ Handoff to ' + label + ' failed.';
+              updateMessage(msgId, fullContent);
+            }).catch(() => {
+              fullContent = '⚠️ Handoff to ' + label + ' failed.';
+              updateMessage(msgId, fullContent);
+            });
+          }
         } else if (data.type === 'done') {
           // Add sources and meta to message
           const msgEl = document.getElementById(msgId);

--- a/web/chat/conversations.js
+++ b/web/chat/conversations.js
@@ -2,7 +2,7 @@
 // relative-time labels, and the mobile sidebar toggle + swipe gesture.
 // Extracted verbatim from index.html's inline <script>.
 
-import { state, elements, endpoints } from './session.js';
+import { state, config, elements, endpoints } from './session.js';
 import { addMessage, escapeHtml } from './thread.js';
 
 export function toggleSidebar() {
@@ -62,7 +62,10 @@ export function setupSwipeGestures() {
 
 export async function loadConversations() {
   try {
-    const response = await fetch(endpoints.conversations);
+    // Scope the sidebar to the selected persona (#359). Conversation detail
+    // (loadConversation / search) is fetched by id and is not persona-scoped.
+    const personaId = config.personaId || 'primary';
+    const response = await fetch(`${endpoints.conversations}?persona_id=${encodeURIComponent(personaId)}`);
     if (response.ok) {
       const data = await response.json();
       state.allConversations = data.conversations || [];

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -18,6 +18,7 @@ import {
   filterConversations, loadConversation, deleteConversation, loadConversations,
 } from './conversations.js';
 import { sendMessage, askQuestion } from './ask-stream.js';
+import { loadPersonas, onPersonaChange } from './persona.js';
 
 // Boot the chat surface. The shell passes in the explicit DOM element map (so
 // the modules never getElementById), the API endpoints, and integration hooks
@@ -45,6 +46,10 @@ export function initChat({ elements: els, endpoints: eps, hooks: hks } = {}) {
 
   setupAttachmentHandlers();
   setupSwipeGestures();
+  // loadPersonas() sets config.personaId synchronously (from sessionStorage)
+  // before its fetch, so the persona-scoped loadConversations() below is correct
+  // on first paint.
+  loadPersonas();
   loadConversations();
   setStatus('', 'Ready');
   inputField.focus();
@@ -63,4 +68,6 @@ Object.assign(window, {
   openFilePicker, removeAttachment,
   // ask-stream.js
   sendMessage, askQuestion,
+  // persona.js
+  onPersonaChange,
 });

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -15,7 +15,7 @@ import { addMessage, copyMessage, toggleSources, setStatus } from './thread.js';
 import { setupAttachmentHandlers, openFilePicker, removeAttachment } from './attachments.js';
 import {
   setupSwipeGestures, toggleSidebar, closeSidebar, newChat,
-  filterConversations, loadConversation, deleteConversation, loadConversations,
+  filterConversations, loadConversation, deleteConversation,
 } from './conversations.js';
 import { sendMessage, askQuestion } from './ask-stream.js';
 import { loadPersonas, onPersonaChange } from './persona.js';
@@ -46,11 +46,11 @@ export function initChat({ elements: els, endpoints: eps, hooks: hks } = {}) {
 
   setupAttachmentHandlers();
   setupSwipeGestures();
-  // loadPersonas() sets config.personaId synchronously (from sessionStorage)
-  // before its fetch, so the persona-scoped loadConversations() below is correct
-  // on first paint.
+  // loadPersonas() resolves the persona (from sessionStorage, validated against
+  // /api/personas) and then loads the persona-scoped conversation sidebar — it
+  // owns the single initial loadConversations() so the picker and sidebar stay
+  // consistent even when a stored persona has to be reset.
   loadPersonas();
-  loadConversations();
   setStatus('', 'Ready');
   inputField.focus();
 }

--- a/web/chat/persona.js
+++ b/web/chat/persona.js
@@ -8,7 +8,7 @@
 // contract in docs/specs/technical/client-surfaces.md.
 
 import { config, elements, endpoints } from './session.js';
-import { newChat } from './conversations.js';
+import { newChat, loadConversations } from './conversations.js';
 
 const PERSONA_STORAGE_KEY = 'lifeos:chat:persona_id';
 const DEFAULT_PERSONA_ID = 'primary';
@@ -50,10 +50,15 @@ export async function loadPersonas() {
   // If the stored persona is no longer offered, fall back to primary.
   if (personas.length > 0 && !personas.some(p => p.id === config.personaId)) {
     config.personaId = DEFAULT_PERSONA_ID;
-    storePersonaId(config.personaId);
   }
+  storePersonaId(config.personaId);
 
   renderPersonaOptions();
+  // Load the sidebar once the persona is resolved so it is correctly scoped.
+  // initChat no longer calls loadConversations itself — this is the single
+  // initial load, which keeps the picker and the sidebar consistent even when
+  // the stored persona had to be reset.
+  loadConversations();
 }
 
 function renderPersonaOptions() {
@@ -72,6 +77,13 @@ function renderPersonaOptions() {
     picker.appendChild(opt);
   }
   picker.value = config.personaId;
+  // If the stored id isn't among the offered options (e.g. discovery failed and
+  // a non-primary persona was previously chosen), fall back to the first option
+  // and keep config in sync so the picker is never blank.
+  if (picker.selectedIndex < 0 && picker.options.length > 0) {
+    picker.selectedIndex = 0;
+    config.personaId = picker.value;
+  }
 }
 
 export function onPersonaChange() {
@@ -87,12 +99,14 @@ export function onPersonaChange() {
 
 // True iff the selected persona advertises the `handoff` capability. Gates the
 // claude_intent handoff on capabilities rather than a hardcoded `primary`
-// check. When the list hasn't loaded yet (or discovery failed) we preserve the
-// default handoff behavior so a transient /api/personas outage doesn't silently
-// disable handoff for the primary persona.
+// check. Until the list loads (or if discovery failed) we fail open ONLY for
+// the default persona — preserving its pre-#359 handoff behavior — and fail
+// closed for any explicitly-selected persona whose capabilities we can't yet
+// confirm (a returning non-handoff persona restored from sessionStorage must
+// not trigger a handoff during the /api/personas load window).
 export function personaSupportsHandoff() {
   const { personas, personaId } = config;
-  if (!personas || personas.length === 0) return true;
+  if (!personas || personas.length === 0) return personaId === DEFAULT_PERSONA_ID;
   const p = personas.find(x => x.id === personaId);
   return !!(p && p.capabilities && p.capabilities.includes('handoff'));
 }

--- a/web/chat/persona.js
+++ b/web/chat/persona.js
@@ -1,0 +1,98 @@
+// Persona picker for /chat (#359).
+//
+// The user chooses which LifeOS persona to talk to — `primary` or any
+// configured specialized bot. The selection scopes the conversation sidebar
+// (`?persona_id=`), rides along on /api/ask/stream as `persona_id`, and gates
+// the claude_intent handoff on the persona's advertised `capabilities`. The
+// choice persists across refresh in sessionStorage. Implements the persona
+// contract in docs/specs/technical/client-surfaces.md.
+
+import { config, elements, endpoints } from './session.js';
+import { newChat } from './conversations.js';
+
+const PERSONA_STORAGE_KEY = 'lifeos:chat:persona_id';
+const DEFAULT_PERSONA_ID = 'primary';
+
+function readStoredPersonaId() {
+  try {
+    return window.sessionStorage.getItem(PERSONA_STORAGE_KEY) || DEFAULT_PERSONA_ID;
+  } catch (e) {
+    // sessionStorage unavailable (private mode / disabled)
+    return DEFAULT_PERSONA_ID;
+  }
+}
+
+function storePersonaId(id) {
+  try {
+    window.sessionStorage.setItem(PERSONA_STORAGE_KEY, id);
+  } catch (e) {
+    // sessionStorage unavailable — the selection just won't survive a refresh
+  }
+}
+
+export async function loadPersonas() {
+  // Restore the persisted selection synchronously (before the await) so the
+  // first turn and the first conversation fetch already carry the right id.
+  config.personaId = readStoredPersonaId();
+
+  let personas = [];
+  try {
+    const response = await fetch(endpoints.personas);
+    if (response.ok) {
+      const data = await response.json();
+      personas = data.personas || [];
+    }
+  } catch (e) {
+    console.log('Could not load personas');
+  }
+  config.personas = personas;
+
+  // If the stored persona is no longer offered, fall back to primary.
+  if (personas.length > 0 && !personas.some(p => p.id === config.personaId)) {
+    config.personaId = DEFAULT_PERSONA_ID;
+    storePersonaId(config.personaId);
+  }
+
+  renderPersonaOptions();
+}
+
+function renderPersonaOptions() {
+  const picker = elements.personaPicker;
+  if (!picker) return;
+  // Keep the control usable even if discovery failed.
+  const personas = (config.personas && config.personas.length)
+    ? config.personas
+    : [{ id: DEFAULT_PERSONA_ID, label: 'LifeOS' }];
+
+  picker.innerHTML = '';
+  for (const p of personas) {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.label;
+    picker.appendChild(opt);
+  }
+  picker.value = config.personaId;
+}
+
+export function onPersonaChange() {
+  const picker = elements.personaPicker;
+  if (!picker) return;
+  config.personaId = picker.value;
+  storePersonaId(config.personaId);
+  // Switching persona starts a fresh, persona-scoped conversation — the
+  // previous conversation belongs to the previous persona. newChat() re-fetches
+  // the sidebar with the new persona filter.
+  newChat();
+}
+
+// True iff the selected persona advertises the `handoff` capability. Gates the
+// claude_intent handoff on capabilities rather than a hardcoded `primary`
+// check. When the list hasn't loaded yet (or discovery failed) we preserve the
+// default handoff behavior so a transient /api/personas outage doesn't silently
+// disable handoff for the primary persona.
+export function personaSupportsHandoff() {
+  const { personas, personaId } = config;
+  if (!personas || personas.length === 0) return true;
+  const p = personas.find(x => x.id === personaId);
+  return !!(p && p.capabilities && p.capabilities.includes('handoff'));
+}

--- a/web/chat/session.js
+++ b/web/chat/session.js
@@ -22,12 +22,14 @@ export const state = {
   allConversations: [], // all conversations, for client-side filtering
 };
 
-// Optional per-query selectors reserved for the persona (#359) and
-// backend/Voice-Text (#361) follow-ons. Declared now so those PRs don't have to
-// reshape the askStream/session interface; unused in this behavior-neutral PR.
+// Per-query selectors. `personaId` is the selected persona (#359); `backend`
+// is reserved for the #361 Voice|Text follow-on. `personas` caches the list
+// from /api/personas so handoff gating can read the selected persona's
+// capabilities.
 export const config = {
   personaId: null,
   backend: null,
+  personas: [],
 };
 
 // DOM element handles, populated by initChat() (main.js). Modules read

--- a/web/chat/session.js
+++ b/web/chat/session.js
@@ -3,8 +3,8 @@
 // Extracted from the index.html SPA's single inline <script>. These objects are
 // the one source of truth for chat state; the feature modules import them
 // directly, and the classic shell script reaches the same objects through the
-// `window.lifeChat` bridge installed in main.js. No persistence yet —
-// sessionStorage (backend × persona × conversation) is a follow-on (#361).
+// `window.lifeChat` bridge installed in main.js. Persona selection persists in
+// sessionStorage (#359); backend × conversation persistence is a follow-on (#361).
 
 // In-memory chat state. `attachments` and `allConversations` are reassigned in
 // place (e.g. `state.attachments = state.attachments.filter(...)`), so they live

--- a/web/index.html
+++ b/web/index.html
@@ -592,6 +592,25 @@
             color: white;
         }
 
+        /* Persona picker (#359) */
+        .persona-picker {
+            padding: 0.375rem 0.5rem;
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text-primary);
+            font-size: 0.75rem;
+            cursor: pointer;
+            transition: all 0.2s;
+            max-width: 160px;
+        }
+
+        .persona-picker:hover,
+        .persona-picker:focus {
+            outline: none;
+            border-color: var(--accent);
+        }
+
         /* Modal */
         .modal-overlay {
             display: none;
@@ -2562,6 +2581,7 @@
                 </nav>
             </div>
             <div class="header-right">
+                <select class="persona-picker" id="personaPicker" onchange="onPersonaChange()" title="Choose persona" aria-label="Persona"></select>
                 <span class="chat-title" id="chatTitle">New conversation</span>
                 <button class="remember-btn" onclick="openRememberModal()" title="Remember something">
                     <span>💭</span> Remember
@@ -2924,11 +2944,13 @@
                     inputArea: document.getElementById('inputArea'),
                     attachmentsPreview: document.getElementById('attachmentsPreview'),
                     fileInput: document.getElementById('fileInput'),
+                    personaPicker: document.getElementById('personaPicker'),
                 },
                 endpoints: {
                     conversations: '/api/conversations',
                     ask: '/api/ask/stream',
                     handoff: '/api/chat/handoff',
+                    personas: '/api/personas',
                 },
                 hooks: { onAgentThreadReply: sendThreadReply },
             });


### PR DESCRIPTION
## Summary

Adds a persona picker to `/chat`, built on the chat modules extracted in #358. The user can talk to the `primary` LifeOS persona or any configured specialized bot. The backend already supported everything (#355/#351), so this is **frontend-only — no `api/` changes**.

Closes #359

## What it does (per the `client-surfaces.md` persona contract)
- Header `<select>` populated from `GET /api/personas`; manual selection; default `primary`.
- Selected `persona_id` rides along on `POST /api/ask/stream` (the `askStream` signature already accepted it from #358).
- Conversation sidebar scoped with `GET /api/conversations?persona_id=<id>`; conversation detail stays by-id (not persona-scoped, per contract).
- `claude_intent` handoff is **gated on the persona's advertised `capabilities`** (`handoff`), not a hardcoded `primary` check.
- Selection **persists across refresh** in `sessionStorage` (`lifeos:chat:persona_id`); switching persona starts a fresh, persona-scoped conversation.

## Files
- `web/chat/persona.js` (new) — `loadPersonas` / `onPersonaChange` / `personaSupportsHandoff`
- `web/chat/{session,conversations,ask-stream,main}.js` — small wiring edits
- `web/index.html` — header `<select>` + dark-theme CSS + `initChat` elements/endpoints + shim
- `docs/specs/technical/client-surfaces.md` — notes the web picker

## Test evidence
- All 7 modules + the inline `<script>` pass `node --check`; import graph is a clean DAG (no cycles).
- `pytest -m "unit and not slow"` green; `test.sh auto` unchanged (14 failures are pre-existing non-`unit` data-integrity tests, identical on `main`; diff touches **zero Python**).
- **Headless Playwright** against a stub mimicking `/api/personas`, `/api/conversations?persona_id=`, `/api/ask/stream`, `/api/chat/handoff` (no personal data) — **0 console errors**, verified end-to-end:
  - picker populates `[primary, fitness]`, default `primary`, sidebar scoped to `primary`.
  - send as `primary` → `persona_id=primary` on ask/stream; handoff **fires** (capability present); "handed off" rendered.
  - switch to `fitness` → `config.personaId`/`sessionStorage`/sidebar all re-scope; send → `persona_id=fitness`; handoff **gated off** (no capability), content preserved.
  - reload → persona restored from `sessionStorage` (`fitness`), sidebar re-scoped.

## Review focus
- Handoff gating: `personaSupportsHandoff()` is fail-open when the persona list hasn't loaded / discovery failed, so a transient `/api/personas` outage doesn't silently disable handoff for `primary`.
- Persona switch → `newChat()` (fresh persona-scoped conversation) — intentional, since conversations are persona-tagged at creation.
- `sessionStorage` is guarded for unavailability (private mode); default `primary` is implicit (not written on fresh load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)