### PR TITLE
feat(agent-worker): [GOAL] tag → worker /goal injection on approval

### DIFF
--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -39,8 +39,13 @@ logger = logging.getLogger(__name__)
 HEARTBEAT_INTERVAL = 300  # 5 minutes between progress pings
 
 
-_NOTIFY_RE = re.compile(r"\[NOTIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY)\]|\Z)", re.DOTALL)
-_CLARIFY_RE = re.compile(r"\[CLARIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY)\]|\Z)", re.DOTALL)
+_NOTIFY_RE = re.compile(r"\[NOTIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY|GOAL)\]|\Z)", re.DOTALL)
+_CLARIFY_RE = re.compile(r"\[CLARIFY\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY|GOAL)\]|\Z)", re.DOTALL)
+# [GOAL] proposes a success condition for the operator to approve; once
+# approved, the worker injects `/goal <condition>` at resume (#398). It mirrors
+# the [NOTIFY]/[CLARIFY] split so an interleaved GOAL doesn't bleed into an
+# adjacent tag's body.
+_GOAL_RE = re.compile(r"\[GOAL\]\s*(.*?)(?=\[(?:NOTIFY|CLARIFY|GOAL)\]|\Z)", re.DOTALL)
 # Fenced code blocks: a fence marker (``` or ~~~) at the START of a line
 # through its matching closing fence on its own line. Tags inside these are
 # illustrative — the agent quoting the protocol or showing example output — so
@@ -58,24 +63,27 @@ _FENCE_RE = re.compile(r"^[ \t]*(`{3,}|~{3,}).*?^[ \t]*\1[ \t]*$", re.MULTILINE 
 # operator-facing narrative so raw control tokens never leak (#402). The
 # closing bracket is optional to catch unclosed tags; the (?![A-Za-z]) boundary
 # stops it from eating the prefix of unrelated words like "[NOTIFYING ...]".
-_ORPHAN_TAG_RE = re.compile(r"\[(?:NOTIFY|CLARIFY)(?![A-Za-z])\]?")
+_ORPHAN_TAG_RE = re.compile(r"\[(?:NOTIFY|CLARIFY|GOAL)(?![A-Za-z])\]?")
 
 
 class _TagScan(NamedTuple):
     """Result of a fence-aware scan of assistant text for control tags.
 
-    ``clarify`` / ``notify`` are the non-empty tag bodies in document order,
-    drawn only from outside fenced code blocks. ``narrative`` is the text with
-    all control tags + orphaned markers removed from non-fenced regions and
+    ``clarify`` / ``notify`` / ``goal`` are the non-empty tag bodies in document
+    order, drawn only from outside fenced code blocks. ``narrative`` is the text
+    with all control tags + orphaned markers removed from non-fenced regions and
     fenced code blocks preserved verbatim — i.e. the agent's prose as the
     operator should see it.
     """
     clarify: list[str]
     notify: list[str]
+    goal: list[str]
     narrative: str
 
 
-def _scan_segment(seg: str, clarify: list[str], notify: list[str], parts: list[str]) -> None:
+def _scan_segment(
+    seg: str, clarify: list[str], notify: list[str], goal: list[str], parts: list[str]
+) -> None:
     """Extract tag bodies from one non-fenced segment and append its cleaned
     narrative to ``parts``."""
     for match in _CLARIFY_RE.finditer(seg):
@@ -86,27 +94,33 @@ def _scan_segment(seg: str, clarify: list[str], notify: list[str], parts: list[s
         body = match.group(1).strip()
         if body:
             notify.append(body)
+    for match in _GOAL_RE.finditer(seg):
+        body = match.group(1).strip()
+        if body:
+            goal.append(body)
     cleaned = _NOTIFY_RE.sub("", seg)
     cleaned = _CLARIFY_RE.sub("", cleaned)
+    cleaned = _GOAL_RE.sub("", cleaned)
     cleaned = _ORPHAN_TAG_RE.sub("", cleaned)
     parts.append(cleaned)
 
 
 def _scan_protocol_tags(text: str) -> _TagScan:
-    """Fence-aware extraction of ``[NOTIFY]``/``[CLARIFY]`` tags from assistant
-    text. Tags inside fenced code blocks are left untouched (neither extracted
-    nor stripped); outside fences, well-formed bodies are extracted and the
-    tags plus any orphaned/malformed markers are stripped from the narrative."""
+    """Fence-aware extraction of ``[NOTIFY]``/``[CLARIFY]``/``[GOAL]`` tags from
+    assistant text. Tags inside fenced code blocks are left untouched (neither
+    extracted nor stripped); outside fences, well-formed bodies are extracted and
+    the tags plus any orphaned/malformed markers are stripped from the narrative."""
     clarify: list[str] = []
     notify: list[str] = []
+    goal: list[str] = []
     parts: list[str] = []
     pos = 0
     for fence in _FENCE_RE.finditer(text):
-        _scan_segment(text[pos:fence.start()], clarify, notify, parts)
+        _scan_segment(text[pos:fence.start()], clarify, notify, goal, parts)
         parts.append(text[fence.start():fence.end()])  # fenced block, verbatim
         pos = fence.end()
-    _scan_segment(text[pos:], clarify, notify, parts)
-    return _TagScan(clarify, notify, "".join(parts))
+    _scan_segment(text[pos:], clarify, notify, goal, parts)
+    return _TagScan(clarify, notify, goal, "".join(parts))
 
 
 # Common install locations for the Claude CLI when launchd-style minimal PATHs
@@ -199,6 +213,7 @@ The user will review and approve the plan before you proceed.
 # to discriminate without parsing prose.
 REASON_AWAITING_PLAN_APPROVAL = "awaiting_plan_approval"
 REASON_AWAITING_CLARIFICATION = "awaiting_clarification"
+REASON_AWAITING_GOAL_APPROVAL = "awaiting_goal_approval"
 REASON_TIMEOUT = "timeout"
 REASON_BINARY_NOT_FOUND = "binary_not_found"
 
@@ -222,6 +237,8 @@ class _RunState:
     notify_bodies: list[str] = field(default_factory=list)
     awaiting_approval: bool = False   # plan-mode result event reached
     awaiting_clarification: bool = False
+    pending_goal: str = ""            # Last [GOAL] body, awaiting approval (#398)
+    awaiting_goal: bool = False
     cost_usd: float = 0.0
     last_activity: str = ""
     notifications_sent: int = 0
@@ -504,6 +521,17 @@ class ClaudeCodeExecutor:
                 final_text=state.pending_clarification,
             )
 
+        if state.awaiting_goal:
+            self.session_store.update_status(session.task_id, STATUS_BLOCKED)
+            self.transcript_store.append(sid, "claude_code_awaiting_goal_approval", {
+                "condition": state.pending_goal, "condition_chars": len(state.pending_goal),
+            })
+            return ExecutorOutcome(
+                status=STATUS_BLOCKED,
+                reason=REASON_AWAITING_GOAL_APPROVAL,
+                final_text=state.pending_goal,
+            )
+
         if state.awaiting_approval:
             self.session_store.update_status(session.task_id, STATUS_BLOCKED)
             self.transcript_store.append(sid, "claude_code_awaiting_plan_approval", {
@@ -643,6 +671,22 @@ class ClaudeCodeExecutor:
                     })
                     if state.plan_mode and not state.awaiting_approval:
                         state.plan_text += body + "\n"
+                for body in scan.goal:
+                    # The agent proposed a success condition (#398). Stream it so
+                    # the operator can SEE what they're approving, then the result
+                    # event flips the session to BLOCKED awaiting their yes/no.
+                    # Child sessions stay silent to the operator like [NOTIFY].
+                    state.pending_goal = body
+                    state.notifications_sent += 1
+                    state.last_notify_at = time.time()
+                    if not state.is_child:
+                        try:
+                            self._notify(body)
+                        except Exception as exc:  # pragma: no cover — defensive
+                            logger.warning("notification callback raised: %s", exc)
+                    self.transcript_store.append(sid, "claude_code_goal", {
+                        "body": body, "body_chars": len(body),
+                    })
             elif btype == "tool_use":
                 tool_name = block.get("name", "")
                 tool_input = block.get("input", {}) or {}
@@ -668,6 +712,13 @@ class ClaudeCodeExecutor:
             # Agent asked a question — surface as BLOCKED outcome so the
             # worker can register the question for follow-up reply routing.
             state.awaiting_clarification = True
+            state.terminal = True
+            return
+
+        if state.pending_goal:
+            # Agent proposed a goal — block for operator approval (#398). On
+            # approval the worker injects `/goal <condition>` at resume.
+            state.awaiting_goal = True
             state.terminal = True
             return
 

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -718,6 +718,9 @@ class ClaudeCodeExecutor:
         if state.pending_goal:
             # Agent proposed a goal — block for operator approval (#398). On
             # approval the worker injects `/goal <condition>` at resume.
+            # Clarification is checked first above: a same-turn [CLARIFY]
+            # supersedes [GOAL], so the goal must be re-proposed after the
+            # clarification resolves.
             state.awaiting_goal = True
             state.terminal = True
             return

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -80,6 +80,19 @@ _BLOCKED_PROMPT_RETRY_DELAY_S = 0.5
 # schedule instead of a new note per fire.
 _SCHED_TAG_RE = re.compile(r"^sched-(\w+)$")
 
+# Affirmative replies that lock a proposed [GOAL] (#398). A goal-approval reply
+# that isn't affirmative is treated as a refinement and passed back verbatim.
+_GOAL_AFFIRMATIVE = {
+    "yes", "y", "yep", "yeah", "approve", "approved", "ok", "okay", "go",
+    "do it", "ship it", "lock it", "lock", "start",
+}
+
+
+def _is_affirmative(text: str) -> bool:
+    """True when a goal-approval reply means 'lock it and go' (#398)."""
+    t = text.strip().lower().rstrip("!. ")
+    return t in _GOAL_AFFIRMATIVE or t.startswith("yes") or t.startswith("approve")
+
 
 def _slugify(text: str) -> str:
     """Lowercase, hyphenated, filesystem-safe slug capped at 60 chars.
@@ -663,6 +676,10 @@ class Worker:
             answer = q["answer"] or ""
             kind = q.get("kind") or "clarification"
 
+            if kind == "goal_approval":
+                self._resume_goal(q, session, answer)
+                continue
+
             if kind == "followup":
                 self._resume_as_followup(q, session, answer)
                 continue
@@ -769,6 +786,50 @@ class Worker:
                     session, task,
                     "managed clarification resume not yet supported",
                 )
+
+    def _resume_goal(self, q: dict, session: Session, answer: str) -> None:
+        """Operator replied to a proposed [GOAL] (#398). On approval, inject
+        `/goal <condition>` so Claude Code's native goal mode is armed for the
+        resumed session; on a refinement (non-affirmative) reply, pass the raw
+        answer back so the doctor re-proposes. Mirrors the `claude_code` branch
+        of `_resume_as_followup` — enqueue a pending message and flip status to
+        CLAIMED so `_dispatch_claude_code_session` drains it and resumes.
+        """
+        sid = session.session_id
+        task_id = session.task_id
+        condition = self._pending_goal_condition(sid)
+        if condition and _is_affirmative(answer):
+            resume_msg = f"/goal {condition}"
+            self.transcript_store.append(sid, "claude_code_goal_locked", {
+                "condition_chars": len(condition),
+            })
+        else:
+            resume_msg = answer  # refinement — doctor re-proposes
+            self.transcript_store.append(sid, "claude_code_goal_refine", {
+                "answer_chars": len(answer),
+            })
+        # Operator root-spawns (#235) have no backing vault task, so skip the
+        # tag/status mutations (they would 404).
+        if session.origin != "operator":
+            self._swap_tag(task_id, BLOCKED_TAG, RUNNING_TAG)
+            self._set_task_status(task_id, "in_progress")
+        self.session_store.enqueue_message(sid, "operator", resume_msg)
+        self.session_store.update_status(task_id, STATUS_CLAIMED)
+        self.session_store.mark_question_processed(q["id"])
+
+    def _pending_goal_condition(self, session_id: str) -> str | None:
+        """The most recent proposed-but-not-yet-locked [GOAL] condition for a
+        session, or None. Scans the transcript: an `awaiting_goal_approval`
+        event sets the pending condition; a later `goal_locked` clears it (so a
+        second proposal after a refinement supersedes the first)."""
+        condition = None
+        for ev in self.transcript_store.read(session_id):
+            k = ev.get("kind")
+            if k == "claude_code_awaiting_goal_approval":
+                condition = (ev.get("payload") or {}).get("condition")
+            elif k == "claude_code_goal_locked":
+                condition = None
+        return condition
 
     def _resume_as_followup(self, q: dict, session: Session, answer: str) -> None:
         """Operator replied to a completion message — reopen the COMPLETED
@@ -1220,6 +1281,7 @@ class Worker:
         """
         from api.services.agent_worker.claude_code_executor import (
             REASON_AWAITING_CLARIFICATION,
+            REASON_AWAITING_GOAL_APPROVAL,
             REASON_AWAITING_PLAN_APPROVAL,
         )
         from api.services.agent_worker.claude_code_spawn import parse_claude_code_spawn_payload
@@ -1282,8 +1344,13 @@ class Worker:
                 prompt = "Plan ready — reply 'approve' to proceed, 'reject' to cancel, or send feedback to refine."
             elif outcome.reason == REASON_AWAITING_CLARIFICATION:
                 prompt = "Awaiting your reply — answer the question above to continue."
+            elif outcome.reason == REASON_AWAITING_GOAL_APPROVAL:
+                prompt = "Reply 'yes' to lock this goal and start, or send changes to refine it."
             else:
                 prompt = "Awaiting your reply to continue."
+            # Goal-approval replies route through `_resume_goal` (which injects
+            # `/goal <condition>` on a yes); everything else is a followup (#398).
+            kind = "goal_approval" if outcome.reason == REASON_AWAITING_GOAL_APPROVAL else "followup"
             sent_ids: list = []
             for attempt in range(_BLOCKED_PROMPT_SEND_ATTEMPTS):
                 try:
@@ -1310,7 +1377,7 @@ class Worker:
                     question=prompt,
                     sent_message_id=sent_ids[0],
                     sent_message_ids=sent_ids,
-                    kind="followup",
+                    kind=kind,
                     bot=bot,
                 )
                 self.transcript_store.append(sid, "code_block_prompt_registered", {

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -83,14 +83,30 @@ _SCHED_TAG_RE = re.compile(r"^sched-(\w+)$")
 # Affirmative replies that lock a proposed [GOAL] (#398). A goal-approval reply
 # that isn't affirmative is treated as a refinement and passed back verbatim.
 _GOAL_AFFIRMATIVE = {
-    "yes", "y", "yep", "yeah", "approve", "approved", "ok", "okay", "go",
-    "do it", "ship it", "lock it", "lock", "start",
+    "yes", "y", "yep", "yeah", "approve", "approved", "ok", "okay", "k",
+    "go", "go ahead", "do it", "ship it", "lock it", "lock", "start",
+    "sounds good", "sure", "lgtm", "looks good", "yes please",
 }
+# Phrases that signal the operator wants changes, not a lock. These take
+# precedence over the affirmative prefix check so "yes but make it stricter"
+# is treated as a refinement (it must NOT lock the stale condition).
+_GOAL_REFINE_SIGNALS = (
+    "but ", "however", "instead", "except", "change", "make it", " also ",
+    "add ", "remove", "stricter", "actually", "with change", "no,", "don't",
+    "rather", "tweak", "adjust",
+)
 
 
 def _is_affirmative(text: str) -> bool:
-    """True when a goal-approval reply means 'lock it and go' (#398)."""
-    t = text.strip().lower().rstrip("!. ")
+    """True when a goal-approval reply means 'lock it and go' (#398).
+
+    A refinement signal anywhere in the reply wins over the affirmative prefix
+    so "yes but make it stricter" / "approve with changes" don't lock the stale
+    proposed condition — they fall through to the refinement path."""
+    t = text.strip().lower()
+    if any(sig in t for sig in _GOAL_REFINE_SIGNALS):
+        return False
+    t = t.rstrip("!. ")
     return t in _GOAL_AFFIRMATIVE or t.startswith("yes") or t.startswith("approve")
 
 
@@ -798,11 +814,22 @@ class Worker:
         sid = session.session_id
         task_id = session.task_id
         condition = self._pending_goal_condition(sid)
-        if condition and _is_affirmative(answer):
-            resume_msg = f"/goal {condition}"
-            self.transcript_store.append(sid, "claude_code_goal_locked", {
-                "condition_chars": len(condition),
-            })
+        if _is_affirmative(answer):
+            if condition:
+                resume_msg = f"/goal {condition}"
+                self.transcript_store.append(sid, "claude_code_goal_locked", {
+                    "condition_chars": len(condition),
+                })
+            else:
+                # Approved, but the proposed condition couldn't be recovered from
+                # the transcript (e.g. it was already locked, or never recorded).
+                # Forwarding a bare "yes" would be meaningless to the agent — ask
+                # it to re-propose so the operator can approve a real goal.
+                resume_msg = (
+                    "Approval received, but I couldn't recover the proposed goal "
+                    "to lock. Please re-emit the [GOAL] you proposed."
+                )
+                self.transcript_store.append(sid, "claude_code_goal_lock_failed", {})
         else:
             resume_msg = answer  # refinement — doctor re-proposes
             self.transcript_store.append(sid, "claude_code_goal_refine", {

--- a/docs/specs/product/claude-code-orchestration.md
+++ b/docs/specs/product/claude-code-orchestration.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** Orchestrator
-**Last Updated:** 2026-05-27
+**Last Updated:** 2026-06-25
 
 LifeOS spawns a **Claude Code** subprocess from Telegram when the operator sends `/claude <task>` (or when a natural-language message is classified as requiring terminal / filesystem / browser access). The subprocess runs the task on the server, streams progress back as Telegram messages, and terminates. The operator can monitor (`/claude_status`) and cancel (`/claude_cancel`) the active session.
 
@@ -74,6 +74,8 @@ RUNNING   (Claude Code subprocess emits stdout JSONL events; orchestrator parses
    ↓
 [optional] CLARIFY_PENDING   (Claude asked a question; operator must answer)
    ↓
+[optional] GOAL_PENDING   (Claude proposed a [GOAL]; operator approves to lock it — the worker then injects /goal on resume — or replies with changes to refine)
+   ↓
 COMPLETED  (subprocess exited; final summary sent to Telegram)
    or
 FAILED / TIMEOUT / CANCELLED   (operator-visible terminal state with reason)
@@ -118,6 +120,23 @@ While a clarification is pending, all non-command Telegram messages route as the
 
 ---
 
+## Goal approval
+
+For longer or fuzzier objectives, Claude can propose a **success condition** with `[GOAL] <condition>` before it starts working. The proposed goal is relayed to the operator, the session pauses, and the operator either approves it or replies with changes.
+
+**Flow:**
+
+1. Claude: `[GOAL] All unit tests pass and the linter is clean.`
+2. LifeOS: "Reply 'yes' to lock this goal and start, or send changes to refine it."
+3. Operator: `yes` → the worker locks the goal (it arms Claude Code's native goal mode by injecting `/goal <condition>` on resume) and Claude begins.
+   Or: `make it also require the docs to build` → treated as a refinement; the raw reply goes back to Claude, which re-proposes an updated `[GOAL]`.
+
+Approval is recognized from short affirmatives (`yes`, `approve`, `go ahead`, `sounds good`, `lgtm`, …). A reply that also asks for changes (`yes, but make it stricter`) is treated as a refinement, not a lock.
+
+**Note:** `[GOAL]` is a first-class protocol tag with its own pending state (`REASON_AWAITING_GOAL_APPROVAL`). The doctor persona is the first to emit it; that persona change is tracked separately (issue #397).
+
+---
+
 ## Telegram notifications
 
 Claude sends three kinds of messages via Telegram:
@@ -126,9 +145,10 @@ Claude sends three kinds of messages via Telegram:
 |--------|------|---------|
 | `[NOTIFY] ...` | Progress checkpoint or completion summary | `[NOTIFY] Created backup script at ~/scripts/backup.sh and added daily cron job at 2am.` |
 | `[CLARIFY] ...` | Claude needs an answer | `[CLARIFY] Which backlog section — Work or Personal?` |
+| `[GOAL] ...` | Claude proposes a success condition to lock before starting | `[GOAL] All unit tests pass and the linter is clean.` |
 | heartbeat | Every 5 minutes while running | `Still working... (5m elapsed)` |
 
-Only `[NOTIFY]` and `[CLARIFY]` lines are relayed. All other output (tool calls, file reads, intermediate steps) stays in the subprocess. The heartbeat is sent by the orchestrator (not Claude) so the operator always knows the session is alive even when Claude is busy without notifying.
+Only `[NOTIFY]`, `[CLARIFY]`, and `[GOAL]` lines are relayed. All other output (tool calls, file reads, intermediate steps) stays in the subprocess. The heartbeat is sent by the orchestrator (not Claude) so the operator always knows the session is alive even when Claude is busy without notifying.
 
 ---
 

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -21,6 +21,7 @@ import pytest
 
 from api.services.agent_worker.claude_code_executor import (
     REASON_AWAITING_CLARIFICATION,
+    REASON_AWAITING_GOAL_APPROVAL,
     REASON_AWAITING_PLAN_APPROVAL,
     REASON_BINARY_NOT_FOUND,
     ClaudeCodeExecutor,
@@ -607,3 +608,108 @@ def test_result_event_fenced_tag_preserved_in_final_text(tmp_path: Path):
     assert outcome.status == STATUS_COMPLETED
     assert "[NOTIFY] example" in outcome.final_text  # fenced tag preserved
     assert notifications == []  # result path never streams
+
+
+# ---------------------------------------------------------------------------
+# [GOAL] tag (#398)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_extracts_goal_body_and_strips_from_narrative():
+    """A [GOAL] body is extracted and removed from the operator-facing narrative
+    just like [NOTIFY]/[CLARIFY]."""
+    from api.services.agent_worker.claude_code_executor import _scan_protocol_tags
+
+    scan = _scan_protocol_tags("here's the plan [GOAL] all tests pass")
+    assert scan.goal == ["all tests pass"]
+    assert scan.notify == []
+    assert scan.clarify == []
+    assert scan.narrative.strip() == "here's the plan"
+
+
+def test_scan_splits_goal_interleaved_with_notify_and_clarify():
+    """GOAL interleaved with NOTIFY/CLARIFY splits into discrete bodies and none
+    bleeds into another tag's body (shared lookahead)."""
+    from api.services.agent_worker.claude_code_executor import _scan_protocol_tags
+
+    scan = _scan_protocol_tags(
+        "lead [NOTIFY] alpha [GOAL] beta [CLARIFY] gamma [GOAL] delta"
+    )
+    assert scan.notify == ["alpha"]
+    assert scan.goal == ["beta", "delta"]
+    assert scan.clarify == ["gamma"]
+    assert scan.narrative.strip() == "lead"
+
+
+def test_scan_ignores_goal_inside_code_fence():
+    """A [GOAL] inside a fenced block is illustrative — not extracted, preserved
+    verbatim in the narrative."""
+    from api.services.agent_worker.claude_code_executor import _scan_protocol_tags
+
+    text = "do it [GOAL] real\n```\n[GOAL] example only\n```\nend"
+    scan = _scan_protocol_tags(text)
+    assert scan.goal == ["real"]  # fenced one not extracted
+    assert "[GOAL] example only" in scan.narrative
+
+
+def test_scan_ignores_empty_goal_body():
+    from api.services.agent_worker.claude_code_executor import _scan_protocol_tags
+
+    scan = _scan_protocol_tags("[GOAL]   ")
+    assert scan.goal == []
+    assert scan.narrative.strip() == ""
+
+
+def test_goal_returns_blocked_streams_and_records(tmp_path: Path):
+    """End-to-end: an assistant [GOAL] then a result event yields a BLOCKED
+    outcome awaiting approval, the body is streamed to the operator, and the
+    transcript records the proposed condition."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[GOAL] all tests pass"}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": ""},
+    ]
+    notifications: list[str] = []
+    executor, store, transcripts = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events), notifications=notifications,
+    )
+    session = _seed_session(store)
+
+    outcome = executor.execute(session, {"description": "make the suite green"})
+
+    assert outcome.status == STATUS_BLOCKED
+    assert outcome.reason == REASON_AWAITING_GOAL_APPROVAL
+    assert outcome.final_text == "all tests pass"
+    # The operator must SEE the proposed goal to approve it.
+    assert notifications == ["all tests pass"]
+    assert store.get(session.task_id).status == STATUS_BLOCKED
+    events_out = _read_transcript(transcripts, session.session_id)
+    awaiting = [e for e in events_out if e["kind"] == "claude_code_awaiting_goal_approval"]
+    assert awaiting and awaiting[0]["payload"]["condition"] == "all tests pass"
+
+
+def test_child_goal_not_streamed_to_operator(tmp_path: Path):
+    """A spawned child's [GOAL] stays silent to the operator (like [NOTIFY])
+    while still blocking and recording the condition."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[GOAL] benchmark beats baseline"}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": ""},
+    ]
+    notifications: list[str] = []
+    executor, store, _ = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events), notifications=notifications,
+    )
+    session = _seed_child_session(store)
+
+    outcome = executor.execute(session, {"description": "tune the model"})
+
+    assert outcome.status == STATUS_BLOCKED
+    assert outcome.reason == REASON_AWAITING_GOAL_APPROVAL
+    assert notifications == []  # child stays silent

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -713,3 +713,32 @@ def test_child_goal_not_streamed_to_operator(tmp_path: Path):
     assert outcome.status == STATUS_BLOCKED
     assert outcome.reason == REASON_AWAITING_GOAL_APPROVAL
     assert notifications == []  # child stays silent
+
+
+def test_clarify_takes_precedence_over_goal_in_same_turn(tmp_path: Path):
+    """When one assistant turn emits BOTH [CLARIFY] and [GOAL], clarification
+    wins — the session blocks awaiting the answer and the goal is NOT locked
+    (it must be re-proposed once the clarification resolves)."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text",
+                "text": "[CLARIFY] which suite? [GOAL] all tests pass"}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": ""},
+    ]
+    notifications: list[str] = []
+    executor, store, transcripts = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events), notifications=notifications,
+    )
+    session = _seed_session(store)
+
+    outcome = executor.execute(session, {"description": "make it green"})
+
+    assert outcome.status == STATUS_BLOCKED
+    assert outcome.reason == REASON_AWAITING_CLARIFICATION  # clarification wins
+    assert outcome.final_text == "which suite?"
+    # The goal proposal did NOT produce a goal-approval block this turn.
+    kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
+    assert "claude_code_awaiting_goal_approval" not in kinds

--- a/tests/test_doctor_bot.py
+++ b/tests/test_doctor_bot.py
@@ -538,16 +538,24 @@ class TestGoalApproval:
         from api.services.agent_worker.worker import _is_affirmative
         assert _is_affirmative("yes")
         assert _is_affirmative("Yes!")
-        assert _is_affirmative("yes, go ahead")
         assert _is_affirmative("approve")
         assert _is_affirmative("Approved.")
         assert _is_affirmative("lock it")
+        assert _is_affirmative("go ahead")
+        assert _is_affirmative("sounds good")
+        assert _is_affirmative("sure")
+        assert _is_affirmative("yes please")
 
     def test_is_affirmative_rejects_refinements(self):
         from api.services.agent_worker.worker import _is_affirmative
         assert not _is_affirmative("no, make it stricter")
         assert not _is_affirmative("change it to all tests AND lint pass")
         assert not _is_affirmative("hmm")
+        # "yes but ..." / "approve with changes" must NOT lock the stale goal —
+        # the refinement signal wins over the affirmative prefix (#406 review).
+        assert not _is_affirmative("yes but make it stricter")
+        assert not _is_affirmative("approve with changes: also require lint")
+        assert not _is_affirmative("yes, also require lint")
 
     def test_goal_block_registers_goal_approval_question(self, tmp_path):
         """A goal-approval BLOCKED outcome registers a kind='goal_approval'
@@ -634,3 +642,109 @@ class TestGoalApproval:
         kinds = [e["kind"] for e in w.transcript_store.read(session.session_id)]
         assert "claude_code_goal_locked" not in kinds
         assert "claude_code_goal_refine" in kinds
+
+    def test_affirmative_without_recoverable_condition_reprompts(self, tmp_path):
+        """An affirmative reply when the proposed condition can't be recovered
+        (e.g. it was already locked) must NOT forward a bare 'yes' — it asks the
+        agent to re-emit the [GOAL], and records a goal_lock_failed event."""
+        from api.services.agent_worker.session_store import STATUS_BLOCKED
+
+        w = self._make_worker(tmp_path, self._goal_blocked_stub())
+        session = w.session_store.create(
+            task_id="task-goal-nofind",
+            routing="claude_code",
+            origin="operator",
+            bot="doctor",
+            status=STATUS_BLOCKED,
+        )
+        w.session_store.set_claude_code_session_id(session.task_id, "cli-goal-nf")
+        # A proposal that was already locked → _pending_goal_condition returns None.
+        w.transcript_store.append(
+            session.session_id, "claude_code_awaiting_goal_approval",
+            {"condition": "all tests pass", "condition_chars": 14},
+        )
+        w.transcript_store.append(
+            session.session_id, "claude_code_goal_locked", {"condition_chars": 14},
+        )
+        w.session_store.create_pending_question(
+            session_id=session.session_id,
+            task_id=session.task_id,
+            question="Reply 'yes' to lock this goal and start, or send changes to refine it.",
+            sent_message_id=9200,
+            sent_message_ids=[9200],
+            kind="goal_approval",
+            bot="doctor",
+        )
+
+        assert w.session_store.deposit_answer(9200, "yes", bot="doctor") is True
+        w._process_clarification_answers()
+
+        pending = w.session_store.drain_pending_messages(session.session_id)
+        assert len(pending) == 1
+        msg = pending[0]["content"]
+        assert not msg.startswith("/goal")  # no stale/bare command forwarded
+        assert msg != "yes"
+        assert "re-emit" in msg.lower()
+        kinds = [e["kind"] for e in w.transcript_store.read(session.session_id)]
+        assert "claude_code_goal_lock_failed" in kinds
+
+    def test_goal_condition_survives_restart_and_reinjects(self, tmp_path):
+        """The #398 acceptance criterion: the proposed condition is durable via
+        the transcript (no DB column). A fresh Worker over the SAME paths
+        (simulating a restart) still injects `/goal <condition>` on approval."""
+        from api.services.agent_worker.session_store import STATUS_BLOCKED, STATUS_CLAIMED
+
+        # First worker: seed the blocked goal + answered approval question.
+        w1 = self._make_worker(tmp_path, self._goal_blocked_stub())
+        session = w1.session_store.create(
+            task_id="task-goal-restart",
+            routing="claude_code",
+            origin="operator",
+            bot="doctor",
+            status=STATUS_BLOCKED,
+        )
+        w1.session_store.set_claude_code_session_id(session.task_id, "cli-goal-rs")
+        w1.transcript_store.append(
+            session.session_id, "claude_code_awaiting_goal_approval",
+            {"condition": "all tests pass", "condition_chars": 14},
+        )
+        w1.session_store.create_pending_question(
+            session_id=session.session_id,
+            task_id=session.task_id,
+            question="Reply 'yes' to lock this goal and start, or send changes to refine it.",
+            sent_message_id=9300,
+            sent_message_ids=[9300],
+            kind="goal_approval",
+            bot="doctor",
+        )
+        assert w1.session_store.deposit_answer(9300, "yes", bot="doctor") is True
+
+        # Simulate a worker restart: a brand-new Worker over the same DB +
+        # transcript dir processes the still-unprocessed answered question.
+        w2 = self._make_worker(tmp_path, self._goal_blocked_stub())
+        w2._process_clarification_answers()
+
+        pending = w2.session_store.drain_pending_messages(session.session_id)
+        assert [m["content"] for m in pending] == ["/goal all tests pass"]
+        assert w2.session_store.get_by_session_id(session.session_id).status == STATUS_CLAIMED
+
+    def test_pending_goal_condition_returns_latest_after_relock_cycle(self, tmp_path):
+        """A later awaiting_goal_approval supersedes an earlier locked one:
+        awaiting{A} → locked → awaiting{B} resolves to B."""
+        from api.services.agent_worker.session_store import STATUS_BLOCKED
+
+        w = self._make_worker(tmp_path, self._goal_blocked_stub())
+        session = w.session_store.create(
+            task_id="task-goal-cycle",
+            routing="claude_code",
+            origin="operator",
+            bot="doctor",
+            status=STATUS_BLOCKED,
+        )
+        sid = session.session_id
+        w.transcript_store.append(sid, "claude_code_awaiting_goal_approval",
+                                  {"condition": "A", "condition_chars": 1})
+        w.transcript_store.append(sid, "claude_code_goal_locked", {"condition_chars": 1})
+        w.transcript_store.append(sid, "claude_code_awaiting_goal_approval",
+                                  {"condition": "B", "condition_chars": 1})
+        assert w._pending_goal_condition(sid) == "B"

--- a/tests/test_doctor_bot.py
+++ b/tests/test_doctor_bot.py
@@ -474,3 +474,163 @@ class TestBlockedSessionEscalation:
         # ...and the success path did NOT escalate or mark the session failed.
         assert w._escalations == []
         assert w.session_store.get_by_session_id(result["session_id"]).status != "failed"
+
+
+# ---------------------------------------------------------------------------
+# 6. [GOAL] tag → worker /goal injection on approval (#398)
+# ---------------------------------------------------------------------------
+
+class TestGoalApproval:
+    def _make_worker(self, tmp_path, executor):
+        from api.services.agent_worker.session_store import SessionStore
+        from api.services.agent_worker.spend_tracker import SpendTracker
+        from api.services.agent_worker.transcript_store import TranscriptStore
+        from api.services.agent_worker.worker import Worker, _SynchronousPool
+
+        transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+        client = httpx.Client(transport=transport, base_url="http://api")
+        sent_with_ids: list[tuple] = []
+
+        def _send_with_id(text, chat_id=None, bot=None):
+            msg_id = len(sent_with_ids) + 6000
+            sent_with_ids.append((msg_id, text, bot))
+            return [msg_id]
+
+        def _send(text, chat_id=None, bot=None):
+            return True
+
+        w = Worker(
+            api_base="http://api",
+            session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+            transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+            spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+            poll_seconds=0.01,
+            telegram_send=_send,
+            telegram_send_with_id=_send_with_id,
+            http_client=client,
+            claude_code_executor=executor,
+            cli_pool=_SynchronousPool(),
+        )
+        w._sent_with_ids = sent_with_ids  # type: ignore[attr-defined]
+        return w
+
+    def _goal_blocked_stub(self):
+        from dataclasses import dataclass
+        from api.services.agent_worker.claude_code_executor import REASON_AWAITING_GOAL_APPROVAL
+        from api.services.agent_worker.local_executor import ExecutorOutcome
+        from api.services.agent_worker.session_store import STATUS_BLOCKED
+
+        @dataclass
+        class _Stub:
+            outcome: ExecutorOutcome
+            def execute(self, session, task):
+                return self.outcome
+            def resume(self, session, message, working_dir=None):
+                return self.outcome
+
+        return _Stub(ExecutorOutcome(
+            status=STATUS_BLOCKED,
+            reason=REASON_AWAITING_GOAL_APPROVAL,
+            final_text="all tests pass",
+        ))
+
+    def test_is_affirmative_recognizes_yes_and_approve(self):
+        from api.services.agent_worker.worker import _is_affirmative
+        assert _is_affirmative("yes")
+        assert _is_affirmative("Yes!")
+        assert _is_affirmative("yes, go ahead")
+        assert _is_affirmative("approve")
+        assert _is_affirmative("Approved.")
+        assert _is_affirmative("lock it")
+
+    def test_is_affirmative_rejects_refinements(self):
+        from api.services.agent_worker.worker import _is_affirmative
+        assert not _is_affirmative("no, make it stricter")
+        assert not _is_affirmative("change it to all tests AND lint pass")
+        assert not _is_affirmative("hmm")
+
+    def test_goal_block_registers_goal_approval_question(self, tmp_path):
+        """A goal-approval BLOCKED outcome registers a kind='goal_approval'
+        pending question scoped to the doctor bot, with the goal prompt."""
+        from api.services.agent_worker.claude_code_spawn import spawn_claude_code_session
+
+        w = self._make_worker(tmp_path, self._goal_blocked_stub())
+        result = spawn_claude_code_session(
+            w.session_store, "make the suite green", chat_id="123", bot="doctor",
+        )
+        w._dispatch_spawned_sessions()
+
+        assert w._sent_with_ids, "no id-captured message was sent"
+        msg_id, text, bot = w._sent_with_ids[-1]
+        assert bot == "doctor"
+        assert "lock this goal" in text.lower()
+        q = w.session_store.get_open_question_by_message_id(msg_id, bot="doctor")
+        assert q is not None
+        assert q["kind"] == "goal_approval"
+        assert q["session_id"] == result["session_id"]
+
+    def _seed_blocked_goal_session(self, w, *, condition="all tests pass"):
+        """Drop a BLOCKED doctor session with a pending (proposed-not-locked)
+        goal in its transcript, plus an open goal_approval question — the shape
+        left behind after a goal-block round-trips through dispatch."""
+        from api.services.agent_worker.session_store import STATUS_BLOCKED
+
+        session = w.session_store.create(
+            task_id="task-goal-1",
+            routing="claude_code",
+            origin="operator",
+            bot="doctor",
+            status=STATUS_BLOCKED,
+        )
+        w.session_store.set_claude_code_session_id(session.task_id, "cli-goal-1")
+        w.transcript_store.append(
+            session.session_id, "claude_code_awaiting_goal_approval",
+            {"condition": condition, "condition_chars": len(condition)},
+        )
+        qid = w.session_store.create_pending_question(
+            session_id=session.session_id,
+            task_id=session.task_id,
+            question="Reply 'yes' to lock this goal and start, or send changes to refine it.",
+            sent_message_id=9100,
+            sent_message_ids=[9100],
+            kind="goal_approval",
+            bot="doctor",
+        )
+        return session, qid
+
+    def test_affirmative_reply_injects_slash_goal(self, tmp_path):
+        """An affirmative reply enqueues `/goal <condition>` as the resume
+        message and records a goal_locked transcript event."""
+        w = self._make_worker(tmp_path, self._goal_blocked_stub())
+        session, _ = self._seed_blocked_goal_session(w, condition="all tests pass")
+
+        # Operator replies 'yes' on the goal-approval message.
+        assert w.session_store.deposit_answer(9100, "yes", bot="doctor") is True
+        w._process_clarification_answers()
+
+        # The resume message injected is the native /goal command.
+        pending = w.session_store.drain_pending_messages(session.session_id)
+        assert [m["content"] for m in pending] == ["/goal all tests pass"]
+        # The session is flipped back to CLAIMED for re-dispatch.
+        from api.services.agent_worker.session_store import STATUS_CLAIMED
+        assert w.session_store.get_by_session_id(session.session_id).status == STATUS_CLAIMED
+        # A goal_locked event was recorded (the refine event was not).
+        kinds = [e["kind"] for e in w.transcript_store.read(session.session_id)]
+        assert "claude_code_goal_locked" in kinds
+        assert "claude_code_goal_refine" not in kinds
+
+    def test_refinement_reply_passes_raw_answer_without_locking(self, tmp_path):
+        """A non-affirmative reply is a refinement: the raw answer is enqueued
+        (so the doctor re-proposes) and NO goal_locked event is written."""
+        w = self._make_worker(tmp_path, self._goal_blocked_stub())
+        session, _ = self._seed_blocked_goal_session(w, condition="all tests pass")
+
+        answer = "make it all tests AND lint pass"
+        assert w.session_store.deposit_answer(9100, answer, bot="doctor") is True
+        w._process_clarification_answers()
+
+        pending = w.session_store.drain_pending_messages(session.session_id)
+        assert [m["content"] for m in pending] == [answer]
+        kinds = [e["kind"] for e in w.transcript_store.read(session.session_id)]
+        assert "claude_code_goal_locked" not in kinds
+        assert "claude_code_goal_refine" in kinds


### PR DESCRIPTION
## Summary

Plumbs the `[GOAL] <condition>` control tag through the Claude Code executor and worker so an orchestrating persona (the doctor, #397) can propose a success condition, have the operator approve it, and have the worker arm Claude Code's native `/goal` mode on resume.

The model **cannot** self-issue `/goal` — only the launcher can, via `claude -r <uuid> -p "/goal <condition>"`. Once set, `/goal` survives `claude -r` natively, so the proposed condition lives in the transcript until approval and is injected then — **no persistence column needed**.

This issue is the plumbing only. The `doctor.md` persona change to actually emit `[GOAL]` is a separate issue (**#397**) and is not touched here.

### Executor (`claude_code_executor.py`)
- `_scan_protocol_tags` now extracts `[GOAL]` bodies — fence-aware, interleaves correctly with `[NOTIFY]`/`[CLARIFY]` (shared lookahead), stripped from the operator-facing narrative, fenced/orphaned markers handled identically to the existing tags.
- A proposed goal **streams to the operator** (so they can see what they're approving) and records a `claude_code_goal` transcript event. Child sessions stay silent like `[NOTIFY]`.
- The result event flips the session to `BLOCKED` with `REASON_AWAITING_GOAL_APPROVAL` (precedence: clarification → goal → plan), recording `claude_code_awaiting_goal_approval` with the condition.

### Worker (`worker.py`)
- The BLOCKED branch registers a `kind="goal_approval"` pending question with a goal-specific prompt; retry/escalation behavior (#402) is preserved for it.
- New `_resume_goal`: on an affirmative reply it enqueues `/goal <condition>` as the resume message and records `claude_code_goal_locked`; on a refinement (non-affirmative) reply it passes the raw answer back verbatim (doctor re-proposes) and records `claude_code_goal_refine`. Mirrors the `claude_code` branch of `_resume_as_followup`.
- `_pending_goal_condition` scans the transcript for the proposed-but-not-yet-locked condition.
- Module-level `_is_affirmative` / `_GOAL_AFFIRMATIVE` classify the approval reply.

Existing `[NOTIFY]`/`[CLARIFY]` behavior is byte-identical (the #402 hardening tests all still pass).

## Test evidence

Targeted suite on the Linux server (`tests/test_agent_worker_claude_code_executor.py test_doctor_bot.py test_agent_worker_clarifications.py test_agent_worker_loop.py test_agent_worker_claude_code_dispatch.py`): **130 passed**.

Full unit suite (`pytest -m unit`): result appended in a comment once it finishes.

New tests:
- Executor: `[GOAL]` extraction (plain / interleaved with NOTIFY+CLARIFY / fenced-ignored / empty-ignored); end-to-end BLOCKED outcome with streamed body + recorded condition; child-stays-silent.
- Doctor bot: `_is_affirmative` unit checks; goal-block registers a `kind="goal_approval"` doctor-scoped question with the goal prompt; full round-trip where an affirmative reply enqueues `/goal <condition>` and writes `goal_locked`, and a refinement reply enqueues the raw answer with no `goal_locked`.

## Review focus

The worker resume-injection path (`_resume_goal` + `_pending_goal_condition`): condition is read from the transcript, not a column, so it survives a worker restart; an affirmative match injects the native command while any refinement passes through untouched so the doctor can re-propose.

Closes #398.
Part of #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)