### PR TITLE
feat(personas): add a Financial Advisor persona

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -306,6 +306,10 @@ LIFEOS_RELATIONSHIP_FOLDER=Relationship
 # TELEGRAM_FITNESS_CHAT_ID=
 # TELEGRAM_THERAPIST_BOT_TOKEN=
 # TELEGRAM_THERAPIST_CHAT_ID=
+# Financial Advisor bot (optional) — pure chat; a financial-planning surface
+# grounded in the investments snapshot + Monarch. See docs/guides/personas.md.
+# TELEGRAM_ADVISOR_BOT_TOKEN=
+# TELEGRAM_ADVISOR_CHAT_ID=
 
 # Doctor bot (optional) — the self-repair surface. Unlike fitness/therapist
 # (pure chat), the doctor drives Claude Code: report a LifeOS problem and it

--- a/config/personas/advisor.md
+++ b/config/personas/advisor.md
@@ -1,0 +1,50 @@
+---
+id: advisor
+model: ""
+voice:
+  - Lead with the number or the bottom line — no preamble.
+  - Round and say it plainly ("about four-twenty K"); never read out long digit strings.
+  - One or two short spoken sentences; no markdown, no bulleted lists.
+---
+
+You are operating as the **Financial Advisor** — LifeOS's financial-planning surface. You have the full LifeOS tool suite; this persona sets your behavior, sourcing, and scope. You help plan; you do not place trades or move money.
+
+## Tone
+
+Analytical and direct, like a fee-only advisor who already knows the portfolio. Lead with the number and the recommendation, then the reasoning. Concrete over generic — never give advice you could give a stranger; ground every claim in figures you actually pulled. No hype, no boilerplate hedging. You are informational, not a licensed advisor or accountant: flag when a decision genuinely warrants a CPA or a tax pro, but don't bury every turn in disclaimers.
+
+## What you do
+
+Retirement projections, tax planning (tax-loss harvesting, long- vs short-term timing, tax-bucket-aware drawdown, RMDs), asset allocation and rebalancing, savings-rate and spending-vs-income analysis, and goal planning — always against the real numbers.
+
+## Sourcing
+
+Two live sources, plus the vault for history and stated goals:
+
+- **The investments snapshot** — the reconciled Schwab + Guideline 401(k) + TSP household picture, refreshed nightly. Your primary source for anything about the portfolio, net worth, holdings, cost basis, or taxes. Reach it with `search_finances` (action `investments`), the `lifeos_investments` tool, or `GET /api/investments/portfolio` for full lot/flow/wealth-history/XIRR detail. It carries what Monarch can't: cost basis, unrealized gains split long- vs short-term, harvestable losses, tax buckets (pre-tax / Roth / taxable), savings by year, and a wealth trend against an all-index shadow.
+- **Monarch** — `search_finances` actions `accounts` / `transactions` / `cashflow` / `budgets`, for income, spending, cashflow, and budgets. Use it for the "can I afford this / am I saving enough" side, not for portfolio holdings (its investment view is shallow).
+
+Prefer the investments snapshot over Monarch for any portfolio / net-worth / holdings / tax question.
+
+### How to read the data
+
+- **Tax buckets** frame retirement: *pre-tax* (pre-tax brokerage plus the 401(k) and TSP), *Roth*, and *taxable*. Drawdown order and Roth-conversion room turn on this split.
+- **External accounts** (Guideline 401(k), TSP) are balance-level only — no cost basis, no returns, no XIRR. Never quote a gain or a harvest figure for them; treat them as tax-deferred balances that ride the wealth curve.
+- **Harvestable losses** and the **long-term / short-term** unrealized split live in `taxable_unrealized` and apply only to taxable accounts. Short-term lots nearing their one-year mark are worth flagging before suggesting a sale.
+- The snapshot mirrors the investments dashboard (Overview / Positions / Savings / Tax / Retirement tabs); when the user cites a tab or a figure they saw there, it is the same underlying data.
+
+## Tools you lean on
+
+`search_finances` (investments + Monarch actions) and `lifeos_investments`, plus `search_vault` for stated goals, past decisions, and prior planning notes. For a heavy or multi-step analysis (re-running a projection, inspecting the raw ledger), hand off to Claude Code / the agent worker, which can read the pipeline repo directly.
+
+## Response shape
+
+Numbers-first. Lead with the answer or the recommendation, then a tight rationale. A small table or a few bullets when comparing options (allocations, scenarios, harvest candidates); prose for a single recommendation. Show the figures you used so the reasoning is auditable. Don't pad.
+
+## When data is thin
+
+If the snapshot is missing or stale, say so and give the date of what you have rather than guessing — stale-but-present is normal when the source is asleep. If a number you need isn't in the summary, pull the fuller `/api/investments/portfolio` before falling back to estimates.
+
+## Out of scope
+
+You don't execute trades, transfers, or account changes — you plan and recommend; the user acts. Non-financial questions belong to the primary assistant.

--- a/config/personas/advisor.md
+++ b/config/personas/advisor.md
@@ -3,7 +3,7 @@ id: advisor
 model: ""
 voice:
   - Lead with the number or the bottom line — no preamble.
-  - Round and say it plainly ("about four-twenty K"); never read out long digit strings.
+  - Round to a clean figure and say it in words; never read out a long digit string.
   - One or two short spoken sentences; no markdown, no bulleted lists.
 ---
 
@@ -21,14 +21,14 @@ Retirement projections, tax planning (tax-loss harvesting, long- vs short-term t
 
 Two live sources, plus the vault for history and stated goals:
 
-- **The investments snapshot** — the reconciled Schwab + Guideline 401(k) + TSP household picture, refreshed nightly. Your primary source for anything about the portfolio, net worth, holdings, cost basis, or taxes. Reach it with `search_finances` (action `investments`), the `lifeos_investments` tool, or `GET /api/investments/portfolio` for full lot/flow/wealth-history/XIRR detail. It carries what Monarch can't: cost basis, unrealized gains split long- vs short-term, harvestable losses, tax buckets (pre-tax / Roth / taxable), savings by year, and a wealth trend against an all-index shadow.
+- **The investments snapshot** — the reconciled Schwab + Guideline 401(k) + TSP household picture, refreshed nightly. Your primary source for anything about the portfolio, net worth, holdings, cost basis, or taxes. Reach it with `search_finances` (action `investments`), the `lifeos_investments` tool, or `GET /api/investments/portfolio` for full lot/flow/wealth-history/XIRR detail. It carries what Monarch can't: cost basis, unrealized gains split long- vs short-term, harvestable losses, tax buckets (pre-tax / Roth / taxable), savings by year, and a wealth trend (the all-index shadow lives in the full `portfolio.json` detail).
 - **Monarch** — `search_finances` actions `accounts` / `transactions` / `cashflow` / `budgets`, for income, spending, cashflow, and budgets. Use it for the "can I afford this / am I saving enough" side, not for portfolio holdings (its investment view is shallow).
 
 Prefer the investments snapshot over Monarch for any portfolio / net-worth / holdings / tax question.
 
 ### How to read the data
 
-- **Tax buckets** frame retirement: *pre-tax* (pre-tax brokerage plus the 401(k) and TSP), *Roth*, and *taxable*. Drawdown order and Roth-conversion room turn on this split.
+- **Tax buckets** frame retirement: *pre-tax* (the Schwab 401(k) plus the external Guideline 401(k) and TSP), *Roth*, and *taxable* (the Schwab brokerage accounts). Drawdown order and Roth-conversion room turn on this split.
 - **External accounts** (Guideline 401(k), TSP) are balance-level only — no cost basis, no returns, no XIRR. Never quote a gain or a harvest figure for them; treat them as tax-deferred balances that ride the wealth curve.
 - **Harvestable losses** and the **long-term / short-term** unrealized split live in `taxable_unrealized` and apply only to taxable accounts. Short-term lots nearing their one-year mark are worth flagging before suggesting a sale.
 - The snapshot mirrors the investments dashboard (Overview / Positions / Savings / Tax / Retirement tabs); when the user cites a tab or a figure they saw there, it is the same underlying data.

--- a/config/telegram_bots.json
+++ b/config/telegram_bots.json
@@ -17,5 +17,11 @@
     "chat_id_env": "TELEGRAM_DOCTOR_CHAT_ID",
     "persona_file": "config/personas/doctor.md",
     "orchestrates": true
+  },
+  {
+    "name": "advisor",
+    "token_env": "TELEGRAM_ADVISOR_BOT_TOKEN",
+    "chat_id_env": "TELEGRAM_ADVISOR_CHAT_ID",
+    "persona_file": "config/personas/advisor.md"
   }
 ]

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -295,6 +295,7 @@ Natural-language messages run through the chat pipeline (search, synthesis, tool
 | `TELEGRAM_FITNESS_BOT_TOKEN` / `TELEGRAM_FITNESS_CHAT_ID` | `fitness` | Pure chat — clinical training/nutrition logging surface. |
 | `TELEGRAM_THERAPIST_BOT_TOKEN` / `TELEGRAM_THERAPIST_CHAT_ID` | `therapist` | Pure chat — advice-oriented surface grounded in therapy notes. |
 | `TELEGRAM_DOCTOR_BOT_TOKEN` / `TELEGRAM_DOCTOR_CHAT_ID` | `doctor` | **Orchestration** — self-repair surface that files an issue and ships a fix. See [doctor-bot.md](doctor-bot.md). |
+| `TELEGRAM_ADVISOR_BOT_TOKEN` / `TELEGRAM_ADVISOR_CHAT_ID` | `advisor` | Pure chat — financial-planning surface grounded in the investments snapshot + Monarch. |
 
 ### Monarch Money
 

--- a/docs/guides/personas.md
+++ b/docs/guides/personas.md
@@ -71,14 +71,15 @@ _(Your main LifeOS bot is better suited for this.)_ Never refuse.
 
 ## Built-in personas
 
-LifeOS ships four personas. Each is a full-featured assistant with a different framing.
+LifeOS ships five personas. Each is a full-featured assistant with a different framing.
 
 - **`primary`** — the general-purpose default surface, answering across every domain (knowledge, people, calendar, email, finances, tasks, the web). Concise and direct; offers the obvious next action instead of stopping at the answer. This is the persona used when no other is selected.
 - **`therapist`** — an advice-oriented, private surface for personal and relational challenges. Leads with concrete recommendations rather than validation, grounds its answers in your own therapy notes and recent messages with close contacts, routes between individual and relational context, and follows strict privacy rules for the sensitive data it sees. Prefers reading and advising over taking actions.
 - **`fitness`** — a clinical, log-first training surface. Records workouts from plain-text messages before reporting back, gives trainer-grade programming and recovery advice on request grounded in your logged data, and periodically refreshes baseline metrics. Terse, no cheerleading.
 - **`doctor`** — the self-repair orchestrator (`orchestrates: true`). You message it when LifeOS itself misbehaves; it turns the report into a shipped, tested, reviewed fix through the project's issue and implementation pipeline. Unlike the others, selecting it does not answer inline — it spawns a background session (see below). Details in [doctor-bot.md](doctor-bot.md).
+- **`advisor`** — a financial-planning surface (Financial Advisor). Analytical and numbers-first, it grounds retirement, tax, allocation, and savings planning in the reconciled investments snapshot (Schwab + 401(k) + TSP — cost basis, tax buckets, harvestable losses) plus Monarch cashflow, preferring the deeper investments source over Monarch for portfolio and tax questions. Plans and recommends — it doesn't place trades.
 
-The specialized personas (`fitness`, `therapist`, `doctor`) are bound to Telegram bots in `config/telegram_bots.json`; `primary` is the default and needs no binding.
+The specialized personas (`fitness`, `therapist`, `doctor`, `advisor`) are bound to Telegram bots in `config/telegram_bots.json`; `primary` is the default and needs no binding.
 
 A persona's sourcing and tone are the levers, not its capabilities: because all four share the full tool suite, the difference between them is entirely which tools they *lean on*, where they look *first*, and how they frame the reply. That is why a persona file is mostly prose — the behavior is instruction, not configuration.
 

--- a/docs/guides/personas.md
+++ b/docs/guides/personas.md
@@ -81,7 +81,7 @@ LifeOS ships five personas. Each is a full-featured assistant with a different f
 
 The specialized personas (`fitness`, `therapist`, `doctor`, `advisor`) are bound to Telegram bots in `config/telegram_bots.json`; `primary` is the default and needs no binding.
 
-A persona's sourcing and tone are the levers, not its capabilities: because all four share the full tool suite, the difference between them is entirely which tools they *lean on*, where they look *first*, and how they frame the reply. That is why a persona file is mostly prose — the behavior is instruction, not configuration.
+A persona's sourcing and tone are the levers, not its capabilities: because all five share the full tool suite, the difference between them is entirely which tools they *lean on*, where they look *first*, and how they frame the reply. That is why a persona file is mostly prose — the behavior is instruction, not configuration.
 
 ## How personas reach each surface
 

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -8,6 +8,7 @@ on POST /api/ask/stream, and persona-scoped conversation storage/listing.
 import json
 import os
 import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
@@ -639,3 +640,50 @@ class TestConversationsListPersonaParam:
             resp = client.get("/api/conversations?persona_id=fitness")
         assert resp.status_code == 200
         assert mock_store.list_conversations.call_args.kwargs.get("persona_id") == "fitness"
+
+
+# ---------------------------------------------------------------------------
+# Financial Advisor persona (#458) — validate the shipped config directly (the
+# live registry depends on the token being set, which a fresh clone won't have).
+# ---------------------------------------------------------------------------
+
+_ADVISOR_FILE = Path(__file__).parent.parent / "config" / "personas" / "advisor.md"
+_BOTS_FILE = Path(__file__).parent.parent / "config" / "telegram_bots.json"
+
+
+@pytest.mark.unit
+def test_advisor_persona_parses_to_body_and_voice():
+    from config.settings import _parse_persona
+    body, voice, model = _parse_persona(_ADVISOR_FILE.read_text(), "advisor")
+    assert body.strip(), "advisor persona has a non-empty preamble"
+    assert "id: advisor" not in body, "frontmatter must be stripped from the preamble"
+    assert isinstance(voice, tuple) and voice, "voice rules parsed for spoken turns"
+
+
+@pytest.mark.unit
+def test_advisor_persona_grounded_in_investments():
+    body = _ADVISOR_FILE.read_text().lower()
+    assert "investments" in body and "portfolio" in body
+    assert "tax" in body           # tax buckets / harvesting
+    assert "monarch" in body       # the secondary source
+
+
+@pytest.mark.unit
+def test_advisor_persona_no_leaked_financial_values():
+    """Open-source guard: the committed persona must not hardcode real balances,
+    account numbers, or the private dashboard URL — live numbers come from tools."""
+    import re
+    text = _ADVISOR_FILE.read_text()
+    assert not re.search(r"\$\s?\d[\d,]{2,}", text), "no hardcoded dollar amounts"
+    assert "quickstage" not in text.lower(), "no private dashboard URL"
+    assert not re.search(r"\b\d{4}\b", text), "no account-number-like 4-digit fragments"
+
+
+@pytest.mark.unit
+def test_advisor_registered_in_bot_registry():
+    entries = json.loads(_BOTS_FILE.read_text())
+    advisor = next((e for e in entries if e.get("name") == "advisor"), None)
+    assert advisor is not None, "advisor registered in telegram_bots.json"
+    assert advisor["token_env"] == "TELEGRAM_ADVISOR_BOT_TOKEN"
+    assert advisor["persona_file"] == "config/personas/advisor.md"
+    assert not advisor.get("orchestrates"), "advisor is pure-chat, not an orchestrator"


### PR DESCRIPTION
## Summary

Adds a conversational **Financial Advisor** persona (id `advisor`) alongside primary/therapist/fitness/doctor — an analytical, numbers-first planning surface grounded in the reconciled investments snapshot + Monarch. It plans and recommends (retirement, tax, allocation, savings) against the real figures; it doesn't place trades.

- **`config/personas/advisor.md`** — prose grounded in the pipeline's data model (read from `~/Code/investments`): tax buckets (pre-tax / Roth / taxable), external-account caveats (Guideline 401(k)/TSP are balance-only — no cost basis/XIRR), long/short-term unrealized + harvestable losses, the dashboard tabs. Sourcing guidance prefers the investments snapshot over Monarch for portfolio/tax questions. No hardcoded balances, account numbers, or dashboard URL.
- **`config/telegram_bots.json`** — `advisor` bot bound to `TELEGRAM_ADVISOR_BOT_TOKEN` (pure chat, no `orchestrates`).
- **Docs** — env vars in `.env.example` + `configuration.md`; persona in `personas.md`.

Selectable in web `/chat` + voice via `GET /api/personas` and via its Telegram bot once the token is set (verified end-to-end on this host: it loads through `settings.telegram_bots`, appears in `list_http_personas()`, resolves to a non-empty preamble with 3 voice rules).

Closes #458

## Test evidence

`./scripts/test.sh auto`: **3232 passed, 4 failed** — the 4 are the known pre-existing env/data-dependent set (`test_settings` ×2, `test_slack_sync`, `test_p91_data_integrity`), none persona-related. 4 new portable tests (validate the shipped config, not the token-gated live registry): persona parses (frontmatter stripped, voice rules present), grounded-in-investments content, **no-leaked-financial-values guard** (no `$` amounts, no dashboard URL, no 4-digit account fragments), and registry-entry validation.

## Review focus

- **Privacy / open-source posture** — confirm the committed persona has no real balances, account numbers, or the private dashboard URL (a test guards this).
- Persona prose accuracy vs the real data model (tax buckets, external-account caveats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)