### PR TITLE
test: isolate Telegram state file from production (#357)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,6 +259,27 @@ def _isolate_vault_indexer_stores(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_telegram_state_file(tmp_path, monkeypatch):
+    """Keep tests off the production Telegram offset file (#357).
+
+    ``TelegramBotListener._STATE_FILE`` defaults to the process-global relative
+    path ``data/telegram_state.json``. Any listener built without patching it —
+    notably the ones ``api.main``'s lifespan starts for a real ``TestClient``
+    app — reads and (via ``_save_last_update_id``) writes that shared file, which
+    is the suspected source of the order-dependent flake in
+    ``test_primary_uses_legacy_state_file``. Redirect the legacy/primary state
+    file to a per-test tmp path so no test touches or leaks the shared default;
+    the telegram tests that patch ``_STATE_FILE`` themselves simply nest over
+    this. Mirrors ``_isolate_vault_indexer_stores`` above.
+    """
+    from api.services.telegram import TelegramBotListener
+
+    monkeypatch.setattr(
+        TelegramBotListener, "_STATE_FILE", tmp_path / "telegram_state.json"
+    )
+
+
+@pytest.fixture(autouse=True)
 def _isolate_conversation_store_db(tmp_path, monkeypatch):
     """Stop tests from opening (and migrating) the production conversations DB.
 


### PR DESCRIPTION
## Summary
Closes **#357**. Adds an autouse fixture that redirects `TelegramBotListener._STATE_FILE` to a per-test tmp path, so no test relies on or leaks the process-global default `data/telegram_state.json`. Mirrors the existing `_isolate_vault_indexer_stores` / `_isolate_conversation_store_db` autouse fixtures.

## Reproduction note (transparency)
I could **not** reproduce the original intermittent failure across many real-mode (`-n auto --dist loadscope`) runs (6 real-mode + 1 sequential + 3 forced-order, all green). Both of the test's asserts are **deterministic** — an explicit `primary` config makes `_is_primary` true, and its own `patch.object(_STATE_FILE, state)` makes `_state_file == state` — so the failure is a cross-module isolation leak, not the test's logic.

The most likely leak is reliance on the shared default state-file path: any listener built without patching `_STATE_FILE` (e.g. the ones `api.main`'s lifespan starts for a real `TestClient`) reads and (via `_save_last_update_id`) writes the real `data/telegram_state.json`. This PR removes that gap.

**Honest scope:** AC #2 ("no reliance on process-global/default state-file paths") is fully met. AC #1 ("deterministic across repeated/randomized runs") is *supported* by 10/10 green real-mode runs on the branch, but since the rare flake never reproduced, I can't prove it's eliminated — this hardens the established cause rather than fixing a reproduced failure.

## Test evidence
10/10 real-mode full-suite runs green on the branch (2252 passed, 8 skipped each). No test asserts the default `_STATE_FILE` value; telegram tests that patch it themselves nest over the fixture.

## Review focus
The autouse fixture affects all tests — confirm it can't alter telegram-test behavior (those that patch `_STATE_FILE` nest fine; named-bot tests use the else-branch path) and that `monkeypatch` restores cleanly.