### PR TITLE
fix(security): stop logging the Telegram bot token via httpx request logs

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -34,7 +34,18 @@ from pathlib import Path
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, investments, jobs, perf, agents, vault, fitness, voice, agent_proxy
+from api.services.log_redaction import configure_telegram_log_redaction
 from config.settings import settings
+
+# Configure root logging here, explicitly, rather than leaving it to whatever
+# module happens to call `logging.basicConfig()` first. `scripts/merge_people`
+# (imported lazily on startup below) does exactly that with this same
+# level/format, so this is a no-op for existing log output — but doing it up
+# front, and pairing it with `configure_telegram_log_redaction()`, is what
+# keeps httpx's request logger (which logs full URLs, and the Telegram Bot
+# API embeds the bot token in the URL) from ever logging at INFO here (#519).
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+configure_telegram_log_redaction()
 
 logger = logging.getLogger(__name__)
 

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -58,6 +58,7 @@ from api.services.agent_worker.spend_tracker import SpendTracker
 from api.services.agent_worker.transcript_store import TranscriptStore
 from api.services.conversation_store import ConversationStore
 from api.services.interaction_store import build_obsidian_link
+from api.services.log_redaction import configure_telegram_log_redaction
 from config.settings import settings
 
 
@@ -3061,6 +3062,10 @@ def main() -> None:
         level=os.environ.get("LIFEOS_LOG_LEVEL", "INFO"),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
+    # This worker sends progress/completion updates via Telegram. Without
+    # this, httpx's request logger (INFO by default, logs the full request
+    # URL — which embeds the bot token) would leak the token every send (#519).
+    configure_telegram_log_redaction()
     # Wire up real Telegram senders in production. Worker() defaults to
     # no-op senders so tests can't accidentally hit a real chat — see
     # comment in __init__. If telegram.py isn't importable or the bot

--- a/api/services/log_redaction.py
+++ b/api/services/log_redaction.py
@@ -1,0 +1,97 @@
+"""Redaction of Telegram bot tokens from log records (#519).
+
+The Telegram Bot API embeds the bot token directly in the request path
+(``https://api.telegram.org/bot<digits>:<secret>/<method>``). ``httpx``'s
+request logger defaults to INFO and logs the full URL of every request —
+which is how a live, full-control credential ended up in plaintext in
+``logs/server.log`` and ``logs/sync.log``.
+
+This module provides two layers of defense:
+
+1. ``silence_noisy_http_loggers()`` — the direct fix. Raises the relevant
+   HTTP client loggers to WARNING so a *successful* send never logs the URL
+   (and therefore the token) in the first place.
+2. ``TelegramTokenRedactionFilter`` / ``install_telegram_redaction_filter()``
+   — a defensive backstop. Installed on the root logger's handlers, it
+   rewrites any log record whose rendered message contains a Telegram bot
+   token shape, so a future library, log level change, or code path (e.g. an
+   httpx exception whose string form embeds the request URL) can't
+   reintroduce the leak even if the level-based fix above is bypassed.
+
+Call ``configure_telegram_log_redaction()`` once per process, after the
+process's own root logging setup (``logging.basicConfig`` or equivalent) has
+run — it needs at least one handler already attached to root for the filter
+to have something to attach to.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+# Matches a Telegram bot token wherever it shows up in a message: the
+# `bot<digits>:<secret>` path segment the Telegram Bot API uses (whether or
+# not `api.telegram.org` precedes it — e.g. a stringified httpx exception
+# may render just the path, or a relative URL). `[A-Za-z0-9_-]+` covers the
+# base64url-ish token body Telegram issues.
+TELEGRAM_TOKEN_PATTERN = re.compile(r"bot\d+:[A-Za-z0-9_-]+")
+
+REDACTED_TOKEN = "bot<REDACTED>"
+
+# Loggers that log full outbound request URLs at INFO by default. httpx logs
+# "HTTP Request: <method> <url> ..." for every request it makes, and the
+# Telegram Bot API puts the token in that URL.
+_NOISY_HTTP_LOGGER_NAMES = ("httpx",)
+
+
+class TelegramTokenRedactionFilter(logging.Filter):
+    """Rewrites any log record whose message contains a Telegram bot token.
+
+    Never drops a record — only redacts the token in place — so error paths
+    stay visible. Safe to attach to a `Logger` or a `Handler`; attaching to
+    handlers on the root logger is what lets it catch records that
+    *propagate* up from other loggers (httpx, or anything not otherwise
+    silenced), not just ones logged directly against the object it's on.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            # Don't let a malformed record (bad % args, etc.) break logging.
+            return True
+
+        if TELEGRAM_TOKEN_PATTERN.search(message):
+            record.msg = TELEGRAM_TOKEN_PATTERN.sub(REDACTED_TOKEN, message)
+            record.args = ()
+
+        return True
+
+
+def silence_noisy_http_loggers(logger_names=_NOISY_HTTP_LOGGER_NAMES) -> None:
+    """Raise HTTP client request loggers to WARNING so successful requests
+    stop logging their (token-bearing) URLs. Failures still log — this only
+    raises the level of the *request* log line, not error handling."""
+    for name in logger_names:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def install_telegram_redaction_filter() -> None:
+    """Install `TelegramTokenRedactionFilter` on the root logger and every
+    handler currently attached to it. Idempotent."""
+    root = logging.getLogger()
+    filt = TelegramTokenRedactionFilter()
+
+    if not any(isinstance(f, TelegramTokenRedactionFilter) for f in root.filters):
+        root.addFilter(filt)
+
+    for handler in root.handlers:
+        if not any(isinstance(f, TelegramTokenRedactionFilter) for f in handler.filters):
+            handler.addFilter(filt)
+
+
+def configure_telegram_log_redaction() -> None:
+    """Apply both defenses. Call once per process, after root logging is
+    configured (i.e. after `logging.basicConfig(...)` has given root at
+    least one handler)."""
+    silence_noisy_http_loggers()
+    install_telegram_redaction_filter()

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -61,6 +61,7 @@ from api.services.sync_health import (
     reap_orphan_sync_runs,
     detect_silent_source_entity_drift,
 )
+from api.services.log_redaction import configure_telegram_log_redaction
 from config.settings import settings
 
 # =============================================================================
@@ -579,6 +580,11 @@ logging.basicConfig(
         logging.FileHandler(log_file),
     ]
 )
+# This sync sends a Telegram notification with a run summary. httpx's request
+# logger defaults to INFO and logs the full request URL — and the Telegram
+# Bot API embeds the bot token in that URL — so without this, every sync run
+# writes a live credential into logs/sync_*.log (#519).
+configure_telegram_log_redaction()
 logger = logging.getLogger(__name__)
 
 # =============================================================================

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -1,0 +1,161 @@
+"""Tests for Telegram bot token log redaction (#519).
+
+The Telegram Bot API embeds the bot token in the request URL
+(`api.telegram.org/bot<digits>:<secret>/<method>`), and httpx's request
+logger defaults to INFO and logs that full URL. These tests use an obviously
+fake token — never a real one.
+"""
+import logging
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+FAKE_TOKEN = "bot123456:FAKE_TOKEN_FOR_TESTS"
+
+
+def _make_record(message: str, level: int = logging.INFO) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="httpx",
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+
+
+class TestTelegramTokenRedactionFilter:
+    def test_redacts_telegram_request_url(self):
+        from api.services.log_redaction import (
+            TelegramTokenRedactionFilter,
+            REDACTED_TOKEN,
+        )
+
+        record = _make_record(
+            f'HTTP Request: POST https://api.telegram.org/{FAKE_TOKEN}/sendMessage "HTTP/1.1 200 OK"'
+        )
+        result = TelegramTokenRedactionFilter().filter(record)
+
+        assert result is True  # never drops the record
+        message = record.getMessage()
+        assert FAKE_TOKEN not in message
+        assert "FAKE_TOKEN_FOR_TESTS" not in message
+        assert REDACTED_TOKEN in message
+
+    def test_redacts_bare_bot_token_pattern_anywhere(self):
+        """Generic `bot\\d+:secret` shape, not just the full telegram.org URL —
+        e.g. what a stringified httpx exception might embed."""
+        from api.services.log_redaction import (
+            TelegramTokenRedactionFilter,
+            REDACTED_TOKEN,
+        )
+
+        record = _make_record(f"getUpdates error: connection to {FAKE_TOKEN} timed out")
+        TelegramTokenRedactionFilter().filter(record)
+
+        message = record.getMessage()
+        assert FAKE_TOKEN not in message
+        assert REDACTED_TOKEN in message
+
+    def test_leaves_unrelated_messages_untouched(self):
+        from api.services.log_redaction import TelegramTokenRedactionFilter
+
+        original = "Calendar sync scheduler started (times: 08:00, 12:00, 15:00 America/New_York)"
+        record = _make_record(original)
+        result = TelegramTokenRedactionFilter().filter(record)
+
+        assert result is True
+        assert record.getMessage() == original
+
+    def test_leaves_unrelated_messages_with_args_untouched(self):
+        """Records logged with %-args (not pre-formatted f-strings) should be
+        unaffected when there's no token to redact."""
+        from api.services.log_redaction import TelegramTokenRedactionFilter
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="Restored update offset for '%s': %s",
+            args=("primary", 42),
+            exc_info=None,
+        )
+        TelegramTokenRedactionFilter().filter(record)
+        assert record.getMessage() == "Restored update offset for 'primary': 42"
+
+    def test_does_not_raise_on_bad_percent_args(self):
+        """A record whose msg/args can't be formatted shouldn't crash filtering."""
+        from api.services.log_redaction import TelegramTokenRedactionFilter
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="%s %s",
+            args=("only one",),
+            exc_info=None,
+        )
+        result = TelegramTokenRedactionFilter().filter(record)
+        assert result is True
+
+
+class TestConfigureTelegramLogRedaction:
+    def setup_method(self, method):
+        self._root = logging.getLogger()
+        self._root_filters_before = list(self._root.filters)
+
+    def teardown_method(self, method):
+        # Reset httpx logger level and any root-logger filters this test
+        # installed, so tests don't leak global logging state into each other.
+        logging.getLogger("httpx").setLevel(logging.NOTSET)
+        self._root.filters = self._root_filters_before
+
+    def test_httpx_logger_raised_to_warning(self):
+        from api.services.log_redaction import configure_telegram_log_redaction
+
+        # Simulate an app that (like real callers) sets httpx to INFO
+        # somewhere along the way, e.g. via a root-level basicConfig whose
+        # effective level httpx inherits.
+        logging.getLogger("httpx").setLevel(logging.INFO)
+
+        configure_telegram_log_redaction()
+
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_installs_redaction_filter_on_root_handlers(self):
+        from api.services.log_redaction import (
+            configure_telegram_log_redaction,
+            TelegramTokenRedactionFilter,
+        )
+
+        handler = logging.StreamHandler()
+        self._root.addHandler(handler)
+        try:
+            configure_telegram_log_redaction()
+            assert any(
+                isinstance(f, TelegramTokenRedactionFilter) for f in handler.filters
+            )
+        finally:
+            self._root.removeHandler(handler)
+
+    def test_idempotent_does_not_duplicate_filter(self):
+        from api.services.log_redaction import (
+            configure_telegram_log_redaction,
+            TelegramTokenRedactionFilter,
+        )
+
+        handler = logging.StreamHandler()
+        self._root.addHandler(handler)
+        try:
+            configure_telegram_log_redaction()
+            configure_telegram_log_redaction()
+            count = sum(
+                1 for f in handler.filters if isinstance(f, TelegramTokenRedactionFilter)
+            )
+            assert count == 1
+        finally:
+            self._root.removeHandler(handler)


### PR DESCRIPTION
## Summary

The Telegram bot token was written to logs in plaintext — `httpx` logs full request URLs at INFO, and the Bot API embeds the token in the URL path. **~93,000 occurrences across 109 log files** were found on the host, going back to March, spanning **5 distinct tokens** (each persona bot has its own).

Closes #519

## Root cause (deeper than the issue assumed)

`api/main.py` had **no logging configuration of its own**. The root logger was being configured accidentally by `scripts/merge_people.py`'s unguarded module-level `logging.basicConfig()`, imported lazily inside `lifespan()` on every startup — which is what gave httpx's INFO records a real handler.

The same httpx-default problem independently affected `scripts/run_all_syncs.py` and `api/services/agent_worker/worker.py`, so **`agent-worker.log` was leaking too** — beyond what the issue identified. `mcp_server.py` is unaffected (it proxies sends through the API and never sees the token).

## Changes

- New `api/services/log_redaction.py`: silences the `httpx` logger to WARNING (direct fix; `logger.error` paths in `telegram.py` still log), plus a defensive `TelegramTokenRedactionFilter` that rewrites `bot\d+:[A-Za-z0-9_-]+` → `bot<REDACTED>` — matching with or without the `api.telegram.org` prefix so it also catches tokens inside stringified httpx exceptions. Never drops a record; tolerates malformed `%`-args.
- Installed on root's **handlers** (not just the logger), so records propagating from any logger are caught.
- `api/main.py` now configures root logging explicitly, using the same level/format `merge_people` was accidentally applying — so no visible change to log output, but the configuration point is now intentional and httpx is silenced before any request happens.

## Test evidence

8 new tests (URL and bare-token redaction, unrelated messages untouched, malformed args safe, httpx level raised, idempotent install) using a fake `bot123456:FAKE_TOKEN_FOR_TESTS`. Telegram + sync suites 146/146; agent-worker 419/419; full unit scope 3,337 passed with 14 pre-existing failures verified identical on unmodified `main` via `git stash`; ruff clean.

Log files were left untouched by the change — the orchestrator redacted them separately (~93,660 occurrences rewritten in place, preserving the logs' diagnostic value). Token rotation was declined by the operator; redaction plus this fix is the remediation.

Implemented by a Sonnet subagent in an isolated worktree; reviewed by the orchestrator.