### PR TITLE
feat(doctor): one anchored goal message, threaded-reply instructions, instant ack

### DIFF
--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -762,23 +762,25 @@ class ClaudeCodeExecutor:
                     if state.plan_mode and not state.awaiting_approval:
                         state.plan_text += body + "\n"
                 for body in scan.goal:
-                    # The agent proposed a success condition (#398). Stream it so
-                    # the operator can SEE what they're approving, then the result
-                    # event flips the session to BLOCKED awaiting their yes/no.
-                    # Child sessions stay silent to the operator like [NOTIFY].
+                    # The agent proposed a success condition (#398). NOT
+                    # streamed to Telegram here: the worker sends ONE anchored
+                    # message — goal body + reply instructions — when the
+                    # session blocks, so the operator's threaded reply lands on
+                    # the message that shows the goal itself (previously the
+                    # goal streamed as its own message and a separate
+                    # instruction message was the reply anchor, which made
+                    # "reply yes — but to which message?" ambiguous). The web
+                    # thread still gets the body live via the mirror. The
+                    # notify timestamps still advance so the heartbeat doesn't
+                    # race the blocked-prompt send with a "Still working".
                     state.pending_goal = body
                     state.notifications_sent += 1
                     state.last_notify_at = time.time()
-                    if not state.is_child:
-                        try:
-                            self._notify(body)
+                    if not state.is_child and self._conversation_mirror:
+                        try:  # #311: stream into the web thread
+                            self._conversation_mirror(session.session_id, body)
                         except Exception as exc:  # pragma: no cover — defensive
-                            logger.warning("notification callback raised: %s", exc)
-                        if self._conversation_mirror:  # #311: stream into the web thread
-                            try:
-                                self._conversation_mirror(session.session_id, body)
-                            except Exception as exc:  # pragma: no cover — defensive
-                                logger.warning("conversation mirror raised: %s", exc)
+                            logger.warning("conversation mirror raised: %s", exc)
                     self.transcript_store.append(sid, "claude_code_goal", {
                         "body": body, "body_chars": len(body),
                     })

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -1188,7 +1188,8 @@ class SessionStore:
         return dict(row) if row else None
 
     def get_open_question_by_message_id(
-        self, sent_message_id: int, bot: str | None = None
+        self, sent_message_id: int, bot: str | None = None,
+        include_answered: bool = False,
     ) -> dict | None:
         """Return the open (unanswered, not-timed-out) question a reply to
         `sent_message_id` matches — on any chunk — or None.
@@ -1196,13 +1197,18 @@ class SessionStore:
         Read-only sibling of `deposit_answer`: lets a caller inspect the matched
         row's `kind` before recording an answer (e.g. so the Telegram listener
         can recognize a ``routing='code'`` follow-up). When `bot` is given, the
-        match is scoped to that bot (see :meth:`_bot_scope_clause`).
+        match is scoped to that bot (see :meth:`_bot_scope_clause`). With
+        ``include_answered=True`` the answered_at filter is dropped, so a
+        caller can recognize a reply landing on an ALREADY-answered question
+        (check ``answered_at`` on the returned row) instead of treating it as
+        unrelated.
         """
         bot_clause, bot_params = self._bot_scope_clause(bot)
+        answered_clause = "" if include_answered else "answered_at IS NULL AND "
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT * FROM pending_questions "
-                "WHERE answered_at IS NULL AND timed_out = 0 "
+                "WHERE " + answered_clause + "timed_out = 0 "
                 "AND (sent_message_id = ? OR (sent_message_ids IS NOT NULL "
                 "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?)))"
                 + bot_clause +

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -1614,7 +1614,20 @@ class Worker:
             elif outcome.reason == REASON_AWAITING_CLARIFICATION:
                 prompt = "Awaiting your reply — answer the question above to continue."
             elif outcome.reason == REASON_AWAITING_GOAL_APPROVAL:
-                prompt = "Reply 'yes' to lock this goal and start, or send changes to refine it."
+                # ONE anchored message: the goal body (the executor defers its
+                # Telegram delivery to here) plus how to answer it. Only a
+                # THREADED reply to this message reaches the session — on an
+                # orchestration bot a plain chat message spawns a fresh
+                # session instead — so the instruction names the mechanics
+                # and lives on the same message as the goal it gates.
+                goal_body = (outcome.final_text or "").strip()
+                instruction = (
+                    "Reply to this message with 'yes' to lock this goal and "
+                    "start, or with changes to refine it. (Use Telegram's "
+                    "Reply on this message — a plain chat message won't "
+                    "reach this session.)"
+                )
+                prompt = f"{goal_body}\n\n{instruction}" if goal_body else instruction
             else:
                 prompt = "Awaiting your reply to continue."
             # Goal-approval replies route through `_resume_goal` (which injects

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -962,7 +962,13 @@ class TelegramBotListener:
         the answer is enough — the worker's ``_resume_as_followup`` picks it
         up on the next tick and routes through the right executor's resume().
 
-        Returns True if the reply was consumed as a CLI follow-up.
+        ``kind='goal_approval'`` replies are also consumed here, with an
+        immediate ack: the worker only drains the answer on its next tick (up
+        to poll_seconds later) and the agent may not emit anything for minutes
+        after that, so without a deposit-time ack the operator can't tell
+        whether their 'yes' landed at all.
+
+        Returns True if the reply was consumed.
         """
         try:
             from api.services.agent_worker.session_store import SessionStore
@@ -971,7 +977,47 @@ class TelegramBotListener:
         except Exception as exc:
             logger.warning(f"cli reply lookup failed: {exc}")
             return False
-        if not q or q.get("kind") != "followup":
+        if not q:
+            # A reply landing on an ALREADY-answered goal message must not fall
+            # through — on an orchestration bot it would spawn a brand-new
+            # session with the bare reply as its "report" (the yes/yes/approved
+            # fan-out). Consume it with a pointer instead.
+            try:
+                done = store.get_open_question_by_message_id(
+                    reply_to_message_id, bot=self._bot.name, include_answered=True,
+                )
+            except Exception as exc:
+                logger.warning(f"answered-question lookup failed: {exc}")
+                done = None
+            if done and done.get("answered_at") and done.get("kind") == "goal_approval":
+                await send_message_async(
+                    "I already have your answer for that goal — it's in motion. "
+                    "To add something, reply to my latest update.",
+                    chat_id=chat_id,
+                )
+                return True
+            return False
+        if q.get("kind") == "goal_approval":
+            # Same affirmative parser the worker's _resume_goal uses, so the
+            # ack never disagrees with what the worker will actually do.
+            from api.services.agent_worker.worker import _is_affirmative
+            if not store.deposit_answer(reply_to_message_id, text, bot=self._bot.name):
+                # Race: answered between the lookup above and this deposit.
+                await send_message_async(
+                    "I already have your answer for that goal — it's in motion. "
+                    "To add something, reply to my latest update.",
+                    chat_id=chat_id,
+                )
+                return True
+            if _is_affirmative(text):
+                ack = ("✅ Goal locked — starting work now. "
+                       "I'll post updates here as I go.")
+            else:
+                ack = ("✏️ Got it — reworking the goal with your changes. "
+                       "I'll propose an updated version shortly.")
+            await send_message_async(ack, chat_id=chat_id)
+            return True
+        if q.get("kind") != "followup":
             return False
         session_id = q.get("session_id")
         if not session_id:

--- a/docs/guides/doctor-bot.md
+++ b/docs/guides/doctor-bot.md
@@ -1,7 +1,7 @@
 # Doctor Bot — Self-Repair Surface
 
 **Status:** Complete
-**Last Updated:** 2026-06-26
+**Last Updated:** 2026-07-09
 **Audience:** Operator
 
 The **doctor** bot's only job is fixing LifeOS itself. You message it when you notice LifeOS misbehaving or missing something; it converses with you to define the **goal**, locks that goal, then — on your approval — orchestrates the work end to end and reports back. It is a **goal-first orchestrator**: it supervises the implementation (subagents do the coding via `/implement`) rather than hand-coding inline, and every change lands through a reviewed, tested PR — never a direct push to `main`.
@@ -19,7 +19,7 @@ This is the operator's-eye summary; the exact contract the session runs lives in
 
 1. **You report a problem**, e.g. _"the calendar tool returns last week's events when I ask for this week."_
 2. **Clarify the goal.** The doctor investigates the code and asks the minimum `[CLARIFY]` questions needed to pin down what "done" means. No work starts yet.
-3. **Propose + approve the goal.** It emits a `[GOAL]` — a crisp success condition (issue filed, tested PR merged to `main`, restarted, confirmed). **This is the single human gate.** Reply **yes** to lock it (which arms the session's `/goal`), or send changes to refine it.
+3. **Propose + approve the goal.** It emits a `[GOAL]` — a crisp success condition (issue filed, tested PR merged to `main`, restarted, confirmed). **This is the single human gate.** The goal arrives as one message that ends with the reply instructions; use Telegram's **Reply on that message** with **yes** to lock it (which arms the session's `/goal`), or with changes to refine it. Your reply is acked immediately ("Goal locked — starting work now"). A plain, non-threaded message starts a **new** repair instead of answering.
 4. **Execute.** On approval it files the issue(s) via `/draft-issue`, then ships — adaptive to size:
    - **Small goal:** one branch → `/implement` → one PR → `main`.
    - **Multi-part goal:** an **integration branch** off `main`, each part landed as a sub-PR onto it (`/implement <issue> --base <integration-branch>`), then one PR integration→`main`, then cleanup.

--- a/docs/specs/product/claude-code-orchestration.md
+++ b/docs/specs/product/claude-code-orchestration.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** Orchestrator
-**Last Updated:** 2026-06-25
+**Last Updated:** 2026-07-09
 
 LifeOS spawns a **Claude Code** subprocess from Telegram when the operator sends `/claude <task>` (or when a natural-language message is classified as requiring terminal / filesystem / browser access). The subprocess runs the task on the server, streams progress back as Telegram messages, and terminates. The operator can monitor (`/claude_status`) and cancel (`/claude_cancel`) the active session.
 
@@ -122,16 +122,15 @@ While a clarification is pending, all non-command Telegram messages route as the
 
 ## Goal approval
 
-For longer or fuzzier objectives, Claude can propose a **success condition** with `[GOAL] <condition>` before it starts working. The proposed goal is relayed to the operator, the session pauses, and the operator either approves it or replies with changes.
+For longer or fuzzier objectives, Claude can propose a **success condition** with `[GOAL] <condition>` before it starts working. The session pauses and the goal is relayed to the operator as **one message** carrying both the proposed condition and how to answer it — the operator's threaded reply lands on the message that shows the goal itself.
 
 **Flow:**
 
-1. Claude: `[GOAL] All unit tests pass and the linter is clean.`
-2. LifeOS: "Reply 'yes' to lock this goal and start, or send changes to refine it."
-3. Operator: `yes` → the worker locks the goal (it arms Claude Code's native goal mode by injecting `/goal <condition>` on resume) and Claude begins.
-   Or: `make it also require the docs to build` → treated as a refinement; the raw reply goes back to Claude, which re-proposes an updated `[GOAL]`.
+1. LifeOS (single message): the proposed goal, followed by "Reply to this message with 'yes' to lock this goal and start, or with changes to refine it." The instruction spells out that only a **threaded reply** (Telegram's Reply on that message) reaches the session — a plain chat message doesn't.
+2. Operator replies `yes` on that message → LifeOS immediately acks ("✅ Goal locked — starting work now…"), then the worker locks the goal (it arms Claude Code's native goal mode by injecting `/goal <condition>` on resume) and Claude begins.
+   Or: `make it also require the docs to build` → acked as a rework; the raw reply goes back to Claude, which re-proposes an updated `[GOAL]`.
 
-Approval is recognized from short affirmatives (`yes`, `approve`, `go ahead`, `sounds good`, `lgtm`, …). A reply that also asks for changes (`yes, but make it stricter`) is treated as a refinement, not a lock.
+Approval is recognized from short affirmatives (`yes`, `approve`, `go ahead`, `sounds good`, `lgtm`, …). A reply that also asks for changes (`yes, but make it stricter`) is treated as a refinement, not a lock. A reply landing on a goal message that already has an answer is acknowledged ("already in motion") rather than treated as a new report.
 
 **Note:** `[GOAL]` is a first-class protocol tag with its own pending state (`REASON_AWAITING_GOAL_APPROVAL`). The doctor persona emits it as the gate of its goal-first pipeline (see [doctor-bot.md](../../guides/doctor-bot.md)).
 
@@ -145,7 +144,7 @@ Claude sends three kinds of messages via Telegram:
 |--------|------|---------|
 | `[NOTIFY] ...` | Progress checkpoint or completion summary | `[NOTIFY] Created backup script at ~/scripts/backup.sh and added daily cron job at 2am.` |
 | `[CLARIFY] ...` | Claude needs an answer | `[CLARIFY] Which backlog section — Work or Personal?` |
-| `[GOAL] ...` | Claude proposes a success condition to lock before starting | `[GOAL] All unit tests pass and the linter is clean.` |
+| `[GOAL] ...` | Claude proposes a success condition to lock before starting; delivered as one message with the reply instructions when the session blocks | `[GOAL] All unit tests pass and the linter is clean.` |
 | heartbeat | Every 5 minutes while running | `Still working... (5m elapsed)` |
 
 Only `[NOTIFY]`, `[CLARIFY]`, and `[GOAL]` lines are relayed. All other output (tool calls, file reads, intermediate steps) stays in the subprocess. The heartbeat is sent by the orchestrator (not Claude) so the operator always knows the session is alive even when Claude is busy without notifying.

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -337,8 +337,10 @@ def test_child_clarify_folds_into_final_text_and_does_not_block(tmp_path: Path):
 
 def test_conversation_mirror_invoked_for_each_streamed_body(tmp_path: Path):
     """#311: when a conversation_mirror is wired, the executor calls it with
-    (session_id, body) for each streamed [NOTIFY]/[CLARIFY]/[GOAL] — the same
-    bodies it relays to Telegram — so the web thread mirrors live progress."""
+    (session_id, body) for each streamed [NOTIFY]/[CLARIFY]/[GOAL] so the web
+    thread mirrors live progress. [NOTIFY]/[CLARIFY] also relay to Telegram;
+    [GOAL] is mirror-only — its Telegram delivery is the worker's single
+    anchored goal + reply-instructions message at block time."""
     events = [
         {"type": "system", "subtype": "init", "session_id": "cli-1"},
         {
@@ -365,14 +367,15 @@ def test_conversation_mirror_invoked_for_each_streamed_body(tmp_path: Path):
 
     executor.execute(session, {"description": "do the thing"})
 
-    # Every streamed body is mirrored with the session id, in order, matching
-    # exactly what Telegram received.
+    # Every streamed body is mirrored with the session id, in order. Telegram
+    # received everything except the goal (delivered by the worker at block
+    # time instead).
     assert mirror_calls == [
         (session.session_id, "Reading the file."),
         (session.session_id, "Which repo?"),
         (session.session_id, "Tests pass."),
     ]
-    assert [b for _, b in mirror_calls] == notifications
+    assert notifications == ["Reading the file.", "Which repo?"]
 
 
 def test_child_session_does_not_mirror(tmp_path: Path):
@@ -878,10 +881,13 @@ def test_scan_ignores_empty_goal_body():
     assert scan.narrative.strip() == ""
 
 
-def test_goal_returns_blocked_streams_and_records(tmp_path: Path):
+def test_goal_returns_blocked_without_streaming_and_records(tmp_path: Path):
     """End-to-end: an assistant [GOAL] then a result event yields a BLOCKED
-    outcome awaiting approval, the body is streamed to the operator, and the
-    transcript records the proposed condition."""
+    outcome awaiting approval, carrying the condition as final_text, and the
+    transcript records it. The body is NOT streamed as its own Telegram
+    notification — the worker delivers goal + reply instructions as ONE
+    anchored message at block time, so the operator replies to the message
+    that shows the goal itself."""
     events = [
         {"type": "system", "subtype": "init", "session_id": "cli-1"},
         {
@@ -900,9 +906,10 @@ def test_goal_returns_blocked_streams_and_records(tmp_path: Path):
 
     assert outcome.status == STATUS_BLOCKED
     assert outcome.reason == REASON_AWAITING_GOAL_APPROVAL
+    # The condition rides the outcome so the worker can compose the single
+    # goal + instructions message the operator replies to.
     assert outcome.final_text == "all tests pass"
-    # The operator must SEE the proposed goal to approve it.
-    assert notifications == ["all tests pass"]
+    assert notifications == []  # no separate streamed goal message
     assert store.get(session.task_id).status == STATUS_BLOCKED
     events_out = _read_transcript(transcripts, session.session_id)
     awaiting = [e for e in events_out if e["kind"] == "claude_code_awaiting_goal_approval"]

--- a/tests/test_doctor_bot.py
+++ b/tests/test_doctor_bot.py
@@ -347,6 +347,95 @@ class TestDoctorListener:
         mock_resume.assert_awaited_once()
         mock_spawn.assert_not_called()
 
+    def _seed_goal_question(self, tmp_path, message_id=5000):
+        """A BLOCKED doctor session with an open goal_approval question
+        anchored to `message_id`, on an isolated store."""
+        from api.services.agent_worker.session_store import STATUS_BLOCKED, SessionStore
+
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        session = store.create(
+            task_id="t-goal", routing="claude_code", origin="operator",
+            bot="doctor", status=STATUS_BLOCKED,
+        )
+        store.create_pending_question(
+            session_id=session.session_id, task_id="t-goal",
+            question="goal body + reply instructions", sent_message_id=message_id,
+            sent_message_ids=[message_id], kind="goal_approval", bot="doctor",
+        )
+        return store
+
+    @pytest.mark.asyncio
+    async def test_goal_approval_yes_acks_immediately(self, tmp_path):
+        """A threaded 'yes' on the goal message deposits the answer AND gets a
+        deposit-time ack. The worker only drains answers on its next tick (up
+        to poll_seconds later) and the agent may then work silently for
+        minutes — without this ack the operator can't tell the 'yes' landed."""
+        store = self._seed_goal_question(tmp_path)
+        listener = self._listener("doctor", "999", persona="P", orchestrates=True)
+        sent: list[str] = []
+
+        async def _capture(text, chat_id=None):
+            sent.append(text)
+
+        with patch("api.services.agent_worker.session_store.SessionStore",
+                   return_value=store), \
+             patch("api.services.telegram.send_message_async", side_effect=_capture):
+            consumed = await listener._maybe_handle_claude_code_reply(5000, "yes", "999")
+
+        assert consumed is True
+        assert any("Goal locked" in s for s in sent)
+        # The answer is queued for the worker's goal_approval resume path.
+        answered = store.list_answered_unprocessed_questions()
+        assert [q["answer"] for q in answered] == ["yes"]
+
+    @pytest.mark.asyncio
+    async def test_goal_approval_refinement_acks_with_rework(self, tmp_path):
+        """A non-affirmative threaded reply is a refinement: deposited for the
+        worker, acked as a rework (not as a lock)."""
+        store = self._seed_goal_question(tmp_path)
+        listener = self._listener("doctor", "999", persona="P", orchestrates=True)
+        sent: list[str] = []
+
+        async def _capture(text, chat_id=None):
+            sent.append(text)
+
+        with patch("api.services.agent_worker.session_store.SessionStore",
+                   return_value=store), \
+             patch("api.services.telegram.send_message_async", side_effect=_capture):
+            consumed = await listener._maybe_handle_claude_code_reply(
+                5000, "make it also require lint", "999")
+
+        assert consumed is True
+        assert any("reworking the goal" in s for s in sent)
+        assert not any("Goal locked" in s for s in sent)
+        answered = store.list_answered_unprocessed_questions()
+        assert [q["answer"] for q in answered] == ["make it also require lint"]
+
+    @pytest.mark.asyncio
+    async def test_goal_approval_duplicate_reply_consumed_not_respawned(self, tmp_path):
+        """A second reply to an already-answered goal message is consumed with
+        an "already have an answer" notice — it must NOT fall through to the
+        orchestration handler and spawn a fresh session (the yes/yes/approved
+        fan-out failure mode)."""
+        store = self._seed_goal_question(tmp_path)
+        listener = self._listener("doctor", "999", persona="P", orchestrates=True)
+        sent: list[str] = []
+
+        async def _capture(text, chat_id=None):
+            sent.append(text)
+
+        with patch("api.services.agent_worker.session_store.SessionStore",
+                   return_value=store), \
+             patch("api.services.telegram.send_message_async", side_effect=_capture):
+            first = await listener._maybe_handle_claude_code_reply(5000, "yes", "999")
+            second = await listener._maybe_handle_claude_code_reply(5000, "yes", "999")
+
+        assert first is True and second is True
+        assert any("already have your answer" in s for s in sent)
+        # Only ONE answer reached the queue.
+        answered = store.list_answered_unprocessed_questions()
+        assert len(answered) == 1
+
     @pytest.mark.asyncio
     async def test_pure_chat_bot_never_spawns(self):
         listener = self._listener("fitness", "999", persona="P", orchestrates=False)
@@ -569,8 +658,12 @@ class TestGoalApproval:
         assert not _is_affirmative("yes, also require lint")
 
     def test_goal_block_registers_goal_approval_question(self, tmp_path):
-        """A goal-approval BLOCKED outcome registers a kind='goal_approval'
-        pending question scoped to the doctor bot, with the goal prompt."""
+        """A goal-approval BLOCKED outcome sends ONE anchored message — the
+        goal body plus the threaded-reply instructions — and registers it as a
+        kind='goal_approval' pending question scoped to the doctor bot. (The
+        goal used to stream as its own message with a separate instruction
+        message as the reply anchor, which made "reply yes — to which
+        message?" ambiguous.)"""
         from api.services.agent_worker.claude_code_spawn import spawn_claude_code_session
 
         w = self._make_worker(tmp_path, self._goal_blocked_stub())
@@ -582,7 +675,10 @@ class TestGoalApproval:
         assert w._sent_with_ids, "no id-captured message was sent"
         msg_id, text, bot = w._sent_with_ids[-1]
         assert bot == "doctor"
+        # The goal itself is ON the anchored message the operator replies to.
+        assert "all tests pass" in text
         assert "lock this goal" in text.lower()
+        assert "reply to this message" in text.lower()
         q = w.session_store.get_open_question_by_message_id(msg_id, bot="doctor")
         assert q is not None
         assert q["kind"] == "goal_approval"


### PR DESCRIPTION
Fixes the goal-approval Telegram UX that caused today's yes/yes/approved session fan-out (related: #453).

## Before (three messages, ambiguous)

1. Doctor: `[GOAL]` body streamed as its own message
2. Doctor: "Reply 'yes' to lock this goal and start, or send changes to refine it." ← the *actual* reply anchor, but nothing said the reply must be threaded, or to which message
3. Operator's plain "yes" → fell through to the orchestration handler → **spawned a brand-new doctor session** with "yes" as its report; a correctly-threaded "yes" got **no acknowledgment** until the worker tick + the agent's next `[NOTIFY]` (minutes of silence)

## After

- **One anchored message** at block time: the goal body + "Reply to this message with 'yes' to lock this goal and start, or with changes to refine it. (Use Telegram's Reply on this message — a plain chat message won't reach this session.)" The executor no longer streams `[GOAL]` to Telegram separately (the web-thread mirror still gets it live; heartbeat-suppression timestamps unchanged).
- **Instant deposit-time ack** from the Telegram listener: "✅ Goal locked — starting work now…" for affirmatives, "✏️ Got it — reworking the goal…" for refinements. Uses the worker's own `_is_affirmative`, so the ack can't disagree with what the worker then does.
- **Duplicate replies consumed**: a reply landing on an already-answered goal message gets "I already have your answer for that goal — it's in motion" instead of falling through and spawning a fresh session. (`get_open_question_by_message_id` gains `include_answered=True`.)

## Tests

- Executor: `[GOAL]` blocks without a separate Telegram notification; condition rides `final_text`; mirror still receives it; child sessions unchanged.
- Worker dispatch: the anchored message contains the goal body + "reply to this message" + "lock this goal", registered as `kind='goal_approval'`.
- Listener: instant ack on yes; rework ack on refinement; duplicate reply consumed (not respawned); answer actually queued for `_resume_goal` in each case.
- Targeted files: 138 passed. Pre-push unit suite: green (one scheduler-watcher timing flake under 16-way load, passes in isolation and in xdist for its file; unrelated subsystem).

## Docs

`claude-code-orchestration.md` (goal-approval flow + `[GOAL]` table row) and `doctor-bot.md` (the human gate now describes the single-message contract and the instant ack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)