### PR TITLE
test(pre-push): run the server-free browser tests at pre-push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Audience:** All AI coding agents (Claude Code, Cursor, Copilot, etc.)
 > **Status:** Complete
-> **Last Updated:** 2026-07-07
+> **Last Updated:** 2026-08-10
 
 LifeOS is a self-hosted personal AI assistant with two halves:
 
@@ -266,7 +266,8 @@ Quick-reference guardrails for all contributors. These complement the Developmen
 
 - **No local venv (the MacBook)** — `./scripts/test.sh` only runs where a venv exists (the server). From the Mac, run **`./scripts/remote-test.sh`**: it rsyncs your uncommitted working tree to an isolated branch-keyed dir on nathan-linux and runs the same `test.sh auto` scope there. Get a green run **before** committing — no push required, and committing/pushing "so tests can run" is neither necessary nor allowed.
 - **Parallelism:** unit tests run under pytest-xdist (`-n auto --dist loadscope`) — reproduce flakes in that mode, not sequentially.
-- **Browser tests:** the web SPA is served at `/chat` (not `/`); `test.sh browser` covers only `test_ui_browser.py` and `test_e2e_flow.py` — run new browser test files directly with pytest.
+- **Browser tests:** the web SPA is served at `/chat` (not `/`); `test.sh browser` covers only `test_ui_browser.py`, `test_e2e_flow.py`, and `test_voice_mic_block_ui_browser.py` — run new browser test files directly with pytest.
+- **Server-free browser tests:** most browser tests point at a running `lifeos-api` and carry `requires_server` on top of `browser`. A browser test that serves `web/` itself on an ephemeral port and stubs every `/api/` call (see `tests/test_voice_mic_block_ui_browser.py`) omits that marker, so `browser and not requires_server` selects it. The pre-push hook runs that set alongside `unit and not slow` — it's the only gate that catches a `web/` JS regression before it reaches main, so prefer the self-contained pattern for new frontend tests.
 
 ---
 

--- a/docs/specs/standards/testing-standards.md
+++ b/docs/specs/standards/testing-standards.md
@@ -1,7 +1,7 @@
 # Testing Standards
 
 > **Status:** Complete
-> **Last Updated:** 2026-06-18
+> **Last Updated:** 2026-08-10
 > **Audience:** All developers and AI agents
 
 Testing patterns and conventions for the LifeOS codebase.
@@ -80,6 +80,14 @@ Custom markers are registered in `conftest.py`:
 | `@pytest.mark.requires_db` | Tests needing direct database access |
 
 Apply `pytestmark = pytest.mark.unit` at the module level for unit test files.
+
+### Browser tests and `requires_server`
+
+`browser` and `requires_server` are independent. A browser test that points at a running `lifeos-api` carries both; one that serves `web/` itself on an ephemeral port and intercepts every `/api/` call carries only `browser`.
+
+That distinction is load-bearing: `browser and not requires_server` is the set the pre-push hook runs, so it is the only gate that catches a `web/` JS regression before it reaches `main`. Pushes must not depend on a shared server that other agents restart, so a browser test that needs one is excluded there and runs under `./scripts/test.sh browser` instead.
+
+Prefer the self-contained pattern for new frontend tests — it also means the test exercises the checkout under test rather than whatever a running server has deployed.
 
 ## Fixture Patterns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ markers = [
     "integration: Tests that require running server or external APIs",
     "browser: Browser-based UI tests using Playwright",
     "requires_ollama: Tests that require Ollama to be running",
-    "requires_server: Tests that require the API server to be running",
+    "requires_server: Tests that require the API server to be running. On a browser test this is what separates it from the server-free set (`browser and not requires_server`) that the pre-push hook runs.",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -54,6 +54,12 @@ if [ -f "$HOME/.venvs/lifeos/bin/activate" ]; then
     source "$HOME/.venvs/lifeos/bin/activate"
 fi
 
+fail() {
+    echo "FAILED ($(tail -1 "$LOG"))"
+    echo "  Full output: $LOG"
+    exit 1
+}
+
 echo -n "Running unit tests... "
 
 # Parallelize across all cores via pytest-xdist (-n auto).
@@ -65,13 +71,29 @@ if [ -f ".pytest_cache/v/cache/lastfailed" ]; then
     PYTEST_OPTS+=(--lf)
 fi
 
-if python -m pytest -m "unit and not slow" tests/ -q --tb=line --no-header "${PYTEST_OPTS[@]}" > "$LOG" 2>&1; then
-    SUMMARY=$(tail -1 "$LOG")
-    echo "passed ($SUMMARY)"
-    exit 0
-else
-    SUMMARY=$(tail -1 "$LOG")
-    echo "FAILED ($SUMMARY)"
-    echo "  Full output: $LOG"
-    exit 1
+python -m pytest -m "unit and not slow" tests/ -q --tb=line --no-header \
+    "${PYTEST_OPTS[@]}" > "$LOG" 2>&1 || fail
+echo "passed ($(tail -1 "$LOG"))"
+
+# Browser tests that need no running server. Server-dependent ones carry
+# `requires_server`; including those would tie every push to the health of a
+# shared lifeos-api that other agents bounce constantly. The rest serve web/
+# themselves and stub every /api/ call, and are the only gate that catches a
+# regression in the chat SPA's JS before it reaches main.
+#
+# Deliberately a second pytest process, not another marker in the run above:
+# pytest-playwright's sync API leaves its own event loop current, so any async
+# test that lands after a browser test in the same process is silently never
+# awaited. Under `-n auto` that ordering is nondeterministic.
+#
+# -p no:cacheprovider keeps this run out of .pytest_cache — otherwise a failure
+# here would seed `lastfailed` with tests the unit run's --lf can't select,
+# and the next push would run nothing at all.
+if python -c "import playwright" 2>/dev/null; then
+    echo -n "Running server-free browser tests... "
+    python -m pytest -m "browser and not requires_server" tests/ -q --tb=line \
+        --no-header -p no:cacheprovider > "$LOG" 2>&1 || fail
+    echo "passed ($(tail -1 "$LOG"))"
 fi
+
+exit 0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -125,8 +125,9 @@ run_browser_tests() {
     fi
 
     # test_voice_mic_block_ui_browser.py serves web/ itself on an ephemeral port
-    # and stubs every /api/ call, so it needs no server — but it is a Playwright
-    # test, so `browser` is the only scope that can reach it.
+    # and stubs every /api/ call, so it needs no server and carries no
+    # `requires_server` marker — that's what lets pre-push run it. This scope
+    # deliberately runs the full `browser` set, server-dependent tests included.
     python -m pytest tests/test_ui_browser.py tests/test_e2e_flow.py \
         tests/test_voice_mic_block_ui_browser.py -v \
         --ignore=tests/archive \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,11 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "integration: Integration tests (server required)")
     config.addinivalue_line("markers", "browser: Browser tests using Playwright")
     config.addinivalue_line("markers", "requires_ollama: Requires Ollama running")
-    config.addinivalue_line("markers", "requires_server: Requires API server running")
+    config.addinivalue_line(
+        "markers",
+        "requires_server: Requires API server running. On a browser test this is "
+        "what excludes it from the server-free set the pre-push hook runs.",
+    )
     config.addinivalue_line("markers", "requires_db: Requires direct database access (may conflict with running server)")
     config.addinivalue_line(
         "markers",

--- a/tests/test_agent_threads_ui_browser.py
+++ b/tests/test_agent_threads_ui_browser.py
@@ -12,7 +12,7 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-pytestmark = [pytest.mark.browser, pytest.mark.slow]
+pytestmark = [pytest.mark.browser, pytest.mark.slow, pytest.mark.requires_server]
 
 DESKTOP_VIEWPORT = {"width": 1280, "height": 800}
 

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -10,12 +10,11 @@ These tests verify the complete request flow works, including:
 Run with server: pytest tests/test_e2e_flow.py -v
 """
 import pytest
-import asyncio
 import httpx
 from unittest.mock import patch, MagicMock
 
 # Mark as integration tests (require server or mocking)
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.requires_server]
 
 
 class TestConfigurationValidation:
@@ -86,7 +85,6 @@ class TestUIErrorDisplay:
     @pytest.mark.browser
     def test_api_error_shown_to_user(self, page):
         """API errors or success should be displayed to the user, not silently fail."""
-        from playwright.sync_api import expect
 
         page.set_viewport_size({"width": 1280, "height": 800})
         page.goto("http://localhost:8000")
@@ -115,7 +113,6 @@ class TestUIErrorDisplay:
     @pytest.mark.browser
     def test_loading_indicator_clears_on_completion(self, page):
         """Loading indicator should clear when response completes."""
-        from playwright.sync_api import expect
 
         page.set_viewport_size({"width": 1280, "height": 800})
         page.goto("http://localhost:8000")
@@ -128,7 +125,7 @@ class TestUIErrorDisplay:
         # Wait for typing indicator to appear (may not appear for fast responses)
         try:
             page.wait_for_selector(".typing", timeout=5000)
-        except:
+        except Exception:
             pass  # Fast response, no typing indicator
 
         # Wait for response to complete - use longer timeout for streaming
@@ -154,7 +151,7 @@ class TestRequestTimeouts:
         """Requests should have timeouts to prevent indefinite hangs."""
         # Test that httpx client has reasonable timeout (using sync client)
         try:
-            response = httpx.post(
+            httpx.post(
                 "http://localhost:8000/api/ask/stream",
                 json={"question": "test"},
                 timeout=5.0  # 5 second timeout for test
@@ -214,7 +211,7 @@ class TestHealthCheck:
             response = client.get("/health")
             data = response.json()
             assert data['status'] == 'degraded'
-            assert data['checks']['api_key_configured'] == False
+            assert not data['checks']['api_key_configured']
 
 
 class TestRealUserFlow:
@@ -311,7 +308,6 @@ class TestRealUserFlow:
     @pytest.mark.browser
     def test_user_clicks_suggestion(self, page):
         """User can click a suggestion to send it as a query."""
-        from playwright.sync_api import expect
 
         page.set_viewport_size({"width": 1280, "height": 800})
         page.goto("http://localhost:8000")
@@ -321,7 +317,6 @@ class TestRealUserFlow:
         suggestions = page.locator(".suggestion")
         if suggestions.count() > 0:
             first_suggestion = suggestions.first
-            suggestion_text = first_suggestion.text_content()
 
             first_suggestion.click()
 
@@ -334,7 +329,6 @@ class TestRealUserFlow:
     @pytest.mark.browser
     def test_mobile_user_flow(self, page):
         """Test the full user flow on mobile viewport."""
-        from playwright.sync_api import expect
 
         # Mobile viewport (iPhone X)
         page.set_viewport_size({"width": 375, "height": 812})

--- a/tests/test_pending_question_ui_browser.py
+++ b/tests/test_pending_question_ui_browser.py
@@ -21,7 +21,7 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-pytestmark = [pytest.mark.browser, pytest.mark.slow]
+pytestmark = [pytest.mark.browser, pytest.mark.slow, pytest.mark.requires_server]
 
 DESKTOP_VIEWPORT = {"width": 1280, "height": 800}
 # The production server owns :8000; a worktree run can point at its own instance

--- a/tests/test_ui_browser.py
+++ b/tests/test_ui_browser.py
@@ -8,7 +8,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 # Mark all tests as requiring browser
-pytestmark = [pytest.mark.browser, pytest.mark.slow]
+pytestmark = [pytest.mark.browser, pytest.mark.slow, pytest.mark.requires_server]
 
 # Viewport sizes
 DESKTOP_VIEWPORT = {"width": 1280, "height": 800}

--- a/tests/test_voice_mic_block_ui_browser.py
+++ b/tests/test_voice_mic_block_ui_browser.py
@@ -9,6 +9,9 @@ context offers a tappable link to the configured HTTPS origin.
 Unlike the rest of the browser suite this serves `web/` itself from an ephemeral
 port rather than pointing at a running API, because the assertions are about the
 JS in *this* checkout and every API call the page makes is intercepted anyway.
+That is why it carries no `requires_server` marker, and so runs at pre-push
+(`browser and not requires_server`). Keep it that way — reaching for a live
+server here would silently drop `web/chat/` from the push gate.
 """
 import http.server
 import json


### PR DESCRIPTION
Fixes #526

## What

Browser tests never ran at pre-push. The hook runs `pytest -m "unit and not slow"` directly, so a regression in the chat SPA's JS reached `main` unless someone separately ran `./scripts/test.sh auto`.

This splits the browser suite by whether it needs a live server, and adds the server-free half to the push gate.

## Marker shape

Reused the **existing** `requires_server` marker rather than inventing a new one — it already means exactly "needs a running API server", is already registered in both `pyproject.toml` and `conftest.py`, and `scripts/test.sh` already excludes it from unit scope.

- All five browser modules keep `browser`.
- The four that point at `localhost:8000` (`test_ui_browser.py`, `test_e2e_flow.py`, `test_agent_threads_ui_browser.py`, `test_pending_question_ui_browser.py`) gain `requires_server`. Note the issue named only two — there are four.
- `tests/test_voice_mic_block_ui_browser.py` (serves `web/` itself on an ephemeral port, stubs every `/api/` call) stays unmarked.
- Pre-push selects `browser and not requires_server`.

Chosen over an opt-in marker on the self-contained test because the failure direction is safer: a new browser test that forgets `requires_server` breaks pre-push loudly, whereas a forgotten opt-in marker would silently reopen exactly the gap this issue is about.

The pytest config lives in `pyproject.toml`, not `pytest.ini` (the issue said `pytest.ini`); both it and `conftest.py` now describe the split.

## Two pytest processes, not one marker expression

The obvious implementation — `-m "(unit and not slow) or (browser and not requires_server)"` in the existing run — **does not work**, and this is a real pre-existing landmine worth knowing about:

`pytest-playwright`'s sync API leaves its own event loop current after a browser test. Any async test that runs *after* a browser test **in the same process** is then never awaited. Reproducible serially, independent of my change:

```
$ pytest tests/test_voice_mic_block_ui_browser.py tests/test_telegram_multibot.py
12 failed, 20 passed        # RuntimeWarning: coroutine ... was never awaited

$ pytest tests/test_telegram_multibot.py tests/test_voice_mic_block_ui_browser.py
32 passed                   # reverse order is fine
```

Under `-n auto` that ordering is nondeterministic — the combined expression produced **5–11 varying failures per run** across unrelated modules (`test_llm_client`, `test_telegram_multibot`, `test_voice_proxy`, `test_web_search`). `./scripts/test.sh` never hit this because it already runs browser tests in a separate invocation.

So the hook runs the browser set as a second process. It also passes `-p no:cacheprovider`, so a browser failure can't seed `lastfailed` with tests the unit run's `--lf` cannot select (which would make the *next* push run nothing at all).

## Evidence

**Marker selects exactly the intended set** — `browser` = 67 tests / 5 modules both before and after this change:

```
-m "browser"                          →  67 tests   (5 modules)
-m "browser and not requires_server"  →   7 tests   (test_voice_mic_block_ui_browser.py only)
-m "browser and requires_server"      →  60 tests   (the other 4 modules)
```

**`./scripts/test.sh browser` is not narrowed** — its `-m "browser"` over the same three files still collects 47. Adding a marker cannot deselect from a `-m "browser"` expression; only the comment in `run_browser_tests()` changed.

**No dependency on `lifeos-api`** — the service was *not* stopped (other agents depend on it). Instead the run was traced at the syscall level:

```
$ strace -f -e trace=connect pytest -m "browser and not requires_server" tests/
7 passed, 3654 deselected in 6.22s
connects to port 8000: 0
ports connected to:  35559 (its own ephemeral server, 84×), 0, 53 (DNS), 443
```

Zero connections to the API. The 53/443 traffic is Chromium's own background DoH/component probes (8.8.8.8, Cloudflare), present in any Playwright run and failing harmlessly; the test never navigates off its own origin. Statically the module contains no `localhost:8000`, no `LIFEOS_TEST_BASE_URL` — it binds `("127.0.0.1", 0)` and calls `page.route("**/api/**", ...)`.

I could not produce a hard network-isolated run: `unshare -rn` is blocked by `kernel.apparmor_restrict_unprivileged_userns=1`, and `bwrap --unshare-net` can't bring up loopback (`RTM_NEWADDR: Operation not permitted`). The strace evidence is what stands in for it.

**Deliberate break fails the gate** — reverting the #516 fix in `web/chat/voice.js` (`no_getusermedia` → `insecure_context`), then running the hook end to end:

```
Running unit tests... passed (2399 passed, 8 skipped in 47.04s)
Running server-free browser tests... FAILED (2 failed, 5 passed in 15.66s)
HOOK EXIT: 1

FAILED test_missing_getusermedia_is_not_reported_as_https[chromium]
FAILED test_a_different_reason_is_still_reported[chromium]
  AssertionError: Locator expected to have text 'Mic unavailable — this browser exposes no microphone API'
  Actual value: Mic blocked — this page is not on HTTPS
```

Break reverted (`git diff -- web/` clean). Confirmed `.pytest_cache/v/cache/lastfailed` was **not** written by the failing browser run.

**Wall time** — old vs new hook, back to back on a settled machine:

| | unit | browser | total |
|---|---|---|---|
| before | 47.72s | — | **47.72s** |
| after | 47.20s | 5.46s | **54.82s** |

**+7.1s** (5.5s of tests, ~1.6s of pytest startup/collection). Three green runs of the new hook: 54.83s / 55.88s / 55.13s.

## Note: no hook reinstall needed

The issue and the task assumed `.git/hooks/pre-push` is an installed copy needing a manual re-copy. It isn't — this repo sets `core.hooksPath = scripts`, so git runs the **tracked** `scripts/pre-push` directly. The `.git/hooks/pre-push` file is a stale leftover from Jul 9 that never executes. The push of this branch already ran the new hook, browser step included:

```
Running server-free browser tests... passed (7 passed, 3654 deselected in 5.37s)
```

So this takes effect on merge with no deploy step. (The stale `.git/hooks/pre-push` is untracked cruft — flagging it, not deleting it.)

## Collateral: pre-existing lint in `test_e2e_flow.py`

Marking that file brought it under the pre-commit ruff hook, which flagged nine **pre-existing** findings (four unused `expect` imports, an unused `asyncio` import, a bare `except:`, `== False`, two dead locals). The hook is not skippable, so they're fixed in place. None change behaviour; the module still collects 16 tests. Called out because it's diff noise unrelated to the marker split.

## Docs

- `AGENTS.md` § Testing — the blanket "browser tests need a running server" line is replaced with the split, and the stale file list for `test.sh browser` is corrected (it has covered `test_voice_mic_block_ui_browser.py` since #518).
- `docs/specs/standards/testing-standards.md` — new "Browser tests and `requires_server`" subsection under § Markers; `Last Updated` bumped. Still 208 lines, well under the 700-line standards cap.

## Not verified

- `./scripts/test.sh browser` was proven unnarrowed by collection only, not executed — a full run drives real chat queries against the shared production `lifeos-api`.
- Playwright-absent path (`python -c "import playwright"` guard) reasoned about, not exercised; Playwright is installed on this host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
