### PR TITLE
fix(scheduler): swap the schedule index atomically instead of clearing in place

### DIFF
--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -330,6 +330,17 @@ class SchedulerStore:
     rebuildable query cache holding the full entry (including payload fields
     and computed ``next_trigger_at``). Thread-safe.
 
+    Concurrency invariant — ``self._entries`` is **never mutated in place**.
+    Writers hold ``self._lock``, build a new dict, and rebind the attribute;
+    the rebind is atomic, so a lock-free reader (``get``, ``list_all``,
+    ``get_due_reminders``) always sees a complete map — either wholly before or
+    wholly after the write. Readers therefore take no lock: the scheduler tick
+    and the API read this on hot paths, and a reader-side lock would only add
+    contention. Mutating in place instead would let a reader observe a
+    half-rebuilt index (a schedule that momentarily doesn't exist, so a due
+    notification is silently skipped) or raise "dictionary changed size during
+    iteration" mid-scan.
+
     For backward compatibility a ``file_path=`` argument (the old JSON path)
     is accepted: it becomes the index path and its parent directory becomes an
     isolated vault root, so existing callers and tests keep working.
@@ -369,9 +380,11 @@ class SchedulerStore:
         if self.index_path.exists():
             try:
                 data = json.loads(self.index_path.read_text(encoding="utf-8"))
+                loaded: dict[str, ScheduleEntry] = {}
                 for item in data.get("schedules", data.get("reminders", [])):
                     entry = ScheduleEntry.from_dict(item)
-                    self._entries[entry.id] = entry
+                    loaded[entry.id] = entry
+                self._entries = loaded
                 logger.info(f"Loaded {len(self._entries)} schedules from index")
                 return
             except (json.JSONDecodeError, KeyError, TypeError) as e:
@@ -456,7 +469,7 @@ class SchedulerStore:
             )
             entry.next_trigger_at = compute_next_trigger(entry)
             self._insert_block_at_top(_format_entry_block(entry))
-            self._entries[entry.id] = entry
+            self._entries = {**self._entries, entry.id: entry}
             self._save()
             logger.info(f"Created schedule: {entry.id} - {entry.name}")
             return entry
@@ -488,7 +501,7 @@ class SchedulerStore:
     def delete(self, entry_id: str) -> bool:
         with self._lock:
             if entry_id in self._entries:
-                del self._entries[entry_id]
+                self._entries = {k: v for k, v in self._entries.items() if k != entry_id}
                 self._remove_block(entry_id)
                 self._save()
                 return True
@@ -572,35 +585,41 @@ class SchedulerStore:
         if not path.exists():
             with self._lock:
                 if self._entries:
-                    self._entries.clear()
+                    self._entries = {}
                     self._save()
             return
 
         with self._lock:
-            # Preserve payload + history from the current cache, merged by ID.
-            prior = {eid: e for eid, e in self._entries.items()}
-            self._entries.clear()
             try:
                 lines = path.read_text(encoding="utf-8").splitlines()
             except Exception as e:
                 logger.warning(f"Could not read {file_path}: {e}")
                 return
-            for _start, _end, entry in _iter_entry_blocks(lines):
-                self._merge_prior(entry, prior.get(entry.id))
-                entry.next_trigger_at = compute_next_trigger(entry) if entry.enabled else None
-                self._entries[entry.id] = entry
+            self._entries = self._parse_into_index(lines)
             self._save()
 
     def rebuild_index(self):
         """Full re-parse of Inbox.md into the cache."""
-        prior = {eid: e for eid, e in self._entries.items()}
-        self._entries.clear()
-        for _start, _end, entry in _iter_entry_blocks(self._read_inbox_lines()):
+        with self._lock:
+            self._entries = self._parse_into_index(self._read_inbox_lines())
+            self._save()
+        logger.info(f"Rebuilt scheduler index: {len(self._entries)} schedules")
+
+    def _parse_into_index(self, lines: list[str]) -> dict[str, ScheduleEntry]:
+        """Parse markdown ``lines`` into a fresh index dict.
+
+        Returns a new dict rather than filling ``self._entries``, so the caller
+        can swap it in atomically (see the class docstring's concurrency
+        invariant). Payload + history are merged forward from the current cache
+        by ID. Must be called with ``self._lock`` held.
+        """
+        prior = self._entries
+        entries: dict[str, ScheduleEntry] = {}
+        for _start, _end, entry in _iter_entry_blocks(lines):
             self._merge_prior(entry, prior.get(entry.id))
             entry.next_trigger_at = compute_next_trigger(entry) if entry.enabled else None
-            self._entries[entry.id] = entry
-        self._save()
-        logger.info(f"Rebuilt scheduler index: {len(self._entries)} schedules")
+            entries[entry.id] = entry
+        return entries
 
     @staticmethod
     def _merge_prior(entry: ScheduleEntry, prior: Optional[ScheduleEntry]):

--- a/tests/test_scheduler_store.py
+++ b/tests/test_scheduler_store.py
@@ -5,6 +5,8 @@ Covers CRUD, cron computation, auto-disable, due detection, suppression,
 prompt execution, the markdown round-trip, markdown-as-source-of-truth, and
 the auto-generated dashboard.
 """
+import threading
+
 import pytest
 from datetime import datetime, timezone, timedelta
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -300,6 +302,93 @@ class TestDueChecking:
         entry.next_trigger_at = past
         entry.last_triggered_at = datetime.now(timezone.utc).isoformat()  # just fired
         assert store.get_due_reminders() == []
+
+
+class TestIndexSwapAtomicity:
+    """The index must never be observable half-rebuilt (issue #524).
+
+    ``get`` / ``list_all`` / ``get_due_reminders`` read without the lock, so
+    every write has to swap in a complete map rather than mutate the live one.
+    """
+
+    def test_reader_midway_through_reindex_sees_the_whole_index(self, store, monkeypatch):
+        """A read pinned to the middle of a reindex still sees every schedule."""
+        import api.services.scheduler_store as mod
+
+        ids = [
+            store.create(name=f"Job {n}", schedule_type="cron",
+                         schedule_value="0 9 * * *", message_type="static",
+                         message_content=f"body {n}").id
+            for n in range(3)
+        ]
+        # Make one schedule due. A reader that misses it mid-reindex loses the
+        # fire for good — the reindex recomputes next_trigger_at to the future.
+        store.get(ids[0]).next_trigger_at = (
+            datetime.now(timezone.utc) - timedelta(minutes=5)
+        ).isoformat()
+
+        writer_inside = threading.Event()
+        reader_done = threading.Event()
+        observed = {}
+        real_merge_prior = mod.SchedulerStore._merge_prior
+
+        def hooked_merge_prior(entry, prior):
+            # Runs inside the reindex loop — the exact point at which the old
+            # code had already torn the index down and not yet refilled it.
+            if not writer_inside.is_set():
+                writer_inside.set()
+                reader_done.wait(timeout=10)
+            real_merge_prior(entry, prior)
+
+        monkeypatch.setattr(mod.SchedulerStore, "_merge_prior",
+                            staticmethod(hooked_merge_prior))
+
+        def read_midway():
+            try:
+                if not writer_inside.wait(timeout=10):
+                    return
+                observed["get"] = store.get(ids[1])
+                observed["list_all"] = store.list_all()
+                observed["due"] = store.get_due_reminders()
+            finally:
+                reader_done.set()
+
+        reader = threading.Thread(target=read_midway, name="scheduler-race-reader")
+        reader.start()
+        try:
+            store.reindex_file(str(store.inbox_path))
+        finally:
+            reader_done.set()
+            reader.join(timeout=10)
+
+        assert not reader.is_alive()
+        assert writer_inside.is_set(), "reindex never entered the merge loop"
+        assert observed["get"] is not None, "get() returned None for a live schedule"
+        assert len(observed["list_all"]) == 3, "list_all() saw a partial index"
+        assert [e.id for e in observed["due"]] == [ids[0]], "a due schedule was missed"
+
+    def test_create_and_delete_swap_the_index_instead_of_mutating_it(self, store):
+        """An in-flight scan of the index survives a concurrent create/delete.
+
+        Reaches into ``_entries`` because there is no public way to pause a
+        reader partway through its scan; the property under test is that the
+        dict a reader is iterating is never the one a writer touches.
+        """
+        keep = store.create(name="Keep", schedule_type="cron", schedule_value="0 9 * * *",
+                            message_type="static", message_content="a")
+        doomed = store.create(name="Doomed", schedule_type="cron", schedule_value="0 9 * * *",
+                              message_type="static", message_content="b")
+
+        scan = iter(store._entries.values())
+        assert next(scan).id == keep.id
+        added = store.create(name="Added", schedule_type="cron", schedule_value="0 9 * * *",
+                             message_type="static", message_content="c")
+        assert [e.id for e in scan] == [doomed.id]  # no "changed size during iteration"
+
+        scan = iter(store._entries.values())
+        assert next(scan).id == keep.id
+        store.delete(doomed.id)
+        assert [e.id for e in scan] == [doomed.id, added.id]
 
 
 class TestAutoDisable:


### PR DESCRIPTION
Fixes #524.

## The bug is in the store, not the test

`tests/test_scheduler_watcher.py` was reporting a real product race, so it is untouched here.

`SchedulerStore` kept its index in `self._entries`. `reindex_file()` cleared that dict and repopulated it key by key while holding `self._lock`; `rebuild_index()` did the same clear-then-fill with **no lock at all**. But the readers — `get()`, `list_all()`, `get_due_reminders()` — never acquired the lock, so the lock protected nothing. Any reader could land inside the window where the index had been torn down and not yet refilled:

- `get()` returns `None` for a schedule that exists — the flake in #524.
- `list_all()` returns a partial or empty list — wrong dashboard.
- `get_due_reminders()` iterates `self._entries.values()` while the dict is mutating — either `RuntimeError: dictionary changed size during iteration`, or it silently sees no due schedules. **That last one is the consequence that matters**: the reindex recomputes `next_trigger_at` into the future, so a fire skipped during the window is lost for good, not merely delayed.

## The fix: copy-on-write

Writers build a fresh dict and rebind `self._entries` instead of mutating the live one. The rebind is atomic, so a lock-free reader always observes a complete map — wholly before or wholly after the write. `reindex_file` and `rebuild_index` now share a `_parse_into_index()` helper that returns a new dict; `create` and `delete` rebind a copy.

Readers are unchanged and stay lock-free. They run on the 60s scheduler tick and on API request paths, and a reader-side lock would add contention while buying nothing that the atomic swap doesn't already provide.

The invariant — *`self._entries` is never mutated in place* — is written into the class docstring so the next person doesn't reintroduce a clear-then-fill.

## Judgment calls

**1. Does `rebuild_index()` still need the lock?** Yes, but for a different reason than the one that motivated this issue. Copy-on-write is what makes it safe for *readers*, so no lock is needed on that account. It still needs the lock for **writer-writer** exclusion: it read-modify-writes the index (it merges `prior` forward by ID) and rewrites `data/scheduler_index.json` plus `Dashboard.md` via `_save()`. Without the lock, a concurrent `create()` or `reindex_file()` could interleave and have its entry silently dropped by the losing rebind, or the two could race on the cache file. Deadlock check: its only callers are `api/main.py:149` (startup) and `_load()` from `__init__`, neither of which holds the lock, so taking a non-reentrant `Lock` here is safe.

**2. Copy-on-write for the single-key mutators, or snapshotting in the readers?** Copy-on-write, for `create` and `delete` specifically.

Only those two change the dict's *size*, which is what raises "dictionary changed size during iteration" in a reader mid-scan. `update`, `mark_triggered` and `record_run` mutate the `ScheduleEntry` object in place and leave the dict's key set alone, so they cannot trigger that crash — they are left as-is rather than gold-plated into entry-level copy-on-write.

I chose writer-side copy-on-write over reader-side snapshotting because it gives **one** invariant that covers every reader, present and future, instead of a rule each new reader has to remember to follow. It also avoids leaning on the CPython-specific detail that `list(d.values())` is atomic under the GIL. The cost is an O(n) dict copy per create/delete on a collection that holds a few dozen schedules and changes only on user action — irrelevant next to the file I/O those methods already do.

Known residual, deliberately not addressed: because `update()` mutates an entry in place, a reader can observe a torn entry (e.g. `enabled` already flipped but `next_trigger_at` not yet). This cannot crash and cannot lose a notification — `get_due_reminders()`' 90s cooldown covers the `mark_triggered` interleaving, and the fire path already copies entries out of the store before dispatching asynchronously, so a disable racing a fire is a pre-existing and wider window than anything in this diff. Fixing it means making entries immutable, which is a much larger change than this issue warrants.

## Side effect worth flagging

`reindex_file` now reads the markdown file *before* touching the index, where the old code cleared first and read second. So a transient read failure now leaves the existing index intact instead of wiping it. Strictly an improvement, but it is a behavior change, not just a reordering.

## Verification

The regression tests are deterministic — no sleeps, no timing luck. `test_reader_midway_through_reindex_sees_the_whole_index` monkeypatches `_merge_prior` to block on an `Event` the first time it is called, which pins a reader thread to the exact instant the reindex is partway through the entry loop, then asserts `get()`, `list_all()` and `get_due_reminders()` all see the complete index (including a schedule rigged to be due). `test_create_and_delete_swap_the_index_instead_of_mutating_it` holds an in-flight iterator across a `create` and a `delete` and asserts the scan completes.

**Red before, green after** — confirmed by stashing `api/services/scheduler_store.py` and rerunning the two new tests against unmodified store code:

```
FAILED test_reader_midway_through_reindex_sees_the_whole_index
  AssertionError: get() returned None for a live schedule
FAILED test_create_and_delete_swap_the_index_instead_of_mutating_it
  RuntimeError: dictionary changed size during iteration
2 failed in 0.31s
```

With the fix restored, both pass, and 5 consecutive runs of the new tests plus the whole of `test_scheduler_watcher.py` were green (8 passed each time).

Pre-push scope (`-m "unit and not slow" -n auto`), run three times plus once more by the pre-push hook: **2401 passed, 8 skipped** every time. Baseline at the branch point (33e290c) is 2399 — main advanced past the 2396 measured earlier — so 2399 + 2 new tests = 2401, no test lost or changed. All runs used `HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES=""` to force CPU embeddings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
