### PR TITLE
fix(agent-worker): codex dispatch crash-before-init guard + terminal-status persistence

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1506,9 +1506,8 @@ class Worker:
         # `claude` binary (spawn event written, but no subprocess) is NOT
         # misdiagnosed as a side-effecting interruption — that case re-executes
         # safely once Fix A (terminal-status persistence below) stops the loop.
-        # Scope: claude_code only. The codex path (_dispatch_codex_session) has
-        # the same spawn-before-init window unguarded — intentionally out of #400
-        # (doctor == claude_code); tracked as a follow-up.
+        # The codex path (_dispatch_codex_session) carries the same guard via the
+        # shared _cli_subprocess_launch_count helper (#411).
         prior_launches = self._cli_subprocess_launch_count(
             sid, "claude_code_spawn", "claude_code_binary_not_found"
         )
@@ -1740,7 +1739,7 @@ class Worker:
         if not is_resume and self._cli_subprocess_launch_count(
             sid, "codex_spawn", "codex_binary_not_found"
         ) > 0:
-            self.transcript_store.append(sid, "codex_reexecute_prevented", {
+            self.transcript_store.append(sid, "codex_reexecute_averted", {
                 "reason": "subprocess launched without a persisted session id "
                           "(interrupted before init); not re-executing to avoid repeating side effects",
             })

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1728,6 +1728,34 @@ class Worker:
         sid = session.session_id
 
         is_resume = bool(session.claude_code_session_id)
+
+        # Re-execute guard (#411) — mirrors the claude_code dispatch (#400/#408).
+        # The codex executor writes `codex_spawn` immediately before launching the
+        # subprocess and only persists the session id on `codex_init`. A spawn with
+        # a still-NULL claude_code_session_id (the reused session-id column) means a
+        # subprocess launched but init never persisted — a non-restart re-dispatch
+        # would re-run the original prompt and repeat side effects. (A genuine crash
+        # is finalized by resume_pending() at startup; a missing codex binary is
+        # excluded by the launch-count's not-found subtraction.)
+        if not is_resume and self._cli_subprocess_launch_count(
+            sid, "codex_spawn", "codex_binary_not_found"
+        ) > 0:
+            self.transcript_store.append(sid, "codex_reexecute_prevented", {
+                "reason": "subprocess launched without a persisted session id "
+                          "(interrupted before init); not re-executing to avoid repeating side effects",
+            })
+            self.session_store.update_status(session.task_id, STATUS_FAILED)
+            try:
+                self._telegram_send(
+                    "⚠️ A codex session may have already started before it could be "
+                    "resumed safely, so it wasn't retried automatically. It's marked "
+                    "failed — re-trigger it to retry."
+                )
+            except Exception as exc:  # best-effort; the surface may be down
+                logger.warning("codex re-execute-prevented notify failed: %s", exc)
+            self._reconcile_vault_terminal(session, STATUS_FAILED)
+            return
+
         if is_resume:
             resume_message = pending[0]["content"] if pending else ""
             task: dict = {"id": session.task_id, "description": resume_message}
@@ -1788,6 +1816,10 @@ class Worker:
             self._telegram_send(f"⚠️ {label} hit its budget ({outcome.reason}).")
         elif outcome.status == STATUS_FAILED:
             self._telegram_send(f"⚠️ {label} failed: {outcome.reason}.")
+        # Persist the terminal status to the session row so an operator/child codex
+        # session (no vault row → _reconcile_vault_terminal is a no-op for it) can't
+        # linger CLAIMED and be re-dispatched every tick (mirrors #408 / #400).
+        self.session_store.update_status(session.task_id, outcome.status)
         self._reconcile_vault_terminal(session, outcome.status)
 
     def _get_codex_executor(self):

--- a/tests/test_agent_worker_codex_dispatch.py
+++ b/tests/test_agent_worker_codex_dispatch.py
@@ -18,6 +18,7 @@ import pytest
 from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_COMPLETED,
+    STATUS_FAILED,
     SessionStore,
 )
 from api.services.agent_worker.spend_tracker import SpendTracker
@@ -113,3 +114,78 @@ def test_codex_completion_empty_final_registers_no_anchor(tmp_path: Path):
 
     assert withid_sends == []
     assert worker.session_store.get_open_question_by_message_id(777) is None
+
+
+# ---------------------------------------------------------------------------
+# Crash-before-init re-execute guard + terminal-status persistence (#411,
+# mirroring #400/#408 for the claude_code path)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ResumableStubCodexExecutor(_StubCodexExecutor):
+    resume_calls: list = field(default_factory=list)
+
+    def resume(self, session, message):
+        self.resume_calls.append((session.task_id, message))
+        return self.outcome
+
+
+def test_codex_crash_before_init_does_not_reexecute(tmp_path: Path):
+    """A codex session whose subprocess launched once (a `codex_spawn` event is
+    present) but never persisted its session id must NOT re-run the original
+    prompt on redispatch — re-execution could repeat side effects."""
+    plain_sends: list[str] = []
+    withid_sends: list[str] = []
+    # COMPLETED makes a regression obvious: if the guard fails to fire, execute()
+    # runs and the session would end COMPLETED instead of FAILED.
+    stub = _ResumableStubCodexExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run")
+    )
+    worker = _make_worker(tmp_path, codex_executor=stub, plain_sends=plain_sends, withid_sends=withid_sends)
+    session = worker.session_store.create(task_id="cx-crash", routing="codex", origin="operator")
+    worker.transcript_store.append(session.session_id, "codex_spawn", {"resume": False})
+
+    worker._dispatch_codex_session(session, [{"content": "file the report"}])
+
+    assert stub.calls == [] and stub.resume_calls == []  # neither re-ran the prompt
+    assert worker.session_store.get("cx-crash").status == STATUS_FAILED
+    kinds = [e["kind"] for e in worker.transcript_store.read(session.session_id)]
+    assert "codex_reexecute_prevented" in kinds
+    assert any("already started" in s for s in plain_sends)
+
+
+def test_codex_binary_not_found_does_not_trip_guard(tmp_path: Path):
+    """A missing codex binary writes `codex_spawn` then `codex_binary_not_found`,
+    but no subprocess launched — the guard must NOT misread that as a crashed run.
+    Execute still runs; FAILED is persisted to the row (FIX A)."""
+    plain_sends: list[str] = []
+    withid_sends: list[str] = []
+    stub = _StubCodexExecutor(outcome=ExecutorOutcome(status=STATUS_FAILED, reason="binary_not_found"))
+    worker = _make_worker(tmp_path, codex_executor=stub, plain_sends=plain_sends, withid_sends=withid_sends)
+    session = worker.session_store.create(task_id="cx-bn", routing="codex", origin="operator")
+    worker.transcript_store.append(session.session_id, "codex_spawn", {"resume": False})
+    worker.transcript_store.append(session.session_id, "codex_binary_not_found", {"error": "no codex"})
+
+    worker._dispatch_codex_session(session, [{"content": "do it"}])
+
+    assert stub.calls == [("cx-bn", "do it")]  # guard skipped → execute ran
+    assert worker.session_store.get("cx-bn").status == STATUS_FAILED
+    kinds = [e["kind"] for e in worker.transcript_store.read(session.session_id)]
+    assert "codex_reexecute_prevented" not in kinds
+
+
+def test_codex_failed_finalizes_session_row(tmp_path: Path):
+    """A FAILED codex outcome persists the terminal status to the session row, so
+    an operator codex session isn't left CLAIMED and re-dispatched every tick."""
+    plain_sends: list[str] = []
+    withid_sends: list[str] = []
+    stub = _StubCodexExecutor(outcome=ExecutorOutcome(status=STATUS_FAILED, reason="boom"))
+    worker = _make_worker(tmp_path, codex_executor=stub, plain_sends=plain_sends, withid_sends=withid_sends)
+    session = worker.session_store.create(task_id="cx-fail", routing="codex", origin="operator")
+
+    worker._dispatch_codex_session(session, [{"content": "do a thing"}])
+
+    assert stub.calls == [("cx-fail", "do a thing")]
+    assert worker.session_store.get("cx-fail").status == STATUS_FAILED
+    assert any("failed" in s.lower() for s in plain_sends)

--- a/tests/test_agent_worker_codex_dispatch.py
+++ b/tests/test_agent_worker_codex_dispatch.py
@@ -151,7 +151,7 @@ def test_codex_crash_before_init_does_not_reexecute(tmp_path: Path):
     assert stub.calls == [] and stub.resume_calls == []  # neither re-ran the prompt
     assert worker.session_store.get("cx-crash").status == STATUS_FAILED
     kinds = [e["kind"] for e in worker.transcript_store.read(session.session_id)]
-    assert "codex_reexecute_prevented" in kinds
+    assert "codex_reexecute_averted" in kinds
     assert any("already started" in s for s in plain_sends)
 
 
@@ -172,7 +172,7 @@ def test_codex_binary_not_found_does_not_trip_guard(tmp_path: Path):
     assert stub.calls == [("cx-bn", "do it")]  # guard skipped → execute ran
     assert worker.session_store.get("cx-bn").status == STATUS_FAILED
     kinds = [e["kind"] for e in worker.transcript_store.read(session.session_id)]
-    assert "codex_reexecute_prevented" not in kinds
+    assert "codex_reexecute_averted" not in kinds
 
 
 def test_codex_failed_finalizes_session_row(tmp_path: Path):


### PR DESCRIPTION
## Summary
Closes **#411** — mirrors the #408/#400 fix (claude_code path) into `_dispatch_codex_session`, which the #408 review flagged as having the same spawn-before-init re-execute window unguarded.

- **Re-execute guard**: a codex session with a `codex_spawn` transcript event but a NULL session id (subprocess launched, `codex_init` never persisted) is finalized FAILED + notified rather than re-executed. Reuses `_cli_subprocess_launch_count` with codex's event kinds, so a missing codex binary (`codex_spawn` + `codex_binary_not_found`) is correctly excluded.
- **Terminal-status persistence**: the FAILED/BUDGET tail now persists the session-row status so an operator codex session can't linger CLAIMED and re-dispatch.

## Test evidence
3 new codex tests (crash-before-init → FAILED, no re-execute; binary-not-found excluded; FAILED finalizes the row). Targeted codex + claude_code dispatch suites: 14 passed. Full suite running.

## Review focus
Does the guard correctly mirror #408 for codex's structure (direct `_telegram_send`, the reused `claude_code_session_id` column for codex's thread id)? Any codex-specific edge the claude_code path didn't have.