### PR TITLE
fix(sync): close the remaining latent no-op bugs from #496/#497

### DIFF
--- a/scripts/link_imessage_entities.py
+++ b/scripts/link_imessage_entities.py
@@ -7,7 +7,12 @@ phone numbers in the CRM source_entities table.
 """
 import sqlite3
 import logging
+import sys
 from pathlib import Path
+
+# Running `python scripts/foo.py` puts scripts/ on sys.path, not the project
+# root, so `import api` fails without this. Mirrors the sibling sync scripts.
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)
@@ -93,16 +98,20 @@ def link_imessage_entities(dry_run: bool = True) -> dict:
         if not normalized:
             continue
 
-        # Check if already linked
+        # Skip only handles with NOTHING left to link. Testing for the
+        # presence of a linked message instead (the previous behaviour) meant a
+        # handle whose messages were partially linked — one linked row was
+        # enough — was skipped forever, so its remaining rows could never be
+        # backfilled (#497). The UPDATE below is already scoped to unlinked
+        # rows, so re-visiting a partially-linked handle is safe.
         cursor = conn.execute("""
-            SELECT person_entity_id FROM messages
+            SELECT 1 FROM messages
             WHERE handle_normalized = ?
-            AND person_entity_id IS NOT NULL
+            AND (person_entity_id IS NULL OR person_entity_id = '')
             LIMIT 1
         """, (handle,))
-        existing = cursor.fetchone()
 
-        if existing:
+        if cursor.fetchone() is None:
             stats['already_linked'] += 1
             continue
 

--- a/scripts/link_source_entities.py
+++ b/scripts/link_source_entities.py
@@ -75,7 +75,6 @@ def link_source_entities(
     resolver = get_entity_resolver()
 
     stats = {
-        'total_unlinked': 0,
         'eligible_for_matching': 0,
         'entities_processed': 0,
         'newly_linked': 0,
@@ -86,11 +85,6 @@ def link_source_entities(
         'by_source': {},
         'by_match_type': {},
     }
-
-    # Get counts
-    stats['total_unlinked'] = source_store.count() - sum(
-        1 for _ in range(1)  # placeholder - we'll get actual count
-    )
 
     # Get all eligible entities upfront to avoid re-fetching in dry run mode
     # We fetch in large batches to build the complete list
@@ -122,6 +116,12 @@ def link_source_entities(
 
     if stats['eligible_for_matching'] == 0:
         logger.info("No unlinked entities to process!")
+        # Emit on the early-return path too. A stats call that only runs at the
+        # bottom of the function is invisible whenever the function returns
+        # early — the exact reason sync_apple_contacts never reported (#497).
+        # An explicit zero here is meaningful: it says "ran, nothing eligible".
+        from api.services.sync_health import emit_sync_stats
+        emit_sync_stats({"processed": 0, "people_updated": 0, "errors": 0})
         return stats
 
     # Process in batches

--- a/scripts/sync_consistency_verify.py
+++ b/scripts/sync_consistency_verify.py
@@ -526,6 +526,17 @@ def main():
     }
     print(f"CONSISTENCY_SUMMARY:{json.dumps(summary)}")
 
+    # Canonical line consumed by run_all_syncs._parse_sync_output. The
+    # CONSISTENCY_SUMMARY keys above have no columns in record_sync_complete,
+    # so they never reached sync_health and this phase always recorded 0/0/0
+    # (#496). Repairs are genuine record updates; issues found are what was
+    # examined, so they map onto `updated` and `processed` respectively.
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "processed": int(result.get("total_issues", 0) or 0),
+        "updated": int(result.get("total_fixed", 0) or 0),
+    })
+
     return 0
 
 


### PR DESCRIPTION
## Summary

Follow-up to #498, addressing the items deliberately left open on #496 and #497.

**`consistency_verify` (#496)** — now emits `SYNC_STATS` alongside its existing `CONSISTENCY_SUMMARY`, whose `total_issues`/`total_fixed` keys have no columns in `record_sync_complete()` and so never reached `sync_health`. Repairs are genuine record updates, so `total_fixed` → `updated`, `total_issues` → `processed`.

**`link_imessage` (#497)** — a handle was skipped as "already linked" if **any** of its messages had a `person_entity_id`. A partially-linked handle could therefore never be backfilled, and new messages arriving for an already-known contact would be stranded permanently. Now it skips only handles with nothing left to link; the `UPDATE` was already scoped to unlinked rows, so re-visiting is safe.

**`link_source_entities` (#497)** — emits stats on the early-return path too. A stats call that only runs at the bottom of a function is invisible whenever the function returns early — the exact reason `sync_apple_contacts` never reported. An explicit zero is meaningful here ("ran, nothing eligible"). Also removes the dead `total_unlinked` placeholder (`count() - sum(1 for _ in range(1))`, i.e. `count() - 1`), only ever assigned, never read.

## Test evidence

Every touched script was run **under production conditions** (`PYTHONPATH=<project root>`, as `run_all_syncs` sets) — all exit 0 and emit parseable stats. Unit tests: 84 passed.

The numbers these phases had been silently reporting as **zero** are substantial:

| Phase | Was reported | Actually |
|---|---|---|
| `strengths` | 0 | **14,131** people updated |
| `person_stats_full` | 0 | **10,184** updated across **411,174** interactions |
| `google_docs` | 0 | 6 docs |

`link_imessage` behaviour verified unchanged today against the live DB (2,518 handles checked / 536 already linked / 1 newly linkable) — 0 handles are currently partially linked, so this prevents future stranding rather than altering present behaviour.

## Note

`link_imessage` also gains the standard `sys.path` bootstrap its siblings have so it can be run standalone. The orchestrator sets `PYTHONPATH`, so its absence was never a production failure — worth stating plainly since I initially misread a direct-invocation `ModuleNotFoundError` as a shipped bug.