### PR TITLE
feat(skills): add /routing-health — on-demand chat routing matrix check

### DIFF
--- a/.claude/skills/routing-health/SKILL.md
+++ b/.claude/skills/routing-health/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: routing-health
+description: On-demand routing health check for /chat. Verifies every model (auto / Sonnet / Opus / Gemma-local / Claude Code) on BOTH text and voice, across every persona, and that messaging a persona in /chat is identical to messaging its Telegram bot.
+argument-hint: [--live]
+---
+
+# Routing Health Check
+
+Arguments: `$ARGUMENTS`
+
+Modes:
+- *(default)* — deterministic dispatch matrix + cheap liveness probes. No cloud cost beyond a single Haiku voice turn; **no Claude Code workers are spawned**. ~30–60s.
+- **--live** — additionally runs a real generation per model on text AND voice (verified against the recorded routing model), plus one `claude_code`-via-voice handoff for a no-handoff persona — which spawns a Claude Code worker and then kills it (process included). Real cloud cost (≈ one Opus + one Sonnet + local + Haiku turns, twice). A few minutes.
+
+## Why this exists
+
+The `/chat` model picker (`auto` / `Sonnet` / `Opus` / `Gemma (local)` / `Claude Code`) and the voice surface route a turn through several independent layers: the web/voice client, `model_override` on `/api/ask/stream`, the orchestrator's model resolution + escalation, the whisper-relay voice gateway, and the Claude Code engine handoff. A regression in any one layer — a new picker value with no backend support, a persona that stops resolving, the voice gateway dropping `model_override`, the `claude_code` short-circuit breaking, the handoff gate suppressing a non-handoff persona — is **silent** until someone hits that exact cell. This check exercises the whole grid (2 surfaces × 5 models × every persona) on demand.
+
+It also asserts the design invariant the project depends on: **messaging a persona in `/chat` (text or voice) behaves identically to messaging that persona's Telegram bot** — both resolve the same `bot.persona` preamble from the registry and call the same `run_agent_loop` via `/api/ask/stream`.
+
+## What it checks
+
+- **Inventory** — every model-picker option value in `web/index.html` is one the backend actually handles; enumerates personas from `settings.list_http_personas()`.
+- **Persona ↔ Telegram equivalence** — `/api/personas` matches the Telegram bot registry; `resolve_persona(id)` returns each bot's exact `persona` preamble; and *empirically*, `run_agent_loop` receives the **identical** persona whether the turn arrives the `/chat` way (`persona_id`) or the Telegram way (`persona` preamble).
+- **Text routing matrix** — every persona × {`auto`, `opus`, `sonnet`, `gemma`, `claude_code`}: the correct model id is resolved (mocked dispatch — **no LLM calls**), `force_local` is set for gemma, the persona preamble is passed through, and `claude_code` short-circuits to a `claude_intent` handoff (no agent loop, no inline answer).
+- **Voice forwarding + gate** — whisper-relay forwards `model_override` and bypasses the persona handoff gate for `claude_code` (runs its `tests/test_model_override.py`).
+- **Liveness** — the deployed service actually emits `claude_intent` and serves a real voice turn end-to-end.
+- **--live only** — a real generation per model on text and voice (asserted against the conversation's recorded routing model), and a live `claude_code`-via-voice handoff for a no-handoff persona (spawned worker + killed, OS process included).
+
+## Instructions
+
+### Step 0: Pre-flight
+
+!`curl -s -m4 http://localhost:8000/health >/dev/null 2>&1 && echo "lifeos-api: up" || echo "lifeos-api: DOWN"; [ -x "$HOME/.venvs/lifeos/bin/python" ] && echo "venv: ok" || echo "venv: MISSING"; pgrep -f "voice_gateway.main" >/dev/null 2>&1 && echo "voice-gateway: up" || echo "voice-gateway: down (voice live-probes will fail)"`
+
+If `lifeos-api` is DOWN, stop and tell the user to start it (`sudo systemctl start lifeos-api`) — every live probe needs it. If the voice gateway is down, the voice liveness probe (and `--live` voice cells) will FAIL; note it but the rest still runs.
+
+### Step 1: Run the checker
+
+Run from the repo root with the project venv. Include `--live` **only if** `$ARGUMENTS` contains `--live`:
+
+```
+~/.venvs/lifeos/bin/python .claude/skills/routing-health/scripts/routing_check.py [--live]
+```
+
+The script prints a `[PASS]/[FAIL]/[WARN]` line per check, a final `ROUTING-HEALTH-VERDICT:` line, and a `ROUTING-HEALTH-JSON:` summary blob. It **cleans up its own** probe conversations (across every persona scope) and, under `--live`, kills the worker session it spawns (and its OS subprocess). Suppress noisy warnings with `2>/dev/null`.
+
+### Step 2: Report
+
+Interpret the script's output (do **not** re-run the underlying tests yourself). Produce a concise report:
+
+- **Overall** — 🟢 HEALTHY / 🟡 DEGRADED (any WARN) / 🔴 FAILING (any FAIL), taken from the verdict line.
+- **Coverage** — state what actually ran: N personas × 5 models on text (always), voice forwarding + gate, liveness, and — if `--live` — the live generation matrix and the `claude_code` voice handoff.
+- **Equivalence** — explicitly confirm or deny that `/chat` (text + voice) behaves identically to the Telegram bots for personas (from the `equivalence/*` checks).
+- **Failures** — for each FAIL, name the cell and the detail, and point at where to look (table below).
+- **Cleanup** — confirm probe conversations were deleted; under `--live`, confirm no stray worker remains (the script's `live-voice/claude_code-cleanup` line, and you may verify with `pgrep -af "claude -p"`).
+
+If the script itself crashed (a `deterministic-harness FAIL` line or a Python traceback), surface that and stop — the matrix didn't run.
+
+### Failure → where to look
+
+| Failing check | Look at |
+|---|---|
+| `inventory/model-picker-options` | `web/index.html` `#modelPicker` options vs the handled set in `api/routes/chat.py` (`model_override` resolution, ~L1243) |
+| `equivalence/*` | `config/settings.py` (`resolve_persona`, `list_http_personas`, telegram bot registry) and `api/services/telegram.py` (`chat_via_api`) |
+| `text-matrix/<persona>/<model>` | `api/routes/chat.py` `ask_stream` — model_override resolution + persona handling + the `claude_code` short-circuit |
+| `voice/whisper-relay-*` | `~/Code/whisper-relay` adapter (`src/voice_gateway/adapters/lifeos.py`) + `web/chat/voice.js` (model_override on the voice FormData) |
+| `live/*`, `live-text/*`, `live-voice/*` | deployed service (restart `lifeos-api`); for voice cells, the whisper-relay gateway on :9788 |
+
+## Notes
+
+- **Read-mostly.** The only writes are throwaway probe conversations (auto-deleted) and, under `--live`, one Claude Code worker session — killed, OS process included (operator-kill alone leaves the process; see issue #379).
+- **Requirements:** `lifeos-api` running; for voice checks, the whisper-relay gateway on :9788; for the local/`gemma` cells, `lifeos-llm` active.
+- **whisper-relay location** defaults to `~/Code/whisper-relay` — override with `WHISPER_RELAY_DIR`. If it's absent, the voice-forwarding checks WARN (skipped) rather than fail, and the verdict degrades to 🟡 rather than 🔴.
+- The deterministic matrix loads the app in-process (TestClient) and mocks `run_agent_loop`, so it makes **no** real LLM calls and spawns nothing — it's safe to run frequently. The cost and side effects live entirely in `--live`.

--- a/.claude/skills/routing-health/scripts/routing_check.py
+++ b/.claude/skills/routing-health/scripts/routing_check.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Routing-health checker for the LifeOS chat router.
+
+Verifies that every chat configuration routes correctly:
+  surfaces  = text (/api/ask/stream) + voice (/api/voice/turn/stream)
+  models    = auto / sonnet / opus / gemma(local) / claude_code
+  personas  = every persona in settings.list_http_personas()
+
+and that messaging a persona in /chat is IDENTICAL to messaging the matching
+Telegram bot (same run_agent_loop, same persona preamble).
+
+Modes:
+  (default)  deterministic checks + two cheap liveness probes. No cloud cost
+             beyond one Haiku voice turn; no Claude Code workers are spawned.
+  --live     also runs the full live generation matrix (a real turn per model
+             on text AND voice) and one live claude_code-via-voice handoff for a
+             no-handoff persona — spawning a Claude Code worker that is then
+             killed (process included, per issue #379).
+
+Prints a human-readable report and a final `ROUTING-HEALTH-VERDICT:` line plus a
+JSON blob the calling skill interprets. Read-mostly: the only writes are
+throwaway probe conversations (deleted) and, under --live, one worker session
+(killed). Run from the repo root.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO = Path(__file__).resolve().parents[4]
+os.chdir(REPO)
+sys.path.insert(0, str(REPO))
+
+BASE = os.environ.get("LIFEOS_BASE_URL", "http://localhost:8000")
+WHISPER_RELAY = Path(os.environ.get("WHISPER_RELAY_DIR", str(Path.home() / "Code" / "whisper-relay")))
+LIVE = "--live" in sys.argv or "--deep" in sys.argv
+MODELS = ["auto", "opus", "sonnet", "gemma", "claude_code"]
+BACKEND_HANDLED = {"auto", "sonnet", "opus", "gemma", "local", "claude_code"}
+
+results: list[dict] = []          # {check, status(PASS/FAIL/WARN/SKIP), detail}
+created_convs: list[str] = []     # conversation ids to clean up
+PROBE = "routing-health probe — please ignore"
+
+
+def record(check: str, status: str, detail: str = "") -> None:
+    results.append({"check": check, "status": status, "detail": detail})
+    print(f"  [{status:4}] {check}" + (f" — {detail}" if detail else ""))
+
+
+def http_json(method: str, path: str, body: dict | None = None, timeout: int = 12):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method,
+                                 headers={"Content-Type": "application/json"} if data else {})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        raw = r.read().decode()
+    try:
+        return r.status, json.loads(raw)
+    except Exception:
+        return r.status, raw
+
+
+# ---------------------------------------------------------------------------
+# In-process harness: capture what chat.py dispatches to run_agent_loop.
+# ---------------------------------------------------------------------------
+_captured: list[dict] = []
+
+
+async def _fake_loop(**kwargs):
+    _captured.append(kwargs)
+    yield {"type": "result", "result": SimpleNamespace(
+        total_input_tokens=0, total_output_tokens=0, total_cost_usd=0.0,
+        model="(mock)", tool_calls_log=[], full_text="(mock)")}
+
+
+def _post(client, payload):
+    """POST to the in-process app, swallowing the route's own print() noise."""
+    with contextlib.redirect_stdout(io.StringIO()):
+        return client.post("/api/ask/stream", json=payload)
+
+
+def _conv_id(sse_text: str):
+    for line in sse_text.splitlines():
+        if line.startswith("data: "):
+            try:
+                d = json.loads(line[6:])
+            except Exception:
+                continue
+            if d.get("type") == "conversation_id":
+                return d.get("conversation_id")
+    return None
+
+
+def deterministic_checks():
+    """Inventory, telegram equivalence, and the text routing matrix — all
+    in-process with run_agent_loop mocked (no LLM calls, no spawns)."""
+    from unittest.mock import patch
+    import api.services.agent_loop as agent_loop_mod
+    from config.settings import settings
+    from fastapi.testclient import TestClient
+    from api.main import app
+
+    client = TestClient(app)
+    personas = settings.list_http_personas()
+    persona_ids = [p.id for p in personas]
+    print(f"\n## Inventory — {len(persona_ids)} personas: {persona_ids}")
+
+    # --- A. Model-picker option values vs backend support -------------------
+    html = (REPO / "web" / "index.html").read_text()
+    m = re.search(r'id="modelPicker".*?</select>', html, re.S)
+    picker_vals = re.findall(r'<option value="([^"]+)"', m.group(0)) if m else []
+    print(f"## Model picker values: {picker_vals}")
+    unknown = [v for v in picker_vals if v not in BACKEND_HANDLED
+               and agent_loop_mod.resolve_model_alias(v) == v]
+    if not picker_vals:
+        record("inventory/model-picker-options", "FAIL", "could not parse #modelPicker options")
+    elif unknown:
+        record("inventory/model-picker-options", "FAIL",
+               f"picker has values the backend does not handle: {unknown}")
+    else:
+        record("inventory/model-picker-options", "PASS",
+               f"{len(picker_vals)} options, all backend-handled: {picker_vals}")
+
+    # --- B. /api/personas matches the Telegram bot registry -----------------
+    try:
+        _, live_personas = http_json("GET", "/api/personas")
+        live_ids = sorted(p["id"] for p in (
+            live_personas if isinstance(live_personas, list)
+            else live_personas.get("personas", live_personas.get("items", []))))
+        if live_ids == sorted(persona_ids):
+            record("equivalence/personas-vs-registry", "PASS",
+                   f"/api/personas == settings registry ({live_ids})")
+        else:
+            record("equivalence/personas-vs-registry", "FAIL",
+                   f"/api/personas={live_ids} != registry={sorted(persona_ids)}")
+    except Exception as e:
+        record("equivalence/personas-vs-registry", "WARN", f"live /api/personas unreachable: {e}")
+
+    # --- C. Telegram-bot persona preamble == resolve_persona(id) ------------
+    bots = {b.name: b.persona for b in settings.telegram_bots}
+    mism = []
+    for pid in persona_ids:
+        resolved = settings.resolve_persona(pid)
+        expected = "" if pid == "primary" else bots.get(pid)
+        if resolved is None or (pid != "primary" and pid not in bots) or resolved != expected:
+            mism.append(pid)
+    if mism:
+        record("equivalence/persona-preamble-source", "FAIL",
+               f"resolve_persona != bot.persona for: {mism}")
+    else:
+        record("equivalence/persona-preamble-source", "PASS",
+               "resolve_persona(id) == matching Telegram bot.persona for every persona")
+
+    # --- D. Empirical: /chat persona_id path == Telegram persona path -------
+    eq_fail = []
+    for pid in persona_ids:
+        pre = settings.resolve_persona(pid)
+        _captured.clear()
+        with patch.object(agent_loop_mod, "run_agent_loop", _fake_loop):
+            r1 = _post(client, {"question": PROBE, "persona_id": pid})
+        chat_persona = _captured[-1].get("persona") if _captured else "<none>"
+        created_convs.append(_conv_id(r1.text))
+        _captured.clear()
+        with patch.object(agent_loop_mod, "run_agent_loop", _fake_loop):
+            r2 = _post(client, {"question": PROBE, "persona": pre})
+        tg_persona = _captured[-1].get("persona") if _captured else "<none>"
+        created_convs.append(_conv_id(r2.text))
+        if not (chat_persona == tg_persona == pre):
+            eq_fail.append(f"{pid}(chat={chat_persona!r},tg={tg_persona!r})")
+    if eq_fail:
+        record("equivalence/chat-vs-telegram-orchestrator-input", "FAIL", "; ".join(eq_fail))
+    else:
+        record("equivalence/chat-vs-telegram-orchestrator-input", "PASS",
+               "run_agent_loop receives identical persona via /chat persona_id and Telegram persona, all personas")
+
+    # --- E. TEXT routing matrix: persona x model dispatch -------------------
+    def expected_model(mo):
+        if mo == "auto":
+            return getattr(settings, "anthropic_model", "claude-haiku-4-5")
+        if mo == "gemma":
+            return "local"
+        if mo in ("opus", "sonnet"):
+            return agent_loop_mod.resolve_model_alias(mo)
+        return None
+
+    npass = ntotal = 0
+    for pid in persona_ids:
+        pre = settings.resolve_persona(pid)
+        for mo in MODELS:
+            ntotal += 1
+            _captured.clear()
+            payload = {"question": PROBE, "persona_id": pid}
+            if mo != "auto":
+                payload["model_override"] = mo
+            with patch.object(agent_loop_mod, "run_agent_loop", _fake_loop):
+                r = _post(client, payload)
+            created_convs.append(_conv_id(r.text))
+            ok = False
+            if mo == "claude_code":
+                t = r.text
+                ok = ('"type": "claude_intent"' in t and '"engine": "claude_code"' in t
+                      and '"type": "content"' not in t and len(_captured) == 0)
+            elif _captured:
+                k = _captured[-1]
+                ok = (k.get("model_tier") == expected_model(mo)
+                      and bool(k.get("force_local")) == (mo == "gemma")
+                      and k.get("persona") == pre)
+            npass += 1 if ok else 0
+            if not ok:
+                record(f"text-matrix/{pid}/{mo}", "FAIL", json.dumps(_captured[-1] if _captured else {}, default=str)[:160])
+    if npass == ntotal:
+        record("text-matrix/all-cells", "PASS", f"{npass}/{ntotal} (persona x model) cells dispatch correctly")
+    else:
+        record("text-matrix/all-cells", "FAIL", f"{npass}/{ntotal} cells passed — see per-cell failures above")
+
+    return persona_ids
+
+
+def voice_forwarding_checks():
+    """whisper-relay forwards model_override + bypasses the persona handoff gate
+    for claude_code. Prefer running its test suite; fall back to a static check."""
+    if not WHISPER_RELAY.exists():
+        record("voice/whisper-relay-present", "WARN",
+               f"whisper-relay not found at {WHISPER_RELAY} (set WHISPER_RELAY_DIR); voice forwarding unverified")
+        return
+    adapter = WHISPER_RELAY / "src" / "voice_gateway" / "adapters" / "lifeos.py"
+    txt = adapter.read_text() if adapter.exists() else ""
+    if "model_override" in txt and "handoff_override_for_model" in txt:
+        record("voice/whisper-relay-forwarding", "PASS",
+               "adapter forwards model_override and has handoff_override_for_model (claude_code gate bypass)")
+    else:
+        record("voice/whisper-relay-forwarding", "FAIL",
+               "adapter missing model_override forwarding or handoff_override_for_model")
+    test_file = WHISPER_RELAY / "tests" / "test_model_override.py"
+    if test_file.exists():
+        py = os.environ.get("WHISPER_RELAY_PYTHON", sys.executable)
+        proc = subprocess.run([py, "-m", "pytest", "tests/test_model_override.py", "-q"],
+                              cwd=WHISPER_RELAY, capture_output=True, text=True,
+                              env={**os.environ, "PYTHONPATH": "src"})
+        tail = (proc.stdout + proc.stderr).strip().splitlines()[-1] if (proc.stdout or proc.stderr) else ""
+        record("voice/whisper-relay-tests", "PASS" if proc.returncode == 0 else "FAIL", tail)
+    else:
+        record("voice/whisper-relay-tests", "WARN", "tests/test_model_override.py not found")
+
+
+def liveness_probes():
+    """Cheap live probes against the DEPLOYED service: the claude_code
+    short-circuit (no spawn) and one Haiku voice turn (the real chain)."""
+    # Live claude_intent (no worker spawned — the SSE event only).
+    try:
+        req = urllib.request.Request(
+            BASE + "/api/ask/stream", method="POST",
+            data=json.dumps({"question": PROBE, "model_override": "claude_code"}).encode(),
+            headers={"Content-Type": "application/json"})
+        body = urllib.request.urlopen(req, timeout=20).read().decode()
+        created_convs.append(_conv_id(body))
+        if '"type": "claude_intent"' in body and '"type": "content"' not in body:
+            record("live/text-claude_code-shortcircuit", "PASS", "deployed /api/ask/stream emits claude_intent, no inline answer")
+        else:
+            record("live/text-claude_code-shortcircuit", "FAIL", "claude_intent not emitted by deployed service")
+    except Exception as e:
+        record("live/text-claude_code-shortcircuit", "FAIL", f"request failed: {e}")
+
+    # Live voice chain (auto + primary): proxy -> gateway -> /api/ask/stream -> TTS.
+    cell = _voice_turn("primary", "auto")
+    if cell.get("response"):
+        record("live/voice-chain-auto-primary", "PASS",
+               f"voice turn answered ({cell['routing']}); resp={cell['response'][:40]!r}")
+    else:
+        record("live/voice-chain-auto-primary", "FAIL", f"no voice response (chain broken): {cell}")
+
+
+def _voice_turn(persona: str, model: str, transcript: str = "what is two plus two") -> dict:
+    fields = ["-F", "transcript=" + transcript, "-F", "backend=lifeos", "-F", "persona_id=" + persona]
+    if model and model != "auto":
+        fields += ["-F", "model_override=" + model]
+    out = subprocess.run(["curl", "-s", "-m", "150", "-N", "-X", "POST", BASE + "/api/voice/turn/stream"] + fields,
+                         capture_output=True, text=True).stdout
+    conv = resp = handoff = None
+    for line in out.splitlines():
+        if line.startswith("data: "):
+            try:
+                d = json.loads(line[6:])
+            except Exception:
+                continue
+            if d.get("type") == "done":
+                dd = d.get("data", {})
+                conv, resp, handoff = dd.get("conversation_id"), dd.get("response_text"), dd.get("handoff")
+    if conv:
+        created_convs.append(conv)
+    routing = None
+    if conv:
+        try:
+            _, c = http_json("GET", "/api/conversations/" + conv)
+            for msg in reversed(c.get("messages", []) if isinstance(c, dict) else []):
+                if msg.get("role") == "assistant":
+                    routing = (msg.get("routing") or {}).get("reasoning")
+                    break
+        except Exception:
+            pass
+    return {"persona": persona, "model": model, "conv": conv, "response": resp, "handoff": handoff, "routing": routing}
+
+
+def live_matrix(persona_ids: list[str]):
+    """Expensive end-to-end: a real generation per model on text and voice, and
+    one claude_code-via-voice handoff (spawned worker, then killed)."""
+    from config.settings import settings
+    import api.services.agent_loop as agent_loop_mod
+
+    def exp(mo):
+        return ({"auto": getattr(settings, "anthropic_model", "claude-haiku-4-5"),
+                 "gemma": "local"}.get(mo) or agent_loop_mod.resolve_model_alias(mo))
+
+    # Spread models across personas so each persona is exercised live too.
+    plan = list(zip(["auto", "opus", "sonnet", "gemma"], (persona_ids * 4)))
+    # --- live TEXT generation per model ---
+    for mo, pid in plan:
+        try:
+            payload = {"question": "what is two plus two", "persona_id": pid}
+            if mo != "auto":
+                payload["model_override"] = mo
+            req = urllib.request.Request(BASE + "/api/ask/stream", method="POST",
+                                         data=json.dumps(payload).encode(),
+                                         headers={"Content-Type": "application/json"})
+            body = urllib.request.urlopen(req, timeout=120).read().decode()
+            created_convs.append(_conv_id(body))
+            want = exp(mo)
+            ok = (f"({want})" in body) or (want in body)
+            record(f"live-text/{mo}+{pid}", "PASS" if ok else "FAIL",
+                   f"expected routing model {want}" + ("" if ok else " not found in stream"))
+        except Exception as e:
+            record(f"live-text/{mo}+{pid}", "FAIL", f"request failed: {e}")
+
+    # --- live VOICE generation per model ---
+    for mo, pid in plan:
+        cell = _voice_turn(pid, mo)
+        want = exp(mo)
+        ok = cell.get("routing") and (want in cell["routing"])
+        record(f"live-voice/{mo}+{pid}", "PASS" if ok else "FAIL",
+               f"routing={cell.get('routing')!r} (want {want})")
+
+    # --- live claude_code via VOICE for a NO-HANDOFF persona (hardest cell) ---
+    no_handoff = next((p.id for p in settings.list_http_personas() if not p.capabilities), persona_ids[-1])
+    cell = _voice_turn(no_handoff, "claude_code", transcript="please refactor the nonexistent zztest sample module")
+    ho = cell.get("handoff") or {}
+    sid = ho.get("session_id") if isinstance(ho, dict) else None
+    if cell.get("handoff") and sid:
+        record(f"live-voice/claude_code+{no_handoff}", "PASS",
+               f"handoff fired for no-handoff persona; spawned {sid}")
+        # Kill the session AND its OS subprocess (HTTP kill alone leaves it — issue #379).
+        try:
+            http_json("POST", f"/api/agents/sessions/{sid}/kill", {"reason": "routing-health cleanup"}, timeout=20)
+        except Exception as e:
+            record("live-voice/claude_code-kill", "WARN", f"kill endpoint error: {e}")
+        subprocess.run(["pkill", "-9", "-f", sid], capture_output=True)
+        record("live-voice/claude_code-cleanup", "PASS", f"killed session + subprocess for {sid}")
+    else:
+        record(f"live-voice/claude_code+{no_handoff}", "FAIL", f"handoff did not fire: {cell}")
+
+
+def cleanup():
+    n = 0
+    for cid in [c for c in dict.fromkeys(created_convs) if c]:
+        try:
+            urllib.request.urlopen(urllib.request.Request(
+                BASE + "/api/conversations/" + cid, method="DELETE"), timeout=8)
+            n += 1
+        except Exception:
+            pass
+    print(f"\n## Cleanup: deleted {n} probe conversations")
+
+
+def main():
+    print("# ROUTING-HEALTH" + ("  (--live)" if LIVE else ""))
+    print("\n## Deterministic checks (mocked dispatch — no LLM calls, no spawns)")
+    try:
+        persona_ids = deterministic_checks()
+    except Exception as e:
+        record("deterministic-harness", "FAIL", f"in-process harness crashed: {e}")
+        persona_ids = []
+    print("\n## Voice forwarding + gate")
+    voice_forwarding_checks()
+    print("\n## Liveness (deployed service)")
+    liveness_probes()
+    if LIVE and persona_ids:
+        print("\n## Live generation matrix (real turns; spawns + kills one worker)")
+        live_matrix(persona_ids)
+    cleanup()
+
+    fails = [r for r in results if r["status"] == "FAIL"]
+    warns = [r for r in results if r["status"] == "WARN"]
+    verdict = "FAILING" if fails else ("DEGRADED" if warns else "HEALTHY")
+    summary = {"verdict": verdict, "live": LIVE,
+               "counts": {s: sum(1 for r in results if r["status"] == s) for s in ("PASS", "FAIL", "WARN", "SKIP")},
+               "failures": [{"check": r["check"], "detail": r["detail"]} for r in fails],
+               "warnings": [{"check": r["check"], "detail": r["detail"]} for r in warns]}
+    print(f"\nROUTING-HEALTH-VERDICT: {verdict}")
+    print("ROUTING-HEALTH-JSON: " + json.dumps(summary))
+    sys.exit(1 if verdict == "FAILING" else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a `/routing-health` skill (sibling to `/sync-health`) that verifies, on demand, that every `/chat` configuration routes correctly — and that `/chat` behaves identically to the Telegram bots per persona.

Covers **2 surfaces × 5 models × every persona**:
- surfaces: text (`/api/ask/stream`) + voice (`/api/voice/turn/stream` → whisper-relay)
- models: `auto` / `sonnet` / `opus` / `gemma`(local) / `claude_code`
- personas: every entry from `settings.list_http_personas()`

## Checks

- **Inventory** — model-picker option values in `web/index.html` are all backend-handled.
- **Persona ↔ Telegram equivalence** — `/api/personas` matches the bot registry; `resolve_persona(id) == bot.persona`; and *empirically*, `run_agent_loop` receives the identical persona whether the turn comes via `/chat` (`persona_id`) or Telegram (`persona` preamble).
- **Text routing matrix** — every persona × model: correct resolved model, `force_local` for gemma, persona preamble passed, `claude_code` short-circuits to a `claude_intent` handoff. Mocked dispatch — **no LLM calls, no spawns**.
- **Voice forwarding + gate** — runs whisper-relay's `test_model_override.py` (forwards `model_override`, bypasses the persona handoff gate for `claude_code`).
- **Liveness** — the deployed service emits `claude_intent` and serves a real voice turn.
- **`--live`** — a real generation per model on text and voice (asserted against the recorded routing model) + one `claude_code`-via-voice handoff for a no-handoff persona (spawned worker killed, OS process included per #379).

## Design

- Default mode is deterministic and cheap (mocks `run_agent_loop`, ~30–60s, no cloud cost beyond one Haiku voice turn). Cost/side-effects are confined to `--live`.
- The script cleans up its own probe conversations (across every persona scope) and, under `--live`, kills the worker session **and** its OS subprocess.
- whisper-relay path defaults to `~/Code/whisper-relay` (override `WHISPER_RELAY_DIR`); absent → WARN, not FAIL.

## Files

- `.claude/skills/routing-health/SKILL.md`
- `.claude/skills/routing-health/scripts/routing_check.py`

## Test

Ran the script against the live deployment:
- **default**: 9/9 PASS → HEALTHY.
- **--live**: 19/19 PASS → HEALTHY (live text + voice per model all routed to the expected model; claude_code-via-voice handoff fired for the non-handoff `fitness` persona; worker spawned + killed; 39 probe conversations cleaned up; no stray workers).
- `ruff` clean; `py_compile` OK; pre-push unit suite **2133 passed, 8 skipped**.

Related: depends on the routing wired up in #377 (merged) and whisper-relay#24/#25 (merged). Surfaced the operator-kill latency issue as #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)