### PR TITLE
Replace wildcard CORS with an explicit allowlist

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -184,10 +184,27 @@ app = FastAPI(
     lifespan=lifespan
 )
 
-# CORS middleware for local development
+# CORS: an explicit allowlist of the addresses this app answers on.
+#
+# The web UI does not depend on any of this — it is served by this app and
+# addresses it with root-relative paths, so its requests are same-origin and
+# never consult these rules. The list covers a page loaded at one of these
+# addresses that calls the API at another.
+#
+# A wildcard here was both ineffective and dangerous. Browsers reject `*` on
+# credentialed requests, so it never granted what it appeared to; and because
+# this app has no authentication of its own, `*` widened the security boundary
+# from "the tailnet" to "any page a tailnet device happens to have open".
+_cors_origins = [
+    f"http://localhost:{settings.port}",
+    f"http://127.0.0.1:{settings.port}",
+]
+if settings.tailnet_https_url:
+    _cors_origins.append(settings.tailnet_https_url.rstrip("/"))
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/config/settings.py
+++ b/config/settings.py
@@ -168,6 +168,11 @@ class Settings(BaseSettings):
     port: int = Field(default=8000, alias="LIFEOS_PORT")
     host: str = Field(default="0.0.0.0", alias="LIFEOS_HOST")
 
+    # The HTTPS front `tailscale serve` publishes (scripts/setup-tailscale.sh).
+    # Also the one non-local origin CORS allows, so a browser loading the UI from
+    # the tailnet hostname can call the API. Empty simply drops it from the list.
+    tailnet_https_url: str = Field(default="", alias="TAILNET_HTTPS_URL")
+
     # API Keys (no prefix - standard env var names)
     anthropic_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")
 


### PR DESCRIPTION
Closes the CORS item tracked as nbramia/ramia#15.

`api/main.py` configured `allow_origins=["*"]` with `allow_credentials=True`, under a comment saying "for local development".

Two problems:

1. **It never did what it looked like.** Browsers reject a wildcard origin on credentialed requests, so the combination is incoherent — it granted nothing while appearing permissive.
2. **It widened the security boundary.** This app has no authentication of its own; the tailnet is the boundary. Wildcard CORS extended that to "any page a tailnet device happens to have open", against 79 non-GET routes.

## The change

An explicit list: `localhost`, `127.0.0.1`, and the `tailscale serve` HTTPS front. The tailnet hostname comes from a new `tailnet_https_url` setting (`TAILNET_HTTPS_URL`, already in `.env`) rather than being written into source; unset simply drops it from the list.

## Why the UI cannot break

The web UI is served by this app and addresses it with root-relative paths only — verified by sweeping `web/` for `fetch(` call sites, all of which are `/api/...`. Those requests are same-origin, and same-origin requests never consult CORS rules. Nothing else calls this API from a browser at another origin; the MCP bridge and the `local-processing` watchers are server-side, where CORS does not apply.

So the practical blast radius is close to zero — this closes a hole rather than changing behaviour.

## Verification status — please read

**This is untested against a running server.** nathanramia-linux has been offline throughout, so I could not exercise it. What I did verify: both files compile, and the origin list builds correctly with and without `TAILNET_HTTPS_URL` set.

Worth a click-around after merge, since `lifeos-autodeploy` will ship it within ~10 minutes of the host coming back. If anything did depend on cross-origin access, the symptom is requests failing in the browser while `curl` still succeeds.