### PR TITLE
feat(server): verify-deployed guard so the doctor can't falsely report 'Shipped'

### DIFF
--- a/config/personas/doctor.md
+++ b/config/personas/doctor.md
@@ -33,7 +33,7 @@ First **file the work as GitHub issue(s)** via `/draft-issue` (capture the numbe
 
 **Supervise; don't hand-code.** You decompose the goal and review; **subagents do the implementation** (each `/implement` run is itself a supervised implementer with its own adversarial review). Keep sub-tasks bounded — a single supervised `/implement` run can exceed the headless background-wait ceiling, so size the pieces or drive `/implement` runs sequentially rather than spawning one giant waited subagent.
 
-**After the final merge to `main`:** bring the canonical checkout to the merged code before restarting — `git -C ~/Code/LifeOS checkout main && git -C ~/Code/LifeOS pull` — then clean up any remaining worktree/branch, then restart (see Restarting below).
+**After the final merge to `main`:** bring the canonical checkout to the merged code — `git -C ~/Code/LifeOS checkout main && git -C ~/Code/LifeOS pull` — then **verify the deploy actually landed** before anything else: `./scripts/server.sh verify-deployed` (checks the checkout is a real work tree whose HEAD matches `origin/main`; pass an explicit `<merged-sha>` to pin it). If it exits non-zero, the pull silently failed (e.g. a bare/misconfigured checkout) and the running code is **still the old version** — do **not** report "Shipped". Instead `[NOTIFY]` the failure with the rollback handle (e.g. `⚠️ Merged #<n> but the server is still on <old-sha> — deploy failed: <reason>. Code is NOT live; needs a manual pull/fix. Revert with: gh pr revert <n>`) and stop. Only once it passes: clean up any remaining worktree/branch, then restart (see Restarting below).
 
 **Confirm with the rollback handle:** `[NOTIFY] Shipped: PR #<n> merged to main, server restarted. Issue #<i> closed. Revert with: gh pr revert <n>`
 

--- a/docs/guides/doctor-bot.md
+++ b/docs/guides/doctor-bot.md
@@ -1,7 +1,7 @@
 # Doctor Bot — Self-Repair Surface
 
 **Status:** Complete
-**Last Updated:** 2026-06-25
+**Last Updated:** 2026-06-26
 **Audience:** Operator
 
 The **doctor** bot's only job is fixing LifeOS itself. You message it when you notice LifeOS misbehaving or missing something; it converses with you to define the **goal**, locks that goal, then — on your approval — orchestrates the work end to end and reports back. It is a **goal-first orchestrator**: it supervises the implementation (subagents do the coding via `/implement`) rather than hand-coding inline, and every change lands through a reviewed, tested PR — never a direct push to `main`.
@@ -46,7 +46,7 @@ This is the operator's-eye summary; the exact contract the session runs lives in
 - **Always PR-gated, always revertable.** Even the smallest fix goes branch → PR → `main` with tests + docs + review; the doctor never pushes to `main`, and each change lands as a single revertable merge commit whose `gh pr revert` handle it reports.
 - **Escalation respected.** If `/implement` can't resolve its review findings after its rounds, the doctor leaves the PR open and reports the escalation instead of merging.
 - **Isolation.** Implementation happens in throwaway worktrees off `origin/main` (pre-flight-cleaned via `scripts/cleanup-worktrees.sh` so a prior crashed run can't block the `add`), so the canonical checkout other agents share is never left on a feature branch.
-- **Pick-up after merge.** The doctor pulls merged `main` into the canonical checkout before restarting, so the running server actually reflects the change.
+- **Pick-up after merge.** The doctor pulls merged `main` into the canonical checkout, then runs `./scripts/server.sh verify-deployed` to confirm the checkout is a real work tree on the merged commit **before** restarting — so a silently-failed pull (e.g. a bare/misconfigured checkout) is reported as a deploy failure instead of a false "Shipped" (#419). Only on success does it restart, so the running server actually reflects the change.
 - **Safe self-restart.** The doctor runs *inside* `lifeos-agent-worker`. It uses `./scripts/server.sh classify-change` to tell an API-only change (plain `lifeos-api` restart; its session survives) from an agent-worker change (which would kill it mid-run). For the latter it uses `./scripts/server.sh restart-worker-detached`, which flushes the final notice and marks the restart deliberate **before** bouncing the worker in a detached process — so the "Shipped" notice always lands and the run isn't surfaced as a spurious failure.
 
 ## Adding another orchestration bot

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -2,7 +2,7 @@
 # LifeOS Server Management Script
 # Designed for reliable server management from Claude or command line
 #
-# Usage: ./scripts/server.sh [start|stop|restart|status|wait|preflight|classify-change|restart-worker-detached]
+# Usage: ./scripts/server.sh [start|stop|restart|status|wait|preflight|classify-change|verify-deployed|restart-worker-detached]
 #
 # Commands:
 #   start                    - Kill any existing processes, start server, wait for health check
@@ -12,6 +12,7 @@
 #   wait                     - Wait for server to be healthy (use after manual start)
 #   preflight                - Check prerequisites before first start
 #   classify-change          - Print whether a diff needs a worker or api-only restart (#401)
+#   verify-deployed          - Exit 0 only if the checkout is a real work tree on the expected SHA (#419)
 #   restart-worker-detached  - Detached restart of lifeos-agent-worker for the doctor (#401)
 #
 # Expected startup time: 30-60 seconds (loading sentence-transformers model)
@@ -323,6 +324,46 @@ classify_change() {
     fi
 }
 
+# verify-deployed [<expected-sha>] — confirm the canonical checkout actually
+# advanced to the merged code and is a real work tree (#419).
+#
+# The doctor's deploy step pulls main then restarts; a silent pull failure — most
+# notably a bare/misconfigured checkout (core.bare=true makes `git pull`/`checkout`
+# error out as a no-op) — otherwise lets it report "Shipped" while the OLD code is
+# still running. This is the guard: prints "deployed: <head>" and exits 0 only when
+# PROJECT_DIR is a real work tree AND its HEAD matches <expected-sha> (or origin/main
+# when no arg is given). On any mismatch it prints "not-deployed: <reason>" to stderr
+# and exits 1, so the doctor reports a deploy failure instead of a false success.
+verify_deployed() {
+    local expected="${1:-}"
+    # A bare repo (core.bare=true) or non-work-tree can't pull/checkout, so a
+    # "successful" deploy there never changed the code on disk.
+    if [ "$(git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree 2>/dev/null)" != "true" ]; then
+        echo "not-deployed: $PROJECT_DIR is not a work tree (core.bare?) — pull/checkout cannot apply" >&2
+        return 1
+    fi
+    local head
+    if ! head=$(git -C "$PROJECT_DIR" rev-parse HEAD 2>/dev/null); then
+        echo "not-deployed: cannot read HEAD of $PROJECT_DIR" >&2
+        return 1
+    fi
+    if [ -z "$expected" ]; then
+        if ! expected=$(git -C "$PROJECT_DIR" rev-parse origin/main 2>/dev/null); then
+            echo "not-deployed: cannot resolve origin/main (fetch first)" >&2
+            return 1
+        fi
+    fi
+    # Accept an abbreviated <expected-sha> (prefix match), the way git does.
+    case "$head" in
+        "$expected"*)
+            echo "deployed: HEAD=$head"
+            return 0 ;;
+        *)
+            echo "not-deployed: HEAD=$head != expected=$expected — deploy did NOT take effect" >&2
+            return 1 ;;
+    esac
+}
+
 # restart-worker-detached [--session ID] [--notify TEXT] [--bot NAME]
 #
 # Restart lifeos-agent-worker such that any pending final notice is delivered
@@ -434,6 +475,9 @@ case "${1:-status}" in
     classify-change)
         classify_change "${2:-}"
         ;;
+    verify-deployed)
+        verify_deployed "${2:-}"
+        ;;
     restart-worker-detached)
         shift
         restart_worker_detached "$@"
@@ -441,7 +485,7 @@ case "${1:-status}" in
     *)
         echo "LifeOS Server Management"
         echo ""
-        echo "Usage: $0 {start|stop|restart|status|wait [timeout]|foreground|preflight|classify-change [range]|restart-worker-detached [opts]}"
+        echo "Usage: $0 {start|stop|restart|status|wait [timeout]|foreground|preflight|classify-change [range]|verify-deployed [sha]|restart-worker-detached [opts]}"
         echo ""
         echo "Commands:"
         echo "  start                    - Start server (kills existing, waits for healthy)"
@@ -453,6 +497,8 @@ case "${1:-status}" in
         echo "  preflight                - Check prerequisites before first start"
         echo "  classify-change [range]  - Print 'worker' or 'api': which restart a diff needs"
         echo "                             (default range HEAD~1..HEAD; e.g. 'main..HEAD')"
+        echo "  verify-deployed [sha]    - Exit 0 only if the checkout is a real work tree on"
+        echo "                             <sha> (default origin/main); else exit 1 (#419)"
         echo "  restart-worker-detached  - Detached restart of $WORKER_UNIT for the doctor"
         echo "                             [--session ID] [--notify TEXT] [--bot NAME]"
         echo ""

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -336,6 +336,13 @@ classify_change() {
 # and exits 1, so the doctor reports a deploy failure instead of a false success.
 verify_deployed() {
     local expected="${1:-}"
+    # Reject an ambiguously-short explicit sha: a 1-2 char prefix could match an
+    # unrelated HEAD and yield a false "deployed". Require full or git-abbrev
+    # (>=7 chars); omit the arg to compare against origin/main instead.
+    if [ -n "$expected" ] && [ "${#expected}" -lt 7 ]; then
+        echo "verify-deployed: expected sha '$expected' is too short to be unambiguous (need >=7 chars, or omit to use origin/main)" >&2
+        return 2
+    fi
     # A bare repo (core.bare=true) or non-work-tree can't pull/checkout, so a
     # "successful" deploy there never changed the code on disk.
     if [ "$(git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree 2>/dev/null)" != "true" ]; then

--- a/tests/test_agent_worker_self_restart.py
+++ b/tests/test_agent_worker_self_restart.py
@@ -367,3 +367,63 @@ def test_server_sh_known_subcommands_still_parse(tmp_path: Path):
     assert usage.returncode == 1
     assert "restart-worker-detached" in usage.stdout
     assert "classify-change" in usage.stdout
+    assert "verify-deployed" in usage.stdout
+
+
+@pytest.mark.unit
+def test_verify_deployed_checks_worktree_and_head(tmp_path: Path):
+    """verify-deployed (#419) exits 0 only when the checkout is a real work tree
+    whose HEAD matches the expected sha (or origin/main); else exits 1. This is
+    the doctor's guard against reporting "Shipped" after a silently-failed pull
+    (e.g. a bare/misconfigured checkout)."""
+    if not SERVER_SH.exists():
+        pytest.skip("server.sh not present")
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "server.sh").write_text(SERVER_SH.read_text(), encoding="utf-8")
+
+    def _git(*args):
+        subprocess.run(["git", *args], cwd=repo, check=True,
+                       capture_output=True, text=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@t.t")
+    _git("config", "user.name", "t")
+    (repo / "f.txt").write_text("base\n")
+    _git("add", "-A")
+    _git("commit", "-qm", "base")
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                          capture_output=True, text=True).stdout.strip()
+
+    def _verify(*extra):
+        return subprocess.run(
+            ["bash", str(scripts / "server.sh"), "verify-deployed", *extra],
+            cwd=repo, capture_output=True, text=True, timeout=30,
+        )
+
+    # exact full sha → deployed, exit 0
+    r = _verify(head)
+    assert r.returncode == 0, r.stderr
+    assert "deployed" in r.stdout
+
+    # abbreviated sha (prefix match, like git) → deployed, exit 0
+    assert _verify(head[:8]).returncode == 0
+
+    # wrong sha → not-deployed, exit 1
+    r = _verify("0" * 40)
+    assert r.returncode == 1
+    assert "not-deployed" in r.stderr
+
+    # bare repo (core.bare=true) can't pull/checkout → not a work tree → exit 1
+    _git("config", "core.bare", "true")
+    r = _verify(head)
+    assert r.returncode == 1
+    assert "work tree" in r.stderr
+    _git("config", "core.bare", "false")
+
+    # no arg → compares HEAD against origin/main; point origin/main at HEAD → deployed
+    _git("update-ref", "refs/remotes/origin/main", head)
+    r = _verify()
+    assert r.returncode == 0, r.stderr
+    assert "deployed" in r.stdout

--- a/tests/test_agent_worker_self_restart.py
+++ b/tests/test_agent_worker_self_restart.py
@@ -415,6 +415,16 @@ def test_verify_deployed_checks_worktree_and_head(tmp_path: Path):
     assert r.returncode == 1
     assert "not-deployed" in r.stderr
 
+    # ambiguously-short explicit sha → rejected (non-zero), never a false match
+    r = _verify("5")
+    assert r.returncode != 0
+    assert "too short" in r.stderr
+
+    # no arg + no origin/main yet → cannot resolve → exit 1 (the "fetch first" branch)
+    r = _verify()
+    assert r.returncode == 1
+    assert "origin/main" in r.stderr
+
     # bare repo (core.bare=true) can't pull/checkout → not a work tree → exit 1
     _git("config", "core.bare", "true")
     r = _verify(head)

--- a/tests/test_doctor_bot.py
+++ b/tests/test_doctor_bot.py
@@ -66,7 +66,7 @@ class TestDoctorRegistry:
         for needle in (
             "/draft-issue", "/implement", "worktree", "[clarify]", "[notify]", "restart",
             "[goal]", "integration branch", "cleanup-worktrees.sh",
-            "restart-worker-detached", "--base",
+            "restart-worker-detached", "--base", "verify-deployed",
         ):
             assert needle in text, f"doctor persona missing '{needle}'"
 


### PR DESCRIPTION
## Summary
Closes **#419**. The goal-first doctor pulls `main` then restarts and reports "Shipped" — but never verified the pull landed. A silent pull failure (notably a bare/misconfigured checkout: `core.bare=true` makes `git pull`/`checkout` a no-op error — hit in practice this past session) let it claim success while the **old code kept running**.

- `scripts/server.sh`: new `verify-deployed [<sha>]` — exits 0 only if `PROJECT_DIR` is a real work tree (not bare) whose HEAD matches `<sha>` (or `origin/main` when omitted); else prints `not-deployed: <reason>` to stderr and exits 1.
- `config/personas/doctor.md`: after the post-merge pull, run `verify-deployed` **before** "Shipped"; on failure `[NOTIFY]` a deploy failure (naming the stuck SHA + reason) and stop.
- `docs/guides/doctor-bot.md`: document it in the pick-up-after-merge step.

The issue's optional secondary item (a "prod is N commits behind `origin/main`" health signal) is **deferred** to keep this focused on the high-value guard.

## Test evidence
Targeted: **40 passed** (`test_agent_worker_self_restart.py` + `test_doctor_bot.py`), incl. the new `test_verify_deployed_checks_worktree_and_head` (deployed / abbreviated-sha / wrong-sha / **bare-repo** / no-arg-vs-origin-main) and a persona-contract needle so the verification can't silently regress. Full unit suite running. Local smoke: `verify-deployed <HEAD>` → exit 0; wrong sha → exit 1.

## Review focus
The `verify_deployed` bash function (abbreviated-sha prefix match; the `is-inside-work-tree` / bare-repo guard; no-arg origin/main fallback) and that the doctor.md wiring makes "Shipped" strictly conditional on a passing verify.