### PR TITLE
fix(agent-worker): route a spawned child's [CLARIFY] to its parent, not the operator

### DIFF
--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -652,9 +652,25 @@ class ClaudeCodeExecutor:
                 if scan.narrative.strip():
                     state.final_text = scan.narrative.strip()
                 for body in scan.clarify:
-                    state.pending_clarification = body
                     state.notifications_sent += 1
                     state.last_notify_at = time.time()
+                    if state.is_child:
+                        # #356: a spawned child must not pause on an operator reply.
+                        # The operator owns no thread to a child, and a BLOCKED child
+                        # would strand its yielded parent (which only resumes once
+                        # every child is terminal). So fold the question into the
+                        # child's output — prefixed so the parent recognizes it as a
+                        # request, like [NOTIFY] folding (#349) — and let the turn
+                        # complete. The PARENT, which owns the operator conversation,
+                        # reads it on resume and decides (answer via a re-spawn,
+                        # relay to the operator, or proceed). Crucially DON'T set
+                        # pending_clarification: no BLOCKED outcome, no operator notify.
+                        state.notify_bodies.append(f"[needs clarification] {body}")
+                        self.transcript_store.append(sid, "claude_code_child_clarify_folded", {
+                            "body": body, "body_chars": len(body),
+                        })
+                        continue
+                    state.pending_clarification = body
                     try:
                         self._notify(body)
                     except Exception as exc:  # pragma: no cover — defensive

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -278,6 +278,51 @@ def test_child_notify_not_streamed_and_folded_into_final_text(tmp_path: Path):
     assert "Match 1: A vs B." in persisted and "Match 2: C vs D." in persisted
 
 
+def test_child_clarify_folds_into_final_text_and_does_not_block(tmp_path: Path):
+    """#356: a spawned child's [CLARIFY] must NOT message the operator and must
+    NOT go BLOCKED (which would strand the yielded parent — it only resumes once
+    every child is terminal). The question is folded into final_text, prefixed
+    [needs clarification], so the parent reads it on resume and decides; the
+    child's turn completes normally."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[CLARIFY] Use API v1 or v2?"}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.05, "result": ""},
+    ]
+    notifications: list[str] = []
+    mirror_calls: list[tuple[str, str]] = []
+    executor, store, transcripts = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events),
+        notifications=notifications, mirror_calls=mirror_calls,
+    )
+    session = _seed_child_session(store)
+
+    outcome = executor.execute(session, {"description": "wire the API call"})
+
+    # Completes (not BLOCKED) so the parent isn't stranded.
+    assert outcome.status == STATUS_COMPLETED
+    # Nothing streamed to the operator — neither Telegram nor the web thread.
+    assert notifications == []
+    assert mirror_calls == []
+    # The question is folded into the text the parent reads, marked as a request.
+    assert "[needs clarification] Use API v1 or v2?" in outcome.final_text
+    # Audit trail: the folded-clarify event, and NOT the operator-facing clarify.
+    kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
+    assert "claude_code_child_clarify_folded" in kinds
+    assert "claude_code_clarify" not in kinds
+    # The completion persists the folded text so the parent reads it via
+    # _child_final_text (the child never streamed it anywhere).
+    completed = [
+        e for e in _read_transcript(transcripts, session.session_id)
+        if e["kind"] == "claude_code_completed"
+    ]
+    assert completed
+    assert "[needs clarification] Use API v1 or v2?" in completed[0]["payload"]["final_text"]
+
+
 def test_conversation_mirror_invoked_for_each_streamed_body(tmp_path: Path):
     """#311: when a conversation_mirror is wired, the executor calls it with
     (session_id, body) for each streamed [NOTIFY]/[CLARIFY]/[GOAL] — the same


### PR DESCRIPTION
## Summary
Closes **#356**. A spawned `claude_code` child that emitted `[CLARIFY]` (a) streamed the question to the **operator** (executor's clarify loop was ungated, unlike `[NOTIFY]`/`[GOAL]`) and (b) went **BLOCKED** with a `pending_question` against the child — which **permanently stranded its yielded parent** (a parent only resumes once every child is terminal, and BLOCKED isn't terminal).

**Fix (executor-only, surgical):** for a child, fold the `[CLARIFY]` question into the child's output (`notify_bodies`, prefixed `[needs clarification]`, mirroring the #349 `[NOTIFY]` folding) and **don't** set `pending_clarification` — so no operator notify and no BLOCKED outcome. The child completes; the parent (which owns the operator conversation) reads the question on resume via `_child_final_text` and decides. Operator `/claude` and vault `#claude` clarifications are **unchanged** (the non-child branch is byte-identical).

## Scope decision (please weigh in)
This removes the leak + the strand and routes the question to the parent. The child **completes** rather than literally resuming its paused session — the parent re-engages (re-spawn with the answer / relay / proceed). True mid-flight **same-session** child resume is a larger inter-agent protocol change: a yielded parent only resumes on *terminal* children, and `inter_agent.send` rejects *terminal* targets, so resuming a paused child mid-flight would require extending the yield/resume model. I judged that out of scope for the bug fix and worth a separate issue if the in-flight-resume capability is wanted. **Is this proportionate, or do you want the fuller protocol change?**

## Test evidence
Targeted (executor + dispatch + inter_agent): **89 passed**, incl. the new `test_child_clarify_folds_into_final_text_and_does_not_block` and the existing `test_clarify_returns_blocked_with_question` (non-child path, unchanged — AC #3). Full unit suite running.

## Review focus
- Does the child path correctly **not** notify (Telegram + web mirror), **not** BLOCK, and fold the question into `final_text` so `_child_final_text` surfaces it to the parent?
- Is the non-child path byte-identical (AC #3)?
- **The scope decision above** — is "child completes, parent re-engages" an acceptable read of AC #2 ("the child can resume once answered"), or is the fuller same-session-resume protocol needed?