### PR TITLE
feat(ops): auto-deploy timer redeploys the host when main advances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,20 @@
 # LIFEOS_MCP_HTTP_URL=https://mcp.example.com/mcp
 
 # =============================================================================
+# AUTO-DEPLOY (self-hosted host pulls + redeploys when main advances)
+# =============================================================================
+
+# Enable the lifeos-autodeploy.timer. Off by default so a fresh clone never
+# silently pulls and restarts on its own. When on, the timer polls origin/main
+# every 10 min and, if it advanced, fast-forward pulls and restarts the code
+# services that changed. Guards: only on the main branch, only with a clean
+# working tree, only --ff-only. Run sudo ./scripts/setup-systemd.sh after changing.
+# LIFEOS_AUTODEPLOY_ENABLED=false
+
+# Telegram notifications from auto-deploy: failure (default) | always | never.
+# LIFEOS_AUTODEPLOY_NOTIFY=failure
+
+# =============================================================================
 # EMBEDDING MODEL — sentence-transformers (cached locally)
 # =============================================================================
 

--- a/config/systemd/lifeos-autodeploy.service
+++ b/config/systemd/lifeos-autodeploy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=LifeOS Auto-Deploy — ff-pulls main and restarts changed services
+After=network-online.target lifeos-api.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Runs as the repo owner (not root): git pull uses the user's SSH key; service
+# restarts go through the passwordless sudoers rule from setup-systemd.sh.
+User=__USER__
+WorkingDirectory=__LIFEOS_DIR__
+ExecStart=__LIFEOS_DIR__/scripts/auto-deploy.sh

--- a/config/systemd/lifeos-autodeploy.timer
+++ b/config/systemd/lifeos-autodeploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=LifeOS Auto-Deploy Timer (every 10 min)
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=10min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Operations
-> **Last Updated:** 2026-07-07
+> **Last Updated:** 2026-07-08
 > **Audience:** Operators
 
 Operational procedures that don't belong in the day-to-day coding reference: the Apple Data Agent, Monarch Money auth, and quick observability commands. Moved here from `AGENTS.md` to keep the agent-facing file lean.
@@ -56,6 +56,33 @@ curl http://localhost:8000/api/perf/traces/{trace_id} | jq        # Single trace
 Set `LIFEOS_ALERT_EMAIL` in `.env` for alerts. Telegram backup via `telegram_bot_token` + `telegram_chat_id`.
 
 Services are tracked on-use, not by polling. Degradation events (fallback usage) are collected and reported in the nightly health check if there are 5+ in 24 hours.
+
+---
+
+## Auto-Deploy (self-hosted redeploy on push to main)
+
+When you push to `main` from another machine, the self-hosted host can pull and redeploy itself instead of you doing it by hand. This is the `lifeos-autodeploy.timer` — a polling systemd timer, off by default.
+
+**How it works:** every 10 minutes `scripts/auto-deploy.sh` runs `git fetch`; if `origin/main` advanced, it fast-forward pulls and restarts the currently-active code services (`lifeos-api`, and if running, `lifeos-agent-worker` / `lifeos-mcp-http`). Docs/tests/frontend-only changes pull without a restart. If `requirements.txt` changed it `pip install`s first. It runs as the repo owner (git pull uses the user's SSH key; restarts use the passwordless sudoers rule).
+
+Pull-based on purpose: it needs no inbound network, so it works on a WiFi-only host and just catches up on the next tick after any outage. Latency is up to the poll interval (~10 min).
+
+**Guards** (any tripped → the run changes nothing): must be on `main`, working tree must be clean (never clobbers local edits on the host), and the pull is `--ff-only` (a diverged `main` alerts instead of resetting).
+
+**Enable it:**
+
+```bash
+# in .env
+LIFEOS_AUTODEPLOY_ENABLED=true
+LIFEOS_AUTODEPLOY_NOTIFY=failure   # failure (default) | always | never
+
+sudo ./scripts/setup-systemd.sh    # installs + enables the timer
+systemctl list-timers lifeos-autodeploy.timer
+```
+
+**Watch it:** `tail -f logs/auto-deploy.log`. Failures (fetch, diverged pull, pip, restart, or `/health` not recovering post-deploy) send a Telegram alert.
+
+**Caveat:** it deploys whatever lands on `main` *without* re-running the test suite — safe only because merged `main` is expected to be green. It does not gate on tests by design (running the suite would take the API down and thrash the shared server).
 
 ---
 

--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# LifeOS Auto-Deploy
+# ==================
+# Polls origin/main and, when it advances, fast-forward pulls the new code and
+# restarts the services whose code the deploy touched. Pull-based by design: it
+# needs no inbound network, so it works on this WiFi-only host and simply catches
+# up on the next tick after any outage.
+#
+# Triggered by lifeos-autodeploy.timer (installed by setup-systemd.sh), default
+# every 10 min. Opt-in: does nothing unless LIFEOS_AUTODEPLOY_ENABLED=true in .env.
+#
+# Safety guards (any tripped → skip this run, change nothing):
+#   - must be on the main branch (never touches a feature branch you're working on)
+#   - working tree must be clean (never clobbers local edits)
+#   - pull is --ff-only (a diverged main is a real problem → alert, never reset)
+#
+# Notifications (LIFEOS_AUTODEPLOY_NOTIFY): failure (default) | always | never.
+#
+# Runs as the repo owner (not root): git pull uses the user's SSH key; service
+# restarts go through the passwordless sudoers rule installed by setup-systemd.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR" || exit 1
+
+LOG_FILE="$PROJECT_DIR/logs/auto-deploy.log"
+ENV_FILE="$PROJECT_DIR/.env"
+VENV_DIR="${LIFEOS_VENV:-$HOME/.venvs/lifeos}"
+# Non-interactive git over SSH: fail fast instead of prompting for a passphrase.
+export GIT_SSH_COMMAND='ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new'
+
+mkdir -p "$PROJECT_DIR/logs"
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$LOG_FILE"; }
+
+# Read a KEY=value from .env, stripping quotes/whitespace/inline comments.
+_read_env() {
+    local key="$1" default="$2" val
+    val=$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- \
+        | sed "s/^['\"]//;s/['\"]$//;s/ *#.*//" | tr -d '[:space:]')
+    echo "${val:-$default}"
+}
+
+send_telegram() {
+    local message="$1"
+    [ -f "$ENV_FILE" ] || return 0
+    local bot_token chat_id
+    bot_token=$(grep '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" | cut -d= -f2)
+    chat_id=$(grep '^TELEGRAM_CHAT_ID=' "$ENV_FILE" | cut -d= -f2)
+    [ -n "$bot_token" ] && [ -n "$chat_id" ] || return 0
+    /usr/bin/curl -s -X POST "https://api.telegram.org/bot${bot_token}/sendMessage" \
+        -d "chat_id=${chat_id}" \
+        -d "text=${message}" \
+        -d "parse_mode=Markdown" > /dev/null 2>&1 || true
+}
+
+NOTIFY=$(_read_env "LIFEOS_AUTODEPLOY_NOTIFY" "failure")
+notify_failure() { [ "$NOTIFY" != "never" ] && send_telegram "$1"; }
+notify_success() { [ "$NOTIFY" = "always" ] && send_telegram "$1"; }
+
+# --- Opt-in gate ---------------------------------------------------------------
+case "$(_read_env "LIFEOS_AUTODEPLOY_ENABLED" "false" | tr '[:upper:]' '[:lower:]')" in
+    true|1|yes) ;;
+    *) exit 0 ;;
+esac
+
+# --- Guards: only auto-deploy a clean main --------------------------------------
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$BRANCH" != "main" ]; then
+    log "skip: on branch '$BRANCH', not main"
+    exit 0
+fi
+if [ -n "$(git status --porcelain)" ]; then
+    log "skip: working tree dirty — not auto-deploying over local edits"
+    exit 0
+fi
+
+# --- Fetch and compare ----------------------------------------------------------
+if ! git fetch --quiet origin main 2>>"$LOG_FILE"; then
+    log "ERROR: git fetch failed"
+    notify_failure "🚨 *LifeOS Auto-Deploy*
+\`git fetch\` failed on the host — check network / SSH auth."
+    exit 1
+fi
+
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+[ "$LOCAL" = "$REMOTE" ] && exit 0   # up to date — the common case, stay silent
+
+log "main advanced: ${LOCAL:0:7} -> ${REMOTE:0:7}"
+CHANGED=$(git diff --name-only "$LOCAL" "$REMOTE")   # capture before the pull moves HEAD
+
+# --- Fast-forward pull ----------------------------------------------------------
+if ! git pull --ff-only --quiet origin main 2>>"$LOG_FILE"; then
+    log "ERROR: --ff-only pull failed (local main diverged from origin)"
+    notify_failure "🚨 *LifeOS Auto-Deploy*
+Fast-forward pull failed — local \`main\` has diverged from origin. Manual fix needed."
+    exit 1
+fi
+
+# --- Install dependencies if they changed ---------------------------------------
+if echo "$CHANGED" | grep -q '^requirements\.txt$'; then
+    log "requirements.txt changed — installing into $VENV_DIR"
+    if ! "$VENV_DIR/bin/pip" install -q -r requirements.txt >>"$LOG_FILE" 2>&1; then
+        log "ERROR: pip install failed — NOT restarting services"
+        notify_failure "🚨 *LifeOS Auto-Deploy*
+\`pip install\` failed after pulling new requirements. Services were NOT restarted."
+        exit 1
+    fi
+fi
+
+# --- Decide whether a restart is needed -----------------------------------------
+# Docs / tests / static frontend / CI config ship without a service restart.
+CODE_CHANGED=$(echo "$CHANGED" | grep -vE '^(docs/|tests/|web/|\.github/|plans/)|\.md$' || true)
+if [ -z "$CODE_CHANGED" ]; then
+    log "deployed ${REMOTE:0:7} (docs/tests only — no restart)"
+    notify_success "✅ *LifeOS Auto-Deploy*
+Pulled \`${REMOTE:0:7}\` (docs/tests only — no restart)."
+    exit 0
+fi
+
+# Restart every *currently active* code service. Restarting only running units
+# keeps opt-in services (agent-worker, mcp-http) off if the operator left them
+# off, and restarting the API on any code change is correct because it imports
+# the worker/mcp modules too. llm + chromadb hold no repo Python that changes.
+RESTARTED=()
+FAILED=()
+for unit in lifeos-api lifeos-agent-worker lifeos-mcp-http; do
+    systemctl is-active --quiet "$unit" || continue
+    if sudo -n systemctl restart "$unit" 2>>"$LOG_FILE"; then
+        RESTARTED+=("$unit")
+    else
+        FAILED+=("$unit")
+        log "ERROR: restart failed for $unit"
+    fi
+done
+
+if [ "${#FAILED[@]}" -gt 0 ]; then
+    log "deployed ${REMOTE:0:7} but restart FAILED: ${FAILED[*]}"
+    notify_failure "🚨 *LifeOS Auto-Deploy*
+Pulled \`${REMOTE:0:7}\` but restart failed: ${FAILED[*]}. Manual intervention needed."
+    exit 1
+fi
+
+# --- Post-deploy health check (API takes ~30-60s to reload its ML model) --------
+HEALTHY=0
+for _ in $(seq 1 18); do
+    if curl -s -f --max-time 5 http://localhost:8000/health > /dev/null 2>&1; then
+        HEALTHY=1
+        break
+    fi
+    sleep 5
+done
+
+if [ "$HEALTHY" -ne 1 ]; then
+    log "deployed ${REMOTE:0:7}, restarted ${RESTARTED[*]}, but /health did not recover"
+    notify_failure "🚨 *LifeOS Auto-Deploy*
+Deployed \`${REMOTE:0:7}\` and restarted ${RESTARTED[*]}, but \`/health\` never came back. Check the host."
+    exit 1
+fi
+
+log "deployed ${REMOTE:0:7}, restarted ${RESTARTED[*]}, health OK"
+notify_success "✅ *LifeOS Auto-Deploy*
+Deployed \`${REMOTE:0:7}\`, restarted ${RESTARTED[*]}. Health OK."
+exit 0

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -59,6 +59,7 @@ LLM_MMPROJ_PATH=$(_read_env "LIFEOS_LLM_MMPROJ_PATH" "")
 LLM_AUTOSTART=$(_read_env "LIFEOS_LOCAL_LLM_AUTOSTART" "false")
 MCP_BEARER_TOKEN=$(_read_env "LIFEOS_MCP_BEARER_TOKEN" "")
 AGENT_WORKER_AUTOSTART=$(_read_env "LIFEOS_AGENT_WORKER_AUTOSTART" "false")
+AUTODEPLOY_ENABLED=$(_read_env "LIFEOS_AUTODEPLOY_ENABLED" "false")
 
 # Normalize boolean
 case "$(echo "$LLM_AUTOSTART" | tr '[:upper:]' '[:lower:]')" in
@@ -69,6 +70,11 @@ esac
 case "$(echo "$AGENT_WORKER_AUTOSTART" | tr '[:upper:]' '[:lower:]')" in
     true|1|yes) AGENT_WORKER_AUTOSTART="true" ;;
     *)          AGENT_WORKER_AUTOSTART="false" ;;
+esac
+
+case "$(echo "$AUTODEPLOY_ENABLED" | tr '[:upper:]' '[:lower:]')" in
+    true|1|yes) AUTODEPLOY_ENABLED="true" ;;
+    *)          AUTODEPLOY_ENABLED="false" ;;
 esac
 
 if [ "$LLM_AUTOSTART" = "true" ]; then
@@ -114,6 +120,7 @@ else
     echo "  MCP HTTP:   disabled (set LIFEOS_MCP_BEARER_TOKEN to enable)"
 fi
 echo "  Agent Worker: $AGENT_WORKER_AUTOSTART"
+echo "  Auto-Deploy:  $AUTODEPLOY_ENABLED"
 echo ""
 
 # Install unit files with variable substitution
@@ -197,6 +204,18 @@ else
     systemctl disable lifeos-agent-worker.service 2>/dev/null || true
     systemctl stop lifeos-agent-worker.service 2>/dev/null || true
     echo "  lifeos-agent-worker: disabled (set LIFEOS_AGENT_WORKER_AUTOSTART=true to enable)"
+fi
+
+# Auto-deploy is opt-in via LIFEOS_AUTODEPLOY_ENABLED. Off by default so a fresh
+# clone never silently pulls + restarts on its own. When on, the timer polls
+# origin/main every 10 min and ff-deploys new commits (see scripts/auto-deploy.sh).
+if [ "$AUTODEPLOY_ENABLED" = "true" ]; then
+    systemctl enable --now lifeos-autodeploy.timer
+    echo "  lifeos-autodeploy.timer: $(systemctl is-active lifeos-autodeploy.timer) (autostart enabled)"
+else
+    systemctl disable lifeos-autodeploy.timer 2>/dev/null || true
+    systemctl stop lifeos-autodeploy.timer 2>/dev/null || true
+    echo "  lifeos-autodeploy.timer: disabled (set LIFEOS_AUTODEPLOY_ENABLED=true to enable)"
 fi
 
 # Install logrotate config with substitution


### PR DESCRIPTION
## What

Adds an **opt-in** systemd timer so the self-hosted host redeploys itself after a push to `main` from another machine (e.g. the MacBook), instead of pulling + restarting by hand.

## How it works

`scripts/auto-deploy.sh` runs every 10 min (via `lifeos-autodeploy.timer`):
1. Opt-in gate — does nothing unless `LIFEOS_AUTODEPLOY_ENABLED=true`.
2. `git fetch`; if `origin/main` advanced → `git pull --ff-only`.
3. If `requirements.txt` changed → `pip install` first.
4. Restart the **currently-active** code services (`lifeos-api`, plus `lifeos-agent-worker` / `lifeos-mcp-http` if running). Docs/tests/frontend-only changes pull without a restart.
5. Post-deploy `/health` check.

Runs as the repo owner: `git pull` uses the user's SSH key; restarts go through the existing passwordless-sudo rule (no sudoers change needed — `restart` for api/agent-worker/mcp-http is already granted).

**Guards** (any tripped → run changes nothing): on `main` only, clean working tree only (never clobbers local edits on the host), `--ff-only` only (a diverged `main` alerts instead of resetting).

**Pull-based on purpose:** needs no inbound network, so it works on the WiFi-only host and just catches up on the next tick after any outage.

## Design choices

- **Polling, not webhook** — no exposed endpoint; survives the host being offline; mirrors the existing `lifeos-*-watchdog` timers.
- **Off by default** — a fresh clone never silently pulls + restarts. Enabled per-host via `.env` + `sudo ./scripts/setup-systemd.sh`.
- **No test gate** — deploys whatever lands on `main` (expected green from the PR flow). Running the suite would take the API down and thrash the shared server, so it's intentionally omitted.
- **Notifications** — `LIFEOS_AUTODEPLOY_NOTIFY`: `failure` (default) | `always` | `never`, reusing the watchdog Telegram pattern.

## Files

- `scripts/auto-deploy.sh` (new)
- `config/systemd/lifeos-autodeploy.{service,timer}` (new)
- `scripts/setup-systemd.sh` — install + gate enablement behind `LIFEOS_AUTODEPLOY_ENABLED`
- `.env.example` — document the two new flags
- `docs/guides/operations.md` — Auto-Deploy section

## Testing

- `bash -n` clean on both scripts; changed-files filter verified (docs/tests/web → no restart; code → restart).
- Ran `scripts/auto-deploy.sh` on this branch: opt-in gate passes, branch guard correctly stops it off `main`, clean exit, logged.
- Verified non-interactive `git fetch` works with `BatchMode=yes` and no SSH agent (the timer's execution context).
- `./scripts/test.sh`: **3120 passed, 5 failed.** All 5 failures are pre-existing/environment-dependent and unrelated to this PR (no Python touched): the two `test_settings.py` LLM-default tests read the host's real `.env` (which overrides LLM autostart + model), and `test_slack_sync` / `test_p91_data_integrity` depend on local vault/DB state.

## Activation (per host)

```
# .env
LIFEOS_AUTODEPLOY_ENABLED=true
sudo ./scripts/setup-systemd.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)