### PR TITLE
fix(embeddings): cap encode batch_size to stop VRAM spikes that freeze the host

### DIFF
--- a/api/services/embeddings.py
+++ b/api/services/embeddings.py
@@ -197,6 +197,13 @@ class EmbeddingService:
         If the model was loaded on GPU and encode() raises a GPU error,
         the model is reloaded on CPU and the encode is retried.
         """
+        # Bound the batch so a large document's chunks are encoded in small
+        # groups instead of one giant allocation. An unbounded batch of a
+        # multi-MB note's chunks spiked ~10GB of VRAM in a single call, which
+        # exhausted the gfx1151 iGPU's SDMA queues and froze the host (#483).
+        # This is semantically neutral: batching changes only peak memory, not
+        # the resulting vectors. Callers may still override batch_size.
+        kwargs.setdefault("batch_size", settings.embedding_batch_size)
         try:
             return self.model.encode(data, **kwargs)
         except RuntimeError as e:

--- a/config/settings.py
+++ b/config/settings.py
@@ -183,6 +183,15 @@ class Settings(BaseSettings):
         alias="LIFEOS_EMBEDDING_CACHE",
         description="Directory for caching embedding model files (leave empty for HuggingFace default)"
     )
+    embedding_batch_size: int = Field(
+        default=8,
+        alias="LIFEOS_EMBEDDING_BATCH_SIZE",
+        description="Max texts per model.encode() batch. Bounds peak VRAM per "
+                    "embedding call so a large document's chunks can't spike GPU "
+                    "memory in one allocation and exhaust the iGPU's SDMA queues, "
+                    "freezing the host (issue #483). Semantically neutral — "
+                    "batching changes only peak memory, not the embedding values."
+    )
 
     # Chunking
     chunk_size: int = 500  # tokens

--- a/tests/test_embedding_fallback.py
+++ b/tests/test_embedding_fallback.py
@@ -229,3 +229,66 @@ class TestGpuToCpuFallback:
 
         state = get_service_health().get_state("embedding_model")
         assert state.status.value == "healthy"
+
+
+class TestBatchSizeCap:
+    """The encode batch is bounded so a large document can't spike VRAM in one
+    allocation and exhaust the iGPU's SDMA queues, freezing the host (#483)."""
+
+    @staticmethod
+    def _fake_encode(data, **kwargs):
+        # Mirror sentence-transformers: a list in → a vector per item; a single
+        # string in → one vector. Each vector exposes .tolist().
+        if isinstance(data, list):
+            return [MagicMock(tolist=lambda: [0.1, 0.2]) for _ in data]
+        return MagicMock(tolist=lambda: [0.1, 0.2])
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_embed_texts_passes_configured_batch_size(self, mock_st_class):
+        from api.services.embeddings import EmbeddingService
+        from config.settings import settings
+
+        model = MagicMock()
+        model.encode.side_effect = self._fake_encode
+        mock_st_class.return_value = model
+
+        svc = EmbeddingService(model_name="test-model")
+        svc.embed_texts(["a", "b", "c"])
+
+        _, kwargs = model.encode.call_args
+        assert kwargs["batch_size"] == settings.embedding_batch_size
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_embed_text_passes_configured_batch_size(self, mock_st_class):
+        from api.services.embeddings import EmbeddingService
+        from config.settings import settings
+
+        model = MagicMock()
+        model.encode.side_effect = self._fake_encode
+        mock_st_class.return_value = model
+
+        svc = EmbeddingService(model_name="test-model")
+        svc.embed_text("hello")
+
+        _, kwargs = model.encode.call_args
+        assert kwargs["batch_size"] == settings.embedding_batch_size
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_caller_can_override_batch_size(self, mock_st_class):
+        """setdefault means an explicit batch_size still wins."""
+        from api.services.embeddings import EmbeddingService
+
+        model = MagicMock()
+        model.encode.side_effect = self._fake_encode
+        mock_st_class.return_value = model
+
+        svc = EmbeddingService(model_name="test-model")
+        svc._encode_with_fallback(["a"], convert_to_numpy=True, batch_size=1)
+
+        _, kwargs = model.encode.call_args
+        assert kwargs["batch_size"] == 1
+
+    def test_default_batch_size_is_bounded(self):
+        """Guard against a future edit restoring a dangerously large default."""
+        from config.settings import settings
+        assert 1 <= settings.embedding_batch_size <= 32


### PR DESCRIPTION
## Summary

`embed_texts`/`embed_text` called `model.encode()` with **no `batch_size`**, so a large document's chunks were embedded in one unbounded call. On the gfx1151 iGPU that spiked **~10 GB of VRAM in a single allocation** → OOM → CPU fallback, and with concurrent embedders it exhausted the 8 SDMA queues, wedging the GPU and **freezing the host**.

Add a configurable `embedding_batch_size` (default **8**, `LIFEOS_EMBEDDING_BATCH_SIZE`) applied via `kwargs.setdefault` in `_encode_with_fallback`, so every encode is bounded while callers can still override.

**Semantically neutral:** batching changes only peak memory, not the vectors — existing indexed content stays consistent. (This is why `max_seq_length`, which *would* alter embeddings, is deliberately left untouched.)

Closes #483

## Test evidence

**Unit (mocked, no GPU):** 4 new tests confirm the cap is threaded through `embed_texts`/`embed_text`, that an explicit `batch_size` still overrides, and that the default stays bounded. Full suite: **2383 passed, 0 failed** (run GPU-hidden).

**Live GPU verification** — embedded the 3.47 MB "Listening Tour" file (**1736 chunks**), the exact input that OOM'd and froze the box before, single-process alongside the loaded LLM:

| Metric | Before (unbounded) | After (batch=8) |
|---|---|---|
| Single allocation | ~10.05 GB → OOM | — |
| Peak torch VRAM | — | **5.88 GB** |
| Device | CPU fallback | **GPU, no fallback** |
| SDMA-queue errors | exhausted → freeze | **0** |
| Host | froze / rebooted | stable |

## Review focus

- Default of **8** is conservative (peak ~5.9 GB); it's env-tunable if throughput matters more once the machine is stable.
- `setdefault` placement in `_encode_with_fallback` means the cap applies to both the initial GPU encode and the CPU-fallback retry.