### PR TITLE
fix(investments): show all holdings in agent digests, not just top 15

### DIFF
--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -1781,8 +1781,8 @@ async def _tool_search_finances(inp: dict) -> str:
         for a in sorted(inv["accounts"], key=lambda x: -x["value"]):
             tag = " (external)" if a["external"] else ""
             lines.append(f"- {a['name']} [{a['key']}]{tag}: ${a['value']:,.0f}")
-        lines += ["", "Top positions:"]
-        for pos in inv["positions"][:15]:
+        lines += ["", f"Positions ({len(inv['positions'])}):"]
+        for pos in inv["positions"]:
             unrl = f", unrealized ${pos['unrealized']:+,.0f}" if pos.get("unrealized") is not None else ""
             lines.append(f"- {pos['symbol']}: ${pos['value']:,.0f} ({pos['weight_pct']}%{unrl})")
         tu = inv["taxable_unrealized"]

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1620,8 +1620,8 @@ class LifeOSMCPServer:
                     lines.append(f"- {a.get('name', '')} [{a.get('key', '')}]{tag}: ${(a.get('value') or 0):,.0f}")
             positions = data.get("positions", [])
             if positions:
-                lines += ["", "Top positions:"]
-                for pos in positions[:15]:
+                lines += ["", f"Positions ({len(positions)}):"]
+                for pos in positions:
                     unrl = (f", unrealized ${pos['unrealized']:+,.0f}"
                             if pos.get("unrealized") is not None else "")
                     lines.append(f"- {pos.get('symbol', '')}: ${(pos.get('value') or 0):,.0f} "

--- a/tests/test_investments.py
+++ b/tests/test_investments.py
@@ -3,15 +3,59 @@
 Focus: the freshness check (#448) that warns when the Schwab-pipeline snapshot
 (delivered via Syncthing) goes stale, with stale-but-present semantics — a
 missing file is never an error, and a normal weekend cadence never warns.
+Also covers the search_finances 'investments' digest (#452): every holding is
+listed, so a beyond-top-15 position is never silently dropped.
 """
+import json
 import os
 import time
 
 import pytest
 
 from api.routes import investments as inv
+from api.services.agent_tools import _tool_search_finances
 
 pytestmark = pytest.mark.unit
+
+
+def _snapshot_with_many_positions():
+    """A summary-style snapshot with 20 positions, value-descending, where a
+    low-value holding ("SPCX") sits at rank 20 — beyond the old top-15 cap."""
+    positions = [
+        {"symbol": f"FIL{i:02d}", "value": 100000 - i * 1000,
+         "weight_pct": 5, "unrealized": 1000}
+        for i in range(19)
+    ]
+    positions.append({"symbol": "SPCX", "value": 3050, "weight_pct": 0.37})
+    return {
+        "as_of": "2026-07-09",
+        "totals": {
+            "all_investments": 1234567, "schwab": 1000000, "external_retirement": 234567,
+            "tax_buckets": {"pretax": 500000, "roth": 300000, "taxable": 434567},
+        },
+        "accounts": [
+            {"key": "brokerage", "name": "Synthetic Brokerage", "value": 1000000, "external": False},
+        ],
+        "positions": positions,
+        "taxable_unrealized": {"long_term": 80000, "short_term": 5000, "harvestable_losses": -2000},
+        "savings_net_by_year": {"2025": 1000},
+    }
+
+
+async def test_search_finances_investments_lists_all_positions(tmp_path, monkeypatch):
+    """The investments digest must include a beyond-top-15 holding (regression
+    for #452, where SPCX at rank 44 was silently dropped by a [:15] cap)."""
+    home = tmp_path / "home"
+    inv_dir = home / "Code" / "Sync" / "investments"
+    inv_dir.mkdir(parents=True)
+    (inv_dir / "summary.json").write_text(json.dumps(_snapshot_with_many_positions()))
+    monkeypatch.setenv("HOME", str(home))  # ~ in the digest path resolves here
+
+    out = await _tool_search_finances({"action": "investments"})
+
+    assert "SPCX" in out                 # beyond-top-15 holding is present
+    assert "Positions (20):" in out      # header reflects the full count
+    assert "Top positions:" not in out   # old truncating header is gone
 
 
 def _write_summary(tmp_path, age_days: float):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -456,6 +456,39 @@ def test_investments_format_digest():
 
 
 @pytest.mark.unit
+def test_investments_format_lists_all_positions():
+    """The MCP digest must include a beyond-top-15 holding (regression for #452,
+    where SPCX at rank 44 was silently dropped by a [:15] cap). Mirrors the
+    search_finances 'investments' digest, so header/format stay consistent."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    server = module.LifeOSMCPServer()
+    positions = [
+        {"symbol": f"FIL{i:02d}", "value": 100000 - i * 1000, "weight_pct": 5,
+         "unrealized": 1000}
+        for i in range(19)
+    ]
+    positions.append({"symbol": "SPCX", "value": 3050, "weight_pct": 0.37})
+    data = {
+        "synced_at": "2026-07-09T03:26:00", "as_of": "2026-07-09",
+        "totals": {"all_investments": 1234567, "schwab": 1000000,
+                   "external_retirement": 234567,
+                   "tax_buckets": {"pretax": 500000, "roth": 300000, "taxable": 434567}},
+        "accounts": [{"key": "brokerage", "name": "Synthetic Brokerage",
+                      "value": 1000000, "external": False}],
+        "positions": positions,
+        "taxable_unrealized": {"long_term": 80000, "short_term": 5000,
+                               "harvestable_losses": -2000},
+    }
+    out = server._format_response("lifeos_investments", data)
+    assert "SPCX" in out                 # beyond-top-15 holding is present
+    assert "Positions (20):" in out      # header reflects the full count
+    assert "Top positions:" not in out   # old truncating header is gone
+
+
+@pytest.mark.unit
 def test_investments_not_synced_is_graceful():
     """A missing snapshot yields a friendly message, not an 'Error:' string."""
     import importlib.util


### PR DESCRIPTION
Closes #452.

## Problem

Both investments digests — the `search_finances investments` action (`agent_tools.py`) and the `lifeos_investments` MCP tool (`mcp_server.py`) — capped the holdings list at the top 15 positions by value. Any smaller holding (e.g. a position ranked 44/47) was silently invisible to the orchestrator, so "how much X do I own?" produced a confidently wrong "you don't own any X."

## Fix

Surface **all** positions in both digests, and retitle the section from "Top positions:" to "Positions (N):" so the count is explicit. A full portfolio is a few dozen lines — well within context budget, and correctness beats brevity here.

## Tests

- `tests/test_investments.py`: digest includes positions beyond rank 15; section header carries the count.
- `tests/test_mcp_server.py`: same assertions for the MCP tool digest.
- Targeted run: 31 passed. Full pre-push suite: green.

## Provenance

Authored by the doctor session responding to the "How much SpaceX stock do I have?" miss (its goal was approved via Telegram). That session was killed before it could push: its own commit touched `api/` + `mcp_server.py`, the post-commit hook auto-restarted `lifeos-api`, and the `BindsTo=lifeos-api` cascade bounced `lifeos-agent-worker` — SIGTERM'ing the doctor's claude subprocess (exit 143). Salvaged from its worktree, author fixed (repo config had been contaminated with a test identity — separate fix incoming), verified, and shipped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)