### PR TITLE
fix(macos): LifeOS.app wrapper must not start a server by default

### DIFF
--- a/scripts/create-lifeos-app.sh
+++ b/scripts/create-lifeos-app.sh
@@ -76,15 +76,36 @@ cat > "$APP_PATH/Contents/MacOS/LifeOS" << SCRIPT
 # All scripts that need FDA or access to ~/Documents/ should route through here.
 #
 # Usage:
-#   LifeOS                  - Start the API server (default, used by launchd)
+#   LifeOS                  - Prints this usage and exits 1 (no default action)
+#   LifeOS server           - Start the API server (must be explicit)
 #   LifeOS fda-sync         - Run FDA sync (phone/iMessage via Terminal.app)
 #   LifeOS watchdog         - ChromaDB health check and auto-restart
 #   LifeOS server-watchdog  - Server health check and auto-restart
 #   LifeOS exec <cmd>       - Run arbitrary command with FDA permissions
+#   LifeOS run <cmd>        - Run command as subprocess, keeping LifeOS.app as parent (preserves FDA)
+#
+# IMPORTANT: no-arg invocation must NEVER default to 'server'. This app is
+# often installed as a login item on machines that only run the export agent
+# (the API server lives on the Linux host per the architecture) — an
+# implicit 'server' default means every login silently launches a rogue
+# uvicorn on :8000 via Terminal.app. 'server' requires an explicit argument.
 
 LIFEOS_DIR="$PROJECT_DIR"
 
-case "\${1:-server}" in
+case "\${1:-}" in
+    "")
+        echo "Usage: LifeOS <command> [args]" >&2
+        echo "" >&2
+        echo "Commands:" >&2
+        echo "  server           - Start the API server (must be explicit)" >&2
+        echo "  fda-sync         - Run FDA sync (phone/iMessage via Terminal.app)" >&2
+        echo "  watchdog         - ChromaDB health check and auto-restart" >&2
+        echo "  server-watchdog  - Server health check and auto-restart" >&2
+        echo "  exec <cmd>       - Run arbitrary command with FDA permissions" >&2
+        echo "  run <cmd>        - Run command as subprocess, keeping LifeOS.app as parent" >&2
+        exit 1
+        ;;
+
     server)
         osascript <<'EOF'
 tell application "Terminal"
@@ -133,9 +154,17 @@ EOF
         exec "\$@"
         ;;
 
+    run)
+        # Run command as subprocess, keeping LifeOS.app as parent process.
+        # Unlike exec, this preserves FDA because macOS TCC checks the
+        # responsible process (LifeOS.app) rather than the child binary.
+        shift
+        "\$@"
+        ;;
+
     *)
         echo "Unknown command: \$1" >&2
-        echo "Usage: LifeOS [server|fda-sync|watchdog|server-watchdog|exec <cmd>]" >&2
+        echo "Usage: LifeOS [server|fda-sync|watchdog|server-watchdog|exec <cmd>|run <cmd>]" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary

The FDA wrapper generated by `scripts/create-lifeos-app.sh` defaulted to `server` on a no-arg invocation, so the app auto-started a LifeOS API server via Terminal.app. On the Mac Mini — which per the architecture runs only the *export agent*, with the server on the Linux host — the app in login items booted a **rogue uvicorn on :8000 at every login**. An operator disabled the whole bundle to stop it, which silently broke the nightly Apple export (`Export: FAILED ... No such file or directory`, 2026-08-09).

Now: no-arg prints usage and exits 1 without touching osascript. `LifeOS server` still works when explicitly requested. Also adds the missing `run` subcommand (template drift — the deployed copy had it, the generator didn't).

## Test evidence

Generated the bundle to a scratch path and verified the *generated* script: `bash -n` clean, no-arg → usage + exit 1 with no osascript invocation, `run echo hello` works, `run)` block matches deployed semantics. Full suite 2,385 passed / 8 skipped.

Notable catch during verification: backticks in a comment inside the unquoted `<< SCRIPT` heredoc were live command substitution, breaking generation — confirmed not pre-existing and fixed.

Implemented by a Sonnet subagent in an isolated worktree; reviewed by the orchestrator.