### PR TITLE
fix(investments): carry security names into the digests, not just tickers

### DIFF
--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -1784,7 +1784,14 @@ async def _tool_search_finances(inp: dict) -> str:
         lines += ["", f"Positions ({len(inv['positions'])}):"]
         for pos in inv["positions"]:
             unrl = f", unrealized ${pos['unrealized']:+,.0f}" if pos.get("unrealized") is not None else ""
-            lines.append(f"- {pos['symbol']}: ${pos['value']:,.0f} ({pos['weight_pct']}%{unrl})")
+            # Include the security name alongside the ticker: the model's
+            # world knowledge can be stale (a recently-IPO'd company reads as
+            # "private, can't be in a portfolio"), so a bare ticker it doesn't
+            # recognize gets overridden by that prior. The desc makes
+            # "do I own <company>?" a literal text match.
+            desc = (pos.get("desc") or "").strip()
+            label = f"{pos['symbol']} — {desc}" if desc else pos["symbol"]
+            lines.append(f"- {label}: ${pos['value']:,.0f} ({pos['weight_pct']}%{unrl})")
         tu = inv["taxable_unrealized"]
         lines += [
             "",

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1624,7 +1624,14 @@ class LifeOSMCPServer:
                 for pos in positions:
                     unrl = (f", unrealized ${pos['unrealized']:+,.0f}"
                             if pos.get("unrealized") is not None else "")
-                    lines.append(f"- {pos.get('symbol', '')}: ${(pos.get('value') or 0):,.0f} "
+                    # Ticker + security name: stale world knowledge (e.g. a
+                    # recently-IPO'd company "can't be in a portfolio") beats
+                    # an unrecognized bare ticker; the desc makes company-name
+                    # questions a literal text match.
+                    desc = (pos.get("desc") or "").strip()
+                    symbol = pos.get("symbol", "")
+                    label = f"{symbol} — {desc}" if desc else symbol
+                    lines.append(f"- {label}: ${(pos.get('value') or 0):,.0f} "
                                  f"({pos.get('weight_pct') or 0}%{unrl})")
             tu = data.get("taxable_unrealized")
             if tu:

--- a/tests/test_investments.py
+++ b/tests/test_investments.py
@@ -26,7 +26,8 @@ def _snapshot_with_many_positions():
          "weight_pct": 5, "unrealized": 1000}
         for i in range(19)
     ]
-    positions.append({"symbol": "SPCX", "value": 3050, "weight_pct": 0.37})
+    positions.append({"symbol": "SPCX", "desc": "SpaceX Class A (SPV)",
+                      "value": 3050, "weight_pct": 0.37})
     return {
         "as_of": "2026-07-09",
         "totals": {
@@ -56,6 +57,12 @@ async def test_search_finances_investments_lists_all_positions(tmp_path, monkeyp
     assert "SPCX" in out                 # beyond-top-15 holding is present
     assert "Positions (20):" in out      # header reflects the full count
     assert "Top positions:" not in out   # old truncating header is gone
+    # The security NAME rides along with the ticker: a bare ticker the model
+    # doesn't recognize loses to stale world knowledge ("SpaceX is private"),
+    # so "do I own SpaceX?" must be answerable by literal text match.
+    assert "SPCX — SpaceX Class A (SPV)" in out
+    # Positions without a desc (the FIL fillers) keep the bare-ticker line.
+    assert "FIL01:" in out
 
 
 def _write_summary(tmp_path, age_days: float):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -470,7 +470,8 @@ def test_investments_format_lists_all_positions():
          "unrealized": 1000}
         for i in range(19)
     ]
-    positions.append({"symbol": "SPCX", "value": 3050, "weight_pct": 0.37})
+    positions.append({"symbol": "SPCX", "desc": "SpaceX Class A (SPV)",
+                      "value": 3050, "weight_pct": 0.37})
     data = {
         "synced_at": "2026-07-09T03:26:00", "as_of": "2026-07-09",
         "totals": {"all_investments": 1234567, "schwab": 1000000,
@@ -486,6 +487,10 @@ def test_investments_format_lists_all_positions():
     assert "SPCX" in out                 # beyond-top-15 holding is present
     assert "Positions (20):" in out      # header reflects the full count
     assert "Top positions:" not in out   # old truncating header is gone
+    # Ticker + security name, so company-name questions are a text match
+    # (stale world knowledge otherwise overrides an unrecognized ticker).
+    assert "SPCX — SpaceX Class A (SPV)" in out
+    assert "FIL01:" in out               # desc-less positions keep bare ticker
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Follow-up to #454 / #452. Relates to #452.

## Problem

#454 made every position visible, but the digests still listed bare tickers. A ticker the model doesn't recognize loses to stale world knowledge: "how much SpaceX stock do I have?" still answered "you don't have any — SpaceX is a private company," even though `SPCX` was right there in the digest — every model's training predates the IPO, and nothing in the tool output connected the ticker to the company name. The orchestrator's investigation was correct (it called `search_finances` and read the positions); the tool output lacked the mapping data.

## Fix

The snapshot already carries a `desc` per position. Both digests (`search_finances investments` in `agent_tools.py`, `lifeos_investments` in `mcp_server.py`) now render:

```
- SPCX — SpaceX Class A (SPV): $3,051 (0.37%)
```

so "do I own ⟨company⟩?" resolves by literal text match against the data instead of the model's prior. **Generic for every position — no per-security logic**; positions without a `desc` keep the bare-ticker line.

## Tests

- Both digest tests extended: `SPCX — SpaceX Class A (SPV)` appears; desc-less fillers keep the bare-ticker format. 31 passed.
- Full suite: same 14 known env-dependent failures as `main` (CRM data-integrity, settings-env, meeting-prep, slack-sync) — verified identical set, nothing related to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)