### PR TITLE
fix(sync): self-explanatory health summary + damp never-yielded warnings

### DIFF
--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -984,7 +984,17 @@ def check_sync_health() -> tuple[bool, str]:
     summary = get_sync_summary()
 
     if summary["all_healthy"]:
-        return True, f"All {summary['total_sources']} sources are healthy"
+        total = summary["total_sources"]
+        disabled = summary["disabled"]
+        if disabled:
+            # Self-explanatory breakdown (issue #494 follow-up): total tracked
+            # sources includes ones that are intentionally disabled (e.g.
+            # macOS-only "phone" on a Linux host) and therefore don't appear
+            # in the nightly run order — without the breakdown this line
+            # looked like it contradicted "Total sources: N" a few lines up.
+            enabled = summary["enabled_sources"]
+            return True, f"All {total} tracked sources healthy ({enabled} active + {disabled} disabled)"
+        return True, f"All {total} sources are healthy"
 
     issues = []
     if summary["stale"]:

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -38,7 +38,7 @@ import time
 import traceback
 import urllib.error
 import urllib.request
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Add project root to path
@@ -56,6 +56,7 @@ from api.services.sync_health import (
     get_typical_yield,
     get_yield_history,
     get_consecutive_zero_yield_runs,
+    get_recent_errors,
     check_sync_health,
     reap_orphan_sync_runs,
     detect_silent_source_entity_drift,
@@ -861,6 +862,41 @@ def _detect_never_yielded(source: str, stats: dict) -> dict | None:
     }
 
 
+# A chronic never-yielded source (link_slack, repoint_stale_ids, google_sheets,
+# etc.) is a fixed, known-benign condition every night — issue #494's
+# acceptance criterion was "report once, not nightly", not "warn every night
+# forever". Re-warn periodically so a genuinely-fixed source's silence isn't
+# permanent, but damp the common case.
+NEVER_YIELDED_REWARN_DAYS = 7
+
+
+def _recently_warned_never_yielded(source: str, within_days: int = NEVER_YIELDED_REWARN_DAYS) -> bool:
+    """True if a ``never_yielded`` warning was already recorded for ``source``
+    within the last ``within_days`` days.
+
+    Never raises — a sync_health DB hiccup must not fail the sync. On error we
+    fall through to "not recently warned", since a duplicate warning is
+    harmless while a silently-dropped one defeats the point of the check.
+    """
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=within_days)
+        for err in get_recent_errors(source=source, limit=20):
+            if err.get("error_type") != "never_yielded":
+                continue
+            ts = err.get("timestamp")
+            if not ts:
+                continue
+            err_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if err_dt.tzinfo is None:
+                err_dt = err_dt.replace(tzinfo=timezone.utc)
+            if err_dt >= cutoff:
+                return True
+    except Exception as e:
+        logger.warning(f"Never-yielded rewarn check failed for {source}: {e}")
+        return False
+    return False
+
+
 def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
     """
     Run a single sync operation.
@@ -991,12 +1027,19 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             never_yielded = _detect_never_yielded(source, stats)
             if never_yielded:
                 stats["never_yielded"] = never_yielded
-                logger.warning(
-                    f"{source} has never produced records in "
-                    f"{never_yielded['runs']} runs (avg "
-                    f"{never_yielded['avg_duration_seconds']:.1f}s) — likely "
-                    f"dead or misconfigured"
-                )
+                # Damped (#494 follow-up): only warn when the condition is
+                # newly true, or periodically — not every night for the same
+                # chronic sources.
+                if not _recently_warned_never_yielded(source):
+                    msg = (
+                        f"{source} has never produced records in "
+                        f"{never_yielded['runs']} runs (avg "
+                        f"{never_yielded['avg_duration_seconds']:.1f}s) — likely "
+                        f"dead or misconfigured"
+                    )
+                    logger.warning(msg)
+                    record_sync_error(source, msg, error_type="never_yielded")
+                    stats["never_yielded_warned"] = True
 
         if skipped_reason:
             stats["skipped"] = True
@@ -1436,7 +1479,7 @@ def run_all_syncs(
                     duration_collapsed.append(source)
                 if stats.get("yield_collapse"):
                     yield_collapsed.append(source)
-                if stats.get("never_yielded"):
+                if stats.get("never_yielded_warned"):
                     never_yielded_sources.append(source)
 
             # Restart LLM after last embedding phase completes (if we stopped it)

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -768,6 +768,107 @@ class TestNeverYielded:
             assert _detect_never_yielded("contacts", {"created": 0}) is None
 
 
+class TestNeverYieldedDamping:
+    """Never-yielded warning must fire once, not nightly (#494 follow-up):
+    a chronic source (link_slack, repoint_stale_ids, google_sheets) should
+    only re-warn every ``NEVER_YIELDED_REWARN_DAYS`` days, not every run."""
+
+    def test_no_prior_warning_not_recently_warned(self):
+        from scripts.run_all_syncs import _recently_warned_never_yielded
+
+        with patch("scripts.run_all_syncs.get_recent_errors", return_value=[]):
+            assert _recently_warned_never_yielded("link_slack") is False
+
+    def test_recent_warning_suppresses(self):
+        from datetime import datetime, timezone, timedelta
+        from scripts.run_all_syncs import _recently_warned_never_yielded
+
+        recent = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+        errors = [{"error_type": "never_yielded", "timestamp": recent}]
+        with patch("scripts.run_all_syncs.get_recent_errors", return_value=errors):
+            assert _recently_warned_never_yielded("link_slack") is True
+
+    def test_warning_older_than_window_rewarns(self):
+        from datetime import datetime, timezone, timedelta
+        from scripts.run_all_syncs import _recently_warned_never_yielded
+
+        stale = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+        errors = [{"error_type": "never_yielded", "timestamp": stale}]
+        with patch("scripts.run_all_syncs.get_recent_errors", return_value=errors):
+            assert _recently_warned_never_yielded("link_slack") is False
+
+    def test_other_error_types_ignored(self):
+        from datetime import datetime, timezone
+        from scripts.run_all_syncs import _recently_warned_never_yielded
+
+        now = datetime.now(timezone.utc).isoformat()
+        errors = [{"error_type": "yield_collapse", "timestamp": now}]
+        with patch("scripts.run_all_syncs.get_recent_errors", return_value=errors):
+            assert _recently_warned_never_yielded("link_slack") is False
+
+    def test_db_error_never_raises(self):
+        from scripts.run_all_syncs import _recently_warned_never_yielded
+
+        with patch("scripts.run_all_syncs.get_recent_errors", side_effect=RuntimeError("db gone")):
+            assert _recently_warned_never_yielded("link_slack") is False
+
+    def test_run_sync_skips_warning_and_error_when_recently_warned(self):
+        """End-to-end through run_sync: when damped, neither the WARNING log
+        nor a new sync_errors row should be produced, and the source must not
+        land in the nightly 'Never produced records' rollup."""
+        import subprocess
+        from scripts.run_all_syncs import run_sync, SYNC_SCRIPTS
+
+        source = next(iter(SYNC_SCRIPTS))
+        never_yielded_info = {"runs": 185, "avg_duration_seconds": 3.0}
+
+        completed = subprocess.CompletedProcess(args=["fake"], returncode=0, stdout="", stderr="")
+        with (
+            patch("scripts.run_all_syncs.subprocess.run", return_value=completed),
+            patch("scripts.run_all_syncs.record_sync_start", return_value=999),
+            patch("scripts.run_all_syncs.record_sync_complete"),
+            patch("scripts.run_all_syncs.record_sync_error") as record_error_mock,
+            patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_never_yielded", return_value=never_yielded_info),
+            patch("scripts.run_all_syncs._recently_warned_never_yielded", return_value=True),
+        ):
+            success, stats = run_sync(source, dry_run=False)
+
+        assert success is True
+        assert stats["never_yielded"] == never_yielded_info
+        assert "never_yielded_warned" not in stats
+        record_error_mock.assert_not_called()
+
+    def test_run_sync_warns_and_records_error_when_not_recently_warned(self):
+        """When not damped, run_sync must log the warning, record a
+        sync_errors row with error_type='never_yielded', and mark the stats
+        so the nightly rollup line includes this source."""
+        import subprocess
+        from scripts.run_all_syncs import run_sync, SYNC_SCRIPTS
+
+        source = next(iter(SYNC_SCRIPTS))
+        never_yielded_info = {"runs": 185, "avg_duration_seconds": 3.0}
+
+        completed = subprocess.CompletedProcess(args=["fake"], returncode=0, stdout="", stderr="")
+        with (
+            patch("scripts.run_all_syncs.subprocess.run", return_value=completed),
+            patch("scripts.run_all_syncs.record_sync_start", return_value=999),
+            patch("scripts.run_all_syncs.record_sync_complete"),
+            patch("scripts.run_all_syncs.record_sync_error") as record_error_mock,
+            patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_never_yielded", return_value=never_yielded_info),
+            patch("scripts.run_all_syncs._recently_warned_never_yielded", return_value=False),
+        ):
+            success, stats = run_sync(source, dry_run=False)
+
+        assert success is True
+        assert stats["never_yielded_warned"] is True
+        record_error_mock.assert_called_once()
+        assert record_error_mock.call_args.kwargs.get("error_type") == "never_yielded"
+
+
 class TestSkippedMarker:
     """SYNC_SKIPPED marker parsing (#494/#495): an unconfigured source must not
     be recorded as a healthy success."""

--- a/tests/test_sync_health.py
+++ b/tests/test_sync_health.py
@@ -272,6 +272,40 @@ class TestSyncHealthSummary:
             assert is_healthy is True
             assert "healthy" in message.lower()
 
+    def test_check_sync_health_healthy_breakdown_when_disabled(self, temp_db):
+        """When some tracked sources are disabled, the healthy message must
+        break the total down (active vs disabled) so it doesn't read as
+        contradicting a nightly 'Total sources: N' line that only counts the
+        sources actually run (issue #494 follow-up)."""
+        summary = {
+            "all_healthy": True,
+            "total_sources": 28,
+            "enabled_sources": 27,
+            "disabled": 1,
+        }
+        with patch('api.services.sync_health.get_sync_summary', return_value=summary):
+            is_healthy, message = check_sync_health()
+
+        assert is_healthy is True
+        assert "28" in message
+        assert "27" in message
+        assert "1" in message
+        assert "healthy" in message.lower()
+
+    def test_check_sync_health_healthy_no_disabled_sources(self, temp_db):
+        """When nothing is disabled, keep the original simple message."""
+        summary = {
+            "all_healthy": True,
+            "total_sources": 28,
+            "enabled_sources": 28,
+            "disabled": 0,
+        }
+        with patch('api.services.sync_health.get_sync_summary', return_value=summary):
+            is_healthy, message = check_sync_health()
+
+        assert is_healthy is True
+        assert message == "All 28 sources are healthy"
+
     def test_check_sync_health_unhealthy(self, temp_db):
         """Test health check when there are issues."""
         with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):


### PR DESCRIPTION
## Summary

Follow-ups from the post-#498 nightly audit (items 3 and 5).

**Health-line mismatch** — the nightly log said `Total sources: 27` then `All 28 sources are healthy`. The 28th is the platform-disabled `phone` source (macOS-only, not in the nightly order), not a bug. `check_sync_health()` now emits a self-explanatory breakdown when any tracked source is disabled: `All 28 tracked sources healthy (27 active + 1 disabled)`.

**Never-yielded damping** — issue #494's acceptance criterion was "report once, not nightly"; as shipped it warned every night for the same chronic trio (link_slack, repoint_stale_ids, google_sheets). Now warns at most once per 7 days per source, backed by `sync_errors` rows (`error_type='never_yielded'`), fail-open on DB errors. Detection still runs nightly for observability; only the warning/rollup is damped.

## Test evidence

9 new tests (damping unit + end-to-end through `run_sync`, health-message breakdown). Affected suites: **93 passed**. Pre-push full suite: **2,385 passed, 8 skipped**. Ruff clean.

Implemented by a Sonnet subagent in an isolated worktree; reviewed by the orchestrator.