### PR TITLE
feat(investments): on-demand movers via a search_finances action

### DIFF
--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -445,6 +445,8 @@ TOOL_DEFINITIONS = [
             "'investments' (Nathan's full portfolio: Schwab + Guideline 401k + TSP — totals, tax "
             "buckets, per-position holdings with cost basis, savings by year, wealth trend, taxable "
             "unrealized gains; aggregated nightly by the investments pipeline). "
+            "'movers' (which held positions moved most today — live day-change % for the snapshot's "
+            "tickers, past an optional 'threshold' percent, default 5). "
             "For historical monthly summaries, use search_vault with 'finance' or 'spending'."
         ),
         "input_schema": {
@@ -452,7 +454,7 @@ TOOL_DEFINITIONS = [
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["accounts", "transactions", "cashflow", "budgets", "investments"],
+                    "enum": ["accounts", "transactions", "cashflow", "budgets", "investments", "movers"],
                     "description": "What financial data to retrieve.",
                 },
                 "start_date": {
@@ -470,6 +472,10 @@ TOOL_DEFINITIONS = [
                 "search": {
                     "type": "string",
                     "description": "Search transactions by merchant name.",
+                },
+                "threshold": {
+                    "type": "number",
+                    "description": "For action 'movers': only positions whose absolute day change exceeds this percent (default 5).",
                 },
             },
             "required": ["action"],
@@ -1801,6 +1807,23 @@ async def _tool_search_finances(inp: dict) -> str:
         ]
         return "\n".join(lines)
 
+    if action == "movers":
+        # On-demand "which of my positions moved most today?" — reuses the noon
+        # big-mover check (live day-change via yfinance for the snapshot's tickers).
+        from api.routes.investments import MOVER_THRESHOLD_PCT, _held_tickers, investments_movers
+        threshold = inp.get("threshold")
+        if not isinstance(threshold, (int, float)) or threshold <= 0:
+            threshold = MOVER_THRESHOLD_PCT
+        if not _held_tickers():
+            # Distinguish "couldn't check" from a genuinely quiet day — on an
+            # on-demand ask, an empty count from a missing snapshot shouldn't read
+            # as "the market was flat."
+            return "Couldn't check movers right now — the investments snapshot isn't available."
+        result = await investments_movers(threshold=threshold)
+        if result.get("count"):
+            return result["scheduler_message"]
+        return f"No held position moved more than {threshold:g}% today."
+
     client = get_monarch_client()
 
     if action == "accounts":
@@ -1933,6 +1956,7 @@ TOOL_STATUS_MESSAGES = {
     "search_finances.transactions": "Searching transactions...",
     "search_finances.cashflow": "Loading cashflow summary...",
     "search_finances.budgets": "Checking budgets...",
+    "search_finances.movers": "Checking today's movers...",
     "create_email_draft": "Drafting email...",
     "send_email_draft": "Sending email...",
     "create_calendar_event": "Creating calendar event...",

--- a/tests/test_investments.py
+++ b/tests/test_investments.py
@@ -188,3 +188,58 @@ def test_scheduler_endpoint_prefers_scheduler_message_field():
     dumped = _format_endpoint_result({"status": "ok", "message": "done"})
     assert '"status"' in dumped and '"message"' in dumped   # generic {message} left as JSON
     assert '"foo"' in _format_endpoint_result({"foo": 1})
+
+
+# ---------------------------------------------------------------------------
+# On-demand movers via search_finances (#468)
+# ---------------------------------------------------------------------------
+
+async def test_search_finances_movers_action(monkeypatch):
+    """search_finances(action='movers') returns the on-demand day-movers digest,
+    reusing investments_movers — tickers + % only, no dollar amounts."""
+    from unittest.mock import AsyncMock
+    from api.services.agent_tools import _tool_search_finances
+    monkeypatch.setattr(inv, "_held_tickers", lambda: ["AMD"])
+    monkeypatch.setattr(inv, "investments_movers", AsyncMock(return_value={
+        "scheduler_message": "Positions moving more than 5% today:\n- AMD: ▲ +5.8%", "count": 1}))
+    out = await _tool_search_finances({"action": "movers"})
+    assert "AMD" in out and "5.8%" in out
+    assert "$" not in out
+
+
+async def test_search_finances_movers_none_today(monkeypatch):
+    """When nothing moved past the (custom) threshold, the tool answers plainly
+    rather than returning an empty string."""
+    from unittest.mock import AsyncMock
+    from api.services.agent_tools import _tool_search_finances
+    monkeypatch.setattr(inv, "_held_tickers", lambda: ["AMD"])
+    monkeypatch.setattr(inv, "investments_movers", AsyncMock(return_value={
+        "scheduler_message": "", "count": 0}))
+    out = await _tool_search_finances({"action": "movers", "threshold": 3})
+    assert "No held position moved more than 3% today" in out
+
+
+async def test_search_finances_movers_threshold_zero_uses_default(monkeypatch):
+    """An explicit threshold of 0 (or non-positive/non-numeric) falls back to the
+    5% default rather than listing every position that moved at all."""
+    from api.services.agent_tools import _tool_search_finances
+    monkeypatch.setattr(inv, "_held_tickers", lambda: ["AMD"])
+    captured = {}
+
+    async def fake(threshold):
+        captured["threshold"] = threshold
+        return {"scheduler_message": "", "count": 0}
+
+    monkeypatch.setattr(inv, "investments_movers", fake)
+    out = await _tool_search_finances({"action": "movers", "threshold": 0})
+    assert captured["threshold"] == inv.MOVER_THRESHOLD_PCT
+    assert "more than 5% today" in out
+
+
+async def test_search_finances_movers_snapshot_not_synced(monkeypatch):
+    """On-demand: a missing snapshot says 'couldn't check' — distinct from a
+    genuinely quiet day, so the user isn't misled that the market was flat."""
+    from api.services.agent_tools import _tool_search_finances
+    monkeypatch.setattr(inv, "_held_tickers", lambda: [])
+    out = await _tool_search_finances({"action": "movers"})
+    assert "couldn't check" in out.lower() or "isn't available" in out.lower()


### PR DESCRIPTION
## Summary

Adds a `movers` action to the `search_finances` agent tool so the orchestrator (especially the finance persona) can answer *"which of my positions moved most today?"* in chat / voice / Telegram **on demand** — not just via the noon scheduled alert (#463). Reuses `investments_movers` (live day-change via yfinance for the snapshot's held tickers, offloaded off the event loop). Tickers + % only, no dollar amounts.

Closes #468

> **Scope note:** this PR originally also carried the #470 retired-specialist-model fix, but while it was in review another PR (#474) fixed #470 independently — and better (resolves the model from a new `LIFEOS_ANTHROPIC_SPECIALIST_MODEL` setting). So the branch was **rebased onto current main to contain only the #468 movers commit**; the redundant #470 change and an orphaned #471 base commit (a timestamp-normalization race) were dropped.

## Review fixes applied

- **Robust threshold:** `threshold` defaults to 5 for missing/None/non-numeric/≤0 input (an explicit `0` no longer silently lists every position).
- **Honest on-demand failure:** a missing snapshot now returns *"couldn't check right now"* rather than *"nothing moved today"* — so an on-demand ask isn't misread as a flat market.

## Test evidence

Run in a worktree off `main`. 9 movers/search_finances tests pass (action, none-today, threshold-zero→default, snapshot-not-synced). Full unit suite green earlier (2364 passed, 1 unrelated flaky-latency). **Live:** `search_finances(action='movers')` returned real day-movers.

## Review focus

- The reused `investments_movers` (async-offloaded, no dollar amounts), the threshold guard, and the snapshot-presence branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)