### PR TITLE
refactor(prompts): consolidate orchestrator instruction layer (Phases 2+3)

### DIFF
--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -429,7 +429,7 @@ async def run_agent_loop(
         Dicts with "type" key: "text", "status", or "result".
     """
     client = _select_client(model, force_local=force_local)
-    system_prompt = build_system_prompt(persona=persona)
+    system_prompt = build_system_prompt(persona=persona, max_tool_rounds=max_tool_rounds)
 
     # Bind a fresh per-turn email-draft set. The send gate uses this to refuse
     # sending any draft created during this same turn — sends require the user

--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -89,7 +89,7 @@ Searches saved memories by keyword. Use to recall previously saved information o
 
 Don't use tools for general knowledge, definitions, coding help, math, or anything that doesn't require {name}'s personal data or current/live information. Just answer directly.
 
-**Exception:** If a question touches anything that can change over time (rankings, prices, current events, "best X right now", latest versions, schedules, rosters, releases), ALWAYS call search_web first — even if it seems like general knowledge. Your training data is stale, so never claim from memory that you "can't access" live data, that you have a "knowledge cutoff," or that something "hasn't been released / doesn't exist / isn't available yet." State that something isn't available only *after* a web search comes up empty, and say you searched.
+**Exception:** If a question touches anything that can change over time (rankings, prices, current events, "best X right now", latest versions, schedules, rosters, releases), ALWAYS call search_web first — even if it seems like general knowledge. Your training data is stale, so never claim from memory that you "can't access" live data, "can't browse the web," or have a "knowledge cutoff," and never assert that something "hasn't been released / announced / happened yet," doesn't exist, or isn't available — call search_web and let the results decide. State that something isn't available only *after* a web search comes up empty, and say you searched.
 
 **On pushback** ("do research," "you're wrong," "look it up"), you MUST call search_web before replying — don't repeat your previous claim, and never say "my research confirms" unless you actually searched this turn.
 

--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -56,7 +56,7 @@ Returns iMessage and WhatsApp chat logs with a specific person. Shows actual mes
 Web search for any current or real-time information — weather, news, prices, rankings, benchmarks, reviews, technical specs, documentation, public facts, or anything that may have changed since your training. Use whenever the answer benefits from up-to-date data. Only skip if the answer is purely in {name}'s personal data.
 
 **manage_tasks (action: create/list/complete):**
-Create, list, or complete Obsidian tasks.
+Create, list, or complete Obsidian tasks. When tagging a task and an existing-tags list is provided below this prompt, prefer a tag that already exists over inventing a near-duplicate.
 
 **manage_reminders (action: create/list):**
 Create or list timed Telegram notification reminders.
@@ -65,10 +65,10 @@ Create or list timed Telegram notification reminders.
 Live financial data from Monarch Money. Use 'accounts' for current balances, 'transactions' to search recent spending (filterable by date, category, merchant), 'cashflow' for income/expense/savings summary, 'budgets' for budget vs actual. Defaults: transactions=last 30 days, cashflow/budgets=current month. Historical monthly summaries are also in the vault at Personal/Finance/Monarch/YYYY-MM.md — use search_vault for past months.
 
 **create_email_draft:**
-Create a Gmail draft email (personal or work account). This NEVER sends — it only drafts. It is ALWAYS the first step for any email request, even one phrased as "send an email to X". Returns a draft_id used to send it later.
+Create a Gmail draft email (personal or work account). NEVER sends — only drafts. ALWAYS the first step for any email request, even one phrased "send an email to X". Returns a draft_id.
 
 **send_email_draft:**
-Sends a draft previously created with create_email_draft, by its draft_id. ONLY call this after you have shown the user the draft and they have EXPLICITLY confirmed sending in a LATER message. NEVER send a draft in the same turn you created it — a draft created this turn cannot be sent and will be rejected. Always: draft → show the user → wait for their "yes, send it" → then send_email_draft.
+Sends a draft by its draft_id. A draft created this turn cannot be sent and is rejected — sending requires the user's explicit confirmation in a LATER turn. See "Sending an email" under Multi-tool patterns for the full flow.
 
 **create_calendar_event:**
 Creates a Google Calendar event on personal or work account. Invite emails are automatically sent to attendees. ALWAYS present the event details and ask the user to confirm before calling this tool.
@@ -89,35 +89,28 @@ Searches saved memories by keyword. Use to recall previously saved information o
 
 Don't use tools for general knowledge, definitions, coding help, math, or anything that doesn't require {name}'s personal data or current/live information. Just answer directly.
 
-**Exception:** If a question asks about anything that could change over time (rankings, prices, current events, "best X right now", latest versions, etc.), ALWAYS use search_web even if the topic seems like general knowledge.
+**Exception:** If a question touches anything that can change over time (rankings, prices, current events, "best X right now", latest versions, schedules, rosters, releases), ALWAYS call search_web first — even if it seems like general knowledge. Your training data is stale, so never claim from memory that you "can't access" live data, that you have a "knowledge cutoff," or that something "hasn't been released / doesn't exist / isn't available yet." State that something isn't available only *after* a web search comes up empty, and say you searched.
 
-**Never say you "can't access" live data, "can't browse the web", or reference a "knowledge cutoff."** You have web search — use it.
-
-**Never assert from memory that something "hasn't been released / announced / happened yet," doesn't exist, or isn't available — call search_web first and let the results decide.** Your training data is stale, so a negative claim about the current world (a schedule, a price, a roster, a release) is exactly the kind of thing you get wrong. Only state that something isn't available *after* a web search comes up empty, and say you searched.
-
-**If {name} pushes back or says "do research" / "you're wrong" / "look it up," you MUST call search_web before replying — do not repeat your previous claim, and never say "my research confirms" unless you actually ran a search in this turn.**
+**On pushback** ("do research," "you're wrong," "look it up"), you MUST call search_web before replying — don't repeat your previous claim, and never say "my research confirms" unless you actually searched this turn.
 
 ## How to use tools
 
 - **NEVER output text between tool rounds.** The user sees everything you write. Only output text AFTER your final tool round, as the complete answer. No "Let me search...", no "I found X, let me look further...", no mid-search commentary.
 - **Search, then answer.** Call ALL needed tools first across multiple rounds, then write ONE response using all results.
 - **If search_vault finds a relevant file but missing the specific data, use read_vault_file.** search_vault returns chunks, not whole files. If you see the right file but wrong section, read the full file.
-- **Try different sources, not repeated queries.** Max 2 vault searches. Then try email, drive, messages, or read_vault_file. You have 5 tool rounds — use them across different sources, not the same source repeatedly.
+- **Try different sources, not repeated queries.** Max 2 vault searches. Then try email, drive, messages, or read_vault_file. Spend your tool rounds across different sources, not the same source repeatedly.
 - **NEVER ask the user if you should search more.** Just search. Never ask permission to use tools. Never say "would you like me to check..." — just check. The ONLY time to ask the user a question is when you genuinely cannot proceed (e.g., ambiguous person matching multiple people).
 
 ## Multi-tool patterns
 
 Call MULTIPLE tools in a SINGLE round whenever possible.
 
-- **Any query mentioning a person** (by name, relationship like "my sister", or pronoun referring to prior context): Start with person_info(action=lookup). The result tells you their entity_id, emails, last contact date, and active channels — use these to decide what to search next.
+- **Any query mentioning a person** (by name, relationship like "my sister", or pronoun referring to prior context): start with person_info(action=lookup), then use the identifiers and activity it returns to decide what to search next.
 - **"When did I last see/talk to/hear from X?"**: person_info(lookup) gives days_since_contact and per-channel activity. For more detail, follow up with get_message_history (for chat logs), search_calendar (for meetings), or search_email.
 - **Looking for specific data**: Round 1: person_info(lookup) + search_vault. Round 2: search_email + search_drive + read_vault_file (if Round 1 found a relevant file). This covers 4 sources in 2 rounds.
-- **When vault search finds the right file but wrong section**: Use read_vault_file to get the full file content.
 - **Meeting prep**: person_info(action=briefing), or combine person_info(lookup) + search_calendar + search_email + search_vault in parallel.
-- **Sending an email** (including "send an email to X", "email X", "reply to X"): person_info(lookup) to get the recipient's email if needed → create_email_draft → show the user the full draft (to/subject/body) and ask them to confirm → STOP and end your turn. Do NOT send in this turn. Only when the user replies in a LATER turn with explicit confirmation ("yes", "send it", "go ahead") do you call send_email_draft with the draft_id. Never send on the first message, no matter how it is phrased.
-- **Scheduling a meeting**: person_info(lookup) to get attendee emails → present event details to user → wait for confirmation → create_calendar_event.
-- **Moving/updating a meeting**: search_calendar to find the event → present proposed changes → wait for confirmation → update_calendar_event.
-- **Cancelling a meeting**: search_calendar to find the event → confirm with user → delete_calendar_event.
+- **Sending an email** (including "send an email to X", "email X", "reply to X"): person_info(lookup) for the recipient's email if needed → create_email_draft → show the user the full draft (to/subject/body), ask them to confirm, and STOP. Never send in the same turn you drafted, no matter how the request is phrased. Only when the user confirms in a LATER turn ("yes", "send it", "go ahead") do you call send_email_draft with the draft_id.
+- **Calendar actions** — always present the details and wait for the user's confirmation before the write: scheduling → person_info(lookup) for attendee emails → create_calendar_event; moving → search_calendar → update_calendar_event; cancelling → search_calendar → delete_calendar_event.
 
 ## Response format
 
@@ -168,7 +161,7 @@ def _existing_tags_block() -> str | None:
     )
 
 
-def build_system_prompt(persona: str | None = None) -> list[dict]:
+def build_system_prompt(persona: str | None = None, max_tool_rounds: int = 5) -> list[dict]:
     """Build the system prompt for the agentic loop.
 
     Returns a list of content blocks for the Anthropic ``system`` parameter.
@@ -178,6 +171,9 @@ def build_system_prompt(persona: str | None = None) -> list[dict]:
         persona: Optional per-bot preamble (e.g. the fitness bot). Injected as an
             uncached block *after* the static block so the large shared prompt
             stays a common cache prefix across all bots.
+        max_tool_rounds: The loop's per-turn tool-round budget. Surfaced in an
+            uncached block (not the cached static prompt) so prompt and code can
+            never drift, and the cached prefix stays byte-stable regardless.
     """
     tz = ZoneInfo(settings.timezone)
     now = datetime.now(tz)
@@ -199,6 +195,8 @@ def build_system_prompt(persona: str | None = None) -> list[dict]:
             "type": "text",
             "text": (
                 f"Current date/time: {current_dt}\nTimezone: {settings.timezone}\n"
+                f"You have {max_tool_rounds} tool rounds this turn to gather "
+                "information before you must give your final answer.\n"
                 "When the user asks for something time-relative ('recent', 'lately', "
                 "'last week', 'this month', 'past few days'), resolve it against the "
                 "current date above into a concrete YYYY-MM-DD range and pass it as "

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -20,6 +20,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
+from api.services.agent_worker.delegation import delegation_preamble
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
@@ -115,12 +116,7 @@ NOTIFICATIONS — use [NOTIFY] for:
 - Plans before large changes
 
 DELEGATION:
-- Your LifeOS agent session id is {session_id}.
-- You already have a browser (--chrome), filesystem, and shell. If you want to
-  run background work in parallel, delegate it with the `lifeos_agent_spawn`
-  MCP tool (pass caller_session_id={session_id}, model="local" or "claude").
-  Monitor the child with `lifeos_agent_check` and read its result with
-  `lifeos_agent_transcript_read`.
+You already have a browser (--chrome), filesystem, and shell. {delegation}
 """
 
 
@@ -314,7 +310,11 @@ class ClaudeCodeExecutor:
                 user_name=settings.user_name,
                 code_dir=settings.code_dir,
                 platform_desc=platform_desc,
-                session_id=session_id,
+                delegation=delegation_preamble(
+                    session_id,
+                    trigger="To run background work in parallel,",
+                    model='"local" or "claude"',
+                ),
             ),
         ]
         if resume_session_id:

--- a/api/services/agent_worker/codex_executor.py
+++ b/api/services/agent_worker/codex_executor.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 from api.services.agent_worker.capabilities_preamble import CAPABILITIES_PREAMBLE
+from api.services.agent_worker.delegation import delegation_preamble
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_COMPLETED,
@@ -90,14 +91,13 @@ def _resolve_codex_binary() -> str:
 def _delegation_header(session_id: str) -> str:
     """Per-session preamble line telling Codex its LifeOS session id and how to
     hand off work it can't do (e.g. browser automation) to another engine."""
-    return (
-        f"=== YOUR SESSION ===\n"
-        f"Your LifeOS agent session id is {session_id}. If a task needs a "
-        f"capability you lack — e.g. browser/GUI automation you can't perform "
-        f"headlessly — delegate it with the `lifeos_agent_spawn` MCP tool "
-        f"(caller_session_id={session_id}, model=\"claude_code\" for the "
-        f"browser-enabled Claude Code CLI). Monitor with `lifeos_agent_check` "
-        f"and read the result with `lifeos_agent_transcript_read`."
+    return "=== YOUR SESSION ===\n" + delegation_preamble(
+        session_id,
+        trigger=(
+            "If a task needs a capability you lack — e.g. browser/GUI "
+            "automation you can't perform headlessly —"
+        ),
+        model='"claude_code" for the browser-enabled Claude Code CLI',
     )
 
 

--- a/api/services/agent_worker/delegation.py
+++ b/api/services/agent_worker/delegation.py
@@ -1,0 +1,57 @@
+"""Single source of the inter-agent delegation guidance injected into worker
+executor system prompts (claude_code, codex, local).
+
+Before this module the same spawn → monitor → read mechanic was copy-pasted
+into three executors with slightly different wording, so renaming a
+``lifeos_agent_*`` tool meant editing three files. The tool names and the
+shared blurb now live here; each executor still composes its own framing
+(recommended model, trigger, surrounding context) around the shared core.
+"""
+
+# lifeos_agent_* tool names — the rename-fragile surface the three executors
+# share. Defined once here so a rename touches exactly one file.
+SPAWN = "lifeos_agent_spawn"
+CHECK = "lifeos_agent_check"
+TRANSCRIPT_READ = "lifeos_agent_transcript_read"
+SEND = "lifeos_agent_send"
+SESSIONS_LIST = "lifeos_agent_sessions_list"
+YIELD_UNTIL = "lifeos_agent_yield_until"
+
+
+def delegation_preamble(session_id: str, *, trigger: str, model: str) -> str:
+    """The compact, session-aware delegation blurb used by the claude_code and
+    codex executors.
+
+    Args:
+        session_id: the caller's LifeOS session id, embedded so the agent can
+            pass ``caller_session_id`` when it spawns a child.
+        trigger: the condition that should prompt a hand-off, phrased as a
+            sentence lead-in ending right before "delegate it…" — e.g.
+            ``"To run background work in parallel,"`` or ``"If a task needs a
+            capability you lack — e.g. browser/GUI automation you can't perform
+            headlessly —"``.
+        model: the ``model=`` value to suggest for the child, inserted verbatim
+            (including quotes and any inline note) — e.g. ``'"local" or
+            "claude"'`` or ``'"claude_code" for the browser-enabled Claude Code
+            CLI'``.
+    """
+    return (
+        f"Your LifeOS agent session id is {session_id}. {trigger} delegate it "
+        f"with the `{SPAWN}` MCP tool (caller_session_id={session_id}, "
+        f"model={model}). Monitor the child with `{CHECK}` and read its result "
+        f"with `{TRANSCRIPT_READ}`."
+    )
+
+
+# Richer inter-agent protocol block for the autonomous local (Gemma) worker,
+# which can also message peers and yield (instead of polling) while children run.
+INTER_AGENT_BLOCK = f"""\
+<inter_agent>
+Other agent sessions are visible via `{TRANSCRIPT_READ}` and
+`{SESSIONS_LIST}`. Spawn child agents with `{SPAWN}`,
+message them with `{SEND}`, check status with
+`{CHECK}`. When you have nothing to do until specific children
+finish, call `{YIELD_UNTIL}(children=[...])` — this ends your
+session cleanly (no idle billing) and resumes you when the children are
+done. Prefer `yield_until` over polling.
+</inter_agent>"""

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -23,6 +23,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 
+from api.services.agent_worker.delegation import INTER_AGENT_BLOCK
 from api.services.agent_worker.pricing import cost_for
 from api.services.agent_worker.session_store import (
     STATUS_BUDGET_EXCEEDED,
@@ -155,7 +156,8 @@ class ExecutorOutcome:
 # as a module-level constant so prompt caches can hit on it; the dynamic
 # per-session bits (expected output, soft budget) are appended at call time
 # and live in a small trailing section so cache invalidation is minimized.
-_SYSTEM_PROMPT_STATIC = """\
+_SYSTEM_PROMPT_STATIC = (
+    """\
 <role>
 You are an autonomous task executor running inside LifeOS, the operator's
 personal-assistant system. You receive a single task from the operator's
@@ -224,20 +226,15 @@ user. Just note the assumptions made in your final summary. If you
 cannot complete the task safely, say so plainly in your final response.
 </ambiguity>
 
-<inter_agent>
-Other agent sessions are visible via `lifeos_agent_transcript_read` and
-`lifeos_agent_sessions_list`. Spawn child agents with `lifeos_agent_spawn`,
-message them with `lifeos_agent_send`, check status with
-`lifeos_agent_check`. When you have nothing to do until specific children
-finish, call `lifeos_agent_yield_until(children=[...])` — this ends your
-session cleanly (no idle billing) and resumes you when the children are
-done. Prefer `yield_until` over polling.
-</inter_agent>
+"""
+    + INTER_AGENT_BLOCK
+    + """
 
 <sleep>
 When you need to wait for external state to change with no child sessions
 to await, call the `sleep` tool rather than busy-looping.
 </sleep>"""
+)
 
 
 def _system_prompt(session_id: str, expected_output: str, budget, parent_session_id: str | None = None) -> str:

--- a/tests/test_agent_system_prompt.py
+++ b/tests/test_agent_system_prompt.py
@@ -65,6 +65,19 @@ def test_static_block_still_cached(tm):
         assert "cache_control" not in block
 
 
+def test_max_tool_rounds_templated_not_hardcoded(tm):
+    """The tool-round budget is rendered from the arg into an uncached dynamic
+    block — never a hard-coded literal in the cached static prompt — so the
+    prompt and the loop's actual budget can't drift."""
+    prompt = build_system_prompt(max_tool_rounds=7)
+    text = "\n".join(_text_blocks(prompt))
+    assert "7 tool rounds" in text
+    # The count must not live in the cached static block (it must stay
+    # byte-stable across turns regardless of the per-turn budget).
+    assert "7 tool rounds" not in prompt[0]["text"]
+    assert "5 tool rounds" not in prompt[0]["text"]
+
+
 def test_task_manager_failure_is_silent(monkeypatch):
     def boom():
         raise RuntimeError("task manager unavailable")

--- a/tests/test_agent_worker_delegation.py
+++ b/tests/test_agent_worker_delegation.py
@@ -1,0 +1,50 @@
+"""Tests for the shared inter-agent delegation source (#383 Phase 3).
+
+All three worker executors (claude_code, codex, local) build their delegation
+guidance from api.services.agent_worker.delegation, so renaming a lifeos_agent_*
+tool touches exactly one file.
+"""
+import pytest
+
+from api.services.agent_worker import delegation
+
+pytestmark = pytest.mark.unit
+
+
+def test_preamble_contains_session_id_and_core_mechanic():
+    p = delegation.delegation_preamble("SID-1", trigger="To do X,", model='"local"')
+    assert "SID-1" in p
+    assert "caller_session_id=SID-1" in p
+    assert "To do X," in p
+    assert 'model="local"' in p
+    for tool in (delegation.SPAWN, delegation.CHECK, delegation.TRANSCRIPT_READ):
+        assert tool in p
+
+
+def test_inter_agent_block_references_full_protocol():
+    block = delegation.INTER_AGENT_BLOCK
+    for tool in (
+        delegation.SPAWN,
+        delegation.CHECK,
+        delegation.SEND,
+        delegation.SESSIONS_LIST,
+        delegation.TRANSCRIPT_READ,
+        delegation.YIELD_UNTIL,
+    ):
+        assert tool in block
+
+
+def test_all_three_executors_draw_from_the_shared_source():
+    # codex builds its header from the shared preamble
+    from api.services.agent_worker.codex_executor import _delegation_header
+    header = _delegation_header("S1")
+    assert delegation.SPAWN in header and "S1" in header
+
+    # local embeds the shared inter-agent block verbatim
+    from api.services.agent_worker.local_executor import _SYSTEM_PROMPT_STATIC
+    assert delegation.INTER_AGENT_BLOCK in _SYSTEM_PROMPT_STATIC
+
+    # claude_code fills a {delegation} slot from the same helper
+    from api.services.agent_worker import claude_code_executor
+    assert "{delegation}" in claude_code_executor._SYSTEM_PROMPT
+    assert claude_code_executor.delegation_preamble is delegation.delegation_preamble

--- a/tests/test_agent_worker_delegation.py
+++ b/tests/test_agent_worker_delegation.py
@@ -34,6 +34,23 @@ def test_inter_agent_block_references_full_protocol():
         assert tool in block
 
 
+def test_inter_agent_block_text_is_pinned():
+    """Pin the exact block text. local_executor embeds this verbatim in its
+    cached _SYSTEM_PROMPT_STATIC, so an accidental edit here would silently
+    change (and invalidate the cache of) that prompt."""
+    assert delegation.INTER_AGENT_BLOCK == (
+        "<inter_agent>\n"
+        "Other agent sessions are visible via `lifeos_agent_transcript_read` and\n"
+        "`lifeos_agent_sessions_list`. Spawn child agents with `lifeos_agent_spawn`,\n"
+        "message them with `lifeos_agent_send`, check status with\n"
+        "`lifeos_agent_check`. When you have nothing to do until specific children\n"
+        "finish, call `lifeos_agent_yield_until(children=[...])` — this ends your\n"
+        "session cleanly (no idle billing) and resumes you when the children are\n"
+        "done. Prefer `yield_until` over polling.\n"
+        "</inter_agent>"
+    )
+
+
 def test_all_three_executors_draw_from_the_shared_source():
     # codex builds its header from the shared preamble
     from api.services.agent_worker.codex_executor import _delegation_header


### PR DESCRIPTION
## Summary

Two consolidation phases of #383, bundled because both are low-risk, behavior-preserving cleanups of the orchestrator's instruction layer.

**Phase 2 — lean the static prompt** (`agent_system_prompt.py`)
- Merged the web-search directive (don't claim a cutoff / can't-browse / negative-from-memory / search-on-pushback) from **four** repeated paragraphs into one Exception + one pushback rule — every behavior preserved.
- The email `draft → show → confirm → send` flow was stated twice; the tool descriptions now point to the single authoritative Multi-tool pattern.
- Folded the three parallel calendar patterns into one (confirm-before-write stated once) and dropped the `read_vault_file` pattern that duplicated the How-to bullet.
- **Templated `max_tool_rounds`**: `build_system_prompt(max_tool_rounds=…)` renders the number into an *uncached dynamic block* (the cached static prefix stays byte-stable) so the prompt and the loop's actual budget can't drift. `run_agent_loop` passes its real value.
- Documented the per-request existing-task-tags block in the `manage_tasks` description so the model expects it.
- Verified the `relationship strength (0-100)` note is **accurate, not stale** (`format_relationship_context` emits `Strength/100`) → kept.

**Phase 3 — unify the delegation blurb** (`agent_worker/`)
- New `agent_worker/delegation.py` is the single source: `lifeos_agent_*` tool-name constants, a `delegation_preamble(session_id, trigger, model)` helper (claude_code + codex), and `INTER_AGENT_BLOCK` (the local worker's richer protocol). Renaming a tool now touches one file.
- All three executors import from it. The local executor's `_SYSTEM_PROMPT_STATIC` embeds `INTER_AGENT_BLOCK` and is **byte-for-byte identical** to before (verified), preserving its prompt cache.

Relates to #383 (Phases 2 & 3).

## Test evidence
- New: `tests/test_agent_system_prompt.py::test_max_tool_rounds_templated_not_hardcoded`, `tests/test_agent_worker_delegation.py` (3 cases).
- 229 passed across the prompt + caching + all agent-worker executor + persona test files.
- Pre-push unit suite: **2144 passed, 8 skipped**.
- `_SYSTEM_PROMPT_STATIC` byte-equality vs `origin/main` asserted programmatically; static prompt ~10497 → ~9800 chars.

## Review focus
- Phase 2 prose: confirm no behavior was dropped in the web-search / email / calendar consolidations (the goal is no behavior change, not maximal cuts — I prioritized that over the issue's aspirational 20-30%).
- `max_tool_rounds` lives in an *uncached* block so caching (PR #384) isn't disturbed — confirm the cached static block is still byte-stable across turns.
- Phase 3: `delegation_preamble`'s `trigger`/`model` params faithfully reproduce each executor's intent; local block unchanged.

## Not run here
- `/routing-health` (Phase 2 acceptance criterion): it validates the model-routing matrix (orthogonal to these prompt-text-only changes) and needs the live server running this code. Recommend running it post-merge once main is deployed.