### PR TITLE
style(chat): breathing room below the voice record button

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -953,6 +953,8 @@
             align-items: center;
             justify-content: center;
             gap: 1rem;
+            /* a little extra breathing room below the record button */
+            margin-top: 0.6rem;
         }
 
         .dock-toggle {


### PR DESCRIPTION
## Summary

Cosmetic: a small `margin-top` (0.6rem) on `.voice-dock-toggles` so the Mute/2×/Auto row sits a touch further below the record button in voice mode. Total gap ~18px (was ~8px).

Frontend-only, no restart needed. Verified headlessly (computed `margin-top: 9.6px`, 0 console errors) + screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)