### PR TITLE
fix(personas): show the financial persona as "Finance" in the chat UI

### DIFF
--- a/config/telegram_bots.json
+++ b/config/telegram_bots.json
@@ -20,6 +20,7 @@
   },
   {
     "name": "advisor",
+    "label": "Finance",
     "token_env": "TELEGRAM_ADVISOR_BOT_TOKEN",
     "chat_id_env": "TELEGRAM_ADVISOR_CHAT_ID",
     "persona_file": "config/personas/advisor.md"

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -686,4 +686,5 @@ def test_advisor_registered_in_bot_registry():
     assert advisor is not None, "advisor registered in telegram_bots.json"
     assert advisor["token_env"] == "TELEGRAM_ADVISOR_BOT_TOKEN"
     assert advisor["persona_file"] == "config/personas/advisor.md"
+    assert advisor["label"] == "Finance", "advisor displays as 'Finance' in the chat UI"
     assert not advisor.get("orchestrates"), "advisor is pure-chat, not an orchestrator"


### PR DESCRIPTION
Closes #462.

Sets an explicit `"label": "Finance"` on the advisor bot entry in `config/telegram_bots.json` — without it, the chat UI falls back to `name.capitalize()` → "Advisor". `label` is already fully plumbed (settings → `/api/personas` → UI); this is the one-line data fix plus a registry test assertion.

## Provenance

Authored by tonight's doctor session (goal approved via Telegram at 6:48 PM). The session was killed at commit time — it committed **in the primary checkout** (not a worktree), the commit touched `config/`, and the post-commit hook's `lifeos-api` restart cascaded to `lifeos-agent-worker` via `BindsTo=`, SIGTERM'ing the doctor before it could push (exit 143 at 6:54 PM). Salvaged from its local branch; tests pass (46 in `test_persona_api.py`).

Root-cause fix for the cascade follows in a separate PR.

## Deploy note

The primary checkout is currently on a feature branch held by an interactive session, so auto-deploy will (correctly) skip until it returns to `main` — the label appears in the UI at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)