### PR TITLE
fix(fitness): set durations + guard against phantom 'Logged' replies

### DIFF
--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -63,16 +63,21 @@ def _looks_like_giving_up(text: str) -> bool:
 # Phantom-write guard: a reply that opens with "Logged …" / "Updated …" claims a
 # state change. If the turn made ZERO tool calls, nothing was written — the model
 # pattern-matched earlier confirmation lines in the conversation history instead
-# of calling the tool (observed with the fitness bot on Haiku: replies like
-# "Logged 6/20: Pec Fly Machine 3×12" with tool_rounds=0 silently lost sets).
+# of calling the tool (observed with the fitness bot on a weak model: "Logged …"
+# replies with tool_rounds=0 silently lost sets). Scope: only the zero-tool-call
+# turn is caught; a turn that makes a READ call and then claims a write still
+# passes — that variant hasn't been observed and distinguishing reads from
+# writes here isn't worth the tool-registry coupling yet.
 _WRITE_CLAIM_PATTERN = re.compile(r"(?i)^\s*(logged|updated|recorded|saved)\b")
 
 PHANTOM_WRITE_NUDGE = (
     "Stop — you replied as if something was recorded, but you made NO tool call "
-    "this turn, so nothing was saved. If the user's message contains data to "
-    "record (a workout, a metric, a task…), call the appropriate tool NOW to "
-    "actually record it, then confirm. If nothing needed recording, rephrase "
-    "your answer without claiming anything was logged or updated."
+    "this turn, so nothing was saved. If the user's CURRENT message contains new "
+    "data to record (a workout, a metric, a task…), call the appropriate tool NOW "
+    "to actually record it, then confirm. If it was already recorded in a "
+    "PREVIOUS turn, do NOT record it again — just answer the question. If "
+    "nothing needed recording, rephrase your answer without claiming anything "
+    "was logged or updated."
 )
 
 

--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -60,6 +60,27 @@ def _looks_like_giving_up(text: str) -> bool:
     return bool(_GIVE_UP_PATTERNS.search(text))
 
 
+# Phantom-write guard: a reply that opens with "Logged …" / "Updated …" claims a
+# state change. If the turn made ZERO tool calls, nothing was written — the model
+# pattern-matched earlier confirmation lines in the conversation history instead
+# of calling the tool (observed with the fitness bot on Haiku: replies like
+# "Logged 6/20: Pec Fly Machine 3×12" with tool_rounds=0 silently lost sets).
+_WRITE_CLAIM_PATTERN = re.compile(r"(?i)^\s*(logged|updated|recorded|saved)\b")
+
+PHANTOM_WRITE_NUDGE = (
+    "Stop — you replied as if something was recorded, but you made NO tool call "
+    "this turn, so nothing was saved. If the user's message contains data to "
+    "record (a workout, a metric, a task…), call the appropriate tool NOW to "
+    "actually record it, then confirm. If nothing needed recording, rephrase "
+    "your answer without claiming anything was logged or updated."
+)
+
+
+def _claims_write_without_tools(text: str) -> bool:
+    """Reply asserts a write ('Logged …') — only meaningful when no tools ran."""
+    return bool(_WRITE_CLAIM_PATTERN.match(text))
+
+
 # Cross-turn escalation (#303). A weak orchestrator sometimes declares something
 # impossible / unavailable / "not released" from stale training and won't budge.
 # When the PRIOR assistant turn refused like that AND the user's NEW message pushes
@@ -475,6 +496,7 @@ async def run_agent_loop(
     messages.append({"role": "user", "content": user_content})
 
     result = AgentResult(full_text="", model="local")
+    phantom_write_nudged = False  # phantom-write self-correction fires at most once per turn
 
     def _track_usage(usage: LLMUsage):
         result.total_input_tokens += usage.input_tokens
@@ -577,6 +599,19 @@ async def run_agent_loop(
                 result.full_text = ""
                 messages.append({"role": "assistant", "content": assistant_content})
                 messages.append({"role": "user", "content": SELF_CORRECTION_NUDGE})
+                continue
+            if (
+                not phantom_write_nudged
+                and not result.tool_calls_log
+                and text_this_round.strip()
+                and _claims_write_without_tools(text_this_round)
+            ):
+                phantom_write_nudged = True
+                print("[agent] Self-correction triggered: reply claims a write but no tool was called")
+                yield {"type": "self_correction"}
+                result.full_text = ""
+                messages.append({"role": "assistant", "content": assistant_content})
+                messages.append({"role": "user", "content": PHANTOM_WRITE_NUDGE})
                 continue
             break
 

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -664,7 +664,11 @@ TOOL_DEFINITIONS = [
             "- 'log': record a session. Pass `sets` (one entry per distinct "
             "exercise/load); use `count` for repeated identical sets ('3x5 @185' = "
             "count 3, reps 5, weight 185; 'bench 135x8' = count 1, reps 8, weight "
-            "135). Omit `date` to log today; pass YYYY-MM-DD for an explicit day. "
+            "135). For timed/cardio work put the count (steps, meters, strokes) in "
+            "`reps` and the elapsed time in `duration_seconds` ('500 stairs in "
+            "7:01' = reps 500, duration_seconds 421; 'ran 4mi 32:10' = "
+            "duration_seconds 1930 with the distance in `notes`). Omit `date` to "
+            "log today; pass YYYY-MM-DD for an explicit day. "
             "After logging, tell the user what was recorded in normalized form.\n"
             "- 'update': correct a session. Defaults to the most recent session; "
             "to fix an OLDER one (e.g. the user threaded-replied to an earlier "
@@ -699,17 +703,18 @@ TOOL_DEFINITIONS = [
                 },
                 "sets": {
                     "type": "array",
-                    "description": "Exercises (for log/update). Each: {exercise, reps, weight, weight_unit, count, rpe, notes}. `count` = number of identical sets (default 1).",
+                    "description": "Exercises (for log/update). Each: {exercise, reps, weight, weight_unit, count, rpe, duration_seconds, notes}. `count` = number of identical sets (default 1).",
                     "items": {
                         "type": "object",
                         "properties": {
                             "exercise": {"type": "string", "description": "Exercise name (normalized server-side)."},
-                            "reps": {"type": "integer", "description": "Reps per set."},
+                            "reps": {"type": "integer", "description": "Reps per set — also the count for timed work (steps climbed, meters rowed)."},
                             "weight": {"type": "number", "description": "Load."},
                             "weight_unit": {"type": "string", "description": "'lb' or 'kg' (default lb)."},
                             "count": {"type": "integer", "description": "Number of identical sets (default 1)."},
                             "rpe": {"type": "number", "description": "Rate of perceived exertion (optional)."},
-                            "notes": {"type": "string", "description": "Per-exercise note, e.g. cardio distance/time."},
+                            "duration_seconds": {"type": "integer", "description": "Elapsed time in seconds for timed work (stairs, runs, planks, hangs) — '7:01' = 421."},
+                            "notes": {"type": "string", "description": "Per-exercise note, e.g. cardio distance ('4 mi')."},
                         },
                     },
                 },
@@ -1467,23 +1472,34 @@ def _fmt_num(n) -> str:
     return str(n)
 
 
+def _fmt_duration(seconds) -> str:
+    """Render seconds as M:SS (or H:MM:SS); empty string for falsy input."""
+    if not seconds:
+        return ""
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
 def _summarize_session(session) -> str:
     """Compact one-line summary, grouping consecutive identical sets."""
     groups: list[list] = []
     for s in session.sets:
-        key = (s.exercise, s.reps, s.weight, s.weight_unit)
+        key = (s.exercise, s.reps, s.weight, s.weight_unit, s.duration_seconds)
         if groups and groups[-1][0] == key:
             groups[-1][1] += 1
         else:
             groups.append([key, 1])
     parts = []
-    for (exercise, reps, weight, unit), count in groups:
+    for (exercise, reps, weight, unit, duration), count in groups:
+        dur = f" in {_fmt_duration(duration)}" if duration else ""
         if reps is None and weight is None:
-            parts.append(exercise)
+            parts.append(f"{exercise}{dur}")
             continue
         rep_part = f"{count}×{reps}" if count > 1 else f"{_fmt_num(reps)}"
         w = f" @{_fmt_num(weight)} {unit}" if weight else ""
-        parts.append(f"{exercise} {rep_part}{w}".strip())
+        parts.append(f"{exercise} {rep_part}{w}{dur}".strip())
     body = "; ".join(parts) if parts else "(no sets)"
     return f"{session.date}: {body}"
 
@@ -1553,8 +1569,9 @@ def _workout_history(inp: dict) -> str:
     for r in rows:
         w = f" @{_fmt_num(r['weight'])} {r['weight_unit']}" if r["weight"] else ""
         rpe = f" RPE {_fmt_num(r['rpe'])}" if r["rpe"] else ""
+        dur = f" in {_fmt_duration(r.get('duration_seconds'))}" if r.get("duration_seconds") else ""
         sid = f" [{r['session_id']}]" if r.get("session_id") else ""
-        lines.append(f"  {r['date']}: {_fmt_num(r['reps'])} reps{w}{rpe}{sid}")
+        lines.append(f"  {r['date']}: {_fmt_num(r['reps'])} reps{w}{rpe}{dur}{sid}")
     return "\n".join(lines)
 
 

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -703,14 +703,14 @@ TOOL_DEFINITIONS = [
                 },
                 "sets": {
                     "type": "array",
-                    "description": "Exercises (for log/update). Each: {exercise, reps, weight, weight_unit, count, rpe, duration_seconds, notes}. `count` = number of identical sets (default 1).",
+                    "description": "Exercises (for log/update). Each: {exercise, reps, weight, unit, count, rpe, duration_seconds, notes}. `count` = number of identical sets (default 1).",
                     "items": {
                         "type": "object",
                         "properties": {
                             "exercise": {"type": "string", "description": "Exercise name (normalized server-side)."},
                             "reps": {"type": "integer", "description": "Reps per set — also the count for timed work (steps climbed, meters rowed)."},
                             "weight": {"type": "number", "description": "Load."},
-                            "weight_unit": {"type": "string", "description": "'lb' or 'kg' (default lb)."},
+                            "unit": {"type": "string", "description": "'lb'/'kg' for weighted sets (defaults to lb when weight is set); for counted work, what reps counts ('steps', 'm'). Omit otherwise."},
                             "count": {"type": "integer", "description": "Number of identical sets (default 1)."},
                             "rpe": {"type": "number", "description": "Rate of perceived exertion (optional)."},
                             "duration_seconds": {"type": "integer", "description": "Elapsed time in seconds for timed work (stairs, runs, planks, hangs) — '7:01' = 421."},
@@ -1486,7 +1486,7 @@ def _summarize_session(session) -> str:
     """Compact one-line summary, grouping consecutive identical sets."""
     groups: list[list] = []
     for s in session.sets:
-        key = (s.exercise, s.reps, s.weight, s.weight_unit, s.duration_seconds)
+        key = (s.exercise, s.reps, s.weight, s.unit, s.duration_seconds)
         if groups and groups[-1][0] == key:
             groups[-1][1] += 1
         else:
@@ -1498,7 +1498,9 @@ def _summarize_session(session) -> str:
             parts.append(f"{exercise}{dur}")
             continue
         rep_part = f"{count}×{reps}" if count > 1 else f"{_fmt_num(reps)}"
-        w = f" @{_fmt_num(weight)} {unit}" if weight else ""
+        if unit and weight is None:
+            rep_part += f" {unit}"   # counted work: "500 steps"
+        w = f" @{_fmt_num(weight)} {unit or 'lb'}" if weight else ""
         parts.append(f"{exercise} {rep_part}{w}{dur}".strip())
     body = "; ".join(parts) if parts else "(no sets)"
     return f"{session.date}: {body}"
@@ -1567,7 +1569,7 @@ def _workout_history(inp: dict) -> str:
         return f"No history for {canonical}."
     lines = [f"{canonical} — recent sets:"]
     for r in rows:
-        w = f" @{_fmt_num(r['weight'])} {r['weight_unit']}" if r["weight"] else ""
+        w = f" @{_fmt_num(r['weight'])} {r['unit']}" if r["weight"] else ""
         rpe = f" RPE {_fmt_num(r['rpe'])}" if r["rpe"] else ""
         dur = f" in {_fmt_duration(r.get('duration_seconds'))}" if r.get("duration_seconds") else ""
         sid = f" [{r['session_id']}]" if r.get("session_id") else ""

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -1473,13 +1473,8 @@ def _fmt_num(n) -> str:
 
 
 def _fmt_duration(seconds) -> str:
-    """Render seconds as M:SS (or H:MM:SS); empty string for falsy input."""
-    if not seconds:
-        return ""
-    seconds = int(seconds)
-    h, rem = divmod(seconds, 3600)
-    m, s = divmod(rem, 60)
-    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+    from api.services.fitness_store import format_duration
+    return format_duration(seconds)
 
 
 def _summarize_session(session) -> str:

--- a/api/services/fitness_sheet_mirror.py
+++ b/api/services/fitness_sheet_mirror.py
@@ -26,7 +26,7 @@ SESSIONS_TAB = "Sessions"
 SETS_TAB = "Sets"
 
 _SESSIONS_HEADER = ["id", "date", "kind", "title", "source", "notes", "created_at"]
-_SETS_HEADER = ["session_id", "date", "exercise", "set_index", "reps", "weight", "weight_unit", "rpe", "notes"]
+_SETS_HEADER = ["session_id", "date", "exercise", "set_index", "reps", "weight", "weight_unit", "rpe", "time", "notes"]
 
 _state_lock = threading.Lock()
 _running = False
@@ -43,6 +43,16 @@ def _cell(v):
     return "" if v is None else v
 
 
+def _time_cell(seconds) -> str:
+    """Duration as M:SS (or H:MM:SS) for the sheet's time column."""
+    if not seconds:
+        return ""
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
 def build_tabs(store) -> dict[str, list[list]]:
     """Build the full tab contents (header + rows) from the store."""
     sessions = store.list_sessions(limit=100000)
@@ -53,7 +63,8 @@ def build_tabs(store) -> dict[str, list[list]]:
         for st in s.sets:
             set_rows.append([
                 s.id, s.date, st.exercise, st.set_index,
-                _cell(st.reps), _cell(st.weight), st.weight_unit, _cell(st.rpe), st.notes,
+                _cell(st.reps), _cell(st.weight), st.weight_unit, _cell(st.rpe),
+                _time_cell(st.duration_seconds), st.notes,
             ])
     return {SESSIONS_TAB: sess_rows, SETS_TAB: set_rows}
 

--- a/api/services/fitness_sheet_mirror.py
+++ b/api/services/fitness_sheet_mirror.py
@@ -47,12 +47,8 @@ def _cell(v):
 
 def _time_cell(seconds) -> str:
     """Duration as M:SS (or H:MM:SS) for the sheet's time column."""
-    if not seconds:
-        return ""
-    seconds = int(seconds)
-    h, rem = divmod(seconds, 3600)
-    m, s = divmod(rem, 60)
-    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+    from api.services.fitness_store import format_duration
+    return format_duration(seconds)
 
 
 def build_tabs(store) -> dict[str, list[list]]:

--- a/api/services/fitness_sheet_mirror.py
+++ b/api/services/fitness_sheet_mirror.py
@@ -24,9 +24,11 @@ logger = logging.getLogger(__name__)
 
 SESSIONS_TAB = "Sessions"
 SETS_TAB = "Sets"
+METRICS_TAB = "Metrics"
 
 _SESSIONS_HEADER = ["id", "date", "kind", "title", "source", "notes", "created_at"]
-_SETS_HEADER = ["session_id", "date", "exercise", "set_index", "reps", "weight", "weight_unit", "rpe", "time", "notes"]
+_SETS_HEADER = ["session_id", "date", "exercise", "set_index", "reps", "weight", "unit", "rpe", "time", "notes"]
+_METRICS_HEADER = ["date", "metric_type", "value", "unit"]
 
 _state_lock = threading.Lock()
 _running = False
@@ -63,10 +65,15 @@ def build_tabs(store) -> dict[str, list[list]]:
         for st in s.sets:
             set_rows.append([
                 s.id, s.date, st.exercise, st.set_index,
-                _cell(st.reps), _cell(st.weight), st.weight_unit, _cell(st.rpe),
+                _cell(st.reps), _cell(st.weight), st.unit, _cell(st.rpe),
                 _time_cell(st.duration_seconds), st.notes,
             ])
-    return {SESSIONS_TAB: sess_rows, SETS_TAB: set_rows}
+    # Manually reported metrics only (body weight etc.) — device imports like
+    # intraday Apple Health samples would flood the sheet.
+    metric_rows = [_METRICS_HEADER]
+    for m in store.list_manual_metrics():
+        metric_rows.append([m.start_at[:10], m.metric_type, m.value, m.unit])
+    return {SESSIONS_TAB: sess_rows, SETS_TAB: set_rows, METRICS_TAB: metric_rows}
 
 
 def _hash_tabs(tabs: dict) -> str:

--- a/api/services/fitness_store.py
+++ b/api/services/fitness_store.py
@@ -61,7 +61,7 @@ class WorkoutSet:
     set_index: int
     reps: Optional[int] = None
     weight: Optional[float] = None
-    weight_unit: str = "lb"
+    unit: str = ""           # lb/kg for weighted sets; steps/m/… for counted work
     rpe: Optional[float] = None
     duration_seconds: Optional[int] = None
     notes: str = ""
@@ -135,17 +135,22 @@ class FitnessStore:
                     set_index INTEGER NOT NULL,
                     reps INTEGER,
                     weight REAL,
-                    weight_unit TEXT DEFAULT 'lb',
+                    unit TEXT DEFAULT '',
                     rpe REAL,
                     duration_seconds INTEGER,
                     notes TEXT DEFAULT '',
                     FOREIGN KEY (session_id) REFERENCES workout_sessions(id) ON DELETE CASCADE
                 )
             """)
-            # Migration: add duration_seconds to workout_sets created before it existed.
+            # Migrations for workout_sets created before these columns existed.
             set_cols = {r[1] for r in conn.execute("PRAGMA table_info(workout_sets)")}
             if "duration_seconds" not in set_cols:
                 conn.execute("ALTER TABLE workout_sets ADD COLUMN duration_seconds INTEGER")
+            if "weight_unit" in set_cols:
+                conn.execute("ALTER TABLE workout_sets RENAME COLUMN weight_unit TO unit")
+                # The old column defaulted to 'lb' unconditionally; a unit is
+                # meaningless without a weight, so clear it on weightless rows.
+                conn.execute("UPDATE workout_sets SET unit = '' WHERE weight IS NULL AND unit = 'lb'")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS health_metrics (
                     id TEXT PRIMARY KEY,
@@ -223,13 +228,18 @@ class FitnessStore:
             exercise = self.normalize_exercise(s.get("exercise", ""))
             count = int(s.get("count", 1) or 1)
             count = max(1, count)
+            # lb/kg only make sense with a weight; counted work may carry its
+            # own unit ('steps', 'm'). Accept the legacy 'weight_unit' key.
+            unit = s.get("unit") or s.get("weight_unit") or ""
+            if not unit and s.get("weight") is not None:
+                unit = "lb"
             for _ in range(count):
                 conn.execute(
-                    "INSERT INTO workout_sets (id, session_id, exercise, set_index, reps, weight, weight_unit, rpe, duration_seconds, notes) "
+                    "INSERT INTO workout_sets (id, session_id, exercise, set_index, reps, weight, unit, rpe, duration_seconds, notes) "
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         uuid.uuid4().hex[:12], session_id, exercise, idx,
-                        s.get("reps"), s.get("weight"), s.get("weight_unit") or "lb",
+                        s.get("reps"), s.get("weight"), unit,
                         s.get("rpe"), s.get("duration_seconds"), s.get("notes", ""),
                     ),
                 )
@@ -254,12 +264,12 @@ class FitnessStore:
 
     def _fetch_sets(self, conn, session_id: str) -> list[WorkoutSet]:
         rows = conn.execute(
-            "SELECT exercise, set_index, reps, weight, weight_unit, rpe, duration_seconds, notes "
+            "SELECT exercise, set_index, reps, weight, unit, rpe, duration_seconds, notes "
             "FROM workout_sets WHERE session_id = ? ORDER BY set_index", (session_id,)
         ).fetchall()
         return [
             WorkoutSet(exercise=r[0], set_index=r[1], reps=r[2], weight=r[3],
-                       weight_unit=r[4], rpe=r[5], duration_seconds=r[6], notes=r[7] or "")
+                       unit=r[4] or "", rpe=r[5], duration_seconds=r[6], notes=r[7] or "")
             for r in rows
         ]
 
@@ -385,7 +395,7 @@ class FitnessStore:
         conn = sqlite3.connect(self.db_path)
         try:
             rows = conn.execute(
-                "SELECT s.date, ws.reps, ws.weight, ws.weight_unit, ws.rpe, ws.duration_seconds, s.id "
+                "SELECT s.date, ws.reps, ws.weight, ws.unit, ws.rpe, ws.duration_seconds, s.id "
                 "FROM workout_sets ws JOIN workout_sessions s ON ws.session_id = s.id "
                 "WHERE ws.exercise = ? ORDER BY s.date DESC, ws.set_index ASC LIMIT ?",
                 (canonical, limit),
@@ -393,7 +403,7 @@ class FitnessStore:
         finally:
             conn.close()
         return [
-            {"date": r[0], "reps": r[1], "weight": r[2], "weight_unit": r[3], "rpe": r[4],
+            {"date": r[0], "reps": r[1], "weight": r[2], "unit": r[3] or "", "rpe": r[4],
              "duration_seconds": r[5], "session_id": r[6]}
             for r in rows
         ]
@@ -536,6 +546,24 @@ class FitnessStore:
                 f"SELECT id, metric_type, value, unit, start_at, end_at, source FROM health_metrics "
                 f"WHERE {' AND '.join(clauses)} ORDER BY start_at DESC LIMIT ?",
                 (*params, limit),
+            ).fetchall()
+        finally:
+            conn.close()
+        return [
+            HealthMetric(id=r[0], metric_type=r[1], value=r[2], unit=r[3] or "",
+                         start_at=r[4], end_at=r[5] or "", source=r[6])
+            for r in rows
+        ]
+
+    def list_manual_metrics(self, limit: int = 10000) -> list[HealthMetric]:
+        """Manually reported metrics (bot-logged; excludes device imports like
+        intraday Apple Health samples), newest first."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            rows = conn.execute(
+                "SELECT id, metric_type, value, unit, start_at, end_at, source FROM health_metrics "
+                "WHERE source = 'manual' ORDER BY start_at DESC LIMIT ?",
+                (limit,),
             ).fetchall()
         finally:
             conn.close()

--- a/api/services/fitness_store.py
+++ b/api/services/fitness_store.py
@@ -92,6 +92,17 @@ class HealthMetric:
     source: str = "manual"
 
 
+def format_duration(seconds) -> str:
+    """Render a set duration in seconds as M:SS (or H:MM:SS); '' for falsy.
+    Single source of truth for session summaries and the sheet mirror."""
+    if not seconds:
+        return ""
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
 def _load_aliases() -> dict:
     try:
         data = json.loads(_ALIASES_FILE.read_text())
@@ -148,9 +159,12 @@ class FitnessStore:
                 conn.execute("ALTER TABLE workout_sets ADD COLUMN duration_seconds INTEGER")
             if "weight_unit" in set_cols:
                 conn.execute("ALTER TABLE workout_sets RENAME COLUMN weight_unit TO unit")
-                # The old column defaulted to 'lb' unconditionally; a unit is
-                # meaningless without a weight, so clear it on weightless rows.
-                conn.execute("UPDATE workout_sets SET unit = '' WHERE weight IS NULL AND unit = 'lb'")
+            # The old weight_unit column defaulted to 'lb' unconditionally; a
+            # lb/kg unit is meaningless without a weight, so clear it on
+            # weightless rows. Unconditional (not gated on the rename) so a
+            # crash between the RENAME (DDL, autocommits) and this commit
+            # can't strand rows — the UPDATE is idempotent.
+            conn.execute("UPDATE workout_sets SET unit = '' WHERE weight IS NULL AND unit IN ('lb', 'kg')")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS health_metrics (
                     id TEXT PRIMARY KEY,
@@ -231,7 +245,10 @@ class FitnessStore:
             # lb/kg only make sense with a weight; counted work may carry its
             # own unit ('steps', 'm'). Accept the legacy 'weight_unit' key.
             unit = s.get("unit") or s.get("weight_unit") or ""
-            if not unit and s.get("weight") is not None:
+            if s.get("weight") is None:
+                if unit in ("lb", "kg"):
+                    unit = ""  # models habitually send lb — enforce the invariant
+            elif not unit:
                 unit = "lb"
             for _ in range(count):
                 conn.execute(

--- a/api/services/fitness_store.py
+++ b/api/services/fitness_store.py
@@ -63,6 +63,7 @@ class WorkoutSet:
     weight: Optional[float] = None
     weight_unit: str = "lb"
     rpe: Optional[float] = None
+    duration_seconds: Optional[int] = None
     notes: str = ""
 
 
@@ -136,10 +137,15 @@ class FitnessStore:
                     weight REAL,
                     weight_unit TEXT DEFAULT 'lb',
                     rpe REAL,
+                    duration_seconds INTEGER,
                     notes TEXT DEFAULT '',
                     FOREIGN KEY (session_id) REFERENCES workout_sessions(id) ON DELETE CASCADE
                 )
             """)
+            # Migration: add duration_seconds to workout_sets created before it existed.
+            set_cols = {r[1] for r in conn.execute("PRAGMA table_info(workout_sets)")}
+            if "duration_seconds" not in set_cols:
+                conn.execute("ALTER TABLE workout_sets ADD COLUMN duration_seconds INTEGER")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS health_metrics (
                     id TEXT PRIMARY KEY,
@@ -219,12 +225,12 @@ class FitnessStore:
             count = max(1, count)
             for _ in range(count):
                 conn.execute(
-                    "INSERT INTO workout_sets (id, session_id, exercise, set_index, reps, weight, weight_unit, rpe, notes) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO workout_sets (id, session_id, exercise, set_index, reps, weight, weight_unit, rpe, duration_seconds, notes) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         uuid.uuid4().hex[:12], session_id, exercise, idx,
                         s.get("reps"), s.get("weight"), s.get("weight_unit") or "lb",
-                        s.get("rpe"), s.get("notes", ""),
+                        s.get("rpe"), s.get("duration_seconds"), s.get("notes", ""),
                     ),
                 )
                 idx += 1
@@ -248,12 +254,12 @@ class FitnessStore:
 
     def _fetch_sets(self, conn, session_id: str) -> list[WorkoutSet]:
         rows = conn.execute(
-            "SELECT exercise, set_index, reps, weight, weight_unit, rpe, notes "
+            "SELECT exercise, set_index, reps, weight, weight_unit, rpe, duration_seconds, notes "
             "FROM workout_sets WHERE session_id = ? ORDER BY set_index", (session_id,)
         ).fetchall()
         return [
             WorkoutSet(exercise=r[0], set_index=r[1], reps=r[2], weight=r[3],
-                       weight_unit=r[4], rpe=r[5], notes=r[6] or "")
+                       weight_unit=r[4], rpe=r[5], duration_seconds=r[6], notes=r[7] or "")
             for r in rows
         ]
 
@@ -379,7 +385,7 @@ class FitnessStore:
         conn = sqlite3.connect(self.db_path)
         try:
             rows = conn.execute(
-                "SELECT s.date, ws.reps, ws.weight, ws.weight_unit, ws.rpe, s.id "
+                "SELECT s.date, ws.reps, ws.weight, ws.weight_unit, ws.rpe, ws.duration_seconds, s.id "
                 "FROM workout_sets ws JOIN workout_sessions s ON ws.session_id = s.id "
                 "WHERE ws.exercise = ? ORDER BY s.date DESC, ws.set_index ASC LIMIT ?",
                 (canonical, limit),
@@ -387,7 +393,8 @@ class FitnessStore:
         finally:
             conn.close()
         return [
-            {"date": r[0], "reps": r[1], "weight": r[2], "weight_unit": r[3], "rpe": r[4], "session_id": r[5]}
+            {"date": r[0], "reps": r[1], "weight": r[2], "weight_unit": r[3], "rpe": r[4],
+             "duration_seconds": r[5], "session_id": r[6]}
             for r in rows
         ]
 

--- a/config/exercise_aliases.json
+++ b/config/exercise_aliases.json
@@ -85,6 +85,9 @@
     "flat abs": "Abs",
     "decline abs": "Decline abs",
     "plank": "Abs",
-    "abs": "Abs"
+    "abs": "Abs",
+    "stair climb": "Stairs",
+    "stair climbing": "Stairs",
+    "stair master": "Stairs"
   }
 }

--- a/config/personas/fitness.md
+++ b/config/personas/fitness.md
@@ -21,8 +21,9 @@ The user logs workouts as plain text. **Log first, report after — never ask fo
 - `bench 135x8` → one set: `{exercise: "bench", reps: 8, weight: 135, count: 1}`.
 - `5x5 squats @185` / `squats 3x5 185` → `{exercise: "squats", reps: 5, weight: 185, count: 5}` (or `count: 3`). `count` is the number of identical sets.
 - A multi-line / multi-exercise message → one `log` call with several entries in `sets`.
-- Timed work (`500 stairs in 7:01`) → the count in `reps`, the time in `duration_seconds`: `{exercise: "stairs", reps: 500, duration_seconds: 421}`. Same for meters rowed, steps climbed, planks, hangs.
+- Timed work (`500 stairs in 7:01`) → the count in `reps` with its `unit`, the time in `duration_seconds`: `{exercise: "stairs", reps: 500, unit: "steps", duration_seconds: 421}`. Same for meters rowed (`unit: "m"`), planks, hangs.
 - Cardio (`ran 4mi 32:10`) → `{exercise: "run", duration_seconds: 1930, notes: "4 mi"}` — time in `duration_seconds`, distance in `notes`.
+- `unit` is only `lb`/`kg` when there's a `weight` (default lb) — never put lb on unweighted work.
 - Omit `date` to log today; pass `YYYY-MM-DD` only when the message names a day ("yesterday", "Mon", "6/5").
 - Reply format after logging: `Logged 6/7: Bench Press 135×8; Back Squat 3×5 @185 lb`. Include the date, nothing more. (Exercise names are normalized server-side.)
 - If something is genuinely unparseable, log what's clear and note the gap in one line. Don't interrogate; don't block the log.

--- a/config/personas/fitness.md
+++ b/config/personas/fitness.md
@@ -16,10 +16,13 @@ Be an instrument, not a coach. No encouragement, no praise, no motivational lang
 
 The user logs workouts as plain text. **Log first, report after — never ask for confirmation before logging.** Parse the message, call `manage_workouts` with `action: "log"`, then state what was recorded in normalized form.
 
+**Every log requires a fresh `manage_workouts` call in the current turn.** Earlier `Logged …` lines in the conversation are history of past turns, not proof this message was recorded. Never reply `Logged` unless the tool was called this turn and returned success.
+
 - `bench 135x8` → one set: `{exercise: "bench", reps: 8, weight: 135, count: 1}`.
 - `5x5 squats @185` / `squats 3x5 185` → `{exercise: "squats", reps: 5, weight: 185, count: 5}` (or `count: 3`). `count` is the number of identical sets.
 - A multi-line / multi-exercise message → one `log` call with several entries in `sets`.
-- Cardio (`ran 4mi 32:10`) → an entry with the distance/time in `notes`.
+- Timed work (`500 stairs in 7:01`) → the count in `reps`, the time in `duration_seconds`: `{exercise: "stairs", reps: 500, duration_seconds: 421}`. Same for meters rowed, steps climbed, planks, hangs.
+- Cardio (`ran 4mi 32:10`) → `{exercise: "run", duration_seconds: 1930, notes: "4 mi"}` — time in `duration_seconds`, distance in `notes`.
 - Omit `date` to log today; pass `YYYY-MM-DD` only when the message names a day ("yesterday", "Mon", "6/5").
 - Reply format after logging: `Logged 6/7: Bench Press 135×8; Back Squat 3×5 @185 lb`. Include the date, nothing more. (Exercise names are normalized server-side.)
 - If something is genuinely unparseable, log what's clear and note the gap in one line. Don't interrogate; don't block the log.

--- a/tests/test_agent_loop_phantom_write.py
+++ b/tests/test_agent_loop_phantom_write.py
@@ -1,0 +1,134 @@
+"""
+Tests for the phantom-write self-correction in run_agent_loop.
+
+Observed failure (fitness bot on Haiku): after a few "Logged …" confirmations
+accumulate in the conversation history, the model starts replying "Logged …"
+WITHOUT calling manage_workouts — the set is confirmed to the user but never
+written (tool_rounds=0). The loop must catch a write-claim reply made with zero
+tool calls and nudge the model to actually call the tool.
+"""
+import pytest
+from unittest.mock import patch
+
+from api.services.agent_loop import (
+    PHANTOM_WRITE_NUDGE,
+    _claims_write_without_tools,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestWriteClaimPattern:
+    def test_matches_logged_confirmation(self):
+        assert _claims_write_without_tools("Logged 6/20: Pec Fly Machine 3×12 @100 lb.")
+
+    def test_matches_updated_confirmation(self):
+        assert _claims_write_without_tools("Updated — 2026-06-20: Bench Press 8 @145 lb")
+
+    def test_matches_case_insensitive_with_leading_space(self):
+        assert _claims_write_without_tools("  logged body weight: 178.4 lb.")
+
+    def test_ignores_ordinary_answers(self):
+        assert not _claims_write_without_tools("Your last squat session was 6/13.")
+        assert not _claims_write_without_tools("You logged 3 sessions last week.")
+        assert not _claims_write_without_tools("No sessions logged.")
+
+
+class _PhantomThenToolClient:
+    """First call replies 'Logged …' with NO tool call; after the nudge, calls
+    manage_workouts and confirms for real. Captures each call's messages."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def astream(self, messages, *, system=None, max_tokens=4096,
+                      tools=None, temperature=None, timeout=None):
+        from api.services.llm_client import LLMUsage
+        self.calls.append(list(messages))
+        n = len(self.calls)
+        if n == 1:
+            yield {"type": "text", "content": "Logged 6/20: Pec Fly Machine 3×12 @100 lb."}
+            yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
+        elif n == 2:
+            yield {"type": "tool_calls", "calls": [{
+                "id": "call_1",
+                "function": {
+                    "name": "manage_workouts",
+                    "arguments": '{"action": "log", "sets": [{"exercise": "pec fly machine", "reps": 12, "weight": 100, "count": 3}]}',
+                },
+            }]}
+            yield {"type": "done", "usage": LLMUsage(), "finish_reason": "tool_calls"}
+        else:
+            yield {"type": "text", "content": "Logged 6/20: Pec Fly Machine 3×12 @100 lb."}
+            yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
+
+
+class _AlwaysPhantomClient:
+    """Claims a write with no tool call every time — the nudge must fire only
+    once (no infinite self-correction loop)."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def astream(self, messages, *, system=None, max_tokens=4096,
+                      tools=None, temperature=None, timeout=None):
+        from api.services.llm_client import LLMUsage
+        self.calls += 1
+        yield {"type": "text", "content": "Logged 6/20: Pec Fly Machine 3×12 @100 lb."}
+        yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
+
+
+async def _run(fake, question="Pec fly machine 3x12 100lb"):
+    from api.services import agent_loop
+    with patch.object(agent_loop, "_select_client", return_value=fake):
+        return [e async for e in agent_loop.run_agent_loop(question)]
+
+
+@pytest.mark.asyncio
+async def test_phantom_write_claim_is_nudged_to_real_tool_call():
+    from unittest.mock import AsyncMock
+    fake = _PhantomThenToolClient()
+    with patch(
+        "api.services.agent_loop.execute_tool_parallel",
+        AsyncMock(return_value="Logged — 2026-06-20: Pec Fly Machine 3×12 @100 lb (session id: abc123def456)"),
+    ):
+        events = await _run(fake)
+    # The phantom reply was retracted and the nudge sent on the second call.
+    assert any(e["type"] == "self_correction" for e in events)
+    assert any(
+        m.get("content") == PHANTOM_WRITE_NUDGE
+        for m in fake.calls[1]
+        if isinstance(m, dict) and m.get("role") == "user"
+    )
+    # The real tool call happened.
+    result = next(e for e in events if e["type"] == "result")
+    assert any(tc["tool"] == "manage_workouts" for tc in result["result"].tool_calls_log)
+
+
+@pytest.mark.asyncio
+async def test_phantom_nudge_fires_at_most_once():
+    fake = _AlwaysPhantomClient()
+    events = await _run(fake)
+    assert fake.calls == 2  # original + one nudged retry, then give up
+    # The (still phantom) retry text is surfaced rather than looping forever.
+    assert any(e["type"] == "text" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_normal_answer_without_tools_is_untouched():
+    """A plain informational answer with no tools must not trigger the nudge."""
+    class _Plain:
+        def __init__(self):
+            self.calls = 0
+
+        async def astream(self, messages, *, system=None, max_tokens=4096,
+                          tools=None, temperature=None, timeout=None):
+            from api.services.llm_client import LLMUsage
+            self.calls += 1
+            yield {"type": "text", "content": "Your last squat session was 6/13."}
+            yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
+
+    fake = _Plain()
+    events = await _run(fake, question="when did I last squat?")
+    assert fake.calls == 1
+    assert not any(e["type"] == "self_correction" for e in events)

--- a/tests/test_agent_loop_phantom_write.py
+++ b/tests/test_agent_loop_phantom_write.py
@@ -1,11 +1,12 @@
 """
 Tests for the phantom-write self-correction in run_agent_loop.
 
-Observed failure (fitness bot on Haiku): after a few "Logged …" confirmations
-accumulate in the conversation history, the model starts replying "Logged …"
-WITHOUT calling manage_workouts — the set is confirmed to the user but never
-written (tool_rounds=0). The loop must catch a write-claim reply made with zero
-tool calls and nudge the model to actually call the tool.
+Observed failure (fitness bot on a small model): after a few "Logged …"
+confirmations accumulate in the conversation history, the model starts replying
+"Logged …" WITHOUT calling manage_workouts — the set is confirmed to the user
+but never written (tool_rounds=0). The loop must catch a write-claim reply made
+with zero tool calls and nudge the model to actually call the tool. All workout
+data below is synthetic.
 """
 import pytest
 from unittest.mock import patch
@@ -20,7 +21,7 @@ pytestmark = pytest.mark.unit
 
 class TestWriteClaimPattern:
     def test_matches_logged_confirmation(self):
-        assert _claims_write_without_tools("Logged 6/20: Pec Fly Machine 3×12 @100 lb.")
+        assert _claims_write_without_tools("Logged 5/05: Zercher Carry 3×10 @95 lb.")
 
     def test_matches_updated_confirmation(self):
         assert _claims_write_without_tools("Updated — 2026-06-20: Bench Press 8 @145 lb")
@@ -47,19 +48,19 @@ class _PhantomThenToolClient:
         self.calls.append(list(messages))
         n = len(self.calls)
         if n == 1:
-            yield {"type": "text", "content": "Logged 6/20: Pec Fly Machine 3×12 @100 lb."}
+            yield {"type": "text", "content": "Logged 5/05: Zercher Carry 3×10 @95 lb."}
             yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
         elif n == 2:
             yield {"type": "tool_calls", "calls": [{
                 "id": "call_1",
                 "function": {
                     "name": "manage_workouts",
-                    "arguments": '{"action": "log", "sets": [{"exercise": "pec fly machine", "reps": 12, "weight": 100, "count": 3}]}',
+                    "arguments": '{"action": "log", "sets": [{"exercise": "zercher carry", "reps": 10, "weight": 95, "count": 3}]}',
                 },
             }]}
             yield {"type": "done", "usage": LLMUsage(), "finish_reason": "tool_calls"}
         else:
-            yield {"type": "text", "content": "Logged 6/20: Pec Fly Machine 3×12 @100 lb."}
+            yield {"type": "text", "content": "Logged 5/05: Zercher Carry 3×10 @95 lb."}
             yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
 
 
@@ -74,11 +75,11 @@ class _AlwaysPhantomClient:
                       tools=None, temperature=None, timeout=None):
         from api.services.llm_client import LLMUsage
         self.calls += 1
-        yield {"type": "text", "content": "Logged 6/20: Pec Fly Machine 3×12 @100 lb."}
+        yield {"type": "text", "content": "Logged 5/05: Zercher Carry 3×10 @95 lb."}
         yield {"type": "done", "usage": LLMUsage(), "finish_reason": "end_turn"}
 
 
-async def _run(fake, question="Pec fly machine 3x12 100lb"):
+async def _run(fake, question="zercher carry 3x10 95lb"):
     from api.services import agent_loop
     with patch.object(agent_loop, "_select_client", return_value=fake):
         return [e async for e in agent_loop.run_agent_loop(question)]
@@ -90,7 +91,7 @@ async def test_phantom_write_claim_is_nudged_to_real_tool_call():
     fake = _PhantomThenToolClient()
     with patch(
         "api.services.agent_loop.execute_tool_parallel",
-        AsyncMock(return_value="Logged — 2026-06-20: Pec Fly Machine 3×12 @100 lb (session id: abc123def456)"),
+        AsyncMock(return_value="Logged — 2026-05-05: Zercher Carry 3×10 @95 lb (session id: abc123def456)"),
     ):
         events = await _run(fake)
     # The phantom reply was retracted and the nudge sent on the second call.

--- a/tests/test_agent_tools_workouts.py
+++ b/tests/test_agent_tools_workouts.py
@@ -174,6 +174,14 @@ class TestSummaryFormatting:
         out = _summarize_session(session)
         assert "Stairs 500 in 7:01" in out
 
+    def test_counted_work_shows_unit_not_lb(self):
+        session = WorkoutSession(id="x", date="2026-06-20", sets=[
+            WorkoutSet(exercise="Stairs", set_index=1, reps=500, unit="steps", duration_seconds=421),
+        ])
+        out = _summarize_session(session)
+        assert "Stairs 500 steps in 7:01" in out
+        assert "lb" not in out
+
     def test_duration_only_no_reps(self):
         session = WorkoutSession(id="x", date="2026-06-20", sets=[
             WorkoutSet(exercise="Run", set_index=1, duration_seconds=1930, notes="4 mi"),

--- a/tests/test_agent_tools_workouts.py
+++ b/tests/test_agent_tools_workouts.py
@@ -165,3 +165,37 @@ class TestSummaryFormatting:
         ])
         out = _summarize_session(session)
         assert "Run" in out
+
+    def test_timed_work_reps_and_duration(self):
+        # 500 stairs in 7:01 — count in reps, time rendered M:SS
+        session = WorkoutSession(id="x", date="2026-06-20", sets=[
+            WorkoutSet(exercise="Stairs", set_index=1, reps=500, duration_seconds=421),
+        ])
+        out = _summarize_session(session)
+        assert "Stairs 500 in 7:01" in out
+
+    def test_duration_only_no_reps(self):
+        session = WorkoutSession(id="x", date="2026-06-20", sets=[
+            WorkoutSet(exercise="Run", set_index=1, duration_seconds=1930, notes="4 mi"),
+        ])
+        out = _summarize_session(session)
+        assert "Run in 32:10" in out
+
+
+class TestDurationThroughTool:
+    def test_log_with_duration(self, temp_store):
+        out = _tool_manage_workouts({
+            "action": "log",
+            "sets": [{"exercise": "stairs", "reps": 500, "duration_seconds": 421}],
+        })
+        assert out.startswith("Logged —")
+        assert "in 7:01" in out
+        assert temp_store.get_latest_session().sets[0].duration_seconds == 421
+
+    def test_history_shows_duration(self, temp_store):
+        _tool_manage_workouts({
+            "action": "log",
+            "sets": [{"exercise": "stairs", "reps": 500, "duration_seconds": 421}],
+        })
+        out = _tool_manage_workouts({"action": "history", "exercise": "stairs"})
+        assert "in 7:01" in out

--- a/tests/test_fitness_sheet_mirror.py
+++ b/tests/test_fitness_sheet_mirror.py
@@ -77,6 +77,20 @@ def test_build_tabs_shapes(wired):
         assert "None" not in [str(c) for c in row]
 
 
+def test_time_column_renders_duration(wired):
+    store, _ = wired
+    store.add_session(sets=[{"exercise": "stairs", "reps": 500, "duration_seconds": 421}], date="2026-06-10")
+    tabs = mirror.build_tabs(store)
+    header = tabs["Sets"][0]
+    assert "time" in header
+    time_idx = header.index("time")
+    stairs_row = next(r for r in tabs["Sets"][1:] if r[2] == "Stairs")
+    assert stairs_row[time_idx] == "7:01"
+    # untimed sets leave the column empty
+    bench_row = next(r for r in tabs["Sets"][1:] if r[2] == "Bench Press")
+    assert bench_row[time_idx] == ""
+
+
 def test_sync_writes_both_tabs(wired):
     _, fake = wired
     assert mirror.sync() is True

--- a/tests/test_fitness_sheet_mirror.py
+++ b/tests/test_fitness_sheet_mirror.py
@@ -65,9 +65,10 @@ def test_disabled_when_no_sheet_id(monkeypatch):
 def test_build_tabs_shapes(wired):
     store, _ = wired
     tabs = mirror.build_tabs(store)
-    assert set(tabs) == {"Sessions", "Sets"}
+    assert set(tabs) == {"Sessions", "Sets", "Metrics"}
     assert tabs["Sessions"][0] == mirror._SESSIONS_HEADER
     assert tabs["Sets"][0] == mirror._SETS_HEADER
+    assert tabs["Metrics"][0] == mirror._METRICS_HEADER
     # 2 sessions + header
     assert len(tabs["Sessions"]) == 3
     # 1 + 3 set rows + header
@@ -91,20 +92,20 @@ def test_time_column_renders_duration(wired):
     assert bench_row[time_idx] == ""
 
 
-def test_sync_writes_both_tabs(wired):
+def test_sync_writes_all_tabs(wired):
     _, fake = wired
     assert mirror.sync() is True
     written_tabs = {rng.split("!")[0] for _, rng, _ in fake.updated}
-    assert written_tabs == {"Sessions", "Sets"}
+    assert written_tabs == {"Sessions", "Sets", "Metrics"}
     # cleared before writing
-    assert len(fake.cleared) == 2
+    assert len(fake.cleared) == 3
 
 
 def test_hash_shortcircuits_second_sync(wired):
     _, fake = wired
     assert mirror.sync() is True
     assert mirror.sync() is False  # unchanged → no write
-    assert len(fake.updated) == 2  # only the first sync wrote
+    assert len(fake.updated) == 3  # only the first sync wrote
 
 
 def test_change_triggers_rewrite(wired):
@@ -112,7 +113,32 @@ def test_change_triggers_rewrite(wired):
     mirror.sync()
     store.add_session(sets=[{"exercise": "deadlift", "reps": 5, "weight": 315}], date="2026-06-09")
     assert mirror.sync() is True
-    assert len(fake.updated) == 4  # two more tab writes
+    assert len(fake.updated) == 6  # three more tab writes
+
+
+def test_metrics_tab_manual_only(wired):
+    store, _ = wired
+    store.log_metric("body_weight", 212.0, unit="lb", start_at="2026-07-09T08:00:00-04:00")
+    store.bulk_insert_metrics([{
+        "metric_type": "steps", "value": 900, "unit": "count",
+        "start_at": "2026-07-09T09:00:00-04:00", "source": "apple_health",
+    }])
+    tabs = mirror.build_tabs(store)
+    rows = tabs["Metrics"][1:]
+    assert ["2026-07-09", "body_weight", 212.0, "lb"] in rows
+    assert not any(r[1] == "steps" for r in rows)  # device imports excluded
+
+
+def test_unit_empty_for_unweighted_sets(wired):
+    store, _ = wired
+    store.add_session(sets=[{"exercise": "stairs", "reps": 500, "unit": "steps", "duration_seconds": 421}], date="2026-06-10")
+    tabs = mirror.build_tabs(store)
+    header = tabs["Sets"][0]
+    unit_idx = header.index("unit")
+    stairs_row = next(r for r in tabs["Sets"][1:] if r[2] == "Stairs")
+    assert stairs_row[unit_idx] == "steps"
+    bench_row = next(r for r in tabs["Sets"][1:] if r[2] == "Bench Press")
+    assert bench_row[unit_idx] == "lb"
 
 
 def test_force_rewrites_even_if_unchanged(wired):

--- a/tests/test_fitness_sheet_mirror.py
+++ b/tests/test_fitness_sheet_mirror.py
@@ -118,14 +118,14 @@ def test_change_triggers_rewrite(wired):
 
 def test_metrics_tab_manual_only(wired):
     store, _ = wired
-    store.log_metric("body_weight", 212.0, unit="lb", start_at="2026-07-09T08:00:00-04:00")
+    store.log_metric("body_weight", 178.4, unit="lb", start_at="2026-07-09T08:00:00-04:00")
     store.bulk_insert_metrics([{
         "metric_type": "steps", "value": 900, "unit": "count",
         "start_at": "2026-07-09T09:00:00-04:00", "source": "apple_health",
     }])
     tabs = mirror.build_tabs(store)
     rows = tabs["Metrics"][1:]
-    assert ["2026-07-09", "body_weight", 212.0, "lb"] in rows
+    assert ["2026-07-09", "body_weight", 178.4, "lb"] in rows
     assert not any(r[1] == "steps" for r in rows)  # device imports excluded
 
 

--- a/tests/test_fitness_store.py
+++ b/tests/test_fitness_store.py
@@ -92,6 +92,50 @@ class TestUpdate:
         assert store.update_session(target="latest", notes="x") is None
 
 
+# -- duration --
+
+class TestDuration:
+    def test_duration_roundtrip(self, store):
+        s = store.add_session(sets=[{"exercise": "stairs", "reps": 500, "duration_seconds": 421}])
+        assert s.sets[0].exercise == "Stairs"
+        assert s.sets[0].reps == 500
+        assert s.sets[0].duration_seconds == 421
+
+    def test_duration_defaults_to_none(self, store):
+        s = store.add_session(sets=[{"exercise": "bench", "reps": 8, "weight": 135}])
+        assert s.sets[0].duration_seconds is None
+
+    def test_exercise_history_includes_duration(self, store):
+        store.add_session(sets=[{"exercise": "stairs", "reps": 500, "duration_seconds": 421}], date="2026-06-10")
+        hist = store.exercise_history("stairs")
+        assert hist[0]["duration_seconds"] == 421
+
+    def test_migrates_pre_duration_db(self, tmp_path):
+        # A workout_sets table created before the duration_seconds column
+        # existed must be ALTERed on open, and logging with duration must work.
+        import sqlite3
+        db = str(tmp_path / "old.db")
+        conn = sqlite3.connect(db)
+        conn.execute("""
+            CREATE TABLE workout_sets (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                exercise TEXT NOT NULL,
+                set_index INTEGER NOT NULL,
+                reps INTEGER,
+                weight REAL,
+                weight_unit TEXT DEFAULT 'lb',
+                rpe REAL,
+                notes TEXT DEFAULT ''
+            )
+        """)
+        conn.commit()
+        conn.close()
+        store = FitnessStore(db_path=db)
+        s = store.add_session(sets=[{"exercise": "stairs", "reps": 500, "duration_seconds": 421}])
+        assert store.get_session(s.id).sets[0].duration_seconds == 421
+
+
 # -- metrics --
 
 class TestMetrics:

--- a/tests/test_fitness_store.py
+++ b/tests/test_fitness_store.py
@@ -51,15 +51,23 @@ class TestSessions:
         assert len(s.sets) == 5  # 1 + 3 + 1
         assert s.sets[-1].exercise == "Run"
 
-    def test_cardio_default_unit_and_count(self, store):
+    def test_unweighted_work_gets_no_unit(self, store):
         s = store.add_session(sets=[{"exercise": "run", "notes": "5k"}])
-        assert s.sets[0].weight_unit == "lb"  # default
+        assert s.sets[0].unit == ""  # no weight → no lb
         assert s.sets[0].reps is None
 
-    def test_explicit_null_weight_unit_defaults(self, store):
-        # The LLM may send weight_unit: null explicitly — must still default to lb.
-        s = store.add_session(sets=[{"exercise": "bench", "reps": 8, "weight": 135, "weight_unit": None}])
-        assert s.sets[0].weight_unit == "lb"
+    def test_weighted_set_defaults_to_lb(self, store):
+        # The LLM may send unit: null explicitly — a weighted set still gets lb.
+        s = store.add_session(sets=[{"exercise": "bench", "reps": 8, "weight": 135, "unit": None}])
+        assert s.sets[0].unit == "lb"
+
+    def test_legacy_weight_unit_key_accepted(self, store):
+        s = store.add_session(sets=[{"exercise": "bench", "reps": 8, "weight": 60, "weight_unit": "kg"}])
+        assert s.sets[0].unit == "kg"
+
+    def test_counted_work_unit(self, store):
+        s = store.add_session(sets=[{"exercise": "stairs", "reps": 500, "unit": "steps", "duration_seconds": 421}])
+        assert s.sets[0].unit == "steps"
 
     def test_list_sessions_newest_first(self, store):
         store.add_session(sets=[{"exercise": "bench", "reps": 8, "weight": 135}], date="2026-06-01")
@@ -111,8 +119,9 @@ class TestDuration:
         assert hist[0]["duration_seconds"] == 421
 
     def test_migrates_pre_duration_db(self, tmp_path):
-        # A workout_sets table created before the duration_seconds column
-        # existed must be ALTERed on open, and logging with duration must work.
+        # A workout_sets table from before duration_seconds/unit must be
+        # migrated on open: duration column added, weight_unit renamed to unit,
+        # and the old unconditional 'lb' cleared on weightless rows.
         import sqlite3
         db = str(tmp_path / "old.db")
         conn = sqlite3.connect(db)
@@ -129,11 +138,24 @@ class TestDuration:
                 notes TEXT DEFAULT ''
             )
         """)
+        conn.execute(
+            "INSERT INTO workout_sets (id, session_id, exercise, set_index, reps, weight, weight_unit) "
+            "VALUES ('a', 's1', 'Stairs', 1, 500, NULL, 'lb')"
+        )
+        conn.execute(
+            "INSERT INTO workout_sets (id, session_id, exercise, set_index, reps, weight, weight_unit) "
+            "VALUES ('b', 's1', 'Bench Press', 1, 8, 135, 'lb')"
+        )
         conn.commit()
         conn.close()
         store = FitnessStore(db_path=db)
         s = store.add_session(sets=[{"exercise": "stairs", "reps": 500, "duration_seconds": 421}])
         assert store.get_session(s.id).sets[0].duration_seconds == 421
+        conn = sqlite3.connect(db)
+        units = dict(conn.execute("SELECT id, unit FROM workout_sets WHERE id IN ('a', 'b')"))
+        conn.close()
+        assert units["a"] == ""    # weightless row: lb cleared
+        assert units["b"] == "lb"  # weighted row: unit kept
 
 
 # -- metrics --

--- a/tests/test_fitness_store.py
+++ b/tests/test_fitness_store.py
@@ -113,6 +113,13 @@ class TestDuration:
         s = store.add_session(sets=[{"exercise": "bench", "reps": 8, "weight": 135}])
         assert s.sets[0].duration_seconds is None
 
+    def test_format_duration_rendering(self, store):
+        from api.services.fitness_store import format_duration
+        assert format_duration(421) == "7:01"
+        assert format_duration(3721) == "1:02:01"  # H:MM:SS branch
+        assert format_duration(0) == ""
+        assert format_duration(None) == ""
+
     def test_exercise_history_includes_duration(self, store):
         store.add_session(sets=[{"exercise": "stairs", "reps": 500, "duration_seconds": 421}], date="2026-06-10")
         hist = store.exercise_history("stairs")


### PR DESCRIPTION
## Problem

Comparing the fitness bot's Telegram transcripts against the SQLite store / Google Sheet mirror surfaced two defects:

**1. Silent data loss — phantom "Logged" replies.** Once a few `Logged …` confirmations accumulate in the conversation history, the orchestrator (Haiku) starts replying `Logged 6/20: Pec Fly Machine 3×12 @100 lb.` **without calling `manage_workouts` at all** (`tool_rounds: 0` in routing metadata). Nine exercises across 6/10 and 6/20 were confirmed to the user but never written. The sheet was never the problem — it faithfully mirrors a store that never got the data. Notably it is *not* exercise-name filtering: unknown names pass through title-cased by design.

**2. No structured time for timed work.** Stairs/cardio time lived in free-text notes (`"500 stairs in 7:01"`), so it can't render as a column or trend.

## Fix

- **Phantom-write guard** (`agent_loop.py`): if the final reply opens with `Logged/Updated/Recorded/Saved` and the turn made **zero** tool calls, retract it and nudge once ("you made no tool call — record it now or rephrase"). Mirrors the existing give-up self-correction; fires at most once per turn. Plus an explicit persona rule that every log needs a fresh tool call in the current turn.
- **`duration_seconds` on sets**: new nullable column on `workout_sets` (ALTER-on-open migration), `manage_workouts` sets schema field, summary/history rendering (`Stairs 500 in 7:01`), and a human-readable `time` column in the sheet mirror's Sets tab. Convention: count (steps/meters) goes in `reps`, time in `duration_seconds`.

## Testing

- 71 tests pass across the four touched test files (7 new phantom-write tests incl. nudge-fires-once and plain-answers-untouched; store migration + roundtrip; mirror time column; tool rendering).
- Full unit suite green via pre-push hook; the CRM/p91 data-integrity failures seen in a bare worktree are environmental (need live `data/`) and pass from the server checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up (same PR): `unit` column + Metrics tab

- `workout_sets.weight_unit` → **`unit`** (RENAME COLUMN migration): `lb`/`kg` only when a weight is present (default lb); counted work can carry its own unit (`steps`, `m`); weightless rows get `''` — the migration clears the old unconditional `lb` on them. The legacy `weight_unit` key is still accepted from the LLM.
- Summaries render counted work as `Stairs 500 steps in 7:01`.
- Sheet mirror: Sets header renamed to `unit`; new **Metrics** tab mirroring manually reported metrics (body weight etc.) — device imports (intraday Apple Health samples) stay out of the sheet.
- Note: unlike the additive duration column, the rename is **not** pre-applied to the live DB — it would break the currently-deployed writer. It runs automatically at first store use after deploy.
