### PR TITLE
feat(api): guard against running a second server on a non-host machine

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -21,6 +21,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 import logging
+import socket
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
@@ -51,10 +52,48 @@ _task_watcher = None
 # the alerts themselves.
 
 
+def check_server_host_guard() -> None:
+    """Refuse to start unless this machine is the designated LifeOS host (#506).
+
+    The LifeOS API is architecturally supposed to run on exactly one machine
+    — every other machine is a client or export agent. A second live server
+    writes to its own SQLite/Chroma copy that silently diverges from the
+    real one, and clients pointed at the wrong host get stale answers with
+    no indication anything is wrong.
+
+    ``LIFEOS_SERVER_HOSTNAME`` unset (the default) disables this guard
+    entirely — a fresh open-source clone must never be blocked from running
+    its own server. Only set it once you've deliberately designated a host.
+    """
+    expected = (settings.server_hostname or "").strip()
+    if not expected:
+        logger.info(
+            "LIFEOS_SERVER_HOSTNAME not set — host guard disabled "
+            "(this or any machine may run the LifeOS API server)."
+        )
+        return
+    actual = socket.gethostname()
+    if actual == expected:
+        return
+    raise RuntimeError(
+        f"Refusing to start: LIFEOS_SERVER_HOSTNAME designates {expected!r} as "
+        f"the only machine allowed to run the LifeOS API server, but this "
+        f"machine's hostname is {actual!r}. Running a second server here would "
+        f"write to its own SQLite/Chroma copy that silently diverges from the "
+        f"real one. Point this machine's clients at the designated host via "
+        f"LIFEOS_API_URL instead of running the server locally."
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifespan - startup and shutdown."""
     global _calendar_indexer, _telegram_listeners, _reminder_scheduler, _scheduler_watcher, _job_queue, _task_watcher
+
+    # Startup: refuse to run a second server on a non-designated machine (#506).
+    # Deliberately not wrapped in try/except — unlike the best-effort blocks
+    # below, this must actually stop startup on a mismatch.
+    check_server_host_guard()
 
     # Startup: Recover any incomplete merge operations
     try:

--- a/config/settings.py
+++ b/config/settings.py
@@ -168,6 +168,24 @@ class Settings(BaseSettings):
     port: int = Field(default=8000, alias="LIFEOS_PORT")
     host: str = Field(default="0.0.0.0", alias="LIFEOS_HOST")
 
+    # Host guard (#506): the ONE machine allowed to run this API server. A
+    # second live server elsewhere writes to its own SQLite/Chroma copy that
+    # silently diverges from the real one, so clients pointed at the wrong
+    # host get stale answers with no signal anything is wrong. Empty
+    # (default) disables the guard entirely — a fresh clone must never be
+    # blocked from starting. Set it only once you've deliberately designated
+    # a host; api/main.py then refuses to start anywhere else.
+    server_hostname: str = Field(
+        default="",
+        alias="LIFEOS_SERVER_HOSTNAME",
+        description="Hostname (as returned by `socket.gethostname()`/`hostname`) "
+                    "of the one machine designated to run the LifeOS API server. "
+                    "Empty (default) disables the guard. When set, api/main.py "
+                    "and scripts/server.sh refuse to start on any other machine "
+                    "— point that machine's clients at LIFEOS_API_URL instead of "
+                    "running a second server."
+    )
+
     # The HTTPS front `tailscale serve` publishes (scripts/setup-tailscale.sh).
     # Also the one non-local origin CORS allows, so a browser loading the UI from
     # the tailnet hostname can call the API. Empty simply drops it from the list.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,7 +1,7 @@
 # Configuration Guide
 
 **Status:** Complete
-**Last Updated:** 2026-07-09
+**Last Updated:** 2026-08-09
 **Audience:** Operators
 
 **This is the single authoritative reference for every `LIFEOS_*` environment variable and the third-party service variables (`ANTHROPIC_API_KEY`, `OLLAMA_*`, `SLACK_*`, `TELEGRAM_*`, `MONARCH_*`) that LifeOS reads.** Other guides reference this file rather than restating defaults — when documentation conflicts, this file wins (and `config/settings.py` wins over both, since the code is the source of truth).
@@ -20,6 +20,7 @@ Each section corresponds roughly to a section in [`config/settings.py`](../../co
 |---|---|---|---|
 | `LIFEOS_HOST` | str | `0.0.0.0` | API server bind address. Keep `0.0.0.0` for Tailscale access; `127.0.0.1` to restrict to localhost only. |
 | `LIFEOS_PORT` | int | `8000` | API server port. |
+| `LIFEOS_SERVER_HOSTNAME` | str | — | Hostname of the one machine designated to run the LifeOS API server (e.g. `<your-host>`, matching `hostname`/`socket.gethostname()` there). Empty (default) disables the guard so a fresh clone is never blocked. When set, `api/main.py` and `scripts/server.sh` refuse to start on any other machine — other machines should point at the designated host via `LIFEOS_API_URL` instead of running their own server (#506). |
 | `LIFEOS_CHROMA_URL` | str | `http://localhost:8001` | ChromaDB server endpoint the API connects to. |
 | `LIFEOS_CHROMA_PATH` | path | `./data/chromadb` | Where ChromaDB persists its data. |
 | `LIFEOS_CODE_DIR` | path | `~/Code` | Parent directory containing LifeOS and (optionally) other projects. Used by `/claude` orchestrator path resolution. |

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -1,7 +1,7 @@
 # LifeOS New Instance Setup
 
 > **Status:** Complete
-> **Last Updated:** 2026-07-09
+> **Last Updated:** 2026-08-09
 > **Audience:** New users
 
 Read this top-to-bottom. Execute each step, verify the check, then proceed.
@@ -227,6 +227,13 @@ curl -s http://localhost:8001/api/v2/heartbeat
 ```bash
 ./scripts/server.sh start
 ```
+
+**Note:** LifeOS is designed to run its API server on exactly one machine; every
+other machine should be a client pointed at it via `LIFEOS_API_URL`, not run its
+own copy of the server. If you have multiple machines and want to enforce this,
+set `LIFEOS_SERVER_HOSTNAME=<your-host>` (the output of `hostname` on the
+designated machine) in `.env` — the server then refuses to start anywhere else.
+Leave it unset for a single-machine setup; the default never blocks a start.
 
 **[VERIFY]** All services are healthy:
 

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -69,6 +69,30 @@ chromadb_healthy() {
     curl -s --max-time 2 "$CHROMADB_URL" > /dev/null 2>&1
 }
 
+# check_host_guard — refuse to start on a non-designated machine (#506).
+#
+# Mirrors check_server_host_guard() in api/main.py so a misconfigured second
+# server fails fast and legibly here, before Python (and the 30-60s model
+# load) even starts. LIFEOS_SERVER_HOSTNAME unset in .env (the default) never
+# blocks a start — safe for a fresh clone.
+check_host_guard() {
+    local expected=""
+    if [ -f "$PROJECT_DIR/.env" ]; then
+        expected=$(grep -E "^LIFEOS_SERVER_HOSTNAME=" "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d ' "'"'" || true)
+    fi
+    if [ -z "$expected" ]; then
+        return 0
+    fi
+    local actual
+    actual="$(hostname)"
+    if [ "$actual" != "$expected" ]; then
+        log_error "Refusing to start: LIFEOS_SERVER_HOSTNAME=$expected but this machine's hostname is $actual."
+        log_error "The LifeOS API must run only on $expected. Point this machine at it via LIFEOS_API_URL instead of running a second server."
+        return 1
+    fi
+    return 0
+}
+
 # Get server PID
 get_server_pid() {
     lsof -ti :$PORT 2>/dev/null || true
@@ -170,6 +194,9 @@ rotate_log() {
 run_foreground() {
     log_info "Starting LifeOS server in foreground mode..."
 
+    # Guard: this machine must be the designated host, if one is configured.
+    check_host_guard || return 1
+
     # Check ChromaDB is running (required dependency)
     if ! chromadb_healthy; then
         log_error "ChromaDB server not running. Start it first."
@@ -195,6 +222,9 @@ uvicorn.run('api.main:app', host='$HOST', port=$PORT, log_level='info', timeout_
 # Start the server
 start_server() {
     log_info "Starting LifeOS server..."
+
+    # Guard: this machine must be the designated host, if one is configured.
+    check_host_guard || return 1
 
     # Rotate logs before starting
     rotate_log

--- a/tests/test_server_host_guard.py
+++ b/tests/test_server_host_guard.py
@@ -1,0 +1,52 @@
+"""Tests for the server host guard (#506).
+
+LIFEOS_SERVER_HOSTNAME designates the one machine allowed to run the LifeOS
+API server. Unset (the default) must never block a start — a fresh
+open-source clone has to work out of the box. Set + matching hostname starts
+normally; set + mismatched hostname refuses to start with a message naming
+both hosts.
+
+The real hostname of whatever machine runs the test suite is irrelevant here
+— every case mocks `socket.gethostname()` rather than depending on it.
+"""
+import pytest
+
+import api.main as main
+from config.settings import settings
+
+
+@pytest.fixture(autouse=True)
+def _restore_server_hostname():
+    """Isolate `settings.server_hostname` across tests (it's a shared singleton)."""
+    original = settings.server_hostname
+    yield
+    settings.server_hostname = original
+
+
+def test_guard_unset_does_not_raise(monkeypatch):
+    """Default (LIFEOS_SERVER_HOSTNAME unset) must never block a start."""
+    settings.server_hostname = ""
+    monkeypatch.setattr(main.socket, "gethostname", lambda: "whatever-host")
+
+    main.check_server_host_guard()  # must not raise
+
+
+def test_guard_set_matching_hostname_does_not_raise(monkeypatch):
+    """Designated host running the server starts normally."""
+    settings.server_hostname = "the-server"
+    monkeypatch.setattr(main.socket, "gethostname", lambda: "the-server")
+
+    main.check_server_host_guard()  # must not raise
+
+
+def test_guard_set_mismatched_hostname_raises(monkeypatch):
+    """A non-designated machine refuses to start; message names both hosts."""
+    settings.server_hostname = "the-server"
+    monkeypatch.setattr(main.socket, "gethostname", lambda: "some-other-machine")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        main.check_server_host_guard()
+
+    message = str(exc_info.value)
+    assert "the-server" in message
+    assert "some-other-machine" in message


### PR DESCRIPTION
## Summary

The LifeOS API is architecturally meant to run on exactly one machine; everything else is a client or export agent. Nothing enforced that. On 2026-08-09 the Mac Mini was found running its own `uvicorn` on `0.0.0.0:8000` plus its own ChromaDB — writing to a separate SQLite/Chroma copy that silently diverges, with clients pointed at the wrong host getting stale answers and no signal.

Adds `LIFEOS_SERVER_HOSTNAME`: when set and the hostname doesn't match, the API refuses to start with an error naming both the expected and actual host. **Unset is the default and disables the guard entirely** — a fresh open-source clone must never be blocked from running its own server.

Also a pre-flight in `scripts/server.sh` (both `start_server` and the systemd `run_foreground` path) so failure happens before Python/model loading.

Closes #506

## Test evidence

3 new tests (unset / matching / mismatched, with `socket.gethostname` mocked so it doesn't depend on the test machine). Full pre-push suite 2,385 passed / 8 skipped; ruff clean; `bash -n` on server.sh.

Verified the live host is unaffected: `LIFEOS_SERVER_HOSTNAME` is absent from `.env`, so the guard is inert until deliberately enabled.

Note: the machine-level Mac Mini remediation (rogue server killed, wrapper patched, app restored, FDA verified) was done separately by the orchestrator; #504 fixed the auto-start root cause.

Implemented by a Sonnet subagent in an isolated worktree; reviewed by the orchestrator.