### PR TITLE
fix(agent-worker): operator kill terminates the local CLI subprocess promptly

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -859,36 +859,44 @@ async def operator_kill_session(session_id: str, body: KillRequest | None = None
     try:
         from api.services.agent_worker.inter_agent import teardown_session as _teardown
 
-        killed: list[str] = []
-        failures: list[dict[str, str]] = []
-        for idx, s in enumerate(subtree):
-            if s.status in TERMINAL_STATUSES:
-                continue
-            if idx == 0:
-                kind = "operator_killed"
-                payload = {
-                    "reason": reason,
-                    "managed_remote": s.managed_agent_session_id,
-                }
-            else:
-                kind = "cascade_killed"
-                payload = {
-                    "root": target.session_id,
-                    "reason": reason,
-                    "managed_remote": s.managed_agent_session_id,
-                }
-            result = _teardown(
-                session_store, transcript_store, s,
-                transcript_kind=kind,
-                transcript_payload=payload,
-                managed_driver=driver,
-            )
-            killed.append(s.session_id)
-            if result.get("managed_failure"):
-                failures.append({
-                    "session_id": s.session_id,
-                    "reason": result["managed_failure"],
-                })
+        def _run_teardown() -> tuple[list[str], list[dict[str, str]]]:
+            # #379: the per-CLI-child subprocess reap inside teardown_session does
+            # a blocking SIGTERM→grace(up to ~2s)→SIGKILL. Run the whole subtree
+            # teardown off the event loop (mirror spawn_agent's asyncio.to_thread)
+            # so a multi-node kill can't stall all HTTP for N×grace seconds.
+            killed: list[str] = []
+            failures: list[dict[str, str]] = []
+            for idx, s in enumerate(subtree):
+                if s.status in TERMINAL_STATUSES:
+                    continue
+                if idx == 0:
+                    kind = "operator_killed"
+                    payload = {
+                        "reason": reason,
+                        "managed_remote": s.managed_agent_session_id,
+                    }
+                else:
+                    kind = "cascade_killed"
+                    payload = {
+                        "root": target.session_id,
+                        "reason": reason,
+                        "managed_remote": s.managed_agent_session_id,
+                    }
+                result = _teardown(
+                    session_store, transcript_store, s,
+                    transcript_kind=kind,
+                    transcript_payload=payload,
+                    managed_driver=driver,
+                )
+                killed.append(s.session_id)
+                if result.get("managed_failure"):
+                    failures.append({
+                        "session_id": s.session_id,
+                        "reason": result["managed_failure"],
+                    })
+            return killed, failures
+
+        killed, failures = await asyncio.to_thread(_run_teardown)
         return {"killed": killed, "failures": failures}
     finally:
         if driver is not None:

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -216,6 +216,10 @@ REASON_AWAITING_CLARIFICATION = "awaiting_clarification"
 REASON_AWAITING_GOAL_APPROVAL = "awaiting_goal_approval"
 REASON_TIMEOUT = "timeout"
 REASON_BINARY_NOT_FOUND = "binary_not_found"
+# #379: the operator kill endpoint flips the session row to FAILED and signals
+# our subprocess. When `proc.wait()` returns after such a kill, we exit silently
+# under this reason so the worker doesn't fire a spurious "session failed" notice.
+REASON_KILLED = "killed"
 
 
 @dataclass
@@ -466,6 +470,10 @@ class ClaudeCodeExecutor:
                 cwd=working_dir,
                 text=True,
                 env=self._clean_env(),
+                # #379: own session/process-group leader so the operator kill can
+                # `os.killpg(pgid, ...)` the CLI + every child it spawns WITHOUT
+                # touching this worker process (which shares the worker's group).
+                start_new_session=True,
             )
         except FileNotFoundError as exc:
             self.transcript_store.append(sid, "claude_code_binary_not_found", {"error": str(exc)})
@@ -478,6 +486,17 @@ class ClaudeCodeExecutor:
         # RUNNING for the duration of the subprocess so an /agents-page
         # observer sees the correct status.
         self.session_store.update_status(session.task_id, STATUS_RUNNING)
+
+        # #379: record the subprocess PID + process-group id so the operator
+        # kill endpoint (a separate process) can signal it. `start_new_session`
+        # makes pid==pgid, but resolve the pgid explicitly so the teardown can
+        # `killpg` the whole group. Separate from the `claude_code_spawn` marker
+        # above, which is the #400 crash-guard written *before* the Popen.
+        try:
+            pgid = os.getpgid(proc.pid)
+        except Exception:  # pragma: no cover — defensive; fall back to the pid
+            pgid = proc.pid
+        self.transcript_store.append(sid, "claude_code_pid", {"pid": proc.pid, "pgid": pgid})
 
         state = _RunState(plan_mode=plan_mode, is_child=bool(session.parent_session_id))
         timed_out = threading.Event()
@@ -509,6 +528,18 @@ class ClaudeCodeExecutor:
         finally:
             watchdog.cancel()
             stop_heartbeat.set()
+
+        # #379: the kill endpoint flips status to FAILED and signals our
+        # subprocess. If the row is already FAILED, the operator killed us
+        # mid-run — exit silently (REASON_KILLED) so the worker doesn't fire a
+        # spurious "session failed" notice (the killpg'd subprocess returns a
+        # negative returncode, which would otherwise fall through to the FAILED
+        # path below). Only the operator kill can flip the row to FAILED while we
+        # run — the executor itself set RUNNING just after the spawn.
+        current = self.session_store.get(session.task_id)
+        if current is not None and current.status == STATUS_FAILED:
+            self.transcript_store.append(sid, "claude_code_killed", {"returncode": proc.returncode})
+            return ExecutorOutcome(status=STATUS_FAILED, reason=REASON_KILLED)
 
         if timed_out.is_set():
             self.session_store.update_status(session.task_id, STATUS_FAILED)

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -530,14 +530,22 @@ class ClaudeCodeExecutor:
             stop_heartbeat.set()
 
         # #379: the kill endpoint flips status to FAILED and signals our
-        # subprocess. If the row is already FAILED, the operator killed us
-        # mid-run — exit silently (REASON_KILLED) so the worker doesn't fire a
-        # spurious "session failed" notice (the killpg'd subprocess returns a
-        # negative returncode, which would otherwise fall through to the FAILED
-        # path below). Only the operator kill can flip the row to FAILED while we
-        # run — the executor itself set RUNNING just after the spawn.
+        # subprocess. If the row is already FAILED *and the subprocess did not
+        # exit cleanly*, treat it as an operator kill — exit silently
+        # (REASON_KILLED) so the worker doesn't fire a spurious "session failed"
+        # notice (the killpg'd subprocess returns a negative returncode, which
+        # would otherwise fall through to the FAILED path below).
+        #
+        # The row can be flipped to FAILED mid-run by two legitimate writers: the
+        # operator kill (signals the subprocess → non-zero/negative returncode)
+        # and `LocalExecutor._cascade_kill_lineage` on a lineage-budget breach
+        # (routing-agnostic — it flips non-terminal CLI descendants too). The
+        # returncode gate keeps these from clobbering a clean completion: a
+        # subprocess that exited 0 *finished its work* and falls through to the
+        # COMPLETED path so its final_text is persisted (a parent reads it via
+        # _child_final_text), even if a cascade raced the FAILED flip in.
         current = self.session_store.get(session.task_id)
-        if current is not None and current.status == STATUS_FAILED:
+        if current is not None and current.status == STATUS_FAILED and proc.returncode != 0:
             self.transcript_store.append(sid, "claude_code_killed", {"returncode": proc.returncode})
             return ExecutorOutcome(status=STATUS_FAILED, reason=REASON_KILLED)
 
@@ -814,6 +822,12 @@ class ClaudeCodeExecutor:
 
     @staticmethod
     def _on_timeout(proc, timed_out: threading.Event) -> None:
+        # MUST NOT write a terminal status to the session row. The #379 kill-guard
+        # (in execute(), after proc.wait()) keys on the row being FAILED to detect
+        # an operator kill; a timed-out session must still be RUNNING when the
+        # guard checks so the timeout path — not REASON_KILLED — claims it. This
+        # only sets the timed_out flag and terminates the OS process; execute()
+        # owns the row transition.
         timed_out.set()
         if proc.poll() is None:
             try:

--- a/api/services/agent_worker/codex_executor.py
+++ b/api/services/agent_worker/codex_executor.py
@@ -372,13 +372,20 @@ class CodexExecutor:
         self._cleanup_tempfile(last_msg_path)
 
         # #379: operator-kill silent guard (parity with ClaudeCodeExecutor). If
-        # the row is already FAILED, the operator killed us mid-run — exit
-        # silently so the worker skips the spurious "session failed" notice (the
-        # killpg'd subprocess returns a negative returncode that would otherwise
-        # hit the FAILED path below). Only the operator kill can flip the row to
-        # FAILED while we run — the executor itself set RUNNING just after spawn.
+        # the row is already FAILED *and the subprocess did not exit cleanly*, the
+        # operator killed us mid-run — exit silently so the worker skips the
+        # spurious "session failed" notice (the killpg'd subprocess returns a
+        # negative returncode that would otherwise hit the FAILED path below).
+        #
+        # Two legitimate writers flip the row FAILED mid-run: the operator kill
+        # (signals the subprocess → non-zero/negative returncode) and
+        # `LocalExecutor._cascade_kill_lineage` on a lineage-budget breach
+        # (routing-agnostic — it flips non-terminal CLI descendants too). The
+        # returncode gate keeps a clean completion (returncode 0 → work finished)
+        # from being mis-tagged REASON_KILLED if a cascade races the FAILED flip:
+        # it falls through to the COMPLETED path below.
         current = self.session_store.get(session.task_id)
-        if current is not None and current.status == STATUS_FAILED:
+        if current is not None and current.status == STATUS_FAILED and proc.returncode != 0:
             self.transcript_store.append(sid, "codex_killed", {"returncode": proc.returncode})
             return ExecutorOutcome(status=STATUS_FAILED, reason=REASON_KILLED)
 
@@ -521,6 +528,12 @@ class CodexExecutor:
 
     @staticmethod
     def _on_timeout(proc, timed_out: threading.Event) -> None:
+        # MUST NOT write a terminal status to the session row. The #379 kill-guard
+        # (in execute(), after proc.wait()) keys on the row being FAILED to detect
+        # an operator kill; a timed-out session must still be RUNNING when the
+        # guard checks so the timeout path — not REASON_KILLED — claims it. This
+        # only sets the timed_out flag and terminates the OS process; execute()
+        # owns the row transition.
         timed_out.set()
         if proc.poll() is None:
             try:

--- a/api/services/agent_worker/codex_executor.py
+++ b/api/services/agent_worker/codex_executor.py
@@ -104,6 +104,10 @@ def _delegation_header(session_id: str) -> str:
 # Reason codes returned in ``ExecutorOutcome.reason``.
 REASON_TIMEOUT = "timeout"
 REASON_BINARY_NOT_FOUND = "binary_not_found"
+# #379: parity with ClaudeCodeExecutor — an operator kill flips the row to
+# FAILED and signals this subprocess; we exit silently under this reason so the
+# worker skips the spurious "session failed" notice.
+REASON_KILLED = "killed"
 
 
 @dataclass
@@ -311,6 +315,10 @@ class CodexExecutor:
                 cwd=working_dir,
                 text=True,
                 env=self._clean_env(),
+                # #379: own process-group leader so the operator kill can
+                # `os.killpg(pgid, ...)` codex + its children without touching
+                # the worker process. Mirrors ClaudeCodeExecutor.
+                start_new_session=True,
             )
         except FileNotFoundError as exc:
             self.transcript_store.append(sid, "codex_binary_not_found", {"error": str(exc)})
@@ -318,6 +326,15 @@ class CodexExecutor:
             return ExecutorOutcome(status=STATUS_FAILED, reason=REASON_BINARY_NOT_FOUND)
 
         self.session_store.update_status(session.task_id, STATUS_RUNNING)
+
+        # #379: record the subprocess pid + pgid so the operator kill endpoint
+        # (a separate process) can signal it via the transcript. Mirrors the
+        # claude_code path; teardown scans for `codex_pid` too.
+        try:
+            pgid = os.getpgid(proc.pid)
+        except Exception:  # pragma: no cover — defensive; fall back to the pid
+            pgid = proc.pid
+        self.transcript_store.append(sid, "codex_pid", {"pid": proc.pid, "pgid": pgid})
 
         state = _RunState()
         timed_out = threading.Event()
@@ -353,6 +370,17 @@ class CodexExecutor:
             except OSError:
                 pass
         self._cleanup_tempfile(last_msg_path)
+
+        # #379: operator-kill silent guard (parity with ClaudeCodeExecutor). If
+        # the row is already FAILED, the operator killed us mid-run — exit
+        # silently so the worker skips the spurious "session failed" notice (the
+        # killpg'd subprocess returns a negative returncode that would otherwise
+        # hit the FAILED path below). Only the operator kill can flip the row to
+        # FAILED while we run — the executor itself set RUNNING just after spawn.
+        current = self.session_store.get(session.task_id)
+        if current is not None and current.status == STATUS_FAILED:
+            self.transcript_store.append(sid, "codex_killed", {"returncode": proc.returncode})
+            return ExecutorOutcome(status=STATUS_FAILED, reason=REASON_KILLED)
 
         if timed_out.is_set():
             self.session_store.update_status(session.task_id, STATUS_FAILED)

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -28,6 +28,9 @@ Security model: no-sandbox per AGENTS.md. The MCP-side wrapping passes
 from __future__ import annotations
 
 import logging
+import os
+import signal
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -471,6 +474,85 @@ def yield_until(ctx: InterAgentContext, args: dict) -> dict:
     return _ok({"yielded": True, "waiting_on": children})
 
 
+# How long to wait between a SIGTERM and the follow-up SIGKILL when reaping a
+# local CLI subprocess (#379) — a brief grace for the process to exit cleanly.
+_LOCAL_KILL_GRACE_S = 2.0
+_LOCAL_KILL_POLL_S = 0.1
+
+
+def _kill_local_subprocess(
+    transcript_store: TranscriptStore, target: Session,
+) -> None:
+    """Best-effort terminate the local CLI subprocess owned by a LOCAL session.
+
+    The `claude_code` / `codex` executors run a `subprocess.Popen` in the
+    *worker* process and record its pid/process-group id via a `claude_code_pid`
+    / `codex_pid` transcript event (the subprocess is its own session leader via
+    `start_new_session=True`). The operator kill runs in the *API* process, so it
+    can only reach that subprocess by signalling the recorded pgid. Same-user
+    `killpg` is permitted; the worker's `proc.wait()` reaps the dead child.
+
+    Best-effort by contract: a missing pid event, a stale pid (process already
+    gone), or a signalling error must NOT break teardown — the managed kill, DB
+    flip, and transcript event have already run by the time this is called.
+    """
+    if target.routing not in CLI_ROUTINGS:
+        return  # pure managed/cloud sessions own no local subprocess
+
+    # Find the most recent pid event in the transcript. Codex records `codex_pid`;
+    # claude_code records `claude_code_pid`. The latest wins (a resumed session
+    # spawns a fresh subprocess and appends a newer event).
+    pid: int | None = None
+    pgid: int | None = None
+    try:
+        for ev in reversed(transcript_store.read(target.session_id)):
+            if ev.get("kind") in ("claude_code_pid", "codex_pid"):
+                payload = ev.get("payload") or {}
+                pid = payload.get("pid")
+                pgid = payload.get("pgid", pid)
+                break
+    except Exception as exc:  # noqa: BLE001 — never break teardown on a read error
+        logger.warning("local kill: transcript read for %s failed: %s",
+                       target.session_id, exc)
+        return
+    if pid is None:
+        return  # subprocess never recorded a pid (e.g. crashed before spawn)
+    if pgid is None:
+        pgid = pid
+
+    try:
+        os.kill(pid, 0)  # liveness check — guards against pid reuse / already-dead
+    except ProcessLookupError:
+        return  # already gone — nothing to signal
+    except (PermissionError, OSError) as exc:
+        logger.warning("local kill: liveness check for pid %s failed: %s", pid, exc)
+        return
+
+    sig_used = "SIGTERM"
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+        # Bounded grace for a clean exit, then SIGKILL the group if still alive.
+        deadline = time.monotonic() + _LOCAL_KILL_GRACE_S
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                break  # exited cleanly under SIGTERM
+            time.sleep(_LOCAL_KILL_POLL_S)
+        else:
+            os.killpg(pgid, signal.SIGKILL)
+            sig_used = "SIGKILL"
+    except ProcessLookupError:
+        pass  # raced to exit between the liveness check and the signal — fine
+    except (PermissionError, OSError) as exc:
+        logger.warning("local kill: killpg(%s) failed: %s", pgid, exc)
+        return
+
+    transcript_store.append(target.session_id, "local_subprocess_killed", {
+        "pid": pid, "pgid": pgid, "signal": sig_used,
+    })
+
+
 def teardown_session(
     session_store: SessionStore,
     transcript_store: TranscriptStore,
@@ -480,7 +562,8 @@ def teardown_session(
     managed_driver: Any | None = None,
 ) -> dict[str, Any]:
     """Tear down a single session: kill the managed remote (best-effort),
-    flip the local DB status to FAILED, and append a transcript event.
+    flip the local DB status to FAILED, append a transcript event, and
+    (for local CLI sessions) terminate the worker-owned subprocess.
 
     Shared between agent-initiated `kill()` (this module) and the operator
     HTTP kill endpoint (`api/routes/agents.py`). Authorization is the
@@ -504,6 +587,12 @@ def teardown_session(
             )
     session_store.update_status(target.task_id, STATUS_FAILED)
     transcript_store.append(target.session_id, transcript_kind, transcript_payload)
+    # #379: flipping the DB to FAILED is what the executor's silent-guard keys on,
+    # so the row is updated *before* we signal the subprocess. The status flip
+    # alone doesn't stop the OS process (the worker's `claude -p` keeps running
+    # until the next poll) — this reaps it promptly so an operator kill actually
+    # stops compute within seconds.
+    _kill_local_subprocess(transcript_store, target)
     return {"managed_failure": managed_failure}
 
 

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -521,7 +521,13 @@ def _kill_local_subprocess(
         pgid = pid
 
     try:
-        os.kill(pid, 0)  # liveness check — guards against pid reuse / already-dead
+        # Best-effort liveness check. If the pid is already gone we skip
+        # signalling entirely. This only *narrows* the pid-reuse TOCTOU window —
+        # it does not eliminate it: the pid could be reused between this probe
+        # and the killpg below. Acceptable because killpg targets the recorded
+        # pgid (the CLI's own process group via start_new_session), so a reused
+        # pid would have to also lead an identically-numbered group to be hit.
+        os.kill(pid, 0)
     except ProcessLookupError:
         return  # already gone — nothing to signal
     except (PermissionError, OSError) as exc:
@@ -531,19 +537,26 @@ def _kill_local_subprocess(
     sig_used = "SIGTERM"
     try:
         os.killpg(pgid, signal.SIGTERM)
-        # Bounded grace for a clean exit, then SIGKILL the group if still alive.
+        # Bounded grace for a clean exit, polling the group LEADER pid.
         deadline = time.monotonic() + _LOCAL_KILL_GRACE_S
         while time.monotonic() < deadline:
             try:
                 os.kill(pid, 0)
             except ProcessLookupError:
-                break  # exited cleanly under SIGTERM
+                break  # leader exited under SIGTERM
             time.sleep(_LOCAL_KILL_POLL_S)
-        else:
+        # SIGKILL sweep the whole group regardless: the grace loop only watches
+        # the leader, but a group child can outlive the leader (the leader exits
+        # while a spawned grandchild lingers). The sweep reaps any survivors.
+        # ProcessLookupError means the group is already fully gone (leader exited
+        # cleanly, no lingering children) — that's the no-op success path.
+        try:
             os.killpg(pgid, signal.SIGKILL)
             sig_used = "SIGKILL"
+        except ProcessLookupError:
+            pass  # group already gone — clean exit under SIGTERM
     except ProcessLookupError:
-        pass  # raced to exit between the liveness check and the signal — fine
+        pass  # raced to exit between the liveness check and the SIGTERM — fine
     except (PermissionError, OSError) as exc:
         logger.warning("local kill: killpg(%s) failed: %s", pgid, exc)
         return

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1494,6 +1494,7 @@ class Worker:
             REASON_AWAITING_CLARIFICATION,
             REASON_AWAITING_GOAL_APPROVAL,
             REASON_AWAITING_PLAN_APPROVAL,
+            REASON_KILLED,
         )
         from api.services.agent_worker.claude_code_spawn import parse_claude_code_spawn_payload
 
@@ -1701,7 +1702,12 @@ class Worker:
         notice = ""
         if outcome.status == STATUS_BUDGET_EXCEEDED:
             notice = f"⚠️ {label} hit its budget ({outcome.reason})."
-        elif outcome.status == STATUS_FAILED:
+        elif outcome.status == STATUS_FAILED and outcome.reason != REASON_KILLED:
+            # #379: an operator-killed session must NOT emit a post-kill notice —
+            # the operator stopped it deliberately. The row is already FAILED and
+            # the kill endpoint owns the operator_killed transcript event; here we
+            # just skip the spurious "failed" notice + web mirror. (Status
+            # persistence and vault reconciliation below still run.)
             notice = f"⚠️ {label} failed: {outcome.reason}."
         if notice:
             _send(notice)
@@ -1763,6 +1769,7 @@ class Worker:
         chat and registers it as a follow-up anchor so a threaded reply
         resumes the session.
         """
+        from api.services.agent_worker.codex_executor import REASON_KILLED
         from api.services.agent_worker.codex_spawn import parse_codex_spawn_payload
 
         codex = self._get_codex_executor()
@@ -1865,7 +1872,11 @@ class Worker:
         notice = ""
         if outcome.status == STATUS_BUDGET_EXCEEDED:
             notice = f"⚠️ {label} hit its budget ({outcome.reason})."
-        elif outcome.status == STATUS_FAILED:
+        elif outcome.status == STATUS_FAILED and outcome.reason != REASON_KILLED:
+            # #379: an operator-killed codex session must NOT emit a post-kill
+            # notice — the operator stopped it deliberately. Parity with the
+            # claude_code dispatch; status persistence + vault reconciliation
+            # below still run.
             notice = f"⚠️ {label} failed: {outcome.reason}."
         if notice:
             self._telegram_send(notice)

--- a/tests/test_agent_kill_api.py
+++ b/tests/test_agent_kill_api.py
@@ -187,6 +187,58 @@ def test_kill_calls_managed_driver_when_present(client, stores, monkeypatch):
     assert called_remote_ids == {"managed-parent", "managed-child"}
 
 
+@pytest.mark.unit
+def test_operator_kill_signals_local_claude_code_subprocess(client, stores, monkeypatch):
+    """#379: an operator kill of a routing='claude_code' session with a recorded
+    pid must signal the worker-owned subprocess (killpg on the pgid) while
+    preserving the cascade, the operator_killed/cascade_killed transcript events,
+    and the `{"killed": [...], "failures": [...]}` response shape."""
+    import signal as _signal
+
+    session_store, transcript_store = stores
+    # A local CLI parent (with a recorded subprocess pid) + a managed child, so we
+    # exercise both the local-subprocess kill and the cascade in one call.
+    parent = session_store.create(
+        task_id="cc-parent", status=STATUS_RUNNING, routing="claude_code",
+    )
+    transcript_store.append(parent.session_id, "claude_code_pid", {"pid": 5151, "pgid": 5151})
+    child = session_store.create(
+        task_id="cc-child", status=STATUS_RUNNING, routing="claude_code",
+        parent_session_id=parent.session_id, root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    transcript_store.append(child.session_id, "claude_code_pid", {"pid": 5252, "pgid": 5252})
+
+    killpg_calls: list[tuple[int, int]] = []
+    # os.kill(pid, 0) liveness checks all report "alive" so SIGTERM fires; we
+    # collapse the grace window to force the SIGKILL fallback deterministically.
+    monkeypatch.setattr(inter_agent.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(inter_agent.os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig)))
+    monkeypatch.setattr(inter_agent, "_LOCAL_KILL_GRACE_S", 0.0)
+
+    r = client.post(f"/api/agents/sessions/{parent.session_id}/kill", json={"reason": "runaway"})
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body["killed"]) == {parent.session_id, child.session_id}
+    assert body["failures"] == []
+
+    # Both subprocesses were signalled on their pgids (SIGTERM then SIGKILL each).
+    signalled_pgids = {pgid for pgid, _sig in killpg_calls}
+    assert signalled_pgids == {5151, 5252}
+    assert _signal.SIGTERM in {sig for _pgid, sig in killpg_calls}
+    assert _signal.SIGKILL in {sig for _pgid, sig in killpg_calls}
+
+    # Cascade + transcript events preserved.
+    assert session_store.get_by_session_id(parent.session_id).status == STATUS_FAILED
+    assert session_store.get_by_session_id(child.session_id).status == STATUS_FAILED
+    parent_kinds = [e["kind"] for e in transcript_store.read(parent.session_id)]
+    child_kinds = [e["kind"] for e in transcript_store.read(child.session_id)]
+    assert "operator_killed" in parent_kinds
+    assert "local_subprocess_killed" in parent_kinds
+    assert "cascade_killed" in child_kinds
+    assert "local_subprocess_killed" in child_kinds
+
+
 # ---------------------------------------------------------------------------
 # Shared helper — used by both inter_agent.kill (agent-to-agent) and the
 # operator kill HTTP endpoint. Confirms the agent path still works.

--- a/tests/test_agent_worker_claude_code_dispatch.py
+++ b/tests/test_agent_worker_claude_code_dispatch.py
@@ -470,3 +470,49 @@ def test_child_completion_does_not_mirror(tmp_path: Path):
     worker._dispatch_claude_code_session(child, [{"content": "list matches"}])
 
     assert conv_store.get_messages(conv.id) == []
+
+
+# =============================================================================
+# #379 — operator-killed session emits no post-kill notice
+# =============================================================================
+
+
+def test_operator_killed_failed_outcome_sends_no_telegram_notice(tmp_path: Path):
+    """A FAILED outcome carrying reason=REASON_KILLED is the executor's signal
+    that the operator deliberately killed the session mid-run. The dispatch path
+    must NOT send the "⚠️ Code session failed" Telegram notice (the operator
+    knows they killed it; the kill endpoint already wrote operator_killed)."""
+    from api.services.agent_worker.claude_code_executor import REASON_KILLED
+
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_FAILED, reason=REASON_KILLED)
+    )
+    worker, store, _, sent = _capturing_worker(tmp_path, claude_code_executor=stub)
+    session = store.create(task_id="op-killed-1", routing="claude_code", origin="operator")
+    store.enqueue_message(session.session_id, "operator", "long task")
+
+    worker._dispatch_claude_code_session(session, [{"content": "long task"}])
+
+    # No operator-facing failure notice.
+    assert not any("failed" in s.lower() for s in sent)
+    # The session row is still persisted terminal (idempotent with the kill's flip).
+    assert store.get("op-killed-1").status == STATUS_FAILED
+
+
+def test_operator_killed_failed_outcome_does_not_mirror_to_web(tmp_path: Path):
+    """Parity for the web/voice thread: a REASON_KILLED FAILED outcome must NOT
+    mirror a failure notice into the linked conversation (#379 + #311)."""
+    from api.services.agent_worker.claude_code_executor import REASON_KILLED
+
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_FAILED, reason=REASON_KILLED)
+    )
+    worker, store, conv_store = _mirroring_worker(tmp_path, claude_code_executor=stub)
+    session = store.create(task_id="web-killed-1", routing="claude_code", origin="operator")
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, session.session_id)
+
+    worker._dispatch_claude_code_session(session, [{"content": "long task"}])
+
+    # Nothing about a failure landed in the thread.
+    assert conv_store.get_messages(conv.id) == []

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -24,6 +24,7 @@ from api.services.agent_worker.claude_code_executor import (
     REASON_AWAITING_GOAL_APPROVAL,
     REASON_AWAITING_PLAN_APPROVAL,
     REASON_BINARY_NOT_FOUND,
+    REASON_KILLED,
     ClaudeCodeExecutor,
 )
 from api.services.agent_worker.session_store import (
@@ -70,16 +71,27 @@ class _FakeStderr:
 
 
 class _FakeProc:
-    """Stand-in for `subprocess.Popen` with predetermined stdout + returncode."""
+    """Stand-in for `subprocess.Popen` with predetermined stdout + returncode.
 
-    def __init__(self, events: Iterable[dict], returncode: int = 0, stderr: str = ""):
+    `pid` is set so the executor's #379 pid-recording (os.getpgid(proc.pid))
+    has something to read; an `on_wait` hook lets a test simulate the operator
+    flipping the session row to FAILED while `wait()` blocks (the kill-mid-run
+    case).
+    """
+
+    def __init__(self, events: Iterable[dict], returncode: int = 0, stderr: str = "",
+                 pid: int = 4242, on_wait=None):
         self.stdout = _FakeStdout(events)
         self.stderr = _FakeStderr(stderr)
         self.returncode = returncode
+        self.pid = pid
+        self._on_wait = on_wait
         self.terminated = False
         self.killed = False
 
     def wait(self, timeout: float | None = None) -> int:
+        if self._on_wait is not None:
+            self._on_wait()
         return self.returncode
 
     def poll(self) -> int | None:
@@ -92,11 +104,11 @@ class _FakeProc:
         self.killed = True
 
 
-def _spawn_with(events, returncode: int = 0, stderr: str = ""):
+def _spawn_with(events, returncode: int = 0, stderr: str = "", pid: int = 4242, on_wait=None):
     """Build a `spawn_fn` callable that returns a fresh _FakeProc per call."""
 
     def _spawn_fn(*_args, **_kwargs):
-        return _FakeProc(events, returncode=returncode, stderr=stderr)
+        return _FakeProc(events, returncode=returncode, stderr=stderr, pid=pid, on_wait=on_wait)
 
     return _spawn_fn
 
@@ -909,3 +921,82 @@ def test_clarify_takes_precedence_over_goal_in_same_turn(tmp_path: Path):
     # The goal proposal did NOT produce a goal-approval block this turn.
     kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
     assert "claude_code_awaiting_goal_approval" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# #379 — operator kill terminates the local subprocess promptly
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_records_pid_event_and_new_session(tmp_path: Path):
+    """#379: a successful spawn records a `claude_code_pid` event carrying the
+    subprocess pid/pgid, and passes `start_new_session=True` to the spawn_fn so
+    the subprocess is its own process-group leader (killable via killpg without
+    touching the worker)."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "done."},
+    ]
+    captured_kwargs: dict = {}
+
+    def _capturing_spawn(*_args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return _FakeProc(events, pid=98765)
+
+    executor, store, transcripts = _build_executor(tmp_path, spawn_fn=_capturing_spawn)
+    session = _seed_session(store)
+
+    outcome = executor.execute(session, {"description": "print a haiku"})
+
+    assert outcome.status == STATUS_COMPLETED
+    # The spawn was asked to start a new session/process-group.
+    assert captured_kwargs.get("start_new_session") is True
+    # The pid event was recorded with both pid and pgid.
+    pid_events = [
+        e for e in _read_transcript(transcripts, session.session_id)
+        if e["kind"] == "claude_code_pid"
+    ]
+    assert len(pid_events) == 1
+    assert pid_events[0]["payload"]["pid"] == 98765
+    assert "pgid" in pid_events[0]["payload"]
+
+
+def test_operator_kill_mid_run_exits_silently(tmp_path: Path):
+    """#379: when the operator kill flips the session row to FAILED while the
+    subprocess runs, `proc.wait()` returns and the executor must exit silently —
+    REASON_KILLED, a `claude_code_killed` event, and NEITHER a
+    `claude_code_failed` nor a COMPLETED transition."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+    ]
+    # Build the store/session first so the on_wait hook can flip its status,
+    # simulating the operator kill endpoint reaching the row mid-run.
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    session = _seed_session(store)
+
+    def _flip_to_failed():
+        store.update_status(session.task_id, STATUS_FAILED)
+
+    # A negative returncode mimics a process killed by a signal (killpg/SIGKILL).
+    spawn_fn = _spawn_with(events, returncode=-9, on_wait=_flip_to_failed)
+    notifications: list[str] = []
+    executor = ClaudeCodeExecutor(
+        session_store=store,
+        transcript_store=transcripts,
+        notification_callback=lambda msg: notifications.append(msg),
+        spawn_fn=spawn_fn,
+        binary_resolver=lambda: "/usr/bin/true",
+        timeout_seconds=30,
+        heartbeat_interval=3600,
+    )
+
+    outcome = executor.execute(session, {"description": "long task"})
+
+    assert outcome.status == STATUS_FAILED
+    assert outcome.reason == REASON_KILLED
+    kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
+    assert "claude_code_killed" in kinds
+    # The spurious failure / completion paths must NOT have run.
+    assert "claude_code_failed" not in kinds
+    assert "claude_code_completed" not in kinds

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -1000,3 +1000,48 @@ def test_operator_kill_mid_run_exits_silently(tmp_path: Path):
     # The spurious failure / completion paths must NOT have run.
     assert "claude_code_failed" not in kinds
     assert "claude_code_completed" not in kinds
+
+
+def test_clean_completion_wins_over_raced_failed_flip(tmp_path: Path):
+    """#379 cascade-race guard: the row can be flipped to FAILED mid-run by a
+    second legitimate writer (LocalExecutor._cascade_kill_lineage on a
+    lineage-budget breach, which is routing-agnostic). If our subprocess exits 0
+    at that instant — it finished its work — the COMPLETED path must win so the
+    final_text is persisted (a parent reads it via _child_final_text). The
+    returncode gate (FAILED *and* returncode != 0 → REASON_KILLED) keeps the
+    silent guard from clobbering a clean completion."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "all done."},
+    ]
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    session = _seed_session(store)
+
+    def _flip_to_failed():
+        # The cascade races our clean exit, flipping the row FAILED.
+        store.update_status(session.task_id, STATUS_FAILED)
+
+    # returncode=0 → the subprocess completed cleanly despite the FAILED flip.
+    spawn_fn = _spawn_with(events, returncode=0, on_wait=_flip_to_failed)
+    executor = ClaudeCodeExecutor(
+        session_store=store,
+        transcript_store=transcripts,
+        spawn_fn=spawn_fn,
+        binary_resolver=lambda: "/usr/bin/true",
+        timeout_seconds=30,
+        heartbeat_interval=3600,
+    )
+
+    outcome = executor.execute(session, {"description": "task"})
+
+    assert outcome.status == STATUS_COMPLETED
+    assert outcome.reason != REASON_KILLED
+    assert outcome.final_text == "all done."
+    kinds = [e["kind"] for e in _read_transcript(transcripts, session.session_id)]
+    # The completion path ran and persisted final_text; the silent guard did not.
+    assert "claude_code_completed" in kinds
+    assert "claude_code_killed" not in kinds
+    completed = [e for e in _read_transcript(transcripts, session.session_id)
+                 if e["kind"] == "claude_code_completed"]
+    assert completed[0]["payload"]["final_text"] == "all done."

--- a/tests/test_agent_worker_codex_dispatch.py
+++ b/tests/test_agent_worker_codex_dispatch.py
@@ -194,6 +194,43 @@ def test_codex_failed_finalizes_session_row(tmp_path: Path):
     assert any("failed" in s.lower() for s in plain_sends)
 
 
+def test_codex_operator_killed_sends_no_telegram_notice(tmp_path: Path):
+    """#379 parity: a FAILED codex outcome carrying reason=REASON_KILLED is the
+    executor's signal that the operator deliberately killed the session. The
+    dispatch path must NOT send the "⚠️ ... failed" Telegram notice (the kill
+    endpoint already wrote operator_killed), while still persisting FAILED."""
+    from api.services.agent_worker.codex_executor import REASON_KILLED
+
+    plain_sends: list[str] = []
+    withid_sends: list[str] = []
+    stub = _StubCodexExecutor(outcome=ExecutorOutcome(status=STATUS_FAILED, reason=REASON_KILLED))
+    worker = _make_worker(tmp_path, codex_executor=stub, plain_sends=plain_sends, withid_sends=withid_sends)
+    session = worker.session_store.create(task_id="cx-killed", routing="codex", origin="operator")
+
+    worker._dispatch_codex_session(session, [{"content": "long task"}])
+
+    # No operator-facing failure notice.
+    assert not any("failed" in s.lower() for s in plain_sends)
+    # Row still persisted terminal (idempotent with the kill's flip).
+    assert worker.session_store.get("cx-killed").status == STATUS_FAILED
+
+
+def test_codex_operator_killed_does_not_mirror_to_web(tmp_path: Path):
+    """#379 + #311 parity: a REASON_KILLED FAILED codex outcome must NOT mirror a
+    failure notice into the linked web/voice conversation."""
+    from api.services.agent_worker.codex_executor import REASON_KILLED
+
+    stub = _StubCodexExecutor(outcome=ExecutorOutcome(status=STATUS_FAILED, reason=REASON_KILLED))
+    worker, conv_store = _mirroring_codex_worker(tmp_path, codex_executor=stub)
+    session = worker.session_store.create(task_id="cx-web-killed", routing="codex", origin="operator")
+    conv = conv_store.create_conversation(title="Web thread")
+    conv_store.set_agent_session_id(conv.id, session.session_id)
+
+    worker._dispatch_codex_session(session, [{"content": "long task"}])
+
+    assert conv_store.get_messages(conv.id) == []
+
+
 # ---------------------------------------------------------------------------
 # Web-thread result mirroring (#311). Codex has no rich [NOTIFY] stream, so the
 # terminal completion/failure mirror is the whole web round-trip for it.

--- a/tests/test_agent_worker_inter_agent.py
+++ b/tests/test_agent_worker_inter_agent.py
@@ -9,12 +9,14 @@ from pathlib import Path
 
 import pytest
 
+from api.services.agent_worker import inter_agent
 from api.services.agent_worker.inter_agent import (
     Caps,
     InterAgentContext,
     DEFAULT_MAX_DESCENDANTS_PER_ROOT,
     DEFAULT_MAX_SPAWN_DEPTH,
     dispatch,
+    teardown_session,
 )
 from api.services.agent_worker.session_store import (
     STATUS_CLAIMED,
@@ -591,3 +593,178 @@ def test_dispatch_handles_handler_exception(store, transcript, parent, monkeypat
     assert not result["ok"]
     assert result["error"] == "crashed"
     assert "kaboom" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# #379 — teardown_session reaps the local CLI subprocess
+# ---------------------------------------------------------------------------
+
+
+class _SignalRecorder:
+    """Records os.kill / os.killpg calls and scripts liveness.
+
+    `alive_for` controls how many `os.kill(pid, 0)` liveness probes return
+    "alive" before the process is considered gone (ProcessLookupError). A
+    large value keeps it alive through the whole grace window so the SIGKILL
+    fallback fires; a small value simulates a clean exit under SIGTERM.
+    """
+
+    def __init__(self, alive_for: int = 1000, initial_lookup_error: bool = False):
+        self.killpg_calls: list[tuple[int, int]] = []
+        self._liveness_probes = 0
+        self._alive_for = alive_for
+        self._initial_lookup_error = initial_lookup_error
+
+    def kill(self, pid, sig):
+        # Liveness probe (sig == 0). The first probe is the up-front liveness
+        # check; subsequent ones poll during the SIGTERM grace window.
+        if sig == 0:
+            if self._initial_lookup_error:
+                raise ProcessLookupError
+            self._liveness_probes += 1
+            if self._liveness_probes > self._alive_for:
+                raise ProcessLookupError
+            return None
+        raise AssertionError(f"unexpected os.kill signal {sig}")
+
+    def killpg(self, pgid, sig):
+        self.killpg_calls.append((pgid, sig))
+
+
+def _seed_claude_code_with_pid(store, transcript, parent, *, pid=4242, pgid=4242):
+    target = store.create(
+        task_id="cc_target", status=STATUS_RUNNING, routing="claude_code",
+        parent_session_id=parent.session_id, root_session_id=parent.session_id,
+    )
+    transcript.append(target.session_id, "claude_code_pid", {"pid": pid, "pgid": pgid})
+    return store.get_by_session_id(target.session_id)
+
+
+@pytest.mark.unit
+def test_teardown_kills_local_subprocess_sigterm_then_sigkill(
+    store, transcript, parent, monkeypatch
+):
+    """A claude_code session with a recorded pid is SIGTERM'd then — when still
+    alive through the grace window — SIGKILL'd, both on the pgid."""
+    import signal as _signal
+
+    target = _seed_claude_code_with_pid(store, transcript, parent, pid=4242, pgid=4242)
+    rec = _SignalRecorder(alive_for=1000)  # never dies → SIGKILL fallback
+    monkeypatch.setattr(inter_agent.os, "kill", rec.kill)
+    monkeypatch.setattr(inter_agent.os, "killpg", rec.killpg)
+    monkeypatch.setattr(inter_agent.time, "sleep", lambda _s: None)
+    # Collapse the grace window so the loop exits to the SIGKILL branch fast.
+    monkeypatch.setattr(inter_agent, "_LOCAL_KILL_GRACE_S", 0.0)
+
+    teardown_session(
+        store, transcript, target,
+        transcript_kind="operator_killed",
+        transcript_payload={"reason": "stop"},
+        managed_driver=None,
+    )
+
+    signals = [sig for _pgid, sig in rec.killpg_calls]
+    assert _signal.SIGTERM in signals
+    assert _signal.SIGKILL in signals
+    assert all(pgid == 4242 for pgid, _sig in rec.killpg_calls)
+    # The kill is audited.
+    kinds = [e["kind"] for e in transcript.read(target.session_id)]
+    assert "local_subprocess_killed" in kinds
+    assert store.get_by_session_id(target.session_id).status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_teardown_local_subprocess_clean_exit_no_sigkill(
+    store, transcript, parent, monkeypatch
+):
+    """If the process exits during the SIGTERM grace window, no SIGKILL fires."""
+    import signal as _signal
+
+    target = _seed_claude_code_with_pid(store, transcript, parent, pid=7, pgid=7)
+    # alive_for=1: the up-front liveness check passes, then the first in-grace
+    # probe reports gone → clean exit under SIGTERM.
+    rec = _SignalRecorder(alive_for=1)
+    monkeypatch.setattr(inter_agent.os, "kill", rec.kill)
+    monkeypatch.setattr(inter_agent.os, "killpg", rec.killpg)
+    monkeypatch.setattr(inter_agent.time, "sleep", lambda _s: None)
+
+    teardown_session(
+        store, transcript, target,
+        transcript_kind="operator_killed",
+        transcript_payload={"reason": "stop"},
+        managed_driver=None,
+    )
+
+    signals = [sig for _pgid, sig in rec.killpg_calls]
+    assert signals == [_signal.SIGTERM]
+    assert _signal.SIGKILL not in signals
+
+
+@pytest.mark.unit
+def test_teardown_stale_pid_does_not_raise_or_signal(
+    store, transcript, parent, monkeypatch
+):
+    """A stale pid (the process already exited — `os.kill(pid, 0)` raises
+    ProcessLookupError) is handled gracefully: no killpg, no raise, and teardown
+    still flips status + writes the kill transcript event."""
+    target = _seed_claude_code_with_pid(store, transcript, parent, pid=999, pgid=999)
+    rec = _SignalRecorder(initial_lookup_error=True)
+    monkeypatch.setattr(inter_agent.os, "kill", rec.kill)
+    monkeypatch.setattr(inter_agent.os, "killpg", rec.killpg)
+
+    # Must not raise.
+    teardown_session(
+        store, transcript, target,
+        transcript_kind="operator_killed",
+        transcript_payload={"reason": "stop"},
+        managed_driver=None,
+    )
+
+    assert rec.killpg_calls == []  # nothing signalled
+    # Teardown's other effects still happened.
+    assert store.get_by_session_id(target.session_id).status == STATUS_FAILED
+    kinds = [e["kind"] for e in transcript.read(target.session_id)]
+    assert "operator_killed" in kinds
+    assert "local_subprocess_killed" not in kinds  # no kill recorded for a dead proc
+
+
+@pytest.mark.unit
+def test_teardown_managed_session_skips_local_kill_but_does_managed(
+    store, transcript, parent, monkeypatch
+):
+    """A pure managed/cloud session (routing='claude', no pid event) must NOT
+    attempt a local kill, but MUST still flip status, append the transcript
+    event, and call the managed driver's kill_session."""
+    target = store.create(
+        task_id="m_target", status=STATUS_RUNNING, routing="claude",
+        parent_session_id=parent.session_id, root_session_id=parent.session_id,
+    )
+    store.set_managed_session_id("m_target", "remote_xyz")
+    target = store.get_by_session_id(target.session_id)
+
+    rec = _SignalRecorder()
+    monkeypatch.setattr(inter_agent.os, "kill", rec.kill)
+    monkeypatch.setattr(inter_agent.os, "killpg", rec.killpg)
+
+    managed_calls = []
+    class _FakeDriver:
+        def kill_session(self, sid, reason=""):
+            managed_calls.append((sid, reason))
+
+    result = teardown_session(
+        store, transcript, target,
+        transcript_kind="operator_killed",
+        transcript_payload={"reason": "stop"},
+        managed_driver=_FakeDriver(),
+    )
+
+    assert result["managed_failure"] is None
+    # No local signal attempt at all (routing is not a CLI route).
+    assert rec.killpg_calls == []
+    # Managed kill still happened.
+    assert managed_calls == [("remote_xyz", "stop")]
+    # Status flip + transcript event still happened.
+    assert store.get_by_session_id(target.session_id).status == STATUS_FAILED
+    kinds = [e["kind"] for e in transcript.read(target.session_id)]
+    assert "operator_killed" in kinds
+    assert "local_subprocess_killed" not in kinds

--- a/tests/test_agent_worker_inter_agent.py
+++ b/tests/test_agent_worker_inter_agent.py
@@ -5,6 +5,7 @@ The worker's resume/dispatch loop is tested separately in test_agent_worker_loop
 """
 from __future__ import annotations
 
+import signal as _signal_module
 from pathlib import Path
 
 import pytest
@@ -607,27 +608,43 @@ class _SignalRecorder:
     "alive" before the process is considered gone (ProcessLookupError). A
     large value keeps it alive through the whole grace window so the SIGKILL
     fallback fires; a small value simulates a clean exit under SIGTERM.
+
+    `group_gone_after` controls the #379 SIGKILL sweep: once the leader pid has
+    been reported gone (its liveness probe raised), `killpg` raises
+    ProcessLookupError to model a fully-exited group (no lingering children). If
+    left None, killpg always succeeds — modelling a group child that outlived the
+    leader, so the sweep lands.
     """
 
-    def __init__(self, alive_for: int = 1000, initial_lookup_error: bool = False):
+    def __init__(self, alive_for: int = 1000, initial_lookup_error: bool = False,
+                 group_gone_when_leader_gone: bool = False):
         self.killpg_calls: list[tuple[int, int]] = []
         self._liveness_probes = 0
         self._alive_for = alive_for
         self._initial_lookup_error = initial_lookup_error
+        self._group_gone_when_leader_gone = group_gone_when_leader_gone
+        self._leader_gone = False
 
     def kill(self, pid, sig):
         # Liveness probe (sig == 0). The first probe is the up-front liveness
         # check; subsequent ones poll during the SIGTERM grace window.
         if sig == 0:
             if self._initial_lookup_error:
+                self._leader_gone = True
                 raise ProcessLookupError
             self._liveness_probes += 1
             if self._liveness_probes > self._alive_for:
+                self._leader_gone = True
                 raise ProcessLookupError
             return None
         raise AssertionError(f"unexpected os.kill signal {sig}")
 
     def killpg(self, pgid, sig):
+        # Model a fully-gone group for the SIGKILL sweep: once the leader is gone
+        # and the test asked for it, killpg raises (no children left to reap).
+        if (self._group_gone_when_leader_gone and self._leader_gone
+                and sig == _signal_module.SIGKILL):
+            raise ProcessLookupError
         self.killpg_calls.append((pgid, sig))
 
 
@@ -677,13 +694,16 @@ def test_teardown_kills_local_subprocess_sigterm_then_sigkill(
 def test_teardown_local_subprocess_clean_exit_no_sigkill(
     store, transcript, parent, monkeypatch
 ):
-    """If the process exits during the SIGTERM grace window, no SIGKILL fires."""
+    """If the leader AND its whole group exit during the SIGTERM grace window,
+    the SIGKILL sweep is a no-op (group already gone) — only SIGTERM lands."""
     import signal as _signal
 
     target = _seed_claude_code_with_pid(store, transcript, parent, pid=7, pgid=7)
     # alive_for=1: the up-front liveness check passes, then the first in-grace
-    # probe reports gone → clean exit under SIGTERM.
-    rec = _SignalRecorder(alive_for=1)
+    # probe reports the leader gone → clean exit under SIGTERM. With
+    # group_gone_when_leader_gone the #379 sweep's killpg(SIGKILL) raises
+    # ProcessLookupError (no lingering children), so no SIGKILL is recorded.
+    rec = _SignalRecorder(alive_for=1, group_gone_when_leader_gone=True)
     monkeypatch.setattr(inter_agent.os, "kill", rec.kill)
     monkeypatch.setattr(inter_agent.os, "killpg", rec.killpg)
     monkeypatch.setattr(inter_agent.time, "sleep", lambda _s: None)
@@ -698,6 +718,42 @@ def test_teardown_local_subprocess_clean_exit_no_sigkill(
     signals = [sig for _pgid, sig in rec.killpg_calls]
     assert signals == [_signal.SIGTERM]
     assert _signal.SIGKILL not in signals
+    # The kill is still audited as a SIGTERM exit.
+    kinds = [e["kind"] for e in transcript.read(target.session_id)]
+    assert "local_subprocess_killed" in kinds
+
+
+@pytest.mark.unit
+def test_teardown_sigkill_sweep_reaps_lingering_group_child(
+    store, transcript, parent, monkeypatch
+):
+    """#379: if the leader exits under SIGTERM but a group child lingers, the
+    SIGKILL sweep still fires on the pgid so the survivor is reaped. (The old
+    grace loop `break`'d on the leader exiting and skipped the SIGKILL.)"""
+    import signal as _signal
+
+    target = _seed_claude_code_with_pid(store, transcript, parent, pid=55, pgid=55)
+    # Leader gone after the first in-grace probe, but group_gone_when_leader_gone
+    # left False → killpg(SIGKILL) lands (a child outlived the leader).
+    rec = _SignalRecorder(alive_for=1)
+    monkeypatch.setattr(inter_agent.os, "kill", rec.kill)
+    monkeypatch.setattr(inter_agent.os, "killpg", rec.killpg)
+    monkeypatch.setattr(inter_agent.time, "sleep", lambda _s: None)
+
+    teardown_session(
+        store, transcript, target,
+        transcript_kind="operator_killed",
+        transcript_payload={"reason": "stop"},
+        managed_driver=None,
+    )
+
+    signals = [sig for _pgid, sig in rec.killpg_calls]
+    # The sweep escalated to SIGKILL even though the leader had exited.
+    assert _signal.SIGTERM in signals
+    assert _signal.SIGKILL in signals
+    assert all(pgid == 55 for pgid, _sig in rec.killpg_calls)
+    kinds = [e["kind"] for e in transcript.read(target.session_id)]
+    assert "local_subprocess_killed" in kinds
 
 
 @pytest.mark.unit

--- a/tests/test_codex_spawn_executor.py
+++ b/tests/test_codex_spawn_executor.py
@@ -11,6 +11,7 @@ from api.services.agent_worker import codex_spawn
 from api.services.agent_worker.codex_executor import (
     CodexExecutor,
     REASON_BINARY_NOT_FOUND,
+    REASON_KILLED,
 )
 from api.services.agent_worker.session_store import (
     STATUS_COMPLETED,
@@ -80,14 +81,22 @@ def test_parse_codex_spawn_payload_falls_back_to_string():
 
 
 class _FakeProc:
-    """Minimal subprocess.Popen substitute for stream-parsing tests."""
-    def __init__(self, lines: list[dict], returncode: int = 0, stderr_text: str = ""):
+    """Minimal subprocess.Popen substitute for stream-parsing tests.
+
+    `on_wait` lets a test simulate the operator (or a lineage cascade) flipping
+    the session row to FAILED while `wait()` blocks — the #379 kill-guard case.
+    """
+    def __init__(self, lines: list[dict], returncode: int = 0, stderr_text: str = "",
+                 pid: int = 12345, on_wait=None):
         self.stdout = io.StringIO("\n".join(json.dumps(line) for line in lines) + "\n")
         self.stderr = io.StringIO(stderr_text)
         self.returncode = returncode
-        self.pid = 12345
+        self.pid = pid
+        self._on_wait = on_wait
 
     def wait(self):
+        if self._on_wait is not None:
+            self._on_wait()
         return self.returncode
 
     def poll(self):
@@ -453,3 +462,139 @@ def test_executor_rejects_empty_prompt(stores, tmp_path):
     outcome = executor.execute(session, {"description": "  "})
     assert outcome.status == STATUS_FAILED
     assert outcome.reason == "empty prompt"
+
+
+# ---------------------------------------------------------------------------
+# #379 — operator kill terminates the local codex subprocess (parity with
+# the claude_code executor coverage)
+# ---------------------------------------------------------------------------
+
+
+def _seed_codex_session(sess_store, *, task_id="cx-379"):
+    return sess_store.create(
+        task_id=task_id,
+        routing="codex",
+        budget={"wall_seconds": 60, "max_tokens": 1000, "max_dollars": 1.0},
+        expected_output="text",
+        origin="operator",
+    )
+
+
+def _spawn_capturing(captured_kwargs, fake_proc, *, final_text="done."):
+    """A spawn_fn that records kwargs (e.g. start_new_session), writes the codex
+    `-o` last-message file, and returns the supplied fake proc."""
+
+    def _fake_spawn(cmd, **kwargs):
+        captured_kwargs.update(kwargs)
+        for i, tok in enumerate(cmd):
+            if tok == "-o" and i + 1 < len(cmd):
+                with open(cmd[i + 1], "w") as f:
+                    f.write(final_text + "\n")
+        return fake_proc
+
+    return _fake_spawn
+
+
+@pytest.mark.unit
+def test_codex_spawn_records_pid_event_and_new_session(stores, tmp_path):
+    """A successful codex spawn records a `codex_pid` event carrying pid/pgid and
+    passes `start_new_session=True` (own process-group leader, killable via
+    killpg without touching the worker)."""
+    sess_store, tr_store = stores
+    session = _seed_codex_session(sess_store, task_id="cx-pid")
+
+    lines = [
+        {"type": "thread.started", "thread_id": "thread-x"},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "hi"}},
+    ]
+    captured: dict = {}
+    fake_proc = _FakeProc(lines, returncode=0, pid=54321)
+    executor = CodexExecutor(
+        session_store=sess_store,
+        transcript_store=tr_store,
+        spawn_fn=_spawn_capturing(captured, fake_proc, final_text="hi"),
+        binary_resolver=lambda: "/usr/bin/true",
+        heartbeat_interval=9999,
+    )
+
+    outcome = executor.execute(session, {"description": "say hi", "working_dir": str(tmp_path)})
+
+    assert outcome.status == STATUS_COMPLETED
+    assert captured.get("start_new_session") is True
+    pid_events = [e for e in tr_store.read(session.session_id) if e["kind"] == "codex_pid"]
+    assert len(pid_events) == 1
+    assert pid_events[0]["payload"]["pid"] == 54321
+    assert "pgid" in pid_events[0]["payload"]
+
+
+@pytest.mark.unit
+def test_codex_operator_kill_mid_run_exits_silently(stores, tmp_path):
+    """When the operator kill flips the row to FAILED while codex runs and the
+    subprocess returns a non-zero (signalled) returncode, the executor exits
+    silently — REASON_KILLED, a `codex_killed` event, and NEITHER `codex_failed`
+    nor `codex_completed`."""
+    sess_store, tr_store = stores
+    session = _seed_codex_session(sess_store, task_id="cx-killed")
+
+    def _flip_to_failed():
+        sess_store.update_status(session.task_id, STATUS_FAILED)
+
+    # returncode=-9 mimics a process killed by signal (killpg/SIGKILL).
+    fake_proc = _FakeProc([{"type": "thread.started", "thread_id": "t"}],
+                          returncode=-9, on_wait=_flip_to_failed)
+    notifications: list[str] = []
+    executor = CodexExecutor(
+        session_store=sess_store,
+        transcript_store=tr_store,
+        notification_callback=notifications.append,
+        spawn_fn=_spawn_capturing({}, fake_proc),
+        binary_resolver=lambda: "/usr/bin/true",
+        heartbeat_interval=9999,
+    )
+
+    outcome = executor.execute(session, {"description": "long task", "working_dir": str(tmp_path)})
+
+    assert outcome.status == STATUS_FAILED
+    assert outcome.reason == REASON_KILLED
+    kinds = [e["kind"] for e in tr_store.read(session.session_id)]
+    assert "codex_killed" in kinds
+    assert "codex_failed" not in kinds
+    assert "codex_completed" not in kinds
+
+
+@pytest.mark.unit
+def test_codex_clean_completion_wins_over_raced_failed_flip(stores, tmp_path):
+    """#379 cascade-race guard: if the row is flipped FAILED mid-run (e.g. a
+    lineage-budget cascade) but the codex subprocess exits 0 — it finished its
+    work — the COMPLETED path wins: status COMPLETED, a `codex_completed` event,
+    and NOT REASON_KILLED / no `codex_killed`. The returncode gate prevents the
+    silent guard from clobbering a clean completion."""
+    sess_store, tr_store = stores
+    session = _seed_codex_session(sess_store, task_id="cx-cascade")
+
+    def _flip_to_failed():
+        # A second legitimate FAILED-writer (the cascade) races our clean exit.
+        sess_store.update_status(session.task_id, STATUS_FAILED)
+
+    lines = [
+        {"type": "thread.started", "thread_id": "thread-ok"},
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "all done"}},
+    ]
+    # returncode=0 → the subprocess completed cleanly despite the FAILED flip.
+    fake_proc = _FakeProc(lines, returncode=0, on_wait=_flip_to_failed)
+    executor = CodexExecutor(
+        session_store=sess_store,
+        transcript_store=tr_store,
+        spawn_fn=_spawn_capturing({}, fake_proc, final_text="all done"),
+        binary_resolver=lambda: "/usr/bin/true",
+        heartbeat_interval=9999,
+    )
+
+    outcome = executor.execute(session, {"description": "task", "working_dir": str(tmp_path)})
+
+    assert outcome.status == STATUS_COMPLETED
+    assert outcome.reason != REASON_KILLED
+    assert outcome.final_text == "all done"
+    kinds = [e["kind"] for e in tr_store.read(session.session_id)]
+    assert "codex_completed" in kinds
+    assert "codex_killed" not in kinds


### PR DESCRIPTION
## Summary
Closes **#379**. `POST /api/agents/sessions/{id}/kill` flipped the DB row FAILED + tore down the managed remote but **never signalled the local `claude -p` (or codex) OS subprocess** — owned by the separate worker process — so it kept running (compute + could still notify) until the next poll. Now the kill terminates it within ~seconds.

**Mechanism (no schema change — the PID rides in the append-only transcript):**
- The executor spawns the subprocess with `start_new_session=True` (its own process-group leader, so `killpg` hits the CLI + its children but **not** the worker) and records a `claude_code_pid` / `codex_pid` `{pid,pgid}` transcript event after spawn.
- `teardown_session` (which the kill endpoint loops over the subtree) reads the latest pid event and, for LOCAL routings, does a liveness check → `killpg(SIGTERM)` → ~2s bounded grace → `killpg(SIGKILL)`. Best-effort: a missing/stale pid or signal error never breaks teardown.
- **No post-kill `[NOTIFY]`**: an externally-killed subprocess would otherwise hit the FAILED path and emit a spurious "session failed" notice. A guard in the executor — if the row is already FAILED when `proc.wait()` returns (only the operator kill flips it mid-run) — returns `REASON_KILLED`, and the dispatch suppresses the notice + web mirror.
- Cascade (`operator_killed`/`cascade_killed`), managed/cloud teardown, and the `{"killed":[...],"failures":[...]}` response are preserved. Full **codex parity**.

## Test evidence
Targeted (executor + inter_agent + dispatch + kill-api): **106 passed**; codex: **26 passed**; full unit suite: **2263 passed, 8 skipped**. New tests cover the pid event + `start_new_session`, the silent guard (REASON_KILLED, no `claude_code_failed`/COMPLETED), teardown SIGTERM→SIGKILL/stale-pid/clean-exit, managed-session skips local kill but still flips status, dispatch notice-suppression, and the endpoint driving a 2-node subtree kill.

## Review focus
- **Cross-process signal safety**: `start_new_session` ⇒ `killpg` can't reach the worker; the pid-reuse liveness check; best-effort never breaks teardown.
- **The kill-detection race**: the guard keys on the DB row (FAILED set only by the operator kill while the executor holds RUNNING) — not the returncode. Is there any other concurrent FAILED-writer (watchdog/timeout, #400 guard)?
- **No post-kill notify** for both claude_code and codex.
- **Dogfooding note**: the real cross-process signal is mocked in tests (`os.kill`/`os.killpg`); the live "kill a real `claude -p` and the OS process is gone in <~3s" path will be dogfooded on the worker after merge.