### PR TITLE
fix(test.sh): widen auto to browser for web/ JS changes

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -336,7 +336,9 @@ decide_plan() {
     # Code change: always run unit; additively widen for the touched areas so
     # a change spanning categories is fully covered.
     local plan="unit"
-    if printf '%s\n' "$files" | grep -qE '\.html$|^static/.*\.js$|^api/routes/|/templates/'; then
+    # Web assets live in web/ and are only *served* under the /static URL
+    # prefix — matching on a `static/` path never fires (#518).
+    if printf '%s\n' "$files" | grep -qE '\.html$|^web/.*\.js$|^api/routes/'; then
         plan="$plan browser"
     fi
     if printf '%s\n' "$files" | grep -qE '^scripts/run_all_syncs\.py$|^api/services/[^/]*sync[^/]*|indexer|embeddings|vectorstore|bm25_index'; then

--- a/tests/test_test_sh_auto.py
+++ b/tests/test_test_sh_auto.py
@@ -63,10 +63,14 @@ _CASES = [
     # plain service/config code -> unit
     ("api/services/llm_client.py", "unit", "service_plain"),
     ("config/settings.py", "unit", "config"),
-    # frontend -> unit + critical browser test
+    # frontend -> unit + critical browser test. These paths must be ones that
+    # really exist: the mapping previously matched on `static/` and
+    # `/templates/`, neither of which is in this repo, and these cases asserted
+    # the same fiction — so a web/-only JS change silently skipped the browser
+    # scope while the suite stayed green (#518).
     ("api/routes/chat.py", "unit browser", "front_routes"),
-    ("static/app.js", "unit browser", "front_js"),
-    ("api/templates/index.html", "unit browser", "front_html"),
+    ("web/chat/voice.js", "unit browser", "front_js"),
+    ("web/index.html", "unit browser", "front_html"),
     # sync / index -> unit + slow
     ("scripts/run_all_syncs.py", "unit slow", "sync_script"),
     ("api/services/slack_sync.py", "unit slow", "sync_service"),
@@ -94,3 +98,15 @@ _CASES = [
 )
 def test_auto_scope_mapping(changed, expected):
     assert _plan(changed) == expected
+
+
+# The frontend cases are the ones that broke: they asserted `static/app.js` and
+# `api/templates/index.html`, paths this repo has never had, so the mapping and
+# its tests agreed on a layout that didn't exist. Pin them to real files so a
+# future move of web/ fails here instead of silently narrowing the scope.
+@pytest.mark.unit
+@pytest.mark.parametrize("path", ["api/routes/chat.py", "web/chat/voice.js", "web/index.html"])
+def test_frontend_fixture_paths_exist(path):
+    assert (REPO / path).exists(), (
+        f"{path} no longer exists — decide_plan's frontend pattern and this "
+        f"test's fixtures are out of sync with the repo layout")


### PR DESCRIPTION
Fixes #518.

## Problem

`decide_plan()` in `scripts/test.sh` widened the `auto` plan to the `browser` scope on:

```
'\.html$|^static/.*\.js$|^api/routes/|/templates/'
```

Two of those four alternatives match paths **this repo has never had**. There is no top-level `static/` (web assets live in `web/` and are only *served* under the `/static` URL prefix), and there is no `templates/` directory anywhere. So a change confined to `web/**/*.js` — e.g. `web/chat/voice.js` — never widened to the browser scope. #517 was covered only incidentally, because it also touched `api/routes/chat.py`.

**Why it survived:** `tests/test_test_sh_auto.py` asserted the same fictional paths (`static/app.js`, `api/templates/index.html`). The suite was green while validating a layout that didn't exist, so the staleness was invisible. Fixing the regex alone would have left that blind spot in place.

## Change

- `scripts/test.sh` — `^static/.*\.js$` → `^web/.*\.js$`. `/templates/` is **dropped** rather than repointed: there's no templates dir, and any HTML under a future one is already covered by `\.html$`.
- `tests/test_test_sh_auto.py` — the two frontend fixtures now point at real files (`web/chat/voice.js`, `web/index.html`). The `web/chat/voice.js` case *is* the regression test #518 asked for.
- New `test_frontend_fixture_paths_exist` — asserts the three frontend fixture paths exist, so a future move of `web/` fails loudly here instead of silently narrowing the scope again.

## Verification

Before/after on the same input, via the script's own plan-only mode:

```
$ LIFEOS_TEST_PLAN_ONLY=1 LIFEOS_TEST_CHANGED_FILES="web/chat/voice.js" bash scripts/test.sh auto
origin/main:  auto-plan: unit
this branch:  auto-plan: unit browser
```

Sanity: `README.md` → `skip`, `api/routes/chat.py` → `unit browser` (unchanged).

`pytest -m "unit and not slow"` (pre-push scope), 3 consecutive runs each:
- `origin/main`: **2396 passed, 8 skipped** ×3
- this branch: **2399 passed, 8 skipped** ×3 (+3 = the new existence-guard params)

## Note: unrelated flake observed

One pre-push run failed `test_scheduler_watcher.py::TestEndToEnd::test_external_edit_propagates_to_store` with `AttributeError: 'NoneType' object has no attribute 'schedule_value'` — `store.get()` returning `None` inside the poll loop while the file is being reindexed. It did not reproduce in 6 subsequent full runs (3 on this branch, 3 on `origin/main`), the file is untouched by this diff, and the test's own comments document it as load-sensitive under xdist. Filed separately rather than papered over here.

## Scope caveat

This fixes `./scripts/test.sh auto`. It does **not** make browser tests run at pre-push: `.git/hooks/pre-push` invokes `pytest -m "unit and not slow"` directly and never calls `test.sh`, and there is no CI workflow. So `auto`/`smoke`/`all` remain the only paths that reach the browser scope — worth knowing, but out of scope for #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
