### PR TITLE
fix(entity-resolution): retry capped source entities instead of locking them out forever

### DIFF
--- a/api/services/source_entity.py
+++ b/api/services/source_entity.py
@@ -79,6 +79,10 @@ class SourceEntity:
     observed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
+    # Re-matching bookkeeping (see get_unlinked_for_rematching / record_match_attempt)
+    match_attempted_at: Optional[datetime] = None
+    match_attempt_count: int = 0
+
     def __post_init__(self):
         """Validate source type."""
         if self.source_type and self.source_type not in SOURCE_TYPES:
@@ -94,6 +98,8 @@ class SourceEntity:
             data["created_at"] = self.created_at.isoformat()
         if self.linked_at:
             data["linked_at"] = self.linked_at.isoformat()
+        if self.match_attempted_at:
+            data["match_attempted_at"] = self.match_attempted_at.isoformat()
         return data
 
     @classmethod
@@ -106,6 +112,8 @@ class SourceEntity:
             data["created_at"] = _make_aware(datetime.fromisoformat(data["created_at"]))
         if data.get("linked_at") and isinstance(data["linked_at"], str):
             data["linked_at"] = _make_aware(datetime.fromisoformat(data["linked_at"]))
+        if data.get("match_attempted_at") and isinstance(data["match_attempted_at"], str):
+            data["match_attempted_at"] = _make_aware(datetime.fromisoformat(data["match_attempted_at"]))
         return cls(**data)
 
     @classmethod
@@ -119,6 +127,10 @@ class SourceEntity:
         observed_at = datetime.fromisoformat(row[11]) if row[11] else datetime.now(timezone.utc)
         created_at = datetime.fromisoformat(row[12]) if row[12] else datetime.now(timezone.utc)
         linked_at = datetime.fromisoformat(row[10]) if row[10] else None
+        match_attempted_at = (
+            datetime.fromisoformat(row[13]) if len(row) > 13 and row[13] else None
+        )
+        match_attempt_count = row[14] if len(row) > 14 and row[14] is not None else 0
         link_method = row[15] if len(row) > 15 else None
 
         return cls(
@@ -136,6 +148,8 @@ class SourceEntity:
             linked_at=_make_aware(linked_at),
             observed_at=_make_aware(observed_at),
             created_at=_make_aware(created_at),
+            match_attempted_at=_make_aware(match_attempted_at),
+            match_attempt_count=match_attempt_count,
         )
 
     @property
@@ -957,26 +971,61 @@ class SourceEntityStore:
         min_days_since_attempt: int = 30,
         max_attempts: int = 3,
         limit: int = 1000,
+        backoff_multiplier: int = 3,
+        max_capped_per_run: Optional[int] = 200,
     ) -> list[SourceEntity]:
         """
         Get unlinked entities eligible for re-matching.
 
-        Filters out:
-        - Entities that were attempted recently (within min_days_since_attempt)
-        - Entities with too many failed attempts (>= max_attempts)
+        Below ``max_attempts``, behavior is unchanged: eligible once
+        ``min_days_since_attempt`` has elapsed since the last attempt.
+
+        At or above ``max_attempts`` ("capped" entities), a hard stop would
+        permanently lock an entity out even as the CRM it failed to match
+        against keeps growing (#507 — 1,678 of 1,729 unlinked entities were
+        stuck this way, forever reporting 0 eligible). Instead we apply
+        exponential backoff: the wait before the next attempt grows as
+        ``min_days_since_attempt * backoff_multiplier ** (match_attempt_count
+        - max_attempts)``. With the defaults (30 days, multiplier 3) that's
+        attempt 4 at 30d, attempt 5 at 90d, attempt 6 at 270d, and so on —
+        no entity is locked out forever, but stale entities are retried
+        exponentially less often, bounding the amortized cost.
+
+        This is deliberately stateless: it reuses the existing
+        match_attempted_at/match_attempt_count columns instead of adding new
+        schema (e.g. a stored PersonEntity-count watermark) to react to CRM
+        growth directly. That's simpler and needs no migration, at the cost
+        of being a proxy — "CRM probably changed enough" — rather than a
+        precise trigger tied to actual PersonEntity growth.
+
+        Because many capped entities can cross their backoff threshold on
+        the same night (they tend to have been last attempted in clusters),
+        ``max_capped_per_run`` bounds how many capped entities are retried
+        per run so a large backlog drains over several nights instead of
+        spiking one night's fuzzy-match cost. Entities below max_attempts
+        are never subject to this per-run cap — that population is small
+        and behaves exactly as before.
 
         Args:
             source_type: Optional filter by source type
             min_days_since_attempt: Skip if attempted within this many days
-            max_attempts: Skip if attempted this many times or more
-            limit: Maximum entities to return
+            max_attempts: Attempts before backoff (instead of a hard stop) kicks in
+            limit: Maximum entities to return overall
+            backoff_multiplier: Growth factor applied per attempt past max_attempts
+            max_capped_per_run: Max capped (attempt_count >= max_attempts) entities
+                to include per call. None disables the cap.
 
         Returns:
             List of SourceEntity objects eligible for re-matching
         """
         conn = self._get_connection()
         try:
-            cutoff_date = (
+            # Most lenient possible cutoff — anything attempted more recently
+            # than this can't be eligible under any backoff tier, so it's
+            # safe (and keeps the query on the existing index) to filter it
+            # out in SQL. The precise per-row backoff check happens in Python
+            # below, since SQLite has no portable POWER() to express it in SQL.
+            base_cutoff = (
                 datetime.now(timezone.utc) - timedelta(days=min_days_since_attempt)
             ).isoformat()
 
@@ -986,62 +1035,122 @@ class SourceEntityStore:
                     WHERE canonical_person_id IS NULL
                       AND source_type = ?
                       AND (match_attempted_at IS NULL OR match_attempted_at < ?)
-                      AND (match_attempt_count IS NULL OR match_attempt_count < ?)
                     ORDER BY observed_at DESC
-                    LIMIT ?
-                """, (source_type, cutoff_date, max_attempts, limit))
+                """, (source_type, base_cutoff))
             else:
                 cursor = conn.execute("""
                     SELECT * FROM source_entities
                     WHERE canonical_person_id IS NULL
                       AND (match_attempted_at IS NULL OR match_attempted_at < ?)
-                      AND (match_attempt_count IS NULL OR match_attempt_count < ?)
                     ORDER BY observed_at DESC
-                    LIMIT ?
-                """, (cutoff_date, max_attempts, limit))
+                """, (base_cutoff,))
 
-            return [SourceEntity.from_row(row) for row in cursor.fetchall()]
+            candidates = [SourceEntity.from_row(row) for row in cursor.fetchall()]
         finally:
             conn.close()
+
+        now = datetime.now(timezone.utc)
+        normal: list[SourceEntity] = []
+        capped_eligible: list[SourceEntity] = []
+
+        for entity in candidates:
+            count = entity.match_attempt_count or 0
+            if count < max_attempts:
+                normal.append(entity)
+                continue
+
+            if entity.match_attempted_at is None:
+                capped_eligible.append(entity)
+                continue
+
+            required_days = min_days_since_attempt * (
+                backoff_multiplier ** (count - max_attempts)
+            )
+            attempted_at = _make_aware(entity.match_attempted_at)
+            if (now - attempted_at).days >= required_days:
+                capped_eligible.append(entity)
+
+        if max_capped_per_run is not None and len(capped_eligible) > max_capped_per_run:
+            # Retry the longest-waiting capped entities first so the backlog
+            # rotates fairly across runs instead of starving the same tail.
+            capped_eligible.sort(
+                key=lambda e: e.match_attempted_at or datetime.min.replace(tzinfo=timezone.utc)
+            )
+            capped_eligible = capped_eligible[:max_capped_per_run]
+
+        combined = normal + capped_eligible
+        combined.sort(key=lambda e: e.observed_at or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
+        return combined[:limit]
 
     def count_unlinked_for_rematching(
         self,
         source_type: Optional[str] = None,
         min_days_since_attempt: int = 30,
         max_attempts: int = 3,
+        backoff_multiplier: int = 3,
+        max_capped_per_run: Optional[int] = 200,
     ) -> int:
         """
-        Count unlinked entities eligible for re-matching.
+        Count unlinked entities eligible for re-matching right now.
+
+        Mirrors the eligibility logic in ``get_unlinked_for_rematching``
+        (including the per-run cap on capped entities), see there for the
+        backoff rationale.
 
         Args:
             source_type: Optional filter by source type
             min_days_since_attempt: Skip if attempted within this many days
-            max_attempts: Skip if attempted this many times or more
+            max_attempts: Attempts before backoff kicks in
+            backoff_multiplier: Growth factor applied per attempt past max_attempts
+            max_capped_per_run: Max capped entities counted as eligible per run
 
         Returns:
             Count of eligible entities
         """
+        return len(self.get_unlinked_for_rematching(
+            source_type=source_type,
+            min_days_since_attempt=min_days_since_attempt,
+            max_attempts=max_attempts,
+            limit=1_000_000,
+            backoff_multiplier=backoff_multiplier,
+            max_capped_per_run=max_capped_per_run,
+        ))
+
+    def count_capped_backlog(
+        self,
+        source_type: Optional[str] = None,
+        max_attempts: int = 3,
+    ) -> int:
+        """
+        Count unlinked entities that have hit ``max_attempts`` or more.
+
+        This is the total capped population regardless of whether backoff
+        currently makes them eligible — used to surface the backlog size in
+        sync stats so a saturated backlog is visible (#507) instead of
+        looking identical to "nothing to do".
+
+        Args:
+            source_type: Optional filter by source type
+            max_attempts: Attempt count considered "capped"
+
+        Returns:
+            Count of unlinked entities with match_attempt_count >= max_attempts
+        """
         conn = self._get_connection()
         try:
-            cutoff_date = (
-                datetime.now(timezone.utc) - timedelta(days=min_days_since_attempt)
-            ).isoformat()
-
             if source_type:
                 cursor = conn.execute("""
                     SELECT COUNT(*) FROM source_entities
                     WHERE canonical_person_id IS NULL
                       AND source_type = ?
-                      AND (match_attempted_at IS NULL OR match_attempted_at < ?)
-                      AND (match_attempt_count IS NULL OR match_attempt_count < ?)
-                """, (source_type, cutoff_date, max_attempts))
+                      AND match_attempt_count >= ?
+                """, (source_type, max_attempts))
             else:
                 cursor = conn.execute("""
                     SELECT COUNT(*) FROM source_entities
                     WHERE canonical_person_id IS NULL
-                      AND (match_attempted_at IS NULL OR match_attempted_at < ?)
-                      AND (match_attempt_count IS NULL OR match_attempt_count < ?)
-                """, (cutoff_date, max_attempts))
+                      AND match_attempt_count >= ?
+                """, (max_attempts,))
 
             return cursor.fetchone()[0]
         finally:

--- a/scripts/link_source_entities.py
+++ b/scripts/link_source_entities.py
@@ -10,7 +10,10 @@ Key behaviors:
 - Does NOT create new people (create_if_missing=False)
 - Skips entities from blocklisted domains (marketing, newsletters, etc.)
 - Skips entities that were recently attempted (within 30 days)
-- Skips entities with 3+ failed attempts (considered unmatchable)
+- Entities with 3+ failed attempts are NOT locked out forever: they're retried
+  under exponential backoff (attempt 4 at 30d, 5 at 90d, 6 at 270d, ...), capped
+  at `max_capped_per_run` retries per run so a large backlog drains gradually
+  instead of spiking one night's fuzzy-match cost (#507)
 - Records match attempts to avoid re-processing
 
 This script is the "safety net" that catches source entities that:
@@ -54,6 +57,8 @@ def link_source_entities(
     batch_size: int = 1000,
     min_days_since_attempt: int = 30,
     max_attempts: int = 3,
+    backoff_multiplier: int = 3,
+    max_capped_per_run: int = 200,
 ) -> dict:
     """
     Link unlinked source entities to existing person entities.
@@ -66,7 +71,12 @@ def link_source_entities(
         dry_run: If True, don't actually update anything
         batch_size: Number of entities to process per batch
         min_days_since_attempt: Skip if attempted within this many days
-        max_attempts: Skip if attempted this many times or more
+        max_attempts: Attempts before exponential backoff kicks in (see
+            SourceEntityStore.get_unlinked_for_rematching) instead of a hard
+            stop (#507)
+        backoff_multiplier: Growth factor applied per attempt past max_attempts
+        max_capped_per_run: Max capped (attempt_count >= max_attempts) entities
+            to retry in a single run, so a large backlog drains gradually
 
     Returns:
         Statistics dict with counts
@@ -84,6 +94,13 @@ def link_source_entities(
         'errors': 0,
         'by_source': {},
         'by_match_type': {},
+        # Total backlog stuck at/above max_attempts, regardless of whether
+        # backoff currently makes any of it eligible. Surfacing this is the
+        # whole point of #507 — without it, a saturated backlog silently
+        # looks identical to "nothing to do".
+        'capped_backlog': source_store.count_capped_backlog(
+            source_type=source_type, max_attempts=max_attempts,
+        ),
     }
 
     # Get all eligible entities upfront to avoid re-fetching in dry run mode
@@ -98,6 +115,8 @@ def link_source_entities(
             min_days_since_attempt=min_days_since_attempt,
             max_attempts=max_attempts,
             limit=fetch_limit,
+            backoff_multiplier=backoff_multiplier,
+            max_capped_per_run=max_capped_per_run,
         )
         if not batch:
             break
@@ -110,7 +129,20 @@ def link_source_entities(
             break
 
     stats['eligible_for_matching'] = len(all_entities)
+    stats['capped_retried_this_run'] = sum(
+        1 for e in all_entities if (e.match_attempt_count or 0) >= max_attempts
+    )
+    stats['capped_deferred'] = max(
+        0, stats['capped_backlog'] - stats['capped_retried_this_run']
+    )
     logger.info(f"Found {stats['eligible_for_matching']:,} unlinked entities eligible for matching")
+    if stats['capped_backlog']:
+        logger.info(
+            f"Capped backlog: {stats['capped_backlog']:,} entities at/above "
+            f"{max_attempts} attempts ({stats['capped_retried_this_run']:,} "
+            f"retried this run, {stats['capped_deferred']:,} still deferred "
+            "by backoff)"
+        )
     if source_type:
         logger.info(f"Filtering to source type: {source_type}")
 
@@ -121,7 +153,13 @@ def link_source_entities(
         # early — the exact reason sync_apple_contacts never reported (#497).
         # An explicit zero here is meaningful: it says "ran, nothing eligible".
         from api.services.sync_health import emit_sync_stats
-        emit_sync_stats({"processed": 0, "people_updated": 0, "errors": 0})
+        emit_sync_stats({
+            "processed": 0,
+            "people_updated": 0,
+            "errors": 0,
+            "capped_backlog": stats['capped_backlog'],
+            "capped_deferred": stats['capped_backlog'],
+        })
         return stats
 
     # Process in batches
@@ -216,6 +254,8 @@ def link_source_entities(
         "processed": int(stats.get("entities_processed", 0) or 0),
         "people_updated": int(stats.get("newly_linked", 0) or 0),
         "errors": int(stats.get("errors", 0) or 0),
+        "capped_backlog": int(stats.get("capped_backlog", 0) or 0),
+        "capped_deferred": int(stats.get("capped_deferred", 0) or 0),
     })
 
     if stats['by_source']:
@@ -284,7 +324,22 @@ Examples:
         '--max-attempts',
         type=int,
         default=3,
-        help='Skip entities with this many or more attempts (default: 3)'
+        help='Attempts before exponential backoff kicks in, instead of a hard '
+             'stop (default: 3)'
+    )
+    parser.add_argument(
+        '--backoff-multiplier',
+        type=int,
+        default=3,
+        help='Growth factor applied per attempt past --max-attempts '
+             '(default: 3, e.g. attempt 4 at 30d, 5 at 90d, 6 at 270d)'
+    )
+    parser.add_argument(
+        '--max-capped-per-run',
+        type=int,
+        default=200,
+        help='Max capped (attempt_count >= max-attempts) entities to retry '
+             'per run, so a large backlog drains gradually (default: 200)'
     )
     parser.add_argument(
         '-v', '--verbose',
@@ -303,6 +358,8 @@ Examples:
         batch_size=args.batch_size,
         min_days_since_attempt=args.min_days,
         max_attempts=args.max_attempts,
+        backoff_multiplier=args.backoff_multiplier,
+        max_capped_per_run=args.max_capped_per_run,
     )
 
 

--- a/scripts/relink_source_entities.py
+++ b/scripts/relink_source_entities.py
@@ -16,6 +16,14 @@ Example:
 - 29 gmail source entities with alex@oldcompany.com are UNLINKED
 - This script will find and link those entities to Alex's person record.
 
+Manual escape hatch: this script queries ALL unlinked entities directly and
+ignores match_attempted_at/match_attempt_count entirely — it neither respects
+the nightly cap/backoff in scripts/link_source_entities.py nor increments the
+counter on a miss. Use it when you want an immediate, unthrottled full sweep
+(e.g. right after a large batch of new PersonEntities was created) instead of
+waiting for the nightly backoff schedule to make capped entities eligible
+again (#507).
+
 Usage:
     # Dry run (default) - see what would be linked
     python scripts/relink_source_entities.py

--- a/tests/test_source_entity.py
+++ b/tests/test_source_entity.py
@@ -1,7 +1,8 @@
 """Tests for SourceEntity and SourceEntityStore."""
+import sqlite3
 import tempfile
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from api.services.source_entity import (
     SourceEntity,
@@ -260,6 +261,134 @@ class TestSourceEntityStore:
         assert stats["unlinked_entities"] == 1
         assert stats["by_source"]["gmail"] == 3
         assert stats["by_source"]["calendar"] == 1
+
+
+class TestRematchingEligibility:
+    """Tests for the #507 backoff retry policy on capped source entities.
+
+    `store.add()` never persists match_attempted_at/match_attempt_count (those
+    are only ever set via `record_match_attempt`), so tests write them
+    directly via raw SQL to simulate an entity with a specific attempt
+    history at a specific point in the past.
+    """
+
+    def _set_attempts(self, store, entity_id, count, days_ago):
+        """Backdate an entity's match attempt bookkeeping for test setup."""
+        attempted_at = (
+            datetime.now(timezone.utc) - timedelta(days=days_ago)
+        ).isoformat()
+        conn = sqlite3.connect(store.db_path)
+        try:
+            conn.execute(
+                "UPDATE source_entities SET match_attempt_count = ?, "
+                "match_attempted_at = ? WHERE id = ?",
+                (count, attempted_at, entity_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_fresh_entity_still_eligible_after_min_days(self, store):
+        """No regression: an entity with 0 prior attempts behaves as before."""
+        entity = SourceEntity(source_type="gmail", source_id="fresh1")
+        store.add(entity)
+        self._set_attempts(store, entity.id, count=0, days_ago=31)
+
+        results = store.get_unlinked_for_rematching(min_days_since_attempt=30, max_attempts=3)
+        assert entity.id in [e.id for e in results]
+
+    def test_fresh_entity_not_eligible_within_min_days(self, store):
+        """No regression: an entity attempted 5 days ago is still on cooldown."""
+        entity = SourceEntity(source_type="gmail", source_id="fresh2")
+        store.add(entity)
+        self._set_attempts(store, entity.id, count=1, days_ago=5)
+
+        results = store.get_unlinked_for_rematching(min_days_since_attempt=30, max_attempts=3)
+        assert entity.id not in [e.id for e in results]
+
+    def test_capped_entity_outside_backoff_window_not_eligible(self, store):
+        """A capped entity (count=3) attempted only 10 days ago must wait."""
+        entity = SourceEntity(source_type="gmail", source_id="capped_recent")
+        store.add(entity)
+        self._set_attempts(store, entity.id, count=3, days_ago=10)
+
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3, backoff_multiplier=3,
+        )
+        assert entity.id not in [e.id for e in results]
+
+    def test_capped_entity_past_backoff_window_is_eligible(self, store):
+        """A capped entity (count=3) past the 30-day window (attempt 4) is eligible again."""
+        entity = SourceEntity(source_type="gmail", source_id="capped_past")
+        store.add(entity)
+        self._set_attempts(store, entity.id, count=3, days_ago=31)
+
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3, backoff_multiplier=3,
+        )
+        assert entity.id in [e.id for e in results]
+
+    def test_backoff_grows_with_attempt_count(self, store):
+        """count=4 (attempt 5) needs the *next* backoff tier (90d), not just 30d."""
+        entity = SourceEntity(source_type="gmail", source_id="capped_grown")
+        store.add(entity)
+        # Past the count=3 tier's 30-day window, but not past count=4's 90-day window.
+        self._set_attempts(store, entity.id, count=4, days_ago=40)
+
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3, backoff_multiplier=3,
+        )
+        assert entity.id not in [e.id for e in results]
+
+        # Same entity, but now 91 days since last attempt clears the 90-day tier.
+        self._set_attempts(store, entity.id, count=4, days_ago=91)
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3, backoff_multiplier=3,
+        )
+        assert entity.id in [e.id for e in results]
+
+    def test_per_run_cap_limits_capped_entities(self, store):
+        """max_capped_per_run bounds how many capped entities surface per call."""
+        ids = []
+        for i in range(10):
+            entity = SourceEntity(source_type="gmail", source_id=f"capped_bulk{i}")
+            store.add(entity)
+            # All well past the 30-day window for count=3, so all are eligible
+            # under backoff alone.
+            self._set_attempts(store, entity.id, count=3, days_ago=60)
+            ids.append(entity.id)
+
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3, max_capped_per_run=4,
+        )
+        assert len(results) == 4
+        assert all(r.id in ids for r in results)
+
+    def test_per_run_cap_does_not_limit_uncapped_entities(self, store):
+        """The per-run cap only applies to capped (count >= max_attempts) entities."""
+        for i in range(5):
+            entity = SourceEntity(source_type="gmail", source_id=f"uncapped{i}")
+            store.add(entity)
+            self._set_attempts(store, entity.id, count=1, days_ago=31)
+
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3, max_capped_per_run=0,
+        )
+        assert len(results) == 5
+
+    def test_count_capped_backlog(self, store):
+        """count_capped_backlog reports the total stuck population, not just eligible."""
+        for i in range(3):
+            entity = SourceEntity(source_type="gmail", source_id=f"backlog{i}")
+            store.add(entity)
+            # Recent attempt — not eligible under backoff, but still "capped".
+            self._set_attempts(store, entity.id, count=3, days_ago=1)
+
+        uncapped = SourceEntity(source_type="gmail", source_id="not_capped")
+        store.add(uncapped)
+        self._set_attempts(store, uncapped.id, count=1, days_ago=1)
+
+        assert store.count_capped_backlog(max_attempts=3) == 3
 
 
 class TestLinkMethod:


### PR DESCRIPTION
## Summary

`link_source_entities` permanently excluded any unlinked entity at `match_attempt_count >= 3`. In production **1,678 of 1,729 unlinked entities sat at exactly 3** — locked out of ever matching again, even as the CRM grew around them. That's why the phase reported `eligible_for_matching: 0` and looked like an idle no-op: it was a saturated backlog.

Replaced the hard cap with **exponential backoff** on the existing `match_attempted_at` / `match_attempt_count` columns — attempt 4 after 30d, 5 after 90d, 6 after 270d. Chosen over a CRM-growth watermark because it's stateless: **no schema change and no migration**. Below the cap, behavior is unchanged.

Added a per-run cap (default 200) because capped entities cluster in a narrow historical window and would otherwise all become eligible on one night; oldest-waiting first, so the backlog drains fairly.

Closes #507

## Production impact (read-only analysis)

| | |
|---|---|
| Unlinked entities | 1,729 (1,678 capped) |
| Eligible tonight under backoff alone | 1,598 |
| **With the 200/run cap** | **200 retried, 1,478 deferred** — drains over ~8 nights |

Stats now include `capped_backlog` and `capped_deferred`, so a saturated backlog reads honestly instead of as `eligible_for_matching: 0`.

## Test evidence

8 new tests (backoff tiers, per-run cap, cap not applied to non-capped entities, no regression for fresh entities); `test_source_entity.py` 36/36; full pre-push suite 2,385 passed / 8 skipped; ruff clean.

Also fixes a latent bug found along the way: `match_attempted_at` / `match_attempt_count` existed in the DB but were silently dropped by `SourceEntity.from_row()` — additive fix, needed for the per-entity backoff.

Implemented by a Sonnet subagent in an isolated worktree; reviewed by the orchestrator.