### PR TITLE
fix(ops): Tailscale HTTPS :443 serves LifeOS for /chat voice

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -24,6 +24,19 @@ Each section corresponds roughly to a section in [`config/settings.py`](../../co
 | `LIFEOS_CHROMA_PATH` | path | `./data/chromadb` | Where ChromaDB persists its data. |
 | `LIFEOS_CODE_DIR` | path | `~/Code` | Parent directory containing LifeOS and (optionally) other projects. Used by `/claude` orchestrator path resolution. |
 | `LIFEOS_BACKUP_PATH` | path | `./data/backups` | Where backup archives are written. |
+| `TAILNET_HTTPS_URL` | str | — | Your machine's Tailscale HTTPS URL (no port), e.g. `https://nathanramia-linux.<tailnet>.ts.net`. Used by `scripts/setup-tailscale.sh` status output. **Open `/chat` on this URL for voice** — the mic requires HTTPS. |
+| `LIFEOS_VOICE_GATEWAY_URL` | str | `http://127.0.0.1:9788` | whisper-relay base URL; LifeOS reverse-proxies `/api/voice/*` here (ADR-016). |
+
+**Tailscale Serve (phone /chat + voice):** run once after install, then enable the user unit so it survives reboot:
+
+```bash
+./scripts/install-systemd-tailscale.sh
+systemctl --user enable --now lifeos-tailscale.service
+# Disable whisper-relay claiming :443 if you still have it:
+systemctl --user disable --now whisper-relay-tailscale.service
+```
+
+This binds Tailscale **HTTPS :443 → LifeOS :8000**. whisper-relay stays on localhost; voice calls go through LifeOS same-origin.
 
 ## LLM Backend — Synthesis and Orchestration
 

--- a/scripts/install-systemd-tailscale.sh
+++ b/scripts/install-systemd-tailscale.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Generate ~/.config/systemd/user/lifeos-tailscale.service (oneshot after API is up).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${DEPLOY_ENV_FILE:-$ROOT/.env}"
+REPO_DIR="${DEPLOY_REPO_DIR:-$ROOT}"
+ENV_PATH="${DEPLOY_ENV_FILE:-$ROOT/.env}"
+LIFEOS_PORT="${LIFEOS_PORT:-8000}"
+
+DEST="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/lifeos-tailscale.service"
+mkdir -p "$(dirname "$DEST")"
+
+cat >"$DEST" <<EOF
+[Unit]
+Description=Tailscale Serve proxy for LifeOS (/chat HTTPS)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=${REPO_DIR}
+EnvironmentFile=${ENV_PATH}
+ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do curl -sf http://127.0.0.1:${LIFEOS_PORT}/health >/dev/null && exit 0; sleep 2; done; echo "LifeOS API not healthy on :${LIFEOS_PORT}"; exit 1'
+ExecStart=${REPO_DIR}/scripts/setup-tailscale.sh
+
+[Install]
+WantedBy=default.target
+EOF
+
+echo "Wrote ${DEST}"
+echo "Enable with: systemctl --user enable --now lifeos-tailscale.service"
+echo "Disable whisper-relay on :443 if still enabled:"
+echo "  systemctl --user disable --now whisper-relay-tailscale.service"

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -262,9 +262,13 @@ show_status() {
 
     # Tailscale URL if available
     if command -v tailscale &> /dev/null; then
-        local ts_ip=$(tailscale ip -4 2>/dev/null || true)
+        local ts_ip
+        ts_ip=$(tailscale ip -4 2>/dev/null || true)
         if [ -n "$ts_ip" ]; then
             echo "  Tailscale: http://$ts_ip:$PORT"
+        fi
+        if [ -n "${TAILNET_HTTPS_URL:-}" ]; then
+            echo "  Voice/chat: ${TAILNET_HTTPS_URL}/chat  (HTTPS — required for mic)"
         fi
     fi
     echo ""

--- a/scripts/setup-tailscale.sh
+++ b/scripts/setup-tailscale.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Expose LifeOS on the tailnet HTTPS front (port 443). Required for /chat voice
+# (getUserMedia needs a secure context). whisper-relay stays on localhost:9788;
+# LifeOS reverse-proxies /api/voice/* (ADR-016).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Port/URL come from the environment (systemd EnvironmentFile or caller export).
+# Do not source .env here — paths may contain spaces.
+
+PORT="${LIFEOS_PORT:-8000}"
+BACKEND="http://127.0.0.1:${PORT}"
+
+tailscale serve reset
+tailscale serve --bg "${BACKEND}"
+
+echo "LifeOS tailnet URLs:"
+if [[ -n "${TAILNET_HTTPS_URL:-}" ]]; then
+  echo "  HTTPS /chat (voice): ${TAILNET_HTTPS_URL}/chat"
+else
+  echo "  Set TAILNET_HTTPS_URL in .env for a stable bookmark hint."
+fi
+tailscale serve status


### PR DESCRIPTION
## Summary
- Add `scripts/setup-tailscale.sh` — Tailscale Serve :443 → LifeOS :8000 (secure context for mic)
- Add `scripts/install-systemd-tailscale.sh` + `lifeos-tailscale.service` (user unit, waits for `/health`)
- `server.sh status` prints `TAILNET_HTTPS_URL/chat` when set
- Document `TAILNET_HTTPS_URL` and voice gateway env in configuration guide

whisper-relay's `whisper-relay-tailscale.service` should stay disabled so it does not reclaim :443 on reboot.

Already applied live on nathan-linux; disable whisper-relay-tailscale and enable lifeos-tailscale there.

## Test plan
- [ ] `https://<machine>.ts.net/chat` loads LifeOS (not whisper-relay static UI)
- [ ] Voice mode: tap to talk works on phone
- [ ] Reboot: `lifeos-tailscale.service` restores :443 → :8000


Made with [Cursor](https://cursor.com)