### PR TITLE
fix(scripts): close remote-test.sh secret-leak, injection, and first-run blockers

### DIFF
--- a/scripts/remote-test.sh
+++ b/scripts/remote-test.sh
@@ -6,7 +6,7 @@
 #
 # Runs the test suite on nathan-linux for checkouts that have no local venv
 # (the MacBook). Rsyncs the CURRENT WORKING TREE — uncommitted and untracked
-# changes included — to a branch-keyed isolated dir on the server, then runs
+# changes included — to an isolated dir on the server, then runs
 # ./scripts/test.sh there. No commit or push is required, so this satisfies
 # AGENTS.md § Testing ("get a green run before committing; rsync the tree to an
 # isolated temp dir") without the contradiction the old push-then-worktree
@@ -17,9 +17,15 @@
 # copy includes .git plus your working-tree edits, so the remote diff matches
 # the Mac's. Pass any test.sh mode to override, e.g. `remote-test.sh unit`.
 #
+# Privacy: rsync does NOT honor .gitignore. We build the exclude list from git
+# so the sync carries only what git tracks plus untracked-unignored files —
+# secrets (.env, config/token-*.json, config/credentials-*.json) and personal
+# data (data/, ~15 GB) are gitignored and therefore never leave the machine.
+#
 # Streaming: remote stdout/stderr stream back live. A final marker line
 #   [remote-test] DONE rc=<code>
-# is always printed, so a backgrounded run can be waited on with:
+# is always printed — even on Ctrl-C / kill — so a backgrounded run can be
+# waited on with:
 #   ./scripts/remote-test.sh > "$OUT" 2>&1 &   # (or run_in_background)
 #   until grep -q "\[remote-test\] DONE" "$OUT"; do sleep 5; done
 #
@@ -35,24 +41,61 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_DIR"
 
-# Branch-keyed remote dir so parallel worktrees/branches don't clobber each
-# other, and re-runs on the same branch sync incrementally (fast).
+# Always clean up the temp exclude file; a dedicated INT/TERM trap guarantees
+# the DONE marker is emitted even when the script is interrupted, so the
+# documented `until grep -q "[remote-test] DONE"` wait loop can never hang.
+EXCLUDE_FILE=""
+cleanup() { [ -n "$EXCLUDE_FILE" ] && rm -f "$EXCLUDE_FILE"; }
+trap cleanup EXIT
+trap 'echo "[remote-test] DONE rc=130 (interrupted)"; exit 130' INT TERM
+
+# Isolated remote dir keyed by BOTH the branch and a hash of this checkout's
+# path, so two agents on the same branch but in different worktrees don't
+# clobber each other's run, while re-runs from the same checkout sync
+# incrementally (fast). Sanitize the branch to a safe charset — a refname may
+# legally contain shell metacharacters (`;`, `$`, quotes) and it is
+# interpolated into the remote path and command below.
 BRANCH="$(git branch --show-current 2>/dev/null || echo detached)"
 [ -z "$BRANCH" ] && BRANCH="detached"
-SAFE_BRANCH="$(printf '%s' "$BRANCH" | tr '/ ' '__')"
-REMOTE_DIR="$REMOTE_BASE/$SAFE_BRANCH"
+SAFE_BRANCH="$(printf '%s' "$BRANCH" | tr -c 'A-Za-z0-9._-' '_')"
+DIR_HASH="$(printf '%s' "$PROJECT_DIR" | cksum | cut -d' ' -f1)"
+REMOTE_DIR="$REMOTE_BASE/${SAFE_BRANCH}-${DIR_HASH}"
 
 # test.sh mode/args (default: diff-aware auto).
 TEST_ARGS=("$@")
 [ ${#TEST_ARGS[@]} -eq 0 ] && TEST_ARGS=(auto)
 
-echo "[remote-test] branch=$BRANCH -> $REMOTE_HOST:$REMOTE_DIR"
-echo "[remote-test] syncing working tree (uncommitted + untracked included)..."
+# Build the rsync exclude list from git: every path git ignores. This is the
+# authoritative privacy boundary (see header) and also mirrors exactly what
+# test.sh's own diff logic ignores. .git is NOT ignored, so it is still synced
+# (the remote `test.sh auto` needs it for the merge-base diff).
+EXCLUDE_FILE="$(mktemp "${TMPDIR:-/tmp}/lifeos-remote-test-exclude.XXXXXX")"
+if ! git ls-files --others --ignored --exclude-standard --directory > "$EXCLUDE_FILE" 2>/dev/null; then
+    echo "[remote-test] could not compute gitignore excludes — refusing to sync (would risk leaking secrets)"
+    echo "[remote-test] DONE rc=1"
+    exit 1
+fi
+# Anchor each pattern to the transfer root so e.g. /data/ excludes only the
+# top-level dir, not any nested directory that happens to share the name.
+sed -i.bak 's#^#/#' "$EXCLUDE_FILE" && rm -f "$EXCLUDE_FILE.bak"
 
-# Rsync the whole tree INCLUDING .git (so the remote `test.sh auto` sees the
-# same merge-base diff). Exclude only heavy/irrelevant local artifacts; never
-# --exclude .git. --delete keeps the remote copy an exact mirror of local.
-rsync -a --delete \
+echo "[remote-test] branch=$BRANCH -> $REMOTE_HOST:$REMOTE_DIR"
+echo "[remote-test] syncing working tree (uncommitted + untracked; gitignored paths excluded)..."
+
+# Create the remote dir (and its parent) first — rsync only creates the final
+# path component, so a missing $REMOTE_BASE makes the first-ever run, and every
+# run after a reboot wipes /tmp, fail. mkdir -p is idempotent.
+if ! ssh "$REMOTE_HOST" "mkdir -p $(printf '%q' "$REMOTE_DIR")"; then
+    echo "[remote-test] cannot reach $REMOTE_HOST (try: tailscale status)"
+    echo "[remote-test] DONE rc=1"
+    exit 1
+fi
+
+# --delete keeps the remote copy an exact mirror; --exclude-from applies the
+# gitignore-derived privacy list. The inline excludes are belt-and-suspenders
+# for heavy build artifacts that aren't necessarily gitignored (node_modules,
+# .gstack, stray *.pyc). Never --exclude .git.
+rsync -a --delete --exclude-from="$EXCLUDE_FILE" \
     --exclude='.venv' \
     --exclude='__pycache__/' \
     --exclude='*.pyc' \
@@ -73,7 +116,13 @@ fi
 echo "[remote-test] running ./scripts/test.sh ${TEST_ARGS[*]} on $REMOTE_HOST..."
 echo "----------------------------------------------------------------------"
 
-ssh "$REMOTE_HOST" "cd '$REMOTE_DIR' && ./scripts/test.sh ${TEST_ARGS[*]}"
+# Build the remote command with the dir and every arg shell-quoted, so a branch
+# name or test arg can never break out of the ssh command string.
+REMOTE_CMD="cd $(printf '%q' "$REMOTE_DIR") && ./scripts/test.sh"
+for arg in "${TEST_ARGS[@]}"; do
+    REMOTE_CMD+=" $(printf '%q' "$arg")"
+done
+ssh "$REMOTE_HOST" "$REMOTE_CMD"
 TEST_RC=$?
 
 echo "----------------------------------------------------------------------"


### PR DESCRIPTION
## Summary

Fixes the three Action Required findings on `scripts/remote-test.sh` from the #480 review, plus two related correctness items. Stacked onto `harness-audit-tier2` so merging it updates #480. Scoped to `remote-test.sh` only — the `claude-session-pane.sh` dead-code finding and the branch-name-convention finding on #480 are untouched and still need a decision.

Relates to #480.

## What changed

- **Secret / personal-data leak → world-readable `/tmp` (Action Required).** rsync ignores `.gitignore`, so the old build-artifact-only exclude list mirrored `.env`, `config/token-*.json`, `config/credentials-*.json` and ~15 GB of personal data under `data/` onto the server at 0644. Now the exclude list is generated from `git ls-files --others --ignored` — the sync carries only tracked + untracked-unignored files, the same boundary `test.sh auto`'s diff logic uses. `.git` is still synced (needed for the merge-base diff).
- **Branch-name command injection → RCE (Action Required).** A refname may legally contain `'`/`;`/`$`/backticks and was interpolated into the remote ssh command. Sanitized with `tr -c 'A-Za-z0-9._-'` **and** the remote command is now assembled with `printf %q` for the dir and every arg.
- **First-run failure (Action Required).** rsync only creates the final path component, so the first run — and every run after `/tmp` is cleared on reboot — failed rc 11. Added `ssh mkdir -p` before rsync.
- **DONE marker on interrupt (Recommended).** Added an `INT`/`TERM` trap so the `[remote-test] DONE` marker is always emitted, so the `until grep -q "[remote-test] DONE"` wait loop this PR adds to `implement/SKILL.md` can't hang forever on a killed run.
- **Same-branch collision (Recommended).** Remote dir is now keyed by branch **and** a hash of the checkout path, so two agents on one branch in different worktrees don't clobber each other; same-checkout re-runs stay incremental.

## Test evidence

Full end-to-end `ssh` transport wasn't runnable from the review environment (no agent SSH creds to `nathan-linux-ts`), so each fix was verified by isolating its mechanism:

- **Privacy:** rsynced the live checkout (which has the real secrets + 15 GB `data/`) through the new gitignore-derived exclude to a local dir — `.env`, all `config/token-*`/`credentials-*`/personal JSONs, and `data/` absent; `.git` + sources present (15 GB → 82 MB). Ran `./scripts/test.sh auto` in that pruned copy: **14 failed, 3243 passed, 35 skipped — byte-identical failing set to the pre-change run with `data/` present**, so no test depends on the excluded data.
- **Injection:** with a malicious branch (`x';touch …;'`) *and* a malicious arg together, the assembled `REMOTE_CMD` neutralizes both — the injected `touch` never executes.
- **First-run:** reproduced the rc-11 missing-parent failure, confirmed `mkdir -p` first → rc 0.
- `bash -n` clean.

## Review focus

- The `git ls-files --others --ignored --exclude-standard --directory` exclude generation + `/`-anchoring, and the fail-closed guard (refuses to sync if the git enumeration fails, rather than syncing everything).
- `printf %q` remote-command assembly portability (targets stock macOS bash 3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)