### PR TITLE
feat(slack): fetch and index thread replies via conversations.replies

### DIFF
--- a/api/services/slack_integration.py
+++ b/api/services/slack_integration.py
@@ -639,9 +639,10 @@ class SlackClient:
 
         ``conversations.history`` returns only top-level messages, so thread
         replies are invisible to it — this is the only way to fetch them
-        (issue #440). The parent message (ts == thread_ts) is returned by the
-        API as the first item and is excluded here: the parent is already
-        indexed from the history fetch.
+        (issue #440). The parent message (ts == thread_ts) is excluded
+        whenever the API returns it — it leads the response on unwindowed
+        calls, while with ``oldest`` set it is typically absent entirely.
+        The parent is already indexed from the history fetch.
 
         Args:
             channel_id: Channel containing the thread
@@ -664,7 +665,13 @@ class SlackClient:
             if cursor:
                 params["cursor"] = cursor
 
-            data = self._api_call("conversations.replies", workspace_id, **params)
+            # max_retries=5 (vs. the default 3): replies fetches are the
+            # rate-limit hot path during a backfill, and retry exhaustion
+            # surfaces as a partial sync that needs a manual full sync to
+            # heal — buy extra headroom.
+            data = self._api_call(
+                "conversations.replies", workspace_id, max_retries=5, **params
+            )
 
             for msg in data.get("messages", []):
                 if msg.get("type") != "message":

--- a/api/services/slack_integration.py
+++ b/api/services/slack_integration.py
@@ -117,6 +117,7 @@ class SlackMessage:
     timestamp: datetime
     thread_ts: Optional[str] = None
     reply_count: int = 0
+    latest_reply: Optional[str] = None  # ts of the newest thread reply (parents only)
     reactions: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
@@ -129,6 +130,7 @@ class SlackMessage:
             "timestamp": self.timestamp.isoformat(),
             "thread_ts": self.thread_ts,
             "reply_count": self.reply_count,
+            "latest_reply": self.latest_reply,
             "reactions": self.reactions,
         }
 
@@ -614,6 +616,7 @@ class SlackClient:
                     timestamp=datetime.fromtimestamp(ts, tz=timezone.utc),
                     thread_ts=msg.get("thread_ts"),
                     reply_count=msg.get("reply_count", 0),
+                    latest_reply=msg.get("latest_reply"),
                     reactions=msg.get("reactions", []),
                 ))
 
@@ -622,6 +625,74 @@ class SlackClient:
                 break
 
         return all_messages
+
+    def get_thread_replies(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        workspace_id: str = "default",
+        oldest: Optional[datetime] = None,
+        max_messages: int = 10000,
+    ) -> list[SlackMessage]:
+        """
+        Get a thread's replies via ``conversations.replies`` with pagination.
+
+        ``conversations.history`` returns only top-level messages, so thread
+        replies are invisible to it — this is the only way to fetch them
+        (issue #440). The parent message (ts == thread_ts) is returned by the
+        API as the first item and is excluded here: the parent is already
+        indexed from the history fetch.
+
+        Args:
+            channel_id: Channel containing the thread
+            thread_ts: The parent message's ts
+            workspace_id: Workspace ID
+            oldest: Only fetch replies after this time (incremental sync)
+            max_messages: Maximum replies to fetch (safety limit)
+
+        Returns:
+            List of SlackMessage reply objects (parent excluded)
+        """
+        replies: list[SlackMessage] = []
+        cursor = None
+
+        while len(replies) < max_messages:
+            params = {"channel": channel_id, "ts": thread_ts, "limit": 200}
+
+            if oldest:
+                params["oldest"] = str(oldest.timestamp())
+            if cursor:
+                params["cursor"] = cursor
+
+            data = self._api_call("conversations.replies", workspace_id, **params)
+
+            for msg in data.get("messages", []):
+                if msg.get("type") != "message":
+                    continue
+                # The parent rides along in the response — skip it.
+                if msg.get("ts") == thread_ts:
+                    continue
+                if msg.get("subtype") in NOISE_MESSAGE_SUBTYPES:
+                    continue
+
+                ts = float(msg["ts"])
+                replies.append(SlackMessage(
+                    ts=msg["ts"],
+                    channel_id=channel_id,
+                    user_id=msg.get("user", ""),
+                    text=msg.get("text", ""),
+                    timestamp=datetime.fromtimestamp(ts, tz=timezone.utc),
+                    thread_ts=msg.get("thread_ts"),
+                    reply_count=msg.get("reply_count", 0),
+                    latest_reply=msg.get("latest_reply"),
+                    reactions=msg.get("reactions", []),
+                ))
+
+            cursor = data.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+
+        return replies
 
     def get_user_cached(self, user_id: str, workspace_id: str = "default") -> Optional[SlackUser]:
         """Get user with caching to reduce API calls."""

--- a/api/services/slack_sync.py
+++ b/api/services/slack_sync.py
@@ -37,6 +37,13 @@ DEFAULT_CHANNEL_HISTORY_DAYS = 90  # 90 days for channels
 # for new replies. A reply to a parent older than this is missed by the
 # nightly sync (trade-off documented in issue #440).
 THREAD_RESCAN_DAYS = 7
+# Inter-thread pacing for conversations.replies (Slack Tier 3 is ~50 req/min).
+# A backfill (no reply cursor) walks every thread in a channel, so it paces
+# well under the limit — correctness over speed on a rare manual run.
+# Incremental fetches are bounded by nightly activity, so a short delay
+# suffices.
+THREAD_FETCH_DELAY_BACKFILL = 1.2
+THREAD_FETCH_DELAY_INCREMENTAL = 0.1
 
 
 class SlackSync:
@@ -220,6 +227,10 @@ class SlackSync:
                     stats["messages_indexed"] += channel_stats["messages_indexed"]
                     stats["interactions_created"] += channel_stats["interactions_created"]
                     stats["affected_person_ids"].update(channel_stats.get("affected_person_ids", set()))
+                    # Surface non-fatal channel errors (e.g. a thread fetch
+                    # that exhausted retries) so the run reports "partial"
+                    # instead of silently dropping data.
+                    stats["errors"].extend(channel_stats.get("errors", []))
                     # Aggregate message counts from each channel
                     for person_id, count in channel_stats.get("message_counts", {}).items():
                         stats["message_counts"][person_id] = stats["message_counts"].get(person_id, 0) + count
@@ -271,7 +282,14 @@ class SlackSync:
             "messages_indexed": 0,
             "interactions_created": 0,
             "affected_person_ids": set(),
+            "errors": [],
         }
+
+        # Captured before the main history fetch: replies posted after this
+        # instant are deferred to the next run, so indexing them can't advance
+        # the channel cursor past a top-level message posted mid-run that the
+        # main fetch never saw (issue #445 review).
+        sync_start = datetime.now(timezone.utc)
 
         # Determine oldest timestamp for fetch
         oldest = None
@@ -308,12 +326,15 @@ class SlackSync:
         # Fetch + index thread replies. Runs even when the main fetch is
         # empty: a reply posted today to an old parent doesn't surface the
         # parent in a cursor-windowed conversations.history call — issue #440.
-        stats["messages_indexed"] += self._sync_thread_replies(
+        replies_indexed, reply_errors = self._sync_thread_replies(
             channel=channel,
             messages=messages,
             oldest=oldest,
             full=full,
+            sync_start=sync_start,
         )
+        stats["messages_indexed"] += replies_indexed
+        stats["errors"].extend(reply_errors)
 
         if not messages:
             return stats
@@ -340,7 +361,8 @@ class SlackSync:
         messages: list[SlackMessage],
         oldest: Optional[datetime],
         full: bool,
-    ) -> int:
+        sync_start: datetime,
+    ) -> tuple[int, list[str]]:
         """
         Fetch and index thread replies for a channel (issue #440).
 
@@ -356,14 +378,33 @@ class SlackSync:
         cursor are skipped without an API call. Replies are indexed for search
         only — they don't feed CRM interactions or message counts.
 
+        Replies with a timestamp after ``sync_start`` are deferred: indexing
+        them would advance the channel cursor past top-level messages posted
+        during this run that the main fetch never saw. Deferred replies are
+        recovered next run — the cursor stays behind them, so their parent's
+        ``latest_reply > cursor`` re-triggers the fetch.
+
+        Fetch failures are collected and returned rather than raised, so a
+        single thread can't fail the whole channel while still surfacing in
+        sync stats (status "partial"). There is no persistent retry queue:
+        the healing path is the nightly summary flagging the partial run
+        and, if needed, a manual full sync re-walking every thread.
+
         Returns:
-            Number of thread replies indexed
+            Tuple of (number of thread replies indexed, error strings)
         """
+        errors: list[str] = []
         candidates: dict[str, SlackMessage] = {
             m.ts: m for m in messages if m.reply_count > 0
         }
 
         reply_oldest = None if full else oldest
+        # No reply cursor means a backfill that walks every thread — pace it.
+        delay = (
+            THREAD_FETCH_DELAY_BACKFILL
+            if reply_oldest is None
+            else THREAD_FETCH_DELAY_INCREMENTAL
+        )
 
         # Incremental rescan for replies to parents older than the cursor.
         # Skipped when the main fetch's window already covers the rescan
@@ -378,9 +419,9 @@ class SlackSync:
                         oldest=rescan_start,
                     )
                 except Exception as e:
-                    logger.warning(
-                        f"Thread rescan failed for {channel.channel_id}: {e}"
-                    )
+                    error_msg = f"Thread rescan failed for {channel.channel_id}: {e}"
+                    logger.warning(error_msg)
+                    errors.append(error_msg)
                     recent_parents = []
                 for m in recent_parents:
                     if m.ts in candidates or m.reply_count <= 0:
@@ -406,23 +447,30 @@ class SlackSync:
                     oldest=reply_oldest,
                 )
             except Exception as e:
-                # A single thread failing shouldn't fail the whole channel.
-                logger.warning(
-                    f"Failed to fetch thread {ts} in {channel.channel_id}: {e}"
-                )
+                # A single thread failing shouldn't fail the whole channel,
+                # but the loss must be visible: this run's main fetch advances
+                # the cursor, so a silently skipped thread is filtered out of
+                # every future incremental run by the latest_reply check above.
+                error_msg = f"Failed to fetch thread {ts} in {channel.channel_id}: {e}"
+                logger.warning(error_msg)
+                errors.append(error_msg)
                 continue
 
             if replies:
-                indexed += self.indexer.index_messages(
-                    messages=replies,
-                    channel=channel,
-                    workspace_id=self._workspace_id,
-                )
+                # Drop replies posted after sync_start (see docstring) —
+                # they're picked up by the next run.
+                fresh = [r for r in replies if r.timestamp <= sync_start]
+                if fresh:
+                    indexed += self.indexer.index_messages(
+                        messages=fresh,
+                        channel=channel,
+                        workspace_id=self._workspace_id,
+                    )
 
-            # Rate limit: small delay between thread fetches
-            time.sleep(0.1)
+            # Rate limit: delay between thread fetches
+            time.sleep(delay)
 
-        return indexed
+        return indexed, errors
 
     def _create_interactions_for_channel(
         self,

--- a/api/services/slack_sync.py
+++ b/api/services/slack_sync.py
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 # Default sync configuration
 DEFAULT_DM_HISTORY_DAYS = None  # Full history for DMs
 DEFAULT_CHANNEL_HISTORY_DAYS = 90  # 90 days for channels
+# Incremental thread-reply rescan window: how far back to re-check parents
+# for new replies. A reply to a parent older than this is missed by the
+# nightly sync (trade-off documented in issue #440).
+THREAD_RESCAN_DAYS = 7
 
 
 class SlackSync:
@@ -290,18 +294,29 @@ class SlackSync:
             oldest=oldest,
         )
 
+        if messages:
+            logger.debug(f"Fetched {len(messages)} messages from {channel.channel_id}")
+
+            # Index messages
+            indexed = self.indexer.index_messages(
+                messages=messages,
+                channel=channel,
+                workspace_id=self._workspace_id,
+            )
+            stats["messages_indexed"] = indexed
+
+        # Fetch + index thread replies. Runs even when the main fetch is
+        # empty: a reply posted today to an old parent doesn't surface the
+        # parent in a cursor-windowed conversations.history call — issue #440.
+        stats["messages_indexed"] += self._sync_thread_replies(
+            channel=channel,
+            messages=messages,
+            oldest=oldest,
+            full=full,
+        )
+
         if not messages:
             return stats
-
-        logger.debug(f"Fetched {len(messages)} messages from {channel.channel_id}")
-
-        # Index messages
-        indexed = self.indexer.index_messages(
-            messages=messages,
-            channel=channel,
-            workspace_id=self._workspace_id,
-        )
-        stats["messages_indexed"] = indexed
 
         # Create interactions for DMs
         if create_interactions and (channel.is_im or channel.is_mpim):
@@ -318,6 +333,96 @@ class SlackSync:
                 stats["message_counts"][person_id] = stats["message_counts"].get(person_id, 0) + count
 
         return stats
+
+    def _sync_thread_replies(
+        self,
+        channel: SlackChannel,
+        messages: list[SlackMessage],
+        oldest: Optional[datetime],
+        full: bool,
+    ) -> int:
+        """
+        Fetch and index thread replies for a channel (issue #440).
+
+        Thread parents come from two sources:
+        1. The main history fetch — any message with ``reply_count > 0``.
+        2. Incremental only: a rescan of the last ``THREAD_RESCAN_DAYS`` of
+           parents. A new reply does not resurface its parent in a
+           cursor-windowed history call, so replies to parents older than the
+           cursor would otherwise be missed permanently.
+
+        Incremental runs pass ``oldest`` to ``conversations.replies`` so only
+        new replies are fetched; threads whose ``latest_reply`` predates the
+        cursor are skipped without an API call. Replies are indexed for search
+        only — they don't feed CRM interactions or message counts.
+
+        Returns:
+            Number of thread replies indexed
+        """
+        candidates: dict[str, SlackMessage] = {
+            m.ts: m for m in messages if m.reply_count > 0
+        }
+
+        reply_oldest = None if full else oldest
+
+        # Incremental rescan for replies to parents older than the cursor.
+        # Skipped when the main fetch's window already covers the rescan
+        # window (first sync of a channel).
+        if not full and oldest is not None:
+            rescan_start = datetime.now(timezone.utc) - timedelta(days=THREAD_RESCAN_DAYS)
+            if oldest > rescan_start:
+                try:
+                    recent_parents = self.client.get_all_channel_history(
+                        channel_id=channel.channel_id,
+                        workspace_id=self._workspace_id,
+                        oldest=rescan_start,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Thread rescan failed for {channel.channel_id}: {e}"
+                    )
+                    recent_parents = []
+                for m in recent_parents:
+                    if m.ts in candidates or m.reply_count <= 0:
+                        continue
+                    candidates[m.ts] = m
+
+        indexed = 0
+        for ts, parent in candidates.items():
+            # Skip threads with no replies newer than the cursor.
+            if (
+                not full
+                and oldest is not None
+                and parent.latest_reply
+                and float(parent.latest_reply) <= oldest.timestamp()
+            ):
+                continue
+
+            try:
+                replies = self.client.get_thread_replies(
+                    channel_id=channel.channel_id,
+                    thread_ts=ts,
+                    workspace_id=self._workspace_id,
+                    oldest=reply_oldest,
+                )
+            except Exception as e:
+                # A single thread failing shouldn't fail the whole channel.
+                logger.warning(
+                    f"Failed to fetch thread {ts} in {channel.channel_id}: {e}"
+                )
+                continue
+
+            if replies:
+                indexed += self.indexer.index_messages(
+                    messages=replies,
+                    channel=channel,
+                    workspace_id=self._workspace_id,
+                )
+
+            # Rate limit: small delay between thread fetches
+            time.sleep(0.1)
+
+        return indexed
 
     def _create_interactions_for_channel(
         self,

--- a/docs/guides/slack-integration.md
+++ b/docs/guides/slack-integration.md
@@ -11,9 +11,12 @@ Setup guide for Slack message search and sync.
 ## Overview
 
 LifeOS integrates with Slack to:
-- Index DM messages for semantic search
+- Index messages for semantic search:
+  - **DMs and group DMs** — full history, for users linked to CRM people
+  - **Public/private channels you are a member of** — 90-day window on first sync, incremental after (enumerated via `users.conversations`; archived channels excluded)
+  - **Thread replies** — fetched via `conversations.replies`; incremental runs rescan the last 7 days of parents so replies to older messages are still caught
 - Sync user profiles to CRM
-- Track interaction history with colleagues
+- Track interaction history with colleagues (DMs only)
 
 ---
 
@@ -34,8 +37,10 @@ LifeOS integrates with Slack to:
 2. Under **User Token Scopes**, add:
    - `users:read` - List users
    - `users:read.email` - Get user emails (for CRM linking)
-   - `im:history` - Read DM messages
-   - `im:read` - List DMs
+   - `im:history` / `im:read` - Read and list DMs
+   - `mpim:history` / `mpim:read` - Read and list group DMs
+   - `channels:history` / `channels:read` - Read and list public channels you're in
+   - `groups:history` / `groups:read` - Read and list private channels you're in
 
 **Note**: Use **User Token Scopes**, not Bot Token Scopes. LifeOS needs to access your messages as you, not as a bot.
 
@@ -94,7 +99,7 @@ SLACK_TEAM_ID=T02XXXXX
 
 This will:
 1. Sync all Slack users to SourceEntity
-2. Index DM messages to ChromaDB
+2. Index DM, member-channel, and thread-reply messages to ChromaDB
 3. Link Slack users to existing PersonEntity records by email
 
 ---

--- a/tests/test_slack_integration.py
+++ b/tests/test_slack_integration.py
@@ -388,3 +388,88 @@ class TestGetAllChannelHistoryNoiseFiltering:
 
         assert len(messages) == 1
         assert messages[0].text == "Deploy finished: build 42"
+
+
+@patch("api.services.slack_integration.SLACK_USER_TOKEN", "")
+class TestGetThreadReplies:
+    """Issue #440: conversations.replies fetch — paginated, parent excluded."""
+
+    def _client(self, pages):
+        from api.services.slack_integration import SlackClient
+
+        store = MagicMock()
+        store.get_token.return_value = "xoxp-test-fake-token"
+        client = SlackClient(token_store=store)
+        client._api_call = MagicMock(side_effect=pages)
+        return client
+
+    def test_excludes_parent_and_parses_replies(self):
+        client = self._client([{
+            "ok": True,
+            "messages": [
+                {"type": "message", "ts": "1700000000.000100",
+                 "thread_ts": "1700000000.000100", "user": "U1",
+                 "text": "parent message", "reply_count": 2},
+                {"type": "message", "ts": "1700000100.000200",
+                 "thread_ts": "1700000000.000100", "user": "U2",
+                 "text": "first reply"},
+                {"type": "message", "ts": "1700000200.000300",
+                 "thread_ts": "1700000000.000100", "user": "U1",
+                 "text": "second reply"},
+            ],
+            "response_metadata": {},
+        }])
+
+        replies = client.get_thread_replies("C123", "1700000000.000100")
+
+        assert [r.text for r in replies] == ["first reply", "second reply"]
+        assert all(r.thread_ts == "1700000000.000100" for r in replies)
+
+    def test_paginates_with_cursor(self):
+        client = self._client([
+            {"ok": True,
+             "messages": [{"type": "message", "ts": "1700000100.000200",
+                           "thread_ts": "1700000000.000100", "user": "U2",
+                           "text": "reply page 1"}],
+             "response_metadata": {"next_cursor": "cur2"}},
+            {"ok": True,
+             "messages": [{"type": "message", "ts": "1700000200.000300",
+                           "thread_ts": "1700000000.000100", "user": "U1",
+                           "text": "reply page 2"}],
+             "response_metadata": {}},
+        ])
+
+        replies = client.get_thread_replies("C123", "1700000000.000100")
+
+        assert [r.text for r in replies] == ["reply page 1", "reply page 2"]
+        assert client._api_call.call_count == 2
+        second_kwargs = client._api_call.call_args_list[1].kwargs
+        assert second_kwargs["cursor"] == "cur2"
+
+    def test_oldest_is_passed_through(self):
+        from datetime import datetime, timezone
+
+        client = self._client([{"ok": True, "messages": [], "response_metadata": {}}])
+        oldest = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+        client.get_thread_replies("C123", "1700000000.000100", oldest=oldest)
+
+        kwargs = client._api_call.call_args.kwargs
+        assert kwargs["oldest"] == str(oldest.timestamp())
+
+    def test_history_parses_latest_reply(self):
+        """get_all_channel_history must surface latest_reply so the sync can
+        tell which threads have new activity."""
+        client = self._client([{
+            "ok": True,
+            "messages": [
+                {"type": "message", "ts": "1700000000.000100", "user": "U1",
+                 "text": "parent", "reply_count": 3,
+                 "latest_reply": "1700009999.000500"},
+            ],
+            "response_metadata": {},
+        }])
+
+        messages = client.get_all_channel_history("C123")
+
+        assert messages[0].latest_reply == "1700009999.000500"

--- a/tests/test_slack_sync.py
+++ b/tests/test_slack_sync.py
@@ -4,13 +4,17 @@ from unittest.mock import MagicMock
 
 
 @pytest.fixture
-def sync_with_mocks():
+def sync_with_mocks(monkeypatch):
     """A SlackSync wired up with mock client/indexer/entity_store/interaction_store.
 
     Patches the heavy collaborators so we can assert on call ordering and
-    return shape without touching the network or any SQLite store.
+    return shape without touching the network or any SQLite store. The
+    rate-limit pacing sleeps (inter-channel and inter-thread — up to 1.2s
+    per thread on backfills) are zeroed out so tests stay fast.
     """
     from api.services.slack_sync import SlackSync
+
+    monkeypatch.setattr("api.services.slack_sync.time.sleep", lambda _s: None)
 
     mock_client = MagicMock()
     mock_indexer = MagicMock()
@@ -413,6 +417,10 @@ class TestThreadReplySync:
         assert sync.client.get_thread_replies.call_count == 1
 
     def test_thread_fetch_failure_does_not_kill_channel(self, sync_with_mocks):
+        """A failed thread fetch must not fail the channel, but it must be
+        visible: the same run's main fetch advances the cursor, so a silently
+        skipped thread is filtered out of every future incremental run —
+        silent success would be permanent silent loss."""
         sync = sync_with_mocks
         sync.client.list_channels.return_value = [self._channel()]
         sync.client.get_all_channel_history.return_value = [self._parent(reply_count=2)]
@@ -424,3 +432,92 @@ class TestThreadReplySync:
         # main history still indexed; channel not recorded as a hard failure
         assert stats["messages_indexed"] == 1
         assert stats["channels_processed"] == 1
+        # ... but the loss is surfaced: run reports partial with an error
+        assert stats["status"] == "partial"
+        assert any("thread" in e.lower() and "ratelimited" in e
+                   for e in stats["errors"])
+
+    def test_rescan_failure_surfaces_in_stats(self, sync_with_mocks):
+        """A failed 7-day rescan fetch has the same permanent-loss property
+        as a failed thread fetch — it must reach stats["errors"]."""
+        from datetime import datetime, timedelta, timezone
+
+        sync = sync_with_mocks
+        cursor = datetime.now(timezone.utc) - timedelta(days=1)
+        sync.client.list_channels.return_value = [self._channel()]
+        # First call: main incremental fetch. Second call: rescan blows up.
+        sync.client.get_all_channel_history.side_effect = [
+            [], RuntimeError("ratelimited")]
+        sync.indexer.get_latest_timestamp.return_value = cursor
+
+        stats = sync.sync_messages(full=False, dm_only=False)
+
+        assert stats["channels_processed"] == 1
+        assert stats["status"] == "partial"
+        assert any("rescan" in e.lower() for e in stats["errors"])
+
+    def test_reply_after_sync_start_deferred(self, sync_with_mocks):
+        """A reply posted during the sync run (ts after sync-start) must not
+        be indexed this run: indexing it would advance the channel cursor
+        past top-level messages posted mid-run that the main fetch never saw,
+        permanently skipping them. The deferred reply is recovered next run
+        (its parent's latest_reply stays above the cursor)."""
+        from datetime import datetime, timedelta, timezone
+
+        sync = sync_with_mocks
+        now = datetime.now(timezone.utc)
+        past_reply = self._reply(ts=f"{(now - timedelta(minutes=5)).timestamp():.6f}")
+        future_reply = self._reply(ts=f"{(now + timedelta(minutes=5)).timestamp():.6f}")
+
+        sync.client.list_channels.return_value = [self._channel()]
+        sync.client.get_all_channel_history.return_value = [self._parent(reply_count=2)]
+        sync.client.get_thread_replies.return_value = [past_reply, future_reply]
+        sync.indexer.index_messages.side_effect = lambda messages, **kw: len(messages)
+
+        stats = sync.sync_messages(full=True, dm_only=False)
+
+        # 1 parent from main history + only the pre-sync-start reply
+        assert stats["messages_indexed"] == 2
+        reply_call_kwargs = sync.indexer.index_messages.call_args_list[-1].kwargs
+        assert reply_call_kwargs["messages"] == [past_reply]
+
+    def test_rescan_history_window_is_rescan_days(self, sync_with_mocks):
+        """The rescan's history call must be bounded to THREAD_RESCAN_DAYS —
+        not the channel cursor, and not unbounded."""
+        from datetime import datetime, timedelta, timezone
+        from api.services.slack_sync import THREAD_RESCAN_DAYS
+
+        sync = sync_with_mocks
+        cursor = datetime.now(timezone.utc) - timedelta(days=1)
+        sync.client.list_channels.return_value = [self._channel()]
+        sync.client.get_all_channel_history.side_effect = [[], []]
+        sync.indexer.get_latest_timestamp.return_value = cursor
+
+        sync.sync_messages(full=False, dm_only=False)
+
+        assert sync.client.get_all_channel_history.call_count == 2
+        rescan_kwargs = sync.client.get_all_channel_history.call_args_list[1].kwargs
+        expected = datetime.now(timezone.utc) - timedelta(days=THREAD_RESCAN_DAYS)
+        assert abs((rescan_kwargs["oldest"] - expected).total_seconds()) < 60
+
+    def test_rescan_skipped_when_cursor_covers_window(self, sync_with_mocks):
+        """No second history call when the main fetch's window already covers
+        the rescan window: first incremental sync of a channel (no cursor,
+        90-day history_days window) and a cursor older than the window."""
+        from datetime import datetime, timedelta, timezone
+
+        sync = sync_with_mocks
+        sync.client.list_channels.return_value = [self._channel()]
+        sync.client.get_all_channel_history.return_value = []
+
+        # Case 1: first incremental sync — no cursor, history_days window.
+        sync.indexer.get_latest_timestamp.return_value = None
+        sync.sync_messages(full=False, dm_only=False, channel_history_days=90)
+        assert sync.client.get_all_channel_history.call_count == 1
+
+        # Case 2: cursor older than the rescan window start.
+        sync.client.get_all_channel_history.reset_mock()
+        sync.indexer.get_latest_timestamp.return_value = (
+            datetime.now(timezone.utc) - timedelta(days=30))
+        sync.sync_messages(full=False, dm_only=False)
+        assert sync.client.get_all_channel_history.call_count == 1

--- a/tests/test_slack_sync.py
+++ b/tests/test_slack_sync.py
@@ -225,12 +225,17 @@ class TestChannelIndexing:
     def test_channel_messages_indexed_without_interactions(self, sync_with_mocks):
         """A public channel gets indexed to ChromaDB but never creates CRM
         interactions — channel chatter isn't a 1:1 interaction."""
-        from api.services.slack_integration import SlackChannel
+        from datetime import datetime, timezone
+        from api.services.slack_integration import SlackChannel, SlackMessage
 
         sync = sync_with_mocks
         channel = SlackChannel(channel_id="C123", name="general")
+        message = SlackMessage(
+            ts="1700000000.000100", channel_id="C123", user_id="U1",
+            text="hello", timestamp=datetime.now(timezone.utc),
+        )
         sync.client.list_channels.return_value = [channel]
-        sync.client.get_all_channel_history.return_value = [MagicMock()]
+        sync.client.get_all_channel_history.return_value = [message]
         sync.indexer.get_latest_timestamp.return_value = None
         sync.indexer.index_messages.return_value = 1
         sync._create_interactions_for_channel = MagicMock()
@@ -277,3 +282,145 @@ class TestChannelIndexing:
 
         assert stats["channels_skipped"] == 1  # the unlinked DM
         assert stats["channels_processed"] == 1  # the public channel
+
+
+class TestThreadReplySync:
+    """Issue #440: thread replies must be fetched via conversations.replies and
+    indexed like normal messages — conversations.history only returns
+    top-level messages, so replies were invisible to the index."""
+
+    def _parent(self, ts="1700000000.000100", reply_count=2, latest_reply=None):
+        from datetime import datetime, timezone
+        from api.services.slack_integration import SlackMessage
+
+        return SlackMessage(
+            ts=ts, channel_id="C123", user_id="U1", text="parent",
+            timestamp=datetime.fromtimestamp(float(ts), tz=timezone.utc),
+            thread_ts=ts if reply_count else None,
+            reply_count=reply_count, latest_reply=latest_reply,
+        )
+
+    def _reply(self, ts="1700000100.000200"):
+        from datetime import datetime, timezone
+        from api.services.slack_integration import SlackMessage
+
+        return SlackMessage(
+            ts=ts, channel_id="C123", user_id="U2", text="a reply",
+            timestamp=datetime.fromtimestamp(float(ts), tz=timezone.utc),
+            thread_ts="1700000000.000100",
+        )
+
+    def _channel(self):
+        from api.services.slack_integration import SlackChannel
+        return SlackChannel(channel_id="C123", name="general")
+
+    def test_full_sync_fetches_replies_for_threaded_parents(self, sync_with_mocks):
+        sync = sync_with_mocks
+        sync.client.list_channels.return_value = [self._channel()]
+        sync.client.get_all_channel_history.return_value = [self._parent(reply_count=2)]
+        sync.client.get_thread_replies.return_value = [self._reply()]
+        sync.indexer.index_messages.return_value = 1
+
+        stats = sync.sync_messages(full=True, dm_only=False)
+
+        kwargs = sync.client.get_thread_replies.call_args.kwargs
+        assert kwargs["thread_ts"] == "1700000000.000100"
+        assert kwargs["oldest"] is None  # full sync pulls entire threads
+        # main history + replies both indexed
+        assert sync.indexer.index_messages.call_count == 2
+        assert stats["messages_indexed"] == 2
+
+    def test_no_thread_fetch_without_replies(self, sync_with_mocks):
+        sync = sync_with_mocks
+        sync.client.list_channels.return_value = [self._channel()]
+        sync.client.get_all_channel_history.return_value = [self._parent(reply_count=0)]
+        sync.indexer.index_messages.return_value = 1
+
+        sync.sync_messages(full=True, dm_only=False)
+
+        sync.client.get_thread_replies.assert_not_called()
+
+    def test_incremental_catches_reply_to_old_parent(self, sync_with_mocks):
+        """A reply posted today to a week-old parent: the parent doesn't appear
+        in the cursor-windowed history fetch, so a rescan of recent parents
+        must find it via latest_reply."""
+        from datetime import datetime, timedelta, timezone
+
+        sync = sync_with_mocks
+        now = datetime.now(timezone.utc)
+        cursor = now - timedelta(days=1)
+        old_parent_ts = f"{(now - timedelta(days=5)).timestamp():.6f}"
+        new_reply_ts = f"{(now - timedelta(hours=2)).timestamp():.6f}"
+
+        old_parent = self._parent(
+            ts=old_parent_ts, reply_count=3, latest_reply=new_reply_ts)
+
+        sync.client.list_channels.return_value = [self._channel()]
+        # First call: main incremental fetch (empty — no new top-level messages).
+        # Second call: thread rescan window returns the old parent.
+        sync.client.get_all_channel_history.side_effect = [[], [old_parent]]
+        sync.client.get_thread_replies.return_value = [self._reply(ts=new_reply_ts)]
+        sync.indexer.get_latest_timestamp.return_value = cursor
+        sync.indexer.index_messages.return_value = 1
+
+        stats = sync.sync_messages(full=False, dm_only=False)
+
+        kwargs = sync.client.get_thread_replies.call_args.kwargs
+        assert kwargs["thread_ts"] == old_parent_ts
+        # only new replies are fetched
+        expected_oldest = cursor - timedelta(seconds=1)
+        assert abs((kwargs["oldest"] - expected_oldest).total_seconds()) < 2
+        assert stats["messages_indexed"] == 1
+
+    def test_incremental_skips_threads_without_new_replies(self, sync_with_mocks):
+        from datetime import datetime, timedelta, timezone
+
+        sync = sync_with_mocks
+        now = datetime.now(timezone.utc)
+        cursor = now - timedelta(days=1)
+        stale_parent = self._parent(
+            ts=f"{(now - timedelta(days=5)).timestamp():.6f}",
+            reply_count=3,
+            latest_reply=f"{(now - timedelta(days=3)).timestamp():.6f}",  # before cursor
+        )
+
+        sync.client.list_channels.return_value = [self._channel()]
+        sync.client.get_all_channel_history.side_effect = [[], [stale_parent]]
+        sync.indexer.get_latest_timestamp.return_value = cursor
+
+        sync.sync_messages(full=False, dm_only=False)
+
+        sync.client.get_thread_replies.assert_not_called()
+
+    def test_parent_in_both_fetch_and_rescan_fetched_once(self, sync_with_mocks):
+        from datetime import datetime, timedelta, timezone
+
+        sync = sync_with_mocks
+        now = datetime.now(timezone.utc)
+        cursor = now - timedelta(days=1)
+        new_ts = f"{(now - timedelta(hours=3)).timestamp():.6f}"
+        parent = self._parent(ts=new_ts, reply_count=1,
+                              latest_reply=f"{(now - timedelta(hours=1)).timestamp():.6f}")
+
+        sync.client.list_channels.return_value = [self._channel()]
+        sync.client.get_all_channel_history.side_effect = [[parent], [parent]]
+        sync.client.get_thread_replies.return_value = [self._reply()]
+        sync.indexer.get_latest_timestamp.return_value = cursor
+        sync.indexer.index_messages.return_value = 1
+
+        sync.sync_messages(full=False, dm_only=False)
+
+        assert sync.client.get_thread_replies.call_count == 1
+
+    def test_thread_fetch_failure_does_not_kill_channel(self, sync_with_mocks):
+        sync = sync_with_mocks
+        sync.client.list_channels.return_value = [self._channel()]
+        sync.client.get_all_channel_history.return_value = [self._parent(reply_count=2)]
+        sync.client.get_thread_replies.side_effect = RuntimeError("ratelimited")
+        sync.indexer.index_messages.return_value = 1
+
+        stats = sync.sync_messages(full=True, dm_only=False)
+
+        # main history still indexed; channel not recorded as a hard failure
+        assert stats["messages_indexed"] == 1
+        assert stats["channels_processed"] == 1


### PR DESCRIPTION
## Summary

Thread replies were the biggest completeness gap in the Slack index: `conversations.history` returns only top-level messages, so a reply Nathan posts today in a week-old thread was invisible to both the sync and search. This adds a paginated `conversations.replies` fetch wired into `_sync_channel`, with an incremental rescan window so replies to parents older than the cursor are still caught.

Closes #440

## Test evidence

10 new tests (4 in `tests/test_slack_integration.py`, 6 in `tests/test_slack_sync.py`): parent exclusion, pagination, oldest passthrough, `latest_reply` parsing, full-sync fetch, no-fetch without replies, old-parent rescan, stale-thread skip, dedupe across fetch+rescan, per-thread failure isolation. Full unit suite on nathan-linux: 3135 passed; 14 failures identical to the pre-existing data/.env-dependent set on clean main.

## Review focus

- Incremental correctness: the rescan re-fetches the last `THREAD_RESCAN_DAYS` (7) of parents per channel per night (one extra history call) and filters by `latest_reply > cursor` before any `conversations.replies` call. Replies to parents older than 7 days are missed by the nightly — documented trade-off vs. re-walking all threads.
- Cursor interaction: indexed replies advance `get_latest_timestamp` for the channel; the main fetch that night already covered up to now, so no gap — worth an adversarial look.
- Rate-limit posture: per-thread 0.1s delay + existing `_api_call` backoff; incremental thread fetches are bounded by activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)