### PR TITLE
feat(telegram): quoted-reply context for primary-bot threaded replies

### DIFF
--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -27,6 +27,10 @@ logger = logging.getLogger(__name__)
 
 TELEGRAM_API = "https://api.telegram.org"
 MAX_MESSAGE_LENGTH = 4096
+# Cap on quoted text prepended to threaded replies. Generous enough to keep a
+# full nightly priorities summary (~1,000 chars) intact — truncating below that
+# would cut off the bullet a follow-up question is asking about (#435).
+MAX_QUOTED_REPLY_CHARS = 1500
 
 # The bot token for the message currently being handled. A listener sets this
 # once at the top of _handle_update so every outbound send during that update —
@@ -780,14 +784,17 @@ class TelegramBotListener:
             await self._handle_orchestration_message(text, chat_id)
             return
 
-        # Threaded-reply context for specialized bots: when the user replies to
-        # one of the bot's own messages (e.g. correcting a "Logged: …" line), pass
-        # the quoted text as context so the orchestrator can correlate the
-        # correction to the right earlier item, not just the latest. Primary-bot
-        # threaded replies are handled above (agent/Claude-Code resumption).
+        # Threaded-reply context: when the user replies to one of the bot's own
+        # messages (e.g. correcting a "Logged: …" line, or asking about a bullet
+        # in a summary sent via the raw Bot API), pass the quoted text as context
+        # so the orchestrator can resolve deictic questions about it (#435).
+        # Primary-bot agent/Claude-Code reply threads short-circuited above, so
+        # this only sees replies to ordinary messages.
         effective_text = text
-        if not self._is_primary and reply_to and reply_to.get("text"):
+        if reply_to and reply_to.get("text"):
             quoted = reply_to["text"].strip()
+            if len(quoted) > MAX_QUOTED_REPLY_CHARS:
+                quoted = quoted[:MAX_QUOTED_REPLY_CHARS] + "…"
             effective_text = f'[replying to my earlier message: "{quoted}"]\n{text}'
 
         # Send through chat pipeline (intent classification happens there)

--- a/tests/test_telegram_multibot.py
+++ b/tests/test_telegram_multibot.py
@@ -246,6 +246,54 @@ class TestHandleUpdate:
         assert "no, that was 145" in sent_text
 
     @pytest.mark.asyncio
+    async def test_primary_bot_prepends_reply_quote_when_hooks_miss(self):
+        """Issue #435: a reply to an ordinary primary-bot message (not a
+        claude-code/agent-worker thread) carries the quoted text into chat."""
+        listener = self._listener("primary", "999")
+        update = {"message": {
+            "text": "what does the third bullet mean?",
+            "chat": {"id": 999},
+            "message_id": 10,
+            "reply_to_message": {"message_id": 9, "text": "Tonight's priorities:\n- a\n- b\n- c"},
+        }}
+        with patch.object(listener, "_maybe_handle_claude_code_reply", new_callable=AsyncMock, return_value=False), \
+             patch.object(listener, "_maybe_deposit_agent_answer", return_value=False), \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock), \
+             patch("api.services.telegram.TypingIndicator", _DummyTyping), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            mock_chat.return_value = {"answer": "It means c", "conversation_id": "c1"}
+            await listener._handle_update(update)
+        sent_text = mock_chat.call_args.args[0]
+        assert "replying to my earlier message" in sent_text
+        assert "Tonight's priorities" in sent_text
+        assert "what does the third bullet mean?" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_long_quoted_reply_is_truncated(self):
+        from api.services.telegram import MAX_QUOTED_REPLY_CHARS
+        listener = self._listener("primary", "999")
+        long_quote = "x" * (MAX_QUOTED_REPLY_CHARS + 500)
+        update = {"message": {
+            "text": "explain that",
+            "chat": {"id": 999},
+            "message_id": 11,
+            "reply_to_message": {"message_id": 9, "text": long_quote},
+        }}
+        with patch.object(listener, "_maybe_handle_claude_code_reply", new_callable=AsyncMock, return_value=False), \
+             patch.object(listener, "_maybe_deposit_agent_answer", return_value=False), \
+             patch("api.services.telegram.send_typing_indicator", new_callable=AsyncMock), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock), \
+             patch("api.services.telegram.TypingIndicator", _DummyTyping), \
+             patch("api.services.telegram.chat_via_api", new_callable=AsyncMock) as mock_chat:
+            mock_chat.return_value = {"answer": "ok", "conversation_id": "c1"}
+            await listener._handle_update(update)
+        sent_text = mock_chat.call_args.args[0]
+        assert "x" * MAX_QUOTED_REPLY_CHARS + "…" in sent_text
+        assert "x" * (MAX_QUOTED_REPLY_CHARS + 1) not in sent_text
+        assert "explain that" in sent_text
+
+    @pytest.mark.asyncio
     async def test_plain_message_has_no_reply_context(self):
         listener = self._listener("fitness", "999", persona="P")
         update = {"message": {"text": "bench 135x8", "chat": {"id": 999}, "message_id": 8}}


### PR DESCRIPTION
## Summary
Replying to an ordinary primary-bot Telegram message (e.g. the nightly priorities summary, sent via the raw Bot API and thus absent from conversation history) previously reached the chat pipeline as bare text. This PR extends the existing specialized-bot quoted-reply injection (`[replying to my earlier message: "..."]`) to the primary bot, applied only after the claude-code and agent-worker reply hooks miss — both of those return early above, so `/claude` session resume and clarification deposits are byte-identical to before. Quoted text is capped at 1,500 chars (`MAX_QUOTED_REPLY_CHARS`), comfortably above the ~1,000-char priorities summary so bullet-level follow-ups stay grounded.

Closes #435

## Test evidence
Full unit suite on nathan-linux (isolated worktree, `pytest -m unit -q -n auto --dist loadscope`): **2302 passed, 8 skipped**. New tests: `test_primary_bot_prepends_reply_quote_when_hooks_miss`, `test_long_quoted_reply_is_truncated`; existing hook-precedence and no-reply-context tests cover the unchanged paths.

## Review focus
- Ordering in `_handle_update`: the injection block runs after the agent/claude hooks and the orchestration-bot early return — confirm no path re-enters those flows with modified text.
- The `MAX_QUOTED_REPLY_CHARS = 1500` choice vs. prompt-size concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)