### PR TITLE
feat(agent-worker): threaded replies to any session message + reply-affordance footers

### DIFF
--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -318,6 +318,7 @@ class ClaudeCodeExecutor:
         session_store: SessionStore,
         transcript_store: TranscriptStore,
         notification_callback: Optional[NotificationCallback] = None,
+        operator_send: Optional[Callable[[object, str], None]] = None,
         conversation_mirror: Optional[Callable[[str, str], None]] = None,
         spawn_fn: Optional[SpawnFn] = None,
         binary_resolver: Optional[Callable[[], str]] = None,
@@ -327,6 +328,11 @@ class ClaudeCodeExecutor:
         self.session_store = session_store
         self.transcript_store = transcript_store
         self._notify = notification_callback or (lambda _msg: None)
+        # Preferred operator-facing sender: called with (session, body) so the
+        # worker can capture Telegram message ids and register them as reply
+        # anchors (threaded replies route back into the session). Falls back to
+        # the plain `notification_callback` when unset (tests, legacy wiring).
+        self._operator_send = operator_send
         # #311: optional (session_id, body) sink that mirrors each streamed
         # [NOTIFY]/[CLARIFY]/[GOAL] body into the web/voice conversation thread
         # that spawned the session. Additive — `notification_callback` (the
@@ -530,7 +536,7 @@ class ClaudeCodeExecutor:
         # cleanup is a single `stop_heartbeat.set()`.
         heartbeat_thread = threading.Thread(
             target=self._heartbeat_loop,
-            args=(state, stop_heartbeat),
+            args=(session, state, stop_heartbeat),
             daemon=True,
             name=f"CodeHeartbeat-{sid[:8]}",
         )
@@ -728,10 +734,12 @@ class ClaudeCodeExecutor:
                         })
                         continue
                     state.pending_clarification = body
-                    try:
-                        self._notify(body)
-                    except Exception as exc:  # pragma: no cover — defensive
-                        logger.warning("notification callback raised: %s", exc)
+                    # NOT streamed to Telegram here: the worker sends ONE
+                    # anchored message — question + reply instructions — when
+                    # the session blocks, so the operator's threaded reply
+                    # lands on the message that shows the question itself
+                    # (same treatment [GOAL] gets). The web thread still gets
+                    # the body live via the mirror.
                     if self._conversation_mirror:  # #311: stream into the web thread
                         try:
                             self._conversation_mirror(session.session_id, body)
@@ -748,7 +756,10 @@ class ClaudeCodeExecutor:
                     # are folded into final_text for the parent instead (#349).
                     if not state.is_child:
                         try:
-                            self._notify(body)
+                            if self._operator_send is not None:
+                                self._operator_send(session, body)
+                            else:
+                                self._notify(body)
                         except Exception as exc:  # pragma: no cover — defensive
                             logger.warning("notification callback raised: %s", exc)
                         if self._conversation_mirror:  # #311: stream into the web thread
@@ -859,7 +870,7 @@ class ClaudeCodeExecutor:
             except Exception as exc:  # pragma: no cover — defensive
                 logger.warning("watchdog terminate failed: %s", exc)
 
-    def _heartbeat_loop(self, state: _RunState, stop_event: threading.Event) -> None:
+    def _heartbeat_loop(self, session, state: _RunState, stop_event: threading.Event) -> None:
         # Recursive Timers (as used in the legacy orchestrator) are hard to
         # cancel cleanly from the calling thread because each fires the next.
         # An `Event.wait()` loop drops to zero overhead when stopped.
@@ -879,7 +890,11 @@ class ClaudeCodeExecutor:
             activity = f" — {state.last_activity}" if state.last_activity else ""
             cost = f" | ${state.cost_usd:.2f}" if state.cost_usd > 0 else ""
             try:
-                self._notify(f"Still working{activity} ({minutes}m elapsed{cost})")
+                body = f"Still working{activity} ({minutes}m elapsed{cost})"
+                if self._operator_send is not None:
+                    self._operator_send(session, body)
+                else:
+                    self._notify(body)
             except Exception as exc:  # pragma: no cover — defensive
                 logger.warning("heartbeat callback raised: %s", exc)
             state.last_notify_at = now

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -1011,6 +1011,61 @@ class SessionStore:
             )
         return cur.lastrowid
 
+    def add_reply_anchors(
+        self,
+        session_id: str,
+        task_id: str,
+        message_ids: list[int],
+        bot: str | None = None,
+    ) -> None:
+        """Register operator-facing message ids as reply anchors for a session.
+
+        Every message a session sends to Telegram (streamed [NOTIFY] bodies,
+        heartbeats, acks) registers here so a threaded reply to ANY of them can
+        be routed back into the session as a context note. One always-open
+        ``kind='status_anchor'`` row per session accumulates the ids in its
+        ``sent_message_ids`` JSON list — reusing the pending_questions matching
+        machinery without new schema. The row is excluded from deposit_answer,
+        the web open-question lookup, and the timeout sweep: it is a routing
+        index, not a question.
+        """
+        if not message_ids:
+            return
+        ids = [int(i) for i in message_ids]
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id, sent_message_ids FROM pending_questions "
+                "WHERE session_id = ? AND kind = 'status_anchor' LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    """
+                    INSERT INTO pending_questions (
+                        session_id, task_id, question, sent_message_id, sent_at,
+                        kind, sent_message_ids, bot
+                    ) VALUES (?, ?, ?, ?, ?, 'status_anchor', ?, ?)
+                    """,
+                    (session_id, task_id, "(session reply anchors)", ids[0],
+                     _now(), json.dumps(ids), bot),
+                )
+            else:
+                existing = json.loads(row["sent_message_ids"] or "[]")
+                merged = existing + [i for i in ids if i not in existing]
+                conn.execute(
+                    "UPDATE pending_questions SET sent_message_ids = ? WHERE id = ?",
+                    (json.dumps(merged), row["id"]),
+                )
+
+    def has_pending_messages(self, session_id: str) -> bool:
+        """True when undelivered pending messages exist for `session_id`."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM pending_messages WHERE session_id = ? AND delivered = 0 LIMIT 1",
+                (session_id,),
+            ).fetchone()
+        return row is not None
+
     def register_completion_followup(
         self,
         session_id: str,
@@ -1065,6 +1120,7 @@ class SessionStore:
             row = conn.execute(
                 "SELECT id FROM pending_questions "
                 "WHERE answered_at IS NULL AND timed_out = 0 "
+                "AND kind != 'status_anchor' "
                 "AND (sent_message_id = ? OR (sent_message_ids IS NOT NULL "
                 "AND EXISTS (SELECT 1 FROM json_each(sent_message_ids) WHERE value = ?)))"
                 + bot_clause +
@@ -1095,6 +1151,7 @@ class SessionStore:
             row = conn.execute(
                 "SELECT * FROM pending_questions "
                 "WHERE session_id = ? AND answered_at IS NULL AND timed_out = 0 "
+                "AND kind != 'status_anchor' "
                 "ORDER BY id ASC LIMIT 1",
                 (session_id,),
             ).fetchone()
@@ -1238,7 +1295,8 @@ class SessionStore:
         with self._connect() as conn:
             rows = conn.execute(
                 "SELECT * FROM pending_questions "
-                "WHERE answered_at IS NULL AND timed_out = 0 AND sent_at < ?",
+                "WHERE answered_at IS NULL AND timed_out = 0 AND sent_at < ? "
+                "AND kind != 'status_anchor'",
                 (int(before_ts),),
             ).fetchall()
         return [dict(r) for r in rows]

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -177,6 +177,19 @@ def write_self_restart_marker(
     return path
 
 
+# Telegram reply affordance markers. Every operator-facing session message
+# ends with exactly one of these so the operator can tell at a glance whether
+# a threaded reply will reach the session (see #458: any anchored message is
+# replyable; replies queue as context notes and ride the next turn boundary).
+REPLYABLE_FOOTER = "\u21a9\ufe0f reply in thread"
+NO_REPLY_FOOTER = "\U0001f6ab do not reply"
+
+
+def _with_reply_footer(text: str, replyable: bool = True) -> str:
+    """Append the reply-affordance footer as the message's final line."""
+    return f"{text}\n\n{REPLYABLE_FOOTER if replyable else NO_REPLY_FOOTER}"
+
+
 def _is_affirmative(text: str) -> bool:
     """True when a goal-approval reply means 'lock it and go' (#398).
 
@@ -1554,12 +1567,13 @@ class Worker:
                 "duplicate side effects")
             self.session_store.update_status(session.task_id, STATUS_FAILED)
             try:
-                _send(
+                _send(_with_reply_footer(
                     "⚠️ A code session: a previous attempt may have already "
                     "started, so it wasn't retried automatically (to avoid "
                     "repeating side effects). It was marked failed — re-trigger "
-                    "it if you want to retry."
-                )
+                    "it if you want to retry.",
+                    replyable=False,
+                ))
             except Exception as exc:  # best-effort; the surface may be down
                 logger.warning("re-execute-averted notify failed: %s", exc)
             self._reconcile_vault_terminal(session, STATUS_FAILED)
@@ -1612,7 +1626,15 @@ class Worker:
             if outcome.reason == REASON_AWAITING_PLAN_APPROVAL:
                 prompt = "Plan ready — reply 'approve' to proceed, 'reject' to cancel, or send feedback to refine."
             elif outcome.reason == REASON_AWAITING_CLARIFICATION:
-                prompt = "Awaiting your reply — answer the question above to continue."
+                # ONE anchored message: the question itself (the executor
+                # defers its Telegram delivery to here, like [GOAL]) plus how
+                # to answer — the reply must be threaded to THIS message.
+                question_body = (outcome.final_text or "").strip()
+                instruction = "Answer by replying to this message."
+                prompt = (
+                    f"{question_body}\n\n{instruction}" if question_body
+                    else "Awaiting your reply — reply to this message to continue."
+                )
             elif outcome.reason == REASON_AWAITING_GOAL_APPROVAL:
                 # ONE anchored message: the goal body (the executor defers its
                 # Telegram delivery to here) plus how to answer it. Only a
@@ -1636,7 +1658,7 @@ class Worker:
             sent_ids: list = []
             for attempt in range(_BLOCKED_PROMPT_SEND_ATTEMPTS):
                 try:
-                    sent_ids = _send_with_id(prompt) or []
+                    sent_ids = _send_with_id(_with_reply_footer(prompt)) or []
                 except Exception as exc:
                     logger.warning(
                         "code blocked reply prompt send failed (attempt %d/%d): %s",
@@ -1677,10 +1699,11 @@ class Worker:
             })
             self.session_store.update_status(session.task_id, STATUS_FAILED)
             try:
-                _send(
+                _send(_with_reply_footer(
                     "⚠️ A session needs your input, but the question couldn't be "
-                    "delivered. It was marked failed — re-trigger it to retry."
-                )
+                    "delivered. It was marked failed — re-trigger it to retry.",
+                    replyable=False,
+                ))
             except Exception as exc:  # best-effort; the same surface may be down
                 logger.warning("blocked-session escalation send failed: %s", exc)
             self._reconcile_vault_terminal(session, STATUS_FAILED)
@@ -1698,7 +1721,7 @@ class Worker:
             body = outcome.final_text.strip() if outcome.final_text else ""
             if body and not session.parent_session_id:
                 try:
-                    sent_ids = _send_with_id(body) or []
+                    sent_ids = _send_with_id(_with_reply_footer(body)) or []
                 except Exception as exc:
                     logger.warning("code completion send failed: %s", exc)
                     sent_ids = []
@@ -1720,6 +1743,23 @@ class Worker:
                 "final_chars": len(body),
             })
             self._reconcile_vault_terminal(session, STATUS_COMPLETED)
+            # A reply that arrived MID-RUN (status-anchor route, #458) is
+            # queued in pending_messages with nothing to deliver it — the
+            # dispatch tick only drains CLAIMED sessions. Reopen now that the
+            # turn boundary is here, mirroring reopen-on-send (#428): resume
+            # needs the persisted CLI id (re-fetch the row — the executor sets
+            # it during this very run, so the claim-time snapshot may predate
+            # it), and children stay parent-driven.
+            if not session.parent_session_id and self.session_store.has_pending_messages(sid):
+                current = self.session_store.get_by_session_id(sid)
+                if current is not None and current.claude_code_session_id:
+                    if session.origin != "operator":
+                        for terminal_tag in (COMPLETED_TAG, FAILED_TAG, BUDGET_EXCEEDED_TAG):
+                            if self._swap_tag(session.task_id, terminal_tag, RUNNING_TAG):
+                                break
+                        self._set_task_status(session.task_id, "in_progress")
+                    self.session_store.update_status(session.task_id, STATUS_CLAIMED)
+                    self.transcript_store.append(sid, "code_reopened_for_pending_messages", {})
             return
 
         # FAILED / BUDGET_EXCEEDED — surface a brief operator notification.
@@ -1742,7 +1782,32 @@ class Worker:
         # [budget_exceeded] status header, so the notice would be duplicate
         # noise for a session the operator never directly started.
         if notice and not session.parent_session_id:
-            _send(notice)
+            # A failed/budget session with a persisted CLI id is resumable
+            # (`_resume_as_followup` swaps any terminal tag), so register the
+            # notice as a followup anchor and mark it replyable; without the
+            # CLI id there is nothing to resume — say so (#458).
+            current = self.session_store.get_by_session_id(sid)
+            resumable = bool(current is not None and current.claude_code_session_id)
+            sent_ids = []
+            if resumable:
+                try:
+                    sent_ids = _send_with_id(_with_reply_footer(notice)) or []
+                except Exception as exc:
+                    logger.warning("failure notice send (with id) failed: %s", exc)
+            if sent_ids:
+                self.session_store.create_pending_question(
+                    session_id=sid,
+                    task_id=session.task_id,
+                    question=notice[:200],
+                    sent_message_id=sent_ids[0],
+                    sent_message_ids=sent_ids,
+                    kind="followup",
+                    bot=bot,
+                )
+            else:
+                # No registered anchor (unresumable, or id capture failed) —
+                # a "reply in thread" footer would be a lie either way.
+                _send(_with_reply_footer(notice, replyable=False))
             # #311: mirror the same failure/budget notice into the web/voice
             # thread (no-op for Telegram-origin); a child is never
             # conversation-linked, so the child gate above also keeps this correct.
@@ -1760,6 +1825,43 @@ class Worker:
         # this is harmless for vault sessions the executor already finalized.
         self.session_store.update_status(session.task_id, outcome.status)
         self._reconcile_vault_terminal(session, outcome.status)
+
+    def _send_session_message(self, session, body: str) -> None:
+        """Send an operator-facing session message (streamed [NOTIFY] body,
+        heartbeat) with reply-anchor registration: the message ends with the
+        "reply in thread" footer, its Telegram message id(s) are captured and
+        registered against the session, and a threaded reply to it routes back
+        into the session as a context note (#458). Falls back to the plain
+        one-way sender (no footer — the affordance would be a lie) when id
+        capture is unavailable or fails.
+        """
+        bot = session.bot
+        text = _with_reply_footer(body)
+        try:
+            sent_ids = (
+                self._telegram_send_with_id(text, bot=bot) if bot
+                else self._telegram_send_with_id(text)
+            ) or []
+        except Exception as exc:
+            logger.warning("session message send (with id) failed for %s: %s",
+                           session.task_id, exc)
+            sent_ids = []
+        if not sent_ids:
+            try:
+                if bot:
+                    self._telegram_send(body, bot=bot)
+                else:
+                    self._telegram_send(body)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("session message fallback send failed: %s", exc)
+            return
+        try:
+            self.session_store.add_reply_anchors(
+                session.session_id, session.task_id, sent_ids, bot=bot,
+            )
+        except Exception as exc:  # best-effort — a lost anchor only loses
+            logger.warning("reply-anchor registration failed for %s: %s",
+                           session.task_id, exc)  # the reply route, not the message
 
     def _get_claude_code_executor(self, bot: str | None = None):
         """Lazy-construct the ClaudeCodeExecutor for /claude sessions.
@@ -1785,6 +1887,11 @@ class Worker:
             session_store=self.session_store,
             transcript_store=self.transcript_store,
             notification_callback=notify,
+            # Preferred operator sender (#458): captures Telegram ids and
+            # registers them as reply anchors so a threaded reply to ANY
+            # streamed message routes back into the session. The session's own
+            # `bot` picks the surface, so one binding serves every bot.
+            operator_send=self._send_session_message,
             # #311: mirror each streamed [NOTIFY]/[CLARIFY]/[GOAL] into the
             # web/voice thread that spawned the session (no-op when unlinked).
             conversation_mirror=self._mirror_to_conversation,
@@ -2885,11 +2992,11 @@ class Worker:
         """
         sent_ids: list[int] = []
         try:
-            sent_ids = self._telegram_send_with_id(body) or []
+            sent_ids = self._telegram_send_with_id(_with_reply_footer(body)) or []
         except Exception as exc:
             logger.warning("terminal notify (with id) failed for %s: %s", session.task_id, exc)
         if not sent_ids:
-            self._notify(body)
+            self._notify(body)  # no registered anchor → no (false) footer
             return
         try:
             self.session_store.register_completion_followup(

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -685,14 +685,28 @@ class TelegramBotListener:
             f"---\n\n"
             f"The user just sent this report via the {self._bot.name} bot:\n\n{text}"
         )
-        await send_message_async(
-            "🩺 On it — taking a look now. I'll follow up here as I go.",
-            chat_id=chat_id,
-        )
+        # Send the ack with id capture so it can be registered as a reply
+        # anchor once the spawn returns a session id — replying to "On it"
+        # then routes into the session like any other thread message (#458).
+        from api.services.agent_worker.worker import _with_reply_footer
+        ack_ids = []
+        try:
+            ack_ids = send_message_capture_ids(
+                _with_reply_footer("🩺 On it — taking a look now. I'll follow up here as I go."),
+                chat_id,
+            ) or []
+        except Exception as exc:
+            logger.warning(f"orchestration ack send failed: {exc}")
+        if not ack_ids:
+            await send_message_async(
+                "🩺 On it — taking a look now. I'll follow up here as I go.",
+                chat_id=chat_id,
+            )
+        store = SessionStore()
         try:
             result = await asyncio.to_thread(
                 spawn_claude_code_session,
-                SessionStore(),
+                store,
                 prompt,
                 working_dir=working_dir,
                 plan_mode=False,
@@ -705,6 +719,14 @@ class TelegramBotListener:
                 f"Couldn't start the session: {str(exc)[:200]}", chat_id=chat_id,
             )
             return
+        if ack_ids and result.get("ok") and result.get("session_id"):
+            try:
+                store.add_reply_anchors(
+                    result["session_id"], result.get("task_id") or "",
+                    ack_ids, bot=self._bot.name,
+                )
+            except Exception as exc:
+                logger.warning(f"on-it anchor registration failed: {exc}")
         if not result.get("ok"):
             await send_message_async(
                 f"Couldn't start the session: {result.get('error')}", chat_id=chat_id,
@@ -753,7 +775,9 @@ class TelegramBotListener:
             # A reply to a /claude completion resumes that Claude Code session
             # (#237) — checked before the agent-worker deposit since both use
             # the shared follow-up table but resume different subsystems.
-            if await self._maybe_handle_claude_code_reply(reply_to_id, text, chat_id):
+            if await self._maybe_handle_claude_code_reply(
+                reply_to_id, text, chat_id, quoted_text=reply_to.get("text"),
+            ):
                 return
             if self._maybe_deposit_agent_answer(reply_to_id, text):
                 return
@@ -953,7 +977,10 @@ class TelegramBotListener:
     _APPROVAL_KEYWORDS = {"approve", "approved", "yes", "go", "proceed", "ok"}
     _REJECTION_KEYWORDS = {"reject", "rejected", "no", "cancel", "stop"}
 
-    async def _maybe_handle_claude_code_reply(self, reply_to_message_id: int, text: str, chat_id: str) -> bool:
+    async def _maybe_handle_claude_code_reply(
+        self, reply_to_message_id: int, text: str, chat_id: str,
+        quoted_text: str | None = None,
+    ) -> bool:
         """If a reply targets a CLI (Claude Code or Codex) completion message,
         resume the linked agent-worker session.
 
@@ -967,6 +994,13 @@ class TelegramBotListener:
         to poll_seconds later) and the agent may not emit anything for minutes
         after that, so without a deposit-time ack the operator can't tell
         whether their 'yes' landed at all.
+
+        ``kind='status_anchor'`` (#458): every operator-facing session message
+        (streamed [NOTIFY] bodies, heartbeats, acks) registers its Telegram
+        message id against the session. A threaded reply to ANY of them is
+        consumed here as a context note — queued (with ``quoted_text``, the
+        message being replied to, as context) and delivered at the session's
+        next turn boundary; a terminal session is reopened for it.
 
         Returns True if the reply was consumed.
         """
@@ -997,6 +1031,8 @@ class TelegramBotListener:
                 )
                 return True
             return False
+        if q.get("kind") == "status_anchor":
+            return await self._handle_status_anchor_reply(q, text, chat_id, quoted_text)
         if q.get("kind") == "goal_approval":
             # Same affirmative parser the worker's _resume_goal uses, so the
             # ack never disagrees with what the worker will actually do.
@@ -1015,7 +1051,7 @@ class TelegramBotListener:
             else:
                 ack = ("✏️ Got it — reworking the goal with your changes. "
                        "I'll propose an updated version shortly.")
-            await send_message_async(ack, chat_id=chat_id)
+            self._send_anchored_ack(store, q.get("session_id"), q.get("task_id"), ack, chat_id)
             return True
         if q.get("kind") != "followup":
             return False
@@ -1029,6 +1065,74 @@ class TelegramBotListener:
         label = "Codex" if session.routing == "codex" else "Claude Code"
         await send_message_async(f"Resuming {label} session...", chat_id=chat_id)
         return True
+
+    async def _handle_status_anchor_reply(
+        self, q: dict, text: str, chat_id: str, quoted_text: str | None,
+    ) -> bool:
+        """Route a threaded reply on a status/heartbeat/ack message back into
+        its session as a context note (#458).
+
+        The note is queued with the quoted message as context and rides the
+        session's next turn boundary: a RUNNING/CLAIMED/BLOCKED session picks
+        it up when its pending messages next drain; a terminal session with a
+        persisted CLI id is reopened (enqueue-then-CLAIM, mirroring
+        reopen-on-send #428) so the dispatch tick resumes it with the note.
+        """
+        from api.services.agent_worker.session_store import (
+            STATUS_BUDGET_EXCEEDED, STATUS_COMPLETED, STATUS_FAILED, SessionStore,
+        )
+        store = SessionStore()
+        session_id = q.get("session_id")
+        session = store.get_by_session_id(session_id) if session_id else None
+        if session is None:
+            return False
+        quoted = (quoted_text or "").strip()
+        if quoted:
+            if len(quoted) > MAX_QUOTED_REPLY_CHARS:
+                quoted = quoted[:MAX_QUOTED_REPLY_CHARS] + "…"
+            composed = f'[operator replied to your status update: "{quoted}"]\n{text}'
+        else:
+            composed = f"(operator note) {text}"
+        store.enqueue_message(session.session_id, "operator", composed)
+        terminal = session.status in (STATUS_COMPLETED, STATUS_FAILED, STATUS_BUDGET_EXCEEDED)
+        if terminal:
+            if session.routing in ("claude_code", "codex") and session.claude_code_session_id:
+                from api.services.agent_worker.session_store import STATUS_CLAIMED
+                store.update_status(session.task_id, STATUS_CLAIMED)
+                ack = "📨 Got it — waking the session with your note."
+            else:
+                ack = ("📨 Noted, but that session already ended and can't be "
+                       "resumed — send a fresh message to start a new one.")
+        else:
+            ack = "📨 Noted — I'll pass this to the session at its next checkpoint."
+        self._send_anchored_ack(store, session.session_id, session.task_id, ack, chat_id)
+        return True
+
+    def _send_anchored_ack(
+        self, store, session_id: str | None, task_id: str | None,
+        ack: str, chat_id: str,
+    ) -> None:
+        """Send a session-scoped ack with the reply-affordance footer and
+        register its message id as a reply anchor, so the ack itself is part
+        of the replyable work thread (#458). Falls back to a plain, footerless
+        send when id capture is unavailable.
+        """
+        from api.services.agent_worker.worker import _with_reply_footer
+        ids = []
+        try:
+            ids = send_message_capture_ids(_with_reply_footer(ack), chat_id) or []
+        except Exception as exc:
+            logger.warning(f"anchored ack send failed: {exc}")
+        if ids and session_id and task_id:
+            try:
+                store.add_reply_anchors(session_id, task_id, ids, bot=self._bot.name)
+            except Exception as exc:
+                logger.warning(f"ack anchor registration failed: {exc}")
+        elif not ids:
+            try:
+                send_message(ack, chat_id)  # plain, footerless fallback
+            except Exception as exc:
+                logger.warning(f"ack fallback send failed: {exc}")
 
     def _should_use_plan_mode(self, task: str) -> bool:
         """Conservative heuristic: plan mode only for complex-sounding tasks.

--- a/docs/guides/doctor-bot.md
+++ b/docs/guides/doctor-bot.md
@@ -10,7 +10,7 @@ Unlike the `fitness` and `therapist` bots (pure chat surfaces), the doctor **orc
 
 ## Surfaces
 
-- **Telegram** (primary): a dedicated `@BotFather` bot. Full round-trip — reply to a `[CLARIFY]`/`[GOAL]` message (swipe-to-reply) to answer; a fresh, non-threaded message starts a **new** repair.
+- **Telegram** (primary): a dedicated `@BotFather` bot. Full round-trip — reply to a `[CLARIFY]`/`[GOAL]` message (swipe-to-reply) to answer, and reply to **any** other doctor message (status updates, heartbeats, acks, "On it") to drop a context note into that session's thread. Messages end with "↩️ reply in thread" or "🚫 do not reply" so the affordance is explicit. A fresh, non-threaded message starts a **new** repair.
 - **Web / voice**: selecting the `doctor` persona in web chat (or via whisper-relay) spawns the same orchestrating session. You can answer its `[CLARIFY]`/`[GOAL]` from the web conversation too (`POST /api/conversations/{id}/answer`); notices also surface on the doctor's Telegram thread and the `/agents` page.
 
 ## The flow

--- a/docs/specs/product/claude-code-orchestration.md
+++ b/docs/specs/product/claude-code-orchestration.md
@@ -105,13 +105,13 @@ While a plan is pending, normal Telegram messages still reach the chat pipeline 
 
 ## Clarification questions
 
-If a task is vague or ambiguous, Claude asks a clarifying question instead of guessing. The question is relayed via Telegram and the session pauses until the operator answers.
+If a task is vague or ambiguous, Claude asks a clarifying question instead of guessing. The session pauses and the question is relayed via Telegram as **one message** carrying both the question and "Answer by replying to this message" — the operator's threaded reply lands on the message that shows the question itself.
 
 **Flow:**
 
 1. Operator: `/claude add this to the backlog`
-2. Claude: "The backlog has two sections (Work and Personal). Which one?"
-3. Operator: `Work`
+2. Claude (single message): "The backlog has two sections (Work and Personal). Which one? — Answer by replying to this message."
+3. Operator replies `Work` on that message.
 4. Claude resumes with the answer and completes the task.
 
 While a clarification is pending, all non-command Telegram messages route as the answer. The operator uses `/claude_cancel` if they want to chat normally instead.
@@ -148,6 +148,18 @@ Claude sends three kinds of messages via Telegram:
 | heartbeat | Every 5 minutes while running | `Still working... (5m elapsed)` |
 
 Only `[NOTIFY]`, `[CLARIFY]`, and `[GOAL]` lines are relayed. All other output (tool calls, file reads, intermediate steps) stays in the subprocess. The heartbeat is sent by the orchestrator (not Claude) so the operator always knows the session is alive even when Claude is busy without notifying.
+
+---
+
+## Threaded replies — every session message is an anchor
+
+Every operator-facing message a session sends — streamed `[NOTIFY]` updates, heartbeats, blocked prompts (clarify / plan / goal), completion and failure notices, and the acks LifeOS sends back — registers its Telegram message id against the session. A **threaded reply to any of them** routes back into that session:
+
+- Replies to a blocked prompt answer it (clarification answer, plan approve/reject, goal yes/refine).
+- Replies to a completion or failure notice reopen the session as a follow-up turn with full prior context.
+- Replies to anything else (a status update, a heartbeat, an ack) are queued as a **context note** — quoted with the message being replied to — and delivered at the session's next turn boundary. A mid-run reply gets an instant "Noted — I'll pass this to the session at its next checkpoint" ack; a reply to a finished session wakes it back up.
+
+Every message ends with a footer naming its affordance: **"↩️ reply in thread"** when a threaded reply reaches the session, or **"🚫 do not reply"** when it can't (e.g. a dead, unresumable session). A plain, non-threaded message never reaches a session — on an orchestration bot it starts a new one.
 
 ---
 

--- a/tests/test_agent_worker_claude_code_executor.py
+++ b/tests/test_agent_worker_claude_code_executor.py
@@ -119,6 +119,7 @@ def _build_executor(
     spawn_fn,
     notifications: list[str] | None = None,
     mirror_calls: list[tuple[str, str]] | None = None,
+    operator_sends: list[tuple[str, str]] | None = None,
 ):
     db_path = tmp_path / "sessions.db"
     transcript_dir = tmp_path / "transcripts"
@@ -129,10 +130,17 @@ def _build_executor(
     # #311: a fake (session_id, body) sink so a test can assert the executor
     # mirrors each streamed [NOTIFY]/[CLARIFY]/[GOAL] into the web thread.
     mirror = (lambda sid, body: mirror_calls.append((sid, body))) if mirror_calls is not None else None
+    # #458: preferred operator sender — receives (session, body) so the worker
+    # can register reply anchors. Tests capture (session_id, body).
+    op_send = (
+        (lambda session, body: operator_sends.append((session.session_id, body)))
+        if operator_sends is not None else None
+    )
     executor = ClaudeCodeExecutor(
         session_store=store,
         transcript_store=transcripts,
         notification_callback=notify,
+        operator_send=op_send,
         conversation_mirror=mirror,
         spawn_fn=spawn_fn,
         binary_resolver=lambda: "/usr/bin/true",
@@ -338,9 +346,9 @@ def test_child_clarify_folds_into_final_text_and_does_not_block(tmp_path: Path):
 def test_conversation_mirror_invoked_for_each_streamed_body(tmp_path: Path):
     """#311: when a conversation_mirror is wired, the executor calls it with
     (session_id, body) for each streamed [NOTIFY]/[CLARIFY]/[GOAL] so the web
-    thread mirrors live progress. [NOTIFY]/[CLARIFY] also relay to Telegram;
-    [GOAL] is mirror-only — its Telegram delivery is the worker's single
-    anchored goal + reply-instructions message at block time."""
+    thread mirrors live progress. Only [NOTIFY] also relays to Telegram here —
+    [CLARIFY] and [GOAL] deliver via the worker's single anchored
+    body + reply-instructions message at block time (#456, #458)."""
     events = [
         {"type": "system", "subtype": "init", "session_id": "cli-1"},
         {
@@ -368,14 +376,14 @@ def test_conversation_mirror_invoked_for_each_streamed_body(tmp_path: Path):
     executor.execute(session, {"description": "do the thing"})
 
     # Every streamed body is mirrored with the session id, in order. Telegram
-    # received everything except the goal (delivered by the worker at block
-    # time instead).
+    # received only the [NOTIFY] — clarify and goal deliver via the worker's
+    # anchored block-time messages instead.
     assert mirror_calls == [
         (session.session_id, "Reading the file."),
         (session.session_id, "Which repo?"),
         (session.session_id, "Tests pass."),
     ]
-    assert notifications == ["Reading the file.", "Which repo?"]
+    assert notifications == ["Reading the file."]
 
 
 def test_child_session_does_not_mirror(tmp_path: Path):
@@ -567,8 +575,11 @@ def test_clarify_returns_blocked_with_question(tmp_path: Path):
 
     assert outcome.status == STATUS_BLOCKED
     assert outcome.reason == REASON_AWAITING_CLARIFICATION
+    # The question rides the outcome; the worker composes the single anchored
+    # question + reply-instructions message at block time (#458) — no separate
+    # streamed Telegram message.
     assert outcome.final_text == "Which file did you mean?"
-    assert notifications == ["Which file did you mean?"]
+    assert notifications == []
     assert store.get(session.task_id).status == STATUS_BLOCKED
 
 
@@ -829,6 +840,32 @@ def test_result_event_fenced_tag_preserved_in_final_text(tmp_path: Path):
     assert outcome.status == STATUS_COMPLETED
     assert "[NOTIFY] example" in outcome.final_text  # fenced tag preserved
     assert notifications == []  # result path never streams
+
+
+def test_operator_send_preferred_for_notify_bodies(tmp_path: Path):
+    """#458: when operator_send is wired, streamed [NOTIFY] bodies go through
+    it with the session (so the worker can register reply anchors) and the
+    legacy notification_callback is NOT used."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "cli-1"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "[NOTIFY] Reading the file."}]},
+        },
+        {"type": "result", "session_id": "cli-1", "total_cost_usd": 0.01, "result": "done"},
+    ]
+    notifications: list[str] = []
+    operator_sends: list[tuple[str, str]] = []
+    executor, store, _ = _build_executor(
+        tmp_path, spawn_fn=_spawn_with(events),
+        notifications=notifications, operator_sends=operator_sends,
+    )
+    session = _seed_session(store)
+
+    executor.execute(session, {"description": "read it"})
+
+    assert operator_sends == [(session.session_id, "Reading the file.")]
+    assert notifications == []  # legacy path bypassed when operator_send set
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor_bot.py
+++ b/tests/test_doctor_bot.py
@@ -377,8 +377,14 @@ class TestDoctorListener:
         async def _capture(text, chat_id=None):
             sent.append(text)
 
+        def _capture_ids(text, chat_id=None, bot=None):
+            sent.append(text)
+            return [8001]
+
         with patch("api.services.agent_worker.session_store.SessionStore",
                    return_value=store), \
+             patch("api.services.telegram.send_message_capture_ids",
+                   side_effect=_capture_ids), \
              patch("api.services.telegram.send_message_async", side_effect=_capture):
             consumed = await listener._maybe_handle_claude_code_reply(5000, "yes", "999")
 
@@ -399,8 +405,14 @@ class TestDoctorListener:
         async def _capture(text, chat_id=None):
             sent.append(text)
 
+        def _capture_ids(text, chat_id=None, bot=None):
+            sent.append(text)
+            return [8001]
+
         with patch("api.services.agent_worker.session_store.SessionStore",
                    return_value=store), \
+             patch("api.services.telegram.send_message_capture_ids",
+                   side_effect=_capture_ids), \
              patch("api.services.telegram.send_message_async", side_effect=_capture):
             consumed = await listener._maybe_handle_claude_code_reply(
                 5000, "make it also require lint", "999")

--- a/tests/test_session_thread_replies.py
+++ b/tests/test_session_thread_replies.py
@@ -1,0 +1,372 @@
+"""Threaded replies to ANY session message route back into the session (#458).
+
+Covers the three layers of the status-anchor feature:
+  * session_store — the per-session ``kind='status_anchor'`` row that
+    accumulates operator-facing message ids without behaving like a question.
+  * worker — ``_send_session_message`` (footer + id capture + registration)
+    and the completed-with-pending reopen at the turn boundary.
+  * telegram listener — routing a threaded reply on an anchored message into
+    the session as a context note, with the right ack per session state.
+"""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from api.services.agent_worker.session_store import (
+    STATUS_BLOCKED,
+    STATUS_CLAIMED,
+    STATUS_COMPLETED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import (
+    NO_REPLY_FOOTER,
+    REPLYABLE_FOOTER,
+    _with_reply_footer,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# session_store — status_anchor row semantics
+# ---------------------------------------------------------------------------
+
+
+class TestReplyAnchorStore:
+    def _store(self, tmp_path):
+        return SessionStore(db_path=tmp_path / "sessions.db")
+
+    def test_anchors_accumulate_on_one_row_and_resolve_by_any_id(self, tmp_path):
+        store = self._store(tmp_path)
+        s = store.create(task_id="t1", routing="claude_code", origin="operator", bot="doctor")
+        store.add_reply_anchors(s.session_id, "t1", [100, 101], bot="doctor")
+        store.add_reply_anchors(s.session_id, "t1", [102], bot="doctor")
+
+        for mid in (100, 101, 102):
+            q = store.get_open_question_by_message_id(mid, bot="doctor")
+            assert q is not None and q["kind"] == "status_anchor"
+            assert q["session_id"] == s.session_id
+        # One row, not three — the ids merged into its sent_message_ids list.
+        with store._connect() as conn:
+            n = conn.execute(
+                "SELECT COUNT(*) FROM pending_questions WHERE kind='status_anchor'"
+            ).fetchone()[0]
+        assert n == 1
+
+    def test_deposit_answer_never_matches_an_anchor(self, tmp_path):
+        """The anchor row is a routing index, not a question — a stray deposit
+        (e.g. the generic reply-deposit fallback) must not 'answer' it, which
+        would kill the anchor for the whole session."""
+        store = self._store(tmp_path)
+        s = store.create(task_id="t1", routing="claude_code", origin="operator", bot="doctor")
+        store.add_reply_anchors(s.session_id, "t1", [100], bot="doctor")
+
+        assert store.deposit_answer(100, "yes", bot="doctor") is False
+        assert store.get_open_question_by_message_id(100, bot="doctor") is not None
+
+    def test_web_open_question_lookup_skips_anchors(self, tmp_path):
+        """The web answer path takes the OLDEST open question for a session —
+        the always-open anchor row (created at the first notify, i.e. early)
+        must never shadow a real clarification."""
+        store = self._store(tmp_path)
+        s = store.create(task_id="t1", routing="claude_code", origin="operator")
+        store.add_reply_anchors(s.session_id, "t1", [100])
+        store.create_pending_question(
+            session_id=s.session_id, task_id="t1", question="which file?",
+            sent_message_id=200, kind="clarification",
+        )
+        q = store.get_open_question_by_session_id(s.session_id)
+        assert q is not None and q["kind"] == "clarification"
+
+    def test_timeout_sweep_skips_anchors(self, tmp_path):
+        """Anchors are open forever by design — the nudge sweep must not
+        re-prompt the operator about them or expire them."""
+        store = self._store(tmp_path)
+        s = store.create(task_id="t1", routing="claude_code", origin="operator")
+        store.add_reply_anchors(s.session_id, "t1", [100])
+        far_future = 2_000_000_000_000
+        assert store.list_timed_out_questions(far_future) == []
+
+
+# ---------------------------------------------------------------------------
+# worker — _send_session_message + completed-with-pending reopen
+# ---------------------------------------------------------------------------
+
+
+def _make_worker(tmp_path, *, executor=None, send_with_id=None):
+    from api.services.agent_worker.spend_tracker import SpendTracker
+    from api.services.agent_worker.worker import Worker, _SynchronousPool
+    from api.services.conversation_store import ConversationStore
+
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+    sent: list[str] = []
+    sent_with_ids: list[str] = []
+
+    def _default_send_with_id(text, chat_id=None, bot=None):
+        sent_with_ids.append(text)
+        return [9000 + len(sent_with_ids)]
+
+    w = Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        conversation_store=ConversationStore(db_path=str(tmp_path / "conversations.db")),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None, bot=None: sent.append(text) or True,
+        telegram_send_with_id=send_with_id or _default_send_with_id,
+        http_client=client,
+        claude_code_executor=executor,
+        cli_pool=_SynchronousPool(),
+    )
+    w._plain_sent = sent  # type: ignore[attr-defined]
+    w._id_sent = sent_with_ids  # type: ignore[attr-defined]
+    return w
+
+
+class TestSendSessionMessage:
+    def test_footer_and_anchor_registration(self, tmp_path):
+        w = _make_worker(tmp_path)
+        s = w.session_store.create(
+            task_id="t1", routing="claude_code", origin="operator", bot="doctor",
+        )
+
+        w._send_session_message(s, "Running the tests now.")
+
+        assert len(w._id_sent) == 1
+        assert w._id_sent[0].endswith(REPLYABLE_FOOTER)
+        assert "Running the tests now." in w._id_sent[0]
+        # The captured id resolves back to the session as a status anchor.
+        q = w.session_store.get_open_question_by_message_id(9001, bot="doctor")
+        assert q is not None and q["kind"] == "status_anchor"
+        assert q["session_id"] == s.session_id
+
+    def test_fallback_plain_send_has_no_footer(self, tmp_path):
+        """When id capture yields nothing, the reply route doesn't exist — a
+        'reply in thread' footer would be a lie, so the fallback is bare."""
+        w = _make_worker(tmp_path, send_with_id=lambda text, chat_id=None, bot=None: [])
+        s = w.session_store.create(task_id="t1", routing="claude_code", origin="operator")
+
+        w._send_session_message(s, "Running the tests now.")
+
+        assert w._plain_sent == ["Running the tests now."]
+
+
+class TestCompletedWithPendingReopens:
+    def _stub(self, store):
+        from dataclasses import dataclass
+        from api.services.agent_worker.local_executor import ExecutorOutcome
+
+        @dataclass
+        class _Stub:
+            store: SessionStore
+            enqueue_mid_run: bool
+
+            def execute(self, session, task):
+                # Simulate the CLI id persisting during the run, a mid-run
+                # operator reply arriving via the status-anchor route (when
+                # asked), and the real executor's terminal status write.
+                self.store.set_claude_code_session_id(session.task_id, "cli-99")
+                if self.enqueue_mid_run:
+                    self.store.enqueue_message(
+                        session.session_id, "operator", "(operator note) also check X",
+                    )
+                self.store.update_status(session.task_id, STATUS_COMPLETED)
+                return ExecutorOutcome(status=STATUS_COMPLETED, final_text="All done.")
+
+            def resume(self, session, message, working_dir=None):
+                return self.execute(session, {})
+
+        return _Stub
+
+    def test_mid_run_note_reopens_completed_session(self, tmp_path):
+        w = _make_worker(tmp_path)
+        stub_cls = self._stub(w.session_store)
+        w._claude_code_executor = stub_cls(w.session_store, enqueue_mid_run=True)
+        s = w.session_store.create(task_id="t1", routing="claude_code", origin="operator")
+        w.session_store.enqueue_message(s.session_id, "operator", "do the thing")
+
+        w._dispatch_spawned_sessions()
+
+        # The mid-run note reopened the session at the turn boundary so the
+        # next tick resumes with it.
+        assert w.session_store.get("t1").status == STATUS_CLAIMED
+        kinds = [e["kind"] for e in w.transcript_store.read(s.session_id)]
+        assert "code_reopened_for_pending_messages" in kinds
+        pending = w.session_store.drain_pending_messages(s.session_id)
+        assert [m["content"] for m in pending] == ["(operator note) also check X"]
+
+    def test_no_pending_messages_stays_completed(self, tmp_path):
+        w = _make_worker(tmp_path)
+        stub_cls = self._stub(w.session_store)
+        w._claude_code_executor = stub_cls(w.session_store, enqueue_mid_run=False)
+        s = w.session_store.create(task_id="t1", routing="claude_code", origin="operator")
+        w.session_store.enqueue_message(s.session_id, "operator", "do the thing")
+
+        w._dispatch_spawned_sessions()
+
+        assert w.session_store.get("t1").status == STATUS_COMPLETED
+
+    def test_completion_message_carries_replyable_footer(self, tmp_path):
+        w = _make_worker(tmp_path)
+        stub_cls = self._stub(w.session_store)
+        w._claude_code_executor = stub_cls(w.session_store, enqueue_mid_run=False)
+        s = w.session_store.create(task_id="t1", routing="claude_code", origin="operator")
+        w.session_store.enqueue_message(s.session_id, "operator", "do the thing")
+
+        w._dispatch_spawned_sessions()
+
+        completion = [t for t in w._id_sent if "All done." in t]
+        assert completion and completion[0].endswith(REPLYABLE_FOOTER)
+
+
+class TestBlockedClarifyPromptMerged:
+    def test_clarify_prompt_carries_question_and_footer(self, tmp_path):
+        """The clarification question and its reply instructions arrive as ONE
+        anchored message (#458), same treatment [GOAL] got in #456."""
+        from dataclasses import dataclass
+        from api.services.agent_worker.claude_code_executor import (
+            REASON_AWAITING_CLARIFICATION,
+        )
+        from api.services.agent_worker.local_executor import ExecutorOutcome
+
+        @dataclass
+        class _Stub:
+            def execute(self, session, task):
+                return ExecutorOutcome(
+                    status=STATUS_BLOCKED,
+                    reason=REASON_AWAITING_CLARIFICATION,
+                    final_text="Which file did you mean?",
+                )
+
+            def resume(self, session, message, working_dir=None):
+                return self.execute(session, {})
+
+        w = _make_worker(tmp_path, executor=_Stub())
+        s = w.session_store.create(task_id="t1", routing="claude_code", origin="operator")
+        w.session_store.enqueue_message(s.session_id, "operator", "edit the file")
+
+        w._dispatch_spawned_sessions()
+
+        assert len(w._id_sent) == 1
+        text = w._id_sent[0]
+        assert "Which file did you mean?" in text
+        assert "replying to this message" in text.lower()
+        assert text.endswith(REPLYABLE_FOOTER)
+
+
+# ---------------------------------------------------------------------------
+# telegram listener — threaded reply on an anchored message
+# ---------------------------------------------------------------------------
+
+
+class TestStatusAnchorReplies:
+    def _listener(self):
+        from api.services.telegram import TelegramBotListener
+        from config.settings import TelegramBotConfig
+        return TelegramBotListener(TelegramBotConfig(
+            name="doctor", token="TOK", chat_id="999", persona="P", orchestrates=True,
+        ))
+
+    def _seed(self, tmp_path, *, status, cli_id="cli-1"):
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        s = store.create(
+            task_id="t1", routing="claude_code", origin="operator",
+            bot="doctor", status=status,
+        )
+        if cli_id:
+            store.set_claude_code_session_id("t1", cli_id)
+            store.update_status("t1", status)  # set_claude_code_session_id keeps status
+        store.add_reply_anchors(s.session_id, "t1", [7000], bot="doctor")
+        return store, s
+
+    async def _reply(self, listener, store, text, quoted=None):
+        sent: list[str] = []
+
+        def _capture_ids(t, chat_id=None, bot=None):
+            sent.append(t)
+            return [8000 + len(sent)]
+
+        async def _capture_async(t, chat_id=None, bot=None):
+            sent.append(t)
+            return True
+
+        with patch("api.services.agent_worker.session_store.SessionStore",
+                   return_value=store), \
+             patch("api.services.telegram.send_message_capture_ids",
+                   side_effect=_capture_ids), \
+             patch("api.services.telegram.send_message_async",
+                   side_effect=_capture_async):
+            consumed = await listener._maybe_handle_claude_code_reply(
+                7000, text, "999", quoted_text=quoted,
+            )
+        return consumed, sent
+
+    @pytest.mark.asyncio
+    async def test_reply_on_running_session_queues_note_with_context(self, tmp_path):
+        listener = self._listener()
+        store, s = self._seed(tmp_path, status=STATUS_RUNNING)
+
+        consumed, sent = await self._reply(
+            listener, store, "also check the cron logs",
+            quoted="Still working — running tests (5m elapsed)",
+        )
+
+        assert consumed is True
+        assert any("next checkpoint" in t for t in sent)
+        pending = store.drain_pending_messages(s.session_id)
+        assert len(pending) == 1
+        assert "also check the cron logs" in pending[0]["content"]
+        # The quoted status update rides along so the agent knows what the
+        # operator was replying to.
+        assert "Still working — running tests" in pending[0]["content"]
+        # RUNNING session: no status flip — the note rides the next boundary.
+        assert store.get("t1").status == STATUS_RUNNING
+
+    @pytest.mark.asyncio
+    async def test_reply_on_completed_session_reopens_it(self, tmp_path):
+        listener = self._listener()
+        store, s = self._seed(tmp_path, status=STATUS_COMPLETED)
+
+        consumed, sent = await self._reply(listener, store, "one more thing")
+
+        assert consumed is True
+        assert any("waking the session" in t for t in sent)
+        assert store.get("t1").status == STATUS_CLAIMED
+
+    @pytest.mark.asyncio
+    async def test_reply_on_dead_unresumable_session_says_so(self, tmp_path):
+        listener = self._listener()
+        store, s = self._seed(tmp_path, status=STATUS_COMPLETED, cli_id=None)
+
+        consumed, sent = await self._reply(listener, store, "one more thing")
+
+        assert consumed is True
+        assert any("can't be" in t for t in sent)
+        assert store.get("t1").status == STATUS_COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_ack_is_itself_an_anchor(self, tmp_path):
+        """The ack joins the work thread: its captured id registers as another
+        anchor, so replying to the ack also reaches the session."""
+        listener = self._listener()
+        store, s = self._seed(tmp_path, status=STATUS_RUNNING)
+
+        consumed, sent = await self._reply(listener, store, "noted-worthy reply")
+
+        assert consumed is True
+        ack_q = store.get_open_question_by_message_id(8001, bot="doctor")
+        assert ack_q is not None and ack_q["kind"] == "status_anchor"
+        assert ack_q["session_id"] == s.session_id
+        # And the ack text carries the replyable footer.
+        assert any(t.endswith(REPLYABLE_FOOTER) for t in sent)
+
+
+def test_footer_helper_shapes():
+    assert _with_reply_footer("body").endswith(f"\n\n{REPLYABLE_FOOTER}")
+    assert _with_reply_footer("body", replyable=False).endswith(f"\n\n{NO_REPLY_FOOTER}")


### PR DESCRIPTION
Answers "can I reply threaded to any of the messages on a work thread and have them register with appropriate context?" — now yes. Builds on #456; related: #453.

## What changes for the operator

- **Reply to anything on the work thread.** Streamed `[NOTIFY]` status updates, heartbeats, blocked prompts, completion/failure notices, LifeOS acks, and the doctor's "On it" all register their Telegram message ids against the session. A threaded reply to any of them routes back into that session.
- **Context notes at the turn boundary.** A reply to a status message is queued as a context note — composed with the quoted message ("[operator replied to your status update: …]") so the agent knows exactly what you were reacting to — and delivered when the current turn ends. Mid-run replies get an instant "📨 Noted — I'll pass this to the session at its next checkpoint"; replies to a finished session wake it back up (reopen mirrors #428's enqueue-then-CLAIM); a session that completes with a note queued reopens itself.
- **Explicit affordance footers.** Every message ends with "↩️ reply in thread" or "🚫 do not reply" (only truly dead-end messages get the latter: undeliverable-question escalations, unresumable failures).
- **Clarifications get the #456 treatment**: one anchored message — the question + "Answer by replying to this message" — instead of a streamed body plus a separate dangling prompt.
- **Failure/budget notices become resumable anchors** when the CLI session id persisted, matching `_resume_as_followup`'s "every terminal state is replyable" contract.

## Implementation

- **No schema change**: one always-open `kind='status_anchor'` row per session accumulates message ids in `sent_message_ids`, reusing the pending_questions matching machinery. Excluded from `deposit_answer`, the web open-question lookup (#403 path), and the timeout sweep — it's a routing index, not a question.
- **`ClaudeCodeExecutor` gains an `operator_send(session, body)` seam** (default None keeps legacy behavior): the worker owns id capture, footers, and anchor registration; the executor stays dumb.
- Telegram listener consumes `status_anchor` replies with per-state acks; goal acks now register as anchors too (replying "wait, actually…" to "Goal locked" reaches the session).

## Tests

- New `tests/test_session_thread_replies.py` (15): anchor-row semantics (accumulate/resolve/deposit-immunity/web-lookup/timeout-sweep exclusions), worker send+registration+footers, completed-with-pending reopen, merged clarify prompt, listener routing for running/completed/dead sessions, ack-is-an-anchor.
- Updated executor tests for the clarify deferral and the `operator_send` seam; goal-ack tests for the anchored ack sender. 177 passed across the affected suites.
- Full suite: the known env-dependent baseline (14), plus one appearance of a pre-existing settings-monkeypatch ordering flake (`test_therapist_threading_both_paths` — passes in isolation, in xdist for its file, and in the pre-push unit gate; unrelated subsystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)