### PR TITLE
fix(apple-agent): alert and abort on export failure instead of shipping stale data

### DIFF
--- a/scripts/apple_data_agent.sh
+++ b/scripts/apple_data_agent.sh
@@ -75,6 +75,24 @@ retry_with_backoff() {
 # Total wall time on full failure ≈ 30 + 90 + 180 = 5 min before giving up.
 RETRY_DELAYS="30,90,180"
 
+# Send a Telegram alert. Best-effort (`|| true`) — a notification failure
+# must never mask the real error or crash the script. Mirrors the pattern in
+# run_sync_wrapper.sh / auto-deploy.sh: token/chat id are read from the
+# project .env, never hardcoded, and the call is a no-op if either is unset.
+send_telegram() {
+    local message="$1"
+    local env_file="${LIFEOS_DIR}/.env"
+    [[ -f "${env_file}" ]] || return 0
+    local bot_token chat_id
+    bot_token=$(grep '^TELEGRAM_BOT_TOKEN=' "${env_file}" | cut -d= -f2)
+    chat_id=$(grep '^TELEGRAM_CHAT_ID=' "${env_file}" | cut -d= -f2)
+    [[ -n "${bot_token}" && -n "${chat_id}" ]] || return 0
+    curl -s -X POST "https://api.telegram.org/bot${bot_token}/sendMessage" \
+        -d "chat_id=${chat_id}" \
+        -d "text=${message}" \
+        -d "parse_mode=Markdown" > /dev/null 2>&1 || true
+}
+
 # Only run on macOS
 if [[ "$(uname)" != "Darwin" ]]; then
     echo "This script only runs on macOS (Apple Data Agent)."
@@ -121,7 +139,16 @@ if "${LIFEOS_APP}" run "${PYTHON}" scripts/apple_data_export.py --execute >> "${
     log "Export: OK"
 else
     log "Export: FAILED"
-    # Continue anyway — rsync whatever we have
+    # Do NOT proceed to rsync/import: shipping yesterday's exports makes a
+    # hard export failure look like a successful sync downstream (this is
+    # the exact silent-failure class fixed by issue #505 — a stale file is
+    # worse than no file, because it launders a failure into an apparent
+    # success on the Linux side). Alert and abort instead.
+    send_telegram "🚨 *LifeOS Apple Export Failed*
+Export step failed on $(hostname).
+Rsync and import were skipped to avoid shipping stale data.
+See ${LOG_FILE} for details."
+    exit 1
 fi
 
 # -------------------------------------------------------------------

--- a/scripts/apple_data_export.py
+++ b/scripts/apple_data_export.py
@@ -600,6 +600,27 @@ def export_whatsapp(dry_run: bool = False) -> dict:
     }
 
 
+def _finalize_result(result: dict) -> dict:
+    """Guard against a source reporting "ok" with no actual output.
+
+    Observed for `contacts` (issue #505): when no .abcdp files were found,
+    export_contacts returned {"status": "ok", "count": 0, "path": ""} —
+    indistinguishable from a healthy empty result. A source that claims "ok"
+    but produced neither a count nor an output path didn't actually export
+    anything, so treat that combination as an error. This makes the
+    manifest accurate for the Linux side's _manifest_source_errored() check.
+    """
+    if (
+        result.get("status") == "ok"
+        and result.get("count") == 0
+        and result.get("path") == ""
+    ):
+        result = dict(result)
+        result["status"] = "error"
+        result["reason"] = "reported ok with zero count and no output path"
+    return result
+
+
 def main():
     parser = argparse.ArgumentParser(description="Export Apple ecosystem data")
     parser.add_argument("--execute", action="store_true", help="Actually export (not dry-run)")
@@ -635,7 +656,7 @@ def main():
     for name, func in sources.items():
         logger.info(f"{'[DRY RUN] ' if dry_run else ''}Exporting {name}...")
         try:
-            results[name] = func(dry_run=dry_run)
+            results[name] = _finalize_result(func(dry_run=dry_run))
         except Exception as e:
             logger.error(f"Failed to export {name}: {e}")
             results[name] = {"status": "error", "error": str(e)}

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -122,10 +122,24 @@ def _manifest_source_errored(manifest: dict | None, source: str) -> bool:
     return source_result.get("status") == "error"
 
 
-def import_contacts(dry_run: bool = False) -> dict:
-    """Import contacts from JSON export."""
+def import_contacts(dry_run: bool = False, manifest: dict | None = None) -> dict:
+    """Import contacts from JSON export.
+
+    Manifest-aware like import_whatsapp: if the Mac-side export marked
+    contacts as errored (e.g. the zero-count/empty-path pattern from
+    issue #505), propagate that as a failure here too instead of quietly
+    returning "skipped" — a manifest error must not look like a healthy
+    no-op.
+    """
     contacts_path = IMPORT_DIR / "contacts.json"
+    manifest_errored = _manifest_source_errored(manifest, "contacts")
+
     if not contacts_path.exists():
+        if manifest_errored:
+            return {
+                "status": "error",
+                "reason": "contacts.json not found and Mac export marked contacts as error",
+            }
         return {"status": "skipped", "reason": "contacts.json not found"}
 
     with open(contacts_path) as f:
@@ -135,7 +149,11 @@ def import_contacts(dry_run: bool = False) -> dict:
     logger.info(f"Found {len(contacts)} contacts to import (exported {data.get('exported_at', '?')})")
 
     if dry_run:
-        return {"status": "dry_run", "count": len(contacts)}
+        result = {"status": "dry_run", "count": len(contacts)}
+        if manifest_errored:
+            result["status"] = "error"
+            result["reason"] = "Mac export marked contacts as error (stale file used for dry-run counts)"
+        return result
 
     from api.services.source_entity import (
         get_source_entity_store, SourceEntity, LINK_STATUS_AUTO,
@@ -223,7 +241,11 @@ def import_contacts(dry_run: bool = False) -> dict:
             linked += 1
 
     logger.info(f"Contacts: {created} created, {updated} updated, {linked} linked")
-    return {"status": "ok", "created": created, "updated": updated, "linked": linked}
+    result = {"status": "ok", "created": created, "updated": updated, "linked": linked}
+    if manifest_errored:
+        result["status"] = "error"
+        result["reason"] = "Mac export marked contacts as error; imported stale contacts.json"
+    return result
 
 
 def import_imessage(dry_run: bool = False) -> dict:
@@ -777,11 +799,14 @@ def main():
     # Some sources need the manifest to distinguish "nothing exported" from
     # "export attempted and failed". Keep the uniform (dry_run,) signature for
     # the rest so the dispatch stays simple.
+    def _import_contacts_wrapper(dry_run: bool = False) -> dict:
+        return import_contacts(dry_run=dry_run, manifest=manifest)
+
     def _import_whatsapp_wrapper(dry_run: bool = False) -> dict:
         return import_whatsapp(dry_run=dry_run, manifest=manifest)
 
     sources = {
-        "contacts": import_contacts,
+        "contacts": _import_contacts_wrapper,
         "imessage": import_imessage,
         "phone": import_phone_calls,
         "photos": import_photos_faces,

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -236,6 +236,150 @@ class TestContactsExport:
         assert result["count"] == 1
 
 
+class TestExportResultFinalization:
+    """_finalize_result guards against a source reporting "ok" with no
+    actual output. Issue #505's secondary finding: export_contacts returned
+    {"status": "ok", "count": 0, "path": ""} when no .abcdp files existed —
+    indistinguishable from a genuinely healthy empty result."""
+
+    def _finalize(self):
+        from scripts.apple_data_export import _finalize_result
+        return _finalize_result
+
+    def test_ok_zero_count_empty_path_becomes_error(self):
+        finalize = self._finalize()
+        result = finalize({"status": "ok", "count": 0, "path": ""})
+        assert result["status"] == "error"
+        assert "reason" in result
+
+    def test_ok_with_real_output_is_unaffected(self):
+        finalize = self._finalize()
+        result = finalize({"status": "ok", "count": 3, "path": "/tmp/contacts.json"})
+        assert result == {"status": "ok", "count": 3, "path": "/tmp/contacts.json"}
+
+    def test_ok_zero_count_but_written_path_is_unaffected(self):
+        """A genuinely empty but successfully-written export (e.g. 0 phone
+        calls, but phone_calls.json was still written) must not be flagged —
+        only the count-0-AND-path-empty combination means nothing happened."""
+        finalize = self._finalize()
+        result = finalize({"status": "ok", "count": 0, "path": "/tmp/phone_calls.json"})
+        assert result["status"] == "ok"
+
+    def test_non_ok_status_is_unaffected(self):
+        finalize = self._finalize()
+        result = finalize({"status": "skipped", "reason": "AddressBook not found"})
+        assert result == {"status": "skipped", "reason": "AddressBook not found"}
+
+    def test_ok_without_count_or_path_keys_is_unaffected(self):
+        """Sources like imessage/photos/whatsapp use different result
+        shapes (size_mb, people/faces, contacts/messages) and must not be
+        caught by this contacts-shaped check."""
+        finalize = self._finalize()
+        result = finalize({"status": "ok", "size_mb": 12.3, "path": "/tmp/imessage.db"})
+        assert result["status"] == "ok"
+
+    def test_export_contacts_no_abcdp_files_gets_finalized_to_error(self, tmp_path):
+        """Full-loop check: export_contacts's own empty-result, run through
+        _finalize_result exactly as main() does, becomes an error."""
+        from scripts.apple_data_export import export_contacts
+
+        lib_ab = tmp_path / "Library" / "Application Support" / "AddressBook"
+        (lib_ab / "Sources" / "SOURCE-1" / "Metadata").mkdir(parents=True)
+
+        with patch("scripts.apple_data_export.Path.home", return_value=tmp_path):
+            raw = export_contacts(dry_run=False)
+
+        # This is the exact historical bug shape from issue #505.
+        assert raw == {"status": "ok", "count": 0, "path": ""}
+
+        finalized = self._finalize()(raw)
+        assert finalized["status"] == "error"
+
+
+class TestContactsImportManifestAware:
+    """import_contacts must not report success/skip when the Mac-side
+    export marked contacts as errored (issue #505 acceptance criteria:
+    "the Linux import surfaces it rather than reporting success")."""
+
+    def _write_contacts(self, import_dir: Path, contacts: list[dict]):
+        import_dir.mkdir(parents=True, exist_ok=True)
+        with open(import_dir / "contacts.json", "w") as f:
+            json.dump({"contacts": contacts, "exported_at": "2026-01-01T00:00:00+00:00"}, f)
+
+    def _errored_manifest(self):
+        return {
+            "results": {
+                "contacts": {
+                    "status": "error",
+                    "reason": "reported ok with zero count and no output path",
+                }
+            }
+        }
+
+    def test_missing_file_no_manifest_error_is_still_skipped(self, tmp_path):
+        """Regression check: unrelated to #505, unchanged behavior."""
+        from scripts.apple_data_import import import_contacts
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir(parents=True)
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir):
+            result = import_contacts(dry_run=False, manifest=None)
+
+        assert result == {"status": "skipped", "reason": "contacts.json not found"}
+
+    def test_missing_file_with_manifest_error_is_error(self, tmp_path):
+        """The exact issue #505 scenario: export never wrote contacts.json
+        (zero .abcdp files found), the export-side fix now marks that as an
+        error in the manifest, and the import must surface an error instead
+        of a benign "skipped"."""
+        from scripts.apple_data_import import import_contacts
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir(parents=True)
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir):
+            result = import_contacts(dry_run=False, manifest=self._errored_manifest())
+
+        assert result["status"] == "error"
+        assert "contacts.json not found" in result["reason"]
+
+    def test_dry_run_with_manifest_error_is_error(self, tmp_path):
+        from scripts.apple_data_import import import_contacts
+
+        import_dir = tmp_path / "apple-imports"
+        self._write_contacts(import_dir, [{"identifier": "u1", "full_name": "Jane Doe"}])
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir):
+            result = import_contacts(dry_run=True, manifest=self._errored_manifest())
+
+        assert result["status"] == "error"
+        assert result["count"] == 1
+
+    def test_execute_with_manifest_error_still_imports_but_flags_error(self, tmp_path):
+        """A stale contacts.json from a previous good run should still be
+        imported (data is better than nothing) but the run must be flagged
+        as errored so it doesn't look like a clean success — mirrors
+        import_whatsapp's existing manifest-aware behavior."""
+        from scripts.apple_data_import import import_contacts
+        from unittest.mock import MagicMock
+        from api.services.source_entity import SourceEntityStore
+
+        import_dir = tmp_path / "apple-imports"
+        self._write_contacts(import_dir, [{"identifier": "u1", "full_name": "Jane Doe"}])
+
+        se_store = SourceEntityStore(db_path=str(tmp_path / "crm.db"))
+        mock_resolver = MagicMock()
+        mock_pe_store = MagicMock()
+
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir), \
+             patch("api.services.source_entity.get_source_entity_store", return_value=se_store), \
+             patch("api.services.entity_resolver.get_entity_resolver", return_value=mock_resolver), \
+             patch("api.services.person_entity.get_person_entity_store", return_value=mock_pe_store):
+            result = import_contacts(dry_run=False, manifest=self._errored_manifest())
+
+        assert result["status"] == "error"
+        assert result["created"] == 1
+        assert "stale contacts.json" in result["reason"]
+
+
 # ---------------------------------------------------------------------------
 # Staleness alerting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When the Mac-side Apple export failed, the agent logged one line and **continued** — rsyncing the previous day's files to the Linux host and triggering the import, so a hard failure became a green sync downstream. That's how the 2026-08-09 breakage went unnoticed for a day.

Now: export failure sends a Telegram alert and `exit 1` **before** rsync/import. Plus manifest accuracy — a source reporting `status: ok` with `count: 0` and an empty `path` (observed for `contacts`) is recorded as an error, and `import_contacts()` is now manifest-aware so a Mac-side error surfaces as an import failure rather than "skipped".

Closes #505

## Test evidence

The agent **actually ran the failure path**, not just inspected it: with stubbed `ssh`/`rsync`/`curl`/`uname` and `LIFEOS_APP` pointing at the nonexistent path (reproducing the exact incident error), it confirmed exit 1, Telegram called with the right payload, and **`ssh`/`rsync` never invoked**. Also verified `send_telegram` no-ops cleanly with no `.env` under `set -euo pipefail`.

10 new pytest tests; affected suites 74/74 and 15/15 passing; full pre-push suite 2,385 passed / 8 skipped; ruff clean.

Honestly scoped: end-to-end macOS execution (cron + FDA wrapper + real rsync) was not possible from the Linux box; the stub run exercises the real bash control flow.

Implemented by a Sonnet subagent in an isolated worktree; reviewed by the orchestrator.