### PR TITLE
feat(ops): non-TTY Monarch re-auth script + document the TTY limitation

### DIFF
--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -23,7 +23,25 @@ If adding new cron jobs or scripts on macOS that need to access protected direct
 
 Auth uses a cached session token at `data/monarch_session.pickle`. Monthly sync runs on the 1st via `run_all_syncs.py` (phase 5). Live queries at `/api/monarch/*`.
 
-Re-authenticate when token expires (401/525):
+Re-authenticate when the token expires (401/525), or when the nightly sync warns
+that the session is old. Run from the project root — the session path is relative.
+
+**Preferred (works in any shell, including agent/non-TTY sessions):** reads
+`MONARCH_EMAIL` / `MONARCH_PASSWORD` from `.env` and takes the MFA code as an
+argument. TOTP codes expire in ~30s, so read the code and run promptly.
+
+```bash
+~/.venvs/lifeos/bin/python scripts/monarch_reauth.py <6-digit-code>
+```
+
+It verifies the new session with a live authenticated call before reporting
+success — a saved pickle alone does not prove the session works. On success it
+prints how many accounts are reachable.
+
+**Interactive alternative (requires a real TTY):** prompts for email, password,
+and MFA code. This fails with `EOFError: EOF when reading a line` in any
+non-interactive shell, including Claude Code's `!` prefix.
+
 ```bash
 ~/.venvs/lifeos/bin/python -c "
 import asyncio
@@ -34,6 +52,9 @@ mm.save_session('data/monarch_session.pickle')
 print('Session saved!')
 "
 ```
+
+The running API server picks up the refreshed session without a restart; verify
+with `curl -s localhost:8000/api/monarch/accounts | head -c 200`.
 
 ## Performance Tracing — Quick Commands
 

--- a/scripts/monarch_reauth.py
+++ b/scripts/monarch_reauth.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Re-authenticate Monarch Money and save the session.
+
+The documented flow uses ``interactive_login()``, which prompts on stdin and so
+only works from a real TTY. This variant reads the credentials already present
+in ``.env`` and takes the MFA code as an argument, so it can be run from any
+non-interactive shell:
+
+    python scripts/monarch_reauth.py 123456
+
+The MFA code is a short-lived TOTP, so run this promptly after reading it.
+Verifies the saved session with a live authenticated call before declaring
+success — writing the file is not proof that it works.
+"""
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import dotenv_values  # noqa: E402
+from monarchmoney import MonarchMoney  # noqa: E402
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SESSION_PATH = PROJECT_ROOT / "data" / "monarch_session.pickle"
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Re-authenticate Monarch Money")
+    parser.add_argument("code", help="6-digit MFA code from your authenticator")
+    args = parser.parse_args()
+
+    env = dotenv_values(PROJECT_ROOT / ".env")
+    email, password = env.get("MONARCH_EMAIL"), env.get("MONARCH_PASSWORD")
+    if not email or not password:
+        print("MONARCH_EMAIL / MONARCH_PASSWORD missing from .env", file=sys.stderr)
+        return 1
+
+    mm = MonarchMoney()
+    try:
+        await mm.multi_factor_authenticate(email, password, args.code.strip())
+    except Exception as e:
+        print(f"MFA failed ({type(e).__name__}): {str(e)[:200]}", file=sys.stderr)
+        print("If the code expired, get a fresh one and re-run.", file=sys.stderr)
+        return 1
+
+    mm.save_session(str(SESSION_PATH))
+
+    # A saved file proves nothing — confirm the session actually authenticates.
+    try:
+        accounts = await mm.get_accounts()
+        n = len(accounts.get("accounts", []))
+    except Exception as e:
+        print(f"Session saved but verification call FAILED "
+              f"({type(e).__name__}): {str(e)[:200]}", file=sys.stderr)
+        return 1
+
+    print(f"Session saved to {SESSION_PATH} and verified — {n} accounts reachable.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Summary

The documented Monarch re-auth uses `interactive_login()`, which prompts on stdin. That fails with `EOFError: EOF when reading a line` in any non-interactive shell — including Claude Code's `!` prefix — so the procedure couldn't be followed from an agent session, which is exactly where the expiry warning surfaces.

`scripts/monarch_reauth.py` reads the `MONARCH_EMAIL` / `MONARCH_PASSWORD` already in `.env` and takes the MFA code as an argument, so no TTY is needed:

```bash
~/.venvs/lifeos/bin/python scripts/monarch_reauth.py <6-digit-code>
```

It **verifies the saved session with a live `get_accounts()` call** before reporting success — writing the pickle proves nothing on its own, and a silently dead session is the exact failure mode being fixed here.

The guide now leads with this and keeps the interactive form as a labelled alternative.

## Test evidence

Verified end-to-end on the host: session had been expired since May 28 (72 days), re-auth succeeded, **48 accounts reachable**, and `/api/monarch/accounts` immediately served live account data **without a server restart**. `ruff` clean.

## Note

Credentials are read from `.env` (already present) and never printed. The MFA code is passed as an argument — single-use and ~30s-lived, so shell-history exposure is not meaningful.