### PR TITLE
feat(chat): stream web-spawned session output into the conversation thread

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -922,8 +922,11 @@ async def chat_handoff(request: HandoffRequest):
     from api.services.agent_worker.session_store import SessionStore
 
     working_dir = resolve_working_directory(task)
-    # Route the worker's completion notification to the operator's Telegram (the
-    # web thread can't receive an async result yet). None if Telegram isn't set.
+    # Also route the worker's completion notification to the operator's Telegram.
+    # As of #311 the spawned session's progress + result are mirrored back into
+    # this web/voice thread too (the conversation is linked to the session
+    # below), so Telegram is now an additional delivery channel, not the only
+    # one. None if Telegram isn't set.
     chat_id = getattr(settings, "telegram_chat_id", "") or None
 
     if engine == "codex":

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -946,8 +946,8 @@ async def chat_handoff(request: HandoffRequest):
     session_id = result.get("session_id", "")
     ack = (
         f"🤝 Handed off to **{label}** — running in the background "
-        f"(session `{session_id[:12]}`). The result will arrive via Telegram and "
-        f"appear on the /agents page."
+        f"(session `{session_id[:12]}`). The result will appear right here, "
+        f"and also via Telegram and on the /agents page."
     )
     if request.conversation_id:
         try:
@@ -957,6 +957,16 @@ async def chat_handoff(request: HandoffRequest):
             )
         except Exception:
             logger.warning("failed to record handoff acknowledgment", exc_info=True)
+        # #311: link the conversation to the spawned session so the worker can
+        # mirror the session's progress + terminal result back into this thread
+        # (in addition to Telegram). Best-effort — a link failure only loses the
+        # web round-trip, not the Telegram delivery. Mirrors the orchestrating-
+        # persona path (chat.py set_agent_session_id after a doctor spawn).
+        if session_id:
+            try:
+                get_store().set_agent_session_id(request.conversation_id, session_id)
+            except Exception:
+                logger.warning("failed to link conversation to handoff session", exc_info=True)
 
     return {
         "ok": True,

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -67,6 +67,13 @@ class ConversationDetailResponse(BaseModel):
     # conversation is currently awaiting an answer (#403). The client renders
     # an answer affordance and POSTs to `{id}/answer`. Absent/None otherwise.
     pending_question: Optional[PendingQuestionResponse] = None
+    # Whether a session spawned by this conversation is still running (#311).
+    # True iff the conversation links a session whose status is non-terminal.
+    # False when there's no linked session or it has reached a terminal status
+    # (completed/failed/budget_exceeded). The client's result-streaming poll
+    # uses this to STOP once the session is done and nothing awaits an answer —
+    # otherwise the 4s poll would run forever after the session finishes.
+    agent_session_active: bool = False
 
 
 class ConversationListResponse(BaseModel):
@@ -144,19 +151,34 @@ async def get_conversation(conversation_id: str):
     messages = store.get_messages(conversation_id)
 
     # Surface an open [CLARIFY]/[GOAL] from a session this conversation spawned
-    # (#403) so the client can show an answer affordance. Best-effort: a lookup
-    # failure (or no spawned session) just omits it — never breaks the read.
+    # (#403) so the client can show an answer affordance, and report whether that
+    # session is still running (#311) so the client's result-streaming poll can
+    # stop once it's done. Both are best-effort: a lookup failure (or no spawned
+    # session) just leaves pending_question=None / agent_session_active=False and
+    # never breaks the read.
     pending_question = None
+    agent_session_active = False
     if conv.agent_session_id:
         try:
-            from api.services.agent_worker.session_store import SessionStore
-            q = SessionStore().get_open_question_by_session_id(conv.agent_session_id)
+            from api.services.agent_worker.session_store import (
+                SessionStore,
+                TERMINAL_STATUSES,
+            )
+            session_store = SessionStore()
+            q = session_store.get_open_question_by_session_id(conv.agent_session_id)
             if q:
                 pending_question = PendingQuestionResponse(
                     session_id=conv.agent_session_id,
                     question=q.get("question") or "",
                     kind=q.get("kind") or "clarification",
                 )
+            # Active = the linked session row exists and hasn't reached a
+            # terminal status. A missing session row (never created, or pruned)
+            # counts as not-active, so the client stops polling.
+            session = session_store.get_by_session_id(conv.agent_session_id)
+            agent_session_active = bool(
+                session is not None and session.status not in TERMINAL_STATUSES
+            )
         except Exception:  # noqa: BLE001
             logger.warning("pending-question lookup failed", exc_info=True)
 
@@ -177,6 +199,7 @@ async def get_conversation(conversation_id: str):
             for m in messages
         ],
         pending_question=pending_question,
+        agent_session_active=agent_session_active,
     )
 
 

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -660,7 +660,10 @@ class ClaudeCodeExecutor:
                     except Exception as exc:  # pragma: no cover — defensive
                         logger.warning("notification callback raised: %s", exc)
                     if self._conversation_mirror:  # #311: stream into the web thread
-                        self._conversation_mirror(session.session_id, body)
+                        try:
+                            self._conversation_mirror(session.session_id, body)
+                        except Exception as exc:  # pragma: no cover — defensive
+                            logger.warning("conversation mirror raised: %s", exc)
                     self.transcript_store.append(sid, "claude_code_clarify", {
                         "body": body, "body_chars": len(body),
                     })
@@ -676,7 +679,10 @@ class ClaudeCodeExecutor:
                         except Exception as exc:  # pragma: no cover — defensive
                             logger.warning("notification callback raised: %s", exc)
                         if self._conversation_mirror:  # #311: stream into the web thread
-                            self._conversation_mirror(session.session_id, body)
+                            try:
+                                self._conversation_mirror(session.session_id, body)
+                            except Exception as exc:  # pragma: no cover — defensive
+                                logger.warning("conversation mirror raised: %s", exc)
                     self.transcript_store.append(sid, "claude_code_notify", {
                         "body": body, "body_chars": len(body),
                     })
@@ -696,7 +702,10 @@ class ClaudeCodeExecutor:
                         except Exception as exc:  # pragma: no cover — defensive
                             logger.warning("notification callback raised: %s", exc)
                         if self._conversation_mirror:  # #311: stream into the web thread
-                            self._conversation_mirror(session.session_id, body)
+                            try:
+                                self._conversation_mirror(session.session_id, body)
+                            except Exception as exc:  # pragma: no cover — defensive
+                                logger.warning("conversation mirror raised: %s", exc)
                     self.transcript_store.append(sid, "claude_code_goal", {
                         "body": body, "body_chars": len(body),
                     })

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -299,6 +299,7 @@ class ClaudeCodeExecutor:
         session_store: SessionStore,
         transcript_store: TranscriptStore,
         notification_callback: Optional[NotificationCallback] = None,
+        conversation_mirror: Optional[Callable[[str, str], None]] = None,
         spawn_fn: Optional[SpawnFn] = None,
         binary_resolver: Optional[Callable[[], str]] = None,
         timeout_seconds: Optional[int] = None,
@@ -307,6 +308,12 @@ class ClaudeCodeExecutor:
         self.session_store = session_store
         self.transcript_store = transcript_store
         self._notify = notification_callback or (lambda _msg: None)
+        # #311: optional (session_id, body) sink that mirrors each streamed
+        # [NOTIFY]/[CLARIFY]/[GOAL] body into the web/voice conversation thread
+        # that spawned the session. Additive — `notification_callback` (the
+        # Telegram relay) is unchanged. None → no mirroring (the default; tests
+        # and non-web sessions are unaffected).
+        self._conversation_mirror = conversation_mirror
         self._spawn_fn = spawn_fn or subprocess.Popen
         self._binary_resolver = binary_resolver or _resolve_claude_binary
         self._timeout = timeout_seconds if timeout_seconds is not None else settings.claude_timeout_seconds
@@ -652,6 +659,8 @@ class ClaudeCodeExecutor:
                         self._notify(body)
                     except Exception as exc:  # pragma: no cover — defensive
                         logger.warning("notification callback raised: %s", exc)
+                    if self._conversation_mirror:  # #311: stream into the web thread
+                        self._conversation_mirror(session.session_id, body)
                     self.transcript_store.append(sid, "claude_code_clarify", {
                         "body": body, "body_chars": len(body),
                     })
@@ -666,6 +675,8 @@ class ClaudeCodeExecutor:
                             self._notify(body)
                         except Exception as exc:  # pragma: no cover — defensive
                             logger.warning("notification callback raised: %s", exc)
+                        if self._conversation_mirror:  # #311: stream into the web thread
+                            self._conversation_mirror(session.session_id, body)
                     self.transcript_store.append(sid, "claude_code_notify", {
                         "body": body, "body_chars": len(body),
                     })
@@ -684,6 +695,8 @@ class ClaudeCodeExecutor:
                             self._notify(body)
                         except Exception as exc:  # pragma: no cover — defensive
                             logger.warning("notification callback raised: %s", exc)
+                        if self._conversation_mirror:  # #311: stream into the web thread
+                            self._conversation_mirror(session.session_id, body)
                     self.transcript_store.append(sid, "claude_code_goal", {
                         "body": body, "body_chars": len(body),
                     })

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1849,9 +1849,12 @@ class Worker:
                 # #311: mirror the final result into the web/voice thread that
                 # spawned this codex session (no-op for Telegram-origin). Codex
                 # has no rich [NOTIFY] stream, so this terminal mirror is the
-                # whole web round-trip for it. Children have no parent here
-                # (codex isn't spawned as a child), so no extra gate is needed.
-                self._mirror_to_conversation(sid, body)
+                # whole web round-trip for it. Non-child only, for parity with
+                # the claude_code path: codex CAN be a child (it's in
+                # inter_agent.SPAWN_MODELS), and a child is never
+                # conversation-linked — so this is both correct and defensive.
+                if not session.parent_session_id:
+                    self._mirror_to_conversation(sid, body)
             self.transcript_store.append(sid, "codex_handled_completion", {
                 "final_chars": len(body),
             })
@@ -1867,8 +1870,11 @@ class Worker:
         if notice:
             self._telegram_send(notice)
             # #311: mirror the same failure/budget notice into the web/voice
-            # thread (no-op for Telegram-origin).
-            self._mirror_to_conversation(sid, notice)
+            # thread (no-op for Telegram-origin). Non-child only, for parity
+            # with the claude_code path (codex can be a child via
+            # inter_agent.SPAWN_MODELS; a child is never conversation-linked).
+            if not session.parent_session_id:
+                self._mirror_to_conversation(sid, notice)
         # Persist the terminal status to the session row so an operator/child codex
         # session (no vault row → _reconcile_vault_terminal is a no-op for it) can't
         # linger CLAIMED and be re-dispatched every tick (mirrors #408 / #400).

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -56,6 +56,7 @@ from api.services.agent_worker.session_store import (
 from api.services.agent_worker.managed_executor import _sanitize_title as _managed_sanitize_title
 from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.conversation_store import ConversationStore
 from api.services.interaction_store import build_obsidian_link
 from config.settings import settings
 
@@ -320,6 +321,7 @@ class Worker:
         self,
         api_base: str | None = None,
         session_store: SessionStore | None = None,
+        conversation_store: ConversationStore | None = None,
         transcript_store: TranscriptStore | None = None,
         spend_tracker: SpendTracker | None = None,
         poll_seconds: float | None = None,
@@ -335,6 +337,10 @@ class Worker:
     ) -> None:
         self.api_base = (api_base or os.environ.get("LIFEOS_API_URL", "http://localhost:8000")).rstrip("/")
         self.session_store = session_store or SessionStore()
+        # #311: resolves a spawned session back to the web/voice conversation it
+        # originated from, so the session's progress + result can be mirrored
+        # into that thread (additive — Telegram routing is untouched).
+        self.conversation_store = conversation_store or ConversationStore()
         self.transcript_store = transcript_store or TranscriptStore()
         self.spend_tracker = spend_tracker or SpendTracker(
             daily_cap_dollars=settings.agent_daily_cap_dollars,
@@ -1452,6 +1458,28 @@ class Worker:
             logger.warning("spawn-marker read failed for %s: %s", session_id, exc)
             return 0
 
+    def _mirror_to_conversation(self, session_id: str, text: str) -> None:
+        """#311: mirror a web-spawned session's operator-facing output into its
+        linked conversation thread (additive — Telegram is untouched).
+
+        No-op when the session isn't linked to a conversation (i.e.
+        Telegram-origin), which keeps AC2: Telegram-origin handoffs unaffected.
+        Best-effort: a mirror failure only loses the web round-trip, never the
+        session's Telegram delivery. The reverse lookup is keyed on the
+        per-call session_id, so concurrent sessions can't cross-write threads.
+        """
+        if not session_id or not text or not text.strip():
+            return
+        try:
+            conv_id = self.conversation_store.get_conversation_id_by_agent_session_id(session_id)
+            if conv_id:
+                self.conversation_store.add_message(
+                    conv_id, "assistant", text.strip(),
+                    routing={"agent_session_id": session_id},
+                )
+        except Exception as exc:
+            logger.warning("web-thread mirror failed for %s: %s", session_id, exc)
+
     def _dispatch_claude_code_session(self, session, pending: list[dict]) -> None:
         """Drive one ``routing='claude_code'`` session through ``ClaudeCodeExecutor``.
 
@@ -1655,6 +1683,10 @@ class Worker:
                         kind="followup",
                         bot=bot,
                     )
+                # #311: also land the final result in the web/voice thread that
+                # spawned this session (no-op for Telegram-origin). Gated the same
+                # way as the Telegram send above — non-empty, non-child.
+                self._mirror_to_conversation(sid, body)
             self.transcript_store.append(sid, "code_handled_completion", {
                 "final_chars": len(body),
             })
@@ -1666,10 +1698,17 @@ class Worker:
         # vault-routed #claude task still needs its tag/checkbox reconciled —
         # operator-spawned /claude sessions have no vault row and are no-ops.
         label = "Code session"
+        notice = ""
         if outcome.status == STATUS_BUDGET_EXCEEDED:
-            _send(f"⚠️ {label} hit its budget ({outcome.reason}).")
+            notice = f"⚠️ {label} hit its budget ({outcome.reason})."
         elif outcome.status == STATUS_FAILED:
-            _send(f"⚠️ {label} failed: {outcome.reason}.")
+            notice = f"⚠️ {label} failed: {outcome.reason}."
+        if notice:
+            _send(notice)
+            # #311: mirror the same failure/budget notice into the web/voice
+            # thread (no-op for Telegram-origin); a child session has no thread.
+            if not session.parent_session_id:
+                self._mirror_to_conversation(sid, notice)
         # Persist the terminal status to the session ROW (#400). The executor
         # sets RUNNING on launch but doesn't always flip to a terminal status on
         # failure (e.g. the binary-not-found path returns FAILED while leaving the
@@ -1705,6 +1744,9 @@ class Worker:
             session_store=self.session_store,
             transcript_store=self.transcript_store,
             notification_callback=notify,
+            # #311: mirror each streamed [NOTIFY]/[CLARIFY]/[GOAL] into the
+            # web/voice thread that spawned the session (no-op when unlinked).
+            conversation_mirror=self._mirror_to_conversation,
         )
         # CLI dispatch runs on a thread pool, so two same-bot sessions can reach
         # here concurrently. The executor is cheap and stateless (per-session
@@ -1804,6 +1846,12 @@ class Worker:
                         sent_message_ids=sent_ids,
                         kind="followup",
                     )
+                # #311: mirror the final result into the web/voice thread that
+                # spawned this codex session (no-op for Telegram-origin). Codex
+                # has no rich [NOTIFY] stream, so this terminal mirror is the
+                # whole web round-trip for it. Children have no parent here
+                # (codex isn't spawned as a child), so no extra gate is needed.
+                self._mirror_to_conversation(sid, body)
             self.transcript_store.append(sid, "codex_handled_completion", {
                 "final_chars": len(body),
             })
@@ -1811,10 +1859,16 @@ class Worker:
             return
 
         label = "Codex session"
+        notice = ""
         if outcome.status == STATUS_BUDGET_EXCEEDED:
-            self._telegram_send(f"⚠️ {label} hit its budget ({outcome.reason}).")
+            notice = f"⚠️ {label} hit its budget ({outcome.reason})."
         elif outcome.status == STATUS_FAILED:
-            self._telegram_send(f"⚠️ {label} failed: {outcome.reason}.")
+            notice = f"⚠️ {label} failed: {outcome.reason}."
+        if notice:
+            self._telegram_send(notice)
+            # #311: mirror the same failure/budget notice into the web/voice
+            # thread (no-op for Telegram-origin).
+            self._mirror_to_conversation(sid, notice)
         # Persist the terminal status to the session row so an operator/child codex
         # session (no vault row → _reconcile_vault_terminal is a no-op for it) can't
         # linger CLAIMED and be re-dispatched every tick (mirrors #408 / #400).

--- a/api/services/conversation_store.py
+++ b/api/services/conversation_store.py
@@ -70,9 +70,26 @@ class ConversationStore:
         self.db_path = db_path or get_conversation_db_path()
         self._init_db()
 
+    def _connect(self) -> sqlite3.Connection:
+        """Open a connection with a generous busy timeout.
+
+        This PR adds the agent worker as a SECOND concurrent writer to
+        conversations.db (it mirrors a spawned session's output into the linked
+        thread, #311) alongside the web /chat process. Under WAL two writers can
+        still collide on the single write lock; without a busy timeout the loser
+        gets an immediate "database is locked", and the mirror's best-effort
+        try/except would silently drop the message. A 10s busy timeout (matching
+        SessionStore._connect) lets the loser wait out the brief write instead.
+        `sqlite3.connect`'s `timeout=` sets exactly this at the driver level —
+        Python's default is 5s, so this widens it and makes the intent explicit.
+        """
+        conn = sqlite3.connect(self.db_path, timeout=10.0)
+        conn.execute("PRAGMA busy_timeout = 10000")
+        return conn
+
     def _init_db(self):
         """Create database tables if they don't exist."""
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("""
@@ -141,7 +158,7 @@ class ConversationStore:
         title = title or "New Conversation"
         now = datetime.now()
 
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             conn.execute(
                 "INSERT INTO conversations (id, title, persona_id, created_at, updated_at) "
@@ -171,7 +188,7 @@ class ConversationStore:
         Returns:
             Conversation or None if not found
         """
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             cursor = conn.execute(
                 """
@@ -225,7 +242,7 @@ class ConversationStore:
             params.append(persona_id)
         params.append(limit)
 
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             cursor = conn.execute(
                 f"""
@@ -266,7 +283,7 @@ class ConversationStore:
         Returns:
             True if deleted, False if not found
         """
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             # Check if exists
             cursor = conn.execute(
@@ -317,7 +334,7 @@ class ConversationStore:
         sources_json = json.dumps(sources) if sources else None
         routing_json = json.dumps(routing) if routing else None
 
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             conn.execute(
                 """
@@ -360,7 +377,7 @@ class ConversationStore:
         Returns:
             List of messages in chronological order
         """
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             if limit:
                 # Get last N messages
@@ -415,7 +432,7 @@ class ConversationStore:
         Returns:
             True if updated, False if not found
         """
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             cursor = conn.execute(
                 "UPDATE conversations SET title = ?, updated_at = ? WHERE id = ?",
@@ -435,7 +452,7 @@ class ConversationStore:
         overwrites any prior link (a fresh spawn supersedes). Returns True if
         the conversation row was updated.
         """
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             cursor = conn.execute(
                 "UPDATE conversations SET agent_session_id = ?, updated_at = ? "
@@ -459,7 +476,7 @@ class ConversationStore:
         """
         if not session_id:
             return None
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         try:
             row = conn.execute(
                 "SELECT id FROM conversations WHERE agent_session_id = ? LIMIT 1",

--- a/api/services/conversation_store.py
+++ b/api/services/conversation_store.py
@@ -447,6 +447,28 @@ class ConversationStore:
         finally:
             conn.close()
 
+    def get_conversation_id_by_agent_session_id(self, session_id: str) -> Optional[str]:
+        """Reverse of set_agent_session_id: the conversation linked to a spawned
+        session, or None (#311).
+
+        The agent worker runs out-of-process and only knows a session_id; this
+        lets it resolve the web/voice conversation thread that spawned the
+        session so its progress + result can be mirrored back there. Returns
+        None for Telegram-origin sessions (never linked to a conversation),
+        which keeps the mirror a no-op for them.
+        """
+        if not session_id:
+            return None
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT id FROM conversations WHERE agent_session_id = ? LIMIT 1",
+                (session_id,)
+            ).fetchone()
+            return row[0] if row else None
+        finally:
+            conn.close()
+
 
 def generate_title(question: str, max_length: int = 50) -> str:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -258,6 +258,29 @@ def _isolate_vault_indexer_stores(tmp_path, monkeypatch):
             pass
 
 
+@pytest.fixture(autouse=True)
+def _isolate_conversation_store_db(tmp_path, monkeypatch):
+    """Stop tests from opening (and migrating) the production conversations DB.
+
+    ``ConversationStore()`` with no ``db_path`` resolves its path from
+    ``settings.chroma_path`` (``get_conversation_db_path()``) — i.e. the real
+    ``data/conversations.db`` on whatever machine runs the suite. Any helper or
+    fixture that builds a default ``ConversationStore()`` (e.g. the agent-worker
+    dispatch helpers that construct ``Worker()`` without an explicit store) would
+    otherwise open and run migrations against production data. Redirect the
+    default path to a per-test tmp file so no test can ever touch the live DB,
+    mirroring ``_isolate_vault_indexer_stores`` above. Tests that inject their own
+    ``db_path`` are unaffected (the redirect only changes the default).
+    """
+    import api.services.conversation_store as conv_store_mod
+
+    monkeypatch.setattr(
+        conv_store_mod,
+        "get_conversation_db_path",
+        lambda: str(tmp_path / "conversations.db"),
+    )
+
+
 @pytest.fixture(scope="session")
 def embedding_service():
     """

--- a/tests/test_agent_worker_claude_code_dispatch.py
+++ b/tests/test_agent_worker_claude_code_dispatch.py
@@ -330,3 +330,136 @@ def test_fresh_spawn_with_no_prior_spawn_event_still_executes(tmp_path: Path):
     worker._dispatch_claude_code_session(session, [{"content": "do a thing"}])
 
     assert stub.calls == [("op-2", "do a thing")]
+
+
+# =============================================================================
+# Web-thread result mirroring (#311)
+# =============================================================================
+
+from api.services.conversation_store import ConversationStore
+
+
+def _mirroring_worker(tmp_path: Path, claude_code_executor):
+    """Worker with an isolated ConversationStore so a test can assert the
+    spawned session's output is mirrored into the linked conversation (#311)."""
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    conv_store = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+    worker = Worker(
+        api_base="http://api",
+        session_store=store,
+        conversation_store=conv_store,
+        transcript_store=transcripts,
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: True,
+        telegram_send_with_id=lambda text: [1],
+        http_client=client,
+        claude_code_executor=claude_code_executor,
+        cli_pool=_SynchronousPool(),
+    )
+    return worker, store, conv_store
+
+
+def test_mirror_to_conversation_writes_when_linked(tmp_path: Path):
+    """_mirror_to_conversation writes an assistant message into the conversation
+    linked to a session_id."""
+    worker, _, conv_store = _mirroring_worker(tmp_path, claude_code_executor=None)
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, "sess-xyz")
+
+    worker._mirror_to_conversation("sess-xyz", "  progress update  ")
+
+    msgs = conv_store.get_messages(conv.id)
+    assert [(m.role, m.content) for m in msgs] == [("assistant", "progress update")]
+
+
+def test_mirror_to_conversation_noop_when_unlinked(tmp_path: Path):
+    """AC2: a Telegram-origin session is unlinked, so the mirror is a no-op —
+    no conversation is written and no crash."""
+    worker, _, conv_store = _mirroring_worker(tmp_path, claude_code_executor=None)
+    conv = conv_store.create_conversation(title="Unrelated thread")
+
+    worker._mirror_to_conversation("sess-not-linked", "should not land anywhere")
+
+    assert conv_store.get_messages(conv.id) == []
+
+
+def test_mirror_to_conversation_noop_on_empty_text(tmp_path: Path):
+    worker, _, conv_store = _mirroring_worker(tmp_path, claude_code_executor=None)
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, "sess-xyz")
+
+    worker._mirror_to_conversation("sess-xyz", "   ")
+    worker._mirror_to_conversation("", "text")
+
+    assert conv_store.get_messages(conv.id) == []
+
+
+def test_completion_mirrors_final_text_into_linked_conversation(tmp_path: Path):
+    """A completed web-spawned claude_code session lands its final text in the
+    linked conversation thread (in addition to Telegram)."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="All done — opened PR #5.")
+    )
+    worker, store, conv_store = _mirroring_worker(tmp_path, claude_code_executor=stub)
+    session = store.create(task_id="web-1", routing="claude_code", origin="operator")
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, session.session_id)
+
+    worker._dispatch_claude_code_session(session, [{"content": "do the thing"}])
+
+    msgs = conv_store.get_messages(conv.id)
+    assert any(m.role == "assistant" and "All done — opened PR #5." in m.content for m in msgs)
+
+
+def test_completion_does_not_mirror_when_unlinked(tmp_path: Path):
+    """An operator/Telegram-origin completion writes nothing to any conversation
+    (AC2)."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done.")
+    )
+    worker, store, conv_store = _mirroring_worker(tmp_path, claude_code_executor=stub)
+    session = store.create(task_id="tg-1", routing="claude_code", origin="operator")
+    conv = conv_store.create_conversation(title="Some other thread")  # not linked
+
+    worker._dispatch_claude_code_session(session, [{"content": "do the thing"}])
+
+    assert conv_store.get_messages(conv.id) == []
+
+
+def test_failure_mirrors_notice_into_linked_conversation(tmp_path: Path):
+    """A FAILED web-spawned session mirrors its failure notice into the thread."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_FAILED, reason="boom")
+    )
+    worker, store, conv_store = _mirroring_worker(tmp_path, claude_code_executor=stub)
+    session = store.create(task_id="web-fail-1", routing="claude_code", origin="operator")
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, session.session_id)
+
+    worker._dispatch_claude_code_session(session, [{"content": "do the thing"}])
+
+    msgs = conv_store.get_messages(conv.id)
+    assert any(m.role == "assistant" and "failed" in m.content.lower() for m in msgs)
+
+
+def test_child_completion_does_not_mirror(tmp_path: Path):
+    """A spawned child session (has a parent) stays silent to the operator and
+    must not mirror into any conversation — even if one is linked."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="child result")
+    )
+    worker, store, conv_store = _mirroring_worker(tmp_path, claude_code_executor=stub)
+    parent = store.create(task_id="parent-1", routing="local")
+    child = store.create(
+        task_id="child-1", routing="claude_code", parent_session_id=parent.session_id,
+    )
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, child.session_id)
+
+    worker._dispatch_claude_code_session(child, [{"content": "list matches"}])
+
+    assert conv_store.get_messages(conv.id) == []

--- a/tests/test_agent_worker_claude_code_dispatch.py
+++ b/tests/test_agent_worker_claude_code_dispatch.py
@@ -20,6 +20,7 @@ from api.services.agent_worker.session_store import (
 from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
 from api.services.agent_worker.worker import Worker, _SynchronousPool
+from api.services.conversation_store import ConversationStore
 
 
 pytestmark = pytest.mark.unit
@@ -50,6 +51,10 @@ def _make_worker(tmp_path: Path, claude_code_executor):
     return Worker(
         api_base="http://api",
         session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        # Isolate the conversation DB to a tmp file: the default ConversationStore()
+        # resolves to the production data/conversations.db, which a test must never
+        # open or migrate.
+        conversation_store=ConversationStore(db_path=str(tmp_path / "conversations.db")),
         transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
         spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
         poll_seconds=0.01,
@@ -88,6 +93,8 @@ def _recording_worker(tmp_path: Path, claude_code_executor):
     worker = Worker(
         api_base="http://api",
         session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        # Isolate the conversation DB (default resolves to prod data/conversations.db).
+        conversation_store=ConversationStore(db_path=str(tmp_path / "conversations.db")),
         transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
         spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
         poll_seconds=0.01,
@@ -111,6 +118,8 @@ def _capturing_worker(tmp_path: Path, claude_code_executor):
     worker = Worker(
         api_base="http://api",
         session_store=store,
+        # Isolate the conversation DB (default resolves to prod data/conversations.db).
+        conversation_store=ConversationStore(db_path=str(tmp_path / "conversations.db")),
         transcript_store=transcripts,
         spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
         poll_seconds=0.01,
@@ -335,8 +344,6 @@ def test_fresh_spawn_with_no_prior_spawn_event_still_executes(tmp_path: Path):
 # =============================================================================
 # Web-thread result mirroring (#311)
 # =============================================================================
-
-from api.services.conversation_store import ConversationStore
 
 
 def _mirroring_worker(tmp_path: Path, claude_code_executor):

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -344,6 +344,52 @@ def test_child_session_does_not_mirror(tmp_path: Path):
     assert mirror_calls == []
 
 
+def test_raising_conversation_mirror_does_not_abort_run(tmp_path: Path):
+    """#311 (review): a conversation_mirror that raises (e.g. a transient DB
+    lock) must NOT kill the assistant-event loop — the session still completes,
+    later bodies still stream to Telegram, and the terminal result is produced.
+    Mirrors the existing guard around the Telegram notification callback."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] First update."}]},
+        },
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] Second update."}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.02, "result": "All done."},
+    ]
+    notifications: list[str] = []
+
+    def _boom(_sid, _body):
+        raise RuntimeError("mirror sink exploded")
+
+    db_path = tmp_path / "sessions.db"
+    store = SessionStore(db_path=db_path)
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    executor = ClaudeCodeExecutor(
+        session_store=store,
+        transcript_store=transcripts,
+        notification_callback=lambda msg: notifications.append(msg),
+        conversation_mirror=_boom,
+        spawn_fn=_spawn_with(events),
+        binary_resolver=lambda: "/usr/bin/true",
+        timeout_seconds=30,
+        heartbeat_interval=3600,
+    )
+    session = _seed_session(store)
+
+    outcome = executor.execute(session, {"description": "do the thing"})
+
+    # The raising mirror was swallowed: the run reached its terminal result...
+    assert outcome.status == STATUS_COMPLETED
+    assert outcome.final_text == "All done."
+    # ...and BOTH notifies still streamed to Telegram (the loop never aborted).
+    assert notifications == ["First update.", "Second update."]
+
+
 def test_build_command_uses_session_model_tier(tmp_path: Path):
     """A child seeded with claude_code_model='haiku' runs the CLI with
     --model haiku; the default (None) falls back to opus (#349)."""

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -101,17 +101,27 @@ def _spawn_with(events, returncode: int = 0, stderr: str = ""):
     return _spawn_fn
 
 
-def _build_executor(tmp_path: Path, *, spawn_fn, notifications: list[str] | None = None):
+def _build_executor(
+    tmp_path: Path,
+    *,
+    spawn_fn,
+    notifications: list[str] | None = None,
+    mirror_calls: list[tuple[str, str]] | None = None,
+):
     db_path = tmp_path / "sessions.db"
     transcript_dir = tmp_path / "transcripts"
     store = SessionStore(db_path=db_path)
     transcripts = TranscriptStore(transcripts_dir=transcript_dir)
 
     notify = (lambda msg: notifications.append(msg)) if notifications is not None else None
+    # #311: a fake (session_id, body) sink so a test can assert the executor
+    # mirrors each streamed [NOTIFY]/[CLARIFY]/[GOAL] into the web thread.
+    mirror = (lambda sid, body: mirror_calls.append((sid, body))) if mirror_calls is not None else None
     executor = ClaudeCodeExecutor(
         session_store=store,
         transcript_store=transcripts,
         notification_callback=notify,
+        conversation_mirror=mirror,
         spawn_fn=spawn_fn,
         binary_resolver=lambda: "/usr/bin/true",
         timeout_seconds=30,
@@ -266,6 +276,72 @@ def test_child_notify_not_streamed_and_folded_into_final_text(tmp_path: Path):
     assert completed
     persisted = completed[0]["payload"]["final_text"]
     assert "Match 1: A vs B." in persisted and "Match 2: C vs D." in persisted
+
+
+def test_conversation_mirror_invoked_for_each_streamed_body(tmp_path: Path):
+    """#311: when a conversation_mirror is wired, the executor calls it with
+    (session_id, body) for each streamed [NOTIFY]/[CLARIFY]/[GOAL] — the same
+    bodies it relays to Telegram — so the web thread mirrors live progress."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] Reading the file."}]},
+        },
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[CLARIFY] Which repo?"}]},
+        },
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[GOAL] Tests pass."}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.05, "result": ""},
+    ]
+    notifications: list[str] = []
+    mirror_calls: list[tuple[str, str]] = []
+    executor, store, _ = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events),
+        notifications=notifications, mirror_calls=mirror_calls,
+    )
+    session = _seed_session(store)
+
+    executor.execute(session, {"description": "do the thing"})
+
+    # Every streamed body is mirrored with the session id, in order, matching
+    # exactly what Telegram received.
+    assert mirror_calls == [
+        (session.session_id, "Reading the file."),
+        (session.session_id, "Which repo?"),
+        (session.session_id, "Tests pass."),
+    ]
+    assert [b for _, b in mirror_calls] == notifications
+
+
+def test_child_session_does_not_mirror(tmp_path: Path):
+    """#311: a child session stays silent to the operator, and its [NOTIFY]
+    bodies are folded into final_text — so they must NOT be mirrored to a web
+    thread either (parity with the no-Telegram gate)."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] child progress"}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": ""},
+    ]
+    notifications: list[str] = []
+    mirror_calls: list[tuple[str, str]] = []
+    executor, store, _ = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events),
+        notifications=notifications, mirror_calls=mirror_calls,
+    )
+    session = _seed_child_session(store)
+
+    executor.execute(session, {"description": "list matches"})
+
+    assert notifications == []
+    assert mirror_calls == []
 
 
 def test_build_command_uses_session_model_tier(tmp_path: Path):

--- a/tests/test_agent_worker_codex_dispatch.py
+++ b/tests/test_agent_worker_codex_dispatch.py
@@ -259,3 +259,40 @@ def test_codex_failure_mirrors_notice_into_linked_conversation(tmp_path: Path):
 
     msgs = conv_store.get_messages(conv.id)
     assert any(m.role == "assistant" and "failed" in m.content.lower() for m in msgs)
+
+
+def test_codex_child_completion_does_not_mirror(tmp_path: Path):
+    """A codex child (has a parent — codex is in SPAWN_MODELS, so it IS
+    dispatchable as a child) must not mirror its result into a conversation,
+    even one linked to the child. Parity with the claude_code child gate."""
+    stub = _StubCodexExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="child codex result")
+    )
+    worker, conv_store = _mirroring_codex_worker(tmp_path, codex_executor=stub)
+    parent = worker.session_store.create(task_id="cx-parent", routing="local")
+    child = worker.session_store.create(
+        task_id="cx-child", routing="codex", parent_session_id=parent.session_id,
+    )
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, child.session_id)
+
+    worker._dispatch_codex_session(child, [{"content": "do it"}])
+
+    assert conv_store.get_messages(conv.id) == []
+
+
+def test_codex_child_failure_does_not_mirror(tmp_path: Path):
+    """A codex child's failure/budget notice must not mirror into a linked
+    conversation either (parity with the claude_code failure gate)."""
+    stub = _StubCodexExecutor(outcome=ExecutorOutcome(status=STATUS_FAILED, reason="boom"))
+    worker, conv_store = _mirroring_codex_worker(tmp_path, codex_executor=stub)
+    parent = worker.session_store.create(task_id="cx-parent-2", routing="local")
+    child = worker.session_store.create(
+        task_id="cx-child-2", routing="codex", parent_session_id=parent.session_id,
+    )
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, child.session_id)
+
+    worker._dispatch_codex_session(child, [{"content": "do it"}])
+
+    assert conv_store.get_messages(conv.id) == []

--- a/tests/test_agent_worker_codex_dispatch.py
+++ b/tests/test_agent_worker_codex_dispatch.py
@@ -189,3 +189,72 @@ def test_codex_failed_finalizes_session_row(tmp_path: Path):
     assert stub.calls == [("cx-fail", "do a thing")]
     assert worker.session_store.get("cx-fail").status == STATUS_FAILED
     assert any("failed" in s.lower() for s in plain_sends)
+
+
+# ---------------------------------------------------------------------------
+# Web-thread result mirroring (#311). Codex has no rich [NOTIFY] stream, so the
+# terminal completion/failure mirror is the whole web round-trip for it.
+# ---------------------------------------------------------------------------
+
+from api.services.conversation_store import ConversationStore
+
+
+def _mirroring_codex_worker(tmp_path: Path, codex_executor):
+    conv_store = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+    worker = Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        conversation_store=conv_store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: True,
+        telegram_send_with_id=lambda text: [777],
+        http_client=client,
+        codex_executor=codex_executor,
+    )
+    return worker, conv_store
+
+
+def test_codex_completion_mirrors_into_linked_conversation(tmp_path: Path):
+    stub = _StubCodexExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="Done: 3 events.")
+    )
+    worker, conv_store = _mirroring_codex_worker(tmp_path, codex_executor=stub)
+    session = worker.session_store.create(task_id="cx-web", routing="codex", origin="operator")
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, session.session_id)
+
+    worker._dispatch_codex_session(session, [{"content": "events?"}])
+
+    msgs = conv_store.get_messages(conv.id)
+    assert any(m.role == "assistant" and "Done: 3 events." in m.content for m in msgs)
+
+
+def test_codex_completion_does_not_mirror_when_unlinked(tmp_path: Path):
+    """AC2: a Telegram-origin codex session is unlinked → no conversation write."""
+    stub = _StubCodexExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="Done.")
+    )
+    worker, conv_store = _mirroring_codex_worker(tmp_path, codex_executor=stub)
+    session = worker.session_store.create(task_id="cx-tg", routing="codex", origin="operator")
+    conv = conv_store.create_conversation(title="Some other thread")  # not linked
+
+    worker._dispatch_codex_session(session, [{"content": "events?"}])
+
+    assert conv_store.get_messages(conv.id) == []
+
+
+def test_codex_failure_mirrors_notice_into_linked_conversation(tmp_path: Path):
+    stub = _StubCodexExecutor(outcome=ExecutorOutcome(status=STATUS_FAILED, reason="boom"))
+    worker, conv_store = _mirroring_codex_worker(tmp_path, codex_executor=stub)
+    session = worker.session_store.create(task_id="cx-web-fail", routing="codex", origin="operator")
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, session.session_id)
+
+    worker._dispatch_codex_session(session, [{"content": "do it"}])
+
+    msgs = conv_store.get_messages(conv.id)
+    assert any(m.role == "assistant" and "failed" in m.content.lower() for m in msgs)

--- a/tests/test_agent_worker_codex_dispatch.py
+++ b/tests/test_agent_worker_codex_dispatch.py
@@ -24,6 +24,7 @@ from api.services.agent_worker.session_store import (
 from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
 from api.services.agent_worker.worker import Worker
+from api.services.conversation_store import ConversationStore
 
 
 pytestmark = pytest.mark.unit
@@ -55,6 +56,8 @@ def _make_worker(tmp_path: Path, codex_executor, *, plain_sends, withid_sends):
     return Worker(
         api_base="http://api",
         session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        # Isolate the conversation DB (default resolves to prod data/conversations.db).
+        conversation_store=ConversationStore(db_path=str(tmp_path / "conversations.db")),
         transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
         spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
         poll_seconds=0.01,
@@ -195,8 +198,6 @@ def test_codex_failed_finalizes_session_row(tmp_path: Path):
 # Web-thread result mirroring (#311). Codex has no rich [NOTIFY] stream, so the
 # terminal completion/failure mirror is the whole web round-trip for it.
 # ---------------------------------------------------------------------------
-
-from api.services.conversation_store import ConversationStore
 
 
 def _mirroring_codex_worker(tmp_path: Path, codex_executor):

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -772,3 +772,38 @@ class TestConversationWorkflow:
 
         messages2_after = store.get_messages(conv2.id)
         assert len(messages2_after) == 2
+
+
+# =============================================================================
+# Agent-session reverse lookup (#311)
+# =============================================================================
+
+class TestAgentSessionReverseLookup:
+    """get_conversation_id_by_agent_session_id — the worker resolves a spawned
+    session back to the web/voice conversation that started it, so it can mirror
+    the result into that thread."""
+
+    def test_returns_linked_conversation_id(self, store):
+        conv = store.create_conversation(title="Web thread")
+        store.set_agent_session_id(conv.id, "sess-abc")
+
+        assert store.get_conversation_id_by_agent_session_id("sess-abc") == conv.id
+
+    def test_returns_none_when_no_conversation_linked(self, store):
+        # A Telegram-origin session is never linked to a conversation, so the
+        # reverse lookup must return None — this is what keeps the mirror a
+        # no-op for Telegram-origin handoffs (AC2).
+        store.create_conversation(title="Unlinked")
+        assert store.get_conversation_id_by_agent_session_id("sess-telegram") is None
+
+    def test_returns_none_for_empty_session_id(self, store):
+        assert store.get_conversation_id_by_agent_session_id("") is None
+
+    def test_resolves_only_the_matching_conversation(self, store):
+        conv1 = store.create_conversation(title="One")
+        conv2 = store.create_conversation(title="Two")
+        store.set_agent_session_id(conv1.id, "sess-1")
+        store.set_agent_session_id(conv2.id, "sess-2")
+
+        assert store.get_conversation_id_by_agent_session_id("sess-1") == conv1.id
+        assert store.get_conversation_id_by_agent_session_id("sess-2") == conv2.id

--- a/tests/test_conversations_api.py
+++ b/tests/test_conversations_api.py
@@ -611,3 +611,55 @@ class TestPendingQuestionSurfacing:
             response = client.get("/api/conversations/conv-123")
         assert response.status_code == 200
         assert response.json()["pending_question"] is None
+        # No linked session → not active, so the client's result poll won't run.
+        assert response.json()["agent_session_active"] is False
+
+
+@pytest.mark.unit
+class TestAgentSessionActive:
+    """GET /api/conversations/{id} reports whether the spawned session is still
+    running (#311) so the client's result-streaming poll can terminate."""
+
+    def _linked_conversation(self):
+        now = datetime.now()
+        return Conversation(
+            id="conv-403", title="Doctor", created_at=now, updated_at=now,
+            message_count=1, persona_id="doctor", agent_session_id="sess_abc",
+        )
+
+    def _get(self, client, mock_store, fake_session_store):
+        mock_store.get_conversation.return_value = self._linked_conversation()
+        mock_store.get_messages.return_value = []
+        with patch("api.routes.conversations.get_store", return_value=mock_store), \
+             patch("api.services.agent_worker.session_store.SessionStore",
+                   return_value=fake_session_store):
+            return client.get("/api/conversations/conv-403")
+
+    def test_active_when_session_running(self, client, mock_store):
+        """A linked session with a non-terminal status reports active=True."""
+        fake_session_store = MagicMock()
+        fake_session_store.get_open_question_by_session_id.return_value = None
+        fake_session_store.get_by_session_id.return_value = MagicMock(status="running")
+        response = self._get(client, mock_store, fake_session_store)
+        assert response.status_code == 200
+        assert response.json()["agent_session_active"] is True
+
+    def test_inactive_when_session_terminal(self, client, mock_store):
+        """A linked session that reached a terminal status reports active=False
+        so the client stops polling."""
+        fake_session_store = MagicMock()
+        fake_session_store.get_open_question_by_session_id.return_value = None
+        fake_session_store.get_by_session_id.return_value = MagicMock(status="completed")
+        response = self._get(client, mock_store, fake_session_store)
+        assert response.status_code == 200
+        assert response.json()["agent_session_active"] is False
+
+    def test_inactive_when_session_row_missing(self, client, mock_store):
+        """A linked session id with no row (never created / pruned) is treated
+        as not-active — the client must not poll forever for a ghost."""
+        fake_session_store = MagicMock()
+        fake_session_store.get_open_question_by_session_id.return_value = None
+        fake_session_store.get_by_session_id.return_value = None
+        response = self._get(client, mock_store, fake_session_store)
+        assert response.status_code == 200
+        assert response.json()["agent_session_active"] is False

--- a/tests/test_pending_question_ui_browser.py
+++ b/tests/test_pending_question_ui_browser.py
@@ -224,7 +224,9 @@ class TestPendingQuestionUI:
     def test_poll_stops_when_session_terminal_and_no_question(self, page: Page):
         """#311: once the spawned session reaches a terminal status AND no
         question is pending, the client stops the 4s poll instead of running
-        forever. Asserted via the detail-GET count plateauing."""
+        forever. The stop needs TWO consecutive terminal polls (race guard), so
+        this allows a couple of cycles before asserting the detail-GET count
+        plateaus."""
         self._open_conversation(page)
         # A question is pending, so the poll is running and the card is shown.
         expect(page.locator("#pendingQuestionCard")).to_be_visible(timeout=8000)
@@ -234,11 +236,11 @@ class TestPendingQuestionUI:
         self.state["awaiting"] = False
         self.state["agent_session_active"] = False
 
-        # Wait for the poll that observes the terminal status (which stops the
-        # loop), then record the GET count and confirm it no longer grows.
+        # The card clears on the first terminal poll; the loop stops on the
+        # second. Wait past two full intervals so the stop has definitely fired,
+        # then snapshot the GET count and confirm it no longer grows.
         expect(page.locator("#pendingQuestionCard")).to_have_count(0, timeout=8000)
-        # Let any in-flight poll settle, then snapshot the count.
-        page.wait_for_timeout(POLL_INTERVAL_MS_PLUS)
+        page.wait_for_timeout(POLL_INTERVAL_MS_PLUS * 2)
         settled = self.state.get("detail_get_count", 0)
         # Across two more full intervals the count must not increase — the loop
         # is stopped, not merely idle for one tick.
@@ -246,3 +248,52 @@ class TestPendingQuestionUI:
         assert self.state.get("detail_get_count", 0) == settled, (
             "detail GET fired after the session went terminal — poll did not stop"
         )
+
+    def test_terminal_poll_before_result_is_stored_still_renders_result(self, page: Page):
+        """#311 (race guard): the executor flips the session row terminal BEFORE
+        the dispatch handler writes the result mirror, so a poll can see
+        agent_session_active=false with the result not yet in the GET. A single
+        terminal poll must NOT stop — the next poll, once the mirrored result has
+        landed, must render it and only THEN stop. (For the codex handoff path
+        this mirror is the only web output, so a premature stop = lost result.)"""
+        self._open_conversation(page)
+        expect(page.locator("#pendingQuestionCard")).to_be_visible(timeout=8000)
+
+        # Simulate the race window: the session is reported terminal (status
+        # already flipped) and the question is resolved, but the result mirror
+        # has NOT been written to the conversation yet.
+        self.state["awaiting"] = False
+        self.state["agent_session_active"] = False
+
+        # The card clears on the first terminal poll, but the result isn't here.
+        expect(page.locator("#pendingQuestionCard")).to_have_count(0, timeout=8000)
+        expect(page.locator("#messages")).not_to_contain_text("Opened PR #5")
+        # Record the GET count: if the single terminal poll wrongly stopped the
+        # loop, the count will not advance and the result below never renders.
+        count_after_first_terminal = self.state.get("detail_get_count", 0)
+
+        # The mirror lands (the dispatch handler finally wrote the result).
+        self.state["messages"].append({
+            "id": "m3", "role": "assistant",
+            "content": "All done — Opened PR #5.",
+            "created_at": "2026-06-25T10:05:00", "sources": None, "routing": None,
+        })
+
+        # The poll did NOT stop after one terminal observation, so a subsequent
+        # poll fires, renders the late result exactly once, and only then stops.
+        result = page.locator("#messages .message.assistant", has_text="Opened PR #5")
+        expect(result).to_have_count(1, timeout=8000)
+        assert self.state.get("detail_get_count", 0) > count_after_first_terminal, (
+            "no further poll fired after the first terminal poll — the loop "
+            "stopped before the mirrored result was stored (the race bug)"
+        )
+
+        # And now (two consecutive terminal polls observed) the loop stops and
+        # does not duplicate the result.
+        page.wait_for_timeout(POLL_INTERVAL_MS_PLUS * 2)
+        settled = self.state.get("detail_get_count", 0)
+        page.wait_for_timeout(POLL_INTERVAL_MS_PLUS * 2)
+        assert self.state.get("detail_get_count", 0) == settled, (
+            "poll did not stop after the result was rendered + two terminal polls"
+        )
+        expect(result).to_have_count(1)

--- a/tests/test_pending_question_ui_browser.py
+++ b/tests/test_pending_question_ui_browser.py
@@ -34,6 +34,10 @@ CHAT_URL = BASE_URL.rstrip("/") + "/chat"
 CONV_ID = "conv_doctor_1"
 SESSION_ID = "sess_doctor_1"
 
+# The client polls every 4s; wait a touch past one full interval to be sure a
+# second poll fired (so the dedup guard is actually exercised).
+POLL_WAIT_FOR_DEDUP_MS = 4500
+
 
 def _install_conversation_mocks(page: Page, state: dict):
     """Single dispatcher for /api/conversations/* calls, driven by `state`.
@@ -70,13 +74,10 @@ def _install_conversation_mocks(page: Page, state: dict):
                 "title": "Knee pain follow-up",
                 "created_at": "2026-06-25T10:00:00",
                 "updated_at": "2026-06-25T10:01:00",
-                "messages": [
-                    {"id": "m1", "role": "user", "content": "my knee hurts after runs",
-                     "created_at": "2026-06-25T10:00:00", "sources": None, "routing": None},
-                    {"id": "m2", "role": "assistant",
-                     "content": "\U0001fa7a On it — running as a Claude Code session.",
-                     "created_at": "2026-06-25T10:00:05", "sources": None, "routing": None},
-                ],
+                # `state["messages"]` is mutable so a test can simulate a
+                # late-arriving message (the worker mirroring the spawned
+                # session's result, #311) landing in a later poll.
+                "messages": list(state["messages"]),
                 "pending_question": None,
             }
             if state["awaiting"]:
@@ -109,6 +110,13 @@ class TestPendingQuestionUI:
             "question": "Is the goal to draft a PT plan, or just log the symptom?",
             "kind": "goal_approval",
             "answers": [],
+            "messages": [
+                {"id": "m1", "role": "user", "content": "my knee hurts after runs",
+                 "created_at": "2026-06-25T10:00:00", "sources": None, "routing": None},
+                {"id": "m2", "role": "assistant",
+                 "content": "\U0001fa7a On it — running as a Claude Code session.",
+                 "created_at": "2026-06-25T10:00:05", "sources": None, "routing": None},
+            ],
         }
         _install_conversation_mocks(page, self.state)
         page.goto(CHAT_URL)
@@ -170,3 +178,34 @@ class TestPendingQuestionUI:
         self._open_conversation(page)
         page.wait_for_timeout(500)
         expect(page.locator("#pendingQuestionCard")).to_have_count(0)
+
+    def test_late_mirrored_message_renders_once(self, page: Page):
+        """#311: a message that appears in a LATER poll (the worker mirroring the
+        spawned session's result into the thread) is rendered into #messages and
+        is NOT duplicated on subsequent polls.
+
+        Opening with an outstanding question starts the same 4s poll the result
+        rides on. The first poll seeds the seen-set from m1+m2 (already on
+        screen); a later m3 (the mirrored result) is the only id the dedup hasn't
+        seen, so it renders exactly once."""
+        self._open_conversation(page)
+        expect(page.locator("#pendingQuestionCard")).to_be_visible(timeout=8000)
+        # The seeded messages are on screen, but the late result is not yet.
+        expect(page.locator("#messages")).not_to_contain_text("Opened PR #5")
+
+        # The worker mirrors the result: a new assistant message lands in the GET
+        # (and the question resolves, as it would when the session finishes).
+        self.state["messages"].append({
+            "id": "m3", "role": "assistant",
+            "content": "All done — Opened PR #5.",
+            "created_at": "2026-06-25T10:05:00", "sources": None, "routing": None,
+        })
+        self.state["awaiting"] = False
+
+        # The next poll renders it into the thread exactly once.
+        result = page.locator("#messages .message.assistant",
+                              has_text="Opened PR #5")
+        expect(result).to_have_count(1, timeout=8000)
+        # Subsequent polls must NOT duplicate it (dedup by message id).
+        page.wait_for_timeout(POLL_WAIT_FOR_DEDUP_MS)
+        expect(result).to_have_count(1)

--- a/tests/test_pending_question_ui_browser.py
+++ b/tests/test_pending_question_ui_browser.py
@@ -37,6 +37,9 @@ SESSION_ID = "sess_doctor_1"
 # The client polls every 4s; wait a touch past one full interval to be sure a
 # second poll fired (so the dedup guard is actually exercised).
 POLL_WAIT_FOR_DEDUP_MS = 4500
+# A touch past one 4s poll interval — long enough that a still-running loop
+# would have fired at least once more in the window.
+POLL_INTERVAL_MS_PLUS = 4500
 
 
 def _install_conversation_mocks(page: Page, state: dict):
@@ -69,6 +72,9 @@ def _install_conversation_mocks(page: Page, state: dict):
         # GET /{id} detail (a segment after conversations/)
         m = re.search(r"/conversations/([^/]+)$", path)
         if m and m.group(1) != "conversations":
+            # Count detail polls so a test can assert the loop stopped (the count
+            # plateaus once the client stops polling).
+            state["detail_get_count"] = state.get("detail_get_count", 0) + 1
             detail = {
                 "id": CONV_ID,
                 "title": "Knee pain follow-up",
@@ -79,6 +85,11 @@ def _install_conversation_mocks(page: Page, state: dict):
                 # session's result, #311) landing in a later poll.
                 "messages": list(state["messages"]),
                 "pending_question": None,
+                # #311: whether the spawned session is still running. The client
+                # stops polling once this is False AND no question is pending.
+                # Defaults to active so a test that never sets it keeps the
+                # historical "poll runs" behavior.
+                "agent_session_active": state.get("agent_session_active", True),
             }
             if state["awaiting"]:
                 detail["pending_question"] = {
@@ -209,3 +220,29 @@ class TestPendingQuestionUI:
         # Subsequent polls must NOT duplicate it (dedup by message id).
         page.wait_for_timeout(POLL_WAIT_FOR_DEDUP_MS)
         expect(result).to_have_count(1)
+
+    def test_poll_stops_when_session_terminal_and_no_question(self, page: Page):
+        """#311: once the spawned session reaches a terminal status AND no
+        question is pending, the client stops the 4s poll instead of running
+        forever. Asserted via the detail-GET count plateauing."""
+        self._open_conversation(page)
+        # A question is pending, so the poll is running and the card is shown.
+        expect(page.locator("#pendingQuestionCard")).to_be_visible(timeout=8000)
+
+        # The session finishes: the question resolves and the server now reports
+        # the linked session as terminal (not active).
+        self.state["awaiting"] = False
+        self.state["agent_session_active"] = False
+
+        # Wait for the poll that observes the terminal status (which stops the
+        # loop), then record the GET count and confirm it no longer grows.
+        expect(page.locator("#pendingQuestionCard")).to_have_count(0, timeout=8000)
+        # Let any in-flight poll settle, then snapshot the count.
+        page.wait_for_timeout(POLL_INTERVAL_MS_PLUS)
+        settled = self.state.get("detail_get_count", 0)
+        # Across two more full intervals the count must not increase — the loop
+        # is stopped, not merely idle for one tick.
+        page.wait_for_timeout(POLL_INTERVAL_MS_PLUS * 2)
+        assert self.state.get("detail_get_count", 0) == settled, (
+            "detail GET fired after the session went terminal — poll did not stop"
+        )

--- a/web/chat/ask-stream.js
+++ b/web/chat/ask-stream.js
@@ -164,26 +164,37 @@ export async function sendMessage() {
             const label = engine === 'codex' ? 'Codex' : 'Claude Code';
             fullContent = '🤝 Handing off to ' + label + '…';
             updateMessage(msgId, fullContent);
+            // Pin the conversation this handoff targets BEFORE the in-flight
+            // POST: the server links the spawned session to exactly this
+            // conversation, so the post-await poll must target it too. Reading
+            // state.currentConversationId again inside the `.then()` would poll
+            // the wrong thread if the user navigated mid-POST.
+            const handoffConversationId = state.currentConversationId;
             fetch(endpoints.handoff, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({
                 engine: engine,
                 task: data.task || '',
-                conversation_id: state.currentConversationId,
+                conversation_id: handoffConversationId,
               }),
             }).then(r => r.json()).then(d => {
               fullContent = (d && d.message)
                 ? d.message
                 : '⚠️ Handoff to ' + label + ' failed.';
               updateMessage(msgId, fullContent);
-              // #311: the handoff linked the spawned session to this
-              // conversation server-side, so poll for the session's streamed
-              // progress + terminal result and render them into this thread
-              // (parity with the orchestrating-persona path below). Only on a
+              // #311: the handoff linked the spawned session to the conversation
+              // it targeted server-side, so poll THAT conversation for the
+              // session's streamed progress + terminal result and render them
+              // into the thread (parity with the orchestrating-persona path
+              // below). The seen-message seed in startPendingQuestionPolling
+              // assumes the handoff ack message is already persisted server-side
+              // (chat_handoff writes it synchronously before returning) when the
+              // first poll fires — if ack persistence ever becomes async, the
+              // seed must be revisited or the ack would render twice. Only on a
               // successful spawn with a conversation to land results in.
-              if (d && d.ok && state.currentConversationId) {
-                startPendingQuestionPolling(state.currentConversationId);
+              if (d && d.ok && handoffConversationId) {
+                startPendingQuestionPolling(handoffConversationId);
               }
             }).catch(() => {
               fullContent = '⚠️ Handoff to ' + label + ' failed.';

--- a/web/chat/ask-stream.js
+++ b/web/chat/ask-stream.js
@@ -177,6 +177,14 @@ export async function sendMessage() {
                 ? d.message
                 : '⚠️ Handoff to ' + label + ' failed.';
               updateMessage(msgId, fullContent);
+              // #311: the handoff linked the spawned session to this
+              // conversation server-side, so poll for the session's streamed
+              // progress + terminal result and render them into this thread
+              // (parity with the orchestrating-persona path below). Only on a
+              // successful spawn with a conversation to land results in.
+              if (d && d.ok && state.currentConversationId) {
+                startPendingQuestionPolling(state.currentConversationId);
+              }
             }).catch(() => {
               fullContent = '⚠️ Handoff to ' + label + ' failed.';
               updateMessage(msgId, fullContent);

--- a/web/chat/pending-question.js
+++ b/web/chat/pending-question.js
@@ -34,6 +34,18 @@ let pollingConversationId = null;
 let seenMessageIds = new Set();
 let seededSeenSet = false;
 
+// #311: count consecutive polls that report the spawned session terminal AND
+// have no pending question. We require TWO in a row before stopping, to close a
+// race: the executor flips the session row to a terminal status BEFORE the
+// dispatch handler writes the terminal-result mirror into the conversation (the
+// mirror lands ~1s later, after a Telegram send). A single terminal poll could
+// land in that window — session done, result not stored yet — and stop before
+// the result renders. Demanding a second consecutive terminal poll guarantees
+// ≥1 full ~4s cycle after the status flip, by which point the mirror is stored
+// and renderNewMessages (which runs before the stop check) has rendered it. Any
+// active poll or a pending question resets the counter.
+let terminalPollCount = 0;
+
 function answerEndpoint(conversationId) {
   return `${endpoints.conversations}/${encodeURIComponent(conversationId)}/answer`;
 }
@@ -56,6 +68,7 @@ export function startPendingQuestionPolling(conversationId) {
   // render only newly-arrived ones.
   seenMessageIds = new Set();
   seededSeenSet = false;
+  terminalPollCount = 0;
   // Poll once immediately so a re-opened thread shows the affordance without
   // waiting a full interval, then on a cadence.
   pollOnce();
@@ -71,6 +84,7 @@ export function stopPendingQuestionPolling() {
   // #311: drop the dedup state so the next polled conversation seeds fresh.
   seenMessageIds = new Set();
   seededSeenSet = false;
+  terminalPollCount = 0;
 }
 
 async function pollOnce() {
@@ -105,21 +119,33 @@ async function pollOnce() {
   const pq = data && data.pending_question;
   if (pq && pq.question) {
     renderAffordance(conversationId, pq);
+    // A live question means the session isn't done with us — reset the
+    // terminal-stop counter so a later resolution starts the two-poll countdown
+    // fresh.
+    terminalPollCount = 0;
   } else {
     // No (longer a) pending question — the session resolved or hasn't asked
     // yet. Drop any stale card but keep polling so the next [CLARIFY]/[GOAL]
     // (a session can ask more than once) still surfaces.
     clearAffordance();
     // #311: terminate the poll once the spawned session is done AND nothing is
-    // awaiting an answer. Without this the 4s loop runs forever after the
-    // session completes. `agent_session_active === false` is the server's
-    // signal that the linked session reached a terminal status (or there's no
-    // linked session); the `!pq` guard above means we never stop while a
-    // [CLARIFY]/[GOAL] is still pending. We require an explicit `=== false` so
-    // an older server that omits the field (undefined) keeps the prior
-    // run-forever behavior rather than stopping prematurely.
+    // awaiting an answer — but only after TWO consecutive terminal polls, to
+    // avoid stopping inside the status-flip→mirror-write race (see
+    // terminalPollCount above). `agent_session_active === false` is the
+    // server's signal that the linked session reached a terminal status (or
+    // there's no linked session). We require an explicit `=== false` so an
+    // older server that omits the field (undefined) keeps the prior
+    // run-forever behavior rather than stopping prematurely; that same `!==
+    // false` (active OR field-absent) resets the counter. renderNewMessages
+    // above already ran this poll, so a result that landed since the status
+    // flip is rendered on the second terminal poll BEFORE we stop here.
     if (data && data.agent_session_active === false) {
-      stopPendingQuestionPolling();
+      terminalPollCount += 1;
+      if (terminalPollCount >= 2) {
+        stopPendingQuestionPolling();
+      }
+    } else {
+      terminalPollCount = 0;
     }
   }
 }

--- a/web/chat/pending-question.js
+++ b/web/chat/pending-question.js
@@ -25,6 +25,15 @@ const CARD_ID = 'pendingQuestionCard';
 let pollTimer = null;
 let pollingConversationId = null;
 
+// #311: ids of conversation messages already on screen, so a late-arriving
+// message (the spawned session's streamed [NOTIFY] or terminal result) is
+// rendered exactly once. Seeded on the FIRST poll from the messages already in
+// the thread (those were rendered by askStream / loadConversation, not by us),
+// then every subsequent poll appends only messages whose id is new. Reset on
+// stop so a re-opened/other conversation starts clean.
+let seenMessageIds = new Set();
+let seededSeenSet = false;
+
 function answerEndpoint(conversationId) {
   return `${endpoints.conversations}/${encodeURIComponent(conversationId)}/answer`;
 }
@@ -42,6 +51,11 @@ export function startPendingQuestionPolling(conversationId) {
   if (pollTimer && pollingConversationId === conversationId) return;
   stopPendingQuestionPolling();
   pollingConversationId = conversationId;
+  // #311: the first poll seeds the seen-message set from whatever is already in
+  // the thread (so we don't re-render existing messages); subsequent polls
+  // render only newly-arrived ones.
+  seenMessageIds = new Set();
+  seededSeenSet = false;
   // Poll once immediately so a re-opened thread shows the affordance without
   // waiting a full interval, then on a cadence.
   pollOnce();
@@ -54,6 +68,9 @@ export function stopPendingQuestionPolling() {
     pollTimer = null;
   }
   pollingConversationId = null;
+  // #311: drop the dedup state so the next polled conversation seeds fresh.
+  seenMessageIds = new Set();
+  seededSeenSet = false;
 }
 
 async function pollOnce() {
@@ -78,6 +95,13 @@ async function pollOnce() {
   // A late response can arrive after the user navigated away; ignore it.
   if (state.currentConversationId !== conversationId) return;
 
+  // #311: render messages that arrived since the thread was last rendered —
+  // the spawned session's streamed [NOTIFY]/[GOAL] and its terminal result,
+  // written into the conversation by the worker out-of-band. The first poll
+  // only SEEDS the seen-set (those messages are already on screen, rendered by
+  // askStream/loadConversation); later polls append only ids we haven't seen.
+  renderNewMessages(data && data.messages);
+
   const pq = data && data.pending_question;
   if (pq && pq.question) {
     renderAffordance(conversationId, pq);
@@ -86,6 +110,36 @@ async function pollOnce() {
     // yet. Drop any stale card but keep polling so the next [CLARIFY]/[GOAL]
     // (a session can ask more than once) still surfaces.
     clearAffordance();
+  }
+}
+
+// #311: append conversation messages that aren't on screen yet, deduped by id.
+// On the first poll we only record ids (seed) without rendering — those came
+// from the initial thread render. Afterward, any id we haven't recorded is a
+// late arrival from the worker, so we render it and record it. Idempotent: a
+// re-poll of the same messages adds nothing (every id is already seen), so
+// there's no duplication and no extra polling loop — this reuses the 4s poll.
+function renderNewMessages(messages) {
+  if (!Array.isArray(messages)) return;
+
+  if (!seededSeenSet) {
+    for (const m of messages) {
+      if (m && m.id) seenMessageIds.add(m.id);
+    }
+    seededSeenSet = true;
+    return;
+  }
+
+  for (const m of messages) {
+    if (!m || !m.id || seenMessageIds.has(m.id)) continue;
+    seenMessageIds.add(m.id);
+    // Only render assistant output. The worker mirrors its progress/result as
+    // assistant messages; user messages here are the operator's own answer
+    // (POST /answer records it server-side), which submitAnswer already echoed
+    // into the thread with addMessage(answer, 'user') and has no client-side id
+    // to dedup against — so rendering it would duplicate. Skip user roles.
+    if (m.role !== 'assistant') continue;
+    addMessage(m.content, m.role, m.sources || []);
   }
 }
 

--- a/web/chat/pending-question.js
+++ b/web/chat/pending-question.js
@@ -110,6 +110,17 @@ async function pollOnce() {
     // yet. Drop any stale card but keep polling so the next [CLARIFY]/[GOAL]
     // (a session can ask more than once) still surfaces.
     clearAffordance();
+    // #311: terminate the poll once the spawned session is done AND nothing is
+    // awaiting an answer. Without this the 4s loop runs forever after the
+    // session completes. `agent_session_active === false` is the server's
+    // signal that the linked session reached a terminal status (or there's no
+    // linked session); the `!pq` guard above means we never stop while a
+    // [CLARIFY]/[GOAL] is still pending. We require an explicit `=== false` so
+    // an older server that omits the field (undefined) keeps the prior
+    // run-forever behavior rather than stopping prematurely.
+    if (data && data.agent_session_active === false) {
+      stopPendingQuestionPolling();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Closes **#311**. Completes the web/voice ↔ Telegram parity: a web-spawned agent session's progress + result now appear in the same `/chat` conversation thread, not only Telegram + `/agents`. Builds directly on the #409/#412 infra (the `conversations.agent_session_id` link + the existing 4s pending-question poll).

**Mechanism (additive — the Telegram/notify path is byte-identical):**
- `conversation_store.get_conversation_id_by_agent_session_id()` — the reverse of #409's link.
- Worker `_mirror_to_conversation(session_id, text)` — writes operator output into the linked conversation as an assistant message; **no-op when the session isn't linked** (every Telegram-origin session), which is what keeps AC2.
- **Incremental `[NOTIFY]` streaming** via an *additive* `conversation_mirror(session_id, body)` callback on `ClaudeCodeExecutor` (the existing `notification_callback` signature is unchanged; session_id is passed per-call, so it's concurrency-safe across the CLI thread pool). Terminal result/failure are mirrored at the dispatch handlers (covers codex too).
- `/api/chat/handoff` now links the spawned session to the conversation, so codex/claude handoffs mirror via the same path; the client starts the existing poll after a handoff.
- Client renders late-arriving assistant messages from the existing poll (dedup by message id — no new poll loop).

## Test evidence (nathan-linux, isolated worktree)
- Full unit suite: **2246 passed, 8 skipped**.
- Targeted dispatch/store/executor: **116 passed**.
- Browser (`test_pending_question_ui_browser.py`, incl. a new render-once-no-duplicate test): **6 passed**; prod :8000 healthy before/after.

## Review focus
- **AC2** — confirm the mirror is a strict no-op for unlinked (Telegram-origin) sessions and the Telegram send text is unchanged.
- **Client dedup** — the `seenMessageIds` seeding (first poll seeds from already-rendered messages; only assistant roles render; the user answer-echo isn't double-rendered).
- **Concurrency** — session_id passed per-call, no shared mutable state.
- **Test hygiene** — the dispatch test helpers now construct a default `ConversationStore()` (prod db path); read-only no-op there, but worth deciding whether the helpers should inject a temp-db store.