### PR TITLE
fix(llm): resolve the specialist-call model from settings, drop retired pin

### DIFF
--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -643,13 +643,16 @@ def get_anthropic_llm() -> AnthropicLLMClient:
     where frontier model quality provides clear value. These always use the Claude
     API regardless of the LIFEOS_LLM_BACKEND setting.
 
-    Pinned to Sonnet for quality — the orchestrator model (LIFEOS_ANTHROPIC_MODEL)
-    is independent of this.
+    Sonnet-tier for quality — resolved from LIFEOS_ANTHROPIC_SPECIALIST_MODEL
+    (default claude-sonnet-4-6), independent of the orchestrator model
+    (LIFEOS_ANTHROPIC_MODEL). Was previously hardcoded to the dated snapshot
+    claude-sonnet-4-20250514, which retired and 404'd every caller (#470).
     """
     global _anthropic_client
     if _anthropic_client is None:
-        _anthropic_client = AnthropicLLMClient(model="claude-sonnet-4-20250514")
-        logger.info("Created Anthropic client for specialist calls (claude-sonnet-4-20250514)")
+        model = settings.anthropic_specialist_model
+        _anthropic_client = AnthropicLLMClient(model=model)
+        logger.info("Created Anthropic client for specialist calls (%s)", model)
     return _anthropic_client
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -197,6 +197,15 @@ class Settings(BaseSettings):
     # Anthropic model for orchestration
     anthropic_model: str = Field(default="claude-haiku-4-5", alias="LIFEOS_ANTHROPIC_MODEL")
 
+    # Anthropic model for specialist calls (relationship insights, fact
+    # extraction, tone analysis) — Sonnet-tier for quality, independent of the
+    # orchestrator model above. Pin ALIASES here (e.g. claude-sonnet-4-6),
+    # never dated snapshots (claude-*-20YYMMDD): snapshots retire and start
+    # returning 404, silently breaking every specialist feature (#470).
+    anthropic_specialist_model: str = Field(
+        default="claude-sonnet-4-6", alias="LIFEOS_ANTHROPIC_SPECIALIST_MODEL"
+    )
+
     # Local LLM (OpenAI-compatible server, e.g. llama-server)
     local_llm_url: str = Field(default="http://localhost:8080", alias="LIFEOS_LOCAL_LLM_URL")
     local_llm_timeout: int = Field(default=90, alias="LIFEOS_LOCAL_LLM_TIMEOUT")

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -342,17 +342,21 @@ class TestSingleton:
                 pytest.skip("anthropic package not installed")
         reset_local_llm()
 
-    def test_specialist_client_pinned_to_sonnet(self):
-        """get_anthropic_llm() specialist client stays on Sonnet regardless of LIFEOS_ANTHROPIC_MODEL."""
+    def test_specialist_client_resolves_model_from_settings(self):
+        """get_anthropic_llm() resolves LIFEOS_ANTHROPIC_SPECIALIST_MODEL,
+        independent of the orchestrator model (#470 — was a hardcoded dated
+        snapshot that retired and 404'd every specialist caller)."""
         from api.services.llm_client import get_anthropic_llm, reset_local_llm, AnthropicLLMClient
         reset_local_llm()
         with patch("api.services.llm_client.settings") as mock_settings:
             mock_settings.anthropic_api_key = "sk-ant-test-key"
             mock_settings.anthropic_model = "claude-haiku-4-5"
+            mock_settings.anthropic_specialist_model = "claude-sonnet-4-6"
             try:
                 client = get_anthropic_llm()
                 assert isinstance(client, AnthropicLLMClient)
-                assert client._model == "claude-sonnet-4-20250514"
+                assert client._model == "claude-sonnet-4-6"
+                assert client._model != mock_settings.anthropic_model  # independent
             except ImportError:
                 pytest.skip("anthropic package not installed")
         reset_local_llm()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -38,3 +38,35 @@ def test_local_llm_model_from_env(monkeypatch):
     from config.settings import Settings
     s = Settings()
     assert s.local_llm_model == "some-org/qwen3-32b-GGUF"
+
+
+def test_specialist_model_default_is_current_alias():
+    """#470 regression pin: the specialist-call model must be a model ALIAS,
+    never a dated snapshot. The previous pin (claude-sonnet-4-20250514)
+    retired and returned 404 on every relationship-insights / fact-extraction /
+    tone-analysis call — silently, since callers swallow per-item errors.
+    Aliases track the serving model and don't retire out from under us.
+
+    Asserts the FIELD default (env-independent), not the live instance — a
+    host may legitimately override via LIFEOS_ANTHROPIC_SPECIALIST_MODEL.
+    """
+    import re
+
+    from config.settings import Settings
+
+    default = Settings.model_fields["anthropic_specialist_model"].default
+    assert default == "claude-sonnet-4-6"
+    assert not re.search(r"-20\d{6}$", default), (
+        "specialist model default is a dated snapshot — pin an alias instead "
+        "(snapshots retire and 404)"
+    )
+
+
+def test_orchestrator_model_default_is_alias_not_snapshot():
+    """Same rule for the orchestrator default (#470 guard, defense in depth)."""
+    import re
+
+    from config.settings import Settings
+
+    default = Settings.model_fields["anthropic_model"].default
+    assert not re.search(r"-20\d{6}$", default)


### PR DESCRIPTION
Closes #470.

## Problem

`get_anthropic_llm()` was hardcoded to the dated snapshot `claude-sonnet-4-20250514`, which retired and now returns 404 — silently breaking every specialist caller (relationship insights, fact extraction, tone analysis; callers swallow per-item errors, so nothing surfaced).

## Fix

- New setting `LIFEOS_ANTHROPIC_SPECIALIST_MODEL` (default `claude-sonnet-4-6`) resolved at client creation — the issue's suggested "resolve from a setting" approach.
- `claude-sonnet-4-6` chosen over Sonnet 5 deliberately: same price point, current alias, and a true drop-in — this client's generic interface exposes `temperature`, which Sonnet 5 rejects (400 on non-default sampling params) while Sonnet 4.6 accepts.
- **Guard tests** pin the rule from the issue's acceptance criteria: both the specialist and orchestrator defaults must be model *aliases*, never dated snapshots (`-20YYMMDD`) — snapshots retire out from under us; aliases track the serving model. Asserted on the field defaults (env-independent, so host overrides don't break the tests).
- Existing pin test updated for the intentional behavior change, keeping its original intent (specialist model independent of orchestrator model).

End-to-end verification of the three specialist callers happens post-deploy with a live probe call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)