### PR TITLE
feat(personas): primary.md — primary's personality as a tunable peer

### DIFF
--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -114,8 +114,6 @@ Call MULTIPLE tools in a SINGLE round whenever possible.
 
 ## Response format
 
-- Concise and direct. No fluff. Don't narrate your process ("let me look...", "I searched X and found") or over-hedge — just answer. Flag only genuine uncertainty or sparse data.
-- Be proactive: when the answer implies an obvious next action (a reply to draft, a task to add, an event to create), offer to take it — don't stop at the answer. (A specialized persona that prefers advising over acting will say so.)
 - Cite sources naturally ("According to your meeting notes from Jan 15...").
 - Use bullet points for lists.
 - If data is sparse, say so. Don't invent information.

--- a/config/personas/primary.md
+++ b/config/personas/primary.md
@@ -1,0 +1,18 @@
+---
+id: primary
+model: ""
+voice:
+  - Speak in plain sentences — no markdown or bullet lists.
+  - Keep it short — a sentence or two unless asked for more.
+  - Don't read out URLs, IDs, or file paths; summarize instead.
+---
+
+You are LifeOS — the user's general-purpose personal assistant and the default surface, answering across every domain (knowledge, people, calendar, email, finances, tasks, the web) with the full tool suite. This file is your personality; the tool mechanics and the global response rules live in the base instructions.
+
+## Tone
+
+Concise and direct. No fluff, no filler, no cheerleading. Warm but efficient — a sharp assistant who already knows the user's world, not a chatbot. Don't narrate your process ("let me look…", "I searched X and found") or over-hedge; just answer, flagging only genuine uncertainty or sparse data.
+
+## Proactivity
+
+When the answer implies an obvious next action — a reply to draft, a task to add, an event to create — offer to take it; don't stop at the answer.

--- a/config/settings.py
+++ b/config/settings.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 # Registry of specialized Telegram bots (beyond the primary). Committed, no
 # secrets — each entry references the env var holding its token.
 _TELEGRAM_BOTS_FILE = Path("config/telegram_bots.json")
+_PRIMARY_PERSONA_FILE = Path("config/personas/primary.md")
 _BOT_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
 
 
@@ -76,6 +77,18 @@ def _parse_persona(text: str, name: str = "") -> "tuple[str, tuple[str, ...], st
     if fid and name and str(fid) != name:
         logger.warning(f"persona file id={fid!r} does not match bot name {name!r}")
     return post.content.strip(), voice, model
+
+
+def _load_primary_persona() -> "tuple[str, tuple[str, ...], str]":
+    """Load the primary persona from ``config/personas/primary.md`` if present.
+
+    Primary has no registry entry, so its preamble (and ``voice``/``model``) come
+    from this file directly. An absent file → no preamble, the historical default.
+    """
+    try:
+        return _parse_persona(_PRIMARY_PERSONA_FILE.read_text(), "primary")
+    except OSError:
+        return "", (), ""
 
 
 # Capabilities advertised to HTTP clients. The primary persona and any
@@ -776,11 +789,14 @@ class Settings(BaseSettings):
         Named "primary" so its update-offset file stays the legacy
         ``data/telegram_state.json`` and existing behavior is unchanged.
         """
+        persona, voice, model = _load_primary_persona()
         return TelegramBotConfig(
             name="primary",
             token=self.telegram_bot_token,
             chat_id=self.telegram_chat_id,
-            persona="",
+            persona=persona,
+            voice=voice,
+            model=model,
         )
 
     @property
@@ -880,7 +896,7 @@ class Settings(BaseSettings):
         unknown id so the caller can reject it with HTTP 400.
         """
         if persona_id == "primary":
-            return ""
+            return _load_primary_persona()[0]
         for bot in self.telegram_bots:
             if bot.name == persona_id:
                 return bot.persona

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -113,9 +113,22 @@ class TestListHttpPersonas:
 # ---------------------------------------------------------------------------
 
 class TestResolvePersona:
-    def test_primary_resolves_to_empty(self):
+    def test_primary_resolves_to_primary_md(self):
+        # #390 P2: primary's personality now lives in config/personas/primary.md.
         from config.settings import settings
-        assert settings.resolve_persona("primary") == ""
+        pre = settings.resolve_persona("primary")
+        assert pre and "general-purpose" in pre  # body loaded (no longer empty)
+        assert not pre.lstrip().startswith("---")  # frontmatter stripped
+        # The primary Telegram bot draws from the same file (single source).
+        assert settings.telegram_primary_bot.persona == pre
+
+    def test_primary_personality_moved_out_of_static_prompt(self):
+        # The proactivity/tone now lives in primary.md, not the shared static prompt.
+        import api.services.agent_system_prompt as asp
+        from config.settings import _load_primary_persona
+        body = _load_primary_persona()[0]
+        assert "obvious next action" in body
+        assert "obvious next action" not in asp._STATIC_PROMPT
 
     def test_unknown_returns_none(self, tmp_path, monkeypatch):
         monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", tmp_path / "none.json")


### PR DESCRIPTION
## Summary
#390 **Phase 2**. Lifts `primary`'s personality (tone + proactivity) out of the static prompt into `config/personas/primary.md`, so the default persona is a tunable peer like the others — no longer welded into code, no longer duplicated.

Relates to #390. (Phases 3–5 follow.)

## What changed
- `settings._load_primary_persona()` reads `config/personas/primary.md` (frontmatter-aware). `resolve_persona("primary")` and `telegram_primary_bot` both use it → web `/chat` default and the primary Telegram bot share **one source**. Missing file → `""` (historical default), graceful.
- Removed the concise/proactive **tone** lines from `agent_system_prompt`'s static prompt (now in `primary.md`). The static prompt keeps only the **global** rules (cite, bullets, never-expose, use-the-name) that apply to every persona. Specialized personas set their own tone, so they're unaffected.
- New `primary.md` carries the tone + a `voice` frontmatter block (parsed; applied in the voice-awareness phase).

## Test evidence
- Updated `test_primary_resolves_to_primary_md` (primary now resolves to the file body, single-source with the Telegram bot) + `test_primary_personality_moved_out_of_static_prompt` (de-dup guard: "obvious next action" is in `primary.md`, not `_STATIC_PROMPT`).
- Full unit gate: **2155 passed, 8 skipped**. ruff clean. Verified: primary preamble = `primary.md` body (frontmatter stripped, 3 voice rules), static prompt no longer carries it.

## Review focus
- The static/primary split — did any *global* rule get moved out by mistake? (Only the tone/proactivity lines moved.)
- Graceful fallback when `primary.md` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)