### PR TITLE
fix(hooks): make pre-push/post-commit safe to run from linked worktrees

### DIFF
--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -20,6 +20,17 @@ else
     PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 fi
 
+# A commit in a linked worktree doesn't change the code the services run —
+# they execute from the primary checkout — so a restart would be pure
+# disruption (it cascades to lifeos-agent-worker via `Requires=`, killing any
+# in-flight agent session, including the one that just made the commit).
+# Detect BEFORE cd'ing away from the hook's starting cwd; GIT_DIR is exported
+# to hooks, and --absolute-git-dir resolves it either way.
+IN_WORKTREE=""
+case "$(git rev-parse --absolute-git-dir 2>/dev/null)" in
+    */.git/worktrees/*) IN_WORKTREE=1 ;;
+esac
+
 cd "$PROJECT_DIR"
 
 # Normalize commit timestamps to 12:00 UTC (privacy: hides work schedule)
@@ -41,7 +52,9 @@ fi
 # `Requires=lifeos-api.service` in its unit file.
 CHANGED_API=$(git diff-tree --no-commit-id --name-only -r HEAD -- api/ config/)
 
-if [ -n "$CHANGED_API" ]; then
+if [ -n "$IN_WORKTREE" ]; then
+    echo "Worktree commit — skipping service restarts (deploy happens on main)"
+elif [ -n "$CHANGED_API" ]; then
     if [ -x "./scripts/server.sh" ]; then
         nohup ./scripts/server.sh restart > /tmp/lifeos-server-restart.log 2>&1 &
         echo "Server restart triggered (log: /tmp/lifeos-server-restart.log)"
@@ -55,13 +68,13 @@ fi
 # installed by setup-systemd.sh permits passwordless restart.
 CHANGED_MCP=$(git diff-tree --no-commit-id --name-only -r HEAD -- mcp_server.py)
 
-if [ -n "$CHANGED_MCP" ]; then
+if [ -z "$IN_WORKTREE" ] && [ -n "$CHANGED_MCP" ]; then
     if systemctl list-unit-files lifeos-mcp-http.service &>/dev/null; then
         nohup sudo systemctl restart lifeos-mcp-http >> /tmp/lifeos-server-restart.log 2>&1 &
         echo "MCP HTTP service restart triggered (mcp_server.py changed)"
     fi
 fi
 
-if [ -z "$CHANGED_API" ] && [ -z "$CHANGED_MCP" ]; then
+if [ -z "$IN_WORKTREE" ] && [ -z "$CHANGED_API" ] && [ -z "$CHANGED_MCP" ]; then
     echo "No server restart needed"
 fi

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -15,6 +15,13 @@ set -e
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 cd "$PROJECT_ROOT"
 
+# git exports GIT_DIR (absolute when pushing from a worktree) while running
+# hooks. Test subprocesses that spawn `git` in fixture repos inherit it and
+# operate on THIS repo instead — committing fixture files onto real branches,
+# flipping core.bare, and rewriting user identity. Scrub the family so every
+# git call below (and inside pytest) resolves via cwd.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR
+
 # Detect what's being pushed so we can skip tests on docs-only pushes.
 # git feeds pre-push hooks lines of "local_ref local_sha remote_ref remote_sha" on stdin.
 CHANGED_FILES=""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,18 @@ Run categories:
 - pytest -n auto              # Parallel execution (requires pytest-xdist)
 """
 import gc
+import os
 
 import pytest
+
+# git exports GIT_DIR (absolute when the invoker is a linked worktree) to hook
+# subprocesses — and the pre-push hook runs this suite. Tests that spawn `git`
+# in tmp fixture repos would inherit it and silently operate on the REAL repo:
+# committing fixture files onto real branches, flipping core.bare, rewriting
+# user identity. Scrub before any test runs so fixture git calls always
+# resolve via their own cwd.
+for _var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"):
+    os.environ.pop(_var, None)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
Two failure modes discovered when the doctor bot's `/implement` session ran from a `.worktrees/` checkout (the SPCX/investments incident, #452 / PR #454):

## 1. Pre-push test runs contaminated the real repo

git exports `GIT_DIR` (absolute when pushing from a linked worktree) while running hooks. The pre-push hook runs the unit suite, and tests that spawn `git` in tmp fixture repos (`test_agent_worker_self_restart.py`, `test_cleanup_worktrees.py`) inherited it — so their git calls operated on the **real repo**: fixture commits landed on the real branch, `core.bare` got flipped on the primary checkout, repo user identity was rewritten to test values (`t <t@t.t>` — this is why recent doctor commits carry a test author), and a fixture branch + worktree (`doctor/issue-123`) were created for real.

**Fix, twice over:**
- `scripts/pre-push` unsets `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR` up front.
- `tests/conftest.py` scrubs the same family at import, so *any* pytest entry point is hermetic regardless of invoker.

**Verified:** ran the two fixture-git test files with `GIT_DIR` deliberately pointed at a scratch repo — 14 passed, scratch repo untouched (same log, same identity, no stray branches). Before the fix, this exact setup produced the contamination above.

## 2. Post-commit restarts killed the committing agent session

The post-commit hook restarted `lifeos-api` / `lifeos-mcp-http` for **any** commit touching `api/`, `config/`, or `mcp_server.py` — including worktree commits, which don't change the code the services actually run (they execute from the primary checkout). The restart cascades to `lifeos-agent-worker` (`Requires=`/`BindsTo=lifeos-api`), SIGTERM'ing every in-flight CLI session — **including the agent session that just made the commit**. This is exactly how the doctor's SPCX fix session killed itself today (exit 143, one minute after its commit): commit → hook restart → worker bounce → own subprocess dead, work stranded unpushed.

**Fix:** detect linked-worktree commits (`git rev-parse --absolute-git-dir` under `.git/worktrees/`) and skip the service restarts; timestamp normalization still runs everywhere. Primary-checkout commits behave exactly as before.

The installed hooks on the server have been updated to match.

Related: #453 (session fan-out — separate issue, not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)