### PR TITLE
docs(doctor): require a recorded review, a true PR body, and verified side findings

### DIFF
--- a/config/personas/doctor.md
+++ b/config/personas/doctor.md
@@ -42,8 +42,18 @@ First **file the work as GitHub issue(s)** via `/draft-issue` (capture the numbe
 
 - **Always PR-gated.** Every change reaches `main` through a branch → PR → `main` with the full `/implement` quality bar (tests + docs + adversarial review). You **never** push directly to `main`. "Adaptive" scales only the branch topology, never the quality gate.
 - **Always revertable.** Each change lands on `main` as a single, clearly-attributed merge commit (the final integration→main is one squash-merge), and you report its revert handle in the closing `[NOTIFY]`.
+- **The review leaves a trace.** Before merging, post `/implement`'s adversarial-review outcome as a PR comment — what was checked, what it found, what it changed in response, and anything it deliberately left. A merge with no recorded review is indistinguishable from a merge with no review. If the review found nothing, say that and say what you looked for.
+- **The PR description is true at merge time.** If you commit again after opening the PR, update the body before merging — test counts, file lists, and the change summary must describe what actually merged, not the first draft.
 - **Subagents implement; you supervise.** You own the `/goal` and the review; you do not write the production code inline.
 - **GitHub is the durable memory.** Issue numbers, the integration-branch name, and sub-PR progress live in GitHub — not in `/goal` (which is session-scoped and clears once met).
+
+## Side findings (issues you file that aren't the goal)
+
+Noticing an adjacent defect while implementing is good — file it, don't fix it, don't let it grow the goal. But a filed issue is a claim someone will act on, so **verify every assertion in it against the tree before filing**, at the same bar as production code:
+
+- Run the command, `grep` the path, read the hook — don't infer a consequence from what a script *looks like* it does.
+- State the blast radius only as far as you checked, and say which paths you ruled out.
+- Ask *why the defect survived*. If tests cover the broken thing and still pass, the tests are part of the bug and the issue must say so — otherwise the fix reinstates the blind spot.
 
 ## Autonomy
 

--- a/docs/guides/doctor-bot.md
+++ b/docs/guides/doctor-bot.md
@@ -1,7 +1,7 @@
 # Doctor Bot — Self-Repair Surface
 
 **Status:** Complete
-**Last Updated:** 2026-07-09
+**Last Updated:** 2026-08-10
 **Audience:** Operator
 
 The **doctor** bot's only job is fixing LifeOS itself. You message it when you notice LifeOS misbehaving or missing something; it converses with you to define the **goal**, locks that goal, then — on your approval — orchestrates the work end to end and reports back. It is a **goal-first orchestrator**: it supervises the implementation (subagents do the coding via `/implement`) rather than hand-coding inline, and every change lands through a reviewed, tested PR — never a direct push to `main`.
@@ -44,6 +44,7 @@ This is the operator's-eye summary; the exact contract the session runs lives in
 
 - **One gate.** Full-auto from your goal approval through merge; `/implement`'s built-in adversarial review is the quality bar.
 - **Always PR-gated, always revertable.** Even the smallest fix goes branch → PR → `main` with tests + docs + review; the doctor never pushes to `main`, and each change lands as a single revertable merge commit whose `gh pr revert` handle it reports.
+- **The review is on the record.** The adversarial-review outcome is posted as a comment on the PR before it merges — what was checked, what it found, what changed in response. So "reviewed" is something you can read afterwards, not something you take on faith. The PR description is also brought up to date before merge, so it describes what actually shipped.
 - **Escalation respected.** If `/implement` can't resolve its review findings after its rounds, the doctor leaves the PR open and reports the escalation instead of merging.
 - **Isolation.** Implementation happens in throwaway worktrees off `origin/main` (pre-flight-cleaned via `scripts/cleanup-worktrees.sh` so a prior crashed run can't block the `add`), so the canonical checkout other agents share is never left on a feature branch.
 - **Pick-up after merge.** The doctor pulls merged `main` into the canonical checkout, then runs `./scripts/server.sh verify-deployed` to confirm the checkout is a real work tree on the merged commit **before** restarting — so a silently-failed pull (e.g. a bare/misconfigured checkout) is reported as a deploy failure instead of a false "Shipped" (#419). Only on success does it restart, so the running server actually reflects the change.


### PR DESCRIPTION
Targeted tightening of the doctor persona based on reviewing its #516 → #517 → #518 run. That run was good work — correct diagnosis, minimal diff, real tests, an honest "Not verified" section. These three adjustments address what it got wrong, and nothing else.

## What prompted each change

**1. The review left no trace.** #517 opened at 02:25 and merged at 02:36 with zero reviews and zero comments. `/implement`'s adversarial pass may well have run — a second commit fixed real self-found issues (repeat-tap bubble stacking, wiring the new test into `run_browser_tests`), which suggests *something* re-read the work. But nothing on the PR distinguishes that from a merge with no review at all. New invariant: post the review outcome as a PR comment before merging, including when it found nothing.

**2. The PR description went stale.** The body said "5 Playwright tests"; the merged branch has 7 — the second commit added a class and the description was never refreshed. New invariant: if you commit after opening, update the body before merging.

**3. A side-finding issue asserted more than it checked.** #518's core claim was right (`^static/.*\.js$` matches nothing), but:
   - It claimed the pre-push path was affected. It isn't — `.git/hooks/pre-push` runs `pytest -m "unit and not slow"` directly and never invokes `test.sh`, so browser tests never run there regardless.
   - It missed *why* the bug survived: `tests/test_test_sh_auto.py` asserted the same nonexistent paths, so the suite was green while validating fiction. Fixing the regex alone would have reinstated the blind spot.

   New "Side findings" section: verify each claim against the tree, state the blast radius only as far as you checked, and ask why the defect survived — if tests cover the broken thing and still pass, the tests are part of the bug.

## Change

- `config/personas/doctor.md` — two invariants + a "Side findings" section. Deliberately additive; the existing pipeline, ceremony, worktree hygiene, restart, and escalation rules are untouched.
- `docs/guides/doctor-bot.md` — one bullet under "Autonomy and safety" covering the operator-visible half (the review is readable on the PR afterward), plus `Last Updated`.

#518 itself has been corrected and is fixed in #523. The flake surfaced while verifying that fix is #524.

## Verification

Prose-only change to a persona prompt and its guide, so there's no behavior to test directly. Confirmed the persona still loads and no personal values leaked into the committed file:

- `pytest tests/test_doctor_bot.py tests/test_persona_api.py` — **85 passed**
- `pytest -m "unit and not slow"` — **2396 passed, 8 skipped**
- `grep -Ei "nathan|ramia|movementlabs|ts\.net|100\.68|/home/" config/personas/doctor.md` — no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
