### PR TITLE
feat(chat): message-bubble cleanup + voice-dock polish + voice default

### DIFF
--- a/web/chat/ask-stream.js
+++ b/web/chat/ask-stream.js
@@ -182,7 +182,7 @@ export async function sendMessage() {
           // Add sources and meta to message
           const msgEl = document.getElementById(msgId);
           if (msgEl) {
-            let metaHtml = '<div class="message-meta">';
+            let metaHtml = '';
 
             // Show routing sources used
             if (routingSources.length > 0) {
@@ -229,17 +229,15 @@ export async function sendMessage() {
               metaHtml += '</div>';
             }
 
-            metaHtml += `
-                                            <div class="meta-actions">
-                                                <button class="save-btn" onclick="openSaveVaultModal(this)">Save to vault</button>
-                                            </div>
-                                        </div>`;
-
             // Remove any existing meta
             const existingMeta = msgEl.querySelector('.message-meta');
             if (existingMeta) existingMeta.remove();
 
-            msgEl.insertAdjacentHTML('beforeend', metaHtml);
+            // Only render the meta block when there's something to show
+            // (routing sources or vault sources); no save-to-vault button.
+            if (metaHtml) {
+              msgEl.insertAdjacentHTML('beforeend', `<div class="message-meta">${metaHtml}</div>`);
+            }
           }
 
           loadConversations();

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -11,7 +11,7 @@
 // handler runs — so the bridge exists by the time any shell code touches it.
 
 import { state, config, elements, endpoints, hooks } from './session.js';
-import { addMessage, copyMessage, toggleSources, setStatus } from './thread.js';
+import { addMessage, toggleSources, setStatus } from './thread.js';
 import { setupAttachmentHandlers, openFilePicker, removeAttachment } from './attachments.js';
 import {
   setupSwipeGestures, toggleSidebar, closeSidebar, newChat,
@@ -67,7 +67,7 @@ window.lifeChat = { state, config, initChat };
 
 Object.assign(window, {
   // thread.js
-  addMessage, copyMessage, toggleSources,
+  addMessage, toggleSources,
   // conversations.js
   toggleSidebar, closeSidebar, newChat, filterConversations,
   loadConversation, deleteConversation,

--- a/web/chat/thread.js
+++ b/web/chat/thread.js
@@ -40,47 +40,32 @@ export function addMessage(content, type, sources = [], messageId = null, target
   msg.className = 'message ' + type;
   if (messageId) msg.id = messageId;
 
-  let html = `
-                <div class="message-actions">
-                    <button class="action-btn" onclick="copyMessage(this)" title="Copy">📋</button>
-                </div>
-                <div class="message-content">${formatContent(content)}</div>
-            `;
+  let html = `<div class="message-content">${formatContent(content)}</div>`;
 
-  if (type === 'assistant' && content) {
-    html += `<div class="message-meta">`;
+  if (type === 'assistant' && content && sources.length > 0) {
+    // Add collapsed class if more than 3 sources
+    const collapsedClass = sources.length > 3 ? ' collapsed' : '';
+    html += `<div class="message-meta"><div class="sources${collapsedClass}">`;
+    sources.forEach(src => {
+      const fileName = src.file_name || src;
+      const sourceType = src.source_type || 'vault';
 
-    if (sources.length > 0) {
-      // Add collapsed class if more than 3 sources
-      const collapsedClass = sources.length > 3 ? ' collapsed' : '';
-      html += `<div class="sources${collapsedClass}">`;
-      sources.forEach(src => {
-        const fileName = src.file_name || src;
-        const sourceType = src.source_type || 'vault';
-
-        if (sourceType === 'calendar' && src.url) {
-          // Calendar sources use Google Calendar URL
-          html += `<a href="${src.url}" target="_blank" class="source-link">${fileName}</a>`;
-        } else {
-          // Vault sources use Obsidian URL
-          const obsidianPath = src.obsidian_path || fileName;
-          const obsidianUrl = `obsidian://open?vault=Notes%202025&file=${encodeURIComponent(obsidianPath)}`;
-          html += `<a href="${obsidianUrl}" class="source-link">📄 ${fileName}</a>`;
-        }
-      });
-      // Add toggle button if more than 3 sources
-      if (sources.length > 3) {
-        const hiddenCount = sources.length - 3;
-        html += `<button class="sources-toggle" onclick="toggleSources(this)">Show ${hiddenCount} more...</button>`;
+      if (sourceType === 'calendar' && src.url) {
+        // Calendar sources use Google Calendar URL
+        html += `<a href="${src.url}" target="_blank" class="source-link">${fileName}</a>`;
+      } else {
+        // Vault sources use Obsidian URL
+        const obsidianPath = src.obsidian_path || fileName;
+        const obsidianUrl = `obsidian://open?vault=Notes%202025&file=${encodeURIComponent(obsidianPath)}`;
+        html += `<a href="${obsidianUrl}" class="source-link">📄 ${fileName}</a>`;
       }
-      html += `</div>`;
+    });
+    // Add toggle button if more than 3 sources
+    if (sources.length > 3) {
+      const hiddenCount = sources.length - 3;
+      html += `<button class="sources-toggle" onclick="toggleSources(this)">Show ${hiddenCount} more...</button>`;
     }
-
-    html += `
-                    <div class="meta-actions">
-                        <button class="save-btn" onclick="openSaveVaultModal(this)">Save to vault</button>
-                    </div>
-                </div>`;
+    html += `</div></div>`;
   }
 
   msg.innerHTML = html;
@@ -109,19 +94,6 @@ export function formatContent(content) {
     .replace(/\*(.*?)\*/g, '<em>$1</em>')
     .replace(/`(.*?)`/g, '<code>$1</code>')
     .replace(/\n/g, '<br>');
-}
-
-export function copyMessage(btn) {
-  const msg = btn.closest('.message');
-  const content = msg.querySelector('.message-content').textContent;
-  navigator.clipboard.writeText(content).then(() => {
-    btn.classList.add('copied');
-    btn.textContent = '✓';
-    setTimeout(() => {
-      btn.classList.remove('copied');
-      btn.textContent = '📋';
-    }, 2000);
-  });
 }
 
 export function toggleSources(btn) {

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -132,12 +132,26 @@ function isVoiceMode() {
   return config.voiceMode === true;
 }
 
-function readVoiceMode() {
+// Resolve the initial input mode. Precedence: an explicit URL param
+// (/chat?mode=voice | /chat?mode=text), which also sticks; then the stored
+// preference; otherwise VOICE is the default.
+function resolveInitialVoiceMode() {
   try {
-    return window.sessionStorage.getItem(VOICE_MODE_KEY) === '1';
+    const mode = new URLSearchParams(window.location.search).get('mode');
+    if (mode === 'voice') { storeVoiceMode(true); return true; }
+    if (mode === 'text') { storeVoiceMode(false); return false; }
   } catch (e) {
-    return false;
+    /* no URLSearchParams / blocked — fall through */
   }
+  let stored = null;
+  try {
+    stored = window.sessionStorage.getItem(VOICE_MODE_KEY);
+  } catch (e) {
+    /* sessionStorage unavailable */
+  }
+  if (stored === '1') return true;
+  if (stored === '0') return false;
+  return true;  // default: voice
 }
 
 function storeVoiceMode(on) {
@@ -187,7 +201,7 @@ function formatMicError(err) {
 }
 
 export function initVoice() {
-  config.voiceMode = readVoiceMode();
+  config.voiceMode = resolveInitialVoiceMode();
   applyVoiceMode();
 
   loadDockSettings();

--- a/web/index.html
+++ b/web/index.html
@@ -1024,6 +1024,7 @@
         .chat-toolbar {
             display: flex;
             align-items: center;
+            justify-content: center;
             flex-wrap: wrap;
             gap: 0.5rem;
             padding: 0.4rem 1rem;
@@ -1049,8 +1050,8 @@
             justify-content: center;
         }
 
-        /* The run-as-agent routing dropdown is text-mode only. */
-        body.voice-mode .agent-routing-select {
+        /* The model picker is text-mode only (voice turns use the backend). */
+        body.voice-mode #modelPicker {
             display: none;
         }
 
@@ -1060,11 +1061,19 @@
 
         .voice-dock {
             display: none;
+            position: relative;
             flex-direction: column;
             align-items: center;
             gap: 0.5rem;
             max-width: 800px;
             margin: 0 auto;
+        }
+
+        /* The text toggle sits in the dock's bottom-left corner in voice mode. */
+        .voice-dock .dock-keyboard {
+            position: absolute;
+            left: 0;
+            bottom: 0;
         }
 
         .voice-dock-row {
@@ -1139,19 +1148,18 @@
 
         .voice-talk-btn.shutter.recording {
             border-color: var(--error);
+            animation: shutter-pulse 1.4s ease-in-out infinite;
         }
 
         .voice-talk-btn.shutter.recording .shutter-core {
-            width: 30px;
-            height: 30px;
-            border-radius: 8px;
             background: var(--error);
-            animation: shutter-pulse 1.2s ease-in-out infinite;
         }
 
+        /* The whole button pulses (scale + an expanding red glow ring) while
+           recording. --error is #f44336 → rgb(244, 67, 54). */
         @keyframes shutter-pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.55; }
+            0%, 100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(244, 67, 54, 0.5); }
+            50% { transform: scale(1.06); box-shadow: 0 0 0 12px rgba(244, 67, 54, 0); }
         }
 
         .voice-cancel-btn {
@@ -2769,7 +2777,6 @@
         .agent-tool-details details { font-size: 0.76rem; margin-bottom: 0.2rem; }
         .agent-tool-details summary { cursor: pointer; opacity: 0.75; }
         .agent-tool-details pre { font-size: 0.72rem; background: rgba(0,0,0,0.25); padding: 0.4rem 0.5rem; border-radius: 6px; overflow-x: auto; white-space: pre-wrap; }
-        .agent-routing-select { font-size: 0.78rem; border-radius: 8px; border: 1px solid var(--border, #2a2a2a); background: rgba(0,0,0,0.2); color: inherit; padding: 0 0.3rem; }
         .agent-spawn-btn { background: none; border: none; cursor: pointer; font-size: 1.15rem; opacity: 0.75; }
         .agent-spawn-btn:hover { opacity: 1; }
     </style>
@@ -2832,7 +2839,7 @@
         <!-- Top-of-chat selector toolbar (#361 UI): persona + routing + backend -->
         <div class="chat-toolbar">
             <select class="persona-picker" id="personaPicker" onchange="onPersonaChange()" title="Choose persona" aria-label="Persona"></select>
-            <select id="modelPicker" class="agent-routing-select" onchange="onModelChange()" title="Model for this chat" aria-label="Chat model">
+            <select id="modelPicker" class="persona-picker" onchange="onModelChange()" title="Model for this chat" aria-label="Chat model">
                 <option value="auto">🤖 Auto</option>
                 <option value="sonnet">Sonnet</option>
                 <option value="opus">Opus</option>
@@ -2882,8 +2889,8 @@
             </div>
             <!-- Voice dock (#361): tap-to-talk + dock toggles; shown in voice mode -->
             <div class="voice-dock" id="voiceDock">
+                <button class="mode-toggle dock-keyboard" onclick="toggleVoiceMode()" title="Text input" aria-label="Switch to text">⌨️</button>
                 <div class="voice-dock-row">
-                    <button class="mode-toggle" onclick="toggleVoiceMode()" title="Text input" aria-label="Switch to text">⌨️</button>
                     <button class="voice-talk-btn shutter" id="voiceTalkBtn" title="Tap to talk" aria-label="Tap to talk"><span class="shutter-core"></span></button>
                     <button class="voice-cancel-btn" id="voiceCancelBtn" title="Cancel turn">✕</button>
                 </div>


### PR DESCRIPTION
## Summary

Frontend-only chat polish from direct user feedback:

**Message bubbles**
- Removed the 📋 copy action from every bubble and the "Save to vault" button from assistant replies (it was rendered in both `addMessage` and the streaming `done` handler). Meta now renders only when there are sources; dropped the dead `copyMessage` helper.

**Voice dock**
- Record button **pulses while recording** (scale + red glow ring) — a plain red circle, no text or icons inside.
- Moved the ⌨️ text toggle to the dock's **bottom-left corner** in voice mode.

**Mode + pickers**
- **Voice is the default** input mode; `/chat?mode=voice` and `/chat?mode=text` deep-link to a mode (and stick). Precedence: explicit param > stored preference > voice default.
- The model picker now uses the **persona picker's styling** (same UI), and both pickers are **centered** in the toolbar.

## Test evidence
- All modules + inline `<script>` `node --check`. No Python touched (frontend only) → no server restart needed.
- **Headless Playwright** (stub, 0 console errors): no copy/save buttons on replies; record button has `shutter-pulse` animation + empty text; ⌨️ absolute in the dock's bottom-left; `?mode=text`→text, cleared-storage default→voice; toolbar `justify-content: center`; `#modelPicker` class `persona-picker` matching the persona picker's computed font/border/background.

## Heads-up (open-source default)
Voice is now the default mode. A fresh clone **without** whisper-relay will land on the voice dock; tapping shows a clear "mic unavailable (HTTPS required)" message and the ⌨️ (bottom-left) switches to text. It's recoverable, not broken — but if you'd rather gate the voice-default behind a setting (text default for fresh downloaders), say the word and I'll add `LIFEOS_CHAT_DEFAULT_VOICE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)