### PR TITLE
feat(agent-worker): parent can reopen a completed CLI child to answer its clarification

### DIFF
--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -169,9 +169,7 @@ the surrounding system. If you discover the task is bigger than expected
 the minimal safe change.
 
 CLARIFICATION:
-- Use [CLARIFY] to ask a question. Your session will pause and the user's
-  answer will be relayed back to you. After sending [CLARIFY], STOP and do
-  not continue working.
+{clarification}
 
 PERSISTENCE:
 - If your first approach doesn't work, try alternatives before giving up.
@@ -198,6 +196,23 @@ NOTIFICATIONS — use [NOTIFY] for:
 DELEGATION:
 You already have a browser (--chrome), filesystem, and shell. {delegation}
 """
+
+
+# Operator sessions really do pause on [CLARIFY] — the worker goes BLOCKED and
+# relays the Telegram reply. A spawned child does NOT (#356): its question is
+# folded into its output as "[needs clarification] …" and the turn completes;
+# the parent may answer via lifeos_agent_send, which resumes the child's CLI
+# session. Each variant states only what actually happens to that session.
+_CLARIFY_OPERATOR = """\
+- Use [CLARIFY] to ask a question. Your session will pause and the user's
+  answer will be relayed back to you. After sending [CLARIFY], STOP and do
+  not continue working."""
+
+_CLARIFY_CHILD = """\
+- Use [CLARIFY] to ask a question. Your turn will end and the question is
+  delivered to the parent agent that spawned you; if it answers, you will be
+  resumed with the answer as your next turn. After sending [CLARIFY], STOP
+  and do not continue working."""
 
 
 _PLAN_PREFIX = """\
@@ -384,6 +399,7 @@ class ClaudeCodeExecutor:
         resume_session_id: Optional[str],
         session_id: str = "",
         model: str = "opus",
+        is_child: bool = False,
     ) -> list[str]:
         platform_desc = (
             "Linux server running Ubuntu"
@@ -404,6 +420,7 @@ class ClaudeCodeExecutor:
                 user_name=settings.user_name,
                 code_dir=settings.code_dir,
                 platform_desc=platform_desc,
+                clarification=_CLARIFY_CHILD if is_child else _CLARIFY_OPERATOR,
                 delegation=delegation_preamble(
                     session_id,
                     trigger="To run background work in parallel,",
@@ -454,6 +471,7 @@ class ClaudeCodeExecutor:
         cmd = self._build_command(
             prompt, resume_session_id, session_id=sid,
             model=session.claude_code_model or "opus",
+            is_child=bool(session.parent_session_id),
         )
 
         self.transcript_store.append(sid, "claude_code_spawn", {

--- a/api/services/agent_worker/delegation.py
+++ b/api/services/agent_worker/delegation.py
@@ -39,7 +39,12 @@ def delegation_preamble(session_id: str, *, trigger: str, model: str) -> str:
         f"Your LifeOS agent session id is {session_id}. {trigger} delegate it "
         f"with the `{SPAWN}` MCP tool (caller_session_id={session_id}, "
         f"model={model}). Monitor the child with `{CHECK}` and read its result "
-        f"with `{TRANSCRIPT_READ}`."
+        f"with `{TRANSCRIPT_READ}`. If a child's output contains "
+        f"\"[needs clarification] …\", it stopped mid-task to ask you a "
+        f"question: answer with `{SEND}` (session_id=child, message=answer) — "
+        f"this reopens the child with its full prior context — then wait on it "
+        f"again with `{YIELD_UNTIL}`. Send the answer before yielding; a "
+        f"yielded session can't send."
     )
 
 
@@ -53,5 +58,8 @@ message them with `{SEND}`, check status with
 `{CHECK}`. When you have nothing to do until specific children
 finish, call `{YIELD_UNTIL}(children=[...])` — this ends your
 session cleanly (no idle billing) and resumes you when the children are
-done. Prefer `yield_until` over polling.
+done. Prefer `yield_until` over polling. If a child's output contains
+"[needs clarification] …", it stopped mid-task to ask you a question:
+answer with `{SEND}` (this reopens the child with its full prior
+context), then yield on it again — send the answer before yielding.
 </inter_agent>"""

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -7,7 +7,10 @@ core primitives are:
   - **spawn**: create a child session (Claude or local) with budget drawn from
     the caller's lineage budget. Returns immediately with a `child_session_id`.
   - **send**: append a user-role message to a peer/child session. For yielded
-    sessions, the message is queued for the next resume.
+    sessions, the message is queued for the next resume. Sending to your own
+    completed CLI child reopens it (the message becomes its next turn, resumed
+    with full prior context) — the answer path for a child that completed with
+    a "[needs clarification]" question (#356 follow-up).
   - **check**: non-blocking status snapshot of any session.
   - **yield_until**: terminate the caller's session until specified children
     reach a terminal state; on resume, children's outputs are injected as a
@@ -37,6 +40,7 @@ from typing import Any
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
     STATUS_CLAIMED,
+    STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_YIELDED,
     TERMINAL_STATUSES,
@@ -155,7 +159,7 @@ INTER_AGENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
     },
     {
         "name": "lifeos_agent_send",
-        "description": "Append a user-role message to another agent session. For sessions that are yielded or sleeping, the message is queued and delivered on resume.",
+        "description": "Append a user-role message to another agent session. For sessions that are yielded or sleeping, the message is queued and delivered on resume. Sending to your own COMPLETED claude_code/codex child REOPENS it: your message becomes its next turn and it resumes with its full prior context. Use this to answer a child whose output contains '[needs clarification] ...', then wait on it again with `lifeos_agent_yield_until` (send the answer BEFORE yielding).",
         "input_schema": _with_caller({
             "session_id": {"type": "string"},
             "message": {"type": "string"},
@@ -356,7 +360,24 @@ def send(ctx: InterAgentContext, args: dict) -> dict:
     target = ctx.session_store.get_by_session_id(target_id)
     if target is None:
         return _err(f"session {target_id} not found", code="not_found")
-    if target.status in TERMINAL_STATUSES:
+    # Reopen-on-send (#356 follow-up): a spawned CLI child that hits a genuine
+    # fork folds "[needs clarification] …" into its output and COMPLETES (a
+    # BLOCKED child would strand its yielded parent). But its CLI session
+    # persists on disk under claude_code_session_id, so the direct parent can
+    # answer by just sending: the message is queued as the child's next turn
+    # and the status flips back to CLAIMED, which the spawned-session
+    # dispatcher resumes via `-r <claude_code_session_id>` — full prior
+    # context, no re-derivation. Restricted to COMPLETED (a FAILED child has
+    # nothing coherent to continue), to CLI routings (local/managed have no
+    # on-disk resume path here), and to a persisted CLI session id (`-r`
+    # needs the UUID; without it the child would strand CLAIMED).
+    reopen = (
+        target.status == STATUS_COMPLETED
+        and target.parent_session_id == ctx.caller_session_id
+        and target.routing in CLI_ROUTINGS
+        and bool(target.claude_code_session_id)
+    )
+    if target.status in TERMINAL_STATUSES and not reopen:
         return _err(f"session {target_id} is terminal ({target.status})", code="terminal")
 
     # Same-root lineage check — agents can't inject messages into unrelated
@@ -379,6 +400,15 @@ def send(ctx: InterAgentContext, args: dict) -> dict:
     ctx.transcript_store.append(target_id, "inter_agent_send", {
         "from": ctx.caller_session_id, "chars": len(message),
     })
+    if reopen:
+        # Flip AFTER the enqueue so the dispatch tick can never claim the
+        # child before its resume message exists (an empty resume prompt).
+        ctx.session_store.update_status(target.task_id, STATUS_CLAIMED)
+        ctx.transcript_store.append(target_id, "inter_agent_send_reopen", {
+            "from": ctx.caller_session_id,
+            "claude_code_session_id": target.claude_code_session_id,
+        })
+        return _ok({"delivered": True, "message_id": msg_id, "reopened": True})
     return _ok({"delivered": True, "message_id": msg_id, "queued": target.status == STATUS_YIELDED})
 
 

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1485,7 +1485,8 @@ class Worker:
 
         Handles both the fresh-spawn case (``claude_code_session_id`` is NULL
         — call ``execute()``) and the resume case (``claude_code_session_id``
-        set — call ``resume(message)`` with the latest drained pending message).
+        set — call ``resume(message)`` with ALL drained pending messages
+        concatenated in order).
         On a BLOCKED outcome the operator-facing reply prompt is sent via the
         id-capturing Telegram sender and registered in ``pending_questions``
         so a threaded reply round-trips through ``_resume_as_followup``.
@@ -1561,7 +1562,13 @@ class Worker:
             return
 
         if is_resume:
-            resume_message = pending[0]["content"] if pending else ""
+            # Every drained message rides the resume turn, in order. Draining
+            # returns ALL pending rows, and reopen-on-send (#428) makes
+            # multi-enqueue likely (e.g. a parent answers twice before the
+            # dispatch tick claims the reopened child) — resuming with only
+            # pending[0] would silently drop messages `lifeos_agent_send`
+            # already acknowledged as delivered.
+            resume_message = "\n\n".join(m["content"] for m in pending) if pending else ""
             task: dict = {"id": session.task_id, "description": resume_message}
             self.transcript_store.append(sid, "claude_code_user_prompt", {
                 "text": resume_message, "resume": True,
@@ -1805,7 +1812,11 @@ class Worker:
             return
 
         if is_resume:
-            resume_message = pending[0]["content"] if pending else ""
+            # All drained messages ride the resume turn in order — same
+            # multi-enqueue rationale as the claude_code dispatch above
+            # (a codex child can collect both an operator threaded reply
+            # and a parent reopen answer before the tick claims it, #428).
+            resume_message = "\n\n".join(m["content"] for m in pending) if pending else ""
             task: dict = {"id": session.task_id, "description": resume_message}
             self.transcript_store.append(sid, "codex_user_prompt", {
                 "text": resume_message, "resume": True,
@@ -2503,17 +2514,21 @@ class Worker:
             cached = None
         if cached:
             return cached
-        # Fallback: scan the transcript for a `completed`, `managed_completed`,
-        # or `claude_code_completed` event with non-empty `final_text`.
+        # Fallback: scan the transcript for `completed` / `managed_completed` /
+        # `claude_code_completed` events. The LATEST event's final_text wins —
+        # even when empty — so a reopened child's second run can't re-carry the
+        # first run's "[needs clarification] …" question into the parent's
+        # resume turn (#428). All three kinds persist a `final_text` key today;
+        # the key-presence guard keeps a legacy pre-#349 event (final_chars
+        # only) from clobbering a real value.
         path = self.transcript_store.dir / f"{child.session_id}.jsonl"
         last_text = ""
         for d in _iter_transcript(path):
             kind = d.get("kind", "")
             payload = d.get("payload", {}) or {}
             if kind in ("completed", "managed_completed", "claude_code_completed"):
-                ft = payload.get("final_text") or ""
-                if ft:
-                    last_text = ft
+                if "final_text" in payload:
+                    last_text = payload.get("final_text") or ""
         return last_text
 
     def _resume_cloud_parent(

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-06-21
+> **Last Updated:** 2026-07-08
 
 Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
 
@@ -259,7 +259,7 @@ Local agents can spawn child sessions and coordinate via the `lifeos_agent_*` to
 | Tool | Purpose |
 |---|---|
 | `lifeos_agent_spawn` | Create a new agent session (local or claude). Returns `session_id`. Optional `tier` (`haiku`/`sonnet`/`opus`) picks the Claude Code child's CLI model — see [Delegation tier + single-message (#349)](#delegation-tier--single-message-349). |
-| `lifeos_agent_send` | Post a message to a child session's queue. |
+| `lifeos_agent_send` | Post a message to a child session's queue. Also a lifecycle transition: a direct parent sending to its own COMPLETED `claude_code`/`codex` child with a persisted CLI session id **reopens** it — the message is enqueued as the child's next turn *before* the status flips back to `claimed` (so a dispatch tick can never claim an empty resume prompt), and the spawned-session dispatcher resumes the CLI session via `-r` with full prior context. All other terminal sends still reject. |
 | `lifeos_agent_check` | Poll a child's current state. |
 | `lifeos_agent_yield_until` | Pause the caller until specific children reach terminal state — preferred over polling (no idle billing). |
 | `lifeos_agent_kill` | Terminate a child early. |
@@ -330,6 +330,10 @@ For local sessions, the parent session resumes via the existing pending_messages
 For managed sessions, a new remote session is created with the resolved routing.
 
 Clarifications older than `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` (default 72h) are abandoned with a Telegram heads-up; the transcript stays preserved.
+
+### Child clarifications (#422 / #428)
+
+Spawned CLI children never enter the Telegram flow above — the operator owns no thread to a child, and a BLOCKED child would strand its yielded parent (which only resumes once every child is terminal). Instead, a child's `[CLARIFY]` is folded into its output as `[needs clarification] …` and the child COMPLETES (`_effective_final_text` / `claude_code_child_clarify_folded`). The parent reads the question in the child's relayed output on resume and answers via `lifeos_agent_send`, which reopens the completed child (see [Inter-agent coordination](#inter-agent-coordination)); the parent then `yield_until`s the child again. Operator `/claude` sessions keep the pause-and-reply behavior: their `[CLARIFY]` goes BLOCKED and waits on a threaded Telegram reply.
 
 ### Replyable terminal threads
 

--- a/tests/test_agent_worker_claude_code_dispatch.py
+++ b/tests/test_agent_worker_claude_code_dispatch.py
@@ -184,6 +184,73 @@ def test_child_final_text_reads_claude_code_completed_event(tmp_path: Path):
     assert "Match 1: A vs B at noon." in worker._child_final_text(child)
 
 
+def test_resume_delivers_all_pending_messages(tmp_path: Path):
+    """A resume dispatch must carry EVERY drained pending message, in order —
+    not just pending[0]. Reopen-on-send (#428) makes multi-enqueue likely
+    (e.g. a parent sends twice before the dispatch tick claims the reopened
+    child), and each send already returned delivered=true."""
+    stub = _StubClaudeCodeExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="resumed.")
+    )
+    worker, store, _, _ = _capturing_worker(tmp_path, claude_code_executor=stub)
+    parent = store.create(task_id="parent-1", routing="local")
+    store.create(
+        task_id="child-1", routing="claude_code", parent_session_id=parent.session_id,
+    )
+    # A persisted CLI session id is what routes dispatch into the resume branch.
+    store.set_claude_code_session_id("child-1", "cli-uuid-1")
+    child = store.get("child-1")
+
+    worker._dispatch_claude_code_session(child, [
+        {"content": "use the staging repo"},
+        {"content": "and target the v2 branch"},
+    ])
+
+    assert stub.calls == []  # resume, never a fresh execute
+    assert stub.resume_calls == [
+        ("child-1", "use the staging repo\n\nand target the v2 branch"),
+    ]
+
+
+def test_child_final_text_latest_completed_event_wins_even_when_empty(tmp_path: Path):
+    """The LATEST completed event's final_text wins even when empty (#428):
+    a reopened child whose second run completes with no final text must not
+    re-deliver the first run's '[needs clarification] …' question to the
+    parent — that would invite a re-answer loop."""
+    worker, store, transcripts, _ = _capturing_worker(tmp_path, claude_code_executor=None)
+    parent = store.create(task_id="parent-1", routing="local")
+    child = store.create(
+        task_id="child-1", routing="claude_code", parent_session_id=parent.session_id,
+    )
+    transcripts.append(child.session_id, "claude_code_completed", {
+        "final_chars": 33, "final_text": "[needs clarification] which repo?",
+    })
+    transcripts.append(child.session_id, "claude_code_completed", {
+        "final_chars": 0, "final_text": "",
+    })
+
+    assert worker._child_final_text(child) == ""
+
+
+def test_child_final_text_legacy_event_without_key_does_not_clobber(tmp_path: Path):
+    """A legacy completed event that never carried a `final_text` key (pre-#349
+    payloads recorded final_chars only) must not wipe a real value from an
+    earlier event."""
+    worker, store, transcripts, _ = _capturing_worker(tmp_path, claude_code_executor=None)
+    parent = store.create(task_id="parent-1", routing="local")
+    child = store.create(
+        task_id="child-1", routing="claude_code", parent_session_id=parent.session_id,
+    )
+    transcripts.append(child.session_id, "claude_code_completed", {
+        "final_chars": 24, "final_text": "Match 1: A vs B at noon.",
+    })
+    transcripts.append(child.session_id, "claude_code_completed", {
+        "final_chars": 0,  # legacy: no final_text key at all
+    })
+
+    assert worker._child_final_text(child) == "Match 1: A vs B at noon."
+
+
 def test_vault_claude_task_marked_complete_on_finish(tmp_path: Path):
     """A vault-routed ``#agent #claude`` task (origin != 'operator', no parent)
     must be reconciled in the vault when the Claude Code session completes:

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -483,6 +483,45 @@ def test_build_command_defaults_to_opus(tmp_path: Path):
     assert cmd[cmd.index("--model") + 1] == "opus"
 
 
+def _captured_system_prompt(tmp_path: Path, session_factory) -> str:
+    """Run the executor with a capture spawn_fn and return the value passed
+    to --append-system-prompt."""
+    captured: dict = {}
+
+    def _spawn_capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc([
+            {"type": "system", "subtype": "init", "session_id": "cli-1"},
+            {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "ok"},
+        ])
+
+    executor, store, _ = _build_executor(tmp_path, spawn_fn=_spawn_capture)
+    session = session_factory(store)
+    executor.execute(session, {"description": "anything"})
+    cmd = captured["cmd"]
+    return cmd[cmd.index("--append-system-prompt") + 1]
+
+
+def test_operator_system_prompt_keeps_pause_and_relay_clarify_wording(tmp_path: Path):
+    """Operator /claude sessions do pause on [CLARIFY] (BLOCKED + Telegram
+    question) — their prompt must keep promising exactly that."""
+    prompt = _captured_system_prompt(tmp_path, _seed_session)
+    assert "Your session will pause and the user's" in prompt
+    assert "answer will be relayed back to you" in prompt
+    assert "parent agent" not in prompt
+
+
+def test_child_system_prompt_describes_parent_clarify_routing(tmp_path: Path):
+    """A spawned child's [CLARIFY] folds into its output and the turn ends
+    (#356) — its prompt must describe that honestly instead of promising an
+    operator pause-and-relay that never happens."""
+    prompt = _captured_system_prompt(tmp_path, _seed_child_session)
+    assert "Your session will pause and the user's" not in prompt
+    assert "parent agent" in prompt
+    # The child is still told to stop after asking.
+    assert "STOP" in prompt
+
+
 def test_tool_use_records_transcript_event(tmp_path: Path):
     events = [
         {"type": "system", "subtype": "init", "session_id": "cli-1"},

--- a/tests/test_agent_worker_codex_dispatch.py
+++ b/tests/test_agent_worker_codex_dispatch.py
@@ -134,6 +134,31 @@ class _ResumableStubCodexExecutor(_StubCodexExecutor):
         return self.outcome
 
 
+def test_codex_resume_delivers_all_pending_messages(tmp_path: Path):
+    """A codex resume dispatch carries EVERY drained pending message in order —
+    not just pending[0]. A codex child can collect both an operator threaded
+    reply and a parent reopen answer (#428) before the tick claims it; each
+    send already returned delivered=true."""
+    plain_sends: list[str] = []
+    withid_sends: list[str] = []
+    stub = _ResumableStubCodexExecutor(
+        outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="resumed.")
+    )
+    worker = _make_worker(tmp_path, codex_executor=stub, plain_sends=plain_sends, withid_sends=withid_sends)
+    worker.session_store.create(task_id="cx-resume", routing="codex", origin="operator")
+    # A persisted CLI session id routes dispatch into the resume branch.
+    worker.session_store.set_claude_code_session_id("cx-resume", "codex-uuid-1")
+    session = worker.session_store.get("cx-resume")
+
+    worker._dispatch_codex_session(session, [
+        {"content": "first follow-up"},
+        {"content": "second follow-up"},
+    ])
+
+    assert stub.calls == []  # resume, never a fresh execute
+    assert stub.resume_calls == [("cx-resume", "first follow-up\n\nsecond follow-up")]
+
+
 def test_codex_crash_before_init_does_not_reexecute(tmp_path: Path):
     """A codex session whose subprocess launched once (a `codex_spawn` event is
     present) but never persisted its session id must NOT re-run the original

--- a/tests/test_agent_worker_delegation.py
+++ b/tests/test_agent_worker_delegation.py
@@ -21,6 +21,24 @@ def test_preamble_contains_session_id_and_core_mechanic():
         assert tool in p
 
 
+def test_preamble_explains_child_clarification_reopen():
+    """A parent must learn from its prompt what a child's
+    '[needs clarification]' output means and how to answer it: send the
+    answer (which reopens the child with full context), THEN yield again."""
+    p = delegation.delegation_preamble("SID-1", trigger="To do X,", model='"local"')
+    assert "[needs clarification]" in p
+    assert delegation.SEND in p
+    assert delegation.YIELD_UNTIL in p
+    # Ordering matters: a yielded parent can't send, so the answer goes first.
+    assert "before" in p.lower()
+
+
+def test_inter_agent_block_explains_child_clarification_reopen():
+    block = delegation.INTER_AGENT_BLOCK
+    assert "[needs clarification]" in block
+    assert delegation.SEND in block
+
+
 def test_inter_agent_block_references_full_protocol():
     block = delegation.INTER_AGENT_BLOCK
     for tool in (
@@ -46,7 +64,10 @@ def test_inter_agent_block_text_is_pinned():
         "`lifeos_agent_check`. When you have nothing to do until specific children\n"
         "finish, call `lifeos_agent_yield_until(children=[...])` — this ends your\n"
         "session cleanly (no idle billing) and resumes you when the children are\n"
-        "done. Prefer `yield_until` over polling.\n"
+        "done. Prefer `yield_until` over polling. If a child's output contains\n"
+        "\"[needs clarification] …\", it stopped mid-task to ask you a question:\n"
+        "answer with `lifeos_agent_send` (this reopens the child with its full prior\n"
+        "context), then yield on it again — send the answer before yielding.\n"
         "</inter_agent>"
     )
 

--- a/tests/test_agent_worker_inter_agent.py
+++ b/tests/test_agent_worker_inter_agent.py
@@ -281,6 +281,127 @@ def test_send_rejects_terminal_session(ctx, store, parent):
     assert result["error"] == "terminal"
 
 
+def _seed_completed_cli_child(
+    store, parent, *, task_id="cli_child", routing="claude_code",
+    status=STATUS_COMPLETED, cli_session_id="cli-abc-123",
+):
+    """A CLI child that finished a turn — the reopen-on-send target shape."""
+    child = store.create(
+        task_id=task_id, status=status, routing=routing,
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    if cli_session_id:
+        store.set_claude_code_session_id(task_id, cli_session_id)
+    return child
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("routing", ["claude_code", "codex"])
+def test_send_reopens_own_completed_cli_child(ctx, store, transcript, parent, routing):
+    """A parent answering its completed CLI child's [needs clarification]
+    question reopens it: message enqueued, status flipped back to CLAIMED so
+    the spawned-session dispatcher resumes it via the persisted CLI session id."""
+    child = _seed_completed_cli_child(store, parent, routing=routing)
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": child.session_id, "message": "use API v2",
+    })
+    assert result["ok"]
+    assert result["reopened"] is True
+    refreshed = store.get_by_session_id(child.session_id)
+    assert refreshed.status == STATUS_CLAIMED
+    pending = store.drain_pending_messages(child.session_id)
+    assert len(pending) == 1
+    assert pending[0]["content"] == "use API v2"
+    assert pending[0]["sender_id"] == parent.session_id
+    kinds = [e["kind"] for e in transcript.read(child.session_id)]
+    assert "inter_agent_send_reopen" in kinds
+
+
+@pytest.mark.unit
+def test_send_reopen_message_enqueued_before_status_flip(ctx, store, parent, monkeypatch):
+    """The pending message must exist by the time the child turns CLAIMED —
+    otherwise the dispatch tick could resume the child with an empty prompt."""
+    child = _seed_completed_cli_child(store, parent)
+    calls: list[str] = []
+    original_enqueue = store.enqueue_message
+    original_update = store.update_status
+    monkeypatch.setattr(store, "enqueue_message",
+                        lambda *a, **k: (calls.append("enqueue"), original_enqueue(*a, **k))[1])
+    monkeypatch.setattr(store, "update_status",
+                        lambda *a, **k: (calls.append("status"), original_update(*a, **k))[1])
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": child.session_id, "message": "answer",
+    })
+    assert result["ok"]
+    assert calls.index("enqueue") < calls.index("status")
+
+
+@pytest.mark.unit
+def test_send_rejects_reopen_of_failed_child(ctx, store, parent):
+    """Only COMPLETED children reopen — a FAILED child stays terminal."""
+    child = _seed_completed_cli_child(store, parent, status=STATUS_FAILED)
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": child.session_id, "message": "try again",
+    })
+    assert not result["ok"]
+    assert result["error"] == "terminal"
+    assert store.get_by_session_id(child.session_id).status == STATUS_FAILED
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("routing", ["local", "claude"])
+def test_send_rejects_reopen_of_non_cli_child(ctx, store, parent, routing):
+    """local/managed children have no CLI resume path — reopen is CLI-only."""
+    child = _seed_completed_cli_child(store, parent, routing=routing)
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": child.session_id, "message": "hello",
+    })
+    assert not result["ok"]
+    assert result["error"] == "terminal"
+    assert store.get_by_session_id(child.session_id).status == STATUS_COMPLETED
+
+
+@pytest.mark.unit
+def test_send_rejects_reopen_without_cli_session_id(ctx, store, parent):
+    """A completed child whose init never persisted a CLI session id can't be
+    resumed (`-r` needs the UUID) — reopen must refuse, not strand it CLAIMED."""
+    child = _seed_completed_cli_child(store, parent, cli_session_id=None)
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": child.session_id, "message": "hello",
+    })
+    assert not result["ok"]
+    assert result["error"] == "terminal"
+    assert store.get_by_session_id(child.session_id).status == STATUS_COMPLETED
+
+
+@pytest.mark.unit
+def test_send_rejects_reopen_of_non_direct_child(ctx, store, parent):
+    """Only the direct parent may reopen — a same-lineage grandparent or
+    sibling sending to a completed session still gets the terminal error."""
+    middle = store.create(
+        task_id="mid", status=STATUS_RUNNING, routing="claude",
+        parent_session_id=parent.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=1,
+    )
+    grandchild = store.create(
+        task_id="gc", status=STATUS_COMPLETED, routing="claude_code",
+        parent_session_id=middle.session_id,
+        root_session_id=parent.session_id,
+        spawn_depth=2,
+    )
+    store.set_claude_code_session_id("gc", "cli-gc-1")
+    # ctx's caller is `parent` — the grandparent of `grandchild`.
+    result = dispatch(ctx, "lifeos_agent_send", {
+        "session_id": grandchild.session_id, "message": "hi",
+    })
+    assert not result["ok"]
+    assert result["error"] == "terminal"
+    assert store.get_by_session_id(grandchild.session_id).status == STATUS_COMPLETED
+
+
 @pytest.mark.unit
 def test_check_returns_session_metadata(ctx, store, parent):
     child = store.create(


### PR DESCRIPTION
## Summary

Follow-up to #356/#422. A spawned CLI child that emits `[CLARIFY]` folds the question into its output as `[needs clarification] …` and completes — correct for the strand bug, but the parent's only path to get the question answered was re-spawning a fresh child, throwing away all the context the first child built up. That context was never actually lost: the child's CLI session persists on disk under `claude_code_session_id`, and the worker already resumes completed CLI sessions via `-r` for operator follow-ups.

This PR exposes that path to parents (**reopen-on-send**): `lifeos_agent_send` to your own direct COMPLETED `claude_code`/`codex` child enqueues the answer as the child's next turn and flips it back to CLAIMED, which the existing spawned-session dispatcher resumes with full prior context. The parent then just `yield_until`s the child again. All other terminal sends still reject: FAILED/BUDGET_EXCEEDED targets, non-direct-parent callers, `local`/`claude` routings, and children with no persisted CLI session id (`-r` needs the UUID; reopening would strand them CLAIMED).

Also aligns the prompts with reality:
- The CLI system prompt's CLARIFICATION section is now per-audience. Children were still being promised "your session will pause and the user's answer will be relayed" — false since #422. The operator variant is byte-identical to before.
- The delegation preamble, local-worker inter-agent block, and `lifeos_agent_send` tool description now tell parents what `[needs clarification]` means and how to answer it (send first, then yield — a yielded session can't send).

Relates to #356.

## Test evidence

On nathan-linux (worktree of this branch):
- `pytest tests/test_agent_worker_inter_agent.py tests/test_agent_worker_delegation.py tests/test_agent_worker_claude_code_executor.py -q` — **97 passed** (12 new: reopen happy path for both CLI routings, enqueue-before-flip ordering, five rejection cases, per-audience prompt wording, delegation guidance + updated pinned block text).
- Full `pytest -m unit` on the final branch head (cfc7e28): **2286 passed, 0 failed** (8 skipped, 1079 deselected) on nathan-linux.
- Post-fix targeted sweep (review round 1): 174 passed across the six agent-worker test files.

## Review focus

- The reopen gate in `inter_agent.send` — is the eligibility condition (COMPLETED + direct parent + CLI routing + persisted CLI session id) airtight against stranding a child in CLAIMED with no resume path?
- Ordering: message is enqueued before the status flip so a dispatch tick can't claim the child with an empty resume prompt.
- Prompt-text changes are behavior-adjacent: operator CLARIFY wording must remain byte-identical (test-pinned), and the INTER_AGENT_BLOCK pin in test_agent_worker_delegation.py was intentionally updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
