### PR TITLE
feat(chat): minimize response source/meta footprint

### DIFF
--- a/web/chat/ask-stream.js
+++ b/web/chat/ask-stream.js
@@ -4,7 +4,7 @@
 // follow-on surfaces (#359 persona, #361 Voice|Text) can reuse it.
 
 import { state, config, elements, endpoints, hooks } from './session.js';
-import { addMessage, updateMessage, setStatus } from './thread.js';
+import { addMessage, updateMessage, setStatus, buildSourcesHtml } from './thread.js';
 import { clearAttachments } from './attachments.js';
 import { loadConversations } from './conversations.js';
 import { personaSupportsHandoff, personaOrchestrates } from './persona.js';
@@ -207,50 +207,30 @@ export async function sendMessage() {
           if (msgEl) {
             let metaHtml = '';
 
-            // Show routing sources used
-            if (routingSources.length > 0) {
+            // Show routing sources used — but only genuine data sources. The
+            // `routing` event also carries internal plumbing labels (agent,
+            // claude_code, clarification, escalation model names, codex) that
+            // aren't "sources" to the user; those get filtered out here so an
+            // answer that pulled no data doesn't render a lone "agent" pill.
+            const sourceIcons = {
+              vault: '📚',
+              calendar: '📅',
+              gmail: '✉️',
+              drive: '📁',
+              attachment: '📎',
+              people: '👤',
+              actions: '✅'
+            };
+            const dataSources = routingSources.filter(src => sourceIcons[src]);
+            if (dataSources.length > 0) {
               metaHtml += '<div class="routing-sources">';
-              const sourceIcons = {
-                vault: '📚',
-                calendar: '📅',
-                gmail: '✉️',
-                drive: '📁',
-                attachment: '📎',
-                people: '👤',
-                actions: '✅'
-              };
-              routingSources.forEach(src => {
-                const icon = sourceIcons[src] || '📄';
-                metaHtml += `<span class="routing-source ${src}">${icon} ${src}</span>`;
+              dataSources.forEach(src => {
+                metaHtml += `<span class="routing-source ${src}">${sourceIcons[src]} ${src}</span>`;
               });
               metaHtml += '</div>';
             }
 
-            if (sources.length > 0) {
-              // Add collapsed class if more than 3 sources
-              const collapsedClass = sources.length > 3 ? ' collapsed' : '';
-              metaHtml += `<div class="sources${collapsedClass}">`;
-              sources.forEach(src => {
-                const fileName = src.file_name || src;
-                const sourceType = src.source_type || 'vault';
-
-                if (sourceType === 'calendar' && src.url) {
-                  // Calendar sources use Google Calendar URL
-                  metaHtml += `<a href="${src.url}" target="_blank" class="source-link">${fileName}</a>`;
-                } else {
-                  // Vault sources use Obsidian URL
-                  const obsidianPath = src.obsidian_path || fileName;
-                  const obsidianUrl = `obsidian://open?vault=Notes%202025&file=${encodeURIComponent(obsidianPath)}`;
-                  metaHtml += `<a href="${obsidianUrl}" class="source-link">📄 ${fileName}</a>`;
-                }
-              });
-              // Add toggle button if more than 3 sources
-              if (sources.length > 3) {
-                const hiddenCount = sources.length - 3;
-                metaHtml += `<button class="sources-toggle" onclick="toggleSources(this)">Show ${hiddenCount} more...</button>`;
-              }
-              metaHtml += '</div>';
-            }
+            metaHtml += buildSourcesHtml(sources);
 
             // Remove any existing meta
             const existingMeta = msgEl.querySelector('.message-meta');

--- a/web/chat/thread.js
+++ b/web/chat/thread.js
@@ -43,29 +43,7 @@ export function addMessage(content, type, sources = [], messageId = null, target
   let html = `<div class="message-content">${formatContent(content)}</div>`;
 
   if (type === 'assistant' && content && sources.length > 0) {
-    // Add collapsed class if more than 3 sources
-    const collapsedClass = sources.length > 3 ? ' collapsed' : '';
-    html += `<div class="message-meta"><div class="sources${collapsedClass}">`;
-    sources.forEach(src => {
-      const fileName = src.file_name || src;
-      const sourceType = src.source_type || 'vault';
-
-      if (sourceType === 'calendar' && src.url) {
-        // Calendar sources use Google Calendar URL
-        html += `<a href="${src.url}" target="_blank" class="source-link">${fileName}</a>`;
-      } else {
-        // Vault sources use Obsidian URL
-        const obsidianPath = src.obsidian_path || fileName;
-        const obsidianUrl = `obsidian://open?vault=Notes%202025&file=${encodeURIComponent(obsidianPath)}`;
-        html += `<a href="${obsidianUrl}" class="source-link">📄 ${fileName}</a>`;
-      }
-    });
-    // Add toggle button if more than 3 sources
-    if (sources.length > 3) {
-      const hiddenCount = sources.length - 3;
-      html += `<button class="sources-toggle" onclick="toggleSources(this)">Show ${hiddenCount} more...</button>`;
-    }
-    html += `</div></div>`;
+    html += `<div class="message-meta">${buildSourcesHtml(sources)}</div>`;
   }
 
   msg.innerHTML = html;
@@ -96,20 +74,37 @@ export function formatContent(content) {
     .replace(/\n/g, '<br>');
 }
 
+// Build the compact, collapsed-by-default "📄 N sources" block shared by the
+// live stream (ask-stream.js) and the history render (addMessage). The file
+// chips are hidden until the user clicks the toggle; returns '' when there are
+// no sources so no empty block is rendered.
+export function buildSourcesHtml(sources) {
+  if (!sources || sources.length === 0) return '';
+  const label = sources.length === 1 ? '1 source' : `${sources.length} sources`;
+  let html = `<div class="sources collapsed">`
+    + `<button class="sources-toggle" onclick="toggleSources(this)">📄 ${label} <span class="sources-caret">▾</span></button>`
+    + `<div class="source-chips">`;
+  sources.forEach(src => {
+    const fileName = src.file_name || src;
+    const sourceType = src.source_type || 'vault';
+
+    if (sourceType === 'calendar' && src.url) {
+      // Calendar sources use Google Calendar URL
+      html += `<a href="${src.url}" target="_blank" class="source-link">${fileName}</a>`;
+    } else {
+      // Vault sources use Obsidian URL
+      const obsidianPath = src.obsidian_path || fileName;
+      const obsidianUrl = `obsidian://open?vault=Notes%202025&file=${encodeURIComponent(obsidianPath)}`;
+      html += `<a href="${obsidianUrl}" class="source-link">📄 ${fileName}</a>`;
+    }
+  });
+  html += `</div></div>`;
+  return html;
+}
+
 export function toggleSources(btn) {
   const sourcesDiv = btn.closest('.sources');
-  const isCollapsed = sourcesDiv.classList.contains('collapsed');
-  const sourceLinks = sourcesDiv.querySelectorAll('.source-link');
-  const totalCount = sourceLinks.length;
-  const hiddenCount = totalCount - 3;
-
-  if (isCollapsed) {
-    // Expand
-    sourcesDiv.classList.remove('collapsed');
-    btn.textContent = 'Show less';
-  } else {
-    // Collapse
-    sourcesDiv.classList.add('collapsed');
-    btn.textContent = `Show ${hiddenCount} more...`;
-  }
+  const isCollapsed = sourcesDiv.classList.toggle('collapsed');
+  const caret = btn.querySelector('.sources-caret');
+  if (caret) caret.textContent = isCollapsed ? '▾' : '▴';
 }

--- a/web/index.html
+++ b/web/index.html
@@ -551,9 +551,8 @@
 
         .message-meta {
             display: flex;
-            flex-wrap: wrap;
-            justify-content: space-between;
-            align-items: center;
+            flex-direction: column;
+            align-items: flex-start;
             gap: 0.5rem;
             margin-top: 0.75rem;
             padding-top: 0.75rem;
@@ -563,6 +562,13 @@
         }
 
         .sources {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 0.5rem;
+        }
+
+        .source-chips {
             display: flex;
             flex-wrap: wrap;
             gap: 0.5rem;
@@ -587,26 +593,31 @@
             color: var(--accent-hover);
         }
 
-        /* Collapsible sources */
-        .sources.collapsed .source-link:nth-child(n+4) {
+        /* Collapsible sources — collapsed by default, chips hidden until the
+           user clicks the compact "📄 N sources" toggle. */
+        .sources.collapsed .source-chips {
             display: none;
         }
 
         .sources-toggle {
             display: inline-flex;
             align-items: center;
-            padding: 0.375rem 0.625rem;
+            gap: 0.25rem;
+            padding: 0.125rem 0;
             font-size: 0.75rem;
             color: var(--text-muted);
             cursor: pointer;
             transition: color 0.2s;
             background: none;
             border: none;
-            min-height: 32px;
         }
 
         .sources-toggle:hover {
             color: var(--text-secondary);
+        }
+
+        .sources-caret {
+            font-size: 0.625rem;
         }
 
         /* Remember button */


### PR DESCRIPTION
## Problem

The per-response meta block under `/chat` assistant answers was noisy and space-hungry:

- A full row of routing-category pills that included internal plumbing labels — `agent`, `claude_code`, `clarification`, raw escalation model names, `codex` — which aren't user-meaningful "sources." A response that pulled no data would still render a lone `agent` pill.
- An always-expanded list of file-source chips (up to 3, then "Show N more").

## Changes

- **Filter routing pills to genuine data sources only** (`vault / calendar / gmail / drive / people / attachment / actions`). Internal routing labels are dropped, and the pill row is omitted entirely when nothing real remains — so answers that used no data show no stray pill.
- **Collapse file sources behind a compact one-line toggle** (`📄 N sources ▾`), expanded on click with a caret flip. Reclaims vertical space while keeping one-click access to what contributed. Empty sources render nothing.
- **Extract a shared `buildSourcesHtml()` in `thread.js`** so the live stream (`ask-stream.js`) and history reload render sources identically — previously divergent, duplicated markup.

## Files

- `web/chat/ask-stream.js` — filter routing pills; delegate file chips to shared helper
- `web/chat/thread.js` — new `buildSourcesHtml()`; simplified `toggleSources()` (class toggle + caret)
- `web/index.html` — CSS for collapsed `.source-chips`, `.sources-caret`, stacked meta layout

Pure static frontend change — no server restart required.

## Verification

- Both JS modules pass `node --check`.
- Drove the freshly-served `thread.js` module in a browser: collapsed-by-default label `📄 4 sources ▾`, toggle expands chips and flips caret to `▴`, empty sources → `''`, mixed vault/calendar chips render correctly.
- Full unit suite green via pre-push hook (2391 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)