### PR TITLE
fix(chat): accept timeout= on AnthropicLLMClient.astream

### DIFF
--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -528,6 +528,8 @@ class AnthropicLLMClient:
         if temperature is not None:
             kwargs["temperature"] = temperature
         if timeout is not None:
+            # The SDK accepts float | httpx.Timeout; a bare float sets a uniform
+            # per-request timeout. (LocalLLMClient wraps it with connect=10s.)
             kwargs["timeout"] = timeout
 
         async with self._async_client.messages.stream(**kwargs) as stream:

--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -507,10 +507,13 @@ class AnthropicLLMClient:
         max_tokens: int = 4096,
         tools: list[dict] | None = None,
         temperature: float | None = None,
+        timeout: float | None = None,
     ) -> AsyncGenerator[dict, None]:
         """Async streaming via Anthropic API.
 
-        Yields the same event format as LocalLLMClient.astream().
+        Yields the same event format as LocalLLMClient.astream(). ``timeout``
+        (seconds) sets a per-request timeout — the agent loop's synthesis round
+        passes one, and LocalLLMClient.astream accepts the same kwarg.
         """
         kwargs: dict[str, Any] = {
             "model": self._model,
@@ -524,6 +527,8 @@ class AnthropicLLMClient:
             kwargs["tools"] = tools
         if temperature is not None:
             kwargs["temperature"] = temperature
+        if timeout is not None:
+            kwargs["timeout"] = timeout
 
         async with self._async_client.messages.stream(**kwargs) as stream:
             async for event in stream:

--- a/tests/test_agent_loop_caching.py
+++ b/tests/test_agent_loop_caching.py
@@ -83,49 +83,75 @@ async def test_cache_tokens_surface_in_agent_result():
     assert result.full_text == "The answer is 42."
 
 
-class _ExhaustThenSynthesize:
-    """Returns a tool call on every tool round (so the loop exhausts its rounds
-    and falls through to the synthesis round), then a text answer on the
-    synthesis round. astream's signature mirrors the real client exactly,
-    including the ``timeout`` kwarg the synthesis round passes."""
+class _MockAnthropicStream:
+    """Minimal async context manager mimicking anthropic's streaming response,
+    so the REAL AnthropicLLMClient.astream can be exercised against it."""
 
-    def __init__(self):
-        self.calls = []
+    def __init__(self, final_message, deltas=None):
+        self._final = final_message
+        self._deltas = deltas or []
 
-    async def astream(self, messages, *, system=None, max_tokens=4096,
-                      tools=None, temperature=None, timeout=None):
-        from api.services.llm_client import LLMUsage
-        self.calls.append({"has_tools": tools is not None, "timeout": timeout})
-        if tools:
-            yield {"type": "tool_calls", "calls": [
-                {"id": "c1", "type": "function",
-                 "function": {"name": "search_vault", "arguments": "{}"}}]}
-            yield {"type": "done", "usage": LLMUsage(), "finish_reason": "tool_use"}
-        else:
-            yield {"type": "text", "content": "Synthesized answer."}
-            yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for d in self._deltas:
+            yield d
+
+    async def get_final_message(self):
+        return self._final
 
 
 @pytest.mark.asyncio
-async def test_synthesis_round_passes_timeout_and_completes():
-    """When tool rounds are exhausted, the synthesis round calls
-    astream(..., timeout=180) with no tools, and the loop produces the
-    synthesized answer.
-
-    Regression for #385: that call used to raise TypeError on the Anthropic
-    backend (astream had no timeout param), so the user got an error instead of
-    a synthesized answer whenever the loop exhausted its rounds.
+async def test_synthesis_round_drives_real_client_with_timeout():
+    """End-to-end regression for #385. run_agent_loop exhausts its tool rounds
+    and the synthesis round drives the REAL AnthropicLLMClient.astream with
+    timeout=180 (only the SDK is mocked). If astream loses its timeout param the
+    synthesis call raises TypeError, the loop yields "(Error during synthesis…)"
+    instead of the answer, and this test fails — so it genuinely guards the bug,
+    not just the call shape.
     """
+    from types import SimpleNamespace
     from unittest.mock import AsyncMock
     from api.services import agent_loop
+    from api.services.llm_client import AnthropicLLMClient
 
-    fake = _ExhaustThenSynthesize()
-    with patch.object(agent_loop, "_select_client", return_value=fake), \
+    def _usage():
+        return SimpleNamespace(input_tokens=10, output_tokens=5,
+                               cache_creation_input_tokens=0, cache_read_input_tokens=0)
+
+    seen_timeouts = []
+
+    def fake_stream(**kwargs):
+        seen_timeouts.append(kwargs.get("timeout"))
+        if kwargs.get("tools"):
+            # tool round: final message carries a tool_use block so the loop
+            # spends its one round and falls through to synthesis.
+            final = SimpleNamespace(
+                content=[SimpleNamespace(type="tool_use", id="c1",
+                                         name="search_vault", input={})],
+                usage=_usage(), stop_reason="tool_use")
+            return _MockAnthropicStream(final)
+        # synthesis round: a text answer, no tool_use.
+        final = SimpleNamespace(content=[], usage=_usage(), stop_reason="end_turn")
+        delta = SimpleNamespace(type="content_block_delta",
+                                delta=SimpleNamespace(text="Synthesized answer."))
+        return _MockAnthropicStream(final, deltas=[delta])
+
+    client = AnthropicLLMClient(api_key="sk-ant-test")
+    client._async_client = SimpleNamespace(messages=SimpleNamespace(stream=fake_stream))
+
+    with patch.object(agent_loop, "_select_client", return_value=client), \
          patch.object(agent_loop, "execute_tool_parallel",
                       AsyncMock(return_value="vault result")):
         events = [e async for e in agent_loop.run_agent_loop("find X", max_tool_rounds=1)]
 
     result = next(e["result"] for e in events if e["type"] == "result")
     assert result.full_text == "Synthesized answer."
-    # The final call was the synthesis round: no tools, timeout forwarded.
-    assert fake.calls[-1] == {"has_tools": False, "timeout": 180}
+    assert 180 in seen_timeouts  # the synthesis round forwarded the timeout

--- a/tests/test_agent_loop_caching.py
+++ b/tests/test_agent_loop_caching.py
@@ -25,7 +25,7 @@ class _FakeClient:
         self._cache_creation = cache_creation
 
     async def astream(self, messages, *, system=None, max_tokens=4096,
-                      tools=None, temperature=None):
+                      tools=None, temperature=None, timeout=None):
         # Signature mirrors the real AnthropicLLMClient.astream exactly (no
         # **kwargs) so drift between run_agent_loop's calls and the client
         # surfaces as a test failure instead of being silently swallowed.
@@ -81,3 +81,51 @@ async def test_cache_tokens_surface_in_agent_result():
     assert result.total_cache_read_tokens == 2600
     assert result.total_cache_creation_tokens == 512
     assert result.full_text == "The answer is 42."
+
+
+class _ExhaustThenSynthesize:
+    """Returns a tool call on every tool round (so the loop exhausts its rounds
+    and falls through to the synthesis round), then a text answer on the
+    synthesis round. astream's signature mirrors the real client exactly,
+    including the ``timeout`` kwarg the synthesis round passes."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def astream(self, messages, *, system=None, max_tokens=4096,
+                      tools=None, temperature=None, timeout=None):
+        from api.services.llm_client import LLMUsage
+        self.calls.append({"has_tools": tools is not None, "timeout": timeout})
+        if tools:
+            yield {"type": "tool_calls", "calls": [
+                {"id": "c1", "type": "function",
+                 "function": {"name": "search_vault", "arguments": "{}"}}]}
+            yield {"type": "done", "usage": LLMUsage(), "finish_reason": "tool_use"}
+        else:
+            yield {"type": "text", "content": "Synthesized answer."}
+            yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
+
+
+@pytest.mark.asyncio
+async def test_synthesis_round_passes_timeout_and_completes():
+    """When tool rounds are exhausted, the synthesis round calls
+    astream(..., timeout=180) with no tools, and the loop produces the
+    synthesized answer.
+
+    Regression for #385: that call used to raise TypeError on the Anthropic
+    backend (astream had no timeout param), so the user got an error instead of
+    a synthesized answer whenever the loop exhausted its rounds.
+    """
+    from unittest.mock import AsyncMock
+    from api.services import agent_loop
+
+    fake = _ExhaustThenSynthesize()
+    with patch.object(agent_loop, "_select_client", return_value=fake), \
+         patch.object(agent_loop, "execute_tool_parallel",
+                      AsyncMock(return_value="vault result")):
+        events = [e async for e in agent_loop.run_agent_loop("find X", max_tool_rounds=1)]
+
+    result = next(e["result"] for e in events if e["type"] == "result")
+    assert result.full_text == "Synthesized answer."
+    # The final call was the synthesis round: no tools, timeout forwarded.
+    assert fake.calls[-1] == {"has_tools": False, "timeout": 180}

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -634,3 +634,25 @@ class TestAnthropicCaching:
         assert text == "hello"
         done = next(e for e in events if e["type"] == "done")
         assert done["usage"].cache_read_input_tokens == 2600
+
+    @pytest.mark.asyncio
+    async def test_astream_forwards_timeout_to_sdk(self):
+        """astream accepts a per-request timeout and forwards it to the SDK.
+
+        Regression for #385: the agent loop's synthesis round calls
+        astream(..., timeout=180), which used to raise TypeError on the
+        Anthropic backend because the method had no timeout parameter.
+        """
+        from types import SimpleNamespace
+        client = _anthropic_client()
+        captured = {}
+        final = SimpleNamespace(
+            content=[], usage=_fake_anthropic_usage(), stop_reason="end_turn")
+
+        def fake_stream(**kwargs):
+            captured.update(kwargs)
+            return _FakeAnthropicStream(final)
+
+        client._async_client = SimpleNamespace(messages=SimpleNamespace(stream=fake_stream))
+        _ = [e async for e in client.astream([{"role": "user", "content": "hi"}], timeout=180)]
+        assert captured["timeout"] == 180


### PR DESCRIPTION
## Summary

`run_agent_loop`'s synthesis round (the fallback after all tool rounds are exhausted) calls `client.astream(..., timeout=180)`. `LocalLLMClient.astream` accepts a `timeout` kwarg, but `AnthropicLLMClient.astream` did not — so on the Anthropic backend (the default) an exhausted-rounds query raised `TypeError`, caught by the synthesis round's `try/except` and surfaced to the user as `"(Error during synthesis: ...)"` instead of the synthesized answer.

Adds a `timeout` parameter to `AnthropicLLMClient.astream` and forwards it as the per-request timeout (the Anthropic SDK's `messages.stream` accepts `timeout`). Both backends now honor the synthesis-round timeout and share a compatible `astream` signature.

Closes #385.

## Test evidence
- `test_astream_forwards_timeout_to_sdk` (new) — the real client accepts `timeout` and passes it to the SDK (the direct regression guard).
- `test_synthesis_round_passes_timeout_and_completes` (new) — `run_agent_loop` exhausts its rounds, hits the synthesis round, and produces the answer; the faithful fake's `astream` signature now includes `timeout`, mirroring the fixed client.
- `tests/test_llm_client.py` + `tests/test_agent_loop_caching.py`: 43 passed. Pre-push unit suite green. (14 repo-wide `require_db`/`slow` data-integrity failures are pre-existing and outside the `unit` selection.)

## Review focus
- Confirm the Anthropic SDK accepts `timeout=` on `messages.stream` (verified: it's in the `AsyncMessages.stream` signature on anthropic 0.84.0).
- The fix is scoped to `astream` only (matching `LocalLLMClient`, where only `astream` carries `timeout`); `create`/`acreate` are never called with a timeout in-repo.