### PR TITLE
feat(investments): warn when the portfolio snapshot goes stale

### DIFF
--- a/api/routes/investments.py
+++ b/api/routes/investments.py
@@ -71,9 +71,11 @@ def check_investments_freshness() -> Optional[str]:
     lands in the batched health report — not raised, not a CRITICAL page.
     """
     path = os.path.join(SYNC_DIR, "summary.json")
-    if not os.path.exists(path):
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        # Missing / never-synced / vanished mid-check — not an error.
         return None
-    mtime = os.path.getmtime(path)
     age_days = (datetime.now().timestamp() - mtime) / 86400
     if age_days > STALENESS_WARNING_DAYS:
         synced = datetime.fromtimestamp(mtime).isoformat(timespec="seconds")

--- a/api/routes/investments.py
+++ b/api/routes/investments.py
@@ -21,6 +21,12 @@ router = APIRouter(prefix="/api/investments", tags=["investments"])
 
 SYNC_DIR = os.path.expanduser("~/Code/Sync/investments")
 
+# Freshness alerting (#448): the macbook pipeline refreshes on weekdays (~18:30)
+# and Syncthing delivers here. A weekend plus the weekday cadence can leave the
+# file ~3 days old legitimately, so warn only past this threshold — enough to
+# catch a genuinely stuck pipeline / Syncthing without false-alarming on Mondays.
+STALENESS_WARNING_DAYS = 4
+
 
 def _load(name: str):
     path = os.path.join(SYNC_DIR, name)
@@ -52,3 +58,27 @@ async def investments_portfolio(section: Optional[str] = None):
                                 detail=f"no section '{section}'; available: {sorted(data)}")
         return {"synced_at": synced, "section": section, "data": data[section]}
     return {"synced_at": synced, **data}
+
+
+def check_investments_freshness() -> Optional[str]:
+    """Return a staleness warning message if the snapshot is older than
+    STALENESS_WARNING_DAYS, else None.
+
+    Stale-but-present semantics: a missing / never-synced file is NOT an error
+    (returns None) — the pipeline may simply not be set up on this host. Only a
+    present-but-old snapshot warrants a warning (the weekday refresh or Syncthing
+    likely stalled). Intended to be logged at WARNING by the nightly runner so it
+    lands in the batched health report — not raised, not a CRITICAL page.
+    """
+    path = os.path.join(SYNC_DIR, "summary.json")
+    if not os.path.exists(path):
+        return None
+    mtime = os.path.getmtime(path)
+    age_days = (datetime.now().timestamp() - mtime) / 86400
+    if age_days > STALENESS_WARNING_DAYS:
+        synced = datetime.fromtimestamp(mtime).isoformat(timespec="seconds")
+        return (
+            f"Investments snapshot is {age_days:.1f} days old (last synced {synced}); "
+            f"the weekday refresh (~18:30) or Syncthing may have stalled."
+        )
+    return None

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -442,7 +442,7 @@ def send_sync_summary_telegram(result: dict, trigger: str = "unknown"):
 
     # Build message
     collapsed_sources = result.get("duration_collapsed_sources", [])
-    status_emoji = "✅" if result["failed"] == 0 and not collapsed_sources else "⚠️"
+    status_emoji = "✅" if result["failed"] == 0 and not collapsed_sources and not result.get("investments_stale") else "⚠️"
     lines = [
         f"{status_emoji} *LifeOS Sync Complete*",
         f"Trigger: {trigger}",
@@ -511,6 +511,14 @@ def send_sync_summary_telegram(result: dict, trigger: str = "unknown"):
                 lines.append("  Manual review needed — threshold exceeded")
             else:
                 lines.append(f"🔧 *Data Issues:* {total_issues} found, {total_fixed} auto-fixed")
+
+    # Investments-snapshot freshness (#448) — surface the stale WARNING here so
+    # it reaches the operator (the bare log line does not feed any batched report).
+    investments_stale = result.get("investments_stale")
+    if investments_stale:
+        lines.append("")
+        lines.append("⚠️ *Investments snapshot stale:*")
+        lines.append(f"  {investments_stale}")
 
     try:
         success = send_message("\n".join(lines))
@@ -1343,13 +1351,15 @@ def run_all_syncs(
         logger.warning(f"Source-entity drift detector failed: {e}")
 
     # Investments-snapshot freshness (#448): the Schwab pipeline delivers
-    # summary.json via Syncthing (weekday ~18:30 refresh); warn (batched) if it
-    # has gone stale. Non-fatal, and skipped silently when the file is absent.
+    # summary.json via Syncthing (weekday ~18:30 refresh); warn if it has gone
+    # stale. Non-fatal and skipped silently when absent. Surfaced in the nightly
+    # Telegram summary (via result["investments_stale"]) so it reaches the operator.
+    investments_stale = None
     try:
         from api.routes.investments import check_investments_freshness
-        stale_msg = check_investments_freshness()
-        if stale_msg:
-            logger.warning(stale_msg)
+        investments_stale = check_investments_freshness()
+        if investments_stale:
+            logger.warning(investments_stale)
     except Exception as e:
         logger.warning(f"Investments freshness check failed: {e}")
 
@@ -1402,6 +1412,7 @@ def run_all_syncs(
         "interactions_by_source": interactions_by_source,
         "dep_skipped_sources": sorted(dep_skipped),
         "duration_collapsed_sources": duration_collapsed,
+        "investments_stale": investments_stale,
     }
 
     # Exit maintenance mode now that sync is complete

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -1342,6 +1342,17 @@ def run_all_syncs(
     except Exception as e:
         logger.warning(f"Source-entity drift detector failed: {e}")
 
+    # Investments-snapshot freshness (#448): the Schwab pipeline delivers
+    # summary.json via Syncthing (weekday ~18:30 refresh); warn (batched) if it
+    # has gone stale. Non-fatal, and skipped silently when the file is absent.
+    try:
+        from api.routes.investments import check_investments_freshness
+        stale_msg = check_investments_freshness()
+        if stale_msg:
+            logger.warning(stale_msg)
+    except Exception as e:
+        logger.warning(f"Investments freshness check failed: {e}")
+
     # Calculate duration
     end_time = datetime.now()
     duration_seconds = (end_time - start_time).total_seconds()

--- a/tests/test_investments.py
+++ b/tests/test_investments.py
@@ -49,3 +49,17 @@ def test_freshness_missing_file_is_not_an_error(tmp_path, monkeypatch):
     """A never-synced snapshot returns None (skip), not a warning or an error."""
     monkeypatch.setattr(inv, "SYNC_DIR", str(tmp_path))  # empty dir, no file
     assert inv.check_investments_freshness() is None
+
+
+def test_freshness_just_under_threshold_does_not_warn(tmp_path, monkeypatch):
+    """3.9 days (just under the 4-day threshold) must not warn — pins the boundary."""
+    monkeypatch.setattr(inv, "SYNC_DIR", str(tmp_path))
+    _write_summary(tmp_path, age_days=inv.STALENESS_WARNING_DAYS - 0.1)
+    assert inv.check_investments_freshness() is None
+
+
+def test_freshness_just_over_threshold_warns(tmp_path, monkeypatch):
+    """4.5 days (just over the threshold) warns — pins the boundary."""
+    monkeypatch.setattr(inv, "SYNC_DIR", str(tmp_path))
+    _write_summary(tmp_path, age_days=inv.STALENESS_WARNING_DAYS + 0.5)
+    assert inv.check_investments_freshness() is not None

--- a/tests/test_investments.py
+++ b/tests/test_investments.py
@@ -1,0 +1,51 @@
+"""Tests for the investments snapshot route helpers.
+
+Focus: the freshness check (#448) that warns when the Schwab-pipeline snapshot
+(delivered via Syncthing) goes stale, with stale-but-present semantics — a
+missing file is never an error, and a normal weekend cadence never warns.
+"""
+import os
+import time
+
+import pytest
+
+from api.routes import investments as inv
+
+pytestmark = pytest.mark.unit
+
+
+def _write_summary(tmp_path, age_days: float):
+    """Write a summary.json and backdate its mtime by age_days."""
+    p = tmp_path / "summary.json"
+    p.write_text('{"totals": {}}')
+    old = time.time() - age_days * 86400
+    os.utime(p, (old, old))
+    return p
+
+
+def test_freshness_fresh_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(inv, "SYNC_DIR", str(tmp_path))
+    _write_summary(tmp_path, age_days=1)
+    assert inv.check_investments_freshness() is None
+
+
+def test_freshness_weekend_cadence_does_not_warn(tmp_path, monkeypatch):
+    """A file ~3 days old (Friday refresh read on Monday) must not warn."""
+    monkeypatch.setattr(inv, "SYNC_DIR", str(tmp_path))
+    _write_summary(tmp_path, age_days=3)
+    assert inv.check_investments_freshness() is None
+
+
+def test_freshness_stale_returns_warning(tmp_path, monkeypatch):
+    monkeypatch.setattr(inv, "SYNC_DIR", str(tmp_path))
+    _write_summary(tmp_path, age_days=6)
+    msg = inv.check_investments_freshness()
+    assert msg is not None
+    assert "days old" in msg
+    assert not msg.lower().startswith("error")
+
+
+def test_freshness_missing_file_is_not_an_error(tmp_path, monkeypatch):
+    """A never-synced snapshot returns None (skip), not a warning or an error."""
+    monkeypatch.setattr(inv, "SYNC_DIR", str(tmp_path))  # empty dir, no file
+    assert inv.check_investments_freshness() is None

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -636,3 +636,37 @@ class TestDurationCollapse:
         message = send_mock.call_args[0][0]
         assert "silent no-op" not in message
         assert "✅" in message
+
+
+def test_sync_summary_surfaces_investments_stale():
+    """A stale investments snapshot must reach the user via the nightly Telegram
+    summary — a bare logger.warning feeds no batched report (#448)."""
+    from scripts.run_all_syncs import send_sync_summary_telegram
+    result = {
+        "succeeded": 3, "sources_run": 3, "failed": 0, "failed_sources": [],
+        "results": {}, "duration_seconds": 12,
+        "investments_stale": (
+            "Investments snapshot is 6.0 days old (last synced 2026-07-03T18:30:00); "
+            "the weekday refresh (~18:30) or Syncthing may have stalled."
+        ),
+    }
+    with patch("api.services.telegram.send_message", return_value=True) as send_mock:
+        send_sync_summary_telegram(result, trigger="test")
+    message = send_mock.call_args[0][0]
+    assert "Investments snapshot" in message
+    assert "stale" in message.lower()
+    assert message.startswith("⚠️")  # stale flips the top-line status
+
+
+def test_sync_summary_omits_investments_when_fresh():
+    """No investments section (and a clean status) when the snapshot is fresh."""
+    from scripts.run_all_syncs import send_sync_summary_telegram
+    result = {
+        "succeeded": 3, "sources_run": 3, "failed": 0, "failed_sources": [],
+        "results": {}, "duration_seconds": 12, "investments_stale": None,
+    }
+    with patch("api.services.telegram.send_message", return_value=True) as send_mock:
+        send_sync_summary_telegram(result, trigger="test")
+    message = send_mock.call_args[0][0]
+    assert "Investments snapshot stale" not in message
+    assert message.startswith("✅")


### PR DESCRIPTION
## Summary

The Schwab investments pipeline delivers `summary.json` into `~/Code/Sync/investments/` via Syncthing on a weekday (~18:30) cadence. If the mac, launchd job, pipeline, or Syncthing breaks, LifeOS silently keeps serving increasingly stale data with no signal. This surfaces a WARNING — in the nightly report the operator actually sees — when the snapshot goes stale.

- **`api/routes/investments.py`** — `check_investments_freshness()` returns a warning message when `summary.json` is older than `STALENESS_WARNING_DAYS` (**4** — tolerates a weekend + the weekday cadence so a Friday file read on Monday never warns), else `None`. Missing / never-synced (or vanished mid-check) → `None`, not an error (stale-but-present semantics; TOCTOU-safe).
- **`scripts/run_all_syncs.py`** — the nightly runner captures that message into `result["investments_stale"]` and `send_sync_summary_telegram` renders it as a section (flipping the top-line status to ⚠️), so it reaches the operator in the nightly Telegram summary. Non-fatal (try/except), skipped silently when the file is absent. Also logged at WARNING for the log file.

WARNING-only by design — not a CRITICAL page.

> **Round-1 review** established that a bare `logger.warning()` reaches only `logs/sync*.log` — the batched `/health/raw-state` report reads `record_failure` state and the Telegram summary reads the `result` dict — so the warning is routed through the Telegram summary to actually reach the operator. (The pre-existing drift-detector and `apple_data_import` precedents share the log-only gap; fixing those is out of scope here.)

Closes #448

## Test evidence

`./scripts/test.sh auto`: **3205 passed, 4 failed** — all 4 are the known pre-existing environment/data-dependent set (`test_settings` reads the host's real `.env`; `test_slack_sync` / `test_p91_data_integrity` are vault/DB-state dependent), none touching investments. 8 new tests: freshness (fresh / 3d weekend / 3.9d / 4.5d / 6d / missing) + delivery (stale reaches the Telegram summary with ⚠️; fresh omits the section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)