### PR TITLE
feat(personas): personal-context — therapist pre-resolves people from config

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -463,6 +463,15 @@ async def ask_stream(request: AskStreamRequest):
         else ()
     )
 
+    # Personal-context block: the therapist persona pre-resolves the user's people
+    # from config so it can target sessions/messages without a lookup round. Works
+    # on the persona_id path and the raw-`persona` (Telegram) path via a reverse
+    # lookup of the preamble back to a bot name.
+    _effective_pid = request.persona_id
+    if _effective_pid is None and request.persona:
+        _effective_pid = next((b.name for b in settings.telegram_bots if b.persona == request.persona), None)
+    personal_context = settings.personal_context(_effective_pid or "")
+
     async def generate():
         try:
             # Get or create conversation
@@ -741,6 +750,7 @@ async def ask_stream(request: AskStreamRequest):
                 model=orchestrator_model if escalated else "",
                 persona=persona_preamble,
                 voice_rules=voice_rules,
+                personal_context=personal_context,
                 force_local=force_local,
             ):
                 if event["type"] == "text":

--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -403,6 +403,7 @@ async def run_agent_loop(
     model: str = "",
     persona: str = "",
     voice_rules: tuple = (),
+    personal_context: str = "",
     force_local: bool = False,
 ) -> AsyncGenerator[dict, None]:
     """
@@ -432,7 +433,8 @@ async def run_agent_loop(
         Dicts with "type" key: "text", "status", or "result".
     """
     client = _select_client(model, force_local=force_local)
-    system_prompt = build_system_prompt(persona=persona, max_tool_rounds=max_tool_rounds, voice_rules=voice_rules)
+    system_prompt = build_system_prompt(persona=persona, max_tool_rounds=max_tool_rounds,
+                                        voice_rules=voice_rules, personal_context=personal_context)
 
     # Bind a fresh per-turn email-draft set. The send gate uses this to refuse
     # sending any draft created during this same turn — sends require the user

--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -161,7 +161,7 @@ def _existing_tags_block() -> str | None:
 
 
 def build_system_prompt(persona: str | None = None, max_tool_rounds: int = 5,
-                        voice_rules: "tuple[str, ...]" = ()) -> list[dict]:
+                        voice_rules: "tuple[str, ...]" = (), personal_context: str = "") -> list[dict]:
     """Build the system prompt for the agentic loop.
 
     Returns a list of content blocks for the Anthropic ``system`` parameter.
@@ -198,6 +198,9 @@ def build_system_prompt(persona: str | None = None, max_tool_rounds: int = 5,
             "## Spoken response\n\nThis turn will be read aloud — format your reply "
             "for speech, not the screen:\n" + spoken
         )})
+
+    if personal_context:
+        blocks.append({"type": "text", "text": personal_context})
 
     blocks.append(
         {

--- a/config/settings.py
+++ b/config/settings.py
@@ -915,6 +915,33 @@ class Settings(BaseSettings):
                 return bot.voice
         return ()
 
+    def personal_context(self, persona_id: str) -> str:
+        """A resolved people block for a persona, from existing config.
+
+        Scoped to the therapist (the surface built around the user's relationships
+        and therapy). Names come from LIFEOS_PARTNER_NAME / LIFEOS_THERAPIST_PATTERNS
+        — never hardcoded in a persona file, and resolved only at runtime so the
+        committed repo stays clean. Empty for other personas and for a fresh clone
+        with no config set.
+        """
+        if persona_id != "therapist":
+            return ""
+        lines = []
+        partner = (self.partner_name or "").strip()
+        if partner and partner.lower() != "partner":
+            lines.append(f"- Partner: {partner}")
+        therapists = [t.strip() for t in re.split(r"[|,]", self.therapist_patterns or "") if t.strip()]
+        if therapists:
+            lines.append(f"- Therapists (individual + couples): {', '.join(therapists)}")
+        if not lines:
+            return ""
+        return (
+            "## Your people (resolved from config)\n\n"
+            + "\n".join(lines)
+            + "\n\nThese are the actual people behind this surface — search their "
+            "sessions and messages directly rather than asking who they are."
+        )
+
     @property
     def photos_db_path(self) -> str:
         """Get path to Photos.sqlite database."""

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -310,6 +310,68 @@ class TestVoiceAwareness:
 
 
 # ---------------------------------------------------------------------------
+# Personal-context resolution (#390 Phase 4)
+# ---------------------------------------------------------------------------
+
+class TestPersonalContext:
+    def test_personal_context_therapist_from_config(self, monkeypatch):
+        from config.settings import settings
+        monkeypatch.setattr(settings, "partner_name", "Sam")
+        monkeypatch.setattr(settings, "therapist_patterns", "Dr. A|Dr. B")
+        block = settings.personal_context("therapist")
+        assert "Partner: Sam" in block and "Dr. A, Dr. B" in block
+        assert settings.personal_context("primary") == ""   # scoped to therapist
+        assert settings.personal_context("fitness") == ""
+
+    def test_personal_context_empty_when_config_unset(self, monkeypatch):
+        from config.settings import settings
+        monkeypatch.setattr(settings, "partner_name", "Partner")  # the default → skipped
+        monkeypatch.setattr(settings, "therapist_patterns", "")
+        assert settings.personal_context("therapist") == ""
+
+    def test_build_system_prompt_appends_personal_context(self):
+        from api.services.agent_system_prompt import build_system_prompt
+        blocks = build_system_prompt(persona="P", personal_context="## Your people\n\n- Partner: X")
+        assert any("Your people" in b["text"] and "Partner: X" in b["text"] for b in blocks)
+
+    def test_therapist_threading_both_paths(self, client, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+        import api.services.agent_loop as agent_loop_mod
+        from config.settings import settings
+        pf = tmp_path / "therapist.md"
+        pf.write_text("THERAPY PERSONA")
+        reg = _registry(tmp_path, [{"name": "therapist", "token_env": "TG_TH", "persona_file": str(pf)}])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_TH", "tok")
+        monkeypatch.setattr(settings, "partner_name", "Sam")
+        monkeypatch.setattr(settings, "therapist_patterns", "Dr. A")
+        captured: dict = {}
+
+        async def fake_loop(**kwargs):
+            captured.clear()
+            captured.update(kwargs)
+            yield {"type": "result", "result": SimpleNamespace(
+                total_input_tokens=0, total_output_tokens=0, total_cost_usd=0.0,
+                model="m", tool_calls_log=[], full_text="ok")}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr("api.routes.chat.classify_action_intent", fake_classify)
+
+        # persona_id path (web/voice)
+        client.post("/api/ask/stream", json={"question": "hi", "persona_id": "therapist"})
+        assert "Sam" in (captured.get("personal_context") or "")
+        # raw-persona path (Telegram) → reverse-lookup → same block
+        client.post("/api/ask/stream", json={"question": "hi", "persona": "THERAPY PERSONA"})
+        assert "Sam" in (captured.get("personal_context") or "")
+        # a different persona gets none
+        client.post("/api/ask/stream", json={"question": "hi", "persona_id": "primary"})
+        assert captured.get("personal_context") == ""
+
+
+# ---------------------------------------------------------------------------
 # GET /api/personas
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
#390 **Phase 4**. The therapist persona gets a resolved **"your people"** block (partner + therapists) so it can target the right sessions/messages without a `person_info` round. Names are resolved from existing config at **runtime only** — never hardcoded in a committed persona file.

Relates to #390. (Phase 5 follows.)

## What changed
- `settings.personal_context(persona_id)` → a block from `LIFEOS_PARTNER_NAME` + `LIFEOS_THERAPIST_PATTERNS`. **Scoped to `therapist`**; empty for other personas and for a fresh clone with defaults/unset config.
- Threaded `run_agent_loop(personal_context=…)` → `build_system_prompt` (appended like the voice/date blocks), keyed on an **effective persona id**: `request.persona_id`, or a reverse-lookup of the raw `persona` preamble to a bot name (so the **Telegram** therapist gets it too, not just web).

## Privacy
The real names live only in gitignored config and only enter the runtime prompt (which legitimately needs them). Nothing is committed — `/persona-check`'s privacy guard stays green (verified: no names in `config/personas/*.md`).

## Test evidence
- `TestPersonalContext`: resolution from config + therapist-only scoping; empty when config is default/unset; `build_system_prompt` appends the block; and threading on **both** the `persona_id` and reverse-lookup (raw `persona`) paths, with a non-therapist getting `""`.
- Full unit gate: **2165 passed, 8 skipped**. ruff clean.

## Review focus
- The reverse-lookup (`request.persona == bot.persona`) — robustness, and the effective-persona-id resolution.
- Scoping correctness (only therapist) and the graceful-empty behavior for fresh clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)