### PR TITLE
feat(personas): frontmatter loader — strip YAML, parse voice/model

### DIFF
--- a/config/personas/README.md
+++ b/config/personas/README.md
@@ -14,7 +14,7 @@ The loader (`settings._parse_persona`, used by `settings.telegram_bots`) strips 
 
 The frontmatter holds **only what code acts on** — never real names, vault paths, or other personal values (the project's open-source rule; `/persona-check` enforces it). The schema leaves room to add hard tool allow-lists later (a `tools:` field) without restructuring.
 
-Files with no frontmatter still load fine (the whole file is the body), so frontmatter is purely additive.
+A file with no leading `---` block loads whole — frontmatter is purely additive. A file that *starts* with a `---…---` block is always parsed as frontmatter (standard YAML-frontmatter semantics), so don't open a persona body with a raw `---` horizontal rule. A malformed frontmatter block doesn't crash loading — the loader logs a warning and falls back to using the raw file as the preamble.
 
 ## Prose skeleton
 

--- a/config/personas/README.md
+++ b/config/personas/README.md
@@ -1,0 +1,38 @@
+# Persona files
+
+Each persona is a markdown file: an optional YAML **frontmatter** block (machine-read config) followed by the **prose body** (the personality the model reads). The bot registry (`config/telegram_bots.json`) maps a bot `name` → its `persona_file`; this file owns *how the persona behaves*, the registry owns *routing* (token, chat, `orchestrates`). Frontmatter never duplicates registry fields.
+
+The loader (`settings._parse_persona`, used by `settings.telegram_bots`) strips the frontmatter and returns the **body only** as the system-prompt preamble — so the YAML never leaks into the prompt. The body is used **verbatim** (no `str.format`), so a persona may safely contain literal `{...}` examples (e.g. `fitness.md`).
+
+## Frontmatter (YAML, optional)
+
+| Field | Meaning |
+|---|---|
+| `id` | Should equal the bot `name` in `telegram_bots.json` (a mismatch logs a warning). |
+| `model` | Optional per-persona model preference (e.g. `opus`); empty/omitted = orchestrator default + normal escalation. |
+| `voice` | A list of behaviour rules applied **only on voice (spoken) turns**; ignored for text. |
+
+The frontmatter holds **only what code acts on** — never real names, vault paths, or other personal values (the project's open-source rule; `/persona-check` enforces it). The schema leaves room to add hard tool allow-lists later (a `tools:` field) without restructuring.
+
+Files with no frontmatter still load fine (the whole file is the body), so frontmatter is purely additive.
+
+## Prose skeleton
+
+Not every persona needs every section — include what applies. Suggested order:
+
+1. **Opening line** — role + surface, one sentence.
+2. `## Tone` — personality in text.
+3. `## What you do` — core behaviour (for `doctor`, the pipeline).
+4. `## Sourcing` — where to ground answers (omit if nothing special).
+5. `## Tools you lean on` — advisory prose: which tools this persona mainly uses (not enforced).
+6. `## Response shape` — length/format norms for text (voice norms go in frontmatter `voice`).
+7. `## When data is thin` — sparse-data fallback.
+8. `## Out of scope` — redirect behaviour (omit for `primary`, the catch-all).
+
+## Status / roadmap
+
+This file documents the schema as loaded today (frontmatter parsed + stripped; `voice`/`model` stored on `TelegramBotConfig`). Consuming the parsed fields and the rest of the schema is tracked in #390:
+
+- `voice` rules are parsed now but **applied on voice turns** in a follow-up (needs a text-vs-voice modality flag).
+- `model` preference is parsed now; wiring it into model selection is a follow-up.
+- A `primary.md` (lifting `primary`'s personality out of the static prompt) and a resolved **personal-context block** (partner / therapists / inner circle / folders, from existing config — never hardcoded here) are follow-up phases.

--- a/config/personas/doctor.md
+++ b/config/personas/doctor.md
@@ -1,3 +1,8 @@
+---
+id: doctor
+model: ""
+---
+
 You are operating as the **doctor bot** — LifeOS's self-repair and self-improvement surface. The user messages you when they notice LifeOS itself misbehaving or missing a capability. Your job is to turn that observation into a shipped fix: clarify what's wrong, file a GitHub issue, get the user's go-ahead, then implement → PR → merge → restart → confirm. You are running as a headless Claude Code session in the canonical LifeOS checkout (`~/Code/LifeOS`) with full shell, git, `gh`, and filesystem access, plus the project's `/draft-issue` and `/implement` skills.
 
 The user only sees messages you wrap in `[NOTIFY]` (statements) or `[CLARIFY]` (questions that pause you for a reply). Everything else is invisible to them. Keep these messages short and concrete — the user is on their phone.

--- a/config/personas/fitness.md
+++ b/config/personas/fitness.md
@@ -1,3 +1,11 @@
+---
+id: fitness
+model: ""
+voice:
+  - Lead with the number or the confirmation — no preamble.
+  - Say it as one short line; no markdown or bullet lists.
+---
+
 You are operating as the **fitness bot** — a clinical logging-and-advice surface of LifeOS for training, nutrition, recovery, and health metrics. You have the full LifeOS tool suite; this persona sets your behavior and tone.
 
 ## Tone: clinical and dry
@@ -22,7 +30,7 @@ The user logs workouts as plain text. **Log first, report after — never ask fo
 
 When asked (programming, what to train, load/progression, form, nutrition, recovery), act as a knowledgeable trainer who has read the user's data:
 
-1. **Pull the data first.** Call `manage_workouts` with `action: "readiness"` — it returns recent volume, available recovery signals (body weight now; sleep/HR/HRV once Apple Health lands), and the training profile in one call. For a specific lift, also `action: "history"`.
+1. **Pull the data first.** Call `manage_workouts` with `action: "readiness"` — it returns recent volume, available recovery signals (body weight; plus sleep/HR/HRV when those are present), and the training profile in one call. For a specific lift, also `action: "history"`.
 2. **Respect the profile.** Honor stated injuries, equipment, schedule, and goals — never program around a bad knee or kit the user doesn't have. If the profile is empty, ask once for goals/injuries/equipment and `set_profile` the answer.
 3. **Be specific.** Give concrete sets/reps/loads, a session plan, or a progression — not generic advice. Base loads on the user's logged numbers (e.g. progress last week's working weight). State assumptions explicitly.
 4. **Use recovery when present.** If recovery signals are poor (short sleep, elevated resting HR, low HRV) deload or redirect; if absent, say you're going on training history alone.

--- a/config/personas/therapist.md
+++ b/config/personas/therapist.md
@@ -1,3 +1,12 @@
+---
+id: therapist
+model: ""
+voice:
+  - Speak in plain sentences — no markdown, headers, or bullet lists.
+  - Calmer, slightly slower cadence; one idea at a time.
+  - Still lead with the recommendation; skip the spoken preamble.
+---
+
 You are operating as the **therapist bot** — a private, advice-oriented surface of LifeOS for working through personal and relational challenges. This persona shapes your framing, sourcing, and tone; you keep the full LifeOS tool suite.
 
 ## Tone — advice over support

--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,8 @@ import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+
+import frontmatter
 from dotenv import dotenv_values
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
@@ -38,6 +40,33 @@ class TelegramBotConfig:
     persona: str = ""
     label: str = ""
     orchestrates: bool = False
+    # Parsed from the persona file's optional YAML frontmatter (see _parse_persona).
+    # `voice` rules apply only on voice turns; `model` is an optional per-persona
+    # model preference. Both default to unset and are consumed by the orchestrator,
+    # not here.
+    voice: tuple[str, ...] = ()
+    model: str = ""
+
+
+def _parse_persona(text: str, name: str = "") -> "tuple[str, tuple[str, ...], str]":
+    """Split a persona file into ``(body, voice, model)``.
+
+    Personas may carry a leading YAML frontmatter block (``id`` / ``model`` /
+    ``voice``); only the **body** becomes the system-prompt preamble, so the
+    frontmatter never leaks into the prompt. Files without frontmatter pass
+    through unchanged. The body is returned verbatim (no ``str.format``) so a
+    persona may contain literal ``{...}`` examples. ``voice``/``model`` are parsed
+    for the orchestrator to consume later; they are inert here.
+    """
+    post = frontmatter.loads(text)
+    meta = post.metadata or {}
+    raw_voice = meta.get("voice") or []
+    voice = tuple(str(v).strip() for v in raw_voice) if isinstance(raw_voice, list) else ()
+    model = str(meta.get("model") or "").strip()
+    fid = meta.get("id")
+    if fid and name and str(fid) != name:
+        logger.warning(f"persona file id={fid!r} does not match bot name {name!r}")
+    return post.content.strip(), voice, model
 
 
 # Capabilities advertised to HTTP clients. The primary persona and any
@@ -791,11 +820,11 @@ class Settings(BaseSettings):
                 )
                 continue
             chat_id = (env.get(entry.get("chat_id_env", "")) or "").strip() or self.telegram_chat_id
-            persona = ""
+            persona, voice, model = "", (), ""
             persona_file = entry.get("persona_file")
             if persona_file:
                 try:
-                    persona = Path(persona_file).read_text().strip()
+                    persona, voice, model = _parse_persona(Path(persona_file).read_text(), name)
                 except OSError as e:
                     logger.warning(f"Telegram bot '{name}': could not read persona file {persona_file}: {e}")
             label = (entry.get("label") or "").strip()
@@ -803,6 +832,7 @@ class Settings(BaseSettings):
             bots.append(TelegramBotConfig(
                 name=name, token=token, chat_id=chat_id, persona=persona, label=label,
                 orchestrates=bool(entry.get("orchestrates", False)),
+                voice=voice, model=model,
             ))
         return bots
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -58,10 +58,19 @@ def _parse_persona(text: str, name: str = "") -> "tuple[str, tuple[str, ...], st
     persona may contain literal ``{...}`` examples. ``voice``/``model`` are parsed
     for the orchestrator to consume later; they are inert here.
     """
-    post = frontmatter.loads(text)
+    try:
+        post = frontmatter.loads(text)
+    except Exception as e:  # noqa: BLE001 — a malformed persona file must not take down
+        # the whole bot registry (telegram_bots is an uncached property feeding
+        # resolve_persona / list_http_personas). Degrade to the raw file as the preamble.
+        logger.warning(f"persona file {name!r}: frontmatter parse failed ({e}); using the raw file as the preamble")
+        return text.strip(), (), ""
     meta = post.metadata or {}
     raw_voice = meta.get("voice") or []
-    voice = tuple(str(v).strip() for v in raw_voice) if isinstance(raw_voice, list) else ()
+    if raw_voice and not isinstance(raw_voice, list):
+        logger.warning(f"persona file {name!r}: `voice` must be a YAML list; ignoring {type(raw_voice).__name__}")
+        raw_voice = []
+    voice = tuple(str(v).strip() for v in raw_voice)
     model = str(meta.get("model") or "").strip()
     fid = meta.get("id")
     if fid and name and str(fid) != name:

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -192,6 +192,27 @@ class TestPersonaFrontmatter:
             assert body, f"{f.name}: empty body"
             assert not body.lstrip().startswith(("---", "id:")), f"{f.name}: frontmatter leaked into body"
 
+    def test_malformed_frontmatter_falls_back_to_raw_body(self):
+        # Invalid YAML must not raise (would 500 every persona request) — degrade gracefully.
+        from config.settings import _parse_persona
+        body, voice, model = _parse_persona("---\nid: x\nvoice: [unterminated\n---\n\nBODY", "x")
+        assert "BODY" in body
+        assert voice == ()
+        assert model == ""
+
+    def test_non_list_voice_is_ignored(self):
+        from config.settings import _parse_persona
+        body, voice, model = _parse_persona("---\nid: x\nvoice: just a scalar\n---\n\nB", "x")
+        assert voice == ()
+        assert body == "B"
+
+    def test_id_mismatch_warns(self, caplog):
+        import logging
+        from config.settings import _parse_persona
+        with caplog.at_level(logging.WARNING):
+            _parse_persona("---\nid: wrong\n---\n\nB", "right")
+        assert any("does not match" in r.message for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # GET /api/personas

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -138,6 +138,62 @@ class TestResolvePersona:
 
 
 # ---------------------------------------------------------------------------
+# Persona frontmatter loader (#390 Phase 1)
+# ---------------------------------------------------------------------------
+
+class TestPersonaFrontmatter:
+    def test_parse_strips_frontmatter_keeps_body_and_braces(self):
+        from config.settings import _parse_persona
+        text = (
+            "---\n"
+            "id: fitness\n"
+            "model: opus\n"
+            "voice:\n"
+            "  - lead with the number\n"
+            "  - no markdown\n"
+            "---\n\n"
+            'You are the fitness bot. Log `bench 135x8` as {exercise: "bench"}.\n'
+        )
+        body, voice, model = _parse_persona(text, "fitness")
+        assert body.startswith("You are the fitness bot.")
+        assert "---" not in body and "id: fitness" not in body  # frontmatter stripped
+        assert '{exercise: "bench"}' in body  # literal braces survive (no str.format)
+        assert voice == ("lead with the number", "no markdown")
+        assert model == "opus"
+
+    def test_parse_no_frontmatter_passthrough(self):
+        from config.settings import _parse_persona
+        body, voice, model = _parse_persona("Just a body with a {literal} brace.", "x")
+        assert body == "Just a body with a {literal} brace."
+        assert voice == ()
+        assert model == ""
+
+    def test_resolve_persona_returns_body_only(self, tmp_path, monkeypatch):
+        pf = tmp_path / "therapist.md"
+        pf.write_text("---\nid: therapist\nvoice:\n  - calm\n---\n\nADVICE BODY.")
+        reg = _registry(tmp_path, [
+            {"name": "therapist", "token_env": "TG_TH", "persona_file": str(pf)},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_TH", "tok")
+        from config.settings import settings
+        assert settings.resolve_persona("therapist") == "ADVICE BODY."  # no YAML leak
+        bot = settings.telegram_bots[0]
+        assert bot.voice == ("calm",)
+        assert bot.model == ""
+
+    def test_real_persona_files_parse_clean(self):
+        from pathlib import Path
+        from config.settings import _parse_persona
+        files = [f for f in Path("config/personas").glob("*.md") if f.name != "README.md"]
+        assert files, "no persona files found"
+        for f in files:
+            body, _voice, _model = _parse_persona(f.read_text(), f.stem)
+            assert body, f"{f.name}: empty body"
+            assert not body.lstrip().startswith(("---", "id:")), f"{f.name}: frontmatter leaked into body"
+
+
+# ---------------------------------------------------------------------------
 # GET /api/personas
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

#390 **Phase 1** — the persona-schema foundation. Persona files may now carry a YAML frontmatter block (`id` / `model` / `voice`); the loader strips it so only the **body** reaches the system prompt, and parses `voice`/`model` onto `TelegramBotConfig` for later phases to consume. Migrates the three existing personas onto the schema and adds the schema doc.

Relates to #390. (Phases 2–5 — `primary.md`, voice-awareness, personal-context, web-spawn — are follow-up PRs.)

## What changed

- **`settings._parse_persona(text, name)`** → `(body, voice, model)` using the existing `python-frontmatter` dep (same one `chunker.py` uses). `telegram_bots` uses it, so `resolve_persona` and the Telegram path return **body-only** — no YAML leak.
- Body is returned **verbatim** (no `str.format`), so literal `{…}` examples in `fitness.md` survive — the gotcha called out in the issue.
- `TelegramBotConfig` gains `voice: tuple[str, ...]` + `model: str` (parsed now, inert until the voice/model phases).
- Frontmatter added to `fitness` / `therapist` / `doctor`; `config/personas/README.md` documents the schema. Files **without** frontmatter still load unchanged — purely additive.
- Fixed `fitness.md`'s future-dated "once Apple Health lands" wording.

## Test evidence

- New `TestPersonaFrontmatter` (in `test_persona_api.py`): frontmatter stripped + literal braces survive + `voice`/`model` parsed; no-frontmatter passthrough; `resolve_persona` returns body-only with `bot.voice`/`bot.model` populated; every real persona file parses with no frontmatter leaking into the body.
- Full unit gate: **2151 passed, 8 skipped**. Existing persona/telegram/static-prompt tests unchanged. `ruff` clean.
- Sanity: the 3 migrated files parse cleanly (doctor 0 / fitness 2 / therapist 3 voice rules; bodies start with the prose).

## Review focus

- `_parse_persona` edge cases (no frontmatter, non-list `voice`, `id` mismatch warning).
- That nothing `str.format`s a persona body (would break `fitness.md` braces).
- Backward-compat: files without frontmatter behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)