### PR TITLE
feat(skills): configurable base branch for /implement and merge-pr

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -39,9 +39,12 @@ Any text after the leading token controls which phases run. Parse it before boot
 | `quick` or `no-review` | Skip Phase 4 entirely — Phase 1 → 2 → 3 → 5 |
 | `no-plan` | Skip Phase 1 — go straight to Phase 2 |
 | `review-only` | Run Phase 4 only on the target PR (target MUST be a PR number) |
+| `--base <branch>` | Open and merge the PR against `<branch>` instead of `main`, and diff adversarial review against it (see below) |
 | Any other text | Interpret intent. Do more rather than less — the full lifecycle is always safe. |
 
 Modifiers compose (e.g. `no-plan quick` skips Phase 1 and Phase 4). If the target is an existing PR and no instructions are given, skip to Phase 4.
+
+**Base branch.** Parse `--base <branch>` from the trailing instructions; if absent, the base is `main`. The base is the branch the PR targets and merges into. Record it as `<base>` and thread it through Phase 2 (branching point + review diff), Phase 3 (`gh pr create --base`), and Phase 5 (`merge-pr`). With no `--base`, every step below is byte-identical to targeting `main`. This exists so stacked sub-PRs can land on a long-lived integration branch (off `main`) before a single PR merges that branch to `main`.
 
 ---
 
@@ -54,7 +57,7 @@ Modifiers compose (e.g. `no-plan quick` skips Phase 1 and Phase 4). If the targe
 
 ### Phase 2: Implement
 
-1. **Create a branch** if not already on a feature branch: `<type>/<short-description>` per AGENTS.md § Development Workflow.
+1. **Create a branch** if not already on a feature branch: `<type>/<short-description>` per AGENTS.md § Development Workflow. Branch off `<base>` (default `main`): `git fetch origin <base> && git checkout -b <type>/<desc> origin/<base>`.
 2. **Write tests first** for identified test cases. They should fail until implementation is complete.
 3. **Write production code** to make tests pass. Follow existing patterns. Surgical changes only.
 4. **Run the test suite** on the server: `./scripts/test.sh auto` — picks scope (unit/browser/slow/skip) from the git diff and runs it in parallel. All tests must pass before proceeding.
@@ -64,9 +67,9 @@ Modifiers compose (e.g. `no-plan quick` skips Phase 1 and Phase 4). If the targe
 
 1. **Commit** with `<type>: <summary>` format. Separate logical changes into distinct commits.
 2. **Push** the branch.
-3. **Create the PR:**
+3. **Create the PR** against `<base>` (default `main`). Pass `--base <base>` explicitly — when `<base>` is `main` this is identical to the repo default:
    ```
-   gh pr create --title "<type>: <imperative summary>" --body "$(cat <<'EOF'
+   gh pr create --base <base> --title "<type>: <imperative summary>" --body "$(cat <<'EOF'
    ## Summary
    <1-3 sentences: what and why>
 
@@ -249,11 +252,11 @@ Then stop and inform the user directly with the escalation details.
 ### Phase 5: Merge & Finalize
 
 1. **Final test run.** Confirm all tests pass.
-2. **Merge and update issues.** Invoke the merge skill explicitly:
+2. **Merge and update issues.** Invoke the merge skill explicitly, passing the base after the PR number when it is not `main`:
    ```
-   Skill tool → skill: "merge-pr", args: "<pr-number>"
+   Skill tool → skill: "merge-pr", args: "<pr-number> [--base <base>]"
    ```
-   This validates the PR against standards, squash-merges it, deletes the branch, and posts progress updates on all linked GitHub issues.
+   `merge-pr` reads the PR's actual base from GitHub, so the `--base` arg is optional; pass it for clarity when threading a non-`main` base. This validates the PR against standards, squash-merges it into its base, deletes the branch, and posts progress updates on all linked GitHub issues.
 3. Report the result to the user.
 
 ---

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: merge-pr
 description: Merge a PR and update upstream GitHub issues with progress
-argument-hint: <pr-number>
+argument-hint: <pr-number> [--base <branch>]
 ---
 
 # Merge PR and Update Issues
 
-Merge PR #$ARGUMENTS and update all linked GitHub issues with what was delivered.
+Merge the PR named by the leading token of $ARGUMENTS and update all linked GitHub issues with what was delivered.
+
+**Arguments.** The leading token is the PR number. An optional `--base <branch>` may follow; it is informational only — the authoritative base is `baseRefName` from the PR metadata below (the branch the PR actually targets). Default base is `main`. The base determines whether the post-merge timestamp-normalization step runs (see Step 2).
 
 ## PR Context
 
-- PR metadata: !`gh pr view $ARGUMENTS --json number,title,body,state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRefName,baseRefName,additions,deletions,changedFiles`
-- PR checks: !`gh pr checks $ARGUMENTS 2>/dev/null || echo "NO_CHECKS"`
+The PR number is the first whitespace-separated token of `$ARGUMENTS` (anything after it, e.g. `--base <branch>`, is stripped here):
+
+- PR metadata: !`gh pr view $(echo "$ARGUMENTS" | awk '{print $1}') --json number,title,body,state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRefName,baseRefName,additions,deletions,changedFiles`
+- PR checks: !`gh pr checks $(echo "$ARGUMENTS" | awk '{print $1}') 2>/dev/null || echo "NO_CHECKS"`
 
 ## Instructions
 
@@ -31,17 +35,17 @@ Check that the PR is safe to merge. For each check, determine pass/fail:
 
 ### Step 2: Merge
 
-Squash-merge the PR and delete the remote branch:
+Squash-merge the PR into its base branch and delete the remote branch. `gh pr merge` targets the PR's own base (`baseRefName`), so this works for any base. Use only the PR number (first token):
 
 ```
-gh pr merge $ARGUMENTS --squash --delete-branch
+gh pr merge <pr-number> --squash --delete-branch
 ```
 
 If the merge fails, report the error and stop.
 
-**Normalize commit timestamp** (privacy: hides work schedule):
+**Normalize commit timestamp** (privacy: hides work schedule) — **only when the base is `main`.**
 
-After the merge succeeds, pull the merge commit and normalize its timestamp to 12:00 UTC on the same date. This matches the post-commit hook behavior, which doesn't run for GitHub-side merges.
+After a merge into `main` succeeds, pull the merge commit and normalize its timestamp to 12:00 UTC on the same date. This matches the post-commit hook behavior, which doesn't run for GitHub-side merges.
 
 ```bash
 git checkout main && git pull origin main
@@ -52,6 +56,8 @@ git push --force-with-lease origin main
 ```
 
 If the force-push fails (e.g., another commit landed), warn the user but do not retry. The merge itself already succeeded.
+
+**If the base is not `main`** (a stacked sub-PR landing on an integration branch), **skip the normalize-and-force-push step entirely.** Force-pushing an amended commit to a shared integration branch would clobber other sub-PRs that may be landing concurrently, and the final integration→`main` PR's own merge will get its timestamp normalized when it lands on `main` anyway. The squash-merge into the integration branch is sufficient.
 
 ### Step 3: Update Linked Issues
 

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -12,11 +12,12 @@ Pre-flight validation for PR quality.
 
 - Current branch: !`git branch --show-current`
 - PR data: !`gh pr view $ARGUMENTS --json title,body,additions,deletions,changedFiles,commits,baseRefName,number 2>/dev/null || echo "NO_PR_FOUND"`
-- Commits since main: !`git log --oneline main..HEAD`
+- Base branch: !`gh pr view $ARGUMENTS --json baseRefName --jq .baseRefName 2>/dev/null || echo "main"`
+- Commits since base: !`BASE="$(gh pr view $ARGUMENTS --json baseRefName --jq .baseRefName 2>/dev/null || echo main)"; git log --oneline "origin/$BASE..HEAD" 2>/dev/null || git log --oneline "$BASE..HEAD"`
 
 ## Instructions
 
-Validate the current PR against each standard below. If no PR number was provided and `NO_PR_FOUND` appears above, check only what can be validated locally (branch name, commits, diff size) and note that no PR exists yet.
+Validate the current PR against each standard below. The **base branch** is `baseRefName` from the PR data (the branch the PR targets); it defaults to `main` when no PR exists. All "since base" comparisons below diff against this base, not a hardcoded `main` — so a stacked sub-PR targeting an integration branch is sized and scanned against that branch, not against `main`. If no PR number was provided and `NO_PR_FOUND` appears above, check only what can be validated locally (branch name, commits, diff size against the default base `main`) and note that no PR exists yet.
 
 For each check, output one of:
 - **PASS** — Meets the standard
@@ -56,7 +57,7 @@ This project is open-source. The diff MUST NOT contain any of the following. FAI
 - **Real personal names or emails** — real people's names, email addresses, phone numbers, or other PII in code or test fixtures. Synthetic/obviously fake data is OK (e.g., "John Doe", "test@example.com"). Names in git commit metadata, CLAUDE.md, and AGENTS.md are exempt.
 - **Internal infrastructure details** — Tailscale IPs, internal hostnames, or private network addresses in code (their presence in CLAUDE.md/AGENTS.md for developer setup is OK).
 
-To check, read the full diff: !`git diff main..HEAD -- ':!CLAUDE.md' ':!AGENTS.md'`
+To check, read the full diff against the base branch: !`BASE="$(gh pr view $ARGUMENTS --json baseRefName --jq .baseRefName 2>/dev/null || echo main)"; git diff "origin/$BASE..HEAD" -- ':!CLAUDE.md' ':!AGENTS.md' 2>/dev/null || git diff "$BASE..HEAD" -- ':!CLAUDE.md' ':!AGENTS.md'`
 
 ### Output Format
 


### PR DESCRIPTION
## Summary

`/implement` and the `merge-pr` subskill it calls assumed every PR targets `main`. This threads an optional **base branch** through both skills (default `main`, so behavior is byte-identical to today when the arg is absent) so the doctor's stacked sub-PR flow can land sub-PRs on a long-lived integration branch off `main`, then merge that branch to `main` with one PR. Closes #399; part of epic #397.

## What changed

- **`implement/SKILL.md`** — parse `--base <branch>` from the trailing instructions (default `main`). Threaded into Phase 2 (branch off `origin/<base>`), Phase 3 (`gh pr create --base <base>`), and Phase 5 (passes the base to `merge-pr`). Adversarial review (Phase 4) already diffs via `gh pr diff`, which is base-aware automatically — no change needed.
- **`merge-pr/SKILL.md`** — accepts an optional trailing `--base`, but treats `baseRefName` from the PR metadata as authoritative. Context `gh pr view/checks` calls now take only the leading PR-number token. The post-merge timestamp-normalize + force-push-to-`main` step **only runs when the base is `main`**; for a non-`main` base it is skipped (force-pushing an amended commit to a shared integration branch would clobber concurrent sub-PRs; the final integration→`main` merge gets normalized when it lands on `main` anyway).
- **`pr-check/SKILL.md`** — sizing and the secrets/diff scan now compare against the PR's base branch (`baseRefName`, default `main`) instead of a hardcoded `main`, so a sub-PR targeting an integration branch isn't sized/scanned against `main`. Prefers `origin/<base>` with a fallback to the local ref.

## Test evidence

Skill-prompt (markdown) change — there is no pytest for these files. Verified:
- The inline `!`bash`` snippets resolve cleanly: first-token extraction (`awk '{print $1}'`), base resolution with no PR (falls back to `main`), and the `origin/<base>..HEAD` → `<base>..HEAD` git fallbacks all run without error.
- Default-preserves-behavior: with no `--base`, every threaded step targets `main` exactly as before.
- Self-reviewed all three diffs for internal coherence and cross-skill consistency (implement → merge-pr arg passing, pr-check base resolution).

## Review focus

- Whether skipping the normalize/force-push step for a non-`main` base is the right call (vs. adapting it to normalize on the integration branch).
- The `pr-check` shift from local `main` to `origin/<base>` for the diff range — a deliberate refinement; confirm it's acceptable for the default case.
- That no base hardcoding remains in the threaded paths.