### PR TITLE
feat(chat): LifeOS|Agent backend toggle + agent-text proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ flowchart LR
         Gmail["Google\nGmail"]
         LLM["LLM Backend\n(Claude API or local llama-server)"]
         Voice["whisper-relay\nVoice Gateway :9788\n(reverse-proxied)"]
+        Agent["Agent text backend\n(reverse-proxied, optional)"]
     end
 
     style Local fill:#ffcccc

--- a/api/main.py
+++ b/api/main.py
@@ -32,7 +32,7 @@ from fastapi.exceptions import RequestValidationError
 from pathlib import Path
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, jobs, perf, agents, vault, fitness, voice
+from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, jobs, perf, agents, vault, fitness, voice, agent_proxy
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -219,6 +219,7 @@ app.include_router(agents.router)
 app.include_router(vault.router)
 app.include_router(fitness.router)
 app.include_router(voice.router)
+app.include_router(agent_proxy.router)
 
 # Serve static files
 web_dir = Path(__file__).parent.parent / "web"

--- a/api/routes/_proxy.py
+++ b/api/routes/_proxy.py
@@ -1,0 +1,26 @@
+"""Shared helpers for the streaming reverse proxies (voice, agent) — #361.
+
+Keeps the security-relevant header-filtering and timeout in one place so the
+voice and agent proxies stay in lockstep.
+"""
+
+import httpx
+
+# Voice/agent turns run STT → LLM → TTS and can take a while; a generous read
+# budget so long turns aren't cut off.
+TIMEOUT = httpx.Timeout(connect=5.0, read=300.0, write=300.0, pool=5.0)
+
+# Hop-by-hop headers are connection-specific and must not be forwarded by a proxy
+# (RFC 7230 §6.1). Content-Length is dropped too; httpx/Starlette recompute it.
+# `authorization` is stripped so a client can never inject upstream credentials —
+# each proxy adds its own auth (or none) server-side.
+HOP_BY_HOP = frozenset({
+    "host", "content-length", "connection", "keep-alive", "transfer-encoding",
+    "upgrade", "proxy-authenticate", "proxy-authorization", "te", "trailer",
+    "authorization",
+})
+
+
+def filter_headers(headers) -> dict:
+    """Drop hop-by-hop (and inbound auth) headers before forwarding."""
+    return {k: v for k, v in headers.items() if k.lower() not in HOP_BY_HOP}

--- a/api/routes/agent_proxy.py
+++ b/api/routes/agent_proxy.py
@@ -16,20 +16,16 @@ from fastapi.responses import StreamingResponse
 
 from config.settings import settings
 
+from api.routes._proxy import TIMEOUT, filter_headers
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/agent", tags=["agent"])
 
-_HOP_BY_HOP = {
-    "host", "content-length", "connection", "keep-alive", "transfer-encoding",
-    "upgrade", "proxy-authenticate", "proxy-authorization", "te", "trailer",
-}
-_TIMEOUT = httpx.Timeout(connect=5.0, read=300.0, write=300.0, pool=5.0)
-
 
 def _client() -> httpx.AsyncClient:
     """httpx client for the agent backend (a seam for tests)."""
-    return httpx.AsyncClient(timeout=_TIMEOUT)
+    return httpx.AsyncClient(timeout=TIMEOUT)
 
 
 @router.get("/status")
@@ -45,10 +41,9 @@ async def agent_ask_stream(request: Request):
         raise HTTPException(status_code=503, detail="agent backend not configured")
 
     url = f"{settings.agent_backend_url.rstrip('/')}/api/ask/stream"
-    headers = {
-        k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP
-    }
-    # Add the bearer token server-side — never exposed to the browser.
+    # filter_headers() strips any inbound Authorization (and hop-by-hop); the
+    # bearer is added server-side below, so a client can never inject it.
+    headers = filter_headers(request.headers)
     if settings.agent_backend_token:
         headers["authorization"] = f"Bearer {settings.agent_backend_token}"
 
@@ -71,12 +66,9 @@ async def agent_ask_stream(request: Request):
             await upstream.aclose()
             await client.aclose()
 
-    resp_headers = {
-        k: v for k, v in upstream.headers.items() if k.lower() not in _HOP_BY_HOP
-    }
     return StreamingResponse(
         relay(),
         status_code=upstream.status_code,
-        headers=resp_headers,
+        headers=filter_headers(upstream.headers),
         media_type=upstream.headers.get("content-type"),
     )

--- a/api/routes/agent_proxy.py
+++ b/api/routes/agent_proxy.py
@@ -1,0 +1,82 @@
+"""Agent text-backend proxy (#361).
+
+The `/chat` "Agent" backend talks to the OpenClaw voice-adapter, which speaks the
+same `/api/ask/stream` SSE contract as LifeOS but is reached at
+``LIFEOS_AGENT_BACKEND_URL`` and may require a bearer token. LifeOS proxies it at
+``POST /api/agent/ask/stream``, **adding the token server-side** so it never
+reaches the browser. The browser stays same-origin and treats the response
+exactly like a normal ask/stream (minus handoff — the agent backend has none).
+"""
+
+import logging
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/agent", tags=["agent"])
+
+_HOP_BY_HOP = {
+    "host", "content-length", "connection", "keep-alive", "transfer-encoding",
+    "upgrade", "proxy-authenticate", "proxy-authorization", "te", "trailer",
+}
+_TIMEOUT = httpx.Timeout(connect=5.0, read=300.0, write=300.0, pool=5.0)
+
+
+def _client() -> httpx.AsyncClient:
+    """httpx client for the agent backend (a seam for tests)."""
+    return httpx.AsyncClient(timeout=_TIMEOUT)
+
+
+@router.get("/status")
+async def agent_status():
+    """Whether the Agent text backend is configured (drives the UI toggle)."""
+    return {"available": bool(settings.agent_backend_url)}
+
+
+@router.post("/ask/stream")
+async def agent_ask_stream(request: Request):
+    """Proxy a text turn to the agent backend's /api/ask/stream, streaming SSE."""
+    if not settings.agent_backend_url:
+        raise HTTPException(status_code=503, detail="agent backend not configured")
+
+    url = f"{settings.agent_backend_url.rstrip('/')}/api/ask/stream"
+    headers = {
+        k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP
+    }
+    # Add the bearer token server-side — never exposed to the browser.
+    if settings.agent_backend_token:
+        headers["authorization"] = f"Bearer {settings.agent_backend_token}"
+
+    client = _client()
+    try:
+        upstream_req = client.build_request(
+            "POST", url, headers=headers, content=request.stream(),
+        )
+        upstream = await client.send(upstream_req, stream=True)
+    except (httpx.RequestError, httpx.InvalidURL) as exc:
+        await client.aclose()
+        logger.warning("agent backend request failed: %s", exc)
+        raise HTTPException(status_code=502, detail=f"agent backend unreachable: {exc}")
+
+    async def relay():
+        try:
+            async for chunk in upstream.aiter_raw():
+                yield chunk
+        finally:
+            await upstream.aclose()
+            await client.aclose()
+
+    resp_headers = {
+        k: v for k, v in upstream.headers.items() if k.lower() not in _HOP_BY_HOP
+    }
+    return StreamingResponse(
+        relay(),
+        status_code=upstream.status_code,
+        headers=resp_headers,
+        media_type=upstream.headers.get("content-type"),
+    )

--- a/api/routes/voice.py
+++ b/api/routes/voice.py
@@ -22,29 +22,16 @@ from fastapi.responses import StreamingResponse
 
 from config.settings import settings
 
+from api.routes._proxy import TIMEOUT, filter_headers as _filter_headers
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/voice", tags=["voice"])
 
-# Hop-by-hop headers are connection-specific and must not be forwarded by a proxy
-# (RFC 7230 §6.1). Content-Length is dropped too; httpx/Starlette recompute it.
-_HOP_BY_HOP = {
-    "host", "content-length", "connection", "keep-alive", "transfer-encoding",
-    "upgrade", "proxy-authenticate", "proxy-authorization", "te", "trailer",
-}
-
-# Voice turns run STT → LLM → TTS and can take a while; match whisper-relay's
-# generous read budget so long turns aren't cut off.
-_TIMEOUT = httpx.Timeout(connect=5.0, read=300.0, write=300.0, pool=5.0)
-
-
-def _filter_headers(headers) -> dict:
-    return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
-
 
 def _client() -> httpx.AsyncClient:
     """The httpx client used to reach the gateway (a seam for tests)."""
-    return httpx.AsyncClient(timeout=_TIMEOUT)
+    return httpx.AsyncClient(timeout=TIMEOUT)
 
 
 @router.api_route("/{path:path}", methods=["GET", "POST"])

--- a/config/settings.py
+++ b/config/settings.py
@@ -86,6 +86,20 @@ class Settings(BaseSettings):
         description="whisper-relay voice gateway base URL"
     )
 
+    # Agent text backend (OpenClaw voice-adapter). LifeOS proxies the "Agent"
+    # text backend to /api/ask/stream here, adding the bearer token server-side
+    # so it's never exposed to the browser (#361). Empty url = Agent disabled.
+    agent_backend_url: str = Field(
+        default="",
+        alias="LIFEOS_AGENT_BACKEND_URL",
+        description="Agent text backend base URL (empty disables the Agent toggle)"
+    )
+    agent_backend_token: str = Field(
+        default="",
+        alias="LIFEOS_AGENT_BACKEND_TOKEN",
+        description="Optional bearer token for the Agent text backend"
+    )
+
     # Code directory (parent directory containing LifeOS and other projects)
     code_dir: str = Field(default="~/Code", alias="LIFEOS_CODE_DIR")
 

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -159,6 +159,15 @@ Spawn a CLI engine worker session when the orchestrator emits `claude_intent` on
 }
 ```
 
+### Voice & Agent backends
+
+`/chat` reaches two transport surfaces through LifeOS reverse proxies so the browser stays same-origin (#361). The shapes are owned upstream; LifeOS only forwards.
+
+- `POST /api/voice/turn/stream` — multipart voice turn (`audio` or `transcript`, plus `backend`, `persona_id`, `conversation_id`) → SSE turn events (`started` / `transcript` / `status_audio` / `response` / `main_audio` / `done` / `error` / `cancelled`); the `done` data is authoritative. Proxied to `LIFEOS_VOICE_GATEWAY_URL` (whisper-relay). Also `POST /api/voice/turn/{turn_id}/cancel` and `GET /api/voice/audio/{turn_id}/{clip_id}`.
+- `POST /api/agent/ask/stream` — text turn for the "Agent" backend; same SSE as [`POST /api/ask/stream`](#post-apiaskstream) but no handoff and no persona. Proxied to `LIFEOS_AGENT_BACKEND_URL` with a bearer token added **server-side** (never exposed to the browser). `GET /api/agent/status` → `{"available": bool}` (drives the UI toggle).
+
+See [client-surfaces.md](../technical/client-surfaces.md) and [ADR-016](../../adr/016-voice-gateway-reverse-proxy.md).
+
 ### POST /api/search
 
 Vector similarity search across indexed content.

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -62,6 +62,8 @@ With #361, LifeOS `/chat` is the unified text+voice client. Voice *transport* st
 
 Web chat implements voice mode in `web/chat/voice.js` — a faithful port of whisper-relay's `static/app.js` turn lifecycle (Voice|Text toggle, hold-to-talk, render the transcript + response from the `done` data, sequential audio queue, cancel via `AbortController`), adapted to LifeOS state and same-origin endpoints. The mode persists in `sessionStorage` (`lifeos:chat:voice_mode`).
 
+**Agent text backend.** Both modes carry a `backend` (`lifeos` | `agent`). The `agent` backend is the OpenClaw voice-adapter, which speaks the same `/api/ask/stream` SSE contract at `LIFEOS_AGENT_BACKEND_URL` and may require a bearer token. LifeOS proxies it at `POST /api/agent/ask/stream` (`api/routes/agent_proxy.py`), **adding the bearer server-side** so it never reaches the browser; `GET /api/agent/status` reports whether it's configured (drives the UI toggle). The agent backend has no personas and no handoff. Conversation ids are stored per backend in `sessionStorage` (`lifeos:chat:conv:agent`, and `lifeos:chat:conv:lifeos:<persona>` for lifeos) so switching and refreshing continues the right thread. `web/chat/backend.js` owns the toggle + per-backend conversation persistence.
+
 ---
 
 ## Before changing chat or conversation APIs

--- a/tests/test_agent_proxy.py
+++ b/tests/test_agent_proxy.py
@@ -1,0 +1,97 @@
+"""Tests for the agent text-backend proxy (api/routes/agent_proxy.py, #361).
+
+Routes the proxy's httpx client through an in-process stub agent backend via
+ASGITransport (no sockets), so they're fast and deterministic.
+"""
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from api.routes import agent_proxy as ap
+
+pytestmark = pytest.mark.unit
+
+stub_agent = FastAPI()
+_received = {}
+
+
+@stub_agent.post("/api/ask/stream")
+async def _stub_ask(request: Request):
+    _received["authorization"] = request.headers.get("authorization")
+    body = await request.body()
+    _received["body"] = body
+
+    async def gen():
+        yield b'data: {"type": "content", "content": "agent says hi"}\n\n'
+        yield b'data: {"type": "done"}\n\n'
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+@pytest.fixture
+def proxy_client(monkeypatch):
+    _received.clear()
+
+    def _stub_client():
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=stub_agent), base_url="http://agent"
+        )
+
+    monkeypatch.setattr(ap, "_client", _stub_client)
+    monkeypatch.setattr(ap.settings, "agent_backend_url", "http://agent")
+    monkeypatch.setattr(ap.settings, "agent_backend_token", "secret-token")
+
+    app = FastAPI()
+    app.include_router(ap.router)
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://proxy")
+
+
+async def test_status_reflects_configuration(monkeypatch):
+    app = FastAPI()
+    app.include_router(ap.router)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+        monkeypatch.setattr(ap.settings, "agent_backend_url", "http://agent")
+        assert (await c.get("/api/agent/status")).json()["available"] is True
+        monkeypatch.setattr(ap.settings, "agent_backend_url", "")
+        assert (await c.get("/api/agent/status")).json()["available"] is False
+
+
+async def test_ask_stream_injects_bearer_and_streams(proxy_client):
+    # The browser sends NO auth; the proxy adds it server-side.
+    resp = await proxy_client.post("/api/agent/ask/stream", json={"question": "hi"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert "agent says hi" in resp.text
+    assert _received["authorization"] == "Bearer secret-token"
+    assert b'"question"' in _received["body"]
+
+
+async def test_503_when_not_configured(monkeypatch):
+    monkeypatch.setattr(ap.settings, "agent_backend_url", "")
+    app = FastAPI()
+    app.include_router(ap.router)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+        resp = await c.post("/api/agent/ask/stream", json={"question": "hi"})
+    assert resp.status_code == 503
+
+
+async def test_502_when_backend_unreachable(monkeypatch):
+    class _Failing:
+        def build_request(self, *a, **k):
+            return object()
+
+        async def send(self, *a, **k):
+            raise httpx.ConnectError("refused")
+
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr(ap, "_client", _Failing)
+    monkeypatch.setattr(ap.settings, "agent_backend_url", "http://agent")
+    app = FastAPI()
+    app.include_router(ap.router)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+        resp = await c.post("/api/agent/ask/stream", json={"question": "hi"})
+    assert resp.status_code == 502

--- a/tests/test_agent_proxy.py
+++ b/tests/test_agent_proxy.py
@@ -7,7 +7,7 @@ ASGITransport (no sockets), so they're fast and deterministic.
 import httpx
 import pytest
 from fastapi import FastAPI, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 
 from api.routes import agent_proxy as ap
 
@@ -66,6 +66,40 @@ async def test_ask_stream_injects_bearer_and_streams(proxy_client):
     assert "agent says hi" in resp.text
     assert _received["authorization"] == "Bearer secret-token"
     assert b'"question"' in _received["body"]
+
+
+async def test_empty_token_forwards_no_auth(proxy_client, monkeypatch):
+    # No token configured + no client auth → nothing on the wire upstream.
+    monkeypatch.setattr(ap.settings, "agent_backend_token", "")
+    resp = await proxy_client.post(
+        "/api/agent/ask/stream", json={"question": "hi"},
+        headers={"Authorization": "Bearer client-sneaky"},
+    )
+    assert resp.status_code == 200
+    # the client's Authorization is stripped (not forwarded), and no server token
+    assert _received["authorization"] is None
+
+
+_stub_500 = FastAPI()
+
+
+@_stub_500.post("/api/ask/stream")
+async def _stub_err():
+    return Response(status_code=500, content=b"upstream boom")
+
+
+async def test_non_200_upstream_is_passed_through(monkeypatch):
+    monkeypatch.setattr(
+        ap, "_client",
+        lambda: httpx.AsyncClient(transport=httpx.ASGITransport(app=_stub_500), base_url="http://a"),
+    )
+    monkeypatch.setattr(ap.settings, "agent_backend_url", "http://a")
+    monkeypatch.setattr(ap.settings, "agent_backend_token", "")
+    app = FastAPI()
+    app.include_router(ap.router)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+        resp = await c.post("/api/agent/ask/stream", json={"question": "hi"})
+    assert resp.status_code == 500
 
 
 async def test_503_when_not_configured(monkeypatch):

--- a/web/chat/ask-stream.js
+++ b/web/chat/ask-stream.js
@@ -8,6 +8,7 @@ import { addMessage, updateMessage, setStatus } from './thread.js';
 import { clearAttachments } from './attachments.js';
 import { loadConversations } from './conversations.js';
 import { personaSupportsHandoff } from './persona.js';
+import { setStoredConversationId } from './backend.js';
 
 // Low-level SSE transport. Builds the request body, opens the stream, and calls
 // `on(data)` for each parsed `data:` event. If `on` returns `true`, processing
@@ -29,10 +30,13 @@ export async function askStream({ question, conversationId, attachments, persona
     }));
   }
 
-  if (personaId != null) body.persona_id = personaId;
-  if (backend != null) body.backend = backend;
+  // The agent backend has no personas and is reached via its own proxied
+  // endpoint (bearer added server-side); lifeos sends persona_id to
+  // /api/ask/stream exactly as before.
+  const isAgent = backend === 'agent';
+  if (!isAgent && personaId != null) body.persona_id = personaId;
 
-  const response = await fetch(endpoints.ask, {
+  const response = await fetch(isAgent ? endpoints.agentAsk : endpoints.ask, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
@@ -138,6 +142,7 @@ export async function sendMessage() {
           sources = data.sources;
         } else if (data.type === 'conversation_id') {
           state.currentConversationId = data.conversation_id;
+          setStoredConversationId(data.conversation_id);  // per-backend persistence
         } else if (data.type === 'usage') {
           state.sessionCost += data.cost_usd || 0;
           elements.sessionCostEl.textContent = '$' + state.sessionCost.toFixed(3);

--- a/web/chat/backend.js
+++ b/web/chat/backend.js
@@ -45,6 +45,7 @@ function applyBackendUi() {
 }
 
 function setBackendMode(mode) {
+  if (state.isLoading) return;  // don't switch backends mid-turn (would store the id under the wrong key)
   const next = mode === 'agent' ? 'agent' : 'lifeos';
   if (next === getBackendMode()) return;
   // config.backend drives ask/stream routing + voice turns; null = lifeos

--- a/web/chat/backend.js
+++ b/web/chat/backend.js
@@ -1,0 +1,90 @@
+// LifeOS | Agent text-backend toggle + per-backend conversation persistence
+// (#361, PR-D).
+//
+// The composer can target two text backends: `lifeos` (the orchestrator, with
+// personas + handoff) or `agent` (the OpenClaw voice-adapter, proxied with a
+// server-side bearer at /api/agent/ask/stream — no persona, no handoff). The
+// selection persists in sessionStorage, and each backend keeps its own
+// conversation id (lifeos is further scoped per persona) so switching back and
+// forth — and refreshing — continues the right thread.
+
+import { state, config, elements, endpoints } from './session.js';
+import { newChat, loadConversation } from './conversations.js';
+
+const BACKEND_MODE_KEY = 'lifeos:chat:backend_mode';
+
+export function getBackendMode() {
+  try {
+    return window.sessionStorage.getItem(BACKEND_MODE_KEY) === 'agent' ? 'agent' : 'lifeos';
+  } catch (e) {
+    return 'lifeos';
+  }
+}
+
+// Conversation id is stored per backend; lifeos is also scoped per persona.
+function convKey() {
+  if (getBackendMode() === 'agent') return 'lifeos:chat:conv:agent';
+  return `lifeos:chat:conv:lifeos:${config.personaId || 'primary'}`;
+}
+
+export function getStoredConversationId() {
+  try { return window.sessionStorage.getItem(convKey()) || null; } catch (e) { return null; }
+}
+
+export function setStoredConversationId(id) {
+  if (!id) return;
+  try { window.sessionStorage.setItem(convKey(), id); } catch (e) { /* storage blocked */ }
+}
+
+function applyBackendUi() {
+  const agent = getBackendMode() === 'agent';
+  // CSS hides the persona picker in agent mode (no personas there).
+  document.body.classList.toggle('agent-mode', agent);
+  if (elements.backendLifeos) elements.backendLifeos.classList.toggle('active', !agent);
+  if (elements.backendAgent) elements.backendAgent.classList.toggle('active', agent);
+}
+
+function setBackendMode(mode) {
+  const next = mode === 'agent' ? 'agent' : 'lifeos';
+  if (next === getBackendMode()) return;
+  // config.backend drives ask/stream routing + voice turns; null = lifeos
+  // default (omitted from the request body, byte-identical to pre-#361).
+  config.backend = next === 'agent' ? 'agent' : null;
+  try { window.sessionStorage.setItem(BACKEND_MODE_KEY, next); } catch (e) { /* blocked */ }
+  applyBackendUi();
+  restoreBackendConversation();
+}
+
+// Switch the view to the selected backend's stored conversation. LifeOS owns its
+// conversation history (render it); the agent's history isn't LifeOS-owned, so
+// we keep a fresh view but retain its id for turn continuity.
+function restoreBackendConversation() {
+  const storedId = getStoredConversationId();
+  if (storedId && getBackendMode() === 'lifeos') {
+    loadConversation(storedId);
+  } else {
+    newChat();
+    state.currentConversationId = storedId;  // continue the agent thread on next turn
+  }
+}
+
+export async function initBackend() {
+  config.backend = getBackendMode() === 'agent' ? 'agent' : null;
+  if (elements.backendLifeos) elements.backendLifeos.addEventListener('click', () => setBackendMode('lifeos'));
+  if (elements.backendAgent) elements.backendAgent.addEventListener('click', () => setBackendMode('agent'));
+  applyBackendUi();
+
+  // Restore the current backend's conversation id (continuity across refresh).
+  state.currentConversationId = getStoredConversationId();
+
+  // Only expose the Agent toggle when the backend is configured server-side.
+  try {
+    const resp = await fetch(endpoints.agentStatus);
+    if (resp.ok) {
+      const data = await resp.json();
+      document.body.classList.toggle('agent-available', !!data.available);
+    }
+  } catch (e) {
+    /* leave the Agent toggle hidden */
+  }
+}

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -20,6 +20,7 @@ import {
 import { sendMessage, askQuestion } from './ask-stream.js';
 import { loadPersonas, onPersonaChange } from './persona.js';
 import { initVoice, toggleVoiceMode, submitTurn } from './voice.js';
+import { initBackend } from './backend.js';
 
 // Boot the chat surface. The shell passes in the explicit DOM element map (so
 // the modules never getElementById), the API endpoints, and integration hooks
@@ -47,6 +48,7 @@ export function initChat({ elements: els, endpoints: eps, hooks: hks } = {}) {
 
   setupAttachmentHandlers();
   setupSwipeGestures();
+  initBackend();  // LifeOS|Agent toggle + restore per-backend conversation (#361)
   initVoice();  // restore Voice|Text mode + wire the hold-to-talk dock (#361)
   // loadPersonas() resolves the persona (from sessionStorage, validated against
   // /api/personas) and then loads the persona-scoped conversation sidebar — it

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -48,13 +48,14 @@ export function initChat({ elements: els, endpoints: eps, hooks: hks } = {}) {
 
   setupAttachmentHandlers();
   setupSwipeGestures();
+  // loadPersonas() resolves config.personaId synchronously (from sessionStorage,
+  // validated against /api/personas) and then loads the persona-scoped
+  // conversation sidebar. It runs BEFORE initBackend() so the per-backend
+  // conversation key (which is persona-scoped for lifeos) reads the right
+  // persona on a refresh.
+  loadPersonas();
   initBackend();  // LifeOS|Agent toggle + restore per-backend conversation (#361)
   initVoice();  // restore Voice|Text mode + wire the hold-to-talk dock (#361)
-  // loadPersonas() resolves the persona (from sessionStorage, validated against
-  // /api/personas) and then loads the persona-scoped conversation sidebar — it
-  // owns the single initial loadConversations() so the picker and sidebar stay
-  // consistent even when a stored persona has to be reset.
-  loadPersonas();
   setStatus('', 'Ready');
   inputField.focus();
 }

--- a/web/chat/persona.js
+++ b/web/chat/persona.js
@@ -106,6 +106,7 @@ export function onPersonaChange() {
 // not trigger a handoff during the /api/personas load window).
 export function personaSupportsHandoff() {
   const { personas, personaId } = config;
+  if (config.backend === 'agent') return false;  // the agent backend has no handoff
   if (!personas || personas.length === 0) return personaId === DEFAULT_PERSONA_ID;
   const p = personas.find(x => x.id === personaId);
   return !!(p && p.capabilities && p.capabilities.includes('handoff'));

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -16,6 +16,7 @@
 import { state, config, elements, endpoints } from './session.js';
 import { addMessage, setStatus } from './thread.js';
 import { loadConversations } from './conversations.js';
+import { setStoredConversationId } from './backend.js';
 
 const VOICE_MODE_KEY = 'lifeos:chat:voice_mode';
 const DOCK_SETTINGS_KEY = 'lifeos:chat:dock_settings';
@@ -442,6 +443,7 @@ export async function submitTurn({ blob, mime, transcript } = {}) {
 
     if (data.conversation_id) {
       state.currentConversationId = data.conversation_id;
+      setStoredConversationId(data.conversation_id);  // per-backend persistence
       loadConversations();
     }
     clearThinking();

--- a/web/index.html
+++ b/web/index.html
@@ -2785,7 +2785,7 @@
                 </nav>
             </div>
             <div class="header-right">
-                <div class="backend-toggle" id="backendToggle" role="group" aria-label="Text backend">
+                <div class="backend-toggle" role="group" aria-label="Text backend">
                     <button class="backend-option active" id="backendLifeos" type="button" title="LifeOS backend">LifeOS</button>
                     <button class="backend-option" id="backendAgent" type="button" title="Agent backend">Agent</button>
                 </div>

--- a/web/index.html
+++ b/web/index.html
@@ -612,6 +612,41 @@
             border-color: var(--accent);
         }
 
+        /* LifeOS|Agent text-backend toggle (#361); shown only when the agent
+           backend is configured server-side (body.agent-available). */
+        .backend-toggle {
+            display: none;
+            align-items: center;
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            overflow: hidden;
+        }
+
+        body.agent-available .backend-toggle {
+            display: inline-flex;
+        }
+
+        .backend-option {
+            background: none;
+            border: none;
+            color: var(--text-secondary);
+            font-size: 0.72rem;
+            padding: 0.3rem 0.55rem;
+            cursor: pointer;
+            transition: all 0.15s;
+        }
+
+        .backend-option.active {
+            background: var(--accent);
+            color: white;
+        }
+
+        /* Agent mode has no personas — hide the picker. */
+        body.agent-mode .persona-picker {
+            display: none;
+        }
+
         /* Modal */
         .modal-overlay {
             display: none;
@@ -2750,6 +2785,10 @@
                 </nav>
             </div>
             <div class="header-right">
+                <div class="backend-toggle" id="backendToggle" role="group" aria-label="Text backend">
+                    <button class="backend-option active" id="backendLifeos" type="button" title="LifeOS backend">LifeOS</button>
+                    <button class="backend-option" id="backendAgent" type="button" title="Agent backend">Agent</button>
+                </div>
                 <select class="persona-picker" id="personaPicker" onchange="onPersonaChange()" title="Choose persona" aria-label="Persona"></select>
                 <span class="chat-title" id="chatTitle">New conversation</span>
                 <button class="remember-btn" onclick="openRememberModal()" title="Remember something">
@@ -3135,6 +3174,8 @@
                     voiceMute: document.getElementById('voiceMute'),
                     voiceFast: document.getElementById('voiceFast'),
                     voiceAuto: document.getElementById('voiceAuto'),
+                    backendLifeos: document.getElementById('backendLifeos'),
+                    backendAgent: document.getElementById('backendAgent'),
                 },
                 endpoints: {
                     conversations: '/api/conversations',
@@ -3142,6 +3183,8 @@
                     handoff: '/api/chat/handoff',
                     personas: '/api/personas',
                     voice: '/api/voice',
+                    agentAsk: '/api/agent/ask/stream',
+                    agentStatus: '/api/agent/status',
                 },
                 hooks: { onAgentThreadReply: sendThreadReply },
             });


### PR DESCRIPTION
## Summary

Final part of #361 — adds the **LifeOS | Agent** text-backend toggle, the bearer-authed **agent-text proxy**, and **per-backend conversation persistence**. With this, `/chat` is the unified responsive text+voice client across both backends.

Closes #361

## Backend (`api/`)
- `api/routes/agent_proxy.py` — `POST /api/agent/ask/stream` proxies to `LIFEOS_AGENT_BACKEND_URL/api/ask/stream`, **adding the bearer token server-side** (never exposed to the browser); streams request body + SSE; 503 if unconfigured, 502 if unreachable. `GET /api/agent/status` reports availability.
- `config/settings.py` — `LIFEOS_AGENT_BACKEND_URL` / `LIFEOS_AGENT_BACKEND_TOKEN`.

## Frontend
- `web/chat/backend.js` (new) — header LifeOS|Agent toggle (shown only when configured); `config.backend`; per-backend `conversation_id` in `sessionStorage` (`lifeos:chat:conv:agent`, `…:conv:lifeos:<persona>`), restored on init + switch.
- Agent mode hides the persona picker and gates off handoff; text turns route to `/api/agent/ask/stream` (no persona). Voice turns already send `backend`.

## Test evidence
- `tests/test_agent_proxy.py` (4): `status`, **bearer injected server-side** (browser sends none), 503 unconfigured, 502 unreachable. Full unit suite green; all 9 module + inline `<script>` `node --check`.
- **Headless Playwright** (stub gateway, 0 console errors): toggle shown when agent-available; switch → `agent-mode` (persona hidden, `config.backend='agent'`, persisted); a text turn hits `/api/agent/ask/stream`, renders the agent reply, persists `conv:agent`; switch back restores LifeOS + persona.

## Review focus
- **The bearer-auth proxy** (`agent_proxy.py`) — token added server-side only, streaming, header filtering, error/timeout handling.
- Per-backend conversation persistence in `backend.js` — agent history isn't LifeOS-owned, so on switch the agent view is fresh but the id is retained for turn continuity (lifeos history is rendered via `loadConversation`); is that handling sound?
- Live agent backend needs `LIFEOS_AGENT_BACKEND_URL` set + the adapter running (your machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)