### PR TITLE
fix(chat): report the real reason voice recording is unavailable, and link to the HTTPS origin

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -245,8 +245,17 @@ async def list_personas():
 @router.get("/chat/config")
 async def chat_config():
     """Client-facing /chat defaults. `default_voice` drives the web client's
-    default input mode when there's no ?mode= param or stored preference."""
-    return {"default_voice": bool(settings.chat_default_voice)}
+    default input mode when there's no ?mode= param or stored preference.
+
+    `secure_url` is the HTTPS origin (TAILNET_HTTPS_URL) the web client offers as
+    a one-tap escape when the mic is blocked by an insecure context (#516).
+    Trailing slash stripped so clients can append a path directly; "" when unset,
+    in which case the client just reports the insecure context without a link.
+    """
+    return {
+        "default_voice": bool(settings.chat_default_voice),
+        "secure_url": (settings.tailnet_https_url or "").rstrip("/"),
+    }
 
 
 # Attachment configuration

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -25,7 +25,7 @@ Each section corresponds roughly to a section in [`config/settings.py`](../../co
 | `LIFEOS_CHROMA_PATH` | path | `./data/chromadb` | Where ChromaDB persists its data. |
 | `LIFEOS_CODE_DIR` | path | `~/Code` | Parent directory containing LifeOS and (optionally) other projects. Used by `/claude` orchestrator path resolution. |
 | `LIFEOS_BACKUP_PATH` | path | `./data/backups` | Where backup archives are written. |
-| `TAILNET_HTTPS_URL` | str | — | Your machine's Tailscale HTTPS URL (no port), e.g. `https://<your-machine>.<tailnet>.ts.net`. Used by `scripts/setup-tailscale.sh` status output. **Open `/chat` on this URL for voice** — the mic requires HTTPS. |
+| `TAILNET_HTTPS_URL` | str | — | Your machine's Tailscale HTTPS URL (no port), e.g. `https://<your-machine>.<tailnet>.ts.net`. Used by `scripts/setup-tailscale.sh` status output, and returned as `secure_url` by `GET /api/chat/config` so `/chat` can offer a one-tap link here when the mic is blocked by an insecure context. **Open `/chat` on this URL for voice** — the mic requires HTTPS. |
 | `LIFEOS_VOICE_GATEWAY_URL` | str | `http://127.0.0.1:9788` | whisper-relay base URL; LifeOS reverse-proxies `/api/voice/*` here (ADR-016). |
 
 **Tailscale Serve (phone /chat + voice):** run once after install, then enable the user unit so it survives reboot:

--- a/docs/guides/voice-setup.md
+++ b/docs/guides/voice-setup.md
@@ -1,7 +1,7 @@
 # Voice Setup
 
 **Status:** Complete
-**Last Updated:** 2026-07-09
+**Last Updated:** 2026-08-09
 **Audience:** Operators
 
 This guide sets up **voice mode** in LifeOS. Voice is a tap-to-talk input mode *inside* the web `/chat` client — not a separate app or page. It reaches the same orchestrator, the same personas, and the same conversations as text chat. The speech pipeline (STT and TTS) is provided by a **separate** service, **whisper-relay**; LifeOS only reverse-proxies it and adds the browser UI.
@@ -48,7 +48,7 @@ systemctl --user enable --now lifeos-tailscale.service
 
 `install-systemd-tailscale.sh` writes a user systemd unit (`lifeos-tailscale.service`) that waits for the local API to report healthy, then runs `scripts/setup-tailscale.sh` — which calls `tailscale serve` to publish LifeOS on the tailnet HTTPS front. After this, open `/chat` at your tailnet HTTPS URL (`https://<your-machine>.<your-tailnet>.ts.net/chat`); voice will not work over plain `http://` or a bare LAN IP.
 
-`TAILNET_HTTPS_URL` is an **optional** env var. It is read only for a printed bookmark hint by `scripts/setup-tailscale.sh` and `scripts/server.sh` — it configures nothing. Set it to your tailnet URL if you want those scripts to echo a ready-to-open `/chat` link.
+`TAILNET_HTTPS_URL` is an **optional** env var. `scripts/setup-tailscale.sh` and `scripts/server.sh` echo it as a bookmark hint, and `GET /api/chat/config` returns it as `secure_url` so the web client can offer a one-tap **Open over HTTPS** link when the mic is blocked by an insecure context. Leave it unset and that link is simply omitted — nothing else changes.
 
 ### 3. Configure LifeOS env vars
 
@@ -97,7 +97,8 @@ Selecting an **orchestrating** persona (for example the `doctor` self-repair bot
 
 | Symptom | Likely cause / fix |
 |---------|--------------------|
-| No microphone prompt / "insecure context" | Not on HTTPS. Open `/chat` via the tailnet HTTPS URL, not `http://` or a LAN IP. Confirm `lifeos-tailscale.service` is active. |
+| "Mic blocked — this page is not on HTTPS" | Not on HTTPS. If `TAILNET_HTTPS_URL` is set, the message carries an **Open over HTTPS** link to this same page on that origin — tap it. Otherwise reopen `/chat` on your tailnet HTTPS URL, not `http://` or a LAN IP, and confirm `lifeos-tailscale.service` is active. |
+| "Mic unavailable — …" (no microphone API / no MediaRecorder / no supported audio format) | Not an HTTPS problem: the browser itself lacks a recording capability. Use a current Chrome, Safari, or Firefox; in-app webviews and stripped-down browsers often omit these. |
 | Dock present but turns error immediately | whisper-relay isn't running on `LIFEOS_VOICE_GATEWAY_URL` (default `:9788`). Start the gateway; check `curl http://127.0.0.1:9788` locally. |
 | Voice dock never appears | Voice is opt-in per browser. Toggle to Voice with the mic control, or set `LIFEOS_CHAT_DEFAULT_VOICE=true` and restart the API. |
 | `Agent` toggle missing | Expected unless `LIFEOS_AGENT_BACKEND_URL` is set. |

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -110,7 +110,11 @@ run_browser_tests() {
         exit 1
     fi
 
-    python -m pytest tests/test_ui_browser.py tests/test_e2e_flow.py -v \
+    # test_voice_mic_block_ui_browser.py serves web/ itself on an ephemeral port
+    # and stubs every /api/ call, so it needs no server — but it is a Playwright
+    # test, so `browser` is the only scope that can reach it.
+    python -m pytest tests/test_ui_browser.py tests/test_e2e_flow.py \
+        tests/test_voice_mic_block_ui_browser.py -v \
         --ignore=tests/archive \
         -m "browser" \
         --tb=short \

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -481,10 +481,35 @@ class TestPersonasEndpoint:
 
 class TestChatConfigEndpoint:
     def test_default_voice_reflects_setting(self, client, monkeypatch):
+        monkeypatch.setattr("api.routes.chat.settings.tailnet_https_url", "", raising=False)
         monkeypatch.setattr("api.routes.chat.settings.chat_default_voice", False, raising=False)
-        assert client.get("/api/chat/config").json() == {"default_voice": False}
+        assert client.get("/api/chat/config").json() == {
+            "default_voice": False, "secure_url": ""}
         monkeypatch.setattr("api.routes.chat.settings.chat_default_voice", True, raising=False)
-        assert client.get("/api/chat/config").json() == {"default_voice": True}
+        assert client.get("/api/chat/config").json() == {
+            "default_voice": True, "secure_url": ""}
+
+    # secure_url is the web client's one-tap escape from an insecure context to
+    # the HTTPS origin the mic needs (#516).
+    def test_secure_url_reflects_tailnet_setting(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "api.routes.chat.settings.tailnet_https_url",
+            "https://your-machine.your-tailnet.ts.net", raising=False)
+        assert (client.get("/api/chat/config").json()["secure_url"]
+                == "https://your-machine.your-tailnet.ts.net")
+
+    def test_secure_url_strips_trailing_slash(self, client, monkeypatch):
+        """Clients concatenate a path onto it, so it must not end in '/'."""
+        monkeypatch.setattr(
+            "api.routes.chat.settings.tailnet_https_url",
+            "https://your-machine.your-tailnet.ts.net/", raising=False)
+        assert (client.get("/api/chat/config").json()["secure_url"]
+                == "https://your-machine.your-tailnet.ts.net")
+
+    def test_secure_url_empty_when_unset(self, client, monkeypatch):
+        """A fresh clone with no Tailscale must degrade to no link, not break."""
+        monkeypatch.setattr("api.routes.chat.settings.tailnet_https_url", "", raising=False)
+        assert client.get("/api/chat/config").json()["secure_url"] == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_voice_mic_block_ui_browser.py
+++ b/tests/test_voice_mic_block_ui_browser.py
@@ -1,0 +1,130 @@
+"""Browser test for the /chat voice mic-block diagnostics (#516).
+
+Drives `web/chat/voice.js`'s `micBlockReason()` through the real talk button.
+Each of the four preconditions (secure context, getUserMedia, MediaRecorder, a
+supported mime type) used to collapse into one "Mic unavailable (HTTPS required)"
+message; this pins that each now reports its own cause, and that an insecure
+context offers a tappable link to the configured HTTPS origin.
+
+Unlike the rest of the browser suite this serves `web/` itself from an ephemeral
+port rather than pointing at a running API, because the assertions are about the
+JS in *this* checkout and every API call the page makes is intercepted anyway.
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+# Obviously synthetic — never a real tailnet name.
+SECURE_URL = "https://your-machine.your-tailnet.ts.net"
+
+
+class _ChatHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the chat SPA the way api/main.py does: `/chat` is index.html and
+    the module tree hangs off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/chat", "/"):
+            return str(WEB_DIR / "index.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def chat_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _ChatHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _open_voice_chat(page: Page, base_url, *, env_script, secure_url=SECURE_URL):
+    """Load /chat in voice mode with the browser capabilities `env_script` fakes.
+
+    `/api/chat/config` returns `secure_url`; every other API call the SPA makes
+    on load is stubbed empty so nothing depends on a running server.
+    """
+    page.add_init_script(env_script)
+
+    def handler(route):
+        if "/api/chat/config" in route.request.url:
+            body = {"default_voice": True, "secure_url": secure_url}
+        else:
+            body = {}
+        route.fulfill(status=200, content_type="application/json",
+                      body=json.dumps(body))
+
+    page.route("**/api/**", handler)
+    page.goto(f"{base_url}/chat?mode=voice")
+    page.wait_for_selector("#voiceTalkBtn")
+    page.locator("#voiceTalkBtn").click()
+
+
+# `isSecureContext` is read-only and true on localhost, so each scenario
+# redefines exactly the globals `micBlockReason()` inspects.
+INSECURE = """
+Object.defineProperty(window, 'isSecureContext', { value: false });
+"""
+NO_GETUSERMEDIA = """
+Object.defineProperty(navigator, 'mediaDevices', { value: undefined });
+"""
+NO_MEDIARECORDER = """
+Object.defineProperty(navigator, 'mediaDevices',
+                      { value: { getUserMedia: () => Promise.resolve({}) } });
+delete window.MediaRecorder;
+"""
+NO_MIME = """
+Object.defineProperty(navigator, 'mediaDevices',
+                      { value: { getUserMedia: () => Promise.resolve({}) } });
+window.MediaRecorder = function () {};
+window.MediaRecorder.isTypeSupported = () => false;
+"""
+
+
+class TestMicBlockReasons:
+    """Each precondition names itself instead of blaming HTTPS."""
+
+    def test_insecure_context_offers_https_link(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url, env_script=INSECURE)
+        expect(page.locator("#statusText")).to_have_text("Mic blocked — this page is not on HTTPS")
+        link = page.locator(".message.assistant a.source-link")
+        expect(link).to_have_text("🔒 Open over HTTPS")
+        # Same page on the secure origin: path and query both preserved.
+        expect(link).to_have_attribute("href", f"{SECURE_URL}/chat?mode=voice")
+
+    def test_insecure_context_without_secure_url_has_no_link(self, page: Page, chat_base_url):
+        """A fresh clone with no TAILNET_HTTPS_URL still gets an accurate message."""
+        _open_voice_chat(page, chat_base_url, env_script=INSECURE, secure_url="")
+        expect(page.locator("#statusText")).to_have_text("Mic blocked — this page is not on HTTPS")
+        expect(page.locator(".message.assistant")).to_contain_text("not on HTTPS")
+        expect(page.locator(".message.assistant a.source-link")).to_have_count(0)
+
+    def test_missing_getusermedia_is_not_reported_as_https(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url, env_script=NO_GETUSERMEDIA)
+        expect(page.locator("#statusText")).to_have_text(
+            "Mic unavailable — this browser exposes no microphone API")
+        expect(page.locator(".message.assistant a.source-link")).to_have_count(0)
+
+    def test_missing_mediarecorder_is_not_reported_as_https(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url, env_script=NO_MEDIARECORDER)
+        expect(page.locator("#statusText")).to_have_text(
+            "Mic unavailable — this browser has no MediaRecorder")
+
+    def test_unsupported_mime_is_not_reported_as_https(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url, env_script=NO_MIME)
+        expect(page.locator("#statusText")).to_have_text(
+            "Mic unavailable — no supported audio format in this browser")

--- a/tests/test_voice_mic_block_ui_browser.py
+++ b/tests/test_voice_mic_block_ui_browser.py
@@ -128,3 +128,36 @@ class TestMicBlockReasons:
         _open_voice_chat(page, chat_base_url, env_script=NO_MIME)
         expect(page.locator("#statusText")).to_have_text(
             "Mic unavailable — no supported audio format in this browser")
+
+
+class TestReportedOncePerReason:
+    """Tapping a blocked button repeatedly must not stack identical bubbles."""
+
+    def test_repeat_taps_append_one_bubble_but_keep_updating_status(
+            self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url, env_script=INSECURE)
+        expect(page.locator(".message.assistant")).to_have_count(1)
+
+        # Clear the pill so we can prove the next tap still writes to it.
+        page.evaluate("document.getElementById('statusText').textContent = ''")
+        for _ in range(3):
+            page.locator("#voiceTalkBtn").click()
+
+        expect(page.locator("#statusText")).to_have_text("Mic blocked — this page is not on HTTPS")
+        expect(page.locator(".message.assistant")).to_have_count(1)
+        expect(page.locator(".message.assistant a.source-link")).to_have_count(1)
+
+    def test_a_different_reason_is_still_reported(self, page: Page, chat_base_url):
+        """The guard is keyed by reason, so a changed cause isn't swallowed."""
+        _open_voice_chat(page, chat_base_url, env_script=INSECURE)
+        expect(page.locator(".message.assistant")).to_have_count(1)
+
+        # Same page, mic now blocked for a different reason: the secure-context
+        # check passes and getUserMedia is the thing missing.
+        page.evaluate("Object.defineProperty(window, 'isSecureContext', { value: true });"
+                      "Object.defineProperty(navigator, 'mediaDevices', { value: undefined });")
+        page.locator("#voiceTalkBtn").click()
+
+        expect(page.locator("#statusText")).to_have_text(
+            "Mic unavailable — this browser exposes no microphone API")
+        expect(page.locator(".message.assistant")).to_have_count(2)

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -5,7 +5,7 @@
 // record → multipart POST /api/voice/turn/stream → SSE → done data → playback.
 
 import { state, config, elements, endpoints } from './session.js';
-import { addMessage, setStatus } from './thread.js';
+import { addMessage, escapeHtml, setStatus } from './thread.js';
 import { loadConversations } from './conversations.js';
 import { setStoredConversationId } from './backend.js';
 import { personaOrchestrates } from './persona.js';
@@ -157,16 +157,25 @@ function resolveExplicitVoiceMode() {
   return null;
 }
 
+// GET /chat/config, once per page load. Both the default-mode resolution and the
+// insecure-context escape hatch read this, and either may run first, so the
+// promise is cached rather than re-fetched. Always resolves — an unreachable
+// config degrades to {} (text mode, no HTTPS link).
+let chatConfigPromise = null;
+
+function fetchChatConfig() {
+  if (!chatConfigPromise) {
+    chatConfigPromise = fetch(endpoints.chatConfig)
+      .then((resp) => (resp.ok ? resp.json() : {}))
+      .catch(() => ({}));
+  }
+  return chatConfigPromise;
+}
+
 // The server-configured default mode (LIFEOS_CHAT_DEFAULT_VOICE). Off by default
 // so a fresh clone without a voice gateway stays on text.
 async function fetchDefaultVoiceMode() {
-  try {
-    const resp = await fetch(endpoints.chatConfig);
-    if (resp.ok) return !!(await resp.json()).default_voice;
-  } catch (e) {
-    /* config unavailable — keep text */
-  }
-  return false;
+  return !!(await fetchChatConfig()).default_voice;
 }
 
 function storeVoiceMode(on) {
@@ -195,13 +204,48 @@ function pickMimeType() {
   return '';
 }
 
-function canRecordAudio() {
-  return (
-    window.isSecureContext &&
-    !!navigator.mediaDevices?.getUserMedia &&
-    typeof MediaRecorder !== 'undefined' &&
-    (useWebAudioRecorder || pickMimeType() !== '')
-  );
+// Which recording precondition failed, or '' when the mic is usable. These used
+// to collapse into one boolean reported as "HTTPS required", which sent users
+// chasing a TLS problem for three causes that have nothing to do with TLS
+// (#516). Order matters: an insecure context also hides getUserMedia, so it must
+// be checked first to be named as the real cause.
+const MIC_BLOCK_MESSAGES = {
+  insecure_context: 'Mic blocked — this page is not on HTTPS',
+  no_getusermedia: 'Mic unavailable — this browser exposes no microphone API',
+  no_mediarecorder: 'Mic unavailable — this browser has no MediaRecorder',
+  no_mime: 'Mic unavailable — no supported audio format in this browser',
+};
+
+function micBlockReason() {
+  if (!window.isSecureContext) return 'insecure_context';
+  if (!navigator.mediaDevices?.getUserMedia) return 'no_getusermedia';
+  if (typeof MediaRecorder === 'undefined') return 'no_mediarecorder';
+  if (!useWebAudioRecorder && pickMimeType() === '') return 'no_mime';
+  return '';
+}
+
+// Report the specific blocked reason in the thread. For an insecure context the
+// fix is reachable — the same app is fronted over HTTPS at `secure_url`
+// (TAILNET_HTTPS_URL) — so offer a tappable link to this same page there. The
+// user taps it; we never auto-redirect. With no configured secure_url (a fresh
+// clone, no Tailscale) the message stands alone.
+async function reportMicBlocked(reason) {
+  const message = MIC_BLOCK_MESSAGES[reason];
+  setStatus('error', message);
+  const secureUrl = reason === 'insecure_context'
+    ? ((await fetchChatConfig()).secure_url || '').replace(/\/+$/, '')
+    : '';
+  if (!secureUrl) {
+    addMessage('⚠️ ' + message, 'assistant');
+    return;
+  }
+  const target = secureUrl + window.location.pathname + window.location.search;
+  const el = addMessage('', 'assistant');
+  const content = el.querySelector('.message-content');
+  if (content) {
+    content.innerHTML = `⚠️ ${escapeHtml(message)}. `
+      + `<a class="source-link" href="${escapeHtml(target)}">🔒 Open over HTTPS</a>`;
+  }
 }
 
 function formatMicError(err) {
@@ -269,8 +313,9 @@ function setTalkActive(on) {
 function onTalkClick(event) {
   event.preventDefault();
   unlockTtsAudio();
-  if (!canRecordAudio()) {
-    setStatus('error', 'Mic unavailable (HTTPS required)');
+  const blocked = micBlockReason();
+  if (blocked) {
+    reportMicBlocked(blocked);
     return;
   }
   if (voiceBusy || state.isLoading) return;
@@ -309,11 +354,11 @@ async function acquireMicStream() {
 }
 
 function requestMicInGesture() {
-  if (!window.isSecureContext) {
-    return Promise.reject(new Error('Microphone requires HTTPS.'));
-  }
-  if (!navigator.mediaDevices?.getUserMedia) {
-    return Promise.reject(new Error('Microphone not available.'));
+  // Same reasons, same wording as the talk-button guard — this path is also
+  // reached without a tap (auto-continue), so it can't assume onTalkClick ran.
+  const blocked = micBlockReason();
+  if (blocked) {
+    return Promise.reject(new Error(MIC_BLOCK_MESSAGES[blocked]));
   }
   if (micStream?.getAudioTracks().some((t) => t.readyState === 'live')) {
     return Promise.resolve(micStream);

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -224,6 +224,11 @@ function micBlockReason() {
   return '';
 }
 
+// The reason already written to the thread, so repeated taps on a blocked talk
+// button don't stack identical bubbles. Keyed by reason, not a plain boolean, so
+// a *different* cause still gets reported.
+let reportedMicBlock = '';
+
 // Report the specific blocked reason in the thread. For an insecure context the
 // fix is reachable — the same app is fronted over HTTPS at `secure_url`
 // (TAILNET_HTTPS_URL) — so offer a tappable link to this same page there. The
@@ -231,7 +236,9 @@ function micBlockReason() {
 // clone, no Tailscale) the message stands alone.
 async function reportMicBlocked(reason) {
   const message = MIC_BLOCK_MESSAGES[reason];
-  setStatus('error', message);
+  setStatus('error', message);  // every tap gets feedback…
+  if (reportedMicBlock === reason) return;  // …but the thread bubble lands once
+  reportedMicBlock = reason;  // set before awaiting, so a fast second tap loses
   const secureUrl = reason === 'insecure_context'
     ? ((await fetchChatConfig()).secure_url || '').replace(/\/+$/, '')
     : '';


### PR DESCRIPTION
Fixes #516.

## Problem

Tapping talk in `/chat` voice mode reported `Mic unavailable (HTTPS required)` for **all four** `canRecordAudio()` preconditions — insecure context, missing `getUserMedia`, missing `MediaRecorder`, no supported mime type. Three of those have nothing to do with TLS, so the message sent users chasing a problem that didn't exist. And when HTTPS *was* the cause, the message named no fix: the same app is already fronted over HTTPS by `tailscale serve`, but the client never learned that URL.

Reproduced: loading `/chat` on the host's bare tailnet IP fails with the dead-end message; loading it on the tailnet HTTPS hostname works.

## Change

**`api/routes/chat.py`** — `GET /chat/config` gains an **additive** `secure_url` from the existing `TAILNET_HTTPS_URL` setting (trailing slash stripped; `""` when unset). `default_voice` is unchanged, so this is not a breaking change to the HTTP client contract.

**`web/chat/voice.js`** — `canRecordAudio()` becomes `micBlockReason()`, which names the failing precondition; each reason gets its own accurate message. Insecure-context checks first, since an insecure context also hides `getUserMedia` and would otherwise be misreported. When the cause is an insecure context and `secure_url` is configured, the thread gets a tappable **🔒 Open over HTTPS** link to the same `pathname + search` on that origin — the user taps it, we never auto-redirect. `requestMicInGesture()` now shares the same reason map (it's reachable without a tap, so it can't assume the button guard ran).

The `/chat/config` fetch is memoized rather than duplicated — the default-mode resolution and the escape hatch both read it, either may run first, and it always resolves (`{}` on error), preserving the existing "config unavailable → stay on text" behavior.

**Docs** — `voice-setup.md` troubleshooting rows rewritten to match shipped behavior; this also corrects the now-false claim that `TAILNET_HTTPS_URL` "configures nothing". `configuration.md` notes it surfaces as `secure_url`.

## Degradation

With `TAILNET_HTTPS_URL` unset (fresh clone, no Tailscale) `secure_url` is `""`, the link is omitted, and the message stands alone. Synthetic hostnames only in tests and docs.

## Tests

- `tests/test_persona_api.py::TestChatConfigEndpoint` — `secure_url` set / trailing-slash / unset.
- `tests/test_voice_mic_block_ui_browser.py` (new) — 5 Playwright tests covering all four reason codes and the link target, serving `web/` from an ephemeral port so it exercises *this* tree's `voice.js` rather than a running server's.

`pytest -m "unit and not slow"` (the pre-push scope): **2388 passed, 8 skipped, 0 failed**. Browser tests run explicitly: **54 passed**. The 14 failures in the full `./scripts/test.sh` run are pre-existing and environment-dependent (host `.env` values; CRM/interaction data this worktree has no data dir for) — verified byte-identical on a stashed clean tree.

## Not verified

The insecure context is simulated in-browser by redefining `window.isSecureContext`; the fix was not exercised against a real plain-HTTP origin end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
