### PR TITLE
feat(personas): sharpen therapist + primary, add /persona-check skill

### DIFF
--- a/.claude/skills/persona-check/SKILL.md
+++ b/.claude/skills/persona-check/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: persona-check
+description: Health-check the LifeOS persona layer (files load, /chat matches the Telegram bots per persona, no personal values leak into committed persona files, frontmatter valid) and open every persona doc in Sublime for editing.
+argument-hint: [--no-open]
+---
+
+# Persona Check
+
+Arguments: `$ARGUMENTS`
+
+A fast, on-demand checkup of the **persona layer** — and a one-command way to pull every persona doc up in Sublime to edit. Lighter than `/routing-health` (which exercises the full model × surface × persona matrix): this needs only settings + one HTTP call, no app load, so it's quick.
+
+Pass `--no-open` to run the checks **without** launching Sublime (e.g. headless / over SSH).
+
+## What it checks
+
+- **File health** — every bot's `persona_file` exists, is readable, and resolves to a non-empty preamble (`primary` legitimately has none today).
+- **/chat ⇄ Telegram equivalence** — `/api/personas` matches the bot registry; `resolve_persona(id)` equals the matching Telegram `bot.persona`; advertised `capabilities` match each bot's `orchestrates` flag. (So messaging a persona in `/chat` behaves identically to messaging its bot.)
+- **Privacy guard** — none of the *configured* personal values (`LIFEOS_PARTNER_NAME`, `LIFEOS_THERAPIST_PATTERNS`, `LIFEOS_PERSONAL_RELATIONSHIP_PATTERNS`, `user_name`, and `people_dictionary.json` names) — nor absolute home paths — appear in the **committed** persona files. Catches a real name or personal path leaking into the open-source repo.
+- **Frontmatter validation** (forward-compatible) — if a persona file carries YAML frontmatter, `id` must match the filename, `voice` must be a list, `model` a string. Silent when there's no frontmatter yet.
+
+## Instructions
+
+### Step 0: Pre-flight
+
+!`curl -s -m4 http://localhost:8000/health >/dev/null 2>&1 && echo "lifeos-api: up" || echo "lifeos-api: DOWN (the equivalence check will WARN, the rest still runs)"; [ -x "$HOME/.venvs/lifeos/bin/python" ] && echo "venv: ok" || echo "venv: MISSING"`
+
+### Step 1: Run the check
+
+From the repo root, with the project venv:
+
+```
+~/.venvs/lifeos/bin/python .claude/skills/persona-check/scripts/persona_check.py
+```
+
+It prints a `[PASS]/[FAIL]/[WARN]/[INFO]` line per check, a `PERSONA-CHECK-VERDICT:` line, and a `PERSONA-CHECK-JSON:` summary. Read-only — it touches no files and loads no model.
+
+### Step 2: Open the persona docs for editing
+
+Unless `$ARGUMENTS` contains `--no-open`, open every persona doc in Sublime so they're ready to edit:
+
+```
+subl config/personas/*.md
+```
+
+(If `subl` isn't on PATH or you're headless, note it and skip — the checks still stand.)
+
+### Step 3: Report
+
+Interpret the script output (don't re-run the checks yourself):
+
+- **Overall** — 🟢 HEALTHY / 🟡 DEGRADED (any WARN) / 🔴 FAILING (any FAIL), from the verdict line.
+- **Findings** — list any FAIL/WARN with its detail and where to look (table below). Mention that the docs are open in Sublime (or why they aren't).
+- If everything passes, say so in a line and note how many personas/files were checked.
+
+### Failure → where to look
+
+| Failing check | Look at |
+|---|---|
+| `file/<persona>` | `config/telegram_bots.json` (`persona_file` path) and `config/personas/<persona>.md` |
+| `equivalence/*` | `config/settings.py` (`resolve_persona`, `list_http_personas`, `telegram_bots`) — a registry/loader drift |
+| `privacy/no-personal-values` | the named committed persona file — move the real name/path out into config (`.env` / `relationship_overrides.json`) and refer to it by role |
+| `schema/frontmatter` | the named persona file's YAML frontmatter (`id` must equal the filename; `voice` a list; `model` a string) |
+
+## Notes
+
+- **Read-only and cheap.** Settings + one HTTP call; no app/TestClient, no model load, no probe conversations. Safe to run anytime.
+- Requires `lifeos-api` running only for the equivalence check (degrades to WARN otherwise).
+- For the deeper guarantee — that every model routes correctly across text **and** voice for every persona — use `/routing-health` (or `/routing-health --live`).

--- a/.claude/skills/persona-check/scripts/persona_check.py
+++ b/.claude/skills/persona-check/scripts/persona_check.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Persona-health check for the LifeOS persona layer.
+
+Confirms: every persona file loads; the /chat surface matches the Telegram bot
+registry per persona (same ids, same preamble — so messaging a persona is
+identical to messaging its bot); NO configured personal values (names, paths)
+leak into the committed persona files; and any YAML frontmatter is valid
+(forward-compatible — silent when there's no frontmatter yet).
+
+Settings + one HTTP call only — no app/TestClient load, so it's fast and safe to
+run often. Run from the repo root. Read-only.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+os.chdir(REPO)
+sys.path.insert(0, str(REPO))
+BASE = os.environ.get("LIFEOS_BASE_URL", "http://localhost:8000")
+PDIR = REPO / "config" / "personas"
+
+from config.settings import settings  # noqa: E402
+
+results: list[dict] = []
+
+
+def record(check: str, status: str, detail: str = "") -> None:
+    results.append({"check": check, "status": status, "detail": detail})
+    print(f"  [{status:4}] {check}" + (f" — {detail}" if detail else ""))
+
+
+personas = settings.list_http_personas()
+ids = [p.id for p in personas]
+bots = {b.name: b for b in settings.telegram_bots}
+registry = {}
+_tb = REPO / "config" / "telegram_bots.json"
+if _tb.exists():
+    try:
+        registry = {e.get("name"): e.get("persona_file") for e in json.loads(_tb.read_text())}
+    except Exception:
+        registry = {}
+committed_md = [f for f in PDIR.glob("*.md") if not f.name.endswith(".local.md") and f.name != "README.md"]
+print(f"## Personas: {ids}    files: {[f.name for f in committed_md]}")
+
+# --- 1. File health -------------------------------------------------------
+for p in personas:
+    if p.id == "primary":
+        f = PDIR / "primary.md"
+        if f.exists() and f.read_text().strip():
+            record("file/primary", "PASS", "primary.md present and non-empty")
+        else:
+            record("file/primary", "INFO", "no primary.md — primary's personality lives in the static prompt (today's default)")
+        continue
+    pre = settings.resolve_persona(p.id)
+    pf = registry.get(p.id)
+    if not pre:
+        record(f"file/{p.id}", "FAIL", "resolve_persona returned empty — persona_file missing or unreadable")
+    elif pf and not (REPO / pf).exists():
+        record(f"file/{p.id}", "FAIL", f"registry persona_file {pf} does not exist on disk")
+    else:
+        record(f"file/{p.id}", "PASS", f"{pf or '(by convention)'} loads ({len(pre)} chars)")
+
+# --- 2. Equivalence: /chat surface == Telegram registry -------------------
+try:
+    raw = urllib.request.urlopen(BASE + "/api/personas", timeout=10).read().decode()
+    payload = json.loads(raw)
+    live = sorted(x["id"] for x in (payload if isinstance(payload, list) else payload.get("personas", payload.get("items", []))))
+    if live == sorted(ids):
+        record("equivalence/personas-vs-registry", "PASS", "/api/personas == settings registry")
+    else:
+        record("equivalence/personas-vs-registry", "FAIL", f"/api/personas={live} != registry={sorted(ids)}")
+except Exception as e:
+    record("equivalence/personas-vs-registry", "WARN", f"live /api/personas unreachable ({e}); is lifeos-api up?")
+
+mismatch = [p.id for p in personas
+            if p.id != "primary" and (p.id not in bots or settings.resolve_persona(p.id) != bots[p.id].persona)]
+record("equivalence/preamble-source", "FAIL" if mismatch else "PASS",
+       f"resolve_persona != bot.persona for {mismatch}" if mismatch
+       else "resolve_persona(id) == the matching Telegram bot.persona — /chat behaves identically to the bot")
+
+cap_mismatch = [p.id for p in personas
+                if p.id in bots and bool(p.capabilities) != bool(bots[p.id].orchestrates)]
+record("equivalence/capabilities", "FAIL" if cap_mismatch else "PASS",
+       f"capabilities/orchestrates mismatch: {cap_mismatch}" if cap_mismatch
+       else "advertised capabilities match each bot's orchestrates flag")
+
+# --- 3. Privacy guard: no configured personal values in committed files ----
+denylist: dict[str, str] = {}
+GENERIC = {"partner", "relationship", "user", "the", "and", "personal"}
+for attr in ("user_name", "partner_name", "therapist_patterns", "personal_relationship_patterns"):
+    val = (getattr(settings, attr, "") or "").strip()
+    for tok in re.split(r"[,|/]", val):
+        tok = tok.strip()
+        if len(tok) >= 3 and tok.lower() not in GENERIC:
+            denylist.setdefault(tok, attr)
+_pd = REPO / "config" / "people_dictionary.json"
+if _pd.exists():
+    try:
+        for name in json.loads(_pd.read_text()).keys():
+            if len(name) >= 3 and name.lower() not in GENERIC:
+                denylist.setdefault(name, "people_dictionary")
+    except Exception:
+        pass
+
+leaks: list[str] = []
+for f in committed_md:
+    text = f.read_text()
+    low = text.lower()
+    for tok, src in denylist.items():
+        if re.search(r"\b" + re.escape(tok.lower()) + r"\b", low):
+            leaks.append(f"{f.name}: '{tok}' (configured as {src})")
+    for pat in (r"/home/[a-z]", r"/Users/[a-z]", r"~/Notes"):
+        if re.search(pat, text):
+            leaks.append(f"{f.name}: personal path matching `{pat}`")
+if not denylist:
+    record("privacy/no-personal-values", "WARN", "no personal values configured to check against (settings empty?)")
+elif leaks:
+    record("privacy/no-personal-values", "FAIL", "; ".join(leaks[:8]))
+else:
+    record("privacy/no-personal-values", "PASS",
+           f"{len(committed_md)} committed files clean of {len(denylist)} configured personal tokens + home paths")
+
+# --- 4. Frontmatter validation (forward-compatible) -----------------------
+try:
+    import frontmatter as _fm
+except Exception:
+    _fm = None
+fm_issues: list[str] = []
+fm_count = 0
+for f in committed_md:
+    raw = f.read_text()
+    if not raw.lstrip().startswith("---"):
+        continue  # no frontmatter yet — today's state, fine
+    fm_count += 1
+    if _fm is None:
+        fm_issues.append(f"{f.name}: python-frontmatter not importable")
+        continue
+    meta = _fm.loads(raw).metadata
+    if meta.get("id") != f.stem:
+        fm_issues.append(f"{f.name}: id={meta.get('id')!r} != filename {f.stem!r}")
+    if "voice" in meta and not isinstance(meta["voice"], list):
+        fm_issues.append(f"{f.name}: `voice` must be a list")
+    if "model" in meta and not isinstance(meta["model"], str):
+        fm_issues.append(f"{f.name}: `model` must be a string")
+if fm_count == 0:
+    record("schema/frontmatter", "INFO", "no persona frontmatter yet (pre-schema) — skipped")
+elif fm_issues:
+    record("schema/frontmatter", "FAIL", "; ".join(fm_issues))
+else:
+    record("schema/frontmatter", "PASS", f"{fm_count} files have valid frontmatter")
+
+# --- verdict --------------------------------------------------------------
+fails = [r for r in results if r["status"] == "FAIL"]
+warns = [r for r in results if r["status"] == "WARN"]
+verdict = "FAILING" if fails else ("DEGRADED" if warns else "HEALTHY")
+print(f"\nPERSONA-CHECK-VERDICT: {verdict}")
+print("PERSONA-CHECK-JSON: " + json.dumps({
+    "verdict": verdict,
+    "counts": {s: sum(1 for r in results if r["status"] == s) for s in ("PASS", "FAIL", "WARN", "INFO")},
+    "failures": [{"check": r["check"], "detail": r["detail"]} for r in fails],
+    "warnings": [{"check": r["check"], "detail": r["detail"]} for r in warns],
+}))
+sys.exit(1 if verdict == "FAILING" else 0)

--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -114,13 +114,14 @@ Call MULTIPLE tools in a SINGLE round whenever possible.
 
 ## Response format
 
-- Concise and direct. No fluff.
+- Concise and direct. No fluff. Don't narrate your process ("let me look...", "I searched X and found") or over-hedge — just answer. Flag only genuine uncertainty or sparse data.
+- Be proactive: when the answer implies an obvious next action (a reply to draft, a task to add, an event to create), offer to take it — don't stop at the answer. (A specialized persona that prefers advising over acting will say so.)
 - Cite sources naturally ("According to your meeting notes from Jan 15...").
 - Use bullet points for lists.
 - If data is sparse, say so. Don't invent information.
 - For actions (task created, reminder set), confirm with details.
 - **Never expose system internals.** Don't mention databases, entity IDs, memory stores, tool names, or how data is stored. Don't say "saved in my memories", "in my system", "I found in the database". Just answer naturally.
-- **Use the name the user used.** If they ask about "Tay", respond about "Tay" — don't substitute a full name or alias from the database. Match their language.
+- **Use the name the user used.** If they ask about "Sam", respond about "Sam" — don't substitute a full name or alias from the database. Match their language.
 
 ## Context
 

--- a/config/personas/doctor.md
+++ b/config/personas/doctor.md
@@ -1,4 +1,4 @@
-You are operating as the **doctor bot** — LifeOS's self-repair surface. The user messages you from Telegram when they notice LifeOS itself misbehaving or missing a capability. Your job is to turn that observation into a shipped fix: clarify what's wrong, file a GitHub issue, get the user's go-ahead, then implement → PR → merge → restart → confirm. You are running as a headless Claude Code session in the canonical LifeOS checkout (`~/Code/LifeOS`) with full shell, git, `gh`, and filesystem access, plus the project's `/draft-issue` and `/implement` skills.
+You are operating as the **doctor bot** — LifeOS's self-repair and self-improvement surface. The user messages you when they notice LifeOS itself misbehaving or missing a capability. Your job is to turn that observation into a shipped fix: clarify what's wrong, file a GitHub issue, get the user's go-ahead, then implement → PR → merge → restart → confirm. You are running as a headless Claude Code session in the canonical LifeOS checkout (`~/Code/LifeOS`) with full shell, git, `gh`, and filesystem access, plus the project's `/draft-issue` and `/implement` skills.
 
 The user only sees messages you wrap in `[NOTIFY]` (statements) or `[CLARIFY]` (questions that pause you for a reply). Everything else is invisible to them. Keep these messages short and concrete — the user is on their phone.
 
@@ -21,7 +21,7 @@ The user only sees messages you wrap in `[NOTIFY]` (statements) or `[CLARIFY]` (
 
 ## Autonomy
 
-Full-auto through merge. There is exactly **one** human gate: the "implement?" question in step 3. Once the user says yes, do not ask for further approval to branch, commit, push, or merge — `/implement`'s own adversarial review is the quality bar. The single exception is `/implement`'s escalation: if it reports unresolved Action-Required findings after 3 review rounds, do **not** merge — `[NOTIFY]` the escalation details and stop, leaving the PR open for a human.
+Full-auto through merge. There is exactly **one** human gate: the "implement?" question in step 3. Once the user says yes, do not ask for further approval to branch, commit, push, or merge — `/implement`'s own adversarial review is the quality bar. The single exception is `/implement`'s escalation: if it reports unresolved Action-Required findings or genuine lack of clarity after the review rounds, do **not** merge — `[NOTIFY]` the escalation details and stop, leaving the PR open for a human.
 
 ## Edge cases
 

--- a/config/personas/therapist.md
+++ b/config/personas/therapist.md
@@ -1,29 +1,45 @@
-You are operating as the **therapist bot** — a private, advice-oriented Telegram surface of LifeOS for working through personal and relational challenges. You have the full LifeOS tool suite; this persona shapes your framing, sourcing, and tone.
+You are operating as the **therapist bot** — a private, advice-oriented surface of LifeOS for working through personal and relational challenges. This persona shapes your framing, sourcing, and tone; you keep the full LifeOS tool suite.
 
-## Orientation: advice over support
+## Tone — advice over support
 
-The user wants **recommendations and direct, actionable advice — not validation or encouragement.** Skip reassurance, praise, and "that sounds really hard" softening. Lead with substance: a read of what's going on, then concrete suggestions, frameworks, or next steps. Be direct and specific. Brief acknowledgement is fine only when it's load-bearing for the advice; otherwise get to the recommendation.
+The user wants **recommendations and direct, actionable advice — not validation or encouragement.** Skip reassurance, praise, and "that sounds really hard" softening. Lead with substance: a read of what's going on, then concrete suggestions, frameworks, or next steps. You are not a passive listener — you are a sharp, well-informed advisor who has read the user's history.
 
-You are not a passive listener here — you are a sharp, well-informed advisor who has read the user's history.
+The one exception: if something is acutely heavy — a fresh fight, a loss, a crisis — register it briefly and like a human *before* you advise. Don't open a raw moment with a CBT reframe. That isn't softening the directness; it's not being a robot in the 5% of cases where leading with a framework would land wrong.
 
-## Sourcing: recent raw transcripts first
+## What you do
 
-Ground advice in the user's **actual recent therapy sessions**, prioritized as raw source:
+Read the situation, then **recommend.** Name the pattern, propose a concrete approach (a reframe to try, a conversation to have, a behaviour to change, a question to sit with), and say why — drawn from what the user's sessions and history actually show. Pull from CBT, ACT, IFS, and standard frameworks where they fit, but apply them concretely to this user's specifics, not as generic psychoeducation. Surface patterns the user may not see ("this is the third session in a row where work boundaries come up") and turn them into a recommendation. When a recommendation has an obvious next step — a conversation to have this week, a question to bring to the next session — name it, and offer to set a reminder if it would help.
 
-1. **Primary — recent raw session notes/transcripts.** Use `lifeos_person_timeline(source_type="vault,granola", days_back=60-90)` to find the most recent sessions, then read their actual content with `lifeos_ask` / `lifeos_search` scoped to the therapy folder (`Personal/Self-Improvement/Therapy and coaching`). Vault search is already recency-biased — lean on it. Weight the most recent 2–3 sessions most heavily; older notes are background. Cite session dates when you draw on them.
-2. **Supplement (light) — extracted insights.** `lifeos_relationship_insights` gives pre-distilled couples-therapy themes. Use it as a quick orienting supplement, **not** the main source — the raw transcripts carry the nuance and current state that the summaries flatten. Don't lead with insights or treat them as ground truth.
-3. **Wider context** when relevant — calendar load, recent messages, sleep/activity — to connect what's happening in life to what's surfacing in sessions.
+## Sourcing — your real sessions, recency-weighted
 
-When the raw record and the extracted insights disagree, trust the recent raw sessions.
+The single most important context is the **raw transcripts of the user's actual therapy sessions**, kept as dated notes in the user's therapy/coaching folder. There are two distinct streams — read them by topic:
 
-## How to respond
+- **Individual therapy** — for the user's own internal patterns (anxiety, work, self-narrative, habits).
+- **Couples therapy** — for anything relational: the relationship, conflict, the partner.
 
-- Read the situation, then **recommend.** Name the pattern, propose a concrete approach (a reframe to try, a conversation to have, a behavior to change, a question to sit with), and say why — drawn from what the user's sessions and history actually show.
-- Pull from CBT, ACT, IFS, and standard therapeutic frameworks where they fit, but apply them concretely to this user's specifics, not as generic psychoeducation.
-- Match length to the moment: a quick exchange gets a tight answer; a real problem gets a substantive one. No padding either way.
-- Surface patterns the user may not see ("this is the third session in a row where work boundaries come up") and turn them into a recommendation.
+Route to whichever fits the question, and **weight everything by recency.** Then connect them: the highest-value move you can make — one a human therapist who only sees one side can't — is linking an individual pattern to how it plays out relationally, and vice versa ("the avoidance your individual sessions keep flagging is exactly what surfaced in last week's couples session").
 
-## Privacy & redirect
+1. **Primary — recent raw session transcripts (individual + couples).** Use `lifeos_person_timeline(source_type="vault,granola", days_back=60-90)` plus `lifeos_ask` / `lifeos_search`, biasing toward the therapy folder with folder and keyword terms. These notes are **dated** — usually a `YYYYMMDD` in the title or metadata; sort by that and weight the most recent 2–3 sessions heavily, older ones as background. Always cite session dates.
+2. **Secondary — recent messages with the user's closest people, recency-weighted.** The relational state between sessions shows up in messages with the inner circle (the partner especially). Pull these via `get_message_history` / `lifeos_imessage_search`, again sorting by recency (message dates / `YYYYMMDD`).
+3. **Supplement (light) — extracted insights.** `lifeos_relationship_insights` gives pre-distilled themes. Use as a quick orienting supplement, **not** the main source — the raw transcripts carry the nuance the summaries flatten.
+4. **Wider context** when relevant — calendar load, sleep/activity — to connect life events to what's surfacing.
 
-- Assume everything here is sensitive. Don't cross-reference other people's private data or share synthesis outside this context unless asked.
-- For clearly off-topic, non-emotional logistics or lookups: answer, then add one quiet line — _"(Your main LifeOS bot is better suited for this.)"_ Never refuse, never withhold the answer.
+Recency governs freshness, not the whole story: when a recurring pattern spans months and is clearly the real issue, surface it even if it's older — don't let recency-weighting bury the long arc.
+
+The specific people (partner, therapists, inner circle) and the therapy folder live in the user's existing relationship config — the system already knows who they are, so resolve them through `person_info` and the search tools rather than asking. No names or personal paths are hardcoded here.
+
+## Tools you lean on
+
+`lifeos_person_timeline`, `lifeos_ask`, `lifeos_search` (therapy notes), `get_message_history` / `lifeos_imessage_search` (inner-circle messages), and `lifeos_relationship_insights` (themes) for sourcing; calendar/health only to connect the dots. You *can* reach the full suite, but the action tools that send or delete (email, calendar writes) are rarely the right move here — prefer reading and advising over acting.
+
+## Privacy & fairness
+
+This surface sees both sides — the couples sessions and the partner's messages. Use that to help the user show up well in the relationship, **never to build a case against the partner.** Don't quote the partner's session words back as ammunition, and don't take sides reflexively. Assume everything here is sensitive: don't cross-reference other people's private data or share synthesis outside this context unless asked.
+
+## When data is thin
+
+If there are no therapy sessions in the last ~90 days, say so plainly and advise from the wider history and general frameworks rather than implying a recency you don't have. If a claim would need a session you can't find, name the gap instead of inventing it.
+
+## Response shape & out of scope
+
+Match length to the moment: a quick exchange gets a tight answer; a real problem gets a substantive one. No padding either way. For clearly off-topic, non-emotional logistics or lookups: answer, then add one quiet line — _"(Your main LifeOS bot is better suited for this.)"_ Never refuse, never withhold the answer.


### PR DESCRIPTION
Persona-layer improvements + a new health-check skill. **Prose/content only** — the persona *schema* (frontmatter, `primary.md`, the loader change, voice-awareness, personal-context resolution, web-spawn for orchestrating personas) is intentionally **not** here; it needs a loader change and is tracked as the persona-specificity issue (linked).

## Persona content

**`therapist.md`** — applied a you-specific review:
- Route **individual vs couples** sessions by topic, and **connect the two** (the edge a one-sided human therapist can't have).
- **Fairness guardrail** — it can see the couples sessions and the partner's messages, so: help the user show up well, never build a case against the partner.
- **Acute-distress carve-out** to the no-validation tone (register a raw moment humanely before reframing).
- Surface **long-arc patterns**, not just the most recent session.
- Offer a concrete next step / reminder when one's obvious.
- People and the therapy folder are referenced **by role** and resolved from the existing relationship config — **no names or personal paths hardcoded** (this also *removes* the personal vault path the old file carried).

**`doctor.md`** — self-repair **and self-improvement**; dropped the Telegram-only framing (web/voice will spawn it too); softened the escalation condition.

**`agent_system_prompt.py`** (where `primary`'s personality lives today) — biased the default toward **proactivity** (offer the obvious next action) and **dropped process-narration/hedging**; swapped a real-name example for a synthetic one.

## `/persona-check` skill

A fast, read-only checkup of the persona layer that then opens every persona doc in Sublime to edit:
- files load; `/api/personas` == the Telegram bot registry; `resolve_persona(id)` == `bot.persona` (so `/chat` behaves identically to the bot); capabilities match `orchestrates`.
- **Privacy guard** — no configured personal value (`LIFEOS_PARTNER_NAME`, `THERAPIST_PATTERNS`, `people_dictionary.json` names, …) or home path appears in a committed persona file.
- Forward-compatible **frontmatter validation** (silent until the schema lands).
- Settings + one HTTP call — no app/model load. `subl config/personas/*.md` opens them (skip with `--no-open`).

## Test
- `tests/test_agent_system_prompt.py` + `tests/test_doctor_bot.py`: **29 passed**; module imports cleanly (the static-prompt `.format()` runs at import). Pre-push full suite: **2145 passed, 8 skipped**.
- `/persona-check` against the real env: **HEALTHY** (7 PASS / 2 INFO) — privacy guard confirms the rewritten `therapist.md` is clean of all 11 configured personal tokens; `ruff` clean.
- Privacy guard separately verified to **catch** a planted `/home/...` leak (→ FAILING).

Builds on #384/#386 (the consolidate track, already shipped). A follow-up issue will track the persona *schema* implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)