### PR TITLE
fix(doctor): route bare-affirmative plain messages to the open goal gate

### DIFF
--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -1244,6 +1244,27 @@ class SessionStore:
             ).fetchone()
         return dict(row) if row else None
 
+    def get_latest_open_question(
+        self, bot: str | None = None, kind: str | None = None
+    ) -> dict | None:
+        """The most recent open (unanswered, not-timed-out) question, optionally
+        filtered by owning bot and kind. Used to route a bare affirmative sent
+        as a plain message to the goal gate it almost certainly answers (#453)
+        instead of spawning a context-free session."""
+        bot_clause, bot_params = self._bot_scope_clause(bot)
+        kind_clause = " AND kind = ?" if kind else ""
+        params: list = [*bot_params, *([kind] if kind else [])]
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM pending_questions "
+                "WHERE answered_at IS NULL AND timed_out = 0 "
+                "AND kind != 'status_anchor'"
+                + bot_clause + kind_clause +
+                " ORDER BY id DESC LIMIT 1",
+                params,
+            ).fetchone()
+        return dict(row) if row else None
+
     def get_open_question_by_message_id(
         self, sent_message_id: int, bot: str | None = None,
         include_answered: bool = False,

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -679,6 +679,38 @@ class TelegramBotListener:
         from api.services.agent_worker.claude_code_spawn import spawn_claude_code_session
         from api.services.agent_worker.session_store import SessionStore
 
+        # A short bare affirmative ("yes", "approved", "go ahead") is never a
+        # problem report — it's almost certainly a mis-threaded approval of a
+        # pending goal (#453: each such plain message used to spawn a fresh
+        # context-free session). Route it to the most recent open goal gate on
+        # this bot instead; only genuinely unmatched text falls through to a
+        # spawn. The length bound keeps real reports that merely START with
+        # "yes ..." ("yes the calendar tool is broken again") spawning normally.
+        stripped = text.strip()
+        if len(stripped) <= 25:
+            from api.services.agent_worker.worker import _is_affirmative
+            if _is_affirmative(stripped):
+                try:
+                    gate = SessionStore().get_latest_open_question(
+                        bot=self._bot.name, kind="goal_approval",
+                    )
+                except Exception as exc:
+                    logger.warning(f"goal-gate lookup failed: {exc}")
+                    gate = None
+                if gate and await self._maybe_handle_claude_code_reply(
+                    int(gate["sent_message_id"]), stripped, chat_id,
+                ):
+                    return
+                if not gate:
+                    await send_message_async(
+                        f'I got "{stripped}" but there\'s nothing here waiting '
+                        "for an approval — no session was started. If you meant "
+                        "to answer an earlier message, use Telegram's Reply on "
+                        "it; otherwise describe the problem you want me to fix.",
+                        chat_id=chat_id,
+                    )
+                    return
+
         working_dir = os.path.expanduser(os.path.join(str(settings.code_dir), "LifeOS"))
         prompt = (
             f"{self._persona}\n\n"

--- a/tests/test_doctor_bot.py
+++ b/tests/test_doctor_bot.py
@@ -448,6 +448,99 @@ class TestDoctorListener:
         answered = store.list_answered_unprocessed_questions()
         assert len(answered) == 1
 
+    def _seed_goal_gate(self, tmp_path, message_id=5000):
+        from api.services.agent_worker.session_store import STATUS_BLOCKED, SessionStore
+
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        s = store.create(
+            task_id="t-gate", routing="claude_code", origin="operator",
+            bot="doctor", status=STATUS_BLOCKED,
+        )
+        store.create_pending_question(
+            session_id=s.session_id, task_id="t-gate",
+            question="goal + instructions", sent_message_id=message_id,
+            sent_message_ids=[message_id], kind="goal_approval", bot="doctor",
+        )
+        return store, s
+
+    @pytest.mark.asyncio
+    async def test_bare_affirmative_routes_to_open_goal_gate_not_spawn(self, tmp_path):
+        """#453: a plain (non-threaded) "yes" while a goal gate is open must
+        answer THAT gate — not spawn a fresh context-free session (the
+        yes/approved orphan factory of 2026-07-09)."""
+        from unittest.mock import MagicMock
+
+        store, s = self._seed_goal_gate(tmp_path)
+        listener = self._listener("doctor", "999", persona="P", orchestrates=True)
+        sent: list[str] = []
+
+        async def _capture(text, chat_id=None, bot=None):
+            sent.append(text)
+
+        def _capture_ids(text, chat_id=None, bot=None):
+            sent.append(text)
+            return [8001]
+
+        spawn = MagicMock()
+        with patch("api.services.agent_worker.claude_code_spawn.spawn_claude_code_session", spawn), \
+             patch("api.services.agent_worker.session_store.SessionStore",
+                   return_value=store), \
+             patch("api.services.telegram.send_message_capture_ids",
+                   side_effect=_capture_ids), \
+             patch("api.services.telegram.send_message_async", side_effect=_capture):
+            await listener._handle_orchestration_message("Yes", "999")
+
+        spawn.assert_not_called()
+        assert any("Goal locked" in t for t in sent)
+        answered = store.list_answered_unprocessed_questions()
+        assert [q["answer"] for q in answered] == ["Yes"]
+
+    @pytest.mark.asyncio
+    async def test_bare_affirmative_with_no_gate_is_consumed_not_spawned(self, tmp_path):
+        """#453: "yes" with nothing awaiting approval must not spawn a session
+        whose entire "report" is the word yes — it gets a clear pointer back."""
+        from unittest.mock import MagicMock
+        from api.services.agent_worker.session_store import SessionStore
+
+        store = SessionStore(db_path=tmp_path / "sessions.db")
+        listener = self._listener("doctor", "999", persona="P", orchestrates=True)
+        sent: list[str] = []
+
+        async def _capture(text, chat_id=None, bot=None):
+            sent.append(text)
+
+        spawn = MagicMock()
+        with patch("api.services.agent_worker.claude_code_spawn.spawn_claude_code_session", spawn), \
+             patch("api.services.agent_worker.session_store.SessionStore",
+                   return_value=store), \
+             patch("api.services.telegram.send_message_async", side_effect=_capture):
+            await listener._handle_orchestration_message("approved", "999")
+
+        spawn.assert_not_called()
+        assert any("nothing here waiting" in t for t in sent)
+
+    @pytest.mark.asyncio
+    async def test_report_starting_with_yes_still_spawns(self, tmp_path):
+        """A real report that merely STARTS with an affirmative word ("yes the
+        calendar tool is broken again") exceeds the bare-affirmative bound and
+        spawns a session as before."""
+        from unittest.mock import MagicMock
+
+        store, s = self._seed_goal_gate(tmp_path)
+        listener = self._listener("doctor", "999", persona="P", orchestrates=True)
+
+        spawn = MagicMock(return_value={"ok": True, "session_id": "sess-n", "task_id": "t-n"})
+        with patch("api.services.agent_worker.claude_code_spawn.spawn_claude_code_session", spawn), \
+             patch("api.services.agent_worker.session_store.SessionStore",
+                   return_value=store), \
+             patch("api.services.telegram.send_message_capture_ids",
+                   side_effect=lambda t, c=None, bot=None: [1]), \
+             patch("api.services.telegram.send_message_async", new_callable=AsyncMock):
+            await listener._handle_orchestration_message(
+                "yes the calendar tool is broken again", "999")
+
+        spawn.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_pure_chat_bot_never_spawns(self):
         listener = self._listener("fitness", "999", persona="P", orchestrates=False)


### PR DESCRIPTION
Closes #453.

## What the investigation showed

The reported "single reply fans out to three sessions" was a misdiagnosis — verified from the three named transcripts: each orphan session was spawned by a **distinct plain message** (`sess_0185…` from a plain "yes", `sess_1fb90b…` from a plain "approved"), while the canonical session's threaded reply resumed correctly. Reply→session routing was always one-to-one.

## Acceptance criteria → status

- **A reply resumes only the awaiting session** — was already true; #456/#459 additionally consume mis-threaded and duplicate replies with acks (regression-tested).
- **No silent context-free spawns for reply-intent messages** — closed here: a short bare affirmative (≤25 chars, the worker's own `_is_affirmative`) sent as a plain message now answers the most recent open goal gate on the bot exactly as a threaded reply would (deposit + "✅ Goal locked" ack); with no gate open it's consumed with a clear pointer. Real reports that merely start with "yes …" exceed the bound and spawn normally.
- **Orphans reaped** — the four blocked orphan sessions from the incident are being marked failed as operational cleanup alongside this PR.
- **Regression coverage** — three new listener tests (gate-answer, no-gate consumption, long-report passthrough) plus the existing duplicate-reply and threaded-routing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)