### PR TITLE
chore(models): bump the Sonnet-tier references from Sonnet 4.6 to Sonnet 5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,7 +117,7 @@
 #
 # Informational: kept for client-side token-cost accounting and visibility in
 # logs. The actual model the agent uses is whatever the agent preset says.
-# LIFEOS_AGENT_MANAGED_MODEL=claude-sonnet-4-6
+# LIFEOS_AGENT_MANAGED_MODEL=claude-sonnet-5
 #
 # Optional dev-only override of LIFEOS_AGENT_MANAGED_MODEL for prompt-engineering
 # iteration. Set to e.g. claude-haiku-4-5 to swap client-side cost accounting to

--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -166,7 +166,7 @@ def _escalation_ladder(escalation_model: str) -> list[str]:
     (comma-separated model ids / engine names), else derives a default from
     ``escalation_model``: [escalation_model, claude_code] — so the engine
     handoff lands on the 2nd pushback (1st → stronger model, 2nd → Claude Code).
-    Set the env var to e.g. 'claude-sonnet-4-6,claude-opus-4-8,claude_code' to
+    Set the env var to e.g. 'claude-sonnet-5,claude-opus-4-8,claude_code' to
     insert an opus rung in between. Empty when escalation isn't configured.
     Deduped, order preserved."""
     raw = (getattr(settings, "agent_escalation_ladder", "") or "").strip()
@@ -189,7 +189,7 @@ def _escalation_ladder(escalation_model: str) -> list[str]:
 # account is pinned to a different opus release.
 _MODEL_ALIASES = {
     "haiku": "claude-haiku-4-5",
-    "sonnet": "claude-sonnet-4-6",
+    "sonnet": "claude-sonnet-5",
     "opus": "claude-opus-4-8",
 }
 # A directive verb immediately followed by a tier word: "escalate to opus",

--- a/api/services/agent_worker/managed_executor.py
+++ b/api/services/agent_worker/managed_executor.py
@@ -179,7 +179,7 @@ class ManagedExecutor:
         agent_id: str,
         environment_id: str,
         vault_ids: list[str] | None = None,
-        model: str = "claude-sonnet-4-6",
+        model: str = "claude-sonnet-5",
     ):
         self.session_store = session_store
         self.transcript_store = transcript_store

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -48,7 +48,7 @@ OUTPUT_KINDS = ("text", "file", "external_action", "structured")
 # local Gemma backend. None means "no override, use settings.agent_managed_model".
 MODEL_LOCAL = "local"
 MODEL_HAIKU = "claude-haiku-4-5"
-MODEL_SONNET = "claude-sonnet-4-6"
+MODEL_SONNET = "claude-sonnet-5"
 ALLOWED_MODELS = (MODEL_LOCAL, MODEL_HAIKU, MODEL_SONNET)
 
 
@@ -307,7 +307,7 @@ def _apply_tag_overrides(result: PreflightResult, tags: list[str]) -> PreflightR
       `#claude`       → routing=code   (Claude Code CLI, subscription-billed)
       `#codex`        → routing=codex  (Codex CLI, subscription-billed)
       `#cloud-haiku`  → routing=claude, model=claude-haiku-4-5
-      `#cloud-sonnet` → routing=claude, model=claude-sonnet-4-6
+      `#cloud-sonnet` → routing=claude, model=claude-sonnet-5
       `#cloud`        → routing=claude, model=(whatever preflight picked, else Sonnet)
 
     Returns a new PreflightResult so the caller can chain. Tag list is

--- a/api/services/agent_worker/pricing.py
+++ b/api/services/agent_worker/pricing.py
@@ -23,6 +23,7 @@ PRICING: dict[str, dict[str, float]] = {
     "claude-opus-4-8":   {"input": 15.0e-6, "output": 75.0e-6},
     "claude-opus-4-7":   {"input": 15.0e-6, "output": 75.0e-6},
     "claude-opus-4-6":   {"input": 15.0e-6, "output": 75.0e-6},
+    "claude-sonnet-5":   {"input":  3.0e-6, "output": 15.0e-6},
     "claude-sonnet-4-6": {"input":  3.0e-6, "output": 15.0e-6},
     "claude-sonnet-4-5": {"input":  3.0e-6, "output": 15.0e-6},
     "claude-haiku-4-5":  {"input":  0.8e-6, "output":  4.0e-6},

--- a/api/services/claude_code/session_ingest.py
+++ b/api/services/claude_code/session_ingest.py
@@ -400,7 +400,7 @@ def _cost_from_usage(usage: dict[str, Any], model: str) -> float:
     out_tok = int(usage.get(_USAGE_OUTPUT, 0) or 0)
     cache_creation = int(usage.get(_USAGE_CACHE_CREATION, 0) or 0)
     cache_read = int(usage.get(_USAGE_CACHE_READ, 0) or 0)
-    use_model = model or "claude-sonnet-4-6"  # safer default than the Opus fallback
+    use_model = model or "claude-sonnet-5"  # safer default than the Opus fallback
     return cost_for(
         use_model,
         in_tok,

--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -644,7 +644,7 @@ def get_anthropic_llm() -> AnthropicLLMClient:
     API regardless of the LIFEOS_LLM_BACKEND setting.
 
     Sonnet-tier for quality — resolved from LIFEOS_ANTHROPIC_SPECIALIST_MODEL
-    (default claude-sonnet-4-6), independent of the orchestrator model
+    (default claude-sonnet-5), independent of the orchestrator model
     (LIFEOS_ANTHROPIC_MODEL). Was previously hardcoded to the dated snapshot
     claude-sonnet-4-20250514, which retired and 404'd every caller (#470).
     """

--- a/config/settings.py
+++ b/config/settings.py
@@ -199,11 +199,11 @@ class Settings(BaseSettings):
 
     # Anthropic model for specialist calls (relationship insights, fact
     # extraction, tone analysis) — Sonnet-tier for quality, independent of the
-    # orchestrator model above. Pin ALIASES here (e.g. claude-sonnet-4-6),
+    # orchestrator model above. Pin ALIASES here (e.g. claude-sonnet-5),
     # never dated snapshots (claude-*-20YYMMDD): snapshots retire and start
     # returning 404, silently breaking every specialist feature (#470).
     anthropic_specialist_model: str = Field(
-        default="claude-sonnet-4-6", alias="LIFEOS_ANTHROPIC_SPECIALIST_MODEL"
+        default="claude-sonnet-5", alias="LIFEOS_ANTHROPIC_SPECIALIST_MODEL"
     )
 
     # Local LLM (OpenAI-compatible server, e.g. llama-server)
@@ -290,7 +290,7 @@ class Settings(BaseSettings):
                     "classifies #agent tasks (budget, routing, ambiguity, sanity)."
     )
     agent_managed_model: str = Field(
-        default="claude-sonnet-4-6",
+        default="claude-sonnet-5",
         alias="LIFEOS_AGENT_MANAGED_MODEL",
         description="Anthropic model the Managed Agents executor uses for "
                     "Claude-routed #agent tasks. Informational only — the "
@@ -315,7 +315,7 @@ class Settings(BaseSettings):
                     "pushing back ('do research', 'you're wrong'). Empty (default) "
                     "disables escalation — safe for fresh clones and the local "
                     "backend. Set to a stronger model than LIFEOS_ANTHROPIC_MODEL "
-                    "(e.g. claude-sonnet-4-6 or claude-opus-4-8) to enable. Only "
+                    "(e.g. claude-sonnet-5 or claude-opus-4-8) to enable. Only "
                     "applies to the Anthropic backend."
     )
     agent_escalation_ladder: str = Field(
@@ -328,7 +328,7 @@ class Settings(BaseSettings):
                     "from LIFEOS_AGENT_ESCALATION_MODEL: [that model, claude_code] "
                     "— so the Claude Code handoff lands on the 2nd pushback. "
                     "Override to insert rungs, e.g. "
-                    "'claude-sonnet-4-6,claude-opus-4-8,claude_code'."
+                    "'claude-sonnet-5,claude-opus-4-8,claude_code'."
     )
     agent_cost_confirm_threshold_dollars: float = Field(
         default=1.0,

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -194,7 +194,7 @@ Workspace → Agents → New. Paste the YAML below (replace the LifeOS hostname 
 name: LifeOS Worker
 description: Autonomous executor for agent-tagged tasks from LifeOS.
 model:
-  id: claude-sonnet-4-6
+  id: claude-sonnet-5
   speed: standard
 system: |-
   <role>
@@ -308,7 +308,7 @@ Every `mcp_servers` entry must have a matching `mcp_toolset` in `tools` (and vic
 LIFEOS_AGENT_PRESET_ID=agent_<your_agent_id>
 LIFEOS_AGENT_ENVIRONMENT_ID=env_<your_environment_id>
 LIFEOS_AGENT_VAULT_ID=vlt_<your_vault_id>
-LIFEOS_AGENT_MANAGED_MODEL=claude-sonnet-4-6   # informational; actual model lives in the preset
+LIFEOS_AGENT_MANAGED_MODEL=claude-sonnet-5   # informational; actual model lives in the preset
 ANTHROPIC_API_KEY=sk-ant-...                    # already required for the Haiku preflight
 ```
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -56,7 +56,7 @@ Governs chat synthesis, intent classification, and agentic orchestration. The to
 | `LIFEOS_LLM_BACKEND` | str | `anthropic` | `local` (llama-server on `LIFEOS_LOCAL_LLM_URL`) or `anthropic` (Claude API). Recorded in ADR-009. |
 | `LIFEOS_ANTHROPIC_MODEL` | str | `claude-haiku-4-5` | **Base** Claude model for chat orchestration when `LIFEOS_LLM_BACKEND=anthropic`. Per-query escalation can override it for a turn (see below). |
 | `LIFEOS_AGENT_ESCALATION_MODEL` | str | — (off) | Stronger model a chat turn escalates to when the user pushes back on a refusal, or asks ("escalate to opus"). Empty disables escalation. Anthropic backend only. |
-| `LIFEOS_AGENT_ESCALATION_LADDER` | str | — (derived) | Comma-separated escalation rungs (models / engine names `codex`,`claude_code`). Empty derives `[escalation_model, claude_code]` — so a 2nd pushback hands off to Claude Code. Override e.g. `claude-sonnet-4-6,claude-opus-4-8,claude_code`. |
+| `LIFEOS_AGENT_ESCALATION_LADDER` | str | — (derived) | Comma-separated escalation rungs (models / engine names `codex`,`claude_code`). Empty derives `[escalation_model, claude_code]` — so a 2nd pushback hands off to Claude Code. Override e.g. `claude-sonnet-5,claude-opus-4-8,claude_code`. |
 | `ANTHROPIC_API_KEY` | str | — | Required when `LIFEOS_LLM_BACKEND=anthropic`. Also used by specialized calls regardless of backend (relationship insights, fact extraction, web search). |
 | `LIFEOS_LOCAL_LLM_URL` | str | `http://localhost:8080` | Local llama-server endpoint. |
 | `LIFEOS_LOCAL_LLM_TIMEOUT` | int | `90` | Local LLM HTTP request timeout, seconds. |
@@ -119,7 +119,7 @@ The HTTP MCP transport exposes LifeOS tools to remote agents (primarily Anthropi
 | `LIFEOS_AGENT_COST_CONFIRM_THRESHOLD_DOLLARS` | float | varies | Threshold above which preflight requires Telegram confirmation before running a task. |
 | `LIFEOS_AGENT_OUTPUT_DIR` | path | `LifeOS/Tasks/Agent Output` | Vault-relative folder where the worker writes an Agent Output note on every successful task completion (one note per one-off task; one shared, prepended note per recurring cron schedule). |
 | `LIFEOS_AGENT_PREFLIGHT_MODEL` | str | `claude-haiku-4-5` | Model used for preflight (budget parsing, routing, ambiguity, sanity). |
-| `LIFEOS_AGENT_MANAGED_MODEL` | str | `claude-sonnet-4-6` | Informational — actual model lives in the Anthropic Console preset. |
+| `LIFEOS_AGENT_MANAGED_MODEL` | str | `claude-sonnet-5` | Informational — actual model lives in the Anthropic Console preset. |
 | `LIFEOS_AGENT_MANAGED_MODEL_FOR_TESTS` | str | — | Override for test runs. |
 | `LIFEOS_AGENT_MAX_SPAWN_DEPTH` | int | varies | Hard cap on nested spawn depth (parent → child → grandchild). |
 | `LIFEOS_AGENT_MAX_DESCENDANTS_PER_ROOT` | int | varies | Total descendants per root session. |

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -178,7 +178,7 @@ All in `.env` — see [`agent-worker-setup.md`](../../guides/agent-worker-setup.
 | `LIFEOS_AGENT_DEFAULT_BUDGET_DOLLARS` | Default per-task $-cap when title doesn't specify | `5.00` |
 | `LIFEOS_AGENT_WORKER_POLL_SECONDS` | Polling interval | `60` |
 | `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` | Telegram-clarification wait before abandoning | `72` |
-| `LIFEOS_AGENT_MANAGED_MODEL` | Informational; actual model lives in the cloud preset | `claude-sonnet-4-6` |
+| `LIFEOS_AGENT_MANAGED_MODEL` | Informational; actual model lives in the cloud preset | `claude-sonnet-5` |
 
 ---
 

--- a/docs/specs/technical/security-privacy.md
+++ b/docs/specs/technical/security-privacy.md
@@ -38,7 +38,7 @@ Whether chat traffic leaves the machine depends on `LIFEOS_LLM_BACKEND`. The def
 |------|-------------|---------|-----------|
 | Query text (≤64 tokens of classification output) | Anthropic API (default) — Claude Haiku | Intent classification (`code` vs. ambiguous vs. agentic) | Per user query, unless `LIFEOS_LLM_BACKEND=local` |
 | Query text + retrieved tool results | Anthropic API (default) or local llama-server | Agentic orchestration & synthesis | Per user query and per tool round |
-| Email/note snippets for specialist tasks (web-search synthesis, fact extraction, relationship insights) | Anthropic API — pinned to `claude-sonnet-4-20250514` via `get_anthropic_llm()` | Quality-sensitive sub-calls | Per tool invocation, regardless of backend setting |
+| Email/note snippets for specialist tasks (web-search synthesis, fact extraction, relationship insights) | Anthropic API — Sonnet via `get_anthropic_llm()` (resolves from `LIFEOS_ANTHROPIC_SPECIALIST_MODEL`, default `claude-sonnet-5`) | Quality-sensitive sub-calls | Per tool invocation, regardless of backend setting |
 | OAuth authentication flows | Google, Slack | Token refresh | Periodic |
 | Reminder messages, sync summaries | Telegram Bot API | Notification delivery | Per reminder / nightly |
 

--- a/tests/test_agent_escalation.py
+++ b/tests/test_agent_escalation.py
@@ -165,14 +165,14 @@ def test_resolve_no_escalation_when_not_triggered():
     ("use opus please", "claude-opus-4-8"),
     ("with claude opus", "claude-opus-4-8"),
     ("retry on opus", "claude-opus-4-8"),
-    ("use sonnet", "claude-sonnet-4-6"),
-    ("switch to sonnet", "claude-sonnet-4-6"),
+    ("use sonnet", "claude-sonnet-5"),
+    ("switch to sonnet", "claude-sonnet-5"),
     ("use haiku for this", "claude-haiku-4-5"),
 ])
 def test_named_tier_directive_selects_that_model(question, expected):
     # No history / no refusal — the directive alone drives the choice. Base is a
     # model different from the target so escalation is observable.
-    base = "claude-haiku-4-5" if expected != "claude-haiku-4-5" else "claude-sonnet-4-6"
+    base = "claude-haiku-4-5" if expected != "claude-haiku-4-5" else "claude-sonnet-5"
     model, escalated = resolve_orchestrator_model([], question, base_model=base, escalation_model="")
     assert (model, escalated) == (expected, True)
 
@@ -194,9 +194,9 @@ def test_named_tier_works_without_escalation_model_configured():
 ])
 def test_generic_directive_falls_back_to_configured_model(question):
     model, escalated = resolve_orchestrator_model(
-        [], question, base_model="claude-haiku-4-5", escalation_model="claude-sonnet-4-6"
+        [], question, base_model="claude-haiku-4-5", escalation_model="claude-sonnet-5"
     )
-    assert (model, escalated) == ("claude-sonnet-4-6", True)
+    assert (model, escalated) == ("claude-sonnet-5", True)
 
 
 @pytest.mark.parametrize("question", [
@@ -213,7 +213,7 @@ def test_negated_question_and_engine_directives_do_not_escalate(question):
     """Negations, meta-questions, unsupported-engine names, and non-model uses of
     'escalate' must not trigger a model swap."""
     model, escalated = resolve_orchestrator_model(
-        [], question, base_model="claude-haiku-4-5", escalation_model="claude-sonnet-4-6"
+        [], question, base_model="claude-haiku-4-5", escalation_model="claude-sonnet-5"
     )
     assert (model, escalated) == ("claude-haiku-4-5", False)
 
@@ -223,7 +223,7 @@ def test_contrastive_directive_still_honors_named_model():
     model, escalated = resolve_orchestrator_model(
         [], "use sonnet instead of opus", base_model="claude-haiku-4-5", escalation_model=""
     )
-    assert (model, escalated) == ("claude-sonnet-4-6", True)
+    assert (model, escalated) == ("claude-sonnet-5", True)
 
 
 def test_generic_directive_noops_when_unconfigured():
@@ -245,7 +245,7 @@ def test_directive_beats_auto_heuristic_without_refusal():
     model, escalated = resolve_orchestrator_model(
         [FakeMessage("assistant", "Here are your three games.")],
         "actually, use opus",
-        base_model="claude-haiku-4-5", escalation_model="claude-sonnet-4-6",
+        base_model="claude-haiku-4-5", escalation_model="claude-sonnet-5",
     )
     assert (model, escalated) == ("claude-opus-4-8", True)
 
@@ -279,14 +279,14 @@ def _refusal_history(n):
 
 
 @pytest.mark.parametrize("n_refusals, expected", [
-    (1, "claude-sonnet-4-6"),   # rung 0 — the escalation model (1st pushback)
+    (1, "claude-sonnet-5"),   # rung 0 — the escalation model (1st pushback)
     (2, "claude_code"),         # rung 1 — engine handoff (2nd pushback)
     (3, "claude_code"),         # capped at the top rung
 ])
 def test_ladder_climbs_with_each_refusal(n_refusals, expected):
     model, escalated = resolve_orchestrator_model(
         _refusal_history(n_refusals), _PUSHBACK,
-        base_model="claude-haiku-4-5", escalation_model="claude-sonnet-4-6",
+        base_model="claude-haiku-4-5", escalation_model="claude-sonnet-5",
     )
     assert (model, escalated) == (expected, True)
 
@@ -302,9 +302,9 @@ def test_user_directive_overrides_ladder_rung():
     # Even three deep into the ladder, an explicit "use sonnet" wins.
     model, escalated = resolve_orchestrator_model(
         _refusal_history(3), "use sonnet",
-        base_model="claude-haiku-4-5", escalation_model="claude-sonnet-4-6",
+        base_model="claude-haiku-4-5", escalation_model="claude-sonnet-5",
     )
-    assert (model, escalated) == ("claude-sonnet-4-6", True)
+    assert (model, escalated) == ("claude-sonnet-5", True)
 
 
 def test_escalation_cycles_breaks_on_normal_exchange():
@@ -335,9 +335,9 @@ def test_stale_refusals_do_not_jump_to_engine_rung():
         FakeMessage("assistant", _REFUSAL),     # fresh refusal, user about to push back
     ]
     model, escalated = resolve_orchestrator_model(
-        history, _PUSHBACK, base_model="claude-haiku-4-5", escalation_model="claude-sonnet-4-6"
+        history, _PUSHBACK, base_model="claude-haiku-4-5", escalation_model="claude-sonnet-5"
     )
-    assert (model, escalated) == ("claude-sonnet-4-6", True)  # rung 0, not the engine
+    assert (model, escalated) == ("claude-sonnet-5", True)  # rung 0, not the engine
 
 
 def test_engine_handoff_recovers_original_request():
@@ -356,11 +356,11 @@ def test_base_model_filtered_from_ladder(monkeypatch):
     # climb going instead of stalling on the rung that equals base.
     monkeypatch.setattr(
         "api.services.agent_loop.settings.agent_escalation_ladder",
-        "claude-sonnet-4-6,claude-opus-4-8,claude_code", raising=False,
+        "claude-sonnet-5,claude-opus-4-8,claude_code", raising=False,
     )
     model, escalated = resolve_orchestrator_model(
         _refusal_history(2), _PUSHBACK,
-        base_model="claude-opus-4-8", escalation_model="claude-sonnet-4-6",
+        base_model="claude-opus-4-8", escalation_model="claude-sonnet-5",
     )
     # ladder after filtering opus = [sonnet, claude_code]; cycles=1 → rung 1.
     assert (model, escalated) == ("claude_code", True)
@@ -369,12 +369,12 @@ def test_base_model_filtered_from_ladder(monkeypatch):
 def test_explicit_ladder_setting_overrides_default(monkeypatch):
     monkeypatch.setattr(
         "api.services.agent_loop.settings.agent_escalation_ladder",
-        "claude-sonnet-4-6,claude-opus-4-8", raising=False,
+        "claude-sonnet-5,claude-opus-4-8", raising=False,
     )
     # Custom ladder has no engine rung — 3rd refusal caps at opus.
     model, _ = resolve_orchestrator_model(
         _refusal_history(3), _PUSHBACK,
-        base_model="claude-haiku-4-5", escalation_model="claude-sonnet-4-6",
+        base_model="claude-haiku-4-5", escalation_model="claude-sonnet-5",
     )
     assert model == "claude-opus-4-8"
 
@@ -476,7 +476,7 @@ def test_select_client_ignores_model_on_local_backend(monkeypatch):
 
 @pytest.mark.parametrize("name,expected", [
     ("haiku", "claude-haiku-4-5"),
-    ("sonnet", "claude-sonnet-4-6"),
+    ("sonnet", "claude-sonnet-5"),
     ("opus", "claude-opus-4-8"),
     ("Opus", "claude-opus-4-8"),            # case-insensitive
     ("claude-opus-4-8", "claude-opus-4-8"),  # a full id passes through

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -351,11 +351,11 @@ class TestSingleton:
         with patch("api.services.llm_client.settings") as mock_settings:
             mock_settings.anthropic_api_key = "sk-ant-test-key"
             mock_settings.anthropic_model = "claude-haiku-4-5"
-            mock_settings.anthropic_specialist_model = "claude-sonnet-4-6"
+            mock_settings.anthropic_specialist_model = "claude-sonnet-5"
             try:
                 client = get_anthropic_llm()
                 assert isinstance(client, AnthropicLLMClient)
-                assert client._model == "claude-sonnet-4-6"
+                assert client._model == "claude-sonnet-5"
                 assert client._model != mock_settings.anthropic_model  # independent
             except ImportError:
                 pytest.skip("anthropic package not installed")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -55,7 +55,7 @@ def test_specialist_model_default_is_current_alias():
     from config.settings import Settings
 
     default = Settings.model_fields["anthropic_specialist_model"].default
-    assert default == "claude-sonnet-4-6"
+    assert default == "claude-sonnet-5"
     assert not re.search(r"-20\d{6}$", default), (
         "specialist model default is a dated snapshot — pin an alias instead "
         "(snapshots retire and 404)"


### PR DESCRIPTION
## Summary

Moves every **Sonnet-tier** model reference in LifeOS from `claude-sonnet-4-6` to **`claude-sonnet-5`** — the current newest Sonnet, same $3/$15 price tier (a pure quality bump). Per Nathan's call: **Sonnet-tier only** — Opus 4.8 and Haiku 4.5 are already current, and the always-on Haiku orchestrator/classifier is deliberately left cheap. (Note: `claude-sonnet-4-8` doesn't exist — the newest Sonnet is Sonnet 5.)

## What changed

| Slot | File |
|---|---|
| Specialist calls (`LIFEOS_ANTHROPIC_SPECIALIST_MODEL` default) | `config/settings.py` |
| Managed agent executor (`LIFEOS_AGENT_MANAGED_MODEL` default) | `config/settings.py`, `managed_executor.py` |
| `sonnet` escalation alias + agent-worker `#cloud-sonnet` (`MODEL_SONNET`) | `agent_loop.py`, `preflight.py` |
| Claude Code session-ingest default | `session_ingest.py` |
| Pricing table | `pricing.py` — **added** a `claude-sonnet-5` entry ($3/$15), **kept** `claude-sonnet-4-6` for historical cost lookups |
| Docstrings / comments / `.env.example` / docs | `llm_client.py`, `settings.py`, `agent-worker-setup.md`, `configuration.md`, `agent-worker.md` |

Haiku 4.5 (`anthropic_model`, `agent_preflight_model`) and Opus 4.8 (`opus` alias) are untouched.

## Test evidence

`pytest -m unit` (worktree off main): **2369 passed, 0 failed.** Updated the alias/default assertions (`test_settings`, `test_agent_escalation`, `test_llm_client`); intentionally left the fixture/pricing tests that reference the *kept* `sonnet-4-6` entry (`test_agent_worker_managed_driver`, `test_agent_worker_local_executor`, historical-session fixtures).

## Review focus

- No behavioral Sonnet-4.6 default/alias left behind; Haiku/Opus untouched.
- The pricing table keeps `sonnet-4-6` (for old cost logs) and adds `sonnet-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)