### PR TITLE
feat(agent-worker): detached worker-restart primitive for doctor

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -155,7 +155,14 @@ def write_self_restart_marker(
     `python -m api.services.agent_worker.worker --mark-self-restart …`) so the
     bash primitive and the worker share one marker format. Returns the path
     written. `db_path` defaults to the SessionStore default so the caller
-    doesn't need to know where the DB lives."""
+    doesn't need to know where the DB lives.
+
+    The production primitive names the doctor's run by `session_id` (a single-use
+    UUID that never recurs), not `task_id`. That matters: a stale marker (one not
+    consumed for any reason) naming a session_id can match nothing on a later
+    startup, whereas task_ids are vault-stable and could quiet a future real
+    crash of a session reusing that id. The `task_ids` path exists for the
+    CLI/tests; prefer `session_ids` for anything that writes a real marker."""
     from pathlib import Path as _Path
     from api.services.agent_worker.session_store import DEFAULT_DB_PATH
     resolved = _Path(db_path) if db_path is not None else DEFAULT_DB_PATH
@@ -486,7 +493,15 @@ class Worker:
                     {"prior_status": session.status},
                 )
                 self.session_store.update_status(session.task_id, STATUS_COMPLETED)
-                if not session.parent_session_id:
+                # Mirror the canonical COMPLETED path (see _handle_outcome /
+                # _finalize_terminal): advance the vault checkbox to done ([x])
+                # AND swap the tag — gated on has_vault_task. Operator-spawned
+                # roots and spawned children carry a synthetic task_id with no
+                # vault row, so both vault ops are skipped for them (#401 review).
+                # The session-row update_status above stays unconditional.
+                has_vault_task = session.origin != "operator" and not session.parent_session_id
+                if has_vault_task:
+                    self._complete_task(session.task_id)
                     self._swap_tag(session.task_id, RUNNING_TAG, COMPLETED_TAG)
                 logger.info(
                     "session %s finalized after a deliberate self-restart "

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -21,6 +21,7 @@ import logging
 import os
 import re
 import signal
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -95,6 +96,77 @@ _GOAL_REFINE_SIGNALS = (
     "add ", "remove", "stricter", "actually", "with change", "no,", "don't",
     "rather", "tweak", "adjust",
 )
+
+
+# Filename of the self-restart marker the detached worker-restart primitive
+# (`scripts/server.sh restart-worker-detached`) drops next to the session DB
+# before bouncing `lifeos-agent-worker` (#401). `resume_pending()` consults it
+# on startup: a session named here was killed by a *deliberate* end-of-goal
+# restart, not a crash, so it's finalized quietly (COMPLETED, no rollback /
+# "could not be safely resumed" notice). The marker is JSON
+# (`{"session_ids": [...], "task_ids": [...]}`); either key is honored so the
+# primitive can name the doctor's run by whichever id it has on hand.
+_SELF_RESTART_MARKER_NAME = "self_restart.json"
+
+
+def _self_restart_marker_path(db_path: Path) -> Path:
+    """Path to the self-restart marker, co-located with the session DB so the
+    primitive (a separate process) and the worker agree on its location."""
+    from pathlib import Path as _Path  # module-level Path import is TYPE_CHECKING-only
+    return _Path(db_path).parent / _SELF_RESTART_MARKER_NAME
+
+
+def _read_self_restart_marker(db_path: Path) -> tuple[set[str], set[str]]:
+    """Read the self-restart marker → (session_ids, task_ids). Missing or
+    malformed marker yields empty sets — a corrupt marker must never make a
+    real crash look deliberate, so we fail closed (treat nothing as planned)."""
+    path = _self_restart_marker_path(db_path)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return set(), set()
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        logger.warning("self-restart marker at %s is unparseable; ignoring", path)
+        return set(), set()
+    sids = {str(s) for s in (data.get("session_ids") or []) if s}
+    tids = {str(t) for t in (data.get("task_ids") or []) if t}
+    return sids, tids
+
+
+def _clear_self_restart_marker(db_path: Path) -> None:
+    """Remove the self-restart marker. Consumed once per restart, so it's
+    deleted after `resume_pending()` honors it — a leftover would otherwise
+    quiet a later, unrelated session."""
+    try:
+        _self_restart_marker_path(db_path).unlink()
+    except (FileNotFoundError, OSError):
+        pass
+
+
+def write_self_restart_marker(
+    session_ids: list[str] | None = None,
+    task_ids: list[str] | None = None,
+    db_path: Path | str | None = None,
+) -> Path:
+    """Write the self-restart marker before a deliberate end-of-goal worker
+    restart (#401). Called by `scripts/server.sh restart-worker-detached` (via
+    `python -m api.services.agent_worker.worker --mark-self-restart …`) so the
+    bash primitive and the worker share one marker format. Returns the path
+    written. `db_path` defaults to the SessionStore default so the caller
+    doesn't need to know where the DB lives."""
+    from pathlib import Path as _Path
+    from api.services.agent_worker.session_store import DEFAULT_DB_PATH
+    resolved = _Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    path = _self_restart_marker_path(resolved)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_ids": [s for s in (session_ids or []) if s],
+        "task_ids": [t for t in (task_ids or []) if t],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
 
 
 def _is_affirmative(text: str) -> bool:
@@ -379,9 +451,23 @@ class Worker:
           roll the tag back to #agent so the operator can retry. We can't
           safely re-enter a partially-driven LLM conversation without risking
           duplicate side effects (file writes, API calls, etc.).
+
+        Exception — deliberate self-restart (#401): a session named in the
+        self-restart marker was killed by an end-of-goal `restart-worker-detached`
+        (the doctor restarting the worker after shipping an agent-worker-code
+        change), not by a crash. Its final `[NOTIFY]` was already delivered
+        before SIGTERM, so it's finalized quietly as COMPLETED — no FAILED
+        status, no #agent rollback, no "could not be safely resumed" notice.
         """
         pending = self.session_store.list_non_terminal()
+        # Sessions the detached-restart primitive deliberately killed. Read once
+        # and cleared after the loop so a single marker is honored exactly once.
+        self_restart_sids, self_restart_tids = _read_self_restart_marker(
+            self.session_store.db_path
+        )
         if not pending:
+            if self_restart_sids or self_restart_tids:
+                _clear_self_restart_marker(self.session_store.db_path)
             return 0
         recovered = 0
         for session in pending:
@@ -391,6 +477,22 @@ class Worker:
                 continue
             # Blocked sessions are waiting on the user; leave alone.
             if session.status == STATUS_BLOCKED:
+                continue
+            # Deliberate self-restart: finalize quietly, skip the alarming
+            # rollback. The doctor already shipped + notified before the bounce.
+            if sid in self_restart_sids or session.task_id in self_restart_tids:
+                self.transcript_store.append(
+                    sid, "resume_self_restart",
+                    {"prior_status": session.status},
+                )
+                self.session_store.update_status(session.task_id, STATUS_COMPLETED)
+                if not session.parent_session_id:
+                    self._swap_tag(session.task_id, RUNNING_TAG, COMPLETED_TAG)
+                logger.info(
+                    "session %s finalized after a deliberate self-restart "
+                    "(no rollback notice)", sid,
+                )
+                recovered += 1
                 continue
             self.transcript_store.append(sid, "resume_failed", {"prior_status": session.status})
             self.session_store.update_status(session.task_id, STATUS_FAILED)
@@ -414,6 +516,9 @@ class Worker:
                 f"`data/agent_transcripts/{sid}.jsonl`"
             )
             recovered += 1
+        # Consume the marker so it can't quiet a later, unrelated session.
+        if self_restart_sids or self_restart_tids:
+            _clear_self_restart_marker(self.session_store.db_path)
         if recovered:
             logger.info("rolled back %d non-resumable session(s) on startup", recovered)
         return recovered
@@ -2583,7 +2688,28 @@ class Worker:
             )
 
 
+def _mark_self_restart_cli(argv: list[str]) -> int:
+    """`--mark-self-restart [--session ID]... [--task ID]...` — write the
+    self-restart marker, then exit. Invoked by the detached-restart primitive
+    (`scripts/server.sh restart-worker-detached`) before it bounces the worker,
+    so `resume_pending()` finalizes the named session quietly instead of firing
+    the rollback notice (#401). Kept tiny and import-light so the bash primitive
+    can call it without spinning up the full worker."""
+    import argparse
+    parser = argparse.ArgumentParser(prog="agent_worker --mark-self-restart")
+    parser.add_argument("--mark-self-restart", action="store_true")
+    parser.add_argument("--session", action="append", default=[], dest="sessions")
+    parser.add_argument("--task", action="append", default=[], dest="tasks")
+    args = parser.parse_args(argv)
+    path = write_self_restart_marker(session_ids=args.sessions, task_ids=args.tasks)
+    print(str(path))
+    return 0
+
+
 def main() -> None:
+    # Marker-writing subcommand short-circuits before any worker wiring.
+    if "--mark-self-restart" in sys.argv[1:]:
+        raise SystemExit(_mark_self_restart_cli(sys.argv[1:]))
     logging.basicConfig(
         level=os.environ.get("LIFEOS_LOG_LEVEL", "INFO"),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -306,6 +306,12 @@ sctl() {
 # Prints "worker" if any changed file is under WORKER_CODE_PATH, else "api".
 # Default range is the last commit (HEAD~1..HEAD); pass an explicit range
 # (e.g. "main..HEAD") to classify a whole branch.
+#
+# This is a path-prefix HEURISTIC, not a guarantee: a change that alters worker
+# behavior from outside api/services/agent_worker/ (e.g. config/settings.py,
+# which the worker imports) classifies as "api" and would leave the worker on
+# stale code. Acceptable because the doctor ships localized PRs; widen
+# WORKER_CODE_PATH or add paths if that assumption stops holding.
 classify_change() {
     local range="${1:-HEAD~1..HEAD}"
     local changed
@@ -369,8 +375,13 @@ PYEOF
             systemctl restart "$WORKER_UNIT" \
             || log_error "systemd-run restart failed"
     else
-        # Fallback: setsid detaches into a new session so it survives the
-        # worker's process-group teardown; nohup ignores SIGHUP.
+        # Fallback for non-systemd hosts (no systemd-run). setsid+nohup detach
+        # into a new session that survives the worker's process-group teardown
+        # and SIGHUP — but, unlike the systemd-run path, this does NOT move the
+        # restarter into its own cgroup, so a cgroup-level kill of the worker
+        # could still reach it. This branch only runs where `systemctl restart`
+        # itself wouldn't apply anyway, so it's a best-effort degraded path, not
+        # an equivalent guarantee.
         setsid nohup sudo systemctl restart "$WORKER_UNIT" \
             >> "$PROJECT_DIR/logs/worker-restart.log" 2>&1 &
         disown 2>/dev/null || true

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -2,15 +2,17 @@
 # LifeOS Server Management Script
 # Designed for reliable server management from Claude or command line
 #
-# Usage: ./scripts/server.sh [start|stop|restart|status|wait|preflight]
+# Usage: ./scripts/server.sh [start|stop|restart|status|wait|preflight|classify-change|restart-worker-detached]
 #
 # Commands:
-#   start     - Kill any existing processes, start server, wait for health check
-#   stop      - Stop the server
-#   restart   - Stop and start the server
-#   status    - Check if server is running and healthy
-#   wait      - Wait for server to be healthy (use after manual start)
-#   preflight - Check prerequisites before first start
+#   start                    - Kill any existing processes, start server, wait for health check
+#   stop                     - Stop the server
+#   restart                  - Stop and start the server
+#   status                   - Check if server is running and healthy
+#   wait                     - Wait for server to be healthy (use after manual start)
+#   preflight                - Check prerequisites before first start
+#   classify-change          - Print whether a diff needs a worker or api-only restart (#401)
+#   restart-worker-detached  - Detached restart of lifeos-agent-worker for the doctor (#401)
 #
 # Expected startup time: 30-60 seconds (loading sentence-transformers model)
 
@@ -27,6 +29,14 @@ STARTUP_TIMEOUT=180  # seconds to wait for server to start (model loading can ta
 HEALTH_URL="http://127.0.0.1:$PORT/health"
 CHROMADB_URL="http://localhost:8001/api/v2/heartbeat"
 LOG_FILE="$PROJECT_DIR/logs/server.log"
+# The agent worker is its own systemd unit (separate from lifeos-api). The
+# doctor self-repair persona drives a headless session *inside* this unit, so
+# bouncing it kills the doctor's own session — see restart-worker-detached.
+WORKER_UNIT="lifeos-agent-worker"
+VENV_PYTHON="$HOME/.venvs/lifeos/bin/python"
+# Files whose change requires the agent worker (not just lifeos-api) to
+# restart for the change to take effect — see classify-change.
+WORKER_CODE_PATH="api/services/agent_worker/"
 
 # Ensure logs directory exists
 mkdir -p "$PROJECT_DIR/logs"
@@ -285,6 +295,89 @@ sctl() {
     sudo systemctl "$@"
 }
 
+# classify-change <git-range> — print which restart a diff needs.
+#
+# The doctor ships changes through PRs; at end-of-goal it must restart so the
+# change takes effect. API-only changes are cheap (`lifeos-api` restart leaves
+# the worker — and the doctor's own session — alive). Changes under
+# api/services/agent_worker/ require bouncing the worker itself, which kills the
+# doctor mid-run, so they go through restart-worker-detached instead.
+#
+# Prints "worker" if any changed file is under WORKER_CODE_PATH, else "api".
+# Default range is the last commit (HEAD~1..HEAD); pass an explicit range
+# (e.g. "main..HEAD") to classify a whole branch.
+classify_change() {
+    local range="${1:-HEAD~1..HEAD}"
+    local changed
+    changed=$(git -C "$PROJECT_DIR" diff --name-only "$range" 2>/dev/null)
+    if echo "$changed" | grep -q "^${WORKER_CODE_PATH}"; then
+        echo "worker"
+    else
+        echo "api"
+    fi
+}
+
+# restart-worker-detached [--session ID] [--notify TEXT] [--bot NAME]
+#
+# Restart lifeos-agent-worker such that any pending final notice is delivered
+# BEFORE the worker gets SIGTERM (#401). The doctor runs a headless session
+# *inside* the worker, so an inline `systemctl restart` would kill the restart
+# command along with the session. Steps:
+#   1. Send the final notice first (if --notify given) so the operator gets the
+#      "Shipped" message even if the streamed [NOTIFY] raced the SIGTERM.
+#   2. Write the self-restart marker (names --session) so resume_pending()
+#      finalizes that session quietly instead of firing the rollback notice.
+#   3. Restart the worker in a DETACHED process (systemd-run; nohup+setsid
+#      fallback) that outlives the dying session and actually performs the bounce.
+restart_worker_detached() {
+    local session_id="" notify_text="" bot=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --session) session_id="$2"; shift 2 ;;
+            --notify)  notify_text="$2"; shift 2 ;;
+            --bot)     bot="$2"; shift 2 ;;
+            *) log_warn "restart-worker-detached: ignoring unknown arg '$1'"; shift ;;
+        esac
+    done
+
+    # 1. Flush the final notice BEFORE anything can kill the session.
+    if [ -n "$notify_text" ]; then
+        log_info "Sending final notice before worker restart..."
+        "$VENV_PYTHON" - "$notify_text" "$bot" <<'PYEOF' || log_warn "final notice send failed (continuing to restart)"
+import sys
+text = sys.argv[1]
+bot = sys.argv[2] or None
+from api.services.telegram import send_message
+send_message(text, bot=bot)
+PYEOF
+    fi
+
+    # 2. Mark the deliberate self-restart so resume_pending() stays quiet.
+    if [ -n "$session_id" ]; then
+        log_info "Marking session $session_id as a deliberate self-restart..."
+        "$VENV_PYTHON" -m api.services.agent_worker.worker \
+            --mark-self-restart --session "$session_id" \
+            || log_warn "could not write self-restart marker (continuing to restart)"
+    fi
+
+    # 3. Restart the worker in a detached process that outlives this session.
+    log_info "Triggering detached restart of $WORKER_UNIT..."
+    if command -v systemd-run &>/dev/null; then
+        # Transient unit in its own cgroup — fully decoupled from the caller, so
+        # the SIGTERM the worker is about to receive can't kill the restarter.
+        sudo systemd-run --unit="lifeos-worker-restart-$$" --collect \
+            systemctl restart "$WORKER_UNIT" \
+            || log_error "systemd-run restart failed"
+    else
+        # Fallback: setsid detaches into a new session so it survives the
+        # worker's process-group teardown; nohup ignores SIGHUP.
+        setsid nohup sudo systemctl restart "$WORKER_UNIT" \
+            >> "$PROJECT_DIR/logs/worker-restart.log" 2>&1 &
+        disown 2>/dev/null || true
+    fi
+    log_info "Detached worker restart triggered."
+}
+
 # Main
 case "${1:-status}" in
     start)
@@ -327,19 +420,30 @@ case "${1:-status}" in
     preflight)
         exec "$SCRIPT_DIR/preflight.sh"
         ;;
+    classify-change)
+        classify_change "${2:-}"
+        ;;
+    restart-worker-detached)
+        shift
+        restart_worker_detached "$@"
+        ;;
     *)
         echo "LifeOS Server Management"
         echo ""
-        echo "Usage: $0 {start|stop|restart|status|wait [timeout]|foreground|preflight}"
+        echo "Usage: $0 {start|stop|restart|status|wait [timeout]|foreground|preflight|classify-change [range]|restart-worker-detached [opts]}"
         echo ""
         echo "Commands:"
-        echo "  start      - Start server (kills existing, waits for healthy)"
-        echo "  stop       - Stop the server"
-        echo "  restart    - Restart the server"
-        echo "  foreground - Run in foreground (for systemd)"
-        echo "  status     - Show server status"
-        echo "  wait       - Wait for server to become healthy"
-        echo "  preflight  - Check prerequisites before first start"
+        echo "  start                    - Start server (kills existing, waits for healthy)"
+        echo "  stop                     - Stop the server"
+        echo "  restart                  - Restart the server"
+        echo "  foreground               - Run in foreground (for systemd)"
+        echo "  status                   - Show server status"
+        echo "  wait                     - Wait for server to become healthy"
+        echo "  preflight                - Check prerequisites before first start"
+        echo "  classify-change [range]  - Print 'worker' or 'api': which restart a diff needs"
+        echo "                             (default range HEAD~1..HEAD; e.g. 'main..HEAD')"
+        echo "  restart-worker-detached  - Detached restart of $WORKER_UNIT for the doctor"
+        echo "                             [--session ID] [--notify TEXT] [--bot NAME]"
         echo ""
         echo "Expected startup time: 30-60 seconds (ML model loading)"
         exit 1

--- a/tests/test_agent_worker_self_restart.py
+++ b/tests/test_agent_worker_self_restart.py
@@ -68,6 +68,13 @@ class _FakeApi:
             tags[tags.index(from_tag)] = to_tag
             task["tags"] = tags
             return httpx.Response(200, json={"swapped": True})
+        if request.method == "PUT" and path.endswith("/complete"):
+            task_id = path.split("/")[-2]
+            task = self.tasks.get(task_id)
+            if not task:
+                return httpx.Response(404)
+            task["status"] = "done"
+            return httpx.Response(200, json=task)
         if request.method == "PUT" and path.startswith("/api/tasks/"):
             task_id = path.split("/")[-1]
             task = self.tasks.get(task_id)
@@ -153,6 +160,10 @@ def test_resume_pending_self_restart_finalizes_quietly(tmp_path: Path):
     # Tag advanced to completed, NOT rolled back to #agent.
     assert COMPLETED_TAG in api.tasks["doctor_task"]["tags"]
     assert AGENT_TAG not in api.tasks["doctor_task"]["tags"]
+    # Vault checkbox advanced to done ([x]) too — not left stuck at in_progress
+    # ([/]). The quiet-finalize path must call _complete_task like every other
+    # COMPLETED path (#401 review).
+    assert api.tasks["doctor_task"]["status"] == "done"
     # Transcript records the deliberate restart, not a resume_failed.
     kinds = [e["kind"] for e in w.transcript_store.read(session.session_id)]
     assert "resume_self_restart" in kinds

--- a/tests/test_agent_worker_self_restart.py
+++ b/tests/test_agent_worker_self_restart.py
@@ -1,0 +1,358 @@
+"""Self-restart primitive coverage (#401).
+
+Two layers:
+
+1. Python — `resume_pending()` honors the self-restart marker the detached
+   restart primitive writes: the deliberately-killed session is finalized
+   quietly (COMPLETED, no "could not be safely resumed" rollback notice), the
+   marker is consumed, and a session *without* a marker still rolls back as
+   before (regression guard).
+
+2. Bash — `scripts/server.sh restart-worker-detached` sends the final notice
+   BEFORE it triggers the restart (so the doctor's "Shipped" notice beats the
+   worker's SIGTERM), and `classify-change` picks the worker path for an
+   agent_worker-touching diff vs. the api path for an api-only diff. (bash isn't
+   pytest-covered elsewhere; these drive the script as a subprocess with stubbed
+   systemctl/python on PATH so nothing real is restarted.)
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+
+from api.services.agent_worker.session_store import (
+    STATUS_COMPLETED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import (
+    AGENT_TAG,
+    COMPLETED_TAG,
+    RUNNING_TAG,
+    Worker,
+    _read_self_restart_marker,
+    _self_restart_marker_path,
+    write_self_restart_marker,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_SH = REPO_ROOT / "scripts" / "server.sh"
+
+
+# ---------------------------------------------------------------------------
+# Minimal FakeApi (tag swaps + status updates) — self-contained so this file
+# doesn't depend on another test module's helpers.
+# ---------------------------------------------------------------------------
+class _FakeApi:
+    def __init__(self, tasks=None):
+        self.tasks = {t["id"]: t for t in (tasks or [])}
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST" and path.endswith("/swap-tag"):
+            task_id = path.split("/")[-2]
+            from_tag = request.url.params.get("from")
+            to_tag = request.url.params.get("to")
+            task = self.tasks.get(task_id)
+            if not task or from_tag not in task.get("tags", []):
+                return httpx.Response(200, json={"swapped": False})
+            tags = list(task["tags"])
+            tags[tags.index(from_tag)] = to_tag
+            task["tags"] = tags
+            return httpx.Response(200, json={"swapped": True})
+        if request.method == "PUT" and path.startswith("/api/tasks/"):
+            task_id = path.split("/")[-1]
+            task = self.tasks.get(task_id)
+            if not task:
+                return httpx.Response(404)
+            for k, v in json.loads(request.content or b"{}").items():
+                task[k] = v
+            return httpx.Response(200, json=task)
+        if request.method == "GET" and "/api/tasks/" in path:
+            task_id = path.split("/")[-1]
+            task = self.tasks.get(task_id)
+            return httpx.Response(200, json=task) if task else httpx.Response(404)
+        return httpx.Response(404)
+
+
+def _make_worker(tmp_path: Path, api: _FakeApi) -> Worker:
+    client = httpx.Client(transport=httpx.MockTransport(api.handler), base_url="http://api")
+    sent: list[str] = []
+    w = Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: sent.append(text) or True,
+        http_client=client,
+    )
+    w._sent_telegram = sent  # type: ignore[attr-defined]
+    return w
+
+
+# ---------------------------------------------------------------------------
+# Marker round-trip
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_marker_write_read_round_trip(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    path = write_self_restart_marker(session_ids=["sid-1"], task_ids=["task-1"], db_path=db)
+    assert path == _self_restart_marker_path(db)
+    assert path.exists()
+    sids, tids = _read_self_restart_marker(db)
+    assert sids == {"sid-1"} and tids == {"task-1"}
+
+
+@pytest.mark.unit
+def test_corrupt_marker_fails_closed(tmp_path: Path):
+    """A garbage marker must never make a real crash look deliberate."""
+    db = tmp_path / "sessions.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    _self_restart_marker_path(db).write_text("{not json", encoding="utf-8")
+    sids, tids = _read_self_restart_marker(db)
+    assert sids == set() and tids == set()
+
+
+# ---------------------------------------------------------------------------
+# resume_pending honors the marker
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_resume_pending_self_restart_finalizes_quietly(tmp_path: Path):
+    """A session named in the marker is finalized COMPLETED with NO rollback
+    notice — the doctor's own session, killed by the end-of-goal worker bounce,
+    must not surface as a spurious failed/rolled-back task (#401 acceptance)."""
+    api = _FakeApi(tasks=[
+        {"id": "doctor_task", "description": "doctor run", "status": "in_progress",
+         "tags": [RUNNING_TAG, "cloud"]},
+    ])
+    w = _make_worker(tmp_path, api)
+    session = w.session_store.create(
+        task_id="doctor_task", routing="claude", status=STATUS_RUNNING,
+        expected_output="text",
+    )
+    write_self_restart_marker(
+        session_ids=[session.session_id], db_path=w.session_store.db_path,
+    )
+
+    n = w.resume_pending()
+
+    assert n == 1
+    # No operator notice at all — the doctor already sent its "Shipped" [NOTIFY].
+    assert w._sent_telegram == [], f"expected no rollback notice; got {w._sent_telegram}"
+    refreshed = w.session_store.get("doctor_task")
+    assert refreshed.status == STATUS_COMPLETED
+    # Tag advanced to completed, NOT rolled back to #agent.
+    assert COMPLETED_TAG in api.tasks["doctor_task"]["tags"]
+    assert AGENT_TAG not in api.tasks["doctor_task"]["tags"]
+    # Transcript records the deliberate restart, not a resume_failed.
+    kinds = [e["kind"] for e in w.transcript_store.read(session.session_id)]
+    assert "resume_self_restart" in kinds
+    assert "resume_failed" not in kinds
+    # Marker consumed.
+    assert not _self_restart_marker_path(w.session_store.db_path).exists()
+
+
+@pytest.mark.unit
+def test_resume_pending_marker_by_task_id(tmp_path: Path):
+    """The primitive can name the run by task_id when it lacks the session_id."""
+    api = _FakeApi(tasks=[
+        {"id": "doctor_task", "description": "d", "status": "in_progress",
+         "tags": [RUNNING_TAG, "cloud"]},
+    ])
+    w = _make_worker(tmp_path, api)
+    session = w.session_store.create(
+        task_id="doctor_task", routing="claude", status=STATUS_RUNNING,
+        expected_output="text",
+    )
+    write_self_restart_marker(task_ids=["doctor_task"], db_path=w.session_store.db_path)
+
+    w.resume_pending()
+
+    assert w.session_store.get("doctor_task").status == STATUS_COMPLETED
+    assert w._sent_telegram == []
+    _ = session  # session_id path not exercised here; task_id match is enough
+
+
+@pytest.mark.unit
+def test_resume_pending_without_marker_still_rolls_back(tmp_path: Path):
+    """Regression guard: a crash with no marker must still FAIL + notify, so
+    the self-restart path can't silently swallow real crashes (#401)."""
+    api = _FakeApi(tasks=[
+        {"id": "crashed_task", "description": "c", "status": "in_progress",
+         "tags": [RUNNING_TAG, "cloud"]},
+    ])
+    w = _make_worker(tmp_path, api)
+    session = w.session_store.create(
+        task_id="crashed_task", routing="claude", status=STATUS_RUNNING,
+        expected_output="text",
+    )
+
+    n = w.resume_pending()
+
+    assert n == 1
+    assert len(w._sent_telegram) == 1
+    assert "could not be safely resumed" in w._sent_telegram[0]
+    assert AGENT_TAG in api.tasks["crashed_task"]["tags"]
+    kinds = [e["kind"] for e in w.transcript_store.read(session.session_id)]
+    assert "resume_failed" in kinds
+
+
+@pytest.mark.unit
+def test_resume_pending_marker_only_quiets_named_session(tmp_path: Path):
+    """A marker for the doctor's session must NOT quiet an unrelated crashed
+    session resumed in the same startup pass."""
+    api = _FakeApi(tasks=[
+        {"id": "doctor_task", "description": "d", "status": "in_progress",
+         "tags": [RUNNING_TAG, "cloud"]},
+        {"id": "other_task", "description": "o", "status": "in_progress",
+         "tags": [RUNNING_TAG, "cloud"]},
+    ])
+    w = _make_worker(tmp_path, api)
+    doctor = w.session_store.create(
+        task_id="doctor_task", routing="claude", status=STATUS_RUNNING,
+        expected_output="text",
+    )
+    w.session_store.create(
+        task_id="other_task", routing="claude", status=STATUS_RUNNING,
+        expected_output="text",
+    )
+    write_self_restart_marker(session_ids=[doctor.session_id], db_path=w.session_store.db_path)
+
+    w.resume_pending()
+
+    assert w.session_store.get("doctor_task").status == STATUS_COMPLETED
+    # The unrelated crash still rolled back + notified.
+    assert w.session_store.get("other_task").status != STATUS_COMPLETED
+    assert any("could not be safely resumed" in m for m in w._sent_telegram)
+    assert len(w._sent_telegram) == 1  # exactly the one real crash
+
+
+# ---------------------------------------------------------------------------
+# Bash primitive — ordering + classification (subprocess-driven, fully stubbed)
+# ---------------------------------------------------------------------------
+def _stub_bin(dir_: Path, name: str, body: str) -> None:
+    p = dir_ / name
+    p.write_text("#!/bin/bash\n" + body, encoding="utf-8")
+    p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
+
+
+@pytest.mark.unit
+def test_restart_worker_detached_sends_notice_before_restart(tmp_path: Path):
+    """The final notice must be flushed BEFORE the restart is triggered, so the
+    doctor's "Shipped" [NOTIFY] beats the worker's SIGTERM (#401 acceptance)."""
+    if not SERVER_SH.exists():
+        pytest.skip("server.sh not present")
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    order = tmp_path / "order.log"
+    # Stub the venv python: a marker-write call records "mark"; the notice-send
+    # heredoc records "notify". We distinguish by argv ("--mark-self-restart").
+    _stub_bin(bindir, "fake-python", f'''
+for a in "$@"; do
+  if [ "$a" = "--mark-self-restart" ]; then echo mark >> "{order}"; exit 0; fi
+done
+echo notify >> "{order}"
+exit 0
+''')
+    # Stub sudo/systemd-run/systemctl/setsid/nohup so nothing real restarts; each
+    # records "restart" exactly once via the systemctl call they wrap.
+    _stub_bin(bindir, "systemctl", f'echo restart >> "{order}"\nexit 0\n')
+    _stub_bin(bindir, "sudo", 'exec "$@"\n')
+    _stub_bin(bindir, "systemd-run", '''
+# Drop flags, exec the wrapped command (systemctl restart ...).
+while [[ "$1" == --* ]]; do shift; done
+exec "$@"
+''')
+    _stub_bin(bindir, "setsid", 'exec "$@"\n')
+    _stub_bin(bindir, "nohup", 'exec "$@"\n')
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    # Point VENV_PYTHON at our stub by overriding HOME so $HOME/.venvs/... resolves
+    # into the stub tree.
+    venv_py = tmp_path / ".venvs" / "lifeos" / "bin"
+    venv_py.mkdir(parents=True)
+    (venv_py / "python").symlink_to(bindir / "fake-python")
+    env["HOME"] = str(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(SERVER_SH), "restart-worker-detached",
+         "--session", "sid-1", "--notify", "Shipped PR #999"],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    steps = order.read_text().split()
+    # notify must come before restart; mark must come before restart.
+    assert "notify" in steps and "restart" in steps, steps
+    assert steps.index("notify") < steps.index("restart"), steps
+    assert "mark" in steps and steps.index("mark") < steps.index("restart"), steps
+
+
+@pytest.mark.unit
+def test_classify_change_picks_worker_vs_api(tmp_path: Path):
+    """classify-change prints 'worker' for an agent_worker diff, 'api' otherwise."""
+    if not SERVER_SH.exists():
+        pytest.skip("server.sh not present")
+    repo = tmp_path / "repo"
+    (repo / "api" / "services" / "agent_worker").mkdir(parents=True)
+    (repo / "api" / "routes").mkdir(parents=True)
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    (scripts / "server.sh").write_text(SERVER_SH.read_text(), encoding="utf-8")
+
+    def _git(*args):
+        subprocess.run(["git", *args], cwd=repo, check=True,
+                       capture_output=True, text=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@t.t")
+    _git("config", "user.name", "t")
+    (repo / "api" / "routes" / "x.py").write_text("# base\n")
+    _git("add", "-A")
+    _git("commit", "-qm", "base")
+
+    def _classify(rng):
+        r = subprocess.run(
+            ["bash", str(scripts / "server.sh"), "classify-change", rng],
+            cwd=repo, capture_output=True, text=True, timeout=30,
+        )
+        assert r.returncode == 0, r.stderr
+        return r.stdout.strip()
+
+    # api-only change
+    (repo / "api" / "routes" / "x.py").write_text("# changed\n")
+    _git("add", "-A")
+    _git("commit", "-qm", "api change")
+    assert _classify("HEAD~1..HEAD") == "api"
+
+    # agent_worker change
+    (repo / "api" / "services" / "agent_worker" / "worker.py").write_text("# w\n")
+    _git("add", "-A")
+    _git("commit", "-qm", "worker change")
+    assert _classify("HEAD~1..HEAD") == "worker"
+
+
+@pytest.mark.unit
+def test_server_sh_known_subcommands_still_parse(tmp_path: Path):
+    """The new subcommands didn't break the dispatcher: an unknown command
+    still prints usage listing both new commands and exits non-zero, and the
+    script passes `bash -n` syntax check."""
+    if not SERVER_SH.exists():
+        pytest.skip("server.sh not present")
+    syntax = subprocess.run(["bash", "-n", str(SERVER_SH)],
+                            capture_output=True, text=True)
+    assert syntax.returncode == 0, syntax.stderr
+    usage = subprocess.run(["bash", str(SERVER_SH), "definitely-not-a-command"],
+                           capture_output=True, text=True, timeout=30)
+    assert usage.returncode == 1
+    assert "restart-worker-detached" in usage.stdout
+    assert "classify-change" in usage.stdout


### PR DESCRIPTION
## Summary

The doctor self-repair persona drives a headless session **inside** `lifeos-agent-worker`. When a shipped change touches agent-worker code (`api/services/agent_worker/`), the worker must restart for it to take effect — and that restart kills the doctor's own session mid-run. Today that loses the final "Shipped" `[NOTIFY]`, and `resume_pending()` finds the running session, marks it `FAILED`, rolls the tag back, and fires a "could not be safely resumed" notice — so a fix that actually shipped is reported to the operator as a failed task.

This adds the **code-side primitive** (#401) so the contract becomes "call this one command," not "remember to order your steps":

- **`scripts/server.sh restart-worker-detached [--session ID] [--notify TEXT] [--bot NAME]`** — (1) flushes the final notice FIRST (so the operator gets the "Shipped" message even if the streamed `[NOTIFY]` raced the SIGTERM), (2) writes the self-restart marker naming the doctor's session, (3) restarts `lifeos-agent-worker` in a **DETACHED** process (`systemd-run` transient unit; `setsid`+`nohup` fallback) that outlives the dying session and actually performs the bounce.
- **`scripts/server.sh classify-change [range]`** — prints `worker` when a diff touches `api/services/agent_worker/` (needs the detached worker restart), else `api` (`lifeos-api` restart is sufficient; the doctor's own session survives). Default range `HEAD~1..HEAD`; pass `main..HEAD` to classify a branch.
- **`api/services/agent_worker/worker.py`** — self-restart marker (JSON at `data/self_restart.json`, co-located with the session DB) with write/read/clear helpers and a `--mark-self-restart` CLI the bash primitive calls. `resume_pending()` now recognizes a marked session and finalizes it **quietly** as `COMPLETED` (tag → `agent-completed`, transcript `resume_self_restart`) — no `FAILED`, no `#agent` rollback, no "could not be safely resumed" notice.

### How `resume_pending` distinguishes a deliberate self-restart from a crash

The primitive writes the marker (naming the doctor's `session_id`, or `task_id`) **before** triggering the restart. On startup `resume_pending()` reads it: a session named there is finalized quietly; any other non-terminal session in the same pass still rolls back + notifies exactly as before. The marker is **consumed (deleted) after one pass** and **fails closed on corruption** (a garbage marker is ignored, so it can never make a real crash look deliberate).

## Test evidence

New `tests/test_agent_worker_self_restart.py` (9 tests, all `@pytest.mark.unit`):

- **Marker round-trip** + **corrupt marker fails closed**.
- **`resume_pending` self-restart finalizes quietly** — marked session → `COMPLETED`, **no** operator notice, tag → `agent-completed` (not rolled back to `#agent`), transcript records `resume_self_restart` not `resume_failed`, marker consumed. (Covers the #401 acceptance: shipped fix is not surfaced as a spurious failed/rolled-back task.)
- **Marker-by-task-id** path.
- **Regression guard: without a marker, a crash still rolls back + notifies** ("could not be safely resumed").
- **Marker only quiets the named session** — an unrelated crash in the same startup pass still rolls back + notifies.
- **Bash primitive ordering** — drives `server.sh restart-worker-detached` as a subprocess with stubbed `systemctl`/`systemd-run`/`setsid`/`nohup`/venv-python on `PATH` (nothing real restarts) and asserts the **final notice is sent BEFORE the restart is triggered**, and the marker is written before the restart.
- **`classify-change`** — builds a throwaway git repo and asserts `api` for an api-only diff and `worker` for an `api/services/agent_worker/` diff.
- **`server.sh` subcommand smoke** — `bash -n` syntax check passes; an unknown command still prints usage (listing both new commands) and exits non-zero.

Run results (on `nathan-linux`, venv `~/.venvs/lifeos`):

- Targeted: `tests/test_agent_worker_self_restart.py` → **9 passed**.
- Regression: `tests/test_agent_worker_loop.py` (the `resume_pending` home) → **43 passed**.
- **Full unit suite** (`-m unit -p no:cacheprovider`) → **2213 passed, 8 skipped, 1067 deselected** in 879s. (The known-flaky `scheduler_watcher` test passed this run.)
- `server.sh` is bash, not pytest-covered elsewhere — covered here via subprocess tests + `bash -n`. `bash -n scripts/server.sh` → OK.

## Review focus

- **`resume_pending()` change** (`worker.py`) — confirm the marked-session branch can't swallow a real crash: it's gated on an exact `session_id`/`task_id` match, the marker fails closed on corruption, and is consumed once. Non-doctor recovery is unchanged (the 43 loop tests + the "only quiets named session" test guard this).
- **Detached-restart correctness** (`server.sh`) — the `systemd-run` transient unit (own cgroup) is what decouples the restarter from the worker's imminent SIGTERM; the `setsid`+`nohup` fallback covers non-systemd hosts. Ordering (notice → mark → restart) is the load-bearing invariant.
- **Concurrency note:** `worker.py` overlaps with #400 (crash-safety), which is being implemented in parallel on a separate branch and also edits `worker.py`. My edits are localized (new top-level helpers + a localized block inside `resume_pending` + a `main()` short-circuit) but **there will be a `worker.py` overlap to reconcile at merge time.**

## Deferred

Per scope, the `config/personas/doctor.md` "use the primitive" prose (repointing the Edge-cases section at `restart-worker-detached` + `classify-change`) is **deferred to #397** (the doctor goal-first rewrite), where the orchestration contract is being authored.

Closes #401
Part of #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
