### PR TITLE
feat(investments): add lifeos_investments MCP tool + surface action in prompt

### DIFF
--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -61,8 +61,8 @@ Create, list, or complete Obsidian tasks. When tagging a task and an existing-ta
 **manage_reminders (action: create/list):**
 Create or list timed Telegram notification reminders.
 
-**search_finances (action: accounts/transactions/cashflow/budgets):**
-Live financial data from Monarch Money. Use 'accounts' for current balances, 'transactions' to search recent spending (filterable by date, category, merchant), 'cashflow' for income/expense/savings summary, 'budgets' for budget vs actual. Defaults: transactions=last 30 days, cashflow/budgets=current month. Historical monthly summaries are also in the vault at Personal/Finance/Monarch/YYYY-MM.md — use search_vault for past months.
+**search_finances (action: accounts/transactions/cashflow/budgets/investments):**
+Live financial data from Monarch Money. Use 'accounts' for current balances, 'transactions' to search recent spending (filterable by date, category, merchant), 'cashflow' for income/expense/savings summary, 'budgets' for budget vs actual, 'investments' for the full portfolio snapshot (Schwab + Guideline 401(k) + TSP — total value, tax buckets, holdings with cost basis). Prefer 'investments' over 'accounts' for portfolio / net-worth / holdings questions — it is deeper than Monarch's investment balances. Defaults: transactions=last 30 days, cashflow/budgets=current month. Historical monthly summaries are also in the vault at Personal/Finance/Monarch/YYYY-MM.md — use search_vault for past months.
 
 **create_email_draft:**
 Create a Gmail draft email (personal or work account). NEVER sends — only drafts. ALWAYS the first step for any email request, even one phrased "send an email to X". Returns a draft_id.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -282,6 +282,11 @@ CURATED_ENDPOINTS = {
         "description": "Get current budget status from Monarch Money. Returns each budget with budgeted amount, actual spending, and remaining balance. Defaults to current month.",
         "method": "GET"
     },
+    "/api/investments/summary": {
+        "name": "lifeos_investments",
+        "description": "Full investment portfolio (Schwab + 401k + TSP): total value, tax buckets, top holdings with cost basis. Prefer over monarch_accounts for net-worth or portfolio questions.",
+        "method": "GET"
+    },
     "/api/tasks:POST": {
         "name": "lifeos_task_create",
         "description": "Create a task (Obsidian markdown). Supports context, priority, due_date, tags. With dry_run=true + #agent tag, returns preflight routing + cost estimate instead of creating.",
@@ -1157,7 +1162,13 @@ class LifeOSMCPServer:
     def _format_response(self, tool_name: str, data: dict) -> str:
         """Format API response for human readability."""
         if "error" in data:
-            return f"Error: {data['error']}"
+            err = data["error"]
+            # Stale-but-present: a missing snapshot is expected (mac asleep /
+            # refresh hasn't run), not an error worth surfacing as one.
+            if tool_name == "lifeos_investments" and "not synced" in err.lower():
+                return ("Investments snapshot not synced yet — the macbook refresh "
+                        "(weekdays ~18:30) hasn't landed a summary.json here yet.")
+            return f"Error: {err}"
 
         # Tool-specific formatting
         if tool_name == "lifeos_ask":
@@ -1588,6 +1599,41 @@ class LifeOSMCPServer:
                 bal = a.get("balance", 0)
                 text += f"| {a.get('name', '')} | {a.get('type', '')} | ${bal:,.2f} | {a.get('institution', '')} | {a.get('id', '')} |\n"
             return text
+
+        elif tool_name == "lifeos_investments":
+            # Household portfolio snapshot from the Schwab pipeline (synced from
+            # nathan-macbook). Mirrors the search_finances 'investments' digest.
+            totals = data.get("totals", {})
+            tb = totals.get("tax_buckets", {})
+            lines = [
+                f"**Investment portfolio** (as of {data.get('as_of', '?')}, synced {data.get('synced_at', '?')})",
+                "",
+                f"- Total: ${totals.get('all_investments', 0):,.0f} "
+                f"(Schwab ${totals.get('schwab', 0):,.0f} + external retirement ${totals.get('external_retirement', 0):,.0f})",
+                f"- Tax buckets: pre-tax ${tb.get('pretax', 0):,.0f} · Roth ${tb.get('roth', 0):,.0f} · taxable ${tb.get('taxable', 0):,.0f}",
+            ]
+            accounts = data.get("accounts", [])
+            if accounts:
+                lines += ["", "Accounts:"]
+                for a in sorted(accounts, key=lambda x: -(x.get("value") or 0)):
+                    tag = " (external)" if a.get("external") else ""
+                    lines.append(f"- {a.get('name', '')} [{a.get('key', '')}]{tag}: ${(a.get('value') or 0):,.0f}")
+            positions = data.get("positions", [])
+            if positions:
+                lines += ["", "Top positions:"]
+                for pos in positions[:15]:
+                    unrl = (f", unrealized ${pos['unrealized']:+,.0f}"
+                            if pos.get("unrealized") is not None else "")
+                    lines.append(f"- {pos.get('symbol', '')}: ${(pos.get('value') or 0):,.0f} "
+                                 f"({pos.get('weight_pct', 0)}%{unrl})")
+            tu = data.get("taxable_unrealized")
+            if tu:
+                lines += ["", (f"Taxable unrealized: LT ${tu.get('long_term', 0):,.0f} · "
+                               f"ST ${tu.get('short_term', 0):,.0f} · "
+                               f"harvestable ${tu.get('harvestable_losses', 0):,.0f}")]
+            lines.append("\nFull detail (positions incl. lots/flows, wealth history): "
+                         "GET /api/investments/portfolio.")
+            return "\n".join(lines)
 
         elif tool_name == "lifeos_monarch_transactions":
             txns = data.get("transactions", [])

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1603,14 +1603,14 @@ class LifeOSMCPServer:
         elif tool_name == "lifeos_investments":
             # Household portfolio snapshot from the Schwab pipeline (synced from
             # nathan-macbook). Mirrors the search_finances 'investments' digest.
-            totals = data.get("totals", {})
-            tb = totals.get("tax_buckets", {})
+            totals = data.get("totals") or {}
+            tb = totals.get("tax_buckets") or {}
             lines = [
                 f"**Investment portfolio** (as of {data.get('as_of', '?')}, synced {data.get('synced_at', '?')})",
                 "",
-                f"- Total: ${totals.get('all_investments', 0):,.0f} "
-                f"(Schwab ${totals.get('schwab', 0):,.0f} + external retirement ${totals.get('external_retirement', 0):,.0f})",
-                f"- Tax buckets: pre-tax ${tb.get('pretax', 0):,.0f} · Roth ${tb.get('roth', 0):,.0f} · taxable ${tb.get('taxable', 0):,.0f}",
+                f"- Total: ${(totals.get('all_investments') or 0):,.0f} "
+                f"(Schwab ${(totals.get('schwab') or 0):,.0f} + external retirement ${(totals.get('external_retirement') or 0):,.0f})",
+                f"- Tax buckets: pre-tax ${(tb.get('pretax') or 0):,.0f} · Roth ${(tb.get('roth') or 0):,.0f} · taxable ${(tb.get('taxable') or 0):,.0f}",
             ]
             accounts = data.get("accounts", [])
             if accounts:
@@ -1625,12 +1625,12 @@ class LifeOSMCPServer:
                     unrl = (f", unrealized ${pos['unrealized']:+,.0f}"
                             if pos.get("unrealized") is not None else "")
                     lines.append(f"- {pos.get('symbol', '')}: ${(pos.get('value') or 0):,.0f} "
-                                 f"({pos.get('weight_pct', 0)}%{unrl})")
+                                 f"({pos.get('weight_pct') or 0}%{unrl})")
             tu = data.get("taxable_unrealized")
             if tu:
-                lines += ["", (f"Taxable unrealized: LT ${tu.get('long_term', 0):,.0f} · "
-                               f"ST ${tu.get('short_term', 0):,.0f} · "
-                               f"harvestable ${tu.get('harvestable_losses', 0):,.0f}")]
+                lines += ["", (f"Taxable unrealized: LT ${(tu.get('long_term') or 0):,.0f} · "
+                               f"ST ${(tu.get('short_term') or 0):,.0f} · "
+                               f"harvestable ${(tu.get('harvestable_losses') or 0):,.0f}")]
             lines.append("\nFull detail (positions incl. lots/flows, wealth history): "
                          "GET /api/investments/portfolio.")
             return "\n".join(lines)

--- a/tests/test_agent_system_prompt.py
+++ b/tests/test_agent_system_prompt.py
@@ -119,3 +119,11 @@ def test_blank_persona_adds_no_block(tm):
     base = build_system_prompt()
     spaced = build_system_prompt(persona="   ")
     assert len(spaced) == len(base)
+
+
+def test_search_finances_prompt_advertises_investments(tm):
+    """The orchestrator prompt must list the 'investments' action so agents
+    prefer the portfolio snapshot over Monarch for net-worth questions (#447)."""
+    text = "\n".join(_text_blocks(build_system_prompt()))
+    assert "accounts/transactions/cashflow/budgets/investments" in text
+    assert "'investments'" in text

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -400,3 +400,72 @@ def test_call_api_skips_cache_when_session_id_missing():
     server._call_api("lifeos_calendar_upcoming", {"days": 7})
     # Both calls round-trip — no session, no cache.
     assert fake.get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Investments snapshot tool (#447)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_investments_tool_curated():
+    """lifeos_investments is a curated GET tool on the summary endpoint, with a
+    description inside the 30-word cache budget."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    cfg = next((c for c in module.CURATED_ENDPOINTS.values()
+                if c["name"] == "lifeos_investments"), None)
+    assert cfg is not None, "lifeos_investments missing from CURATED_ENDPOINTS"
+    assert cfg["method"] == "GET"
+    assert len(cfg["description"].split()) <= 30
+
+
+@pytest.mark.unit
+def test_investments_format_digest():
+    """_format_response renders a portfolio digest that surfaces synced_at."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    server = module.LifeOSMCPServer()
+    data = {
+        "synced_at": "2026-07-09T03:26:00",
+        "as_of": "2026-07-09",
+        "totals": {
+            "all_investments": 1234567, "schwab": 1000000, "external_retirement": 234567,
+            "tax_buckets": {"pretax": 500000, "roth": 300000, "taxable": 434567},
+        },
+        "accounts": [
+            {"key": "brokerage", "name": "Schwab Brokerage", "value": 1000000, "external": False},
+            {"key": "401k", "name": "Guideline 401(k)", "value": 234567, "external": True},
+        ],
+        "positions": [
+            {"symbol": "VTI", "value": 500000, "weight_pct": 40, "unrealized": 120000},
+            {"symbol": "GFND", "value": 234567, "weight_pct": 19},  # external: no unrealized
+        ],
+        "taxable_unrealized": {"long_term": 80000, "short_term": 5000, "harvestable_losses": -2000},
+    }
+    out = server._format_response("lifeos_investments", data)
+    assert "Investment portfolio" in out
+    assert "2026-07-09T03:26:00" in out       # synced_at surfaced
+    assert "$1,234,567" in out                 # total value
+    assert "Schwab Brokerage" in out
+    assert "(external)" in out                 # external account tagged
+    assert "VTI" in out and "unrealized" in out
+
+
+@pytest.mark.unit
+def test_investments_not_synced_is_graceful():
+    """A missing snapshot yields a friendly message, not an 'Error:' string."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    server = module.LifeOSMCPServer()
+    out = server._format_response(
+        "lifeos_investments",
+        {"error": 'API error 404: {"detail":"summary.json not synced yet — run the macbook refresh"}'},
+    )
+    assert not out.startswith("Error:")
+    assert "not synced yet" in out.lower()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -469,3 +469,48 @@ def test_investments_not_synced_is_graceful():
     )
     assert not out.startswith("Error:")
     assert "not synced yet" in out.lower()
+
+
+@pytest.mark.unit
+def test_investments_format_tolerates_null_fields():
+    """A partial snapshot — present-but-null numbers, or a whole null section —
+    degrades to $0 instead of raising (external accounts can lack figures, and a
+    partial write can null a section)."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    server = module.LifeOSMCPServer()
+    # null numeric leaves within present sections
+    data = {
+        "synced_at": "2026-07-09T03:26:00", "as_of": "2026-07-09",
+        "totals": {"all_investments": None, "schwab": None, "external_retirement": None,
+                   "tax_buckets": {"pretax": None, "roth": None, "taxable": None}},
+        "accounts": [{"key": "401k", "name": "Guideline 401(k)", "value": None, "external": True}],
+        "positions": [{"symbol": "GFND", "value": None, "weight_pct": None}],
+        "taxable_unrealized": {"long_term": None, "short_term": None, "harvestable_losses": None},
+    }
+    out = server._format_response("lifeos_investments", data)  # must not raise
+    assert "Investment portfolio" in out
+    assert "$0" in out
+    assert "None" not in out
+    # whole null sections (plausible on a partial write)
+    out2 = server._format_response(
+        "lifeos_investments",
+        {"synced_at": "x", "as_of": "y", "totals": None, "accounts": None,
+         "positions": None, "taxable_unrealized": None},
+    )
+    assert "Investment portfolio" in out2  # must not raise
+
+
+@pytest.mark.unit
+def test_investments_route_404_matches_mcp_not_synced_branch(tmp_path, monkeypatch):
+    """The MCP graceful branch keys on 'not synced' in the route's 404 detail;
+    guard that cross-file coupling so a reword of the route message can't
+    silently drop the graceful handling."""
+    from fastapi import HTTPException
+    from api.routes import investments as inv_route
+    monkeypatch.setattr(inv_route, "SYNC_DIR", str(tmp_path))  # empty dir → file missing
+    with pytest.raises(HTTPException) as ei:
+        inv_route._load("summary.json")
+    assert "not synced" in str(ei.value.detail).lower()


### PR DESCRIPTION
## Summary

Completes the macbook-handoff investments integration (base `a657a3e`). The API routes (`/api/investments/summary` + `/portfolio`) and the `search_finances` `investments` action already existed; this PR wires up the two remaining **agent-facing** surfaces so the portfolio data is reachable and preferred:

- **`mcp_server.py`** — new `lifeos_investments` MCP tool (a `CURATED_ENDPOINTS` entry proxying `GET /api/investments/summary`, plus a `_format_response` digest of totals, tax buckets, accounts, and top holdings). A not-yet-synced snapshot returns a **graceful message**, not an error (stale-but-present semantics).
- **`api/services/agent_system_prompt.py`** — adds the `investments` action to the `search_finances` enumeration and steers portfolio / net-worth / holdings questions to it (deeper than Monarch: cost basis, tax buckets).

No vault/search indexing of the sensitive financial files is introduced.

Closes #447

## Test evidence

`./scripts/test.sh auto`: **3195 passed, 4 failed** — the 4 failures are the known pre-existing environment-dependent set (`test_settings` reads the host's real `.env` LLM overrides; `test_slack_sync` / `test_p91_data_integrity` are local vault/DB-state dependent), unrelated to this diff. 4 new tests added and passing:
- `test_investments_tool_curated` — tool registered as GET, description within the 30-word cache budget
- `test_investments_format_digest` — digest surfaces `synced_at`, totals, external-account tag, holdings
- `test_investments_not_synced_is_graceful` — missing snapshot → friendly message, not `Error:`
- `test_search_finances_prompt_advertises_investments` — prompt lists the action

The MCP HTTP transport + stdio bridge both reloaded on commit and now expose `lifeos_investments`.

## Review focus

- The `_format_response` digest is defensive (`.get()` throughout) since external positions lack `cost_basis`/`unrealized` — confirm no `KeyError` path on a partial file.
- The graceful-404 branch keys on `tool_name == "lifeos_investments" and "not synced" in err` — confirm it doesn't swallow genuine errors for other tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)