### PR TITLE
feat(chat): voice transport — /api/voice reverse proxy + Voice|Text mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ flowchart LR
         GCal["Google\nCalendar"]
         Gmail["Google\nGmail"]
         LLM["LLM Backend\n(Claude API or local llama-server)"]
+        Voice["whisper-relay\nVoice Gateway :9788\n(reverse-proxied)"]
     end
 
     style Local fill:#ffcccc

--- a/api/main.py
+++ b/api/main.py
@@ -32,7 +32,7 @@ from fastapi.exceptions import RequestValidationError
 from pathlib import Path
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, jobs, perf, agents, vault, fitness
+from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, jobs, perf, agents, vault, fitness, voice
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -218,6 +218,7 @@ app.include_router(perf.router)
 app.include_router(agents.router)
 app.include_router(vault.router)
 app.include_router(fitness.router)
+app.include_router(voice.router)
 
 # Serve static files
 web_dir = Path(__file__).parent.parent / "web"

--- a/api/routes/voice.py
+++ b/api/routes/voice.py
@@ -3,20 +3,26 @@
 LifeOS owns the unified `/chat` client; voice *transport* lives in the separate
 whisper-relay app (STT → backend → TTS). We reverse-proxy ``/api/voice/*`` to
 ``LIFEOS_VOICE_GATEWAY_URL`` so the browser stays same-origin: one HTTPS/Tailscale
-front, one mic permission, no CORS. See ADR-006 and
+front, one mic permission, no CORS. See ADR-016 and
 ``docs/specs/technical/client-surfaces.md``.
 
 LifeOS adds **no** voice logic here — it only forwards the request/response,
 streaming both directions so SSE turn events and audio clips pass through
-unbuffered. The gateway is trusted (localhost); LifeOS is the access-control
-front, consistent with the rest of the API's localhost/Tailscale trust model.
+unbuffered. The gateway is trusted (localhost) and its URL is server config (not
+user-controllable, so no SSRF); LifeOS is the access-control front, consistent
+with the rest of the API's localhost/Tailscale trust model.
 """
 
+import logging
+from urllib.parse import unquote
+
 import httpx
-from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
 
 from config.settings import settings
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/voice", tags=["voice"])
 
@@ -44,17 +50,14 @@ def _client() -> httpx.AsyncClient:
 @router.api_route("/{path:path}", methods=["GET", "POST"])
 async def voice_proxy(path: str, request: Request):
     """Forward any ``/api/voice/<path>`` request to the voice gateway, streaming."""
-    # Defense-in-depth: never let a crafted path escape the /api/voice/ prefix on
-    # the upstream (the gateway exposes only voice/health routes anyway).
-    if ".." in path:
-        return JSONResponse(status_code=400, content={"error": "invalid path"})
+    # Basic guard against an obviously crafted path. The gateway routes by its
+    # declared routes (no filesystem traversal is reachable) and its host is
+    # fixed config, so this is just hygiene, not a security boundary.
+    if ".." in path or ".." in unquote(path):
+        raise HTTPException(status_code=400, detail="invalid path")
 
     base = settings.voice_gateway_url.rstrip("/")
     url = f"{base}/api/voice/{path}"
-
-    # Audio uploads are bounded by the gateway (<=25 MB), so reading the body is
-    # safe; this also lets httpx set a correct Content-Length for the multipart.
-    body = await request.body()
 
     client = _client()
     try:
@@ -63,15 +66,16 @@ async def voice_proxy(path: str, request: Request):
             url,
             params=request.query_params,
             headers=_filter_headers(request.headers),
-            content=body,
+            # Stream the request body upstream rather than buffering it, so a
+            # large audio upload can't OOM LifeOS (the gateway enforces its own
+            # size cap once it receives the stream).
+            content=request.stream() if request.method == "POST" else None,
         )
         upstream = await client.send(upstream_req, stream=True)
-    except httpx.RequestError as exc:
+    except (httpx.RequestError, httpx.InvalidURL) as exc:
         await client.aclose()
-        return JSONResponse(
-            status_code=502,
-            content={"error": "voice gateway unreachable", "detail": str(exc)},
-        )
+        logger.warning("voice gateway request failed (%s %s): %s", request.method, path, exc)
+        raise HTTPException(status_code=502, detail=f"voice gateway unreachable: {exc}")
 
     async def relay():
         try:

--- a/api/routes/voice.py
+++ b/api/routes/voice.py
@@ -1,0 +1,91 @@
+"""Reverse proxy for the voice gateway (whisper-relay) — #361.
+
+LifeOS owns the unified `/chat` client; voice *transport* lives in the separate
+whisper-relay app (STT → backend → TTS). We reverse-proxy ``/api/voice/*`` to
+``LIFEOS_VOICE_GATEWAY_URL`` so the browser stays same-origin: one HTTPS/Tailscale
+front, one mic permission, no CORS. See ADR-006 and
+``docs/specs/technical/client-surfaces.md``.
+
+LifeOS adds **no** voice logic here — it only forwards the request/response,
+streaming both directions so SSE turn events and audio clips pass through
+unbuffered. The gateway is trusted (localhost); LifeOS is the access-control
+front, consistent with the rest of the API's localhost/Tailscale trust model.
+"""
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from config.settings import settings
+
+router = APIRouter(prefix="/api/voice", tags=["voice"])
+
+# Hop-by-hop headers are connection-specific and must not be forwarded by a proxy
+# (RFC 7230 §6.1). Content-Length is dropped too; httpx/Starlette recompute it.
+_HOP_BY_HOP = {
+    "host", "content-length", "connection", "keep-alive", "transfer-encoding",
+    "upgrade", "proxy-authenticate", "proxy-authorization", "te", "trailer",
+}
+
+# Voice turns run STT → LLM → TTS and can take a while; match whisper-relay's
+# generous read budget so long turns aren't cut off.
+_TIMEOUT = httpx.Timeout(connect=5.0, read=300.0, write=300.0, pool=5.0)
+
+
+def _filter_headers(headers) -> dict:
+    return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+
+
+def _client() -> httpx.AsyncClient:
+    """The httpx client used to reach the gateway (a seam for tests)."""
+    return httpx.AsyncClient(timeout=_TIMEOUT)
+
+
+@router.api_route("/{path:path}", methods=["GET", "POST"])
+async def voice_proxy(path: str, request: Request):
+    """Forward any ``/api/voice/<path>`` request to the voice gateway, streaming."""
+    # Defense-in-depth: never let a crafted path escape the /api/voice/ prefix on
+    # the upstream (the gateway exposes only voice/health routes anyway).
+    if ".." in path:
+        return JSONResponse(status_code=400, content={"error": "invalid path"})
+
+    base = settings.voice_gateway_url.rstrip("/")
+    url = f"{base}/api/voice/{path}"
+
+    # Audio uploads are bounded by the gateway (<=25 MB), so reading the body is
+    # safe; this also lets httpx set a correct Content-Length for the multipart.
+    body = await request.body()
+
+    client = _client()
+    try:
+        upstream_req = client.build_request(
+            request.method,
+            url,
+            params=request.query_params,
+            headers=_filter_headers(request.headers),
+            content=body,
+        )
+        upstream = await client.send(upstream_req, stream=True)
+    except httpx.RequestError as exc:
+        await client.aclose()
+        return JSONResponse(
+            status_code=502,
+            content={"error": "voice gateway unreachable", "detail": str(exc)},
+        )
+
+    async def relay():
+        try:
+            # Raw bytes pass through unchanged (preserves any Content-Encoding,
+            # flushes SSE/audio chunks as they arrive).
+            async for chunk in upstream.aiter_raw():
+                yield chunk
+        finally:
+            await upstream.aclose()
+            await client.aclose()
+
+    return StreamingResponse(
+        relay(),
+        status_code=upstream.status_code,
+        headers=_filter_headers(upstream.headers),
+        media_type=upstream.headers.get("content-type"),
+    )

--- a/config/settings.py
+++ b/config/settings.py
@@ -79,7 +79,7 @@ class Settings(BaseSettings):
     )
 
     # Voice gateway (whisper-relay). LifeOS reverse-proxies /api/voice/* here so
-    # the browser stays same-origin for mic/HTTPS (#361). See ADR-006.
+    # the browser stays same-origin for mic/HTTPS (#361). See ADR-016.
     voice_gateway_url: str = Field(
         default="http://127.0.0.1:9788",
         alias="LIFEOS_VOICE_GATEWAY_URL",

--- a/config/settings.py
+++ b/config/settings.py
@@ -78,6 +78,14 @@ class Settings(BaseSettings):
         description="ChromaDB server URL"
     )
 
+    # Voice gateway (whisper-relay). LifeOS reverse-proxies /api/voice/* here so
+    # the browser stays same-origin for mic/HTTPS (#361). See ADR-006.
+    voice_gateway_url: str = Field(
+        default="http://127.0.0.1:9788",
+        alias="LIFEOS_VOICE_GATEWAY_URL",
+        description="whisper-relay voice gateway base URL"
+    )
+
     # Code directory (parent directory containing LifeOS and other projects)
     code_dir: str = Field(default="~/Code", alias="LIFEOS_CODE_DIR")
 

--- a/docs/adr/016-voice-gateway-reverse-proxy.md
+++ b/docs/adr/016-voice-gateway-reverse-proxy.md
@@ -1,0 +1,62 @@
+# ADR-016: Reverse-Proxy the Voice Gateway Through LifeOS
+
+**Status:** Complete
+**Last Updated:** 2026-06-22
+**Decision:** Accepted
+
+## Context
+
+LifeOS `/chat` is becoming the single responsive client for both text and voice (#361). Voice *transport* — speech-to-text, TTS, and the turn pipeline — lives in a separate app, whisper-relay (`~/Code/whisper-relay`), which exposes `POST /api/voice/turn/stream` (multipart audio in, SSE turn events out), a cancel endpoint, and audio-clip serving. whisper-relay's companion ADR-005 ("LifeOS-owned chat client") records that LifeOS owns all UI and that whisper-relay stays transport-only.
+
+The browser needs to: capture the microphone (which requires a **secure context** — HTTPS, satisfied by Tailscale), and reach the voice endpoints. The question is how the same-origin LifeOS page reaches whisper-relay, which runs as a separate process on `:9788`.
+
+## Decision
+
+LifeOS **reverse-proxies** `/api/voice/*` to the voice gateway at `LIFEOS_VOICE_GATEWAY_URL` (default `http://127.0.0.1:9788`). The browser only ever calls LifeOS's own origin; LifeOS forwards each request to the gateway and streams the response back unchanged. LifeOS adds **no** voice logic — it is a pass-through (`api/routes/voice.py`).
+
+## Rationale
+
+- **Same-origin = one HTTPS front, one mic permission, no CORS.** `getUserMedia` needs a secure context; the `/chat` page is already served over Tailscale HTTPS. Keeping voice calls same-origin means no CORS preflight, no second TLS endpoint, and one bookmark.
+- **Transport-only invariant preserved.** LifeOS forwards bytes; whisper-relay keeps doing exactly what it already does. No LifeOS Python is imported into the voice path and no voice logic is duplicated.
+- **Trust model unchanged.** The gateway is unauthenticated and localhost-bound; LifeOS is already the access-control front for localhost/Tailscale. Proxying through LifeOS doesn't widen exposure — the gateway URL is fixed server config (not user-controllable), so there is no SSRF surface.
+
+## Alternatives Considered
+
+### Direct browser → gateway with CORS
+
+The browser calls `http://gateway:9788` directly; the gateway sets CORS headers for the LifeOS/Tailscale origin.
+
+**Rejected because:** it needs a second HTTPS-terminating endpoint for the secure context, CORS configuration on the gateway, and a second origin in the browser — more moving parts for no benefit. Recorded as the documented fallback in whisper-relay#22, not the primary path.
+
+### Fold the voice pipeline into LifeOS
+
+Move STT/TTS/turn logic into LifeOS so there's no separate service.
+
+**Rejected because:** it discards a working, separately-iterated app and violates the transport-only split in ADR-005. whisper-relay's voice pipeline is proven; LifeOS should consume it, not re-implement it.
+
+## Consequences
+
+### Positive
+
+- The unified `/chat` client works for voice with one origin and one mic grant.
+- whisper-relay stays independently deployable and testable; LifeOS holds no voice logic.
+- The proxy is generic (`/api/voice/{path}`), so new gateway endpoints need no LifeOS change.
+
+### Negative
+
+- LifeOS is now in the voice request path; if `lifeos-api` is down, voice is down (already true for the page itself).
+- LifeOS must stream both directions (it does, via httpx `aiter_raw`) and not buffer large uploads (the request body is streamed upstream, not read into memory).
+- One more service dependency to run (`whisper-relay` on `:9788`) and one more env var (`LIFEOS_VOICE_GATEWAY_URL`).
+
+## Related Documents
+
+### Design Context
+- [whisper-relay ADR-005: LifeOS-owned chat client](https://github.com/nbramia/whisper-relay/blob/main/docs/adr/005-lifeos-owned-chat-client.md) — the cross-repo decision this implements
+
+### Specifications
+- [client-surfaces.md](../specs/technical/client-surfaces.md) — the HTTP client surfaces, including the voice reverse-proxy and turn contract
+
+### Code References
+- [api/routes/voice.py](../../api/routes/voice.py) — the streaming reverse proxy
+- [config/settings.py](../../config/settings.py) — `LIFEOS_VOICE_GATEWAY_URL`
+- [tests/test_voice_proxy.py](../../tests/test_voice_proxy.py) — proxy forwarding, error, and guard tests

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-06-21
+> **Last Updated:** 2026-06-22
 
 LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that submit text and consume SSE without importing LifeOS Python modules. Endpoint and event **shapes** are defined in [api-reference.md](../product/api-reference.md); this doc covers **who consumes them**, **whisper-relay integration**, and **breaking-change policy**.
 
@@ -15,6 +15,7 @@ LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that subm
 | Web chat | Browser → FastAPI | personas, ask/stream, handoff, conversation CRUD — `web/index.html` + `web/chat/` |
 | Telegram | In-process `chat_via_api` | Same SSE as ask/stream; handoffs spawn in-process — `api/services/telegram.py` |
 | **whisper-relay** | Separate app → HTTP | ask/stream, handoff, `GET /api/conversations`, `GET /api/conversations/{id}` — see below |
+| **Voice (web)** | Browser → FastAPI reverse-proxy → whisper-relay | LifeOS proxies `/api/voice/*` to the gateway; turn SSE + audio — `web/chat/voice.js`, `api/routes/voice.py` |
 | MCP / Managed Agents | stdio or HTTP MCP | Tool catalog only — `mcp_server.py` |
 
 ---
@@ -44,6 +45,22 @@ Web chat implements this contract in `web/chat/persona.js`: a header `<select>` 
 - Cancel = close the SSE connection (LifeOS has no cancel endpoint).
 
 Upstream mirror of this integration: `whisper-relay/docs/adr/002-upstream-integration-boundaries.md`.
+
+---
+
+## Voice transport (reverse proxy)
+
+With #361, LifeOS `/chat` is the unified text+voice client. Voice *transport* stays in whisper-relay; LifeOS **reverse-proxies** `/api/voice/*` to `LIFEOS_VOICE_GATEWAY_URL` (default `http://127.0.0.1:9788`) so the browser stays same-origin for the mic (HTTPS) and audio. LifeOS adds no voice logic — it forwards and streams both directions (`api/routes/voice.py`). See [ADR-016](../../adr/016-voice-gateway-reverse-proxy.md).
+
+**Voice turn contract** (the gateway's API, reached through the proxy):
+
+- `POST /api/voice/turn/stream` — multipart `audio` (or `transcript`) + `backend` (`lifeos`|`agent`) + `persona_id` (lifeos backend) + `conversation_id`. Responds with an SSE stream: `started` (turn_id, for cancel), `transcript`, `status_audio`/`main_audio` (clip URLs, played as they arrive), `response`, and a terminal `done` whose `data` is **authoritative**: `{transcript, response_text, status_audio_urls, audio_url, conversation_id, handoff, timings_ms}`. `error`/`cancelled` terminate the turn.
+- `POST /api/voice/turn/{turn_id}/cancel` — cancel an in-flight turn.
+- `GET /api/voice/audio/{turn_id}/{clip_id}` — WAV clips (status + main).
+
+**Topology:** browser → LifeOS `/chat` → (proxy) → gateway → for the `lifeos` backend, the gateway calls back into LifeOS `/api/ask/stream` (the consumer-into-LifeOS direction above). Conversation/persona listing is owned by LifeOS, not the gateway.
+
+Web chat implements voice mode in `web/chat/voice.js` — a faithful port of whisper-relay's `static/app.js` turn lifecycle (Voice|Text toggle, hold-to-talk, render the transcript + response from the `done` data, sequential audio queue, cancel via `AbortController`), adapted to LifeOS state and same-origin endpoints. The mode persists in `sessionStorage` (`lifeos:chat:voice_mode`).
 
 ---
 

--- a/tests/test_voice_proxy.py
+++ b/tests/test_voice_proxy.py
@@ -7,7 +7,7 @@ ASGITransport (no real server/sockets), so they're fast and deterministic.
 
 import httpx
 import pytest
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 from starlette.requests import Request as StarletteRequest
 
@@ -110,7 +110,22 @@ async def test_gateway_unreachable_returns_502(monkeypatch):
     ) as client:
         resp = await client.post("/api/voice/turn/stream", content=b"x")
     assert resp.status_code == 502
-    assert resp.json()["error"] == "voice gateway unreachable"
+    assert "voice gateway unreachable" in resp.json()["detail"]
+
+
+def test_filter_headers_drops_hop_by_hop():
+    # The proxy must not forward the *client's* connection-control headers; httpx
+    # sets its own for the upstream hop (a round-trip can't assert their absence).
+    headers = httpx.Headers({
+        "Host": "proxy", "Connection": "keep-alive", "Content-Length": "10",
+        "Content-Type": "multipart/form-data", "X-Keep": "yes",
+    })
+    out = {k.lower(): v for k, v in voice_module._filter_headers(headers).items()}
+    assert "host" not in out
+    assert "connection" not in out
+    assert "content-length" not in out
+    assert out.get("content-type") == "multipart/form-data"
+    assert out.get("x-keep") == "yes"
 
 
 async def test_rejects_parent_traversal_path():
@@ -127,5 +142,6 @@ async def test_rejects_parent_traversal_path():
         return {"type": "http.request", "body": b"", "more_body": False}
 
     req = StarletteRequest(scope, receive)
-    resp = await voice_module.voice_proxy("../secret", req)
-    assert resp.status_code == 400
+    with pytest.raises(HTTPException) as exc:
+        await voice_module.voice_proxy("../secret", req)
+    assert exc.value.status_code == 400

--- a/tests/test_voice_proxy.py
+++ b/tests/test_voice_proxy.py
@@ -1,0 +1,131 @@
+"""Tests for the voice-gateway reverse proxy (api/routes/voice.py, #361).
+
+The proxy forwards /api/voice/* to the whisper-relay voice gateway. These tests
+route the proxy's httpx client through an in-process stub gateway via
+ASGITransport (no real server/sockets), so they're fast and deterministic.
+"""
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import Response, StreamingResponse
+from starlette.requests import Request as StarletteRequest
+
+from api.routes import voice as voice_module
+
+pytestmark = pytest.mark.unit
+
+
+# --- in-process stub gateway (stands in for whisper-relay) ---
+stub_gateway = FastAPI()
+
+
+@stub_gateway.post("/api/voice/turn/stream")
+async def _stub_turn_stream(request: Request):
+    form = await request.form()
+    backend = form.get("backend")
+    persona = form.get("persona_id")
+
+    async def gen():
+        yield b'data: {"type": "started", "turn_id": "t1"}\n\n'
+        yield b'data: {"type": "transcript", "text": "hello"}\n\n'
+        yield (
+            'data: {"type": "done", "data": {"conversation_id": "c1", '
+            f'"backend": "{backend}", "persona_id": "{persona}"}}}}\n\n'
+        ).encode()
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+@stub_gateway.get("/api/voice/audio/{turn_id}/{clip_id}")
+async def _stub_audio(turn_id: str, clip_id: str):
+    return Response(
+        content=b"RIFF....WAVEfmt ",
+        media_type="audio/wav",
+        headers={"Cache-Control": "private, max-age=3600", "X-Clip": clip_id},
+    )
+
+
+@pytest.fixture
+def proxy_client(monkeypatch):
+    """An httpx client hitting the proxy app, whose upstream is the stub gateway."""
+    # Route the proxy's httpx calls into the stub gateway in-process.
+    def _stub_client():
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=stub_gateway),
+            base_url="http://gateway",
+        )
+
+    monkeypatch.setattr(voice_module, "_client", _stub_client)
+    monkeypatch.setattr(voice_module.settings, "voice_gateway_url", "http://gateway")
+
+    app = FastAPI()
+    app.include_router(voice_module.router)
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://proxy")
+
+
+async def test_turn_stream_forwards_multipart_and_sse(proxy_client):
+    files = {"audio": ("turn.webm", b"\x00\x01\x02fakeaudio", "audio/webm")}
+    data = {"backend": "lifeos", "persona_id": "fitness", "conversation_id": "c1"}
+    resp = await proxy_client.post("/api/voice/turn/stream", files=files, data=data)
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    body = resp.text
+    # SSE events streamed through unchanged...
+    assert '"type": "started"' in body
+    assert '"type": "transcript"' in body
+    assert '"type": "done"' in body
+    # ...and the multipart fields actually reached the gateway.
+    assert '"backend": "lifeos"' in body
+    assert '"persona_id": "fitness"' in body
+
+
+async def test_audio_clip_forwards_bytes_and_headers(proxy_client):
+    resp = await proxy_client.get("/api/voice/audio/t1/status-0")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "audio/wav"
+    assert resp.content == b"RIFF....WAVEfmt "
+    # non-hop-by-hop upstream headers pass through
+    assert resp.headers.get("cache-control") == "private, max-age=3600"
+    assert resp.headers.get("x-clip") == "status-0"
+
+
+async def test_gateway_unreachable_returns_502(monkeypatch):
+    class _FailingClient:
+        def build_request(self, *a, **k):
+            return object()
+
+        async def send(self, *a, **k):
+            raise httpx.ConnectError("connection refused")
+
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr(voice_module, "_client", _FailingClient)
+    app = FastAPI()
+    app.include_router(voice_module.router)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://proxy"
+    ) as client:
+        resp = await client.post("/api/voice/turn/stream", content=b"x")
+    assert resp.status_code == 502
+    assert resp.json()["error"] == "voice gateway unreachable"
+
+
+async def test_rejects_parent_traversal_path():
+    """The `..` guard rejects path-escape attempts before any upstream call."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/voice/../secret",
+        "headers": [],
+        "query_string": b"",
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    req = StarletteRequest(scope, receive)
+    resp = await voice_module.voice_proxy("../secret", req)
+    assert resp.status_code == 400

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -19,6 +19,7 @@ import {
 } from './conversations.js';
 import { sendMessage, askQuestion } from './ask-stream.js';
 import { loadPersonas, onPersonaChange } from './persona.js';
+import { initVoice, toggleVoiceMode, submitTurn } from './voice.js';
 
 // Boot the chat surface. The shell passes in the explicit DOM element map (so
 // the modules never getElementById), the API endpoints, and integration hooks
@@ -46,6 +47,7 @@ export function initChat({ elements: els, endpoints: eps, hooks: hks } = {}) {
 
   setupAttachmentHandlers();
   setupSwipeGestures();
+  initVoice();  // restore Voice|Text mode + wire the hold-to-talk dock (#361)
   // loadPersonas() resolves the persona (from sessionStorage, validated against
   // /api/personas) and then loads the persona-scoped conversation sidebar — it
   // owns the single initial loadConversations() so the picker and sidebar stay
@@ -70,4 +72,9 @@ Object.assign(window, {
   sendMessage, askQuestion,
   // persona.js
   onPersonaChange,
+  // voice.js
+  toggleVoiceMode,
 });
+
+// Voice helpers for the headless test harness (mic/audio can't run headless).
+window.lifeChatVoice = { submitTurn };

--- a/web/chat/session.js
+++ b/web/chat/session.js
@@ -30,6 +30,8 @@ export const config = {
   personaId: null,
   backend: null,
   personas: [],
+  // Voice|Text input mode (#361); restored from sessionStorage by initVoice().
+  voiceMode: false,
 };
 
 // DOM element handles, populated by initChat() (main.js). Modules read

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -1,15 +1,17 @@
 // Voice mode for /chat (#361, PR-B).
 //
-// A Voice|Text toggle swaps the text composer for a hold-to-talk dock. In voice
-// mode we record a turn with MediaRecorder, POST it as multipart to the
-// LifeOS-proxied whisper-relay endpoint (/api/voice/turn/stream), and consume
-// the SSE turn events — rendering the transcript + response in the shared thread
-// and playing the returned audio clips in order. Conversation/persona/backend
-// selection is owned by LifeOS (config); the gateway is pure transport.
+// A Voice|Text toggle swaps the text composer for a hold-to-talk dock. The turn
+// lifecycle is a faithful port of whisper-relay's proven static/app.js (record →
+// multipart POST to the LifeOS-proxied /api/voice/turn/stream → consume SSE →
+// render the transcript + response from the final `done` data → play audio clips
+// in order via a promise chain → cancel via AbortController). Conversation /
+// persona / backend selection is LifeOS-owned (config); the gateway is pure
+// transport.
 //
 // PR-B ships the core dock (talk + cancel + mode toggle). The full dock parity
-// (Mute / 2x / Auto-continue / Replay / Skip-silent / status-audio polish) and
-// the LifeOS|Agent backend toggle land in PR-C.
+// (Mute / 2x / Auto-continue / Replay / Skip-silent) and the LifeOS|Agent
+// backend toggle land in PR-C — the seams (shouldPlayAudio / applyPlaybackRate /
+// getBackendMode) are stubbed here so PR-C only extends them.
 
 import { state, config, elements, endpoints } from './session.js';
 import { addMessage, setStatus } from './thread.js';
@@ -20,14 +22,20 @@ const VOICE_MODE_KEY = 'lifeos:chat:voice_mode';
 let mediaRecorder = null;
 let recordedChunks = [];
 let recording = false;
-let currentTurnId = null;
 
-// Sequential audio playback queue (status clips then the main response).
-let audioEl = null;
-let playQueue = [];
-let playing = false;
+let activeTurnId = null;
+let activeTurnAbort = null;
+let activeAudios = [];
+let playbackChain = Promise.resolve();
+let isPlaying = false;
+let thinkingEl = null;
 
-export function isVoiceMode() {
+// --- PR-C seams (stubbed for PR-B) ---
+function shouldPlayAudio() { return true; }          // Mute → PR-C
+function applyPlaybackRate(_audio) { /* 2x → PR-C */ }
+function getBackendMode() { return config.backend || 'lifeos'; }  // LifeOS|Agent toggle → PR-C
+
+function isVoiceMode() {
   return config.voiceMode === true;
 }
 
@@ -53,14 +61,13 @@ export function initVoice() {
 
   const talk = elements.voiceTalkBtn;
   if (talk) {
-    // Hold-to-talk: press to record, release to send.
     talk.addEventListener('mousedown', startRecording);
     talk.addEventListener('touchstart', (e) => { e.preventDefault(); startRecording(); }, { passive: false });
     ['mouseup', 'mouseleave'].forEach(ev => talk.addEventListener(ev, stopRecording));
     ['touchend', 'touchcancel'].forEach(ev => talk.addEventListener(ev, (e) => { e.preventDefault(); stopRecording(); }, { passive: false }));
   }
   if (elements.voiceCancelBtn) {
-    elements.voiceCancelBtn.addEventListener('click', cancelTurn);
+    elements.voiceCancelBtn.addEventListener('click', cancelActiveTurn);
   }
 }
 
@@ -74,6 +81,7 @@ function applyVoiceMode() {
   document.body.classList.toggle('voice-mode', isVoiceMode());
 }
 
+// --- recording (hold-to-talk) ---
 async function startRecording() {
   if (recording || state.isLoading) return;
   let stream;
@@ -83,15 +91,23 @@ async function startRecording() {
     setStatus('error', 'Mic blocked');
     return;
   }
-  recordedChunks = [];
-  mediaRecorder = new MediaRecorder(stream);
-  mediaRecorder.ondataavailable = (e) => { if (e.data && e.data.size > 0) recordedChunks.push(e.data); };
-  mediaRecorder.onstop = () => {
+  try {
+    recordedChunks = [];
+    mediaRecorder = new MediaRecorder(stream);
+    mediaRecorder.ondataavailable = (e) => { if (e.data && e.data.size > 0) recordedChunks.push(e.data); };
+    mediaRecorder.onstop = () => {
+      stream.getTracks().forEach(t => t.stop());
+      const mime = mediaRecorder.mimeType || 'audio/webm';
+      const blob = new Blob(recordedChunks, { type: mime });
+      if (blob.size > 0) submitTurn({ blob, mime });
+    };
+    mediaRecorder.start();
+  } catch (e) {
+    // MediaRecorder unsupported / failed — don't leak the live mic.
     stream.getTracks().forEach(t => t.stop());
-    const blob = new Blob(recordedChunks, { type: mediaRecorder.mimeType || 'audio/webm' });
-    if (blob.size > 0) submitTurn(blob);
-  };
-  mediaRecorder.start();
+    setStatus('error', 'Mic error');
+    return;
+  }
   recording = true;
   setTalkActive(true);
 }
@@ -109,116 +125,179 @@ function setTalkActive(on) {
   if (elements.voiceTalkBtn) elements.voiceTalkBtn.classList.toggle('recording', on);
 }
 
-// Exported so the headless test harness can drive a turn without a real mic.
-export async function submitTurn(blob) {
-  state.isLoading = true;
-  setStatus('loading', 'Listening…');
+function blobFilename(mime) {
+  if (!mime) return 'recording.webm';
+  if (mime.includes('wav')) return 'recording.wav';
+  if (mime.includes('mp4') || mime.includes('aac')) return 'recording.m4a';
+  if (mime.includes('ogg')) return 'recording.ogg';
+  return 'recording.webm';
+}
 
-  const form = new FormData();
-  form.append('audio', blob, 'turn.webm');
-  form.append('backend', config.backend || 'lifeos');
-  if (config.personaId) form.append('persona_id', config.personaId);
-  if (state.currentConversationId) form.append('conversation_id', state.currentConversationId);
+// --- audio playback (sequential promise chain — survives a failed clip) ---
+function playSingleUrl(url) {
+  return new Promise((resolve, reject) => {
+    const audio = new Audio(url);
+    applyPlaybackRate(audio);
+    activeAudios.push(audio);
+    audio.onended = () => resolve();
+    audio.onerror = () => reject(new Error('playback failed'));
+    audio.play().catch(reject);
+  });
+}
 
-  try {
-    const resp = await fetch(`${endpoints.voice}/turn/stream`, { method: 'POST', body: form });
-    if (!resp.ok) throw new Error('voice turn failed');
-    await consumeTurnStream(resp);
-  } catch (e) {
-    console.error('Voice turn error:', e);
-    setStatus('error', 'Error');
-    addMessage('⚠️ Voice turn failed. Please try again.', 'assistant');
-    showCancel(false);
+function enqueueClip(url) {
+  if (!shouldPlayAudio()) return playbackChain;
+  playbackChain = playbackChain
+    .then(() => playSingleUrl(url))
+    .catch((err) => {
+      if (!isBenignPlaybackError(err)) console.warn('voice playback error:', err);
+    });
+  return playbackChain;
+}
+
+function stopAllAudio() {
+  for (const a of activeAudios) {
+    a.onended = null;
+    a.onerror = null;
+    a.pause();
+    a.currentTime = 0;
   }
+  activeAudios = [];
+  isPlaying = false;
+}
 
-  state.isLoading = false;
-  if (elements.statusText && elements.statusText.textContent !== 'Error') {
-    setStatus('', 'Ready');
+function isBenignPlaybackError(err) {
+  const name = err?.name || '';
+  const msg = (err?.message || '').toLowerCase();
+  return name === 'NotAllowedError' || name === 'AbortError'
+    || msg.includes('not allowed by the user agent') || msg.includes('aborted');
+}
+
+// --- thinking placeholder in the thread ---
+function showThinking() {
+  clearThinking();
+  thinkingEl = addMessage('', 'assistant');
+  const content = thinkingEl.querySelector('.message-content');
+  if (content) content.innerHTML = '<div class="typing"><span></span><span></span><span></span></div>';
+}
+
+function clearThinking() {
+  if (thinkingEl) {
+    thinkingEl.remove();
+    thinkingEl = null;
   }
 }
 
-async function consumeTurnStream(resp) {
-  const reader = resp.body.getReader();
+// --- SSE turn stream (ported from whisper-relay consumeTurnStream) ---
+function parseSseChunk(buffer, onEvent) {
+  const lines = buffer.split('\n');
+  const remainder = lines.pop() || '';
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) continue;
+    try {
+      onEvent(JSON.parse(line.slice(6)));
+    } catch {
+      /* ignore malformed chunks */
+    }
+  }
+  return remainder;
+}
+
+async function consumeTurnStream(response) {
+  playbackChain = Promise.resolve();
+  let doneData = null;
+  const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+
+  const handleEvent = (event) => {
+    if (event.type === 'started') {
+      activeTurnId = event.turn_id;
+      showCancel(true);
+    }
+    if (event.type === 'cancelled') {
+      throw new DOMException('Turn cancelled', 'AbortError');
+    }
+    if (event.type === 'error') {
+      throw new Error(event.message || 'Turn failed');
+    }
+    if (event.type === 'status_audio' || event.type === 'main_audio') {
+      if (shouldPlayAudio() && event.url) {
+        isPlaying = true;
+        enqueueClip(event.url);
+      }
+    }
+    if (event.type === 'done') {
+      doneData = event.data;
+    }
+  };
+
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split('\n');
-    buffer = lines.pop();  // keep any partial line for the next chunk
-    for (const line of lines) {
-      if (!line.startsWith('data: ')) continue;
-      try {
-        handleVoiceEvent(JSON.parse(line.slice(6)));
-      } catch (e) {
-        // skip malformed JSON
-      }
-    }
+    buffer = parseSseChunk(buffer, handleEvent);
   }
+  // Flush a final event that wasn't newline-terminated.
+  buffer += decoder.decode();
+  parseSseChunk(`${buffer}\n`, handleEvent);
+  return doneData;
 }
 
-function handleVoiceEvent(data) {
-  switch (data.type) {
-    case 'started':
-      currentTurnId = data.turn_id;
-      showCancel(true);
-      break;
-    case 'transcript':
-      if (data.text) addMessage(data.text, 'user');
-      break;
-    case 'response':
-      if (data.text) addMessage(data.text, 'assistant');
-      break;
-    case 'status_audio':
-    case 'main_audio':
-      if (data.url) enqueueAudio(data.url);
-      break;
-    case 'done': {
-      const d = data.data || {};
-      if (d.conversation_id) state.currentConversationId = d.conversation_id;
-      showCancel(false);
-      currentTurnId = null;
+// Exported so the headless test harness can drive a turn without a real mic
+// (getUserMedia/MediaRecorder don't run headless).
+export async function submitTurn({ blob, mime, transcript } = {}) {
+  setStatus('loading', getBackendMode() === 'agent' ? 'Agent thinking…' : 'Thinking…');
+  showThinking();
+  activeTurnId = null;
+  activeTurnAbort = new AbortController();
+
+  const form = new FormData();
+  if (blob) form.append('audio', blob, blobFilename(mime));
+  if (transcript) form.append('transcript', transcript);
+  if (state.currentConversationId) form.append('conversation_id', state.currentConversationId);
+  form.append('backend', getBackendMode());
+  if (getBackendMode() === 'lifeos' && config.personaId) {
+    form.append('persona_id', config.personaId);
+  }
+
+  try {
+    const res = await fetch(`${endpoints.voice}/turn/stream`, {
+      method: 'POST', body: form, signal: activeTurnAbort.signal,
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      clearThinking();
+      throw new Error(data.detail || `Request failed (${res.status})`);
+    }
+
+    const data = await consumeTurnStream(res);
+    if (!data) {
+      clearThinking();
+      throw new Error('Turn ended without a response');
+    }
+
+    if (data.conversation_id) {
+      state.currentConversationId = data.conversation_id;
       loadConversations();
-      break;
     }
-    case 'error':
-      setStatus('error', 'Error');
-      addMessage('⚠️ ' + (data.message || 'Voice error'), 'assistant');
-      showCancel(false);
-      currentTurnId = null;
-      break;
-    case 'cancelled':
-      showCancel(false);
-      currentTurnId = null;
-      break;
-    default:
-      break;
-  }
-}
+    clearThinking();
+    if (data.transcript) addMessage(data.transcript, 'user');
+    if (data.response_text) addMessage(data.response_text, 'assistant');
 
-function enqueueAudio(url) {
-  playQueue.push(url);
-  if (!playing) playNext();
-}
-
-function playNext() {
-  if (playQueue.length === 0) { playing = false; return; }
-  playing = true;
-  const url = playQueue.shift();
-  if (!audioEl) audioEl = new Audio();
-  audioEl.src = url;
-  audioEl.onended = playNext;
-  // The hold-to-talk gesture satisfies autoplay; ignore play() rejections.
-  audioEl.play().catch(() => playNext());
-}
-
-function stopPlayback() {
-  playQueue = [];
-  playing = false;
-  if (audioEl) {
-    audioEl.pause();
-    audioEl.onended = null;
+    await playbackChain;
+    isPlaying = false;
+    showCancel(false);
+    setStatus('', 'Ready');
+  } catch (err) {
+    if (err?.name === 'AbortError') return;  // cancelled — the cancel handler resets UI
+    clearThinking();
+    showCancel(false);
+    setStatus('error', 'Error');
+    addMessage('⚠️ ' + (err?.message || 'Voice turn failed'), 'assistant');
+  } finally {
+    activeTurnId = null;
+    activeTurnAbort = null;
   }
 }
 
@@ -226,15 +305,16 @@ function showCancel(on) {
   if (elements.voiceCancelBtn) elements.voiceCancelBtn.classList.toggle('visible', on);
 }
 
-async function cancelTurn() {
-  stopPlayback();
-  const turnId = currentTurnId;
-  showCancel(false);
-  currentTurnId = null;
-  if (!turnId) return;
-  try {
-    await fetch(`${endpoints.voice}/turn/${encodeURIComponent(turnId)}/cancel`, { method: 'POST' });
-  } catch (e) {
-    // best-effort cancel
+function cancelActiveTurn() {
+  activeTurnAbort?.abort();
+  if (activeTurnId) {
+    fetch(`${endpoints.voice}/turn/${encodeURIComponent(activeTurnId)}/cancel`, { method: 'POST' }).catch(() => {});
   }
+  playbackChain = Promise.resolve();
+  stopAllAudio();
+  clearThinking();
+  activeTurnId = null;
+  activeTurnAbort = null;
+  showCancel(false);
+  setStatus('', 'Ready');
 }

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -1,0 +1,240 @@
+// Voice mode for /chat (#361, PR-B).
+//
+// A Voice|Text toggle swaps the text composer for a hold-to-talk dock. In voice
+// mode we record a turn with MediaRecorder, POST it as multipart to the
+// LifeOS-proxied whisper-relay endpoint (/api/voice/turn/stream), and consume
+// the SSE turn events — rendering the transcript + response in the shared thread
+// and playing the returned audio clips in order. Conversation/persona/backend
+// selection is owned by LifeOS (config); the gateway is pure transport.
+//
+// PR-B ships the core dock (talk + cancel + mode toggle). The full dock parity
+// (Mute / 2x / Auto-continue / Replay / Skip-silent / status-audio polish) and
+// the LifeOS|Agent backend toggle land in PR-C.
+
+import { state, config, elements, endpoints } from './session.js';
+import { addMessage, setStatus } from './thread.js';
+import { loadConversations } from './conversations.js';
+
+const VOICE_MODE_KEY = 'lifeos:chat:voice_mode';
+
+let mediaRecorder = null;
+let recordedChunks = [];
+let recording = false;
+let currentTurnId = null;
+
+// Sequential audio playback queue (status clips then the main response).
+let audioEl = null;
+let playQueue = [];
+let playing = false;
+
+export function isVoiceMode() {
+  return config.voiceMode === true;
+}
+
+function readVoiceMode() {
+  try {
+    return window.sessionStorage.getItem(VOICE_MODE_KEY) === '1';
+  } catch (e) {
+    return false;
+  }
+}
+
+function storeVoiceMode(on) {
+  try {
+    window.sessionStorage.setItem(VOICE_MODE_KEY, on ? '1' : '0');
+  } catch (e) {
+    // sessionStorage unavailable — selection just won't persist
+  }
+}
+
+export function initVoice() {
+  config.voiceMode = readVoiceMode();
+  applyVoiceMode();
+
+  const talk = elements.voiceTalkBtn;
+  if (talk) {
+    // Hold-to-talk: press to record, release to send.
+    talk.addEventListener('mousedown', startRecording);
+    talk.addEventListener('touchstart', (e) => { e.preventDefault(); startRecording(); }, { passive: false });
+    ['mouseup', 'mouseleave'].forEach(ev => talk.addEventListener(ev, stopRecording));
+    ['touchend', 'touchcancel'].forEach(ev => talk.addEventListener(ev, (e) => { e.preventDefault(); stopRecording(); }, { passive: false }));
+  }
+  if (elements.voiceCancelBtn) {
+    elements.voiceCancelBtn.addEventListener('click', cancelTurn);
+  }
+}
+
+export function toggleVoiceMode() {
+  config.voiceMode = !isVoiceMode();
+  storeVoiceMode(config.voiceMode);
+  applyVoiceMode();
+}
+
+function applyVoiceMode() {
+  document.body.classList.toggle('voice-mode', isVoiceMode());
+}
+
+async function startRecording() {
+  if (recording || state.isLoading) return;
+  let stream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (e) {
+    setStatus('error', 'Mic blocked');
+    return;
+  }
+  recordedChunks = [];
+  mediaRecorder = new MediaRecorder(stream);
+  mediaRecorder.ondataavailable = (e) => { if (e.data && e.data.size > 0) recordedChunks.push(e.data); };
+  mediaRecorder.onstop = () => {
+    stream.getTracks().forEach(t => t.stop());
+    const blob = new Blob(recordedChunks, { type: mediaRecorder.mimeType || 'audio/webm' });
+    if (blob.size > 0) submitTurn(blob);
+  };
+  mediaRecorder.start();
+  recording = true;
+  setTalkActive(true);
+}
+
+function stopRecording() {
+  if (!recording) return;
+  recording = false;
+  setTalkActive(false);
+  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+    mediaRecorder.stop();
+  }
+}
+
+function setTalkActive(on) {
+  if (elements.voiceTalkBtn) elements.voiceTalkBtn.classList.toggle('recording', on);
+}
+
+// Exported so the headless test harness can drive a turn without a real mic.
+export async function submitTurn(blob) {
+  state.isLoading = true;
+  setStatus('loading', 'Listening…');
+
+  const form = new FormData();
+  form.append('audio', blob, 'turn.webm');
+  form.append('backend', config.backend || 'lifeos');
+  if (config.personaId) form.append('persona_id', config.personaId);
+  if (state.currentConversationId) form.append('conversation_id', state.currentConversationId);
+
+  try {
+    const resp = await fetch(`${endpoints.voice}/turn/stream`, { method: 'POST', body: form });
+    if (!resp.ok) throw new Error('voice turn failed');
+    await consumeTurnStream(resp);
+  } catch (e) {
+    console.error('Voice turn error:', e);
+    setStatus('error', 'Error');
+    addMessage('⚠️ Voice turn failed. Please try again.', 'assistant');
+    showCancel(false);
+  }
+
+  state.isLoading = false;
+  if (elements.statusText && elements.statusText.textContent !== 'Error') {
+    setStatus('', 'Ready');
+  }
+}
+
+async function consumeTurnStream(resp) {
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop();  // keep any partial line for the next chunk
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      try {
+        handleVoiceEvent(JSON.parse(line.slice(6)));
+      } catch (e) {
+        // skip malformed JSON
+      }
+    }
+  }
+}
+
+function handleVoiceEvent(data) {
+  switch (data.type) {
+    case 'started':
+      currentTurnId = data.turn_id;
+      showCancel(true);
+      break;
+    case 'transcript':
+      if (data.text) addMessage(data.text, 'user');
+      break;
+    case 'response':
+      if (data.text) addMessage(data.text, 'assistant');
+      break;
+    case 'status_audio':
+    case 'main_audio':
+      if (data.url) enqueueAudio(data.url);
+      break;
+    case 'done': {
+      const d = data.data || {};
+      if (d.conversation_id) state.currentConversationId = d.conversation_id;
+      showCancel(false);
+      currentTurnId = null;
+      loadConversations();
+      break;
+    }
+    case 'error':
+      setStatus('error', 'Error');
+      addMessage('⚠️ ' + (data.message || 'Voice error'), 'assistant');
+      showCancel(false);
+      currentTurnId = null;
+      break;
+    case 'cancelled':
+      showCancel(false);
+      currentTurnId = null;
+      break;
+    default:
+      break;
+  }
+}
+
+function enqueueAudio(url) {
+  playQueue.push(url);
+  if (!playing) playNext();
+}
+
+function playNext() {
+  if (playQueue.length === 0) { playing = false; return; }
+  playing = true;
+  const url = playQueue.shift();
+  if (!audioEl) audioEl = new Audio();
+  audioEl.src = url;
+  audioEl.onended = playNext;
+  // The hold-to-talk gesture satisfies autoplay; ignore play() rejections.
+  audioEl.play().catch(() => playNext());
+}
+
+function stopPlayback() {
+  playQueue = [];
+  playing = false;
+  if (audioEl) {
+    audioEl.pause();
+    audioEl.onended = null;
+  }
+}
+
+function showCancel(on) {
+  if (elements.voiceCancelBtn) elements.voiceCancelBtn.classList.toggle('visible', on);
+}
+
+async function cancelTurn() {
+  stopPlayback();
+  const turnId = currentTurnId;
+  showCancel(false);
+  currentTurnId = null;
+  if (!turnId) return;
+  try {
+    await fetch(`${endpoints.voice}/turn/${encodeURIComponent(turnId)}/cancel`, { method: 'POST' });
+  } catch (e) {
+    // best-effort cancel
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -987,6 +987,81 @@
             display: contents;
         }
 
+        /* Voice mode (#361): the mode toggle + hold-to-talk dock. */
+        .mode-toggle {
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 1.15rem;
+            opacity: 0.75;
+            padding: 0 0.25rem;
+        }
+
+        .mode-toggle:hover {
+            opacity: 1;
+        }
+
+        .voice-dock {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            gap: 0.75rem;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        .voice-talk-btn {
+            flex: 1;
+            max-width: 320px;
+            min-height: 48px;
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 24px;
+            color: var(--text-primary);
+            font-size: 1rem;
+            cursor: pointer;
+            transition: all 0.15s;
+            user-select: none;
+        }
+
+        .voice-talk-btn:hover {
+            border-color: var(--accent);
+        }
+
+        .voice-talk-btn.recording {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: white;
+        }
+
+        .voice-cancel-btn {
+            display: none;
+            width: 48px;
+            height: 48px;
+            background: none;
+            border: 1px solid var(--border);
+            border-radius: 50%;
+            color: var(--text-secondary);
+            cursor: pointer;
+            font-size: 1rem;
+        }
+
+        .voice-cancel-btn.visible {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        /* Mode swap: voice mode hides the text composer, shows the dock. */
+        body.voice-mode .input-container,
+        body.voice-mode .attachments-preview {
+            display: none;
+        }
+
+        body.voice-mode .voice-dock {
+            display: flex;
+        }
+
         .input-wrapper {
             flex: 1;
             position: relative;
@@ -2691,8 +2766,15 @@
                         <option value="claude">cloud</option>
                     </select>
                     <button class="agent-spawn-btn" id="agentSpawnBtn" onclick="spawnAgentFromComposer()" title="Run the composer text as an agent">⚙</button>
+                    <button class="mode-toggle" id="voiceModeBtn" onclick="toggleVoiceMode()" title="Voice input">🎙️</button>
                 </div>
                 <button class="send-btn" id="sendBtn" onclick="sendMessage()" title="Send message">➤</button>
+            </div>
+            <!-- Voice dock (#361): hold-to-talk; shown in voice mode -->
+            <div class="voice-dock" id="voiceDock">
+                <button class="mode-toggle" onclick="toggleVoiceMode()" title="Text input">⌨️</button>
+                <button class="voice-talk-btn" id="voiceTalkBtn" title="Hold to talk">🎙️ Hold to talk</button>
+                <button class="voice-cancel-btn" id="voiceCancelBtn" title="Cancel turn">✕</button>
             </div>
         </footer>
         </div>
@@ -3002,12 +3084,15 @@
                     attachmentsPreview: document.getElementById('attachmentsPreview'),
                     fileInput: document.getElementById('fileInput'),
                     personaPicker: document.getElementById('personaPicker'),
+                    voiceTalkBtn: document.getElementById('voiceTalkBtn'),
+                    voiceCancelBtn: document.getElementById('voiceCancelBtn'),
                 },
                 endpoints: {
                     conversations: '/api/conversations',
                     ask: '/api/ask/stream',
                     handoff: '/api/chat/handoff',
                     personas: '/api/personas',
+                    voice: '/api/voice',
                 },
                 hooks: { onAgentThreadReply: sendThreadReply },
             });


### PR DESCRIPTION
## Summary

Part 2 of 3 for #361 — adds voice to `/chat`: a streaming **reverse proxy** for `/api/voice/*` and a **Voice|Text** toggle with a hold-to-talk dock. LifeOS owns the unified client; whisper-relay stays pure transport. The browser talks to the gateway same-origin through LifeOS (one HTTPS/Tailscale front, mic permission, no CORS).

Relates to #361

## Backend (reverse proxy)
- `api/routes/voice.py` — streaming proxy `/api/voice/{path}` → `VOICE_GATEWAY_URL`: forwards method/headers/body/query, streams SSE turn events + audio back (`aiter_raw`), drops hop-by-hop headers, returns **502** if the gateway is unreachable, rejects `..` paths. LifeOS adds **no** voice logic.
- `config/settings.py` — `LIFEOS_VOICE_GATEWAY_URL` (default `http://127.0.0.1:9788`).

## Frontend (voice mode)
- `web/chat/voice.js` — Voice|Text toggle (swaps composer ↔ dock); record with MediaRecorder → POST multipart to `/api/voice/turn/stream` (`backend` + `persona_id` + `conversation_id`) → consume SSE (`started`/`transcript`/`response`/`status_audio`/`main_audio`/`done`/`error`/`cancelled`) → render transcript + response in the shared thread, play audio clips in order, cancel mid-turn. Mode persists in `sessionStorage`.
- `session.js`/`main.js`/`index.html` — `config.voiceMode`, init wiring, dock markup + CSS (mode swap), element/endpoint wiring.

Conversation/persona/backend selection stays LifeOS-owned. **Core dock only** (talk/cancel/toggle); full 7-control dock parity + the LifeOS|Agent backend toggle land in PR-C.

## Test evidence
- **`tests/test_voice_proxy.py`** (4 tests, in-process `ASGITransport` stub gateway): SSE forwarding with multipart fields reaching the gateway, audio bytes + cache headers pass through, 502 on unreachable, `..` guard. Full unit suite **2108 passed**, 0 regressions.
- All 8 modules + inline `<script>` pass `node --check`.
- **Headless Playwright** (stub gateway, no personal data, 0 console errors): Voice|Text toggle swaps composer↔dock and persists across reload; a driven turn (fake blob via test hook) sends `backend=lifeos`+`persona=primary` to the gateway, renders the SSE transcript (user) + response (assistant), captures `conversation_id`, clears `isLoading`; dock shows talk + cancel.

## Review focus
- **The reverse proxy** (`api/routes/voice.py`) — streaming both directions, header filtering, the `_client()` seam, error/timeout handling, and that it adds no auth surface beyond the existing localhost/Tailscale trust model (gateway is unauthenticated; LifeOS is the front).
- `voice.js` SSE parsing (buffered line-splitting across chunks) and the audio play-queue.
- **Cannot be verified headlessly:** live `getUserMedia`/`MediaRecorder` mic capture and actual audio output — needs whisper-relay running on `:9788` + an HTTPS origin. The submit→SSE→render→playback-attempt path is covered with a fake blob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)