### PR TITLE
feat(chat): make search_web a real web search (DuckDuckGo + Claude native)

### DIFF
--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -572,7 +572,10 @@ class AnthropicLLMClient:
         tool_calls = None
         for block in resp.content:
             if block.type == "text":
-                text = block.text
+                # Accumulate: a response may carry multiple text blocks (e.g. a
+                # native web-search answer split at citation boundaries). Keeping
+                # only the last would truncate the answer to its final fragment.
+                text += block.text
             elif block.type == "tool_use":
                 if tool_calls is None:
                     tool_calls = []

--- a/api/services/web_search.py
+++ b/api/services/web_search.py
@@ -1,65 +1,58 @@
 """
 Web search service for LifeOS.
 
-Uses the Anthropic API to answer web-style queries. The model doesn't
-have real-time web access, but can answer many factual questions from
-its training data. For truly real-time queries (weather, stock prices,
-live scores), it will indicate the limitation.
-"""
-import logging
-from typing import Optional
+Real web search on every LLM backend. The search itself runs in LifeOS via
+DuckDuckGo (no API key), so it works identically whether the orchestrator is on
+Anthropic, Codex, or the local llama-server. On the Anthropic backend we upgrade
+to Claude's native server-side web search (iterative, cited) for higher quality.
 
-from api.services.llm_client import get_anthropic_llm
+Both entry points degrade honestly: a failed or empty search returns nothing to
+say (empty results / empty answer), never a fabricated "from my training data"
+response — that stub behavior is exactly what this module replaces.
+"""
+import asyncio
+import logging
+
+from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
 
-async def search_web(query: str, max_results: int = 5) -> list[dict]:
-    """
-    Answer a web-style query using the local LLM.
+def _ddg_search(query: str, max_results: int = 5) -> list[dict]:
+    """Real web results via DuckDuckGo (no API key), synchronous.
 
-    Args:
-        query: The search query
-        max_results: Maximum number of results to return
-
-    Returns:
-        List of results, each with: title, url, snippet
+    Best-effort: returns [] on any failure (rate-limit, network, parse) so the
+    caller degrades to "nothing found" rather than inventing an answer.
     """
     try:
-        client = get_anthropic_llm()
-        response = client.create(
-            messages=[{
-                "role": "user",
-                "content": (
-                    f"Answer this query using your knowledge: {query}\n\n"
-                    "If this requires real-time data (live prices, current weather, "
-                    "today's news), say so clearly. Otherwise, provide the best "
-                    "factual answer you can."
-                ),
-            }],
-            system="You are a helpful assistant answering factual questions. Be concise and accurate.",
-            max_tokens=1024,
-        )
-        return [{
-            "title": "Knowledge Base Answer",
-            "url": "",
-            "snippet": response.text[:500],
-        }]
+        from ddgs import DDGS
+
+        with DDGS() as ddgs:
+            hits = ddgs.text(query, max_results=max_results)
     except Exception as e:
-        logger.error(f"Web search failed: {e}")
+        logger.warning(f"DuckDuckGo search failed: {e}")
         return []
+    out: list[dict] = []
+    for h in hits or []:
+        out.append({
+            "title": h.get("title") or "",
+            "url": h.get("href") or h.get("url") or "",
+            "snippet": h.get("body") or h.get("snippet") or "",
+        })
+    return out
+
+
+async def search_web(query: str, max_results: int = 5) -> list[dict]:
+    """Real web search results, backend-independent (via DuckDuckGo).
+
+    Returns a list of results, each with: title, url, snippet. [] on failure.
+    The blocking fetch runs in a worker thread so it never stalls the event loop.
+    """
+    return await asyncio.to_thread(_ddg_search, query, max_results)
 
 
 def format_web_results_for_context(results: list[dict]) -> str:
-    """
-    Format web search results as context for synthesis.
-
-    Args:
-        results: List of search results from search_web()
-
-    Returns:
-        Formatted string suitable for inclusion in synthesis prompt
-    """
+    """Format web search results as context for synthesis."""
     if not results:
         return "No web search results found."
 
@@ -79,34 +72,58 @@ def format_web_results_for_context(results: list[dict]) -> str:
     return formatted.strip()
 
 
+def _use_native_anthropic() -> bool:
+    """Native Claude web search is the upgrade path when the orchestrator backend
+    is Anthropic; every other backend (Codex, local) uses DuckDuckGo."""
+    return getattr(settings, "llm_backend", "anthropic").lower() == "anthropic"
+
+
+async def _anthropic_native_search(query: str) -> str:
+    """Claude's native server-side web search (iterative, cited).
+
+    Uses the active Anthropic orchestrator client (a current, web-search-capable
+    model) — not the dedicated ``get_anthropic_llm()`` specialist client, which is
+    pinned to a now-retired model. We declare the basic ``web_search_20250305``
+    variant, which every current Claude model supports. Returns the synthesized
+    answer text, or "" if the search produced nothing usable.
+    """
+    from api.services.llm_client import get_local_llm
+
+    client = get_local_llm()
+    resp = await client.acreate(
+        messages=[{"role": "user", "content": query}],
+        system=(
+            "You are a web research assistant. Search the web and answer the "
+            "question directly and concisely, noting your sources. If the search "
+            "returns nothing useful, say so plainly rather than guessing."
+        ),
+        max_tokens=1024,
+        tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 5}],
+    )
+    return (resp.text or "").strip()
+
+
 async def search_web_with_synthesis(query: str) -> tuple[str, list[dict]]:
-    """
-    Answer a query and return both synthesized answer and raw results.
+    """Answer a web-style query with real, current results on every backend.
 
-    Args:
-        query: The search query
+    - **Anthropic backend:** Claude's native web search (best quality) — returns
+      its synthesized, cited answer.
+    - **Codex / local (and as a fallback if the native path fails):** DuckDuckGo
+      results, formatted for the caller to synthesize on its own backend.
 
-    Returns:
-        Tuple of (synthesized_answer, raw_results)
+    Returns ``(answer_or_context, raw_results)``. On a genuinely empty search,
+    returns ``("", [])`` so the caller can say it found nothing — never a
+    fabricated answer.
     """
-    try:
-        client = get_anthropic_llm()
-        response = client.create(
-            messages=[{"role": "user", "content": query}],
-            system=(
-                "You are a helpful assistant. Answer the question directly and concisely. "
-                "If the question requires truly real-time data (live weather, current stock "
-                "prices, today's breaking news), note that you don't have real-time web access "
-                "but provide the best answer from your training knowledge."
-            ),
-            max_tokens=1024,
-        )
-        results = [{
-            "title": "Answer",
-            "url": "",
-            "snippet": response.text[:500],
-        }]
-        return response.text, results
-    except Exception as e:
-        logger.error(f"Web search with synthesis failed: {e}")
-        return f"I couldn't process this query: {str(e)}", []
+    if _use_native_anthropic():
+        try:
+            answer = await _anthropic_native_search(query)
+            if answer:
+                return answer, [{"title": "Claude web search", "url": "", "snippet": answer[:500]}]
+        except Exception as e:
+            logger.warning(f"Native Anthropic web search failed; falling back to DuckDuckGo: {e}")
+
+    results = await search_web(query)
+    if not results:
+        return "", []
+    return format_web_results_for_context(results), results

--- a/api/services/web_search.py
+++ b/api/services/web_search.py
@@ -86,6 +86,10 @@ async def _anthropic_native_search(query: str) -> str:
     pinned to a now-retired model. We declare the basic ``web_search_20250305``
     variant, which every current Claude model supports. Returns the synthesized
     answer text, or "" if the search produced nothing usable.
+
+    A rare ``pause_turn`` (server hit its search-iteration cap) yields empty or
+    partial text — which degrades to the DuckDuckGo path or a real-but-shorter
+    answer, never a fabricated one — so it needs no explicit resume here.
     """
     from api.services.llm_client import get_local_llm
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,5 +54,8 @@ psutil
 monarchmoneycommunity>=1.3.0  # Community fork with api.monarch.com domain fix
 yfinance>=0.2.40  # Yahoo Finance day-change quotes for the big-mover alert (#463)
 
+# Web Search
+ddgs>=9.0  # DuckDuckGo web search (no API key) — backend-agnostic search_web (#467)
+
 # macOS Integrations (optional)
 pyobjc-framework-Contacts>=10.0; sys_platform == "darwin"  # Apple Contacts integration

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,5 +1,5 @@
 """
-Tests for web search service.
+Tests for the web search service (real search on every backend — #467).
 """
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
@@ -8,16 +8,14 @@ pytestmark = pytest.mark.unit
 
 
 class TestWebSearch:
-    """Tests for web search service functions."""
+    """Tests for the result formatter."""
 
     def test_format_web_results_empty(self):
-        """Empty results should return informative message."""
         from api.services.web_search import format_web_results_for_context
         result = format_web_results_for_context([])
         assert "No web search results found" in result
 
     def test_format_web_results_single(self):
-        """Single result should format correctly."""
         from api.services.web_search import format_web_results_for_context
         results = [
             {"title": "Test Title", "url": "https://example.com", "snippet": "Test snippet"}
@@ -28,7 +26,6 @@ class TestWebSearch:
         assert "Test snippet" in result
 
     def test_format_web_results_multiple(self):
-        """Multiple results should be numbered."""
         from api.services.web_search import format_web_results_for_context
         results = [
             {"title": "First", "url": "https://first.com", "snippet": "First result"},
@@ -39,70 +36,86 @@ class TestWebSearch:
         assert "2. **Second**" in result
 
     def test_format_web_results_missing_fields(self):
-        """Should handle missing optional fields."""
         from api.services.web_search import format_web_results_for_context
-        results = [
-            {"title": "Title Only", "url": "", "snippet": ""}
-        ]
+        results = [{"title": "Title Only", "url": "", "snippet": ""}]
         result = format_web_results_for_context(results)
         assert "Title Only" in result
 
 
-class TestSearchWeb:
-    """Tests for the search_web function."""
+def _fake_ddgs(hits):
+    """Build a DDGS() context manager whose .text() returns `hits`."""
+    inner = MagicMock()
+    inner.text.return_value = hits
+    cm = MagicMock()
+    cm.__enter__.return_value = inner
+    cm.__exit__.return_value = False
+    return cm
+
+
+class TestDuckDuckGoSearch:
+    """The backend-independent DuckDuckGo path."""
+
+    def test_ddg_search_maps_fields(self):
+        from api.services import web_search
+        cm = _fake_ddgs([{"title": "T", "href": "https://x.com", "body": "snip"}])
+        with patch("ddgs.DDGS", return_value=cm):
+            out = web_search._ddg_search("q")
+        assert out == [{"title": "T", "url": "https://x.com", "snippet": "snip"}]
+
+    def test_ddg_search_non_fatal_on_error(self):
+        from api.services import web_search
+        with patch("ddgs.DDGS", side_effect=Exception("rate limited")):
+            assert web_search._ddg_search("q") == []
 
     @pytest.mark.asyncio
-    async def test_search_web_returns_list(self):
-        """search_web should return a list."""
-        mock_response = MagicMock()
-        mock_response.text = "Here are the results..."
-
-        mock_client = MagicMock()
-        mock_client.create.return_value = mock_response
-
-        with patch('api.services.web_search.get_anthropic_llm', return_value=mock_client):
-            from api.services.web_search import search_web
-            results = await search_web("test query")
-            assert isinstance(results, list)
-
-    @pytest.mark.asyncio
-    async def test_search_web_handles_error(self):
-        """search_web should handle errors gracefully."""
-        mock_client = MagicMock()
-        mock_client.create.side_effect = Exception("API Error")
-
-        with patch('api.services.web_search.get_anthropic_llm', return_value=mock_client):
-            from api.services.web_search import search_web
-            results = await search_web("test query")
-            assert results == []
+    async def test_search_web_offloads_to_ddg(self):
+        from api.services import web_search
+        with patch.object(web_search, "_ddg_search", return_value=[{"title": "T", "url": "u", "snippet": "s"}]):
+            out = await web_search.search_web("q")
+        assert out == [{"title": "T", "url": "u", "snippet": "s"}]
 
 
 class TestSearchWebWithSynthesis:
-    """Tests for the search_web_with_synthesis function."""
+    """The hybrid entry point: native on Anthropic, DuckDuckGo elsewhere."""
 
     @pytest.mark.asyncio
-    async def test_returns_tuple(self):
-        """Should return tuple of (synthesized, results)."""
-        mock_response = MagicMock()
-        mock_response.text = "The answer is 42."
-
-        mock_client = MagicMock()
-        mock_client.create.return_value = mock_response
-
-        with patch('api.services.web_search.get_anthropic_llm', return_value=mock_client):
-            from api.services.web_search import search_web_with_synthesis
-            synthesized, results = await search_web_with_synthesis("test query")
-            assert isinstance(synthesized, str)
-            assert isinstance(results, list)
+    async def test_anthropic_backend_uses_native(self):
+        from api.services import web_search
+        with patch.object(web_search, "_use_native_anthropic", return_value=True), \
+             patch.object(web_search, "_anthropic_native_search", new=AsyncMock(return_value="Live answer, sourced.")):
+            synthesized, results = await web_search.search_web_with_synthesis("who won today")
+        assert synthesized == "Live answer, sourced."
+        assert isinstance(results, list) and results
 
     @pytest.mark.asyncio
-    async def test_handles_error_gracefully(self):
-        """Should return error message on failure."""
-        mock_client = MagicMock()
-        mock_client.create.side_effect = Exception("API Error")
+    async def test_local_backend_uses_ddg(self):
+        from api.services import web_search
+        native = AsyncMock()
+        with patch.object(web_search, "_use_native_anthropic", return_value=False), \
+             patch.object(web_search, "_anthropic_native_search", new=native), \
+             patch.object(web_search, "search_web", new=AsyncMock(return_value=[
+                 {"title": "AMD price", "url": "https://finance.example/amd", "snippet": "AMD is up 5.8%"}])):
+            synthesized, results = await web_search.search_web_with_synthesis("amd price")
+        native.assert_not_awaited()                     # local backend never calls Claude
+        assert "AMD price" in synthesized and "finance.example" in synthesized
+        assert results and results[0]["title"] == "AMD price"
 
-        with patch('api.services.web_search.get_anthropic_llm', return_value=mock_client):
-            from api.services.web_search import search_web_with_synthesis
-            synthesized, results = await search_web_with_synthesis("test query")
-            assert "couldn't" in synthesized.lower() or "error" in synthesized.lower()
-            assert results == []
+    @pytest.mark.asyncio
+    async def test_native_failure_falls_back_to_ddg(self):
+        from api.services import web_search
+        with patch.object(web_search, "_use_native_anthropic", return_value=True), \
+             patch.object(web_search, "_anthropic_native_search", new=AsyncMock(side_effect=Exception("anthropic down"))), \
+             patch.object(web_search, "search_web", new=AsyncMock(return_value=[
+                 {"title": "Fallback", "url": "https://x", "snippet": "ddg result"}])):
+            synthesized, results = await web_search.search_web_with_synthesis("q")
+        assert "Fallback" in synthesized                # degraded to DuckDuckGo, not an error string
+        assert results and results[0]["title"] == "Fallback"
+
+    @pytest.mark.asyncio
+    async def test_empty_search_returns_empty_not_fabricated(self):
+        from api.services import web_search
+        with patch.object(web_search, "_use_native_anthropic", return_value=False), \
+             patch.object(web_search, "search_web", new=AsyncMock(return_value=[])):
+            synthesized, results = await web_search.search_web_with_synthesis("q")
+        assert synthesized == ""                          # honest "nothing found", never invented
+        assert results == []

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -119,3 +119,37 @@ class TestSearchWebWithSynthesis:
             synthesized, results = await web_search.search_web_with_synthesis("q")
         assert synthesized == ""                          # honest "nothing found", never invented
         assert results == []
+
+
+class TestNativeAnswerAccumulation:
+    """The native path returns Claude's full cited answer, not its last fragment."""
+
+    def test_parse_anthropic_response_accumulates_text_blocks(self):
+        """A cited web-search answer spans multiple text blocks (split at citation
+        boundaries) interleaved with server-tool blocks — all text must survive,
+        not just the last block (the #469 truncation bug)."""
+        from api.services.llm_client import AnthropicLLMClient
+        # Skip __init__ (needs an API key) — _parse_anthropic_response uses no self state.
+        client = AnthropicLLMClient.__new__(AnthropicLLMClient)
+
+        def blk(btype, **kw):
+            b = MagicMock()
+            b.type = btype
+            for k, v in kw.items():
+                setattr(b, k, v)
+            return b
+
+        resp = MagicMock()
+        resp.content = [
+            blk("text", text="AMD is trading at $210"),
+            blk("server_tool_use"),
+            blk("web_search_tool_result"),
+            blk("text", text=" as of the July 9 close."),
+        ]
+        resp.usage = MagicMock(input_tokens=10, output_tokens=20,
+                               cache_creation_input_tokens=0, cache_read_input_tokens=0)
+        resp.model = "claude-haiku-4-5"
+        resp.stop_reason = "end_turn"
+
+        out = client._parse_anthropic_response(resp)
+        assert out.text == "AMD is trading at $210 as of the July 9 close."


### PR DESCRIPTION
## Summary

`search_web` didn't search the web — it called the LLM with no web access and asked it to answer *"from your knowledge,"* so it could never return live data (prices, weather, news), even though the system prompt tells every persona to *always* search the web first. (The old stub also routed through `get_anthropic_llm()`, pinned to a now-retired model — the "technical error" users saw was that client's 404.) Discovered when the Financial Advisor couldn't answer "which position moved most today."

Now real on **every backend**:
- **DuckDuckGo** (`ddgs`, no API key) fetches real current results *in LifeOS* — backend-independent, so it works identically on Anthropic, Codex, and the local llama-server. Offloaded via `asyncio.to_thread`.
- **Anthropic backend:** upgrades to Claude's **native server-side web search** (`web_search_20250305`) via the active orchestrator model (`get_local_llm()`, current + web-search-capable — sidestepping the retired specialist model) — iterative, cited — with DuckDuckGo as the fallback.
- **Degrades honestly:** an empty/failed search returns nothing to say, never a fabricated "from training data" answer.

`search_web` / `search_web_with_synthesis` signatures are unchanged, so `_tool_search_web` and the chat caller are untouched.

Closes #467

## Test evidence

`./scripts/test.sh auto`: **3242 passed** (failures are the known pre-existing env/data-dependent set only). 11 web-search tests: formatter, DuckDuckGo field-mapping + non-fatal failure, `search_web` thread offload, and `search_web_with_synthesis` across backends (native on Anthropic, DuckDuckGo on local, native→DuckDuckGo fallback, honest empty). **Live smoke tests:** DuckDuckGo returned real AMD quote results; the native path returned a real current-dated answer (both verified against live services).

## Review focus

- **Backend gating** (`_use_native_anthropic` on `settings.llm_backend`) — native only on Anthropic; DuckDuckGo everywhere else and as the fallback.
- **Honest degradation** — no path fabricates an answer when the search is empty/fails.
- **Native path model** — uses `get_local_llm()` (current orchestrator model), not the retired `get_anthropic_llm()` pin.

## Follow-up (separate)

`get_anthropic_llm()` is pinned to a **retired model** (`claude-sonnet-4-20250514` → 404), which also breaks relationship-insights / fact-extraction / tone-analysis specialist calls. Out of scope here (this PR routes around it); worth a separate fix — I'll file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)