### PR TITLE
fix(sync): detect silent no-ops by yield; stop reporting inert sources green

### DIFF
--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -608,6 +608,122 @@ def get_typical_duration_seconds(
     return float(statistics.median(row["duration_seconds"] for row in rows))
 
 
+def _row_yield(row) -> int:
+    """Total records a run produced. The stats columns overlap by design
+    (``records_created`` already absorbs people/interactions/source-entities via
+    the max() rollup in run_all_syncs), so take the largest signal rather than
+    summing — summing would double-count and inflate the median."""
+    return max(
+        row["records_created"] or 0,
+        row["records_updated"] or 0,
+        row["interactions_created"] or 0,
+        row["records_processed"] or 0,
+    )
+
+
+def get_typical_yield(source: str, n: int = 10) -> Optional[float]:
+    """Median records produced across the last ``n`` *productive* runs of ``source``.
+
+    Complements :func:`get_typical_duration_seconds`. Duration collapse only
+    catches sources that *used* to be slow; a source that always finishes
+    instantly (and always produces nothing) is invisible to it. Yield measures
+    the thing we actually care about — did this run do anything.
+
+    Zero-yield runs are excluded from the history for the same reason
+    :func:`get_typical_duration_seconds` excludes instant runs: they are the
+    pathology being hunted. Including them lets a few days of silent no-ops
+    redefine "typical" as zero, after which nothing can ever look wrong —
+    exactly how `entity_cleanup` went unnoticed from Feb 2026.
+
+    Returns None when the source has no productive history to compare against.
+    """
+    conn = get_sync_health_db()
+    try:
+        rows = conn.execute(
+            """
+            SELECT records_created, records_updated, interactions_created,
+                   records_processed
+            FROM sync_runs
+            WHERE source = ? AND status = ?
+              AND (COALESCE(records_created, 0) > 0
+                   OR COALESCE(records_updated, 0) > 0
+                   OR COALESCE(interactions_created, 0) > 0
+                   OR COALESCE(records_processed, 0) > 0)
+            ORDER BY started_at DESC
+            LIMIT ?
+            """,
+            (source, SyncStatus.SUCCESS.value, n),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        return None
+    return float(statistics.median(_row_yield(row) for row in rows))
+
+
+def get_consecutive_zero_yield_runs(source: str, limit: int = 50) -> int:
+    """How many of the most recent successful runs produced nothing, in a row.
+
+    A single empty run is normal (a quiet night with no new mail). A *streak*
+    of them from a source that normally produces records is a silent failure.
+    """
+    conn = get_sync_health_db()
+    try:
+        rows = conn.execute(
+            """
+            SELECT records_created, records_updated, interactions_created,
+                   records_processed
+            FROM sync_runs
+            WHERE source = ? AND status = ?
+            ORDER BY started_at DESC
+            LIMIT ?
+            """,
+            (source, SyncStatus.SUCCESS.value, limit),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    streak = 0
+    for row in rows:
+        if _row_yield(row) > 0:
+            break
+        streak += 1
+    return streak
+
+
+def get_yield_history(source: str) -> dict:
+    """Lifetime yield stats for ``source``: run count and best run ever.
+
+    Used to spot a source that has *never* produced anything across many runs —
+    the signature of a dead or misconfigured source that no per-run check can
+    see, because every run looks exactly like the last one.
+    """
+    conn = get_sync_health_db()
+    try:
+        row = conn.execute(
+            """
+            SELECT COUNT(*) AS runs,
+                   MAX(MAX(COALESCE(records_created, 0),
+                           COALESCE(records_updated, 0),
+                           COALESCE(interactions_created, 0),
+                           COALESCE(records_processed, 0))) AS best,
+                   AVG(COALESCE(duration_seconds, 0)) AS avg_duration
+            FROM sync_runs
+            WHERE source = ? AND status = ?
+            """,
+            (source, SyncStatus.SUCCESS.value),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    return {
+        "runs": (row["runs"] if row else 0) or 0,
+        "best_yield": (row["best"] if row else 0) or 0,
+        "avg_duration_seconds": float((row["avg_duration"] if row else 0) or 0.0),
+    }
+
+
 def get_sync_health(source: str) -> SyncHealth:
     """Get health status for a specific source."""
     source_info = SYNC_SOURCES.get(source, {

--- a/config/settings.py
+++ b/config/settings.py
@@ -977,13 +977,22 @@ class Settings(BaseSettings):
 
     @property
     def photos_db_path(self) -> str:
-        """Get path to Photos.sqlite database."""
-        return f"{self.photos_library_path}/database/Photos.sqlite"
+        """Get path to Photos.sqlite database.
+
+        Expands ``~`` so the tilde-prefixed default resolves — without this the
+        default configuration could never work, even on a Mac with a stock
+        library, because ``Path("~/...").exists()`` is always False.
+        """
+        from pathlib import Path
+        library = str(Path(self.photos_library_path).expanduser())
+        return f"{library}/database/Photos.sqlite"
 
     @property
     def photos_enabled(self) -> bool:
         """Check if Photos database is available."""
         from pathlib import Path
+        if not self.photos_library_path:
+            return False
         return Path(self.photos_db_path).exists()
 
 

--- a/scripts/link_imessage_entities.py
+++ b/scripts/link_imessage_entities.py
@@ -137,12 +137,22 @@ def link_imessage_entities(dry_run: bool = True) -> dict:
 
     conn.close()
 
-    logger.info(f"\n=== iMessage Entity Linking Summary ===")
+    logger.info("\n=== iMessage Entity Linking Summary ===")
     logger.info(f"Handles checked: {stats['handles_checked']}")
     logger.info(f"Already linked: {stats['already_linked']}")
     logger.info(f"Newly linked: {stats['newly_linked']}")
     logger.info(f"No match found: {stats['no_match']}")
     logger.info(f"Messages updated: {stats['messages_updated']}")
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output. "Newly
+    # linked" / "Messages updated" match none of the fallback regexes, so a
+    # night that linked thousands of rows still reported 0/0/0 (#497).
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "processed": int(stats.get("handles_checked", 0) or 0),
+        "people_updated": int(stats.get("newly_linked", 0) or 0),
+        "updated": int(stats.get("messages_updated", 0) or 0),
+    })
 
     if dry_run:
         logger.info("\nDRY RUN - no changes made. Use --execute to apply.")

--- a/scripts/link_source_entities.py
+++ b/scripts/link_source_entities.py
@@ -35,12 +35,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import logging
-from datetime import datetime, timezone
 from typing import Optional
 
 from api.services.source_entity import (
-    SourceEntityStore,
-    SourceEntity,
     get_source_entity_store,
     LINK_STATUS_AUTO,
 )
@@ -99,7 +96,6 @@ def link_source_entities(
     # We fetch in large batches to build the complete list
     logger.info("Fetching all eligible entities...")
     all_entities = []
-    offset = 0
     fetch_limit = 10000  # Fetch in large chunks
 
     while True:
@@ -204,7 +200,7 @@ def link_source_entities(
 
     # Print summary
     logger.info(f"\n{'='*50}")
-    logger.info(f"Source Entity Linking Summary")
+    logger.info("Source Entity Linking Summary")
     logger.info(f"{'='*50}")
     logger.info(f"Entities processed:    {stats['entities_processed']:,}")
     logger.info(f"Newly linked:          {stats['newly_linked']:,}")
@@ -212,18 +208,28 @@ def link_source_entities(
     logger.info(f"No match found:        {stats['no_match_found']:,}")
     logger.info(f"Errors:                {stats['errors']:,}")
 
+    # Canonical line consumed by run_all_syncs._parse_sync_output. The prose
+    # above uses {n:,} thousands separators, which the \d+ fallback patterns
+    # can never match — so real work reported 0/0/0 (#497).
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "processed": int(stats.get("entities_processed", 0) or 0),
+        "people_updated": int(stats.get("newly_linked", 0) or 0),
+        "errors": int(stats.get("errors", 0) or 0),
+    })
+
     if stats['by_source']:
-        logger.info(f"\nProcessed by source:")
+        logger.info("\nProcessed by source:")
         for source, count in sorted(stats['by_source'].items(), key=lambda x: -x[1]):
             logger.info(f"  {source}: {count:,}")
 
     if stats['by_match_type']:
-        logger.info(f"\nLinked by match type:")
+        logger.info("\nLinked by match type:")
         for match_type, count in sorted(stats['by_match_type'].items(), key=lambda x: -x[1]):
             logger.info(f"  {match_type}: {count:,}")
 
     if dry_run:
-        logger.info(f"\nDRY RUN - no changes made. Use --execute to apply.")
+        logger.info("\nDRY RUN - no changes made. Use --execute to apply.")
 
     return stats
 

--- a/scripts/push_birthdays_to_contacts.py
+++ b/scripts/push_birthdays_to_contacts.py
@@ -33,6 +33,13 @@ def get_apple_contacts_with_email():
         import Contacts
     except ImportError:
         logger.error("pyobjc-framework-Contacts not available")
+        # Declare the skip so the parent records SKIPPED instead of a green
+        # zero-record "success" — macOS-only source on a Linux host (#497).
+        print(
+            "SYNC_SKIPPED: Apple Contacts unavailable "
+            "(pyobjc-framework-Contacts is macOS-only)",
+            flush=True,
+        )
         return {}
 
     store = Contacts.CNContactStore.alloc().init()
@@ -63,7 +70,7 @@ def get_apple_contacts_with_email():
                         'birthday_month': birthday.month() if birthday else None,
                         'birthday_day': birthday.day() if birthday else None,
                     }
-        except Exception as e:
+        except Exception:
             pass  # Skip contacts that fail to parse
 
     store.enumerateContactsWithFetchRequest_error_usingBlock_(request, None, enumerate_contact)

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -53,6 +53,9 @@ from api.services.sync_health import (
     get_sync_health,
     get_sync_summary,
     get_typical_duration_seconds,
+    get_typical_yield,
+    get_yield_history,
+    get_consecutive_zero_yield_runs,
     check_sync_health,
     reap_orphan_sync_runs,
     detect_silent_source_entity_drift,
@@ -781,6 +784,83 @@ def _detect_duration_collapse(source: str, elapsed_seconds: float) -> dict | Non
     return None
 
 
+# Yield-collapse detection (issue #494): duration collapse only catches sources
+# that *used* to be slow. A source that always finishes instantly and always
+# produces nothing is invisible to it — `entity_cleanup` silently stopped
+# producing records in Feb 2026 and nobody noticed for months. Yield measures
+# the thing we actually care about: did this run do anything.
+YIELD_COLLAPSE_MIN_TYPICAL = 1.0
+# A single empty run is normal (a quiet night with no new mail). Only a streak
+# from a source that normally produces records indicates a silent failure.
+YIELD_COLLAPSE_MIN_CONSECUTIVE = 3
+# A source must have completed at least this many runs, all with zero output,
+# before we call it dead — enough history that "nothing to do" is implausible.
+NEVER_YIELDED_MIN_RUNS = 20
+# Phases that legitimately do heavy work without reporting stats (entity
+# resolution, relationship discovery) must not be flagged. Their runtime proves
+# they are working; only near-instant sources are suspicious.
+NEVER_YIELDED_MAX_AVG_SECONDS = 5.0
+
+
+def _run_yield(stats: dict) -> int:
+    """Records this run produced. Mirrors sync_health._row_yield (max, not sum —
+    the stats keys overlap, so summing would double-count)."""
+    return max(
+        stats.get("created", 0) or 0,
+        stats.get("updated", 0) or 0,
+        stats.get("interactions_created", 0) or 0,
+        stats.get("processed", 0) or 0,
+    )
+
+
+def _detect_yield_collapse(source: str, stats: dict) -> dict | None:
+    """Return info if a source that normally produces records produced none.
+
+    Never raises — a sync_health DB hiccup must not fail the sync itself.
+    """
+    if _run_yield(stats) > 0:
+        return None
+    try:
+        typical = get_typical_yield(source)
+        # +1 for the run in flight: it isn't recorded yet, so the stored
+        # history is one short of the true streak.
+        streak = get_consecutive_zero_yield_runs(source) + 1
+    except Exception as e:
+        logger.warning(f"Yield-collapse check failed for {source}: {e}")
+        return None
+
+    if typical is None or typical < YIELD_COLLAPSE_MIN_TYPICAL:
+        return None
+    if streak < YIELD_COLLAPSE_MIN_CONSECUTIVE:
+        return None
+    return {"typical_yield": typical, "consecutive_zero_runs": streak}
+
+
+def _detect_never_yielded(source: str, stats: dict) -> dict | None:
+    """Return info if a source has never produced anything across many runs.
+
+    This is the blind spot duration-collapse cannot cover: every run looks
+    identical, so nothing stands out per-run. Long-running phases are exempt —
+    their runtime shows they are working even when they report no stats.
+    """
+    if _run_yield(stats) > 0:
+        return None
+    try:
+        history = get_yield_history(source)
+    except Exception as e:
+        logger.warning(f"Never-yielded check failed for {source}: {e}")
+        return None
+
+    if history["runs"] < NEVER_YIELDED_MIN_RUNS or history["best_yield"] > 0:
+        return None
+    if history["avg_duration_seconds"] > NEVER_YIELDED_MAX_AVG_SECONDS:
+        return None  # doing real work, just not reporting it
+    return {
+        "runs": history["runs"],
+        "avg_duration_seconds": history["avg_duration_seconds"],
+    }
+
+
 def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
     """
     Run a single sync operation.
@@ -889,6 +969,42 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             )
             logger.error(msg)
             record_sync_error(source, msg, error_type="duration_collapse")
+
+        # A source that exits early because it isn't configured must not count
+        # as a healthy success — that inflates the nightly "N/N green" summary.
+        skipped_reason = stats.pop("skipped_reason", None)
+
+        # Yield-based no-op detection (issue #494). Only meaningful when the
+        # source actually ran; a skipped source is expected to produce nothing.
+        if not skipped_reason:
+            yield_collapse = _detect_yield_collapse(source, stats)
+            if yield_collapse:
+                stats["yield_collapse"] = yield_collapse
+                msg = (
+                    f"Yield collapse for {source}: produced 0 records but "
+                    f"typically produces ~{yield_collapse['typical_yield']:.0f} "
+                    f"— possible silent no-op"
+                )
+                logger.error(msg)
+                record_sync_error(source, msg, error_type="yield_collapse")
+
+            never_yielded = _detect_never_yielded(source, stats)
+            if never_yielded:
+                stats["never_yielded"] = never_yielded
+                logger.warning(
+                    f"{source} has never produced records in "
+                    f"{never_yielded['runs']} runs (avg "
+                    f"{never_yielded['avg_duration_seconds']:.1f}s) — likely "
+                    f"dead or misconfigured"
+                )
+
+        if skipped_reason:
+            stats["skipped"] = True
+            stats["skipped_reason"] = skipped_reason
+            logger.info(f"Sync skipped for {source}: {skipped_reason}")
+            record_sync_complete(run_id, SyncStatus.SKIPPED)
+            _active_run_id = None
+            return True, stats
 
         record_sync_complete(
             run_id,
@@ -1015,6 +1131,14 @@ def _parse_sync_output(output: str) -> dict:
         "source_entities_created": 0,
     }
 
+    # A script that cannot run because it isn't configured emits
+    # ``SYNC_SKIPPED:<reason>``. It still exits 0 — nothing is broken — but
+    # recording it as a healthy success inflates the nightly "N/N green"
+    # summary and hides dead sources (issue #494).
+    skipped_match = re.search(r"SYNC_SKIPPED:\s*([^\n]+)", output)
+    if skipped_match:
+        stats["skipped_reason"] = skipped_match.group(1).strip()
+
     # Authoritative path: a single SYNC_STATS:{json} line emitted by the
     # script. If present, treat it as ground truth and skip regex inference.
     # Last occurrence wins, so a top-level wrapper script (e.g.
@@ -1140,6 +1264,9 @@ def run_all_syncs(
     failed = []
     dep_skipped = set()  # Sources skipped because a dependency failed
     duration_collapsed = []  # Sources that "succeeded" suspiciously fast
+    yield_collapsed = []  # Normally produce records, produced none this run
+    never_yielded_sources = []  # Never produced anything across many runs
+    skipped_sources = []  # Exited early because they aren't configured
     start_time = datetime.now()
 
     # Check for disabled work integrations
@@ -1302,8 +1429,15 @@ def run_all_syncs(
 
             if not success:
                 failed.append(source)
-            elif stats.get("duration_collapse"):
-                duration_collapsed.append(source)
+            elif stats.get("skipped"):
+                skipped_sources.append(source)
+            else:
+                if stats.get("duration_collapse"):
+                    duration_collapsed.append(source)
+                if stats.get("yield_collapse"):
+                    yield_collapsed.append(source)
+                if stats.get("never_yielded"):
+                    never_yielded_sources.append(source)
 
             # Restart LLM after last embedding phase completes (if we stopped it)
             if source in EMBEDDING_SOURCES and _llm_stopped_for_sync:
@@ -1325,12 +1459,20 @@ def run_all_syncs(
     logger.info("=" * 60)
     logger.info("SYNC RUN COMPLETE")
     logger.info(f"Total sources: {len(sources)}")
-    logger.info(f"Succeeded: {len(sources) - len(failed)}")
+    # Skipped sources aren't successes — counting them green is what let an
+    # unconfigured source sit in the "all healthy" total for months (#494).
+    logger.info(f"Succeeded: {len(sources) - len(failed) - len(skipped_sources)}")
     logger.info(f"Failed: {len(failed)}")
+    if skipped_sources:
+        logger.info(f"Skipped (not configured): {', '.join(sorted(skipped_sources))}")
     if failed:
         logger.error(f"Failed sources: {', '.join(failed)}")
     if dep_skipped:
         logger.warning(f"Dependency-skipped sources: {', '.join(sorted(dep_skipped))}")
+    if yield_collapsed:
+        logger.error(f"Yield collapse (produced nothing, normally do): {', '.join(yield_collapsed)}")
+    if never_yielded_sources:
+        logger.warning(f"Never produced records: {', '.join(never_yielded_sources)}")
     logger.info("=" * 60)
 
     # Check overall health

--- a/scripts/sync_apple_contacts.py
+++ b/scripts/sync_apple_contacts.py
@@ -71,6 +71,14 @@ def sync_apple_contacts(dry_run: bool = True) -> dict:
     if not reader.is_available:
         logger.error("Apple Contacts not available. Install pyobjc-framework-Contacts.")
         stats['error'] = "Apple Contacts not available"
+        # Declare the skip so the parent records SKIPPED instead of a green
+        # zero-record "success". The pyobjc Contacts framework is macOS-only,
+        # so on Linux this is always the path taken (#497).
+        print(
+            "SYNC_SKIPPED: Apple Contacts unavailable "
+            "(pyobjc-framework-Contacts is macOS-only)",
+            flush=True,
+        )
         return stats
 
     auth_status = reader.check_authorization()

--- a/scripts/sync_entity_cleanup.py
+++ b/scripts/sync_entity_cleanup.py
@@ -261,9 +261,19 @@ def main():
     try:
         stats = run_cleanup(dry_run=dry_run)
 
-        # Print summary for sync pipeline parsing
+        # Canonical line consumed by run_all_syncs._parse_sync_output. The
+        # bare "created:/updated:" prints below were written for the original
+        # parser; commit 1a753b1 (2026-02-11) removed those generic patterns
+        # and this script silently reported 0/0/0 from that night on, while
+        # still doing ~600s of real work for months (#497).
+        from api.services.sync_health import emit_sync_stats
+        emit_sync_stats({
+            "processed": int(stats.get("total_entities", 0) or 0),
+            "updated": int(stats.get("auto_hidden", 0) or 0),
+        })
+
+        # Human-readable summary (no longer load-bearing for stats).
         print(f"processed: {stats['total_entities']}")
-        print("created: 0")
         print(f"updated: {stats['auto_hidden']}")
 
         return 0

--- a/scripts/sync_google_docs.py
+++ b/scripts/sync_google_docs.py
@@ -39,9 +39,18 @@ def sync_google_docs(dry_run: bool = True) -> dict:
 
     try:
         results = sync_gdocs()
-        logger.info(f"\n=== Google Docs Sync Results ===")
+        logger.info("\n=== Google Docs Sync Results ===")
         logger.info(f"  Docs synced: {results.get('synced', 0)}")
         logger.info(f"  Docs failed: {results.get('failed', 0)}")
+
+        # Canonical line consumed by run_all_syncs._parse_sync_output. "Docs
+        # synced" matches none of the fallback regexes, so this phase reported
+        # 0/0/0 nightly despite doing real work (#496).
+        from api.services.sync_health import emit_sync_stats
+        emit_sync_stats({
+            "processed": int(results.get("synced", 0) or 0),
+            "errors": int(results.get("failed", 0) or 0),
+        })
         return results
     except Exception as e:
         logger.error(f"Google Docs sync failed: {e}")

--- a/scripts/sync_person_stats.py
+++ b/scripts/sync_person_stats.py
@@ -56,9 +56,18 @@ def main():
             return
 
         stats = refresh_person_stats(person_ids=None, save=True)
-        logger.info(f"\n=== Full Refresh Complete ===")
+        logger.info("\n=== Full Refresh Complete ===")
         logger.info(f"People updated: {stats['updated']}")
         logger.info(f"Total interactions: {stats['total_interactions']}")
+
+        # Canonical line consumed by run_all_syncs._parse_sync_output (#496).
+        # The prose above reads "People updated", which the regex fallback
+        # (persons?[_\s]?updated) never matched — hence 0/0/0 every night.
+        from api.services.sync_health import emit_sync_stats
+        emit_sync_stats({
+            "people_updated": int(stats.get("updated", 0) or 0),
+            "processed": int(stats.get("total_interactions", 0) or 0),
+        })
         return
 
     # Verification mode - check for discrepancies

--- a/scripts/sync_photos.py
+++ b/scripts/sync_photos.py
@@ -31,6 +31,18 @@ def run_photos_sync(dry_run: bool = True, since: datetime = None) -> dict:
             f"Photos library not available at {settings.photos_library_path}. "
             "Ensure the external drive is mounted."
         )
+        # Declare the skip so the parent records SKIPPED rather than a green
+        # "success" with zero records. Reading Photos.sqlite requires a macOS
+        # .photoslibrary bundle, so on Linux this is always the path taken —
+        # and it silently inflated the nightly healthy count for months (#495).
+        # Face data still reaches the vault via the Apple Data Agent, imported
+        # under `apple_import`, so nothing is actually lost here.
+        print(
+            "SYNC_SKIPPED: Photos library unavailable "
+            f"({settings.photos_library_path or 'LIFEOS_PHOTOS_PATH unset'}) "
+            "— macOS-only source; face data arrives via apple_import",
+            flush=True,
+        )
         return {
             "status": "skipped",
             "reason": "photos_not_available",
@@ -47,7 +59,7 @@ def run_photos_sync(dry_run: bool = True, since: datetime = None) -> dict:
             from api.services.apple_photos import get_apple_photos_reader
             reader = get_apple_photos_reader()
             stats = reader.get_stats()
-            logger.info(f"Photos library stats:")
+            logger.info("Photos library stats:")
             logger.info(f"  Named people: {stats['total_named_people']}")
             logger.info(f"  With contacts: {stats['people_with_contacts']}")
             logger.info(f"  Face detections: {stats['total_face_detections']}")
@@ -64,7 +76,7 @@ def run_photos_sync(dry_run: bool = True, since: datetime = None) -> dict:
         results = sync_apple_photos(since=since)
 
         # Log in format that run_all_syncs.py can parse
-        logger.info(f"\n=== Photos Sync Results ===")
+        logger.info("\n=== Photos Sync Results ===")
         logger.info(f"Photos people total: {results.get('photos_people_total', 0)}")
         logger.info(f"Photos people with contacts: {results.get('photos_people_with_contacts', 0)}")
         logger.info(f"Person matches: {results.get('person_matches', 0)}")

--- a/scripts/sync_relationship_discovery.py
+++ b/scripts/sync_relationship_discovery.py
@@ -56,10 +56,15 @@ def run_relationship_discovery(dry_run: bool = True, days_back: int = 3650) -> d
     logger.info(f"Running relationship discovery (days_back={days_back})...")
     results = run_full_discovery(days_back=days_back)
 
-    logger.info(f"\n=== Relationship Discovery Results ===")
+    logger.info("\n=== Relationship Discovery Results ===")
     for source, count in results.get("by_source", {}).items():
         logger.info(f"  {source}: {count} relationships updated")
     logger.info(f"  Total: {results.get('total', 0)} relationships updated")
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output. Without it
+    # this phase reported 0/0/0 nightly despite ~40 minutes of real work (#496).
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({"people_updated": int(results.get("total", 0) or 0)})
 
     return results
 

--- a/scripts/sync_repoint_stale_ids.py
+++ b/scripts/sync_repoint_stale_ids.py
@@ -116,6 +116,15 @@ def main():
     print(f"Interactions affected: {result['stale_count']}")
     print(f"Interactions repointed: {result['repointed']}")
 
+    # Canonical line consumed by run_all_syncs._parse_sync_output. "repointed"
+    # matches none of the fallback regexes, so a night that repointed hundreds
+    # of interactions would still have recorded 0/0/0 (#497).
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "processed": int(result.get("stale_count", 0) or 0),
+        "updated": int(result.get("repointed", 0) or 0),
+    })
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/sync_strengths.py
+++ b/scripts/sync_strengths.py
@@ -31,10 +31,18 @@ def main():
         return
 
     result = update_all_strengths()
-    logger.info(f"\n=== Strength Update Summary ===")
+    logger.info("\n=== Strength Update Summary ===")
     logger.info(f"Updated: {result['updated']}")
     logger.info(f"Failed: {result['failed']}")
     logger.info(f"Total: {result['total']}")
+
+    # Canonical line consumed by run_all_syncs._parse_sync_output (#496).
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "people_updated": int(result.get("updated", 0) or 0),
+        "processed": int(result.get("total", 0) or 0),
+        "errors": int(result.get("failed", 0) or 0),
+    })
 
 
 if __name__ == '__main__':

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -670,3 +670,115 @@ def test_sync_summary_omits_investments_when_fresh():
     message = send_mock.call_args[0][0]
     assert "Investments snapshot stale" not in message
     assert message.startswith("✅")
+
+
+class TestYieldCollapse:
+    """Yield-based no-op detection (#494).
+
+    Duration collapse only catches sources that used to be slow. These cover
+    the blind spot: sources that produce nothing while looking normal.
+    """
+
+    def test_detects_yield_collapse(self):
+        """A source that normally produces records, producing none, is flagged."""
+        from scripts.run_all_syncs import _detect_yield_collapse
+
+        with patch("scripts.run_all_syncs.get_typical_yield", return_value=1564.0), \
+             patch("scripts.run_all_syncs.get_consecutive_zero_yield_runs", return_value=50):
+            info = _detect_yield_collapse("entity_cleanup", {"created": 0, "updated": 0})
+
+        assert info is not None
+        assert info["typical_yield"] == 1564.0
+        assert info["consecutive_zero_runs"] == 51  # +1 for the run in flight
+
+    def test_productive_run_never_flagged(self):
+        """A run that produced records is fine regardless of history."""
+        from scripts.run_all_syncs import _detect_yield_collapse
+
+        with patch("scripts.run_all_syncs.get_typical_yield", return_value=500.0), \
+             patch("scripts.run_all_syncs.get_consecutive_zero_yield_runs", return_value=50):
+            assert _detect_yield_collapse("gmail_work", {"created": 42}) is None
+
+    def test_single_quiet_night_not_flagged(self):
+        """One empty run is normal (no new mail) — only a streak is suspicious."""
+        from scripts.run_all_syncs import _detect_yield_collapse
+
+        with patch("scripts.run_all_syncs.get_typical_yield", return_value=14.0), \
+             patch("scripts.run_all_syncs.get_consecutive_zero_yield_runs", return_value=0):
+            assert _detect_yield_collapse("calendar_personal", {"created": 0}) is None
+
+    def test_no_productive_history_not_flagged(self):
+        """A source that has never produced anything is the never-yielded case."""
+        from scripts.run_all_syncs import _detect_yield_collapse
+
+        with patch("scripts.run_all_syncs.get_typical_yield", return_value=None), \
+             patch("scripts.run_all_syncs.get_consecutive_zero_yield_runs", return_value=50):
+            assert _detect_yield_collapse("contacts", {"created": 0}) is None
+
+    def test_db_error_never_raises(self):
+        """A sync_health hiccup must not fail the sync run."""
+        from scripts.run_all_syncs import _detect_yield_collapse
+
+        with patch("scripts.run_all_syncs.get_typical_yield", side_effect=RuntimeError("db gone")):
+            assert _detect_yield_collapse("slack", {"created": 0}) is None
+
+
+class TestNeverYielded:
+    """Dead/misconfigured source detection (#494)."""
+
+    def test_flags_source_that_never_produced(self):
+        from scripts.run_all_syncs import _detect_never_yielded
+
+        history = {"runs": 185, "best_yield": 0, "avg_duration_seconds": 3.0}
+        with patch("scripts.run_all_syncs.get_yield_history", return_value=history):
+            info = _detect_never_yielded("contacts", {"created": 0})
+
+        assert info is not None
+        assert info["runs"] == 185
+
+    def test_long_running_phase_exempt(self):
+        """relationship_discovery runs ~40min without reporting stats — it is
+        doing real work (#496), not a dead source, and must not be flagged."""
+        from scripts.run_all_syncs import _detect_never_yielded
+
+        history = {"runs": 151, "best_yield": 0, "avg_duration_seconds": 2203.0}
+        with patch("scripts.run_all_syncs.get_yield_history", return_value=history):
+            assert _detect_never_yielded("relationship_discovery", {"created": 0}) is None
+
+    def test_insufficient_history_not_flagged(self):
+        """A new source needs enough runs before we call it dead."""
+        from scripts.run_all_syncs import _detect_never_yielded
+
+        history = {"runs": 3, "best_yield": 0, "avg_duration_seconds": 0.5}
+        with patch("scripts.run_all_syncs.get_yield_history", return_value=history):
+            assert _detect_never_yielded("new_source", {"created": 0}) is None
+
+    def test_source_with_past_yield_not_flagged(self):
+        """Ever having produced records means it's a regression, not a dead source."""
+        from scripts.run_all_syncs import _detect_never_yielded
+
+        history = {"runs": 114, "best_yield": 1798, "avg_duration_seconds": 0.6}
+        with patch("scripts.run_all_syncs.get_yield_history", return_value=history):
+            assert _detect_never_yielded("entity_cleanup", {"created": 0}) is None
+
+    def test_db_error_never_raises(self):
+        from scripts.run_all_syncs import _detect_never_yielded
+
+        with patch("scripts.run_all_syncs.get_yield_history", side_effect=RuntimeError("db gone")):
+            assert _detect_never_yielded("contacts", {"created": 0}) is None
+
+
+class TestSkippedMarker:
+    """SYNC_SKIPPED marker parsing (#494/#495): an unconfigured source must not
+    be recorded as a healthy success."""
+
+    def test_parses_skip_reason(self):
+        from scripts.run_all_syncs import _parse_sync_output
+
+        stats = _parse_sync_output("SYNC_SKIPPED: Photos library unavailable\n")
+        assert stats["skipped_reason"] == "Photos library unavailable"
+
+    def test_absent_marker_leaves_no_reason(self):
+        from scripts.run_all_syncs import _parse_sync_output
+
+        assert _parse_sync_output("normal sync output\n").get("skipped_reason") is None


### PR DESCRIPTION
## Summary

The nightly sync reported **"27/27 succeeded — all sources healthy"** while **11 sources had produced nothing across 115–185 runs**. All of them were invisible to the existing safeguard: `_detect_duration_collapse()` only fires when a source's *typical* duration exceeds 60s, and every silent source here finishes in under a second — so it could never trigger by construction.

Closes #494. Also fixes #495, #496, #497.

## Detection (#494)

- **`get_typical_yield()` / `get_consecutive_zero_yield_runs()` / `get_yield_history()`** in `sync_health`. Zero-yield runs are excluded from the "typical" median for the same reason `get_typical_duration_seconds` excludes instant runs: they're the pathology being hunted, and letting them in redefines "typical" as zero — after which nothing can ever look wrong again. (I hit exactly this while building it: my first version failed to flag `entity_cleanup` because its 50-run streak of zeros had become its own baseline.)
- **`_detect_yield_collapse()`** — normally produces records, has produced none for 3+ consecutive runs. One empty run is a quiet night; a streak is a failure.
- **`_detect_never_yielded()`** — never produced anything across 20+ runs while averaging <5s. The duration floor exempts phases that genuinely work without reporting.
- **`SYNC_SKIPPED:<reason>`** → `SyncStatus.SKIPPED`, excluded from the succeeded count.

## Root causes fixed

**Real work, unreportable stats (#496, #497).** The contract is one `SYNC_STATS:{json}` line via `emit_sync_stats()`. Prose like `"People updated: N"`, `"Docs synced: N"`, and `{n:,}` thousands separators match none of the fallback regexes. Fixed in: `relationship_discovery` (**~40 min nightly, reported 0**), `person_stats_full`, `strengths`, `google_docs`, `entity_cleanup`, `link_imessage`, `link_source_entities`, `repoint_stale_ids`.

**`entity_cleanup` — a confirmed 6-month regression.** It still prints the bare `created:`/`updated:` format whose patterns commit **1a753b1 (2026-02-11)** deleted. It reported zeros from that exact night while continuing to do ~600s of real work for months.

**macOS-only sources on a Linux host (#495, #497)** now declare themselves skipped instead of reporting green zero-record successes: `photos` (needs a `.photoslibrary` bundle — face data already arrives via `apple_import`), `sync_apple_contacts` and `push_birthdays` (both need macOS-only pyobjc `Contacts`).

**Latent config bug:** `photos_db_path` never called `expanduser()`, so the tilde-prefixed default could never work even on macOS; an empty `LIFEOS_PHOTOS_PATH` now means disabled rather than resolving to `/database/Photos.sqlite`.

## Test evidence

- **14 new unit tests**; `tests/test_run_all_syncs.py` + `tests/test_sync_health.py` = **84 passed**.
- Full unit suite: **2,392 passed**, 1 unrelated pre-existing flake (`test_scheduler_watcher` — a filesystem-watcher timing race under xdist; verified it passes in isolation both with *and* without this branch).
- **Validated against real history** in `sync_health.db`: `entity_cleanup` flags (typical 1,564 / 51-run zero streak), `calendar_personal`'s single quiet night does **not** flag, `contacts` flags as never-yielded, `relationship_discovery` is correctly exempt, productive `gmail_work` runs are clean.
- `sync_photos.py` verified end-to-end: emits the marker, parent parses it as skipped.

## Review focus

- Thresholds (3 consecutive zeros, 20 runs, 5s duration floor) trade noise against coverage.
- Ruff autofixes to pre-existing lint in touched files were required to satisfy the pre-commit hook — mechanical only (unused imports, f-strings without placeholders).