### PR TITLE
feat(whatsapp): create source entities from LID contacts

### DIFF
--- a/api/services/whatsapp.py
+++ b/api/services/whatsapp.py
@@ -124,16 +124,127 @@ def parse_message_timestamp(ts) -> datetime:
 # Contact processing
 # ---------------------------------------------------------------------------
 
-def process_whatsapp_contacts(contacts: list[dict], dry_run: bool = False) -> dict:
+def _upsert_contact_source(
+    source_store,
+    person_store,
+    resolver,
+    stats: dict,
+    source_id: str,
+    existing_source: Optional[SourceEntity],
+    observed_name: str,
+    observed_phone: str,
+    metadata: dict,
+    dry_run: bool,
+) -> bool:
+    """Create/update a WhatsApp SourceEntity and resolve+link it to a PersonEntity.
+
+    Shared by the classic-contact and LID-contact branches of
+    process_whatsapp_contacts so both paths get identical resolve/link/
+    person-update behavior and stats counting. Returns True if a new
+    SourceEntity was created (False on update), so callers can layer their
+    own creation counters (e.g. lid_entities_created) on top.
+    """
+    source_entity = SourceEntity(
+        source_type=SOURCE_WHATSAPP,
+        source_id=source_id,
+        observed_name=observed_name,
+        observed_phone=observed_phone,
+        metadata=metadata,
+        observed_at=datetime.now(timezone.utc),
+    )
+
+    created = False
+    if existing_source:
+        if not dry_run:
+            existing_source.observed_name = source_entity.observed_name
+            existing_source.observed_phone = source_entity.observed_phone
+            existing_source.metadata = source_entity.metadata
+            existing_source.observed_at = datetime.now(timezone.utc)
+            source_store.update(existing_source)
+        stats["source_entities_updated"] += 1
+        source_entity = existing_source
+    else:
+        if not dry_run:
+            source_entity = source_store.add(source_entity)
+        stats["source_entities_created"] += 1
+        created = True
+
+    result = resolver.resolve(
+        name=observed_name,
+        phone=observed_phone,
+        create_if_missing=True,
+    )
+
+    if result and result.entity:
+        person = result.entity
+        person_updated = False
+
+        if not existing_source or existing_source.canonical_person_id != person.id:
+            if not dry_run:
+                source_store.link_to_person(
+                    source_entity.id,
+                    person.id,
+                    confidence=0.95,
+                    status=LINK_STATUS_AUTO,
+                )
+            stats["persons_linked"] += 1
+
+        if observed_phone and observed_phone not in person.phone_numbers:
+            person.phone_numbers.append(observed_phone)
+            if not person.phone_primary:
+                person.phone_primary = observed_phone
+            person_updated = True
+
+        if SOURCE_WHATSAPP not in person.sources:
+            person.sources.append(SOURCE_WHATSAPP)
+            person_updated = True
+
+        if not dry_run:
+            new_count = source_store.count_for_person(person.id)
+            if person.source_entity_count != new_count:
+                person.source_entity_count = new_count
+                person_updated = True
+
+        if person_updated:
+            if not dry_run:
+                person_store.update(person)
+            stats["persons_updated"] += 1
+
+        if result.is_new:
+            stats["persons_created"] += 1
+
+    return created
+
+
+def process_whatsapp_contacts(
+    contacts: list[dict],
+    lid_contacts: Optional[list[dict]] = None,
+    lid_phones: Optional[dict[str, str]] = None,
+    dry_run: bool = False,
+) -> dict:
     """Create/update SourceEntity and PersonEntity records from WhatsApp contacts.
+
+    Also processes `lid_contacts` (WhatsApp's LID privacy migration means new
+    contacts arrive here instead of in `contacts` — see module docstring).
+    Each LID entry needs a non-empty push_name AND a phone resolvable via
+    `lid_phones`; entries missing either are skipped, mirroring the nameless-
+    number filter on the classic branch below. Before creating a new
+    LID-keyed entity, checks whether a classic `whatsapp_{phone-jid}` entity
+    already exists for the same phone and updates that instead — avoids
+    creating a duplicate person for someone who's already a classic contact.
 
     Args:
         contacts: List of contact dicts with keys JID, Phone, Name, Alias.
+        lid_contacts: List of {jid, push_name} for @lid contacts.
+        lid_phones: Map of bare LID → raw phone (from whatsmeow lid_map).
         dry_run: If True, count what would happen without writing.
 
     Returns:
         Stats dict.
     """
+    lid_contacts = lid_contacts or []
+    lid_phones = lid_phones or {}
+
     stats = {
         "contacts_read": len(contacts),
         "source_entities_created": 0,
@@ -143,6 +254,10 @@ def process_whatsapp_contacts(contacts: list[dict], dry_run: bool = False) -> di
         "persons_updated": 0,
         "skipped": 0,
         "errors": 0,
+        "lid_contacts_read": len(lid_contacts),
+        "lid_entities_created": 0,
+        "lid_merged_into_classic": 0,
+        "lid_skipped": 0,
     }
 
     source_store = get_source_entity_store()
@@ -169,9 +284,13 @@ def process_whatsapp_contacts(contacts: list[dict], dry_run: bool = False) -> di
             source_id = f"whatsapp_{jid}"
             existing_source = source_store.get_by_source(SOURCE_WHATSAPP, source_id)
 
-            source_entity = SourceEntity(
-                source_type=SOURCE_WHATSAPP,
+            _upsert_contact_source(
+                source_store,
+                person_store,
+                resolver,
+                stats,
                 source_id=source_id,
+                existing_source=existing_source,
                 observed_name=display_name,
                 observed_phone=phone,
                 metadata={
@@ -179,69 +298,64 @@ def process_whatsapp_contacts(contacts: list[dict], dry_run: bool = False) -> di
                     "alias": alias,
                     "raw_phone": phone_raw,
                 },
-                observed_at=datetime.now(timezone.utc),
+                dry_run=dry_run,
             )
-
-            if existing_source:
-                if not dry_run:
-                    existing_source.observed_name = source_entity.observed_name
-                    existing_source.observed_phone = source_entity.observed_phone
-                    existing_source.metadata = source_entity.metadata
-                    existing_source.observed_at = datetime.now(timezone.utc)
-                    source_store.update(existing_source)
-                stats["source_entities_updated"] += 1
-                source_entity = existing_source
-            else:
-                if not dry_run:
-                    source_entity = source_store.add(source_entity)
-                stats["source_entities_created"] += 1
-
-            result = resolver.resolve(
-                name=display_name,
-                phone=phone,
-                create_if_missing=True,
-            )
-
-            if result and result.entity:
-                person = result.entity
-                person_updated = False
-
-                if not existing_source or existing_source.canonical_person_id != person.id:
-                    if not dry_run:
-                        source_store.link_to_person(
-                            source_entity.id,
-                            person.id,
-                            confidence=0.95,
-                            status=LINK_STATUS_AUTO,
-                        )
-                    stats["persons_linked"] += 1
-
-                if phone and phone not in person.phone_numbers:
-                    person.phone_numbers.append(phone)
-                    if not person.phone_primary:
-                        person.phone_primary = phone
-                    person_updated = True
-
-                if SOURCE_WHATSAPP not in person.sources:
-                    person.sources.append(SOURCE_WHATSAPP)
-                    person_updated = True
-
-                if not dry_run:
-                    new_count = source_store.count_for_person(person.id)
-                    if person.source_entity_count != new_count:
-                        person.source_entity_count = new_count
-                        person_updated = True
-
-                if person_updated:
-                    if not dry_run:
-                        person_store.update(person)
-                    stats["persons_updated"] += 1
-
-                if result.is_new:
-                    stats["persons_created"] += 1
 
         except Exception as e:
             logger.error(f"Error processing contact: {e}")
+            stats["errors"] += 1
+
+    for entry in lid_contacts:
+        try:
+            lid_jid = entry.get("jid", "")
+            push_name = (entry.get("push_name") or "").strip()
+            if not push_name:
+                stats["lid_skipped"] += 1
+                continue
+
+            phone = resolve_lid_phone(lid_jid, lid_phones)
+            if not phone:
+                stats["lid_skipped"] += 1
+                continue
+
+            # Dedup: a classic {phone}@s.whatsapp.net entity for the same
+            # phone already exists → update it, don't create a LID duplicate.
+            classic_jid = f"{phone.lstrip('+')}@s.whatsapp.net"
+            classic_source_id = f"whatsapp_{classic_jid}"
+            existing_classic = source_store.get_by_source(SOURCE_WHATSAPP, classic_source_id)
+
+            if existing_classic:
+                source_id = classic_source_id
+                existing_source = existing_classic
+                stats["lid_merged_into_classic"] += 1
+            else:
+                source_id = f"whatsapp_{lid_jid}"
+                existing_source = source_store.get_by_source(SOURCE_WHATSAPP, source_id)
+
+            bare_lid = lid_jid.split("@")[0].split(":")[0] if lid_jid else ""
+
+            created = _upsert_contact_source(
+                source_store,
+                person_store,
+                resolver,
+                stats,
+                source_id=source_id,
+                existing_source=existing_source,
+                observed_name=push_name,
+                observed_phone=phone,
+                metadata={
+                    "jid": lid_jid,
+                    "lid": True,
+                    "raw_phone": lid_phones.get(bare_lid, ""),
+                },
+                dry_run=dry_run,
+            )
+
+            if created and not existing_classic:
+                stats["lid_entities_created"] += 1
+
+        except Exception as e:
+            logger.error(f"Error processing LID contact: {e}")
             stats["errors"] += 1
 
     if not dry_run:

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -675,12 +675,21 @@ def import_whatsapp(dry_run: bool = False, manifest: dict | None = None) -> dict
         process_whatsapp_messages,
     )
 
-    contact_stats = process_whatsapp_contacts(contacts, dry_run=dry_run)
+    contact_stats = process_whatsapp_contacts(
+        contacts,
+        lid_contacts=lid_contacts,
+        lid_phones=lid_phones,
+        dry_run=dry_run,
+    )
     logger.info(
         f"WhatsApp contacts: {contact_stats['source_entities_created']} created, "
         f"{contact_stats['source_entities_updated']} updated, "
         f"{contact_stats['persons_linked']} linked, "
-        f"{contact_stats['skipped']} skipped"
+        f"{contact_stats['skipped']} skipped, "
+        f"{contact_stats['lid_contacts_read']} lid contacts read "
+        f"({contact_stats['lid_entities_created']} created, "
+        f"{contact_stats['lid_merged_into_classic']} merged into classic, "
+        f"{contact_stats['lid_skipped']} skipped)"
     )
 
     message_stats = process_whatsapp_messages(

--- a/tests/test_whatsapp_service.py
+++ b/tests/test_whatsapp_service.py
@@ -9,13 +9,16 @@ import sqlite3
 from unittest.mock import MagicMock, patch
 
 from api.services.whatsapp import (
+    SOURCE_WHATSAPP,
     extract_phone_from_jid,
     is_group_jid,
     normalize_phone,
     parse_message_timestamp,
+    process_whatsapp_contacts,
     process_whatsapp_messages,
     resolve_lid_phone,
 )
+from api.services.source_entity import SourceEntity
 
 
 # ---------------------------------------------------------------------------
@@ -551,3 +554,195 @@ class TestProcessWhatsAppMessagesLidPhone:
         resolver.resolve.assert_called_with(
             name="Jonathan", phone="+12125550142", create_if_missing=False,
         )
+
+
+# ---------------------------------------------------------------------------
+# Contact processing — LID contacts becoming source entities (#503)
+# ---------------------------------------------------------------------------
+
+class _FakePerson:
+    """Minimal PersonEntity stand-in with real (not MagicMock) list attrs.
+
+    process_whatsapp_contacts mutates person.phone_numbers/sources in place
+    and compares person.source_entity_count, so a MagicMock's auto-generated
+    attributes won't behave correctly here.
+    """
+
+    def __init__(self, person_id: str):
+        self.id = person_id
+        self.phone_numbers = []
+        self.phone_primary = None
+        self.sources = []
+        self.source_entity_count = 0
+
+
+def _mock_contact_stores(get_by_source_result=None, resolved_person: str = "person-x"):
+    """Build source_store/person_store/resolver mocks for process_whatsapp_contacts.
+
+    get_by_source_result: value (or side_effect callable) returned by
+    source_store.get_by_source — None means no existing entity anywhere.
+    """
+    source_store = MagicMock()
+    if callable(get_by_source_result):
+        source_store.get_by_source.side_effect = get_by_source_result
+    else:
+        source_store.get_by_source.return_value = get_by_source_result
+    source_store.add.side_effect = lambda entity: entity
+    source_store.count_for_person.return_value = 1
+
+    person_store = MagicMock()
+
+    person = _FakePerson(resolved_person)
+    result = MagicMock(entity=person, is_new=False)
+    resolver = MagicMock()
+    resolver.resolve.return_value = result
+
+    return source_store, person_store, resolver, person
+
+
+class TestProcessWhatsAppContactsLid:
+    """LID contacts (#503) must produce source entities, deduped against classic ones."""
+
+    def test_lid_with_name_and_resolvable_phone_creates_entity(self):
+        source_store, person_store, resolver, person = _mock_contact_stores(
+            get_by_source_result=None, resolved_person="person-priya",
+        )
+        lid_contacts = [{"jid": "246698660126807@lid", "push_name": "Priya"}]
+        lid_phones = {"246698660126807": "12125550142"}
+
+        with patch("api.services.whatsapp.get_source_entity_store", return_value=source_store), \
+             patch("api.services.whatsapp.get_person_entity_store", return_value=person_store), \
+             patch("api.services.whatsapp.get_entity_resolver", return_value=resolver):
+            stats = process_whatsapp_contacts(
+                contacts=[], lid_contacts=lid_contacts, lid_phones=lid_phones, dry_run=False,
+            )
+
+        assert stats["lid_contacts_read"] == 1
+        assert stats["lid_entities_created"] == 1
+        assert stats["source_entities_created"] == 1
+        assert stats["lid_skipped"] == 0
+        assert stats["lid_merged_into_classic"] == 0
+        resolver.resolve.assert_called_once_with(
+            name="Priya", phone="+12125550142", create_if_missing=True,
+        )
+        added_entity = source_store.add.call_args.args[0]
+        assert added_entity.source_id == "whatsapp_246698660126807@lid"
+        assert added_entity.observed_name == "Priya"
+        assert added_entity.observed_phone == "+12125550142"
+
+    def test_lid_without_push_name_skipped(self):
+        source_store, person_store, resolver, _ = _mock_contact_stores()
+        lid_contacts = [{"jid": "246698660126807@lid", "push_name": ""}]
+
+        with patch("api.services.whatsapp.get_source_entity_store", return_value=source_store), \
+             patch("api.services.whatsapp.get_person_entity_store", return_value=person_store), \
+             patch("api.services.whatsapp.get_entity_resolver", return_value=resolver):
+            stats = process_whatsapp_contacts(
+                contacts=[], lid_contacts=lid_contacts, lid_phones={}, dry_run=False,
+            )
+
+        assert stats["lid_skipped"] == 1
+        assert stats["lid_entities_created"] == 0
+        resolver.resolve.assert_not_called()
+
+    def test_lid_with_unresolvable_phone_skipped(self):
+        source_store, person_store, resolver, _ = _mock_contact_stores()
+        lid_contacts = [{"jid": "999999999999@lid", "push_name": "Bob"}]
+
+        with patch("api.services.whatsapp.get_source_entity_store", return_value=source_store), \
+             patch("api.services.whatsapp.get_person_entity_store", return_value=person_store), \
+             patch("api.services.whatsapp.get_entity_resolver", return_value=resolver):
+            stats = process_whatsapp_contacts(
+                contacts=[], lid_contacts=lid_contacts, lid_phones={}, dry_run=False,
+            )
+
+        assert stats["lid_skipped"] == 1
+        assert stats["lid_entities_created"] == 0
+        resolver.resolve.assert_not_called()
+
+    def test_lid_matching_classic_contact_updates_classic_no_duplicate(self):
+        classic_source_id = "whatsapp_12125550142@s.whatsapp.net"
+        existing_classic = SourceEntity(
+            source_type=SOURCE_WHATSAPP,
+            source_id=classic_source_id,
+            observed_name="Priya Old Name",
+            observed_phone="+12125550142",
+            canonical_person_id="person-priya",
+        )
+
+        def get_by_source(source_type, source_id):
+            return existing_classic if source_id == classic_source_id else None
+
+        source_store, person_store, resolver, person = _mock_contact_stores(
+            get_by_source_result=get_by_source, resolved_person="person-priya",
+        )
+        lid_contacts = [{"jid": "246698660126807@lid", "push_name": "Priya"}]
+        lid_phones = {"246698660126807": "12125550142"}
+
+        with patch("api.services.whatsapp.get_source_entity_store", return_value=source_store), \
+             patch("api.services.whatsapp.get_person_entity_store", return_value=person_store), \
+             patch("api.services.whatsapp.get_entity_resolver", return_value=resolver):
+            stats = process_whatsapp_contacts(
+                contacts=[], lid_contacts=lid_contacts, lid_phones=lid_phones, dry_run=False,
+            )
+
+        assert stats["lid_merged_into_classic"] == 1
+        assert stats["lid_entities_created"] == 0
+        assert stats["source_entities_created"] == 0
+        assert stats["source_entities_updated"] == 1
+        source_store.add.assert_not_called()
+        source_store.update.assert_called_once()
+        updated_entity = source_store.update.call_args.args[0]
+        assert updated_entity.source_id == classic_source_id
+        assert updated_entity.observed_name == "Priya"
+
+    def test_lid_idempotent_second_run_updates_not_creates(self):
+        lid_source_id = "whatsapp_246698660162027@lid"
+        existing_lid_entity = SourceEntity(
+            source_type=SOURCE_WHATSAPP,
+            source_id=lid_source_id,
+            observed_name="Priya",
+            observed_phone="+12125550142",
+            canonical_person_id="person-priya",
+        )
+
+        def get_by_source(source_type, source_id):
+            # No classic entity anywhere; the LID entity from a prior run exists.
+            return existing_lid_entity if source_id == lid_source_id else None
+
+        source_store, person_store, resolver, person = _mock_contact_stores(
+            get_by_source_result=get_by_source, resolved_person="person-priya",
+        )
+        lid_contacts = [{"jid": "246698660162027@lid", "push_name": "Priya"}]
+        lid_phones = {"246698660162027": "12125550142"}
+
+        with patch("api.services.whatsapp.get_source_entity_store", return_value=source_store), \
+             patch("api.services.whatsapp.get_person_entity_store", return_value=person_store), \
+             patch("api.services.whatsapp.get_entity_resolver", return_value=resolver):
+            stats = process_whatsapp_contacts(
+                contacts=[], lid_contacts=lid_contacts, lid_phones=lid_phones, dry_run=False,
+            )
+
+        assert stats["lid_entities_created"] == 0
+        assert stats["source_entities_created"] == 0
+        assert stats["source_entities_updated"] == 1
+        assert stats["lid_merged_into_classic"] == 0
+        source_store.add.assert_not_called()
+        source_store.update.assert_called_once()
+
+    def test_classic_contact_unaffected_by_lid_processing(self):
+        """Baseline: a classic contact with no LID entries still creates as before."""
+        source_store, person_store, resolver, person = _mock_contact_stores(
+            get_by_source_result=None, resolved_person="person-jordan",
+        )
+        contacts = [{"JID": "15551234567@s.whatsapp.net", "Phone": "15551234567", "Name": "Jordan"}]
+
+        with patch("api.services.whatsapp.get_source_entity_store", return_value=source_store), \
+             patch("api.services.whatsapp.get_person_entity_store", return_value=person_store), \
+             patch("api.services.whatsapp.get_entity_resolver", return_value=resolver):
+            stats = process_whatsapp_contacts(contacts=contacts, dry_run=False)
+
+        assert stats["source_entities_created"] == 1
+        assert stats["lid_contacts_read"] == 0
+        assert stats["lid_entities_created"] == 0
+        assert stats["skipped"] == 0


### PR DESCRIPTION
## Summary

WhatsApp's LID privacy migration means new contacts arrive in `lid_contacts` (with `push_name`) plus a `lid_phones` resolution map. The import only used these to resolve *message senders*, so `process_whatsapp_contacts()` never saw them — **no new WhatsApp source entity had been created since 2026-05-17**, which is what the nightly `source_entity drift` warning (84+ days) was reporting.

Now LID contacts produce source entities, with dedup against classic contacts: the LID's resolved phone is mapped to the classic JID form (`{digits}@s.whatsapp.net`) and, if that entity exists, it's updated rather than duplicated.

Closes #503

## Validation against real data

Ran the new resolution/dedup logic against the live export (192 LID contacts):

| Outcome | Count |
|---|---|
| Merge into existing classic entity (no duplicate) | **141** |
| Create genuinely new entity | **49** |
| Skipped — phone unresolvable | 2 |
| Skipped — no push_name | 0 |

So the dedup does the heavy lifting (141 would have been duplicates), and 49 real people who have been invisible to the CRM since May will now be resolvable.

## Test evidence

6 new tests (creation, both skip paths, classic-dedup merge, idempotency, classic-only regression) with synthetic data. Targeted suites 112 passed; full pre-push suite 2,385 passed / 8 skipped; ruff clean.

Implemented by a Sonnet subagent in an isolated worktree; dedup independently validated by the orchestrator against production data before merge.