### PR TITLE
fix(scripts): drop inert remote pane-bind fallback

### DIFF
--- a/scripts/claude-session-pane.sh
+++ b/scripts/claude-session-pane.sh
@@ -57,32 +57,18 @@ if [[ -z "$SESSION_ID" ]]; then
     exit 0
 fi
 
-# Candidate API URLs, tried in order until one accepts the bind. localhost
-# first so the common case — running ON the API host (e.g. nathan-linux) — is a
-# single fast round-trip; fall back to $LIFEOS_API_URL when localhost is down.
-# On the MacBook the API is remote, so localhost:8000 has no listener and the
-# Tailscale $LIFEOS_API_URL (if provided to the hook) is what actually binds.
-URLS=("http://localhost:8000")
-if [[ -n "${LIFEOS_API_URL:-}" && "${LIFEOS_API_URL}" != "http://localhost:8000" ]]; then
-    URLS+=("$LIFEOS_API_URL")
-fi
+LIFEOS_URL="${LIFEOS_API_URL:-http://localhost:8000}"
 
-BODY="$(jq -nc \
-    --arg sid "$SESSION_ID" \
-    --argjson pid "$WEZTERM_PANE" \
-    --arg cwd "$CWD" \
-    '{session_id: $sid, pane_id: $pid, cwd: $cwd}')"
-
-# Fire-and-forget. Short timeout so a stalled/absent server never holds up the
-# user's prompt. Stop at the first URL that accepts the POST.
-for url in "${URLS[@]}"; do
-    if curl -fsS --max-time 2 \
-        -X POST "${url}/api/agents/cc-pane-bind" \
-        -H "Content-Type: application/json" \
-        -d "$BODY" \
-        >/dev/null 2>&1; then
-        break
-    fi
-done
+# Fire-and-forget. Short timeout so a stalled server never holds up the
+# user's prompt. `|| true` swallows curl's non-zero exit on network error.
+curl -fsS --max-time 2 \
+    -X POST "${LIFEOS_URL}/api/agents/cc-pane-bind" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -nc \
+        --arg sid "$SESSION_ID" \
+        --argjson pid "$WEZTERM_PANE" \
+        --arg cwd "$CWD" \
+        '{session_id: $sid, pane_id: $pid, cwd: $cwd}')" \
+    >/dev/null 2>&1 || true
 
 exit 0


### PR DESCRIPTION
## Summary

Addresses the last Action Required finding on #480: the `claude-session-pane.sh` remote fallback added by #480 is dead code. Stacked onto `harness-audit-tier2` so merging it updates #480.

Relates to #480.

## Why

`/api/agents/cc-pane-bind` is deliberately **localhost-only** — it 403s any client that isn't `127.0.0.1`/`::1` (`api/routes/agents.py`), because anyone who could reach it could rewrite the pane mapping for any session. So the #480 fallback to `$LIFEOS_API_URL` can never bind from the MacBook (always 403), and the mapping it would write (a server-side wezterm pid) is meaningless for a Mac pane. The URL loop was inert complexity.

## What changed

Reverted `claude-session-pane.sh` to the original single-POST form. That version already honored `$LIFEOS_API_URL` (defaulting to localhost) and works on nathan-linux, where the API is local. No behavior is lost — remote binding never worked.

Restoring remote pane-binding would require relaxing a deliberate auth boundary — a security-sensitive API change, out of scope here and better handled as its own reviewed feature.

## Test evidence

- `./scripts/test.sh auto` — 3243 passed, 14 pre-existing failures unrelated to this change (a bash SessionStart hook has no Python surface; the failing set is byte-identical to the pre-change baseline).
- `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)