### PR TITLE
fix(agent-worker): kill orphan remote managed sessions in resume_pending

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -528,6 +528,29 @@ class Worker:
                 )
                 recovered += 1
                 continue
+            # #198: a remote Managed Agents session survives a worker restart —
+            # it keeps running on Anthropic's infrastructure, making MCP tool
+            # calls with real side effects (task creation, vault writes, sends)
+            # long after this rollback tells the operator the task was rolled
+            # back. Kill it before finalizing. Best-effort: a kill failure
+            # (404, network) must not block the rollback.
+            if session.managed_agent_session_id:
+                managed = self._get_managed_executor()
+                if managed is not None and managed.driver is not None:
+                    try:
+                        managed.driver.kill_session(
+                            session.managed_agent_session_id,
+                            reason="worker_restart_rollback",
+                        )
+                        self.transcript_store.append(
+                            sid, "orphan_remote_session_killed", {
+                                "managed_agent_session_id": session.managed_agent_session_id,
+                            })
+                    except Exception as exc:
+                        logger.warning(
+                            "kill_session %s on restart rollback failed: %s",
+                            session.managed_agent_session_id, exc,
+                        )
             self.transcript_store.append(sid, "resume_failed", {"prior_status": session.status})
             self.session_store.update_status(session.task_id, STATUS_FAILED)
             # Spawned children belong to a parent's lineage — they have no

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -883,6 +883,79 @@ def test_recovery_inlines_short_text_tool_result(tmp_path: Path):
 
 
 @pytest.mark.unit
+class _FakeManagedDriver:
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.kills: list[tuple[str, str]] = []
+
+    def kill_session(self, session_id: str, reason: str = "") -> None:
+        if self.fail:
+            raise RuntimeError("remote kill 404")
+        self.kills.append((session_id, reason))
+
+
+class _FakeManagedExecutor:
+    def __init__(self, fail: bool = False):
+        self.driver = _FakeManagedDriver(fail=fail)
+
+
+def test_resume_pending_kills_orphan_remote_session(tmp_path: Path):
+    """#198: rolling back a session with a live remote Managed Agents session
+    must kill the remote session — otherwise it keeps running on Anthropic's
+    infrastructure, making MCP tool calls with side effects long after the
+    operator was told the task was rolled back."""
+    from api.services.agent_worker.session_store import STATUS_FAILED, STATUS_RUNNING
+
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "cloud task", "status": "in_progress",
+         "tags": [RUNNING_TAG, "cloud"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude"),
+                     local_executor=executor)
+    fake_managed = _FakeManagedExecutor()
+    w._managed_executor = fake_managed
+    w.session_store.create(
+        task_id="t1", routing="claude", status=STATUS_RUNNING, expected_output="text",
+    )
+    w.session_store.set_managed_session_id("t1", "sesn_remote_orphan")
+
+    n = w.resume_pending()
+
+    assert n == 1
+    assert fake_managed.driver.kills == [("sesn_remote_orphan", "worker_restart_rollback")]
+    assert w.session_store.get("t1").status == STATUS_FAILED
+    sid = w.session_store.get("t1").session_id
+    kinds = [e["kind"] for e in w.transcript_store.read(sid)]
+    assert "orphan_remote_session_killed" in kinds
+
+
+def test_resume_pending_rollback_survives_kill_failure(tmp_path: Path):
+    """#198: a kill failure (remote 404, network error) must not block the
+    local rollback — the session still finalizes FAILED."""
+    from api.services.agent_worker.session_store import STATUS_FAILED, STATUS_RUNNING
+
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "cloud task", "status": "in_progress",
+         "tags": [RUNNING_TAG, "cloud"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude"),
+                     local_executor=executor)
+    w._managed_executor = _FakeManagedExecutor(fail=True)
+    w.session_store.create(
+        task_id="t1", routing="claude", status=STATUS_RUNNING, expected_output="text",
+    )
+    w.session_store.set_managed_session_id("t1", "sesn_remote_orphan")
+
+    n = w.resume_pending()
+
+    assert n == 1
+    assert w.session_store.get("t1").status == STATUS_FAILED
+
+
 def test_resume_pending_does_not_telegram_for_spawned_children(tmp_path: Path):
     """Live bug: after a worker restart, the startup-recovery path saw a
     spawned child stuck in RUNNING, rolled it back, and pinged the


### PR DESCRIPTION
Closes #198.

## Problem (from the issue, observed 2026-05-27)

`resume_pending()` rolls back local state after a worker restart — marks the row FAILED, swaps the vault tag back to `#agent`, notifies the operator — but never terminated the remote Managed Agents session. The orphan kept running on Anthropic's infrastructure, making MCP tool calls against our HTTP endpoint with real side effects (in the observed incident: creating a bogus follow-up task referencing a document it never wrote) long after the operator was told the task was rolled back.

## Fix

Exactly the issue's suggested approach: in the rollback path, when `managed_agent_session_id` is set, call `managed.driver.kill_session(..., reason="worker_restart_rollback")` before finalizing — mirroring the existing block-on-clarification kill at `ask_user_via_telegram`. Wrapped in try/except: a kill failure (remote 404, network error) logs a warning and never blocks the rollback. An `orphan_remote_session_killed` transcript event records the kill.

## Tests

- `test_resume_pending_kills_orphan_remote_session`: remote kill invoked with the right id + reason, session finalizes FAILED, transcript event present.
- `test_resume_pending_rollback_survives_kill_failure`: driver raising doesn't block the rollback.
- Full suite: known env-dependent baseline only.

Context: worker restarts are much rarer since #466 removed the api→worker cascade, but worker-code deploys and genuine crashes still hit this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)