### PR TITLE
fix(ops): stop autodeploy from OOM-freezing the host mid-sync

### DIFF
--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -66,6 +66,23 @@ case "$(_read_env "LIFEOS_AUTODEPLOY_ENABLED" "false" | tr '[:upper:]' '[:lower:
     *) exit 0 ;;
 esac
 
+# --- Defer while the nightly sync is running ------------------------------------
+# Restarting lifeos-api mid-sync SIGTERMs the running reindex, and the restart's
+# fresh allocations landing on top of the still-resident embedding process has
+# OOM-frozen the host (killed the desktop). Never deploy during a sync — the next
+# 10-min tick catches up once it finishes.
+sync_in_progress() {
+    case "$(systemctl show lifeos-sync.service -p ActiveState --value 2>/dev/null)" in
+        activating|active|deactivating|reloading) return 0 ;;
+    esac
+    # Also catch a sync launched manually (not via the systemd unit).
+    pgrep -f "[r]un_all_syncs\.py" >/dev/null 2>&1
+}
+if sync_in_progress; then
+    log "skip: nightly sync in progress — deferring deploy to avoid a mid-sync restart"
+    exit 0
+fi
+
 # --- Guards: only auto-deploy a clean main --------------------------------------
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ "$BRANCH" != "main" ]; then

--- a/scripts/run_sync_wrapper.sh
+++ b/scripts/run_sync_wrapper.sh
@@ -21,6 +21,22 @@ LOG="$LIFEOS_DIR/logs/crm-sync-error.log"
 # reason, this watchdog kills it so launchd can fire the next night's run.
 MAX_RUNTIME=21600
 
+# --- Free RAM before the heavy sync (opt-in) -----------------------------------
+# The embedding/reindex phase co-resident with a memory-hungry desktop app (e.g.
+# Chrome, tens of GB across tabs) has pushed this host into an OOM cascade that
+# killed the desktop. Operators can list process-name patterns to gracefully
+# quit first via LIFEOS_SYNC_QUIT_PROCS (space-separated, default empty = no-op;
+# injected from .env by the systemd unit's EnvironmentFile). Reopen them later —
+# SIGTERM lets the app save its session so tabs are restored.
+if [ -n "${LIFEOS_SYNC_QUIT_PROCS:-}" ]; then
+    LOG="$LIFEOS_DIR/logs/crm-sync-error.log"
+    for proc in $LIFEOS_SYNC_QUIT_PROCS; do
+        if pkill -TERM -f "$proc" 2>/dev/null; then
+            echo "$(date '+%Y-%m-%d %H:%M:%S') [WRAPPER] Quit '$proc' to free RAM for sync" >> "$LOG"
+        fi
+    done
+fi
+
 # --- NVMe pre-flight check ---
 
 MAX_RETRIES=3


### PR DESCRIPTION
## What happened (root cause)

The 2026-07-10 "desktop froze while I was typing" was **a kernel OOM cascade, not a hardware crash** — uptime stayed continuous. Timeline from the logs:

| Time | Event |
|------|-------|
| 04:58 | Nightly sync's `vault_reindex` starts; RAM guard passes ("41273 MB available") |
| 04:58→07:50 | Reindex runs ~3h doing GPU embeddings — RAM footprint grows the whole time |
| 07:50:02 | `lifeos-autodeploy` fires, pulls main, restarts `lifeos-api` → SIGTERM's the in-flight reindex ("killed by signal 15") |
| 07:54:42 | Restart's fresh allocations land on the still-resident embedding process → 62 GB RAM exhausted → kernel OOM killer reaps the whole GNOME session (`gnome-shell`, `chrome`, `dbus`, `pipewire`) |
| 07:54:43 | Desktop session auto-restarts — the "recovery" |

The keystroke was coincidental; `gnome-shell` was already being reaped.

## Changes in this PR

1. **`auto-deploy.sh` defers while a sync is running.** Checks `lifeos-sync.service` ActiveState (and a `run_all_syncs.py` process as a fallback for manual syncs). If a sync is in flight, it skips the run entirely — the next 10-min tick catches up once the sync finishes. Restarting services mid-sync is the trigger and is now impossible.

2. **`run_sync_wrapper.sh` gains an opt-in `LIFEOS_SYNC_QUIT_PROCS` hook** — a space-separated list of process patterns to gracefully SIGTERM before the sync, to free RAM for the reindex. **Default empty = no-op**, so a fresh open-source clone never has its desktop apps touched. This host sets it to `chrome` in `.env`.

## Related: cgroup cap shipped separately

A defense-in-depth cgroup memory cap on `lifeos-sync.service` (`MemoryHigh=60%` / `MemoryMax=75%` / `MemorySwapMax=2G`, portable percentages) was committed **directly to main as `9135e1e`** — it landed there by accident (a concurrent agent sharing this working tree left HEAD on `main` between commits). It's clean, fast-forwarded, and passed the full unit suite, so per operator decision it stays on main rather than being reverted. Noted here so the two halves of the fix aren't confused.

## Testing

- `bash -n` clean on both scripts.
- Full unit suite green (2391 passed via the pre-push hook; `./scripts/test.sh` = 3276 passed, 4 pre-existing environmental failures verified unrelated by stashing these changes).
- Guard logic verified: with no active sync it proceeds; the pre-existing failures are confirmed out of `unit and not slow` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)