### PR TITLE
feat(slack): day-pull endpoint — every message sent on a date

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,7 @@ Quick-reference guardrails for all contributors. These complement the Developmen
 | `api/services/perf_trace.py` | Request-level performance tracing (spans, SQLite) |
 | `api/routes/perf.py` | Performance trace query API |
 | `api/services/agent_worker/` | Autonomous worker for `#agent`-tagged tasks (local Gemma or cloud Claude via Managed Agents) |
-| `mcp_server.py` | MCP server — stdio for Claude Code + HTTP transport for Managed Agents (54 tools) |
+| `mcp_server.py` | MCP server — stdio for Claude Code + HTTP transport for Managed Agents (55 tools) |
 | `tests/test_perf_benchmark.py` | Benchmark suite for query performance and quality |
 
 | Script | Purpose |

--- a/api/routes/slack.py
+++ b/api/routes/slack.py
@@ -4,6 +4,7 @@ Slack API endpoints for LifeOS.
 Provides search and conversation access to Slack data.
 Supports both vector search (semantic) and metadata filtering.
 """
+import re
 import time
 from typing import Optional
 from datetime import datetime, timezone
@@ -111,6 +112,8 @@ class SlackMyMessagesResponse(BaseModel):
     date: str
     user_id: str
     total: int
+    truncated: bool = False  # True if Slack had more matches than were pulled
+    total_available: int = 0  # Slack's paging.total for the query
     messages: list[SlackDayMessage]
 
 
@@ -366,12 +369,9 @@ def _thread_ts_from_permalink(permalink: Optional[str]) -> Optional[str]:
     """
     if not permalink or "thread_ts=" not in permalink:
         return None
-    try:
-        from urllib.parse import parse_qs, urlparse
-        values = parse_qs(urlparse(permalink).query).get("thread_ts")
-        return values[0] if values else None
-    except Exception:
-        return None
+    from urllib.parse import parse_qs, urlparse
+    values = parse_qs(urlparse(permalink).query).get("thread_ts")
+    return values[0] if values else None
 
 
 @router.get("/my-messages", response_model=SlackMyMessagesResponse)
@@ -400,16 +400,30 @@ async def get_my_messages_for_day(
       not UTC.
     - Requires the `search:read` user-token scope (403 with instructions
       if missing).
+    - If the day has more messages than the pagination cap (1,000), the
+      response sets `truncated: true` and `total_available` to Slack's
+      full match count.
     """
     _require_slack_enabled()
 
-    # Validate date format
+    # Validate date format — strict zero-padded YYYY-MM-DD (strptime alone
+    # would accept e.g. "2026-7-8").
     try:
-        datetime.strptime(date, "%Y-%m-%d")
+        parsed = datetime.strptime(date, "%Y-%m-%d")
     except ValueError:
+        parsed = None
+    if parsed is None or parsed.strftime("%Y-%m-%d") != date:
         raise HTTPException(
             status_code=400,
             detail="Invalid date — expected YYYY-MM-DD",
+        )
+
+    # Validate user — it is interpolated into the Slack search query, so a
+    # crafted value could replace the from: filter with arbitrary search terms.
+    if user is not None and not re.fullmatch(r"[UW][A-Z0-9]{2,}", user):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid user — expected a Slack user ID (e.g. U12AB34CD)",
         )
 
     client = get_slack_client()
@@ -422,7 +436,7 @@ async def get_my_messages_for_day(
                 detail="Could not resolve the token owner via auth.test",
             )
 
-        matches = client.search_messages(query=f"from:<@{user_id}> on:{date}")
+        result = client.search_messages(query=f"from:<@{user_id}> on:{date}")
     except SlackAPIError as e:
         error = str(e)
         if error in ("missing_scope", "not_allowed_token_type"):
@@ -438,7 +452,7 @@ async def get_my_messages_for_day(
         raise HTTPException(status_code=502, detail=f"Slack API error: {e}")
 
     messages = []
-    for m in matches:
+    for m in result["matches"]:
         channel = m.get("channel") or {}
         permalink = m.get("permalink")
         ts = m.get("ts", "")
@@ -461,6 +475,8 @@ async def get_my_messages_for_day(
         date=date,
         user_id=user_id,
         total=len(messages),
+        truncated=result["truncated"],
+        total_available=result["total_available"],
         messages=messages,
     )
 

--- a/api/routes/slack.py
+++ b/api/routes/slack.py
@@ -6,7 +6,7 @@ Supports both vector search (semantic) and metadata filtering.
 """
 import time
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -92,6 +92,26 @@ class SlackStatusResponse(BaseModel):
     connected: bool
     indexed_messages: int
     indexed_channels: int
+
+
+class SlackDayMessage(BaseModel):
+    """A single message from the day-pull endpoint."""
+    ts: str
+    timestamp: str
+    text: str
+    channel_id: str
+    channel_name: str
+    channel_type: str  # im, mpim, group (private channel), or channel
+    thread_ts: Optional[str] = None
+    permalink: Optional[str] = None
+
+
+class SlackMyMessagesResponse(BaseModel):
+    """Response for the day-pull endpoint."""
+    date: str
+    user_id: str
+    total: int
+    messages: list[SlackDayMessage]
 
 
 # Helper Functions
@@ -325,6 +345,124 @@ async def sync_slack(full: bool = False):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Sync failed: {e}")
+
+
+def _derive_channel_type(channel: dict) -> str:
+    """Map a search-result channel object to im/mpim/group/channel."""
+    if channel.get("is_im"):
+        return "im"
+    if channel.get("is_mpim"):
+        return "mpim"
+    if channel.get("is_private"):
+        return "group"
+    return "channel"
+
+
+def _thread_ts_from_permalink(permalink: Optional[str]) -> Optional[str]:
+    """Extract thread_ts from a message permalink, if present.
+
+    search.messages matches don't carry thread_ts directly; replies embed it
+    in the permalink query string.
+    """
+    if not permalink or "thread_ts=" not in permalink:
+        return None
+    try:
+        from urllib.parse import parse_qs, urlparse
+        values = parse_qs(urlparse(permalink).query).get("thread_ts")
+        return values[0] if values else None
+    except Exception:
+        return None
+
+
+@router.get("/my-messages", response_model=SlackMyMessagesResponse)
+async def get_my_messages_for_day(
+    date: str = Query(..., description="Day to pull, YYYY-MM-DD"),
+    user: Optional[str] = Query(
+        None,
+        description="Slack user ID to pull messages for (defaults to the token owner)",
+    ),
+):
+    """
+    **Pull every Slack message the user sent on a given day** — across DMs,
+    group DMs, and public and private channels, including thread replies.
+
+    Uses Slack's search.messages API (`from:<@user> on:<date>`) as an exact,
+    on-demand source-of-truth query — unlike /search, this does not depend on
+    the sync index. Results are sorted chronologically.
+
+    Use this for:
+    - "What did I send on Slack yesterday?"
+    - "Show me everything I told people on 2026-07-08"
+    - Reconstructing a day's activity or writing a daily summary
+
+    Notes:
+    - Day boundaries follow the searching user's Slack timezone setting,
+      not UTC.
+    - Requires the `search:read` user-token scope (403 with instructions
+      if missing).
+    """
+    _require_slack_enabled()
+
+    # Validate date format
+    try:
+        datetime.strptime(date, "%Y-%m-%d")
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid date — expected YYYY-MM-DD",
+        )
+
+    client = get_slack_client()
+
+    try:
+        user_id = user or client.auth_test().get("user_id")
+        if not user_id:
+            raise HTTPException(
+                status_code=502,
+                detail="Could not resolve the token owner via auth.test",
+            )
+
+        matches = client.search_messages(query=f"from:<@{user_id}> on:{date}")
+    except SlackAPIError as e:
+        error = str(e)
+        if error in ("missing_scope", "not_allowed_token_type"):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Slack token lacks the search:read user scope. Add "
+                    "search:read under User Token Scopes at api.slack.com/apps "
+                    "and reinstall the app, then update SLACK_USER_TOKEN if it "
+                    "was reissued."
+                ),
+            )
+        raise HTTPException(status_code=502, detail=f"Slack API error: {e}")
+
+    messages = []
+    for m in matches:
+        channel = m.get("channel") or {}
+        permalink = m.get("permalink")
+        ts = m.get("ts", "")
+        try:
+            iso = datetime.fromtimestamp(float(ts), tz=timezone.utc).isoformat()
+        except (TypeError, ValueError):
+            iso = ""
+        messages.append(SlackDayMessage(
+            ts=ts,
+            timestamp=iso,
+            text=m.get("text", ""),
+            channel_id=channel.get("id", ""),
+            channel_name=channel.get("name", ""),
+            channel_type=_derive_channel_type(channel),
+            thread_ts=_thread_ts_from_permalink(permalink),
+            permalink=permalink,
+        ))
+
+    return SlackMyMessagesResponse(
+        date=date,
+        user_id=user_id,
+        total=len(messages),
+        messages=messages,
+    )
 
 
 @router.get("/channels/{channel_id}/messages")

--- a/api/services/slack_integration.py
+++ b/api/services/slack_integration.py
@@ -238,6 +238,7 @@ class SlackClient:
         self._direct_token = token
         self._http_client: Optional[httpx.Client] = None
         self._user_cache: dict[str, SlackUser] = {}
+        self._auth_identity: dict[str, dict] = {}
 
     @property
     def http_client(self) -> httpx.Client:
@@ -706,10 +707,15 @@ class SlackClient:
         """
         Call ``auth.test`` — identifies the user the token belongs to.
 
+        The identity is constant for a given token, so the response is cached
+        on the client instance per workspace (mirrors ``_user_cache``).
+
         Returns:
             API response dict (notably ``user_id`` and ``user``)
         """
-        return self._api_call("auth.test", workspace_id)
+        if workspace_id not in self._auth_identity:
+            self._auth_identity[workspace_id] = self._api_call("auth.test", workspace_id)
+        return self._auth_identity[workspace_id]
 
     def search_messages(
         self,
@@ -718,7 +724,7 @@ class SlackClient:
         sort: str = "timestamp",
         sort_dir: str = "asc",
         max_pages: int = 10,
-    ) -> list[dict]:
+    ) -> dict:
         """
         Search messages via ``search.messages`` with page-number pagination.
 
@@ -736,7 +742,11 @@ class SlackClient:
             max_pages: Safety limit on pages fetched (100 matches per page)
 
         Returns:
-            List of raw match dicts (ts, text, user, username, channel, permalink)
+            Dict with:
+            - ``matches``: list of raw match dicts (ts, text, user, username,
+              channel, permalink)
+            - ``truncated``: True if more pages existed beyond ``max_pages``
+            - ``total_available``: Slack's ``paging.total`` for the query
         """
         import time
 
@@ -748,6 +758,8 @@ class SlackClient:
         page = 1
         retry_delay = 2
         max_retries = 3
+        truncated = False
+        total_available = 0
 
         while page <= max_pages:
             params = {
@@ -785,11 +797,22 @@ class SlackClient:
             matches.extend(payload.get("matches", []))
 
             paging = payload.get("paging", {})
-            if page >= paging.get("pages", 1):
+            total_available = paging.get("total", len(matches))
+            total_pages = paging.get("pages", 1)
+            if page >= total_pages:
+                break
+            if page >= max_pages:
+                # More pages exist but the safety limit stops here — signal
+                # it so callers don't mistake a capped pull for "everything".
+                truncated = True
                 break
             page += 1
 
-        return matches
+        return {
+            "matches": matches,
+            "truncated": truncated,
+            "total_available": total_available,
+        }
 
     def get_user_cached(self, user_id: str, workspace_id: str = "default") -> Optional[SlackUser]:
         """Get user with caching to reduce API calls."""

--- a/api/services/slack_integration.py
+++ b/api/services/slack_integration.py
@@ -46,6 +46,7 @@ SLACK_SCOPES = [
     "im:history",           # Read DM messages
     "mpim:read",            # List group DMs
     "mpim:history",         # Read group DM messages
+    "search:read",          # search.messages (day-pull endpoint — issue #441)
 ]
 
 # Token storage path
@@ -700,6 +701,95 @@ class SlackClient:
                 break
 
         return replies
+
+    def auth_test(self, workspace_id: str = "default") -> dict:
+        """
+        Call ``auth.test`` — identifies the user the token belongs to.
+
+        Returns:
+            API response dict (notably ``user_id`` and ``user``)
+        """
+        return self._api_call("auth.test", workspace_id)
+
+    def search_messages(
+        self,
+        query: str,
+        workspace_id: str = "default",
+        sort: str = "timestamp",
+        sort_dir: str = "asc",
+        max_pages: int = 10,
+    ) -> list[dict]:
+        """
+        Search messages via ``search.messages`` with page-number pagination.
+
+        Requires the ``search:read`` user-token scope and a **user** token —
+        bot tokens cannot call this method. Unlike the conversations APIs,
+        ``search.messages`` paginates by page number (``paging.pages``), not
+        cursors, and searches everything the user can see — including thread
+        replies — in one call (issue #441).
+
+        Args:
+            query: Slack search query (e.g. ``from:<@U123> on:2026-07-08``)
+            workspace_id: Workspace ID
+            sort: Sort field (``timestamp`` or ``score``)
+            sort_dir: ``asc`` or ``desc``
+            max_pages: Safety limit on pages fetched (100 matches per page)
+
+        Returns:
+            List of raw match dicts (ts, text, user, username, channel, permalink)
+        """
+        import time
+
+        token = self._get_token(workspace_id)
+        if not token:
+            raise SlackAPIError(f"No token available for workspace {workspace_id}")
+
+        matches: list[dict] = []
+        page = 1
+        retry_delay = 2
+        max_retries = 3
+
+        while page <= max_pages:
+            params = {
+                "query": query,
+                "count": 100,  # Max per page
+                "page": page,
+                "sort": sort,
+                "sort_dir": sort_dir,
+            }
+
+            # search.messages only accepts form/query encoding, not JSON —
+            # use GET with params like the conversations list calls.
+            for attempt in range(max_retries + 1):
+                response = self.http_client.get(
+                    f"{self.BASE_URL}/search.messages",
+                    headers={"Authorization": f"Bearer {token}"},
+                    params=params,
+                )
+                data = response.json()
+
+                if data.get("ok"):
+                    break
+
+                error = data.get("error", "Unknown API error")
+                if error == "ratelimited" and attempt < max_retries:
+                    retry_after = int(response.headers.get("Retry-After", retry_delay))
+                    logger.warning(f"Rate limited on search.messages, waiting {retry_after}s")
+                    time.sleep(retry_after)
+                    retry_delay *= 2
+                    continue
+
+                raise SlackAPIError(error)
+
+            payload = data.get("messages", {})
+            matches.extend(payload.get("matches", []))
+
+            paging = payload.get("paging", {})
+            if page >= paging.get("pages", 1):
+                break
+            page += 1
+
+        return matches
 
     def get_user_cached(self, user_id: str, workspace_id: str = "default") -> Optional[SlackUser]:
         """Get user with caching to reduce API calls."""

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** API Gateway
-**Last Updated:** 2026-06-25
+**Last Updated:** 2026-07-09
 
 Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two adjacent catalogs split out for size:
 
@@ -355,6 +355,37 @@ Semantic search across Slack messages.
   "user_id": "optional"
 }
 ```
+
+### GET /api/slack/my-messages
+
+Every message the user sent on a given day — DMs, group DMs, public/private channels, thread replies. Exact source-of-truth pull via Slack's `search.messages` (independent of the sync index). Day boundaries follow the user's Slack timezone. Requires the `search:read` user-token scope.
+
+**Query parameters:** `date` (required, zero-padded `YYYY-MM-DD`), `user` (optional Slack user ID; defaults to the token owner).
+
+**Response:**
+```json
+{
+  "date": "2026-07-08",
+  "user_id": "U12AB34CD",
+  "total": 2,
+  "truncated": false,
+  "total_available": 2,
+  "messages": [
+    {
+      "ts": "1751980000.000100",
+      "timestamp": "2026-07-08T14:26:40+00:00",
+      "text": "hello team",
+      "channel_id": "C123",
+      "channel_name": "general",
+      "channel_type": "channel",
+      "thread_ts": null,
+      "permalink": "https://example.slack.com/archives/C123/p1751980000000100"
+    }
+  ]
+}
+```
+
+`truncated: true` means the day exceeded the pagination cap (1,000 messages); `total_available` is Slack's full match count.
 
 ### GET /api/slack/conversations
 

--- a/docs/specs/product/mcp-tools.md
+++ b/docs/specs/product/mcp-tools.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** API Gateway
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-07-09
 
 MCP (Model Context Protocol) server that exposes LifeOS capabilities to AI assistants like Claude Code.
 
@@ -65,6 +65,7 @@ Claude Code  ←→  MCP Protocol  ←→  mcp_server.py  ←→  LifeOS API
 | `lifeos_drive_search` | Search Google Drive files |
 | `lifeos_imessage_search` | Search iMessage/SMS history |
 | `lifeos_slack_search` | Semantic search Slack messages |
+| `lifeos_slack_my_messages` | Every Slack message sent on a date (source-of-truth day pull) |
 
 ### People & CRM Tools
 | Tool | Description |
@@ -292,6 +293,16 @@ Semantic search across Slack messages.
 | top_k | integer | No | Number of results (1-50, default: 20) |
 | channel_id | string | No | Filter by channel ID |
 | user_id | string | No | Filter by user ID |
+
+### lifeos_slack_my_messages
+
+Every message the user sent on a given day (DMs, group DMs, channels, thread replies) via Slack's `search.messages` — exact source-of-truth pull, independent of the sync index.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| date | string | Yes | Day to pull, YYYY-MM-DD (user's Slack timezone) |
+| user | string | No | Slack user ID (defaults to the token owner) |
 
 ### lifeos_people_search
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -129,6 +129,11 @@ CURATED_ENDPOINTS = {
         "description": "Semantic search across Slack DMs, group DMs, and channels. Returns channel, user, content.",
         "method": "POST"
     },
+    "/api/slack/my-messages": {
+        "name": "lifeos_slack_my_messages",
+        "description": "Pull every Slack message the user sent on a date (DMs, group DMs, channels, threads) via search.messages — source-of-truth, not the sync index. date: YYYY-MM-DD (Slack timezone); optional user.",
+        "method": "GET"
+    },
     "/api/crm/people/{person_id}/facts": {
         "name": "lifeos_person_facts",
         "description": "Get extracted facts about a person (family, interests, work, dates, travel) with confidence scores. Requires entity_id. Use before drafting personalized messages.",
@@ -625,6 +630,14 @@ class LifeOSMCPServer:
                     "user_id": {"type": "string", "description": "Filter by specific user ID"}
                 },
                 "required": ["query"]
+            },
+            "lifeos_slack_my_messages": {
+                "type": "object",
+                "properties": {
+                    "date": {"type": "string", "description": "Day to pull, YYYY-MM-DD (user's Slack timezone)"},
+                    "user": {"type": "string", "description": "Slack user ID to pull messages for (defaults to the token owner)"}
+                },
+                "required": ["date"]
             },
             "lifeos_person_facts": {
                 "type": "object",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -114,6 +114,7 @@ class TestMCPServerToolDiscovery:
             "lifeos_ask",
             "lifeos_search",
             "lifeos_health",
+            "lifeos_slack_my_messages",
         }
 
         for expected in expected_tools:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -30,14 +30,16 @@ def api_client():
 
 
 @pytest.fixture(scope="module")
-def openapi_spec(api_client):
-    """Fetch OpenAPI spec from running API."""
-    try:
-        resp = api_client.get("/openapi.json")
-        resp.raise_for_status()
-        return resp.json()
-    except httpx.RequestError:
-        pytest.skip("LifeOS API not running on localhost:8000")
+def openapi_spec():
+    """OpenAPI spec of the code under test (in-process, no server needed).
+
+    Built from api.main.app rather than fetched from localhost:8000 — a
+    running server may be on older code than this checkout, which would
+    make the curated-endpoint sync checks fail for any PR that adds an
+    endpoint and its curated entry together.
+    """
+    from api.main import app
+    return app.openapi()
 
 
 class TestOpenAPIAvailability:
@@ -100,14 +102,22 @@ class TestMCPServerToolDiscovery:
             assert "inputSchema" in tool
             assert tool["inputSchema"].get("type") == "object"
 
-    def test_mcp_server_tool_names(self):
-        """MCP server tools should have expected names."""
+    def test_mcp_server_tool_names(self, openapi_spec):
+        """MCP server tools should have expected names.
+
+        Builds the tool list from this checkout's OpenAPI spec — a running
+        server may be on older code without newly added endpoints.
+        """
         import importlib.util
+        from unittest.mock import patch
         spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
-        server = module.LifeOSMCPServer()
+        with patch.object(module.LifeOSMCPServer, "_load_openapi_spec", lambda self: None):
+            server = module.LifeOSMCPServer()
+        server.openapi_spec = openapi_spec
+        server._build_tools_from_spec()
         tool_names = {t["name"] for t in server.tools}
 
         expected_tools = {

--- a/tests/test_slack_api.py
+++ b/tests/test_slack_api.py
@@ -596,10 +596,16 @@ class TestSlackMyMessages:
             "permalink": permalink or "https://example.slack.com/archives/C123/p1751980000000100",
         }
 
-    def _mock_client(self, matches=None, user_id="U08GTEST001"):
+    def _mock_client(self, matches=None, user_id="U08GTEST001",
+                     truncated=False, total_available=None):
+        matches = matches if matches is not None else []
         mock = MagicMock()
         mock.auth_test.return_value = {"ok": True, "user_id": user_id, "user": "testuser"}
-        mock.search_messages.return_value = matches if matches is not None else []
+        mock.search_messages.return_value = {
+            "matches": matches,
+            "truncated": truncated,
+            "total_available": total_available if total_available is not None else len(matches),
+        }
         return mock
 
     def test_when_disabled(self, client):
@@ -613,6 +619,28 @@ class TestSlackMyMessages:
             response = client.get("/api/slack/my-messages?date=July-8th")
 
         assert response.status_code == 400
+
+    def test_non_zero_padded_date_rejected(self, client):
+        """strptime alone would accept 2026-7-8 — the endpoint must not."""
+        with patch("api.routes.slack.is_slack_enabled", return_value=True):
+            response = client.get("/api/slack/my-messages?date=2026-7-8")
+
+        assert response.status_code == 400
+
+    def test_malformed_user_rejected(self, client):
+        """user is interpolated into the Slack query — a crafted value must
+        not be able to replace the from: filter."""
+        mock = self._mock_client()
+
+        with patch("api.routes.slack.is_slack_enabled", return_value=True), \
+             patch("api.routes.slack.get_slack_client", return_value=mock):
+            response = client.get(
+                "/api/slack/my-messages",
+                params={"date": "2026-07-08", "user": "foo bar on:2020-01-01"},
+            )
+
+        assert response.status_code == 400
+        mock.search_messages.assert_not_called()
 
     def test_success_builds_query_from_auth_test(self, client):
         mock = self._mock_client(matches=[self._match()])
@@ -630,6 +658,8 @@ class TestSlackMyMessages:
         assert data["date"] == "2026-07-08"
         assert data["user_id"] == "U08GTEST001"
         assert data["total"] == 1
+        assert data["truncated"] is False
+        assert data["total_available"] == 1
         assert data["messages"][0]["text"] == "hello team"
         assert data["messages"][0]["channel_id"] == "C123"
         assert data["messages"][0]["channel_name"] == "general"
@@ -645,6 +675,20 @@ class TestSlackMyMessages:
         mock.auth_test.assert_not_called()
         query = mock.search_messages.call_args.kwargs["query"]
         assert "from:<@U99EXPLICIT>" in query
+
+    def test_truncated_pull_surfaced_in_response(self, client):
+        """A >max_pages day must not masquerade as a complete pull."""
+        mock = self._mock_client(matches=[self._match()],
+                                 truncated=True, total_available=1234)
+
+        with patch("api.routes.slack.is_slack_enabled", return_value=True), \
+             patch("api.routes.slack.get_slack_client", return_value=mock):
+            response = client.get("/api/slack/my-messages?date=2026-07-08")
+
+        data = response.json()
+        assert data["truncated"] is True
+        assert data["total_available"] == 1234
+        assert data["total"] == 1
 
     def test_missing_scope_gives_actionable_403(self, client):
         from api.services.slack_integration import SlackAPIError

--- a/tests/test_slack_api.py
+++ b/tests/test_slack_api.py
@@ -573,3 +573,135 @@ class TestSlackResponseModels:
         ]
         for field in result_fields:
             assert field in result, f"Missing result field: {field}"
+
+
+# =============================================================================
+# GET /api/slack/my-messages Tests (issue #441)
+# =============================================================================
+
+@pytest.mark.unit
+class TestSlackMyMessages:
+    """Tests for GET /api/slack/my-messages — the day-pull endpoint."""
+
+    def _match(self, ts="1751980000.000100", text="hello team",
+               channel=None, permalink=None):
+        return {
+            "type": "message",
+            "ts": ts,
+            "text": text,
+            "user": "U08GTEST001",
+            "username": "testuser",
+            "channel": channel or {"id": "C123", "name": "general",
+                                   "is_private": False},
+            "permalink": permalink or "https://example.slack.com/archives/C123/p1751980000000100",
+        }
+
+    def _mock_client(self, matches=None, user_id="U08GTEST001"):
+        mock = MagicMock()
+        mock.auth_test.return_value = {"ok": True, "user_id": user_id, "user": "testuser"}
+        mock.search_messages.return_value = matches if matches is not None else []
+        return mock
+
+    def test_when_disabled(self, client):
+        with patch("api.routes.slack.is_slack_enabled", return_value=False):
+            response = client.get("/api/slack/my-messages?date=2026-07-08")
+
+        assert response.status_code == 503
+
+    def test_invalid_date_rejected(self, client):
+        with patch("api.routes.slack.is_slack_enabled", return_value=True):
+            response = client.get("/api/slack/my-messages?date=July-8th")
+
+        assert response.status_code == 400
+
+    def test_success_builds_query_from_auth_test(self, client):
+        mock = self._mock_client(matches=[self._match()])
+
+        with patch("api.routes.slack.is_slack_enabled", return_value=True), \
+             patch("api.routes.slack.get_slack_client", return_value=mock):
+            response = client.get("/api/slack/my-messages?date=2026-07-08")
+
+        assert response.status_code == 200
+        mock.auth_test.assert_called_once()
+        query = mock.search_messages.call_args.kwargs["query"]
+        assert query == "from:<@U08GTEST001> on:2026-07-08"
+
+        data = response.json()
+        assert data["date"] == "2026-07-08"
+        assert data["user_id"] == "U08GTEST001"
+        assert data["total"] == 1
+        assert data["messages"][0]["text"] == "hello team"
+        assert data["messages"][0]["channel_id"] == "C123"
+        assert data["messages"][0]["channel_name"] == "general"
+
+    def test_explicit_user_param_skips_auth_test(self, client):
+        mock = self._mock_client()
+
+        with patch("api.routes.slack.is_slack_enabled", return_value=True), \
+             patch("api.routes.slack.get_slack_client", return_value=mock):
+            response = client.get("/api/slack/my-messages?date=2026-07-08&user=U99EXPLICIT")
+
+        assert response.status_code == 200
+        mock.auth_test.assert_not_called()
+        query = mock.search_messages.call_args.kwargs["query"]
+        assert "from:<@U99EXPLICIT>" in query
+
+    def test_missing_scope_gives_actionable_403(self, client):
+        from api.services.slack_integration import SlackAPIError
+
+        mock = self._mock_client()
+        mock.search_messages.side_effect = SlackAPIError("missing_scope")
+
+        with patch("api.routes.slack.is_slack_enabled", return_value=True), \
+             patch("api.routes.slack.get_slack_client", return_value=mock):
+            response = client.get("/api/slack/my-messages?date=2026-07-08")
+
+        assert response.status_code == 403
+        assert "search:read" in response.json()["detail"]
+
+    def test_other_slack_error_gives_502(self, client):
+        from api.services.slack_integration import SlackAPIError
+
+        mock = self._mock_client()
+        mock.search_messages.side_effect = SlackAPIError("fatal_error")
+
+        with patch("api.routes.slack.is_slack_enabled", return_value=True), \
+             patch("api.routes.slack.get_slack_client", return_value=mock):
+            response = client.get("/api/slack/my-messages?date=2026-07-08")
+
+        assert response.status_code == 502
+
+    def test_channel_type_derivation(self, client):
+        matches = [
+            self._match(ts="1751980000.000100",
+                        channel={"id": "D1", "name": "U123", "is_im": True}),
+            self._match(ts="1751980001.000100",
+                        channel={"id": "G1", "name": "mpdm-a--b--c-1",
+                                 "is_mpim": True, "is_private": True}),
+            self._match(ts="1751980002.000100",
+                        channel={"id": "G2", "name": "private-proj",
+                                 "is_private": True}),
+            self._match(ts="1751980003.000100",
+                        channel={"id": "C1", "name": "general"}),
+        ]
+        mock = self._mock_client(matches=matches)
+
+        with patch("api.routes.slack.is_slack_enabled", return_value=True), \
+             patch("api.routes.slack.get_slack_client", return_value=mock):
+            response = client.get("/api/slack/my-messages?date=2026-07-08")
+
+        types = [m["channel_type"] for m in response.json()["messages"]]
+        assert types == ["im", "mpim", "group", "channel"]
+
+    def test_thread_ts_extracted_from_permalink(self, client):
+        matches = [self._match(
+            permalink="https://example.slack.com/archives/C123/p1751980000000100"
+                      "?thread_ts=1751970000.000500&cid=C123",
+        )]
+        mock = self._mock_client(matches=matches)
+
+        with patch("api.routes.slack.is_slack_enabled", return_value=True), \
+             patch("api.routes.slack.get_slack_client", return_value=mock):
+            response = client.get("/api/slack/my-messages?date=2026-07-08")
+
+        assert response.json()["messages"][0]["thread_ts"] == "1751970000.000500"

--- a/tests/test_slack_integration.py
+++ b/tests/test_slack_integration.py
@@ -513,9 +513,11 @@ class TestSearchMessages:
     def test_single_page(self):
         client, http = self._client_with_pages([self._page(["msg one"], 1, 1)])
 
-        matches = client.search_messages(query="from:<@U1> on:2026-07-08")
+        result = client.search_messages(query="from:<@U1> on:2026-07-08")
 
-        assert [m["text"] for m in matches] == ["msg one"]
+        assert [m["text"] for m in result["matches"]] == ["msg one"]
+        assert result["truncated"] is False
+        assert result["total_available"] == 1
         url = http.get.call_args.args[0]
         assert url.endswith("/search.messages")
         params = http.get.call_args.kwargs["params"]
@@ -527,11 +529,46 @@ class TestSearchMessages:
             self._page(["page2 msg"], 2, 2),
         ])
 
-        matches = client.search_messages(query="q")
+        result = client.search_messages(query="q")
 
-        assert [m["text"] for m in matches] == ["page1 msg", "page2 msg"]
+        assert [m["text"] for m in result["matches"]] == ["page1 msg", "page2 msg"]
+        assert result["truncated"] is False
         assert http.get.call_count == 2
         assert http.get.call_args_list[1].kwargs["params"]["page"] == 2
+
+    def test_truncation_signaled_when_pages_exceed_max(self):
+        """More pages available than max_pages → stop at the cap and say so."""
+        pages = [self._page([f"page{i} msg"], i, 3) for i in (1, 2)]
+        # Slack reports the true total across all pages.
+        for p in pages:
+            p["messages"]["paging"]["total"] = 3
+        client, http = self._client_with_pages(pages)
+
+        result = client.search_messages(query="q", max_pages=2)
+
+        assert http.get.call_count == 2
+        assert [m["text"] for m in result["matches"]] == ["page1 msg", "page2 msg"]
+        assert result["truncated"] is True
+        assert result["total_available"] == 3
+
+    def test_rate_limit_retry(self):
+        """A ratelimited response with Retry-After is retried after sleeping."""
+        rate_limited = MagicMock()
+        rate_limited.json.return_value = {"ok": False, "error": "ratelimited"}
+        rate_limited.headers = {"Retry-After": "7"}
+
+        ok = MagicMock()
+        ok.json.return_value = self._page(["after retry"], 1, 1)
+
+        client, http = self._client_with_pages([])
+        http.get.side_effect = [rate_limited, ok]
+
+        with patch("time.sleep") as mock_sleep:
+            result = client.search_messages(query="q")
+
+        assert [m["text"] for m in result["matches"]] == ["after retry"]
+        assert http.get.call_count == 2
+        mock_sleep.assert_called_once_with(7)
 
     def test_api_error_raises(self):
         from api.services.slack_integration import SlackAPIError
@@ -551,6 +588,19 @@ class TestSearchMessages:
 
         assert identity["user_id"] == "U08GTEST001"
         client._api_call.assert_called_once_with("auth.test", "default")
+
+    def test_auth_test_cached_per_instance(self):
+        """The token identity never changes — repeat calls skip the API."""
+        client, http = self._client_with_pages([])
+        client._api_call = MagicMock(return_value={
+            "ok": True, "user_id": "U08GTEST001", "user": "testuser",
+        })
+
+        first = client.auth_test()
+        second = client.auth_test()
+
+        assert first == second
+        client._api_call.assert_called_once()
 
     def test_search_read_scope_declared(self):
         from api.services.slack_integration import SLACK_SCOPES

--- a/tests/test_slack_integration.py
+++ b/tests/test_slack_integration.py
@@ -473,3 +473,86 @@ class TestGetThreadReplies:
         messages = client.get_all_channel_history("C123")
 
         assert messages[0].latest_reply == "1700009999.000500"
+
+
+@patch("api.services.slack_integration.SLACK_USER_TOKEN", "")
+class TestSearchMessages:
+    """Issue #441: search.messages client — page-number pagination, GET form."""
+
+    def _client_with_pages(self, pages):
+        from api.services.slack_integration import SlackClient
+
+        store = MagicMock()
+        store.get_token.return_value = "xoxp-test-fake-token"
+        client = SlackClient(token_store=store)
+
+        responses = []
+        for page in pages:
+            r = MagicMock()
+            r.json.return_value = page
+            responses.append(r)
+        http = MagicMock()
+        http.get.side_effect = responses
+        client._http_client = http
+        return client, http
+
+    def _page(self, texts, page, pages):
+        return {
+            "ok": True,
+            "messages": {
+                "matches": [
+                    {"type": "message", "ts": f"175198000{i}.00010{i}",
+                     "text": t, "user": "U1",
+                     "channel": {"id": "C1", "name": "general"}}
+                    for i, t in enumerate(texts)
+                ],
+                "paging": {"count": 100, "total": len(texts), "page": page, "pages": pages},
+            },
+        }
+
+    def test_single_page(self):
+        client, http = self._client_with_pages([self._page(["msg one"], 1, 1)])
+
+        matches = client.search_messages(query="from:<@U1> on:2026-07-08")
+
+        assert [m["text"] for m in matches] == ["msg one"]
+        url = http.get.call_args.args[0]
+        assert url.endswith("/search.messages")
+        params = http.get.call_args.kwargs["params"]
+        assert params["query"] == "from:<@U1> on:2026-07-08"
+
+    def test_paginates_all_pages(self):
+        client, http = self._client_with_pages([
+            self._page(["page1 msg"], 1, 2),
+            self._page(["page2 msg"], 2, 2),
+        ])
+
+        matches = client.search_messages(query="q")
+
+        assert [m["text"] for m in matches] == ["page1 msg", "page2 msg"]
+        assert http.get.call_count == 2
+        assert http.get.call_args_list[1].kwargs["params"]["page"] == 2
+
+    def test_api_error_raises(self):
+        from api.services.slack_integration import SlackAPIError
+
+        client, _ = self._client_with_pages([{"ok": False, "error": "missing_scope"}])
+
+        with pytest.raises(SlackAPIError, match="missing_scope"):
+            client.search_messages(query="q")
+
+    def test_auth_test_returns_identity(self):
+        client, http = self._client_with_pages([])
+        client._api_call = MagicMock(return_value={
+            "ok": True, "user_id": "U08GTEST001", "user": "testuser",
+        })
+
+        identity = client.auth_test()
+
+        assert identity["user_id"] == "U08GTEST001"
+        client._api_call.assert_called_once_with("auth.test", "default")
+
+    def test_search_read_scope_declared(self):
+        from api.services.slack_integration import SLACK_SCOPES
+
+        assert "search:read" in SLACK_SCOPES


### PR DESCRIPTION
## Summary

Adds `GET /api/slack/my-messages?date=YYYY-MM-DD` — an exact, on-demand pull of every message the user sent on a given day across all four conversation types, thread replies included, via `search.messages` (`from:<@user> on:date`). Complements the index (which is a sync artifact) with a source-of-truth query; auto-becomes a `lifeos_*` MCP tool via the OpenAPI bridge.

Closes #441

## Test evidence

14 new tests (8 API in `tests/test_slack_api.py`, 6 client in `tests/test_slack_integration.py`): query construction via `auth.test`, explicit `?user=` override, page-number pagination, channel-type derivation (im/mpim/group/channel), `thread_ts` extraction from permalinks, invalid-date 400, missing-scope 403 with actionable message, other API errors 502, `search:read` in `SLACK_SCOPES`. Full unit suite on nathan-linux: 3152 passed; 14 failures identical to the pre-existing data/.env-dependent set on clean main. The `search.messages` approach itself was validated live against the workspace on 2026-07-09 (78 messages, all four conversation types, one call); post-merge live verification of the endpoint planned once auto-deploy picks it up.

## Review focus

- `search_messages` uses GET with query params (not `_api_call`'s JSON POST) because `search.messages` doesn't accept `application/json` — mirrors the `list_channels` pattern including rate-limit retry.
- Timezone caveat: `on:` filters by the searching user's Slack TZ, documented in the endpoint docstring (which becomes the MCP tool description).
- `thread_ts` is best-effort from the permalink query string — search matches don't carry it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)