### PR TITLE
fix(gpu): serialize GPU embedders and detect SDMA-queue exhaustion

### DIFF
--- a/api/services/embeddings.py
+++ b/api/services/embeddings.py
@@ -7,9 +7,13 @@ Model files are cached at settings.embedding_cache_dir to save internal disk spa
 NOTE: sentence_transformers is imported lazily to avoid slow startup.
 This allows tests to import this module without loading the ML library.
 """
+import errno
+import fcntl
 import logging
 import os
 import threading
+import time
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 from config.settings import settings
@@ -18,6 +22,12 @@ logger = logging.getLogger(__name__)
 
 # GPU error keywords — shared between load-time and encode-time fallback
 _GPU_ERROR_KEYWORDS = ("hip", "cuda", "out of memory", "invalid device", "gpu hang")
+
+# Outcomes of _acquire_gpu_lock(). See its docstring (#521).
+_LOCK_ACQUIRED = "acquired"
+_LOCK_DISABLED = "disabled"
+_LOCK_ERROR = "error"
+_LOCK_TIMEOUT = "timeout"
 
 # Network error keywords — model load tries to check HF for updates even when
 # the snapshot is already cached. We retry offline if any of these fire.
@@ -191,8 +201,110 @@ class EmbeddingService:
                 pass
             return model
 
+    @contextmanager
+    def _acquire_gpu_lock(self):
+        """Cross-process lock serializing GPU embedding across all LifeOS
+        processes (API server, agent worker, nightly sync, ad-hoc scripts) (#521).
+
+        This host's iGPU has only 8 SDMA queues. If several processes each try
+        to grab GPU compute queues at the same time (e.g. the API server and a
+        manual reindex both embedding on GPU), the kernel logs "No more SDMA
+        queue to allocate" and the amdgpu driver has, on this host, wedged into
+        an unrecoverable freeze requiring a hard reboot — the incident #483's
+        per-call batch-size cap only partially addressed (that cap bounds the
+        size of one call; it does nothing about multiple concurrent callers).
+
+        Implementation: ``fcntl.flock`` on a well-known file
+        (``settings.embedding_gpu_lock_path``), not a named semaphore, a
+        lockfile-with-PID, or a DB row. flock is the right tool here because:
+          - It is released automatically by the kernel if the holding process
+            dies or is killed (crash, OOM-kill, SIGKILL) — no staleness
+            detection or cleanup logic is needed, unlike a PID file or a lock
+            row in SQLite that a dead writer can leave held forever.
+          - It needs no extra infrastructure: no server, no port, no schema —
+            just a file, which fits a single-host coordination problem.
+          - It works across independent processes (unlike ``threading.Lock``,
+            which only serializes within one process — the exact gap #521
+            reported: ``self._load_lock`` already does the in-process case).
+
+        Bounded wait: gives up after
+        ``settings.embedding_gpu_lock_timeout_seconds`` and yields
+        ``_LOCK_TIMEOUT`` rather than waiting forever behind a stuck or
+        long-running holder. The caller treats a timeout as "someone else is
+        actively using the GPU" and falls back to CPU instead of piling on.
+
+        Defensive: any error opening or locking the file (permissions, missing
+        parent dir, disk full, an fcntl-less platform) logs a warning and
+        yields ``_LOCK_ERROR``. This is a different outcome from timeout on
+        purpose — an error means the *locking mechanism* is unavailable, not
+        that another process holds the GPU, so the caller proceeds on GPU
+        unserialized rather than needlessly forcing CPU. Serializing GPU access
+        is a safety improvement; failing (or forcibly downgrading) an embed
+        because a lock file couldn't be opened would be strictly worse.
+        """
+        if not settings.embedding_gpu_lock_enabled or not settings.embedding_gpu_lock_path:
+            yield _LOCK_DISABLED
+            return
+
+        lock_path = settings.embedding_gpu_lock_path
+        fd = None
+        try:
+            lock_dir = os.path.dirname(lock_path)
+            if lock_dir:
+                os.makedirs(lock_dir, exist_ok=True)
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        except OSError as e:
+            logger.warning(
+                f"Could not open GPU embedding lock file {lock_path!r} ({e}); "
+                "proceeding without cross-process serialization"
+            )
+            yield _LOCK_ERROR
+            return
+
+        acquired = False
+        try:
+            timeout = settings.embedding_gpu_lock_timeout_seconds
+            deadline = time.monotonic() + timeout
+            outcome = _LOCK_ERROR
+            while True:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    outcome = _LOCK_ACQUIRED
+                    break
+                except OSError as e:
+                    if e.errno not in (errno.EACCES, errno.EAGAIN):
+                        logger.warning(
+                            f"Unexpected error acquiring GPU embedding lock ({e}); "
+                            "proceeding without cross-process serialization"
+                        )
+                        outcome = _LOCK_ERROR
+                        break
+                    if time.monotonic() >= deadline:
+                        logger.warning(
+                            f"Timed out after {timeout}s waiting for the GPU "
+                            f"embedding lock ({lock_path}) — another process is "
+                            "likely embedding on the GPU right now; falling back "
+                            "to CPU for this process."
+                        )
+                        outcome = _LOCK_TIMEOUT
+                        break
+                    time.sleep(0.25)
+            yield outcome
+        finally:
+            if acquired:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
     def _encode_with_fallback(self, data, **kwargs):
-        """Encode with GPU→CPU fallback on RuntimeError.
+        """Encode with GPU→CPU fallback on RuntimeError, serialized against
+        other processes' GPU embedding via a cross-process lock (#521).
 
         If the model was loaded on GPU and encode() raises a GPU error,
         the model is reloaded on CPU and the encode is retried.
@@ -204,22 +316,45 @@ class EmbeddingService:
         # This is semantically neutral: batching changes only peak memory, not
         # the resulting vectors. Callers may still override batch_size.
         kwargs.setdefault("batch_size", settings.embedding_batch_size)
-        try:
-            return self.model.encode(data, **kwargs)
-        except RuntimeError as e:
-            error_msg = str(e).lower()
-            if self._force_cpu or not any(kw in error_msg for kw in _GPU_ERROR_KEYWORDS):
-                raise  # Already on CPU or not a GPU error
 
-            logger.warning(f"GPU encode failed ({e}), reloading model on CPU")
-            from api.services.service_health import record_degradation
-            record_degradation(
-                "embedding_gpu", "encode", "cpu_fallback",
-                f"GPU encode error: {e}",
-            )
-            self._model = None
-            self._force_cpu = True
+        if self._force_cpu:
+            # Already on CPU — nothing to serialize (the lock only protects
+            # concurrent GPU access), so skip the flock overhead entirely.
             return self.model.encode(data, **kwargs)
+
+        with self._acquire_gpu_lock() as outcome:
+            if outcome == _LOCK_TIMEOUT:
+                # Another process is very likely on the GPU right now. Rather
+                # than encode on top of it — the exact concurrent-access
+                # pattern that exhausts the iGPU's SDMA queues — give up on
+                # GPU for the rest of this process's lifetime, same as a real
+                # GPU error would (see the RuntimeError branch below).
+                logger.warning(
+                    "Falling back to CPU embeddings for this process because "
+                    "the GPU embedding lock was not acquired in time"
+                )
+                self._model = None
+                self._force_cpu = True
+                return self.model.encode(data, **kwargs)
+
+            # ACQUIRED, DISABLED, or ERROR all proceed on GPU as before — the
+            # existing GPU->CPU RuntimeError fallback still applies.
+            try:
+                return self.model.encode(data, **kwargs)
+            except RuntimeError as e:
+                error_msg = str(e).lower()
+                if self._force_cpu or not any(kw in error_msg for kw in _GPU_ERROR_KEYWORDS):
+                    raise  # Already on CPU or not a GPU error
+
+                logger.warning(f"GPU encode failed ({e}), reloading model on CPU")
+                from api.services.service_health import record_degradation
+                record_degradation(
+                    "embedding_gpu", "encode", "cpu_fallback",
+                    f"GPU encode error: {e}",
+                )
+                self._model = None
+                self._force_cpu = True
+                return self.model.encode(data, **kwargs)
 
     def embed_text(self, text: str) -> list[float]:
         """

--- a/api/services/embeddings.py
+++ b/api/services/embeddings.py
@@ -246,7 +246,18 @@ class EmbeddingService:
             yield _LOCK_DISABLED
             return
 
+        # Resolve a relative lock path against the PROJECT ROOT, not the
+        # process cwd. Every LifeOS service pins cwd via systemd
+        # WorkingDirectory, but an ad-hoc `python scripts/...` run from
+        # elsewhere would otherwise open a *different* lock file and serialize
+        # against nobody — the exact kind of silent no-op this lock exists to
+        # prevent. An absolute setting is honoured as-is.
         lock_path = settings.embedding_gpu_lock_path
+        if not os.path.isabs(lock_path):
+            project_root = os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            )
+            lock_path = os.path.join(project_root, lock_path)
         fd = None
         try:
             lock_dir = os.path.dirname(lock_path)

--- a/config/settings.py
+++ b/config/settings.py
@@ -215,6 +215,36 @@ class Settings(BaseSettings):
                     "freezing the host (issue #483). Semantically neutral — "
                     "batching changes only peak memory, not the embedding values."
     )
+    embedding_gpu_lock_enabled: bool = Field(
+        default=True,
+        alias="LIFEOS_EMBEDDING_GPU_LOCK_ENABLED",
+        description="Serialize GPU embedding across processes (API server, agent "
+                    "worker, nightly sync, ad-hoc scripts) via a cross-process file "
+                    "lock, so they can't all grab GPU compute queues at once and "
+                    "exhaust the iGPU's 8 SDMA queues (issue #521). Disable if the "
+                    "lock file ever causes more trouble than the contention it "
+                    "prevents."
+    )
+    embedding_gpu_lock_path: str = Field(
+        default="./data/gpu_embed.lock",
+        alias="LIFEOS_EMBEDDING_GPU_LOCK_PATH",
+        description="flock() path used to serialize GPU embedding across "
+                    "processes (#521). Relative paths resolve against the process "
+                    "cwd; every LifeOS process (systemd services set "
+                    "WorkingDirectory to the project root, and scripts/docs "
+                    "instruct running from the project root) shares that cwd, so "
+                    "the default resolves to the same file everywhere without "
+                    "needing an absolute path. Set to empty to disable the lock."
+    )
+    embedding_gpu_lock_timeout_seconds: float = Field(
+        default=300.0,
+        alias="LIFEOS_EMBEDDING_GPU_LOCK_TIMEOUT",
+        description="Max seconds to wait for the cross-process GPU embedding "
+                    "lock before giving up and falling back to CPU for the rest "
+                    "of this process's lifetime, rather than deadlocking or "
+                    "piling onto whichever process is already using the GPU "
+                    "(#521)."
+    )
 
     # Chunking
     chunk_size: int = 500  # tokens

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -72,6 +72,15 @@ curl "http://localhost:8000/api/perf/traces?limit=10" | jq        # Recent trace
 curl http://localhost:8000/api/perf/traces/{trace_id} | jq        # Single trace
 ```
 
+## GPU Watchdog
+
+`scripts/gpu-watchdog.sh` runs every 5 minutes (`lifeos-gpu-watchdog.timer`, Linux only) and watches for two independent GPU failure signals on the gfx1151 iGPU:
+
+- **VRAM saturation** — reads usage from AMDGPU sysfs and alerts above `LIFEOS_VRAM_ALERT_PCT` (default 80%). Guards against the 2026-05-28 incident where VRAM exhaustion during model load locked up the GPU.
+- **SDMA-queue exhaustion (#521)** — the iGPU has only 8 SDMA queues. Concurrent GPU embedders (e.g. the API server and a manual reindex both loading/encoding on GPU at once) can exhaust them with VRAM still healthy — VRAM% alone can't see this. Each tick scans the kernel log (`journalctl -k --since <last tick>`) for `No more SDMA queue to allocate`, the signature that preceded the 2026-07-10 host freeze, and alerts on it with its own cooldown (`LIFEOS_SDMA_ALERT_COOLDOWN_MIN`, defaults to the VRAM cooldown) so it can't spam independently of the VRAM alert.
+
+Both signals alert via Telegram and log to `logs/gpu-watchdog.log`. See `api/services/embeddings.py`'s cross-process `flock` (settings `embedding_gpu_lock_*`) for the mitigation that serializes GPU embedding across processes to prevent SDMA exhaustion in the first place.
+
 ## Alerting Severities
 
 | Severity | When Sent | Examples |

--- a/scripts/gpu-watchdog.sh
+++ b/scripts/gpu-watchdog.sh
@@ -17,6 +17,15 @@
 #   - When rocm-smi is present, includes top per-PID VRAM consumers in the alert
 #   - Posts a recovery message when usage drops back below the threshold
 #
+# SDMA-queue exhaustion detection (#521): the gfx1151 iGPU has only 8 SDMA
+# queues. Concurrent GPU embedders (e.g. the API server and a manual reindex
+# both loading/encoding on GPU at once) can exhaust them with VRAM still
+# perfectly healthy — the kernel logs "No more SDMA queue to allocate", the
+# same signature that preceded the 2026-07-10 host freeze. VRAM% alone can't
+# see this, so each tick also scans the kernel log (via `journalctl -k`) for
+# that signature since the previous tick and alerts on it, with its own
+# cooldown so it can't spam independently of the VRAM alert.
+#
 # Linux: triggered by lifeos-gpu-watchdog.timer (installed by setup-systemd.sh).
 # macOS: not applicable (Metal manages VRAM via OS-level limits).
 
@@ -26,11 +35,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 LOG_FILE="$PROJECT_DIR/logs/gpu-watchdog.log"
 ALERT_STAMP_FILE="$PROJECT_DIR/logs/gpu-watchdog-alert.stamp"
+SDMA_STAMP_FILE="$PROJECT_DIR/logs/gpu-watchdog-sdma.stamp"
+SDMA_ALERT_STAMP_FILE="$PROJECT_DIR/logs/gpu-watchdog-sdma-alert.stamp"
 # Overridable for testing; defaults to the project .env in production.
 ENV_FILE="${ENV_FILE:-$PROJECT_DIR/.env}"
+# Overridable for testing (a stub `journalctl` on $PATH, or a plain command
+# name if journald isn't present).
+JOURNALCTL_CMD="${JOURNALCTL_CMD:-journalctl}"
 
 THRESHOLD_PCT="${LIFEOS_VRAM_ALERT_PCT:-80}"
 COOLDOWN_MIN="${LIFEOS_VRAM_ALERT_COOLDOWN_MIN:-60}"
+SDMA_COOLDOWN_MIN="${LIFEOS_SDMA_ALERT_COOLDOWN_MIN:-$COOLDOWN_MIN}"
+SDMA_PATTERN="No more SDMA queue to allocate"
 
 mkdir -p "$PROJECT_DIR/logs"
 
@@ -60,6 +76,76 @@ send_telegram() {
         --data-urlencode "text=${message}" \
         --data-urlencode "parse_mode=Markdown" > /dev/null 2>&1
 }
+
+# Scan the kernel log for SDMA-queue exhaustion since the previous tick, and
+# alert if any occurred (#521).
+#
+# VRAM% (the check below) can't see this failure mode: the gfx1151 iGPU has
+# only 8 SDMA queues, and concurrent GPU embedders can exhaust those queues
+# — "No more SDMA queue to allocate" — with VRAM usage still low. That
+# signature preceded the 2026-07-10 host freeze.
+#
+# Approach: track only a timestamp (not a running count) in $SDMA_STAMP_FILE,
+# and re-query the kernel log each tick with `journalctl -k --since <that
+# timestamp>`. This was chosen over diffing a persisted occurrence count
+# because a count survives reboots awkwardly (dmesg's ring buffer resets, so
+# a stored count would either have to be reset on every boot or drift out of
+# sync with what's actually still in the buffer) and because `--since` lets
+# journald do the filtering instead of this script re-parsing the entire log
+# every tick. The timestamp is written *before* the query so a slow or
+# failed journalctl call can't cause the same window to be re-scanned (and
+# double-counted) on the next tick.
+check_sdma_exhaustion() {
+    local since_arg
+    if [ -f "$SDMA_STAMP_FILE" ]; then
+        since_arg=$(date -d "@$(cat "$SDMA_STAMP_FILE")" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "10 minutes ago")
+    else
+        since_arg="10 minutes ago"
+    fi
+
+    date +%s > "$SDMA_STAMP_FILE"
+
+    if ! command -v "$JOURNALCTL_CMD" > /dev/null 2>&1; then
+        # No journald (e.g. non-systemd host) — nothing to scan.
+        return 0
+    fi
+
+    local count
+    count=$("$JOURNALCTL_CMD" -k --since "$since_arg" 2>/dev/null | grep -c "$SDMA_PATTERN" || true)
+    [[ "$count" =~ ^[0-9]+$ ]] || count=0
+
+    if [ "$count" -eq 0 ]; then
+        return 0
+    fi
+
+    log "SDMA queue exhaustion detected: ${count} occurrence(s) of '${SDMA_PATTERN}' since ${since_arg}"
+
+    # Separate cooldown/stamp from the VRAM alert so the two signals can't
+    # suppress each other.
+    local now last
+    now=$(date +%s)
+    if [ -f "$SDMA_ALERT_STAMP_FILE" ]; then
+        last=$(cat "$SDMA_ALERT_STAMP_FILE")
+        if [[ "$last" =~ ^[0-9]+$ ]] && (( now - last < SDMA_COOLDOWN_MIN * 60 )); then
+            log "SDMA alert suppressed (cooldown)"
+            return 0
+        fi
+    fi
+
+    local msg
+    msg=$(printf '🔥 *LifeOS GPU SDMA Queues Exhausted*\n\n%d occurrence(s) of "%s" in the kernel log — the same signature that preceded the 2026-07-10 host freeze. VRAM may look healthy; this is a different failure mode (concurrent GPU embedders exhausting the 8 SDMA queues, not memory pressure). Check for overlapping GPU embed jobs (API server, agent worker, sync, ad-hoc scripts).' \
+        "$count" "$SDMA_PATTERN")
+    if send_telegram "$msg"; then
+        echo "$now" > "$SDMA_ALERT_STAMP_FILE"
+    else
+        log "Telegram POST failed for SDMA alert; will retry on next tick"
+    fi
+}
+
+# Run the SDMA check every tick, independent of the VRAM logic below (which
+# has several early exits) — this failure mode can occur regardless of VRAM
+# level.
+check_sdma_exhaustion
 
 # Locate the first AMDGPU card sysfs node that exposes VRAM stats. Multi-GPU
 # systems are not in scope — this picks the first card with sysfs stats.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,6 +29,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_DIR"
 
+# Force CPU-only embeddings for every test run (#521). This host's iGPU has
+# only 8 SDMA queues; `pytest -n auto` below spawns one worker process per
+# core (16 here), and each worker that touches EmbeddingService would
+# otherwise independently try to load the GPU model — several processes
+# grabbing GPU compute queues at once is the exact concurrency pattern that
+# exhausted the queues and preceded the 2026-07-10 host freeze. Tests don't
+# need GPU throughput. `tests/conftest.py`'s pytest_configure hook sets the
+# same vars (defense in depth, and it's the only guard for anyone who runs
+# pytest directly instead of through this script) — exporting here as well
+# covers anything this script shells out to outside of pytest itself.
+export HIP_VISIBLE_DEVICES=""
+export ROCR_VISIBLE_DEVICES=""
+export CUDA_VISIBLE_DEVICES=""
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,37 @@ for _var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"):
     os.environ.pop(_var, None)
 
 
+# ---------------------------------------------------------------------------
+# Force CPU-only embeddings under pytest (#521).
+#
+# This host's iGPU has only 8 SDMA queues. `pytest -n auto` (see
+# scripts/test.sh) spawns one worker process per core (16 here), and any
+# worker that touches EmbeddingService would independently try to load the
+# GPU model — several processes grabbing GPU compute queues at once is
+# exactly the concurrency pattern that exhausted the queues and preceded the
+# 2026-07-10 host freeze. Tests don't need GPU throughput, so hide the GPU
+# unconditionally rather than relying on every future test to remember to.
+#
+# This MUST be a pytest_configure hook, not an autouse fixture. Fixtures run
+# per-test, after collection — by which point pytest has already imported
+# every test module (and conftest fixture module), and any of those imports
+# could have already pulled in torch/ROCm, which reads these env vars once
+# at process start and caches the visible-device list. pytest_configure runs
+# immediately after conftest.py itself is imported but *before* pytest
+# collects/imports any test module, so it's the latest point that's still
+# early enough to change what torch sees.
+#
+# `scripts/test.sh` also exports these (defense in depth) so anything that
+# runs outside pytest itself (e.g. a helper script test.sh shells out to)
+# still gets a CPU-only embedding model.
+def _force_cpu_embeddings_for_tests() -> None:
+    for _var in ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
+        os.environ.setdefault(_var, "")
+
+
 def pytest_configure(config):
     """Register custom markers."""
+    _force_cpu_embeddings_for_tests()
     config.addinivalue_line("markers", "unit: Fast unit tests")
     config.addinivalue_line("markers", "slow: Slow tests (ChromaDB, embeddings)")
     config.addinivalue_line("markers", "integration: Integration tests (server required)")

--- a/tests/test_embedding_fallback.py
+++ b/tests/test_embedding_fallback.py
@@ -464,3 +464,58 @@ class TestGpuLock:
             svc.embed_text("hello")
 
         assert model.encode.call_count == 1
+
+
+class TestGpuLockPathResolution:
+    """A relative lock path must resolve against the project root, not cwd (#521).
+
+    Every LifeOS service pins cwd via systemd WorkingDirectory, but an ad-hoc
+    `python scripts/...` run from another directory would otherwise open a
+    *different* lock file and serialize against nobody — a silent no-op in the
+    exact mechanism meant to prevent GPU-queue exhaustion.
+    """
+
+    def test_relative_path_resolves_to_project_root_from_foreign_cwd(self, tmp_path, monkeypatch):
+        import os
+        from api.services import embeddings as emb
+
+        monkeypatch.chdir(tmp_path)  # a cwd that is NOT the project root
+        svc = emb.EmbeddingService(model_name="test-model")
+        svc._force_cpu = False
+
+        opened: list[str] = []
+        real_open = os.open
+
+        def spy_open(path, *a, **kw):
+            opened.append(str(path))
+            return real_open(path, *a, **kw)
+
+        monkeypatch.setattr(emb.os, "open", spy_open)
+        monkeypatch.setattr(emb.fcntl, "flock", lambda *a, **kw: None)
+
+        with svc._acquire_gpu_lock():
+            pass
+
+        assert opened, "lock file was never opened"
+        lock_path = opened[0]
+        assert os.path.isabs(lock_path), f"lock path not absolute: {lock_path}"
+        # It must NOT have been created under the foreign cwd.
+        assert str(tmp_path) not in lock_path
+        # The project root is the parent of the `api/` package.
+        project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(emb.__file__))))
+        assert lock_path.startswith(project_root)
+
+    def test_absolute_path_is_honoured_as_is(self, tmp_path, monkeypatch):
+        from api.services import embeddings as emb
+        from config.settings import settings
+
+        target = tmp_path / "custom" / "gpu.lock"
+        monkeypatch.setattr(settings, "embedding_gpu_lock_path", str(target))
+        svc = emb.EmbeddingService(model_name="test-model")
+        svc._force_cpu = False
+
+        monkeypatch.setattr(emb.fcntl, "flock", lambda *a, **kw: None)
+        with svc._acquire_gpu_lock():
+            pass
+
+        assert target.exists(), "explicit absolute lock path was not used"

--- a/tests/test_embedding_fallback.py
+++ b/tests/test_embedding_fallback.py
@@ -4,6 +4,7 @@ Unit tests for EmbeddingService GPU-to-CPU fallback logic.
 These tests mock SentenceTransformer to test fallback behavior without
 loading the actual ML model, so they run fast (no @pytest.mark.slow).
 """
+import errno
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -292,3 +293,174 @@ class TestBatchSizeCap:
         """Guard against a future edit restoring a dangerously large default."""
         from config.settings import settings
         assert 1 <= settings.embedding_batch_size <= 32
+
+
+class TestGpuLock:
+    """Cross-process lock serializing GPU embedding across processes (#521).
+
+    All tests mock ``fcntl.flock`` and/or ``SentenceTransformer`` rather than
+    touching a real GPU — this host's iGPU freezes the machine if multiple
+    embedders actually race for GPU queues, which is precisely the bug this
+    lock exists to prevent.
+    """
+
+    @staticmethod
+    def _fake_encode(data, **kwargs):
+        if isinstance(data, list):
+            return [MagicMock(tolist=lambda: [0.1, 0.2]) for _ in data]
+        return MagicMock(tolist=lambda: [0.1, 0.2])
+
+    @pytest.fixture(autouse=True)
+    def _lock_settings(self, monkeypatch, tmp_path):
+        """Point the lock at a scratch file with a short timeout so every
+        test in this class runs fast and isolated from other tests' locks."""
+        from config.settings import settings
+
+        monkeypatch.setattr(settings, "embedding_gpu_lock_enabled", True)
+        monkeypatch.setattr(
+            settings, "embedding_gpu_lock_path", str(tmp_path / "gpu_embed.lock")
+        )
+        monkeypatch.setattr(settings, "embedding_gpu_lock_timeout_seconds", 0.05)
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_lock_acquired_and_released_around_gpu_encode(self, mock_st_class):
+        """A successful acquisition wraps the encode call and is released
+        afterward (real flock on a scratch file — single process, so it
+        always succeeds immediately; this checks the acquire/release calls
+        actually happen around encode())."""
+        import fcntl as fcntl_mod
+
+        from api.services.embeddings import EmbeddingService
+
+        model = MagicMock()
+        model.encode.side_effect = self._fake_encode
+        mock_st_class.return_value = model
+
+        real_flock = fcntl_mod.flock
+        ops_seen = []
+
+        def spy_flock(fd, op):
+            ops_seen.append(op)
+            return real_flock(fd, op)
+
+        svc = EmbeddingService(model_name="test-model")
+        with patch("api.services.embeddings.fcntl.flock", side_effect=spy_flock):
+            svc.embed_texts(["a", "b"])
+
+        assert (fcntl_mod.LOCK_EX | fcntl_mod.LOCK_NB) in ops_seen
+        assert fcntl_mod.LOCK_UN in ops_seen
+        assert model.encode.call_count == 1
+        assert svc._force_cpu is False
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_lock_timeout_falls_back_to_cpu(self, mock_st_class, monkeypatch):
+        """If the lock can't be acquired before the timeout, encode on CPU
+        for this call (and stay on CPU going forward) instead of piling onto
+        whichever process is already using the GPU.
+
+        Exercises this after a GPU model is already loaded (via a first call
+        that acquires the lock normally), so the timeout path is shown to
+        discard the loaded GPU model and reload fresh on CPU — not just skip
+        loading because nothing had loaded yet.
+        """
+        from api.services.embeddings import EmbeddingService
+
+        # Avoid the real 0.25s retry sleep so the test is fast; the timeout
+        # deadline is still real wall-clock time (0.05s from _lock_settings).
+        monkeypatch.setattr("api.services.embeddings.time.sleep", lambda *_: None)
+
+        gpu_model = MagicMock()
+        gpu_model.encode.side_effect = self._fake_encode
+        cpu_model = MagicMock()
+        cpu_model.encode.side_effect = self._fake_encode
+        mock_st_class.side_effect = [gpu_model, cpu_model]
+
+        svc = EmbeddingService(model_name="test-model")
+
+        # First call: lock is free, loads + encodes on GPU normally.
+        svc.embed_texts(["a"])
+        assert mock_st_class.call_count == 1
+        assert svc._force_cpu is False
+
+        # Second call: lock is held by "another process" for the whole
+        # timeout window.
+        def always_locked(fd, op):
+            raise OSError(errno.EAGAIN, "Resource temporarily unavailable")
+
+        with patch("api.services.embeddings.fcntl.flock", side_effect=always_locked):
+            result = svc.embed_texts(["b"])
+
+        assert svc._force_cpu is True
+        assert mock_st_class.call_count == 2
+        _, cpu_kwargs = mock_st_class.call_args
+        assert cpu_kwargs["device"] == "cpu"
+        assert cpu_model.encode.call_count == 1
+        assert gpu_model.encode.call_count == 1  # only the first call touched GPU
+        assert result == [[0.1, 0.2]]
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_lock_skipped_when_already_cpu(self, mock_st_class):
+        """No lock is taken once the service is already on CPU — there's
+        nothing to serialize."""
+        from api.services.embeddings import EmbeddingService
+
+        model = MagicMock()
+        model.encode.side_effect = self._fake_encode
+        mock_st_class.return_value = model
+
+        svc = EmbeddingService(model_name="test-model")
+        svc._force_cpu = True
+        svc._model = model
+
+        def fail_if_called(*_args, **_kwargs):
+            raise AssertionError("flock must not be called when already on CPU")
+
+        with patch("api.services.embeddings.fcntl.flock", side_effect=fail_if_called):
+            svc.embed_text("hello")
+
+        assert model.encode.call_count == 1
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_lock_open_error_degrades_gracefully(self, mock_st_class, monkeypatch):
+        """If the lock file can't even be opened (permissions, disk full,
+        missing dir), proceed on GPU unserialized rather than failing the
+        embed or forcing CPU — an infra error is not evidence another
+        process holds the GPU."""
+        from api.services.embeddings import EmbeddingService
+
+        model = MagicMock()
+        model.encode.side_effect = self._fake_encode
+        mock_st_class.return_value = model
+
+        def broken_open(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("api.services.embeddings.os.open", broken_open)
+
+        svc = EmbeddingService(model_name="test-model")
+        result = svc.embed_text("hello")
+
+        assert result == [0.1, 0.2]
+        assert svc._force_cpu is False
+        assert mock_st_class.call_count == 1
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_lock_disabled_via_settings(self, mock_st_class, monkeypatch):
+        """embedding_gpu_lock_enabled=False skips the lock entirely."""
+        from config.settings import settings
+        from api.services.embeddings import EmbeddingService
+
+        monkeypatch.setattr(settings, "embedding_gpu_lock_enabled", False)
+
+        model = MagicMock()
+        model.encode.side_effect = self._fake_encode
+        mock_st_class.return_value = model
+
+        def fail_if_called(*_args, **_kwargs):
+            raise AssertionError("flock must not be called when the lock is disabled")
+
+        with patch("api.services.embeddings.fcntl.flock", side_effect=fail_if_called):
+            svc = EmbeddingService(model_name="test-model")
+            svc.embed_text("hello")
+
+        assert model.encode.call_count == 1

--- a/tests/test_pytest_gpu_visibility.py
+++ b/tests/test_pytest_gpu_visibility.py
@@ -1,0 +1,53 @@
+"""
+Tests for the CPU-only-embeddings-under-pytest guard (#521).
+
+This host's iGPU has only 8 SDMA queues; `pytest -n auto` spawns one worker
+per core, and each worker independently loading a GPU embedding model would
+exhaust those queues. `tests/conftest.py`'s `pytest_configure` hook hides the
+GPU from every test process by setting HIP_VISIBLE_DEVICES /
+ROCR_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES to empty. These tests confirm
+that guard is actually wired up and behaves correctly (setdefault, not
+overwrite).
+"""
+import os
+
+_GPU_VISIBILITY_VARS = ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
+
+
+def test_pytest_session_has_gpu_hidden():
+    """By the time any test runs, pytest_configure has already fired (it runs
+    before test collection), so these vars should already be set to empty —
+    proving the hook actually ran for this session, not just that the
+    function exists.
+    """
+    for var in _GPU_VISIBILITY_VARS:
+        assert os.environ.get(var) == "", (
+            f"{var} was not hidden by tests/conftest.py's pytest_configure hook"
+        )
+
+
+def test_force_cpu_embeddings_sets_unset_vars(monkeypatch):
+    """The helper sets each visibility var to empty when it isn't already set."""
+    from tests.conftest import _force_cpu_embeddings_for_tests
+
+    for var in _GPU_VISIBILITY_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    _force_cpu_embeddings_for_tests()
+
+    for var in _GPU_VISIBILITY_VARS:
+        assert os.environ[var] == ""
+
+
+def test_force_cpu_embeddings_does_not_override_explicit_value(monkeypatch):
+    """An operator/CI override (e.g. a real single-GPU test rig that wants
+    HIP_VISIBLE_DEVICES=0) must survive — the helper uses setdefault, not
+    unconditional assignment.
+    """
+    from tests.conftest import _force_cpu_embeddings_for_tests
+
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0")
+
+    _force_cpu_embeddings_for_tests()
+
+    assert os.environ["HIP_VISIBLE_DEVICES"] == "0"


### PR DESCRIPTION
## Summary

The gfx1151 iGPU has **8 SDMA queues**. #483's batch-size cap bounded the size of a single encode, but nothing stopped *concurrent* embedders from exhausting the queues — the signature that preceded the July host freezes, and which reappeared on 2026-08-09 (8 errors from an interactive session, almost certainly a test run).

Closes #521

Three parts:

1. **CPU embeddings under pytest** — `pytest -n auto` runs 16 workers here, each able to load a GPU model. Set via `pytest_configure` (must run before test-module import so torch hasn't initialized) plus `scripts/test.sh` for defense in depth, using `setdefault` so an operator override survives. This retires the manual `HIP_VISIBLE_DEVICES=""` prefix that had become tribal knowledge.
2. **Cross-process lock** — `fcntl.flock` around the GPU encode path, chosen over a PID file because the kernel releases it automatically if the holder is killed (no staleness logic). **Timeout → CPU fallback** rather than deadlock; **lock-open error → proceed unserialized** rather than failing an embed. Skipped entirely when already on CPU or disabled by setting.
3. **SDMA detection in `gpu-watchdog.sh`** — scans journald since the last tick for `No more SDMA queue to allocate`, with its own alert cooldown so it can't suppress or be suppressed by VRAM alerts. Previously the watchdog only saw VRAM percentage, so the failure mode that actually froze the machine was the one thing it could not report.

## Review finding fixed before merge

The lock path was resolved relative to **process cwd**. All three services pin cwd via systemd `WorkingDirectory` and `run_all_syncs` pins its children, so production was consistent — but an ad-hoc `python scripts/...` run from elsewhere would have opened a *different* lock file and serialized against nobody: a silent no-op in the exact mechanism meant to prevent queue exhaustion. Relative paths now resolve against the project root (absolute settings honoured as-is), with two tests locking it in.

## Test evidence

New coverage: `TestGpuLock` (5), `TestGpuLockPathResolution` (2), `tests/test_pytest_gpu_visibility.py` (3 — asserts the running session actually has the vars hidden, proving the hook fired). Targeted suites 24 passed; pre-push full unit suite 2,396 passed / 8 skipped; ruff clean; `bash -n` clean on both scripts. SDMA detection exercised with a stubbed `journalctl` (detection, alert-failure path, cooldown suppression).

Full unit suite run twice GPU-hidden: 14 failures, all verified pre-existing on `main` via `git stash`.

Implemented by a Sonnet subagent in an isolated worktree; reviewed and hardened by the orchestrator.