### PR TITLE
fix(chat): stop tools reporting a clamped search scope as missing data

### DIFF
--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -50,7 +50,7 @@ Searches Google Drive docs, sheets, and presentations across both accounts. Retu
 Searches Slack messages across DMs and channels. Returns channel name, sender, timestamp, and message content.
 
 **get_message_history:**
-Returns iMessage and WhatsApp chat logs with a specific person. Shows actual message content with timestamps — what was said and when. Requires entity_id (get it from person_info first). Can filter by date range or search term.
+Returns iMessage and WhatsApp chat logs with a specific person. Shows actual message content with timestamps — what was said and when. Requires entity_id (get it from person_info first). Can filter by date range or search term. Omit the date range when you don't know when something was said — it then widens automatically (90 days → 1 year → all history) and tells you which windows it tried. When it reports no messages, the history genuinely lacks them; say so plainly rather than blaming a sync or permissions fault.
 
 **search_web:**
 Web search for any current or real-time information — weather, news, prices, rankings, benchmarks, reviews, technical specs, documentation, public facts, or anything that may have changed since your training. Use whenever the answer benefits from up-to-date data. Only skip if the answer is purely in {name}'s personal data.

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -198,7 +198,12 @@ TOOL_DEFINITIONS = [
         "description": (
             "Get iMessage and WhatsApp chat logs with a specific person. "
             "Returns actual message content with timestamps — shows what was said and when. "
-            "Requires entity_id from person_info. Can filter by date range or search term."
+            "Requires entity_id from person_info. Can filter by date range or search term. "
+            "With no date range it searches the last 90 days, then the last year, then all "
+            "history, stopping at the first window with matches — so omit dates when you "
+            "don't know when something was said. A 'no messages found' result from this "
+            "tool means the history genuinely does not contain them, not that retrieval "
+            "failed; do not report it as a sync or permissions problem."
         ),
         "input_schema": {
             "type": "object",
@@ -213,7 +218,11 @@ TOOL_DEFINITIONS = [
                 },
                 "start_date": {
                     "type": "string",
-                    "description": "Start date (YYYY-MM-DD). Defaults to last 30 days.",
+                    "description": (
+                        "Start date (YYYY-MM-DD). Omit to auto-widen through "
+                        "90 days → 1 year → all history. Set it only to pin a "
+                        "specific period; doing so disables auto-widening."
+                    ),
                 },
                 "end_date": {
                     "type": "string",
@@ -976,6 +985,18 @@ def _format_whatsapp_interactions(interactions: list) -> str:
     return "\n".join(lines)
 
 
+# Widening ladder for message history when the caller gave no date range.
+# Each step is tried in order and the first one with any hits wins. Widening is
+# cheap by construction: it only happens on threads too sparse to fill the
+# narrow window, so the wider queries scan very little.
+_MSG_HISTORY_LADDER_DAYS = (90, 365, None)  # None = all history
+
+# Payload ceiling for message history, in characters. Message *count* is a poor
+# cost proxy — a year of a quiet thread is ~250 tokens while 1000 messages of a
+# busy one is ~28k — so the budget is applied to formatted output instead.
+_MSG_HISTORY_CHAR_BUDGET = 24000
+
+
 def _tool_get_message_history(inp: dict) -> str:
     from api.services.imessage import query_person_messages, resolve_entity_id
     from api.services.interaction_store import get_interaction_store
@@ -988,84 +1009,189 @@ def _tool_get_message_history(inp: dict) -> str:
     start_date = inp.get("start_date")
     end_date = inp.get("end_date")
     search_term = inp.get("search_term")
-    limit = inp.get("limit", 100)
-    if not start_date and not end_date:
-        start_date = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
+    limit = inp.get("limit", 1000)
 
-    # 1. iMessage/SMS
-    imessage_result = query_person_messages(
-        entity_id=resolved_id,
-        search_term=search_term,
-        start_date=start_date,
-        end_date=end_date,
-        limit=limit,
-    )
+    # An explicit date range is an intentional constraint — answer exactly that
+    # window. Only auto-widen when the caller expressed no preference.
+    caller_set_dates = bool(start_date or end_date)
 
-    # 2. WhatsApp from interaction store
     store = get_interaction_store()
-    days_back = 30
-    if start_date:
-        try:
-            delta = datetime.now() - datetime.strptime(start_date, "%Y-%m-%d")
-            days_back = max(delta.days, 1)
-        except (ValueError, TypeError):
-            pass
 
-    whatsapp_interactions = store.get_for_person(
-        person_id=resolved_id,
-        days_back=days_back,
-        source_type="whatsapp",
-        limit=limit,
-    )
+    def _fetch(window_start: str | None) -> tuple[dict, list]:
+        """Fetch both sources for one window. Returns (imessage_result, whatsapp)."""
+        imsg = query_person_messages(
+            entity_id=resolved_id,
+            search_term=search_term,
+            start_date=window_start,
+            end_date=end_date,
+            limit=limit,
+        )
 
-    # Filter WhatsApp by search_term
-    if search_term and whatsapp_interactions:
-        term_lower = search_term.lower()
-        whatsapp_interactions = [
-            i for i in whatsapp_interactions
-            if i.snippet and term_lower in i.snippet.lower()
-        ]
+        # The interaction store takes a lookback in days rather than a date.
+        days_back = 36500  # ~all history
+        if window_start:
+            try:
+                delta = datetime.now() - datetime.strptime(window_start, "%Y-%m-%d")
+                days_back = max(delta.days, 1)
+            except (ValueError, TypeError):
+                pass
 
-    # Filter WhatsApp by end_date
-    if end_date and whatsapp_interactions:
-        try:
-            end_dt = datetime.strptime(end_date, "%Y-%m-%d").replace(
-                hour=23, minute=59, second=59, tzinfo=timezone.utc
+        wa = store.get_for_person(
+            person_id=resolved_id,
+            days_back=days_back,
+            source_type="whatsapp",
+            limit=limit,
+        )
+
+        if search_term and wa:
+            term_lower = search_term.lower()
+            wa = [i for i in wa if i.snippet and term_lower in i.snippet.lower()]
+
+        if end_date and wa:
+            try:
+                end_dt = datetime.strptime(end_date, "%Y-%m-%d").replace(
+                    hour=23, minute=59, second=59, tzinfo=timezone.utc
+                )
+                wa = [i for i in wa if i.timestamp <= end_dt]
+            except (ValueError, TypeError):
+                pass
+
+        # Store returns most recent first; present chronologically.
+        wa.sort(key=lambda i: i.timestamp)
+        return imsg, wa
+
+    # Walk the widening ladder until either source has hits. Breaking on either
+    # (not just iMessage) keeps a recent iMessage from hiding an older WhatsApp
+    # thread, and vice versa.
+    windows_tried: list[str] = []
+    if caller_set_dates:
+        imessage_result, whatsapp_interactions = _fetch(start_date)
+    else:
+        for days in _MSG_HISTORY_LADDER_DAYS:
+            window_start = (
+                (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+                if days
+                else None
             )
-            whatsapp_interactions = [
-                i for i in whatsapp_interactions if i.timestamp <= end_dt
-            ]
-        except (ValueError, TypeError):
-            pass
-
-    # Sort WhatsApp chronologically (store returns most recent first)
-    whatsapp_interactions.sort(key=lambda i: i.timestamp)
+            imessage_result, whatsapp_interactions = _fetch(window_start)
+            windows_tried.append(f"last {days}d" if days else "all history")
+            if imessage_result["count"] > 0 or whatsapp_interactions:
+                break
 
     imessage_count = imessage_result["count"]
     whatsapp_count = len(whatsapp_interactions)
 
     if imessage_count == 0 and whatsapp_count == 0:
-        return "No messages found."
+        if windows_tried:
+            return (
+                "No messages found. Searched "
+                + ", then ".join(windows_tried)
+                + (f" for {search_term!r}" if search_term else "")
+                + ". There is no iMessage or WhatsApp history on record for this "
+                "person"
+                + (
+                    " matching that term — try again without search_term."
+                    if search_term
+                    else "."
+                )
+            )
+        window_desc = " to ".join(x for x in (start_date, end_date) if x)
+        return (
+            f"No messages found in the requested window ({window_desc})"
+            + (f" for {search_term!r}" if search_term else "")
+            + ". Retry without start_date/end_date to search all history."
+        )
 
-    # Build output
-    parts = []
+    # Note which rungs came up empty, so the model can see the search was already
+    # widened rather than assuming the narrow window was the only one tried.
+    widened_note = ""
+    if len(windows_tried) > 1:
+        widened_note = (
+            f" (nothing in {', '.join(windows_tried[:-1])}; "
+            f"widened to {windows_tried[-1]})"
+        )
+
+    # Build output. The budget is split across sources rather than applied to the
+    # assembled string: the sections are grouped by source, not interleaved by
+    # time, so trimming the tail of the whole document would drop all of iMessage
+    # before touching WhatsApp regardless of recency.
+    imsg_text = imessage_result["formatted"]
+    wa_text = _format_whatsapp_interactions(whatsapp_interactions) if whatsapp_count else ""
+    imsg_text, wa_text, trimmed = _split_to_budget(imsg_text, wa_text)
+
+    trim_note = ""
+    if trimmed:
+        trim_note = (
+            "\n\n[Oldest messages trimmed to fit context — the most recent are "
+            "shown. Narrow with search_term or start_date/end_date for a "
+            "specific period.]"
+        )
 
     if imessage_count > 0 and whatsapp_count > 0:
         # Both sources — label each section
         dr = imessage_result.get("date_range")
         date_info = f" ({dr['start'][:10]} to {dr['end'][:10]})" if dr else ""
-        parts.append(f"## iMessage ({imessage_count} messages{date_info})\n\n{imessage_result['formatted']}")
-        parts.append(f"## WhatsApp ({whatsapp_count} messages)\n\n{_format_whatsapp_interactions(whatsapp_interactions)}")
+        parts = [
+            f"## iMessage ({imessage_count} messages{date_info})\n\n{imsg_text}",
+            f"## WhatsApp ({whatsapp_count} messages)\n\n{wa_text}",
+        ]
         total = imessage_count + whatsapp_count
-        return f"{total} messages from iMessage and WhatsApp:\n\n" + "\n\n".join(parts)
+        return (
+            f"{total} messages from iMessage and WhatsApp{widened_note}{trim_note}:\n\n"
+            + "\n\n".join(parts)
+        )
     elif imessage_count > 0:
         date_info = ""
         if imessage_result.get("date_range"):
             dr = imessage_result["date_range"]
             date_info = f" ({dr['start'][:10]} to {dr['end'][:10]})"
-        return f"{imessage_count} messages{date_info}:\n\n{imessage_result['formatted']}"
+        return f"{imessage_count} messages{date_info}{widened_note}{trim_note}:\n\n{imsg_text}"
     else:
-        return f"{whatsapp_count} WhatsApp messages:\n\n{_format_whatsapp_interactions(whatsapp_interactions)}"
+        return f"{whatsapp_count} WhatsApp messages{widened_note}{trim_note}:\n\n{wa_text}"
+
+
+def _trim_section(formatted: str, budget: int) -> str:
+    """Trim one formatted message block to budget, keeping the most recent.
+
+    Blocks are chronological (oldest first), so the tail is kept. The cut is
+    aligned to a `### date` header so no message is left without the date it
+    belongs under — a shown message with a wrong or missing date is worse than
+    a dropped one.
+    """
+    if len(formatted) <= budget:
+        return formatted
+    kept = formatted[-budget:]
+    idx = kept.find("\n### ")
+    if idx != -1:
+        return kept[idx + 1:]
+    # No header in range — fall back to a clean line boundary.
+    return kept.split("\n", 1)[1] if "\n" in kept else kept
+
+
+def _split_to_budget(imsg_text: str, wa_text: str) -> tuple[str, str, bool]:
+    """Fit both source blocks into the payload budget, keeping recent messages.
+
+    Each source gets an equal share, but a block smaller than its share donates
+    the unused remainder to the other — so one quiet source never wastes budget
+    a busy one could use.
+    """
+    budget = _MSG_HISTORY_CHAR_BUDGET
+    if len(imsg_text) + len(wa_text) <= budget:
+        return imsg_text, wa_text, False
+
+    if not wa_text:
+        return _trim_section(imsg_text, budget), "", True
+    if not imsg_text:
+        return "", _trim_section(wa_text, budget), True
+
+    share = budget // 2
+    imsg_share = share + max(0, share - len(wa_text))
+    wa_share = share + max(0, share - len(imsg_text))
+    return (
+        _trim_section(imsg_text, imsg_share),
+        _trim_section(wa_text, wa_share),
+        True,
+    )
 
 
 # -- People helpers --

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -100,7 +100,12 @@ TOOL_DEFINITIONS = [
                 },
                 "days_range": {
                     "type": "integer",
-                    "description": "Number of days to search. With query: search ±N days (default 180). With date_ref: range from date (default 1).",
+                    "description": (
+                        "Number of days to search. With query: search ±N days — omit "
+                        "to auto-widen through ±180 → ±365 → ±1095 days, stopping at "
+                        "the first span with events; setting it disables widening. "
+                        "With date_ref: range from date (default 1)."
+                    ),
                 },
             },
             "required": [],
@@ -111,7 +116,8 @@ TOOL_DEFINITIONS = [
         "description": (
             "Search Gmail across personal and work accounts. "
             "Returns sender, recipient, subject, date, and body preview. "
-            "Use from_email/to_email for targeted searches (get email from person_info first)."
+            "Use from_email/to_email for targeted searches (get email from person_info first). "
+            "Scope by time with after/before; with neither, all of history is searched."
         ),
         "input_schema": {
             "type": "object",
@@ -128,9 +134,26 @@ TOOL_DEFINITIONS = [
                     "type": "string",
                     "description": "Filter by recipient email address.",
                 },
+                "after": {
+                    "type": "string",
+                    "description": (
+                        "Only emails on or after this date (YYYY-MM-DD). Omit to "
+                        "search back to the beginning of the mailbox."
+                    ),
+                },
+                "before": {
+                    "type": "string",
+                    "description": (
+                        "Only emails on or before this date (YYYY-MM-DD). Omit for "
+                        "no upper bound."
+                    ),
+                },
                 "max_results": {
                     "type": "integer",
-                    "description": "Max emails to return per account (default 5).",
+                    "description": (
+                        "Max emails to return per account (default 15). Raise it when "
+                        "the result says it was capped and you need the rest."
+                    ),
                 },
             },
             "required": [],
@@ -158,7 +181,11 @@ TOOL_DEFINITIONS = [
     },
     {
         "name": "search_slack",
-        "description": "Search Slack messages across DMs and channels.",
+        "description": (
+            "Search Slack messages across DMs and channels. Semantic search over "
+            "indexed messages only — an empty result means nothing indexed matches, "
+            "not a sign the search broke. Optionally scope by date with after/before."
+        ),
         "input_schema": {
             "type": "object",
             "properties": {
@@ -168,7 +195,18 @@ TOOL_DEFINITIONS = [
                 },
                 "top_k": {
                     "type": "integer",
-                    "description": "Number of results (default 10).",
+                    "description": "Number of results (default 20).",
+                },
+                "after": {
+                    "type": "string",
+                    "description": (
+                        "Only messages on or after this date (YYYY-MM-DD). Applied "
+                        "after ranking, so a dated search can return fewer than top_k."
+                    ),
+                },
+                "before": {
+                    "type": "string",
+                    "description": "Only messages on or before this date (YYYY-MM-DD).",
                 },
             },
             "required": ["query"],
@@ -468,7 +506,12 @@ TOOL_DEFINITIONS = [
                 },
                 "start_date": {
                     "type": "string",
-                    "description": "Start date (YYYY-MM-DD). Transactions default to 30 days ago, cashflow/budgets to 1st of current month.",
+                    "description": (
+                        "Start date (YYYY-MM-DD). For transactions, omit to auto-widen "
+                        "through 90 days → 1 year → all history, stopping at the first "
+                        "window with matches; setting it disables widening. "
+                        "cashflow/budgets default to the 1st of the current month."
+                    ),
                 },
                 "end_date": {
                     "type": "string",
@@ -822,32 +865,97 @@ def _tool_search_vault(inp: dict) -> str:
     return "\n\n---\n".join(lines)
 
 
+# Widening ladder for a calendar keyword search with no caller-supplied range.
+# ±180d covers "did we meet recently"; the wider rungs catch anniversaries and
+# one-off events from previous years that the old fixed ±180d silently hid.
+_CALENDAR_LADDER_DAYS = (180, 365, 1095)
+
+
 async def _tool_search_calendar(inp: dict) -> str:
     from api.services.calendar import CalendarService
 
     query = inp.get("query")
     date_ref = inp.get("date_ref")
-    days_range = inp.get("days_range")
-
-    all_events = []
-    for account in get_configured_accounts():
+    # A non-int or non-positive days_range would raise inside
+    # timedelta(days=...) per account, get swallowed by the handler below, and
+    # come back as "No calendar events found. Searched ±30d" — a scoped-looking
+    # empty for a search that never validly ran. Treat it as unstated (so the
+    # ladder applies) and say the value was dropped, rather than clamping it to
+    # some nearby number the caller never asked for.
+    raw_range = inp.get("days_range")
+    days_range = None
+    if raw_range is not None:
         try:
-            cal = CalendarService(account)
-            if query:
-                search_range = days_range or 180
-                events = cal.search_events(query=query, days_back=search_range, days_forward=search_range)
-            elif date_ref:
-                start = datetime.strptime(date_ref, "%Y-%m-%d")
-                end = start + timedelta(days=days_range or 1)
-                events = cal.get_events_in_range(start, end)
-            else:
-                events = cal.get_upcoming_events(days=7, max_results=15)
-            all_events.extend(events)
-        except Exception as e:
-            logger.warning(f"Calendar {account.value} error: {e}")
+            days_range = int(raw_range)
+        except (TypeError, ValueError):
+            days_range = None
+        if days_range is not None and days_range < 1:
+            days_range = None
+    bad_range = (
+        f" [Ignored days_range={raw_range!r} — must be a positive whole number "
+        "of days, so this result is NOT scoped to it.]"
+        if raw_range is not None and days_range is None
+        else ""
+    )
+
+    # Accounts that errored during the search. An expired token used to be
+    # logged and then reported as "no events" — a real fault dressed up as an
+    # empty result, which is the misdiagnosis this whole change exists to stop.
+    failed_accounts: list[str] = []
+
+    def _fetch(search_range: int | None) -> list:
+        """Collect events from every configured account for one window."""
+        events = []
+        failed_accounts.clear()
+        for account in get_configured_accounts():
+            try:
+                cal = CalendarService(account)
+                if query:
+                    events.extend(cal.search_events(query=query, days_back=search_range, days_forward=search_range))
+                elif date_ref:
+                    start = datetime.strptime(date_ref, "%Y-%m-%d")
+                    end = start + timedelta(days=days_range or 1)
+                    events.extend(cal.get_events_in_range(start, end))
+                else:
+                    events.extend(cal.get_upcoming_events(days=7, max_results=15))
+            except Exception as e:
+                logger.warning(f"Calendar {account.value} error: {e}")
+                failed_accounts.append(account.value)
+        return events
+
+    # An explicit days_range is an intentional constraint — answer exactly that
+    # span. Only a keyword search with no stated range walks the ladder.
+    windows_tried: list[str] = []
+    if query and days_range:
+        all_events = _fetch(days_range)
+        windows_tried.append(f"±{days_range}d")
+    elif query:
+        for days in _CALENDAR_LADDER_DAYS:
+            all_events = _fetch(days)
+            windows_tried.append(f"±{days}d")
+            if all_events:
+                break
+    else:
+        # date_ref / upcoming branches set their own range; search_range unused.
+        all_events = _fetch(None)
+
+    failed_note = ""
+    if failed_accounts:
+        failed_note = (
+            f" [Could not reach {', '.join(failed_accounts)} — that account "
+            "errored, so this is an incomplete answer, not necessarily an empty "
+            "calendar. It may need re-authorising.]"
+        )
 
     if not all_events:
-        return "No calendar events found."
+        if windows_tried:
+            hint = f"Nothing on the calendar matches {query!r} in that span."
+            return (
+                _exhausted_note("calendar events", windows_tried, hint)
+                + bad_range
+                + failed_note
+            )
+        return "No calendar events found." + bad_range + failed_note
 
     all_events.sort(key=lambda e: e.start_time or datetime.min)
     lines = []
@@ -857,14 +965,34 @@ async def _tool_search_calendar(inp: dict) -> str:
         attendees = f" with {', '.join(e.attendees[:5])}" if e.attendees else ""
         loc = f" @ {e.location}" if e.location else ""
         lines.append(f"- {e.title} ({start}) {acct}{attendees}{loc}")
-    return "\n".join(lines)
+    body = "\n".join(lines)
+    note = _ladder_note(windows_tried) + bad_range + failed_note
+    return f"{len(all_events)} events{note}:\n{body}" if note else body
 
 
 async def _tool_search_email(inp: dict) -> str:
     from api.services.gmail import GmailService
 
-    max_results = inp.get("max_results", 5)
+    # Normalised, not passed through: max_results is also the yardstick for the
+    # truncation check below, so a None or 0 from the model would both confuse
+    # Gmail and silently disable that disclosure.
+    max_results = _positive_int(inp.get("max_results", 15), 15, 100)
+    after = _parse_ymd(inp.get("after"))
+    before = _parse_ymd(inp.get("before"))
+    ignored = [
+        f"{k}={inp[k]!r}"
+        for k, parsed in (("after", after), ("before", before))
+        if inp.get(k) and not parsed
+    ]
+    ignored_note = (
+        f"\n\n[Ignored unparseable {', '.join(ignored)} — dates must be YYYY-MM-DD, "
+        "so these results are NOT scoped to that range.]"
+        if ignored
+        else ""
+    )
+
     all_messages = []
+    truncated = False
     for account in get_configured_accounts():
         try:
             gmail = GmailService(account)
@@ -872,15 +1000,46 @@ async def _tool_search_email(inp: dict) -> str:
                 keywords=inp.get("keywords"),
                 from_email=inp.get("from_email"),
                 to_email=inp.get("to_email"),
+                after=after,
+                before=before,
                 max_results=max_results,
                 include_body=True,
             )
             all_messages.extend(messages)
+            # A full page back is the only signal Gmail gives that it had more.
+            if len(messages) == max_results:
+                truncated = True
         except Exception as e:
             logger.warning(f"Gmail {account.value} error: {e}")
 
     if not all_messages:
-        return "No emails found."
+        # Name the filters actually applied. A keyword that matches nothing
+        # matches nothing at any max_results, so there is no retry to make —
+        # but the model needs to see what was searched to pick a better filter.
+        applied = [
+            f"{label}={inp[key]!r}"
+            for key, label in (
+                ("keywords", "keywords"),
+                ("from_email", "from"),
+                ("to_email", "to"),
+            )
+            if inp.get(key)
+        ]
+        if after or before:
+            span = " to ".join(
+                d.strftime("%Y-%m-%d") for d in (after, before) if d
+            )
+            applied.append(f"dates {span}")
+        else:
+            applied.append("no date filter")
+        return f"No emails found. Searched with {', '.join(applied)}.{ignored_note}"
+
+    trunc_note = ""
+    if truncated:
+        trunc_note = (
+            f"\n\n[Capped at {max_results} per account — more may exist. Raise "
+            "max_results, or narrow with after/before, to see the rest.]"
+        )
 
     lines = []
     for m in all_messages:
@@ -899,7 +1058,7 @@ async def _tool_search_email(inp: dict) -> str:
             f"Date: {date_str}\n"
             f"{body_preview}"
         )
-    return "\n\n---\n".join(lines)
+    return "\n\n---\n".join(lines) + ignored_note + trunc_note
 
 
 async def _tool_search_drive(inp: dict) -> str:
@@ -936,10 +1095,99 @@ def _tool_search_slack(inp: dict) -> str:
         return "Slack is not configured."
 
     indexer = get_slack_indexer()
-    top_k = inp.get("top_k", 10)
-    results = indexer.search(query=inp["query"], top_k=top_k)
+    # Normalised for the same reason as email's max_results: it doubles as the
+    # truncation yardstick, so None/0 would quietly disable that disclosure.
+    top_k = _positive_int(inp.get("top_k", 20), 20, 200)
+    query = inp["query"]
+    results = indexer.search(query=query, top_k=top_k)
+
+    # A full page back means the ranking was cut off, not that Slack has no more.
+    truncated = len(results) == top_k
+
+    # after/before are post-filters: the indexed metadata carries an ISO
+    # `timestamp` per message, but the vector search itself can't range-filter,
+    # so dates are applied to the already-ranked page. A dated search can
+    # therefore return fewer than top_k even when more matches exist.
+    after = _parse_ymd(inp.get("after"))
+    before = _parse_ymd(inp.get("before"))
+    ignored = [
+        f"{k}={inp[k]!r}"
+        for k, parsed in (("after", after), ("before", before))
+        if inp.get(k) and not parsed
+    ]
+    if after:
+        after = after.replace(tzinfo=timezone.utc)
+    if before:
+        before = before.replace(hour=23, minute=59, second=59, tzinfo=timezone.utc)
+
+    ranked_count = len(results)
+    undateable = 0
+    if after or before:
+        dated = []
+        for msg in results:
+            try:
+                when = datetime.fromisoformat(msg.get("timestamp") or "")
+            except (ValueError, TypeError):
+                # Excluded because we can't place it in time, which is NOT the
+                # same as falling outside the range — counted separately so the
+                # empty-result text doesn't claim something it hasn't shown.
+                undateable += 1
+                continue
+            if when.tzinfo is None:
+                when = when.replace(tzinfo=timezone.utc)
+            if after and when < after:
+                continue
+            if before and when > before:
+                continue
+            dated.append(msg)
+        results = dated
+
+    notes = ""
+    if ignored:
+        notes += (
+            f"\n\n[Ignored unparseable {', '.join(ignored)} — dates must be "
+            "YYYY-MM-DD, so these results are NOT date-scoped.]"
+        )
+    if truncated:
+        notes += (
+            f"\n\n[Ranked top {top_k} only — more may match. Raise top_k to see "
+            "further; note after/before filter this page after ranking, so a "
+            "dated search may return fewer than top_k.]"
+        )
+    if undateable:
+        notes += (
+            f"\n\n[{undateable} matching message(s) had no readable timestamp and "
+            "were excluded from the date filter — they may well be in range.]"
+        )
+
     if not results:
-        return "No Slack messages found."
+        span = " to ".join(d.strftime("%Y-%m-%d") for d in (after, before) if d)
+        if span and ranked_count:
+            # A bigger top_k genuinely helps here: the query did match, but no
+            # match on the ranked page could be shown for this range. Attribute
+            # the exclusions accurately — "outside the range" and "couldn't be
+            # dated" are different facts and only the first is established.
+            dated_out = ranked_count - undateable
+            reasons = []
+            if dated_out:
+                reasons.append(f"{dated_out} outside that range")
+            if undateable:
+                reasons.append(f"{undateable} with no readable timestamp")
+            return (
+                f"No Slack messages for {query!r} between {span} — of "
+                f"{ranked_count} top-ranked matches, {' and '.join(reasons)}. "
+                "Dates are applied after ranking, so raising top_k may surface "
+                "in-range matches." + notes
+            )
+        # Straight top-k nearest-neighbour with no score threshold: zero results
+        # means nothing indexed matches, and a larger top_k cannot change that.
+        return (
+            f"No Slack messages found for {query!r}"
+            + (f" between {span}" if span else "")
+            + ". Slack coverage is limited to the channels and DMs that have been "
+            "indexed, so this means nothing indexed matches — not a sign the "
+            "search broke." + notes
+        )
 
     lines = []
     for msg in results:
@@ -948,7 +1196,7 @@ def _tool_search_slack(inp: dict) -> str:
         ts = msg.get("timestamp", "")[:16]
         content = msg.get("content", "")[:500]
         lines.append(f"**{channel}** - {user} ({ts}):\n{content}")
-    return "\n\n".join(lines)
+    return "\n\n".join(lines) + notes
 
 
 async def _tool_search_web(inp: dict) -> str:
@@ -983,6 +1231,56 @@ def _format_whatsapp_interactions(interactions: list) -> str:
         lines.append(f"- **{time_str}** {direction}{text}")
 
     return "\n".join(lines)
+
+
+def _ladder_note(attempts: list[str]) -> str:
+    """Note which rungs of a widening ladder came up empty.
+
+    Lets the model see the search was already widened rather than assuming the
+    narrow window was the only one tried. Empty when the first rung hit.
+    """
+    if len(attempts) < 2:
+        return ""
+    return f" (nothing in {', '.join(attempts[:-1])}; widened to {attempts[-1]})"
+
+
+def _exhausted_note(noun: str, attempts: list[str], hint: str = "") -> str:
+    """Empty-result text that names every window searched.
+
+    A bare "No X found." reads as a broken backend; naming the windows makes the
+    emptiness a fact about the data instead.
+    """
+    searched = f" Searched {', then '.join(attempts)}." if attempts else ""
+    return f"No {noun} found.{searched}" + (f" {hint}" if hint else "")
+
+
+def _positive_int(raw, default: int, maximum: int) -> int:
+    """Coerce a model-supplied count to a usable bound.
+
+    The LLM fills these in, so None, "20", 0 and -5 all turn up. A bad value
+    must not reach the service layer: `timedelta(days="30")` raises, and a 0 or
+    None cap silently defeats the truncation checks that compare against it.
+    """
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(value, maximum))
+
+
+def _parse_ymd(raw) -> datetime | None:
+    """Parse a 'YYYY-MM-DD' filter value. None if absent or unparseable.
+
+    Callers drop the filter on None rather than raising: a malformed date
+    shouldn't cost the model its whole search, but it must be told the filter
+    was ignored so it doesn't read the results as scoped.
+    """
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d")
+    except (ValueError, TypeError):
+        return None
 
 
 # Widening ladder for message history when the caller gave no date range.
@@ -1102,14 +1400,7 @@ def _tool_get_message_history(inp: dict) -> str:
             + ". Retry without start_date/end_date to search all history."
         )
 
-    # Note which rungs came up empty, so the model can see the search was already
-    # widened rather than assuming the narrow window was the only one tried.
-    widened_note = ""
-    if len(windows_tried) > 1:
-        widened_note = (
-            f" (nothing in {', '.join(windows_tried[:-1])}; "
-            f"widened to {windows_tried[-1]})"
-        )
+    widened_note = _ladder_note(windows_tried)
 
     # Build output. The budget is split across sources rather than applied to the
     # assembled string: the sections are grouped by source, not interleaved by
@@ -1901,6 +2192,18 @@ def _tool_read_vault_file(inp: dict) -> str:
         return f"Error reading {match.name}: {e}"
 
 
+# Widening ladder for transactions when the caller gave no start_date.
+# None = all history (the Monarch client omits start_date entirely).
+_TXN_LADDER_DAYS = (90, 365, None)
+
+# Row cap for a transactions fetch, passed explicitly so the number is known
+# here and can be disclosed. Monarch's own default is also 500, so before this
+# was passed a widened window silently topped out with no indication. Ordering
+# is newest-first (the client hardcodes orderBy="date", verified descending),
+# so hitting the cap drops the OLDEST rows, not the most recent.
+_TXN_ROW_CAP = 500
+
+
 async def _tool_search_finances(inp: dict) -> str:
     from api.services.monarch import get_monarch_client
 
@@ -1976,17 +2279,89 @@ async def _tool_search_finances(inp: dict) -> str:
         return "\n".join(lines)
 
     elif action == "transactions":
-        start = inp.get("start_date")
-        end = inp.get("end_date")
-        if not start:
-            start = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
-        txns = await client.get_transactions(
-            start_date=start, end_date=end,
-            search=inp.get("search", ""), category=inp.get("category"),
+        # Normalise before use: these come from the model, and an unparseable
+        # date passed through to Monarch would either error or be ignored
+        # server-side, leaving results that silently aren't scoped as asked.
+        raw_start, raw_end = inp.get("start_date"), inp.get("end_date")
+        start = raw_start if _parse_ymd(raw_start) else None
+        end = raw_end if _parse_ymd(raw_end) else None
+        dropped = [
+            f"{label}={raw!r}"
+            for raw, label in ((raw_start, "start_date"), (raw_end, "end_date"))
+            if raw and not _parse_ymd(raw)
+        ]
+        dropped_note = (
+            f" [Ignored unparseable {', '.join(dropped)} — dates must be "
+            "YYYY-MM-DD, so this result is NOT scoped to them.]"
+            if dropped
+            else ""
         )
+        search = inp.get("search", "")
+        category = inp.get("category")
+
+        async def _fetch(window_start: str | None) -> list:
+            # Monarch rejects a one-sided range ("You must specify both a
+            # startDate and endDate"), so fill in whichever half is missing.
+            # Unbounded is expressed as *neither* bound, not as a null start.
+            window_end = end
+            if window_start and not window_end:
+                window_end = datetime.now().strftime("%Y-%m-%d")
+            elif window_end and not window_start:
+                window_start = "1900-01-01"
+            return await client.get_transactions(
+                start_date=window_start, end_date=window_end,
+                search=search, category=category, limit=_TXN_ROW_CAP,
+            )
+
+        # An explicit start_date is an intentional constraint — answer exactly
+        # that window. With none, walk the ladder rather than silently clamping
+        # to 30 days: a merchant last charged 8 months ago is not "no data".
+        #
+        # The ladder counts back from end_date when one was given, not from
+        # today. Counting from today would build an inverted start>end window
+        # for any past end_date — a range that can only return zero, which the
+        # ladder note would then misreport as "nothing in the last 90d".
+        anchor = _parse_ymd(end) or datetime.now()
+        anchored = " before " + anchor.strftime("%Y-%m-%d") if _parse_ymd(end) else ""
+        windows_tried: list[str] = []
+        if start:
+            txns = await _fetch(start)
+        else:
+            for days in _TXN_LADDER_DAYS:
+                window_start = (
+                    (anchor - timedelta(days=days)).strftime("%Y-%m-%d")
+                    if days
+                    else None
+                )
+                txns = await _fetch(window_start)
+                windows_tried.append(
+                    f"last {days}d{anchored}" if days else f"all history{anchored}"
+                )
+                if txns:
+                    break
+
         if not txns:
-            return "No transactions found."
-        lines = [f"{len(txns)} transactions:"]
+            if search:
+                hint = f"Nothing matched {search!r} — retry without the search term."
+            elif start:
+                hint = "Retry without start_date to search all history."
+            else:
+                hint = "There are no transactions on record" + (
+                    f" in category {category!r}." if category else "."
+                )
+            return _exhausted_note("transactions", windows_tried, hint) + dropped_note
+
+        capped_note = ""
+        if len(txns) >= _TXN_ROW_CAP:
+            capped_note = (
+                f" [Capped at {_TXN_ROW_CAP} rows — older matches in this window "
+                "were dropped. Narrow with start_date/end_date or a search term "
+                "to see them.]"
+            )
+        lines = [
+            f"{len(txns)} transactions{_ladder_note(windows_tried)}:"
+            f"{dropped_note}{capped_note}"
+        ]
         for t in sorted(txns, key=lambda x: x["date"], reverse=True)[:50]:
             sign = "" if t["amount"] >= 0 else "-"
             lines.append(f"- {t['date']} | {t['merchant']} | {t['category']} | {sign}${abs(t['amount']):,.2f}")

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -870,6 +870,11 @@ def _tool_search_vault(inp: dict) -> str:
 # one-off events from previous years that the old fixed ±180d silently hid.
 _CALENDAR_LADDER_DAYS = (180, 365, 1095)
 
+# Ceiling for a caller-supplied days_range — a century either side of today,
+# far beyond any real calendar and well short of the OverflowError that
+# timedelta(days=...) raises on absurd values.
+_CALENDAR_MAX_DAYS = 36500
+
 
 async def _tool_search_calendar(inp: dict) -> str:
     from api.services.calendar import CalendarService
@@ -882,6 +887,12 @@ async def _tool_search_calendar(inp: dict) -> str:
     # empty for a search that never validly ran. Treat it as unstated (so the
     # ladder applies) and say the value was dropped, rather than clamping it to
     # some nearby number the caller never asked for.
+    # The upper bound matters as much as the lower one: search_events does
+    # `now - timedelta(days=days_back)`, which raises OverflowError past a few
+    # million days. That would land in the per-account handler below and get
+    # reported as an unreachable account needing re-authorisation — a bad
+    # argument blamed on expired credentials, which is this same misdiagnosis
+    # in a new costume.
     raw_range = inp.get("days_range")
     days_range = None
     if raw_range is not None:
@@ -889,11 +900,12 @@ async def _tool_search_calendar(inp: dict) -> str:
             days_range = int(raw_range)
         except (TypeError, ValueError):
             days_range = None
-        if days_range is not None and days_range < 1:
+        if days_range is not None and not 1 <= days_range <= _CALENDAR_MAX_DAYS:
             days_range = None
     bad_range = (
-        f" [Ignored days_range={raw_range!r} — must be a positive whole number "
-        "of days, so this result is NOT scoped to it.]"
+        f" [Ignored days_range={raw_range!r} — must be a whole number of days "
+        f"between 1 and {_CALENDAR_MAX_DAYS}, so this result is NOT scoped to "
+        "it.]"
         if raw_range is not None and days_range is None
         else ""
     )
@@ -2308,10 +2320,21 @@ async def _tool_search_finances(inp: dict) -> str:
                 window_end = datetime.now().strftime("%Y-%m-%d")
             elif window_end and not window_start:
                 window_start = "1900-01-01"
+            # `category` is deliberately NOT passed down. The client applies it
+            # client-side *after* the row cap (monarch.py), so a capped fetch
+            # would hand back a filtered handful and hide the fact that the cap
+            # bound at all. Filtering here keeps the cap and the filter on the
+            # same side, so the pre-filter row count stays knowable.
             return await client.get_transactions(
                 start_date=window_start, end_date=window_end,
-                search=search, category=category, limit=_TXN_ROW_CAP,
+                search=search, limit=_TXN_ROW_CAP,
             )
+
+        def _by_category(rows: list) -> list:
+            if not category:
+                return rows
+            wanted = category.lower()
+            return [r for r in rows if (r.get("category") or "").lower() == wanted]
 
         # An explicit start_date is an intentional constraint — answer exactly
         # that window. With none, walk the ladder rather than silently clamping
@@ -2324,8 +2347,11 @@ async def _tool_search_finances(inp: dict) -> str:
         anchor = _parse_ymd(end) or datetime.now()
         anchored = " before " + anchor.strftime("%Y-%m-%d") if _parse_ymd(end) else ""
         windows_tried: list[str] = []
+        capped = False
         if start:
-            txns = await _fetch(start)
+            fetched = await _fetch(start)
+            capped = len(fetched) >= _TXN_ROW_CAP
+            txns = _by_category(fetched)
         else:
             for days in _TXN_LADDER_DAYS:
                 window_start = (
@@ -2333,14 +2359,35 @@ async def _tool_search_finances(inp: dict) -> str:
                     if days
                     else None
                 )
-                txns = await _fetch(window_start)
+                fetched = await _fetch(window_start)
+                capped = len(fetched) >= _TXN_ROW_CAP
+                txns = _by_category(fetched)
                 windows_tried.append(
                     f"last {days}d{anchored}" if days else f"all history{anchored}"
                 )
                 if txns:
                     break
+                # Rows come back newest-first, so once a window fills the cap the
+                # wider rungs return that same newest page — they can only add
+                # older rows the cap already excluded. Continuing would burn API
+                # calls and, worse, let the note claim "all history" was searched
+                # when it never got past the cap.
+                if capped:
+                    break
 
         if not txns:
+            # A capped fetch means absence was never established: the filter ran
+            # over one page, not the window. Claiming "no transactions on record"
+            # here is the original misdiagnosis wearing a different hat.
+            if capped:
+                scope = f" in category {category!r}" if category else ""
+                return (
+                    _exhausted_note("transactions", windows_tried)
+                    + f" Nothing{scope} in the {_TXN_ROW_CAP} most recent rows of "
+                    "that window, but the window holds more than that — this is "
+                    "NOT a confirmed absence. Narrow with start_date/end_date, or "
+                    "use a search term, to look past the cap." + dropped_note
+                )
             if search:
                 hint = f"Nothing matched {search!r} — retry without the search term."
             elif start:
@@ -2352,11 +2399,11 @@ async def _tool_search_finances(inp: dict) -> str:
             return _exhausted_note("transactions", windows_tried, hint) + dropped_note
 
         capped_note = ""
-        if len(txns) >= _TXN_ROW_CAP:
+        if capped:
             capped_note = (
-                f" [Capped at {_TXN_ROW_CAP} rows — older matches in this window "
-                "were dropped. Narrow with start_date/end_date or a search term "
-                "to see them.]"
+                f" [Fetched the {_TXN_ROW_CAP} most recent rows in this window and "
+                "older ones were dropped, so this may be incomplete. Narrow with "
+                "start_date/end_date or a search term to see past the cap.]"
             )
         lines = [
             f"{len(txns)} transactions{_ladder_note(windows_tried)}:"

--- a/tests/test_agent_tools_message_history.py
+++ b/tests/test_agent_tools_message_history.py
@@ -1,0 +1,225 @@
+"""
+Tests for the get_message_history orchestrator tool's adaptive windowing.
+
+Regression context: the tool used to clamp silently to the last 30 days when the
+caller passed no dates. A message ~7 weeks old was therefore unreachable, and
+because the failure text ("No messages found.") never named the window searched
+— while person_info reported interaction counts over 90 days — the orchestrator
+concluded the backend had a sync or permissions fault instead of widening.
+
+These tests pin the fix: widen 90d -> 1y -> all history, report the window,
+honor explicit dates, and cap the payload without misattributing messages.
+"""
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import api.services.agent_tools as at
+from api.services.agent_tools import (
+    _MSG_HISTORY_CHAR_BUDGET,
+    _split_to_budget,
+    _tool_get_message_history,
+    _trim_section,
+    TOOL_DEFINITIONS,
+    _TOOL_HANDLERS,
+)
+
+pytestmark = pytest.mark.unit
+
+ENTITY = "11111111-2222-3333-4444-555555555555"
+
+
+def _days_ago(n: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=n)
+
+
+@pytest.fixture
+def fake_sources(monkeypatch):
+    """Stub both message sources so windowing is tested without real data.
+
+    Records the start_date of every attempt so the widening ladder is visible.
+    """
+    state = SimpleNamespace(imessages=[], whatsapp=[], attempts=[])
+
+    def fake_resolve(entity_id):
+        return entity_id if entity_id == ENTITY else None
+
+    def fake_query(entity_id, search_term=None, start_date=None, end_date=None, limit=100):
+        state.attempts.append(start_date)
+        hits = list(state.imessages)
+        if start_date:
+            bound = datetime.strptime(start_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            hits = [m for m in hits if m[0] >= bound]
+        if search_term:
+            hits = [m for m in hits if search_term.lower() in m[1].lower()]
+        hits = hits[-limit:]
+        formatted = "\n".join(f"### {ts:%Y-%m-%d}\n- **00:00** <- {text}" for ts, text in hits)
+        date_range = None
+        if hits:
+            date_range = {
+                "start": min(h[0] for h in hits).isoformat(),
+                "end": max(h[0] for h in hits).isoformat(),
+            }
+        return {"messages": hits, "formatted": formatted, "count": len(hits), "date_range": date_range}
+
+    class FakeStore:
+        def get_for_person(self, person_id, days_back, source_type, limit):
+            bound = datetime.now(timezone.utc) - timedelta(days=days_back)
+            return [
+                SimpleNamespace(timestamp=ts, snippet=text)
+                for ts, text in state.whatsapp
+                if ts >= bound
+            ][:limit]
+
+    monkeypatch.setattr("api.services.imessage.resolve_entity_id", fake_resolve)
+    monkeypatch.setattr("api.services.imessage.query_person_messages", fake_query)
+    monkeypatch.setattr(
+        "api.services.interaction_store.get_interaction_store", lambda: FakeStore()
+    )
+    monkeypatch.setattr(
+        at, "_format_whatsapp_interactions",
+        lambda items: "\n".join(f"### {i.timestamp:%Y-%m-%d}\n- **00:00** <- {i.snippet}" for i in items),
+    )
+    return state
+
+
+def test_tool_is_registered():
+    assert "get_message_history" in _TOOL_HANDLERS
+    assert any(t["name"] == "get_message_history" for t in TOOL_DEFINITIONS)
+
+
+def test_unresolvable_entity_is_reported():
+    assert "Could not resolve" in _tool_get_message_history({"entity_id": "nope"})
+
+
+class TestWidening:
+    def test_finds_message_older_than_the_first_rung(self, fake_sources):
+        """The original bug: a 49-day-old message with no dates supplied."""
+        fake_sources.imessages = [(_days_ago(49), "Meet Robin Alex Doe - mom and baby happy")]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "Robin Alex Doe" in out
+
+    def test_stops_at_the_first_rung_that_hits(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(3), "hello")]
+        _tool_get_message_history({"entity_id": ENTITY})
+        assert len(fake_sources.attempts) == 1
+
+    def test_walks_all_rungs_to_reach_old_history(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(900), "ancient")]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "ancient" in out
+        # 90d, 365d, then all-history (None)
+        assert len(fake_sources.attempts) == 3
+        assert fake_sources.attempts[-1] is None
+
+    def test_reports_which_windows_were_empty(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(900), "ancient")]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "nothing in last 90d, last 365d" in out
+        assert "widened to all history" in out
+
+    def test_no_widening_note_when_first_rung_hits(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(3), "hello")]
+        assert "widened" not in _tool_get_message_history({"entity_id": ENTITY})
+
+    def test_widens_for_whatsapp_only_contact(self, fake_sources):
+        """Ladder must break on either source, not iMessage alone."""
+        fake_sources.whatsapp = [(_days_ago(200), "wa only")]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "wa only" in out
+
+    def test_search_term_reaches_all_history(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(800), "the wedding was lovely"), (_days_ago(2), "hi")]
+        out = _tool_get_message_history({"entity_id": ENTITY, "search_term": "wedding"})
+        assert "wedding was lovely" in out
+
+
+class TestExplicitDates:
+    def test_explicit_start_date_disables_widening(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(200), "older")]
+        start = _days_ago(10).strftime("%Y-%m-%d")
+        out = _tool_get_message_history({"entity_id": ENTITY, "start_date": start})
+        assert fake_sources.attempts == [start]
+        assert "older" not in out
+
+    def test_empty_explicit_window_suggests_dropping_dates(self, fake_sources):
+        start = _days_ago(3).strftime("%Y-%m-%d")
+        out = _tool_get_message_history({"entity_id": ENTITY, "start_date": start})
+        assert "Retry without start_date" in out
+
+
+class TestHonestEmpty:
+    def test_empty_result_names_the_windows_searched(self, fake_sources):
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "last 90d, then last 365d, then all history" in out
+
+    def test_empty_result_does_not_suggest_a_backend_fault(self, fake_sources):
+        """The misdiagnosis this whole change exists to prevent."""
+        out = _tool_get_message_history({"entity_id": ENTITY}).lower()
+        for word in ("sync issue", "permission", "failed", "error", "unavailable"):
+            assert word not in out
+
+    def test_unmatched_search_term_suggests_dropping_it(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(5), "hello")]
+        out = _tool_get_message_history({"entity_id": ENTITY, "search_term": "zzqqx"})
+        assert "without search_term" in out
+
+
+class TestBudget:
+    def test_small_result_is_not_trimmed(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(5), "short")]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "trimmed" not in out
+
+    def test_large_result_is_capped(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(5), "x" * 200) for _ in range(1000)]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert len(out) <= _MSG_HISTORY_CHAR_BUDGET + 600
+        assert "trimmed" in out
+
+    def test_trim_keeps_the_most_recent_messages(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(400), "OLDEST " + "x" * 200)] + [
+            (_days_ago(2), "y" * 200) for _ in range(500)
+        ] + [(_days_ago(1), "NEWEST-MARKER")]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "NEWEST-MARKER" in out
+        assert "OLDEST" not in out
+
+    def test_both_source_labels_survive_trimming(self, fake_sources):
+        fake_sources.imessages = [(_days_ago(5), "x" * 200) for _ in range(500)]
+        fake_sources.whatsapp = [(_days_ago(5), "y" * 200) for _ in range(500)]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "## iMessage" in out and "## WhatsApp" in out
+        assert len(out) <= _MSG_HISTORY_CHAR_BUDGET + 600
+
+    def test_trimmed_sections_start_at_a_date_header(self, fake_sources):
+        """A message shown without its date header could be misdated."""
+        fake_sources.imessages = [(_days_ago(5), "x" * 200) for _ in range(500)]
+        fake_sources.whatsapp = [(_days_ago(5), "y" * 200) for _ in range(500)]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        for label in ("## iMessage", "## WhatsApp"):
+            body = out.split(label, 1)[1].split("\n\n", 1)[1]
+            assert body.lstrip().startswith("### "), f"{label} section starts mid-message"
+
+
+class TestBudgetHelpers:
+    def test_trim_section_returns_short_input_unchanged(self):
+        assert _trim_section("### 2020-01-01\n- hi", 1000) == "### 2020-01-01\n- hi"
+
+    def test_trim_section_aligns_to_header(self):
+        text = "\n".join(f"### 2020-01-{d:02d}\n- **00:00** {'z' * 50}" for d in range(1, 28))
+        assert _trim_section(text, 300).startswith("### ")
+
+    def test_quiet_source_donates_unused_budget(self):
+        big = "### 2020-01-01\n" + "a" * (_MSG_HISTORY_CHAR_BUDGET * 2)
+        small = "### 2020-01-01\n- tiny"
+        kept_big, kept_small, trimmed = _split_to_budget(big, small)
+        assert trimmed
+        assert kept_small == small
+        # More than an even split, since the quiet source gave back its share.
+        assert len(kept_big) > _MSG_HISTORY_CHAR_BUDGET // 2
+
+    def test_no_trim_when_combined_fits(self):
+        a, b, trimmed = _split_to_budget("short a", "short b")
+        assert (a, b, trimmed) == ("short a", "short b", False)

--- a/tests/test_agent_tools_scope_widening.py
+++ b/tests/test_agent_tools_scope_widening.py
@@ -21,6 +21,7 @@ import pytest
 import api.services.agent_tools as at
 from api.services.agent_tools import (
     _CALENDAR_LADDER_DAYS,
+    _CALENDAR_MAX_DAYS,
     _positive_int,
     _TXN_LADDER_DAYS,
     _TXN_ROW_CAP,
@@ -260,13 +261,14 @@ class TestFinancesRowCap:
     async def test_cap_is_disclosed_when_hit(self, fake_monarch):
         fake_monarch.txns = self._overflowing_window()
         out = await _transactions()
-        assert f"Capped at {_TXN_ROW_CAP} rows" in out
-        assert "older matches" in out
+        assert f"Fetched the {_TXN_ROW_CAP} most recent rows" in out
+        assert "may be incomplete" in out
+        assert "older ones were dropped" in out
 
     async def test_no_cap_note_below_the_cap(self, fake_monarch):
         fake_monarch.txns = [_txn(i + 1, f"Merchant {i:04d}", -1.00) for i in range(5)]
         out = await _transactions()
-        assert "Capped at" not in out
+        assert "most recent rows" not in out
 
     async def test_cap_drops_the_oldest_rows_not_the_newest(self, fake_monarch):
         """The note claims the oldest go first, which only holds if rows arrive newest-first."""
@@ -276,7 +278,8 @@ class TestFinancesRowCap:
         ]
         out = await _transactions()
         assert "Newest Marker Shop" in out
-        assert f"Capped at {_TXN_ROW_CAP} rows" in out
+        assert f"Fetched the {_TXN_ROW_CAP} most recent rows" in out
+        assert "may be incomplete" in out
 
 
 class TestFinancesExplicitScope:
@@ -1230,3 +1233,114 @@ class TestPositiveIntHelper:
 
     def test_value_inside_bounds_is_unchanged(self):
         assert _positive_int(50, 15, 100) == 50
+
+
+class TestFinancesCategoryRowCapInteraction:
+    """`category` is filtered client-side, downstream of the row cap.
+
+    api/services/monarch.py sends limit/search/dates to the API but applies the
+    category filter to the returned page. So a window dense enough to fill the
+    cap yields a filtered handful drawn from only the newest N rows — and every
+    wider ladder rung re-fetches that same newest page, since wider windows can
+    only add older rows the cap already excluded. Before this was handled, a
+    category with no recent activity produced "There are no transactions on
+    record in category 'X'" over data that was present: the original
+    misdiagnosis, reintroduced through the cap.
+    """
+
+    def _dense_recent(self, n: int = _TXN_ROW_CAP + 100) -> list:
+        """More rows than the cap, all inside the first ladder rung."""
+        return [_txn(i % 80 + 1, f"Merchant {i:04d}", -1.00) for i in range(n)]
+
+    async def test_category_is_not_pushed_down_to_the_client(self, fake_monarch):
+        """Filtering must happen where the cap is visible, or it can't be disclosed."""
+        fake_monarch.txns = self._dense_recent()
+        await _transactions(category="Veterinary")
+        assert fake_monarch.calls
+        assert all(call["category"] is None for call in fake_monarch.calls)
+
+    async def test_capped_miss_is_not_reported_as_confirmed_absence(self, fake_monarch):
+        fake_monarch.txns = self._dense_recent() + [
+            _txn(800, "Cedar Veterinary Clinic", -240.00, category="Veterinary")
+        ]
+        out = await _transactions(category="Veterinary")
+        assert "There are no transactions on record" not in out
+        assert "NOT a confirmed absence" in out
+
+    async def test_capped_miss_names_the_cap_and_the_category(self, fake_monarch):
+        fake_monarch.txns = self._dense_recent()
+        out = await _transactions(category="Veterinary")
+        assert f"{_TXN_ROW_CAP} most recent rows" in out
+        assert "'Veterinary'" in out
+
+    async def test_capped_miss_does_not_claim_windows_it_never_reached(self, fake_monarch):
+        """Once a rung fills the cap, wider rungs are pointless — and claiming
+        them would say all history was searched when it never got past one page.
+        """
+        fake_monarch.txns = self._dense_recent()
+        out = await _transactions(category="Veterinary")
+        assert len(fake_monarch.calls) == 1
+        assert "all history" not in out
+
+    async def test_capped_miss_avoids_fault_language(self, fake_monarch):
+        fake_monarch.txns = self._dense_recent()
+        out = (await _transactions(category="Veterinary")).lower()
+        for word in FAULT_WORDS:
+            assert word not in out, f"capped miss implies a fault: {word!r}"
+
+    async def test_uncapped_absence_is_still_stated_confidently(self, fake_monarch):
+        """The honest-absence path must survive: a sparse window proves absence."""
+        fake_monarch.txns = [_txn(5, "Nimbus Cleaners", -18.00)]
+        out = await _transactions(category="Veterinary")
+        assert "There are no transactions on record" in out
+        assert "NOT a confirmed absence" not in out
+
+    async def test_category_hit_inside_the_cap_is_returned(self, fake_monarch):
+        fake_monarch.txns = [
+            _txn(5, "Cedar Veterinary Clinic", -240.00, category="Veterinary"),
+            _txn(6, "Nimbus Cleaners", -18.00),
+        ]
+        out = await _transactions(category="Veterinary")
+        assert "Cedar Veterinary Clinic" in out
+        assert "Nimbus Cleaners" not in out
+
+    async def test_category_match_is_case_insensitive(self, fake_monarch):
+        fake_monarch.txns = [
+            _txn(5, "Cedar Veterinary Clinic", -240.00, category="Veterinary")
+        ]
+        out = await _transactions(category="veterinary")
+        assert "Cedar Veterinary Clinic" in out
+
+
+class TestCalendarDaysRangeUpperBound:
+    """A huge days_range must not be blamed on the account.
+
+    search_events does `now - timedelta(days=days_back)`, which raises
+    OverflowError past a few million days. That lands in the per-account handler
+    and — now that the handler speaks up instead of staying silent — was reported
+    as an account needing re-authorisation. A bad argument dressed as expired
+    credentials is this same misdiagnosis in a new costume.
+    """
+
+    @pytest.mark.parametrize("huge", [_CALENDAR_MAX_DAYS + 1, 10**9, 4 * 10**8])
+    async def test_absurd_range_is_rejected_not_sent(self, fake_calendar, huge):
+        out = await _tool_search_calendar({"query": "standup", "days_range": huge})
+        assert [s["days_back"] for s in fake_calendar.searches] == list(
+            _CALENDAR_LADDER_DAYS
+        )
+        assert "Ignored days_range" in out
+
+    async def test_absurd_range_is_not_blamed_on_the_account(self, fake_calendar):
+        out = await _tool_search_calendar({"query": "standup", "days_range": 10**9})
+        assert "Could not reach" not in out
+        assert "re-authorising" not in out
+
+    async def test_the_bound_itself_is_still_accepted(self, fake_calendar):
+        await _tool_search_calendar(
+            {"query": "standup", "days_range": _CALENDAR_MAX_DAYS}
+        )
+        assert [s["days_back"] for s in fake_calendar.searches] == [_CALENDAR_MAX_DAYS]
+
+    async def test_bound_does_not_overflow_timedelta(self):
+        """The ceiling must be safely below where timedelta gives out."""
+        assert datetime.now(timezone.utc) - timedelta(days=_CALENDAR_MAX_DAYS)

--- a/tests/test_agent_tools_scope_widening.py
+++ b/tests/test_agent_tools_scope_widening.py
@@ -1,0 +1,1232 @@
+"""
+Tests for adaptive search scope in the finances, calendar, email, and Slack tools.
+
+Regression context: same bug class as tests/test_agent_tools_message_history.py.
+Each of these tools silently clamped its scope — transactions to 30 days,
+calendar keyword search to a fixed ±180 days, email to 5 results per account,
+Slack to 10 — and then reported a bare "No X found." that never named what was
+searched. The orchestrator could not tell "the data isn't there" from "I looked
+in the wrong place", so it invented a backend fault for data that was present.
+
+These tests pin the fix: widen when the caller stated no scope, honor an
+explicit scope exactly, disclose truncation, and make every empty result name
+the scope it searched instead of implying a fault.
+"""
+import re
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import api.services.agent_tools as at
+from api.services.agent_tools import (
+    _CALENDAR_LADDER_DAYS,
+    _positive_int,
+    _TXN_LADDER_DAYS,
+    _TXN_ROW_CAP,
+    _exhausted_note,
+    _ladder_note,
+    _parse_ymd,
+    _tool_search_calendar,
+    _tool_search_email,
+    _tool_search_finances,
+    _tool_search_slack,
+    TOOL_DEFINITIONS,
+    _TOOL_HANDLERS,
+)
+
+pytestmark = pytest.mark.unit
+
+# Phrases that would tell the orchestrator the backend broke. An empty result is
+# a fact about the data, so none of these may appear in one.
+FAULT_WORDS = ("sync issue", "permission", "failed", "error", "unavailable")
+
+
+def _days_ago(n: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=n)
+
+
+def _ymd_days_ago(n: int) -> str:
+    return _days_ago(n).strftime("%Y-%m-%d")
+
+
+def _counts_outside_range(text: str, n: int) -> bool:
+    """Does `text` attribute exactly n results to being outside the date range?
+
+    Matches the fragment and its count with an optional verb ("3 outside",
+    "3 fall outside"), so a harmless copy edit to the sentence can't fail a test
+    that is really about the attribution being right.
+    """
+    return re.search(rf"\b{n} (?:\w+ )?outside that range", text) is not None
+
+
+def _account(value: str = "personal"):
+    """Stand-in for a GoogleAccount enum member; only `.value` is read."""
+    return SimpleNamespace(value=value)
+
+
+@pytest.fixture
+def accounts(monkeypatch):
+    """One configured Google account. Tests may append more in place."""
+    configured = [_account("personal")]
+    monkeypatch.setattr(at, "get_configured_accounts", lambda: list(configured))
+    return configured
+
+
+# ---------------------------------------------------------------------------
+# search_finances — action="transactions"
+# ---------------------------------------------------------------------------
+
+def _txn(days_ago: int, merchant: str, amount: float, category: str = "Shopping") -> dict:
+    return {
+        "date": _ymd_days_ago(days_ago),
+        "merchant": merchant,
+        "category": category,
+        "amount": amount,
+    }
+
+
+@pytest.fixture
+def fake_monarch(monkeypatch):
+    """Stub the Monarch client, recording the bounds of every attempt.
+
+    Records each (start_date, end_date) pair so the widening ladder — and the
+    both-bounds-or-neither rule the real API enforces — are observable.
+    """
+    state = SimpleNamespace(txns=[], calls=[])
+
+    class FakeMonarchClient:
+        async def get_transactions(
+            self, start_date=None, end_date=None, search="", category=None, limit=None
+        ):
+            state.calls.append(
+                {
+                    "start": start_date, "end": end_date, "search": search,
+                    "category": category, "limit": limit,
+                }
+            )
+            hits = list(state.txns)
+            if start_date:
+                hits = [t for t in hits if t["date"] >= start_date]
+            if end_date:
+                hits = [t for t in hits if t["date"] <= end_date]
+            if search:
+                hits = [t for t in hits if search.lower() in t["merchant"].lower()]
+            if category:
+                hits = [t for t in hits if t["category"] == category]
+            # Newest-first, matching the real client (orderBy="date", verified
+            # descending), so the row cap drops the oldest rows.
+            hits.sort(key=lambda t: t["date"], reverse=True)
+            return hits[:limit] if limit else hits
+
+    monkeypatch.setattr("api.services.monarch.get_monarch_client", lambda: FakeMonarchClient())
+    return state
+
+
+async def _transactions(**inp) -> str:
+    return await _tool_search_finances({"action": "transactions", **inp})
+
+
+class TestFinancesWidening:
+    async def test_finds_transaction_just_outside_the_old_30d_clamp(self, fake_monarch):
+        """The original bug: a 45-day-old charge with no start_date supplied."""
+        fake_monarch.txns = [_txn(45, "Plum Grove Diner", -42.10)]
+        out = await _transactions()
+        assert "Plum Grove Diner" in out
+
+    async def test_stops_at_the_first_rung_that_hits(self, fake_monarch):
+        fake_monarch.txns = [_txn(10, "Nimbus Cleaners", -18.00)]
+        await _transactions()
+        assert len(fake_monarch.calls) == 1
+
+    async def test_walks_all_rungs_to_reach_old_history(self, fake_monarch):
+        fake_monarch.txns = [_txn(800, "Orbital Hardware Co", -310.55)]
+        out = await _transactions()
+        assert "Orbital Hardware Co" in out
+        # 90d, 365d, then all history (both bounds dropped)
+        assert len(fake_monarch.calls) == 3
+        assert fake_monarch.calls[-1]["start"] is None
+
+    async def test_ladder_rungs_match_the_declared_ladder(self, fake_monarch):
+        fake_monarch.txns = [_txn(800, "Orbital Hardware Co", -310.55)]
+        await _transactions()
+        assert len(fake_monarch.calls) == len(_TXN_LADDER_DAYS)
+
+    async def test_reports_which_windows_were_empty(self, fake_monarch):
+        fake_monarch.txns = [_txn(800, "Orbital Hardware Co", -310.55)]
+        out = await _transactions()
+        assert "nothing in last 90d, last 365d" in out
+        assert "widened to all history" in out
+
+    async def test_no_widening_note_when_first_rung_hits(self, fake_monarch):
+        fake_monarch.txns = [_txn(5, "Nimbus Cleaners", -18.00)]
+        assert "widened" not in await _transactions()
+
+    async def test_search_term_reaches_all_history(self, fake_monarch):
+        fake_monarch.txns = [
+            _txn(700, "Wexler Piano Tuning", -95.00),
+            _txn(2, "Nimbus Cleaners", -18.00),
+        ]
+        out = await _transactions(search="Wexler")
+        assert "Wexler Piano Tuning" in out
+        assert "Nimbus Cleaners" not in out
+
+
+class TestFinancesMonarchBounds:
+    """Monarch rejects a one-sided range, so every attempt must send both or neither."""
+
+    async def test_every_ladder_attempt_sends_both_bounds_or_neither(self, fake_monarch):
+        await _transactions()
+        assert fake_monarch.calls  # ladder actually ran
+        for call in fake_monarch.calls:
+            assert (call["start"] is None) == (call["end"] is None), call
+
+    async def test_dated_rungs_fill_in_the_missing_end_bound(self, fake_monarch):
+        await _transactions()
+        today = datetime.now().strftime("%Y-%m-%d")
+        for call in fake_monarch.calls[:-1]:
+            assert call["end"] == today
+
+    async def test_all_history_rung_drops_both_bounds(self, fake_monarch):
+        await _transactions()
+        assert fake_monarch.calls[-1]["start"] is None
+        assert fake_monarch.calls[-1]["end"] is None
+
+    async def test_end_date_alone_still_ladders_with_both_bounds(self, fake_monarch):
+        """end_date is not a scope statement, so widening still applies."""
+        end = _ymd_days_ago(1)
+        fake_monarch.txns = [_txn(800, "Orbital Hardware Co", -310.55)]
+        out = await _transactions(end_date=end)
+        assert "Orbital Hardware Co" in out
+        assert len(fake_monarch.calls) == 3
+        last = fake_monarch.calls[-1]
+        assert (last["start"], last["end"]) == ("1900-01-01", end)
+        assert (last["search"], last["category"]) == ("", None)
+
+
+class TestFinancesEndDateAnchor:
+    """With a past end_date the ladder must count back from it, not from today.
+
+    Counting from today would build an inverted start>end window that can only
+    return zero rows — which the ladder note would then misreport as "nothing in
+    the last 90d" when the window was never valid.
+    """
+
+    async def test_rungs_count_back_from_the_end_date(self, fake_monarch):
+        end = _ymd_days_ago(400)
+        await _transactions(end_date=end)
+        anchor = datetime.strptime(end, "%Y-%m-%d")
+        assert fake_monarch.calls[0]["start"] == (anchor - timedelta(days=90)).strftime("%Y-%m-%d")
+        assert fake_monarch.calls[1]["start"] == (anchor - timedelta(days=365)).strftime("%Y-%m-%d")
+
+    async def test_no_window_is_inverted(self, fake_monarch):
+        await _transactions(end_date=_ymd_days_ago(400))
+        for call in fake_monarch.calls:
+            if call["start"] and call["end"]:
+                assert call["start"] <= call["end"], call
+
+    async def test_windows_are_labelled_with_the_anchor(self, fake_monarch):
+        end = _ymd_days_ago(400)
+        fake_monarch.txns = [_txn(900, "Orbital Hardware Co", -310.55)]
+        out = await _transactions(end_date=end)
+        assert "Orbital Hardware Co" in out
+        assert f"nothing in last 90d before {end}, last 365d before {end}" in out
+        assert f"widened to all history before {end}" in out
+
+    async def test_empty_result_names_the_anchored_windows(self, fake_monarch):
+        end = _ymd_days_ago(400)
+        out = await _transactions(end_date=end)
+        assert f"last 90d before {end}, then last 365d before {end}" in out
+        assert f"then all history before {end}" in out
+
+
+class TestFinancesRowCap:
+    """A widened window can hold more rows than Monarch will return in one page."""
+
+    async def test_row_cap_is_passed_on_every_attempt(self, fake_monarch):
+        await _transactions()
+        assert fake_monarch.calls
+        for call in fake_monarch.calls:
+            assert call["limit"] == _TXN_ROW_CAP
+
+    @staticmethod
+    def _overflowing_window(extra: int = 10) -> list:
+        """More rows than the cap, all inside the first ladder rung."""
+        return [
+            _txn(i % 80 + 2, f"Merchant {i:04d}", -1.00)
+            for i in range(_TXN_ROW_CAP + extra)
+        ]
+
+    async def test_cap_is_disclosed_when_hit(self, fake_monarch):
+        fake_monarch.txns = self._overflowing_window()
+        out = await _transactions()
+        assert f"Capped at {_TXN_ROW_CAP} rows" in out
+        assert "older matches" in out
+
+    async def test_no_cap_note_below_the_cap(self, fake_monarch):
+        fake_monarch.txns = [_txn(i + 1, f"Merchant {i:04d}", -1.00) for i in range(5)]
+        out = await _transactions()
+        assert "Capped at" not in out
+
+    async def test_cap_drops_the_oldest_rows_not_the_newest(self, fake_monarch):
+        """The note claims the oldest go first, which only holds if rows arrive newest-first."""
+        fake_monarch.txns = [
+            _txn(1, "Newest Marker Shop", -1.00),
+            *self._overflowing_window(),
+        ]
+        out = await _transactions()
+        assert "Newest Marker Shop" in out
+        assert f"Capped at {_TXN_ROW_CAP} rows" in out
+
+
+class TestFinancesExplicitScope:
+    async def test_explicit_start_date_disables_widening(self, fake_monarch):
+        fake_monarch.txns = [_txn(200, "Orbital Hardware Co", -310.55)]
+        start = _ymd_days_ago(10)
+        out = await _transactions(start_date=start)
+        assert len(fake_monarch.calls) == 1
+        assert fake_monarch.calls[0]["start"] == start
+        assert "Orbital Hardware Co" not in out
+
+    async def test_empty_explicit_window_suggests_dropping_the_date(self, fake_monarch):
+        out = await _transactions(start_date=_ymd_days_ago(3))
+        assert "Retry without start_date" in out
+
+    async def test_explicit_window_result_carries_no_widening_note(self, fake_monarch):
+        fake_monarch.txns = [_txn(2, "Nimbus Cleaners", -18.00)]
+        out = await _transactions(start_date=_ymd_days_ago(10))
+        assert "widened" not in out
+
+
+class TestFinancesUnparseableDates:
+    async def test_unparseable_start_date_never_reaches_monarch(self, fake_monarch):
+        await _transactions(start_date="last month")
+        for call in fake_monarch.calls:
+            assert call["start"] != "last month"
+
+    async def test_unparseable_start_date_does_not_disable_widening(self, fake_monarch):
+        """A garbage date must not be honored as an intentional scope."""
+        fake_monarch.txns = [_txn(200, "Orbital Hardware Co", -310.55)]
+        out = await _transactions(start_date="last month")
+        assert "Orbital Hardware Co" in out
+        assert len(fake_monarch.calls) == 2
+
+    async def test_unparseable_date_is_disclosed_on_a_hit(self, fake_monarch):
+        fake_monarch.txns = [_txn(5, "Nimbus Cleaners", -18.00)]
+        out = await _transactions(start_date="last month")
+        assert "Ignored unparseable start_date='last month'" in out
+        assert "NOT scoped" in out
+
+    async def test_unparseable_date_is_disclosed_on_an_empty_result(self, fake_monarch):
+        out = await _transactions(end_date="soon")
+        assert "Ignored unparseable end_date='soon'" in out
+
+    async def test_a_valid_date_is_not_reported_as_ignored(self, fake_monarch):
+        fake_monarch.txns = [_txn(5, "Nimbus Cleaners", -18.00)]
+        out = await _transactions(start_date=_ymd_days_ago(10))
+        assert "Ignored unparseable" not in out
+
+
+class TestFinancesHonestEmpty:
+    async def test_empty_result_names_the_windows_searched(self, fake_monarch):
+        out = await _transactions()
+        assert "last 90d, then last 365d, then all history" in out
+
+    async def test_empty_result_does_not_suggest_a_backend_fault(self, fake_monarch):
+        """The misdiagnosis this whole change exists to prevent."""
+        out = (await _transactions()).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+    async def test_unmatched_search_suggests_dropping_it(self, fake_monarch):
+        fake_monarch.txns = [_txn(5, "Nimbus Cleaners", -18.00)]
+        out = await _transactions(search="zzqqx")
+        assert "retry without the search term" in out.lower()
+
+    async def test_empty_result_names_the_category_filter(self, fake_monarch):
+        out = await _transactions(category="Veterinary")
+        assert "'Veterinary'" in out
+        for word in FAULT_WORDS:
+            assert word not in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# search_calendar
+# ---------------------------------------------------------------------------
+
+def _event(days_ago: int, title: str, **extra):
+    return SimpleNamespace(
+        title=title,
+        start_time=_days_ago(days_ago),
+        source_account=extra.get("source_account", "personal"),
+        attendees=extra.get("attendees", []),
+        location=extra.get("location", ""),
+    )
+
+
+@pytest.fixture
+def fake_calendar(monkeypatch, accounts):
+    """Stub CalendarService, recording the days_back of every search attempt."""
+    state = SimpleNamespace(events=[], searches=[], range_calls=[], upcoming_calls=[])
+
+    class FakeCalendarService:
+        def __init__(self, account):
+            self.account = account
+
+        def search_events(self, query=None, attendee=None, days_back=30,
+                          days_forward=30, calendar_id="primary"):
+            state.searches.append({"query": query, "days_back": days_back,
+                                   "days_forward": days_forward})
+            now = datetime.now(timezone.utc)
+            lo = now - timedelta(days=days_back)
+            hi = now + timedelta(days=days_forward)
+            return [
+                e for e in state.events
+                if lo <= e.start_time <= hi
+                and (not query or query.lower() in e.title.lower())
+            ]
+
+        def get_events_in_range(self, start, end):
+            state.range_calls.append((start, end))
+            return []
+
+        def get_upcoming_events(self, days=7, max_results=15):
+            state.upcoming_calls.append({"days": days, "max_results": max_results})
+            return []
+
+    monkeypatch.setattr("api.services.calendar.CalendarService", FakeCalendarService)
+    return state
+
+
+class TestCalendarWidening:
+    async def test_finds_event_beyond_the_old_fixed_180d_window(self, fake_calendar):
+        """The clamp that hid it: search_events was pinned to ±180 days."""
+        fake_calendar.events = [_event(250, "Quarterly Review with Team Aster")]
+        out = await _tool_search_calendar({"query": "Aster"})
+        assert "Team Aster" in out
+
+    async def test_stops_at_the_first_rung_that_hits(self, fake_calendar):
+        fake_calendar.events = [_event(20, "Coffee with Rowan Placeholder")]
+        await _tool_search_calendar({"query": "Rowan"})
+        assert len(fake_calendar.searches) == 1
+        assert fake_calendar.searches[0]["days_back"] == _CALENDAR_LADDER_DAYS[0]
+
+    async def test_walks_all_rungs_to_reach_old_events(self, fake_calendar):
+        fake_calendar.events = [_event(1000, "Housewarming at Fig Lane")]
+        out = await _tool_search_calendar({"query": "Housewarming"})
+        assert "Fig Lane" in out
+        assert [s["days_back"] for s in fake_calendar.searches] == list(_CALENDAR_LADDER_DAYS)
+
+    async def test_window_is_symmetric_on_every_rung(self, fake_calendar):
+        await _tool_search_calendar({"query": "nothing-matches-this"})
+        for search in fake_calendar.searches:
+            assert search["days_back"] == search["days_forward"]
+
+    async def test_reports_which_windows_were_empty(self, fake_calendar):
+        fake_calendar.events = [_event(1000, "Housewarming at Fig Lane")]
+        out = await _tool_search_calendar({"query": "Housewarming"})
+        assert "nothing in ±180d, ±365d" in out
+        assert "widened to ±1095d" in out
+
+    async def test_no_widening_note_when_first_rung_hits(self, fake_calendar):
+        fake_calendar.events = [_event(20, "Coffee with Rowan Placeholder")]
+        out = await _tool_search_calendar({"query": "Rowan"})
+        assert "widened" not in out
+
+
+class TestCalendarExplicitScope:
+    async def test_explicit_days_range_is_honored_exactly(self, fake_calendar):
+        fake_calendar.events = [_event(300, "Housewarming at Fig Lane")]
+        out = await _tool_search_calendar({"query": "Housewarming", "days_range": 7})
+        assert len(fake_calendar.searches) == 1
+        attempt = fake_calendar.searches[0]
+        assert (attempt["query"], attempt["days_back"], attempt["days_forward"]) == (
+            "Housewarming", 7, 7,
+        )
+        assert "Fig Lane" not in out
+
+    async def test_explicit_days_range_result_carries_no_widening_note(self, fake_calendar):
+        fake_calendar.events = [_event(3, "Coffee with Rowan Placeholder")]
+        out = await _tool_search_calendar({"query": "Rowan", "days_range": 30})
+        assert "widened" not in out
+
+    async def test_empty_explicit_range_names_the_span_it_searched(self, fake_calendar):
+        out = await _tool_search_calendar({"query": "Housewarming", "days_range": 7})
+        assert "Searched ±7d." in out
+
+
+class TestCalendarUnchangedBranches:
+    async def test_date_ref_branch_does_not_ladder(self, fake_calendar):
+        out = await _tool_search_calendar({"date_ref": "2026-03-14"})
+        assert len(fake_calendar.range_calls) == 1
+        assert fake_calendar.searches == []
+        assert out == "No calendar events found."
+
+    async def test_date_ref_uses_days_range_as_a_forward_span(self, fake_calendar):
+        await _tool_search_calendar({"date_ref": "2026-03-14", "days_range": 5})
+        start, end = fake_calendar.range_calls[0]
+        assert (end - start).days == 5
+
+    async def test_upcoming_branch_does_not_ladder(self, fake_calendar):
+        out = await _tool_search_calendar({})
+        assert fake_calendar.upcoming_calls == [{"days": 7, "max_results": 15}]
+        assert fake_calendar.searches == []
+        assert out == "No calendar events found."
+
+
+class TestCalendarHonestEmpty:
+    async def test_empty_result_names_the_windows_searched(self, fake_calendar):
+        out = await _tool_search_calendar({"query": "Housewarming"})
+        assert "Searched ±180d, then ±365d, then ±1095d." in out
+
+    async def test_empty_result_names_the_query(self, fake_calendar):
+        out = await _tool_search_calendar({"query": "Housewarming"})
+        assert "'Housewarming'" in out
+
+    async def test_empty_result_does_not_suggest_a_backend_fault(self, fake_calendar):
+        out = (await _tool_search_calendar({"query": "Housewarming"})).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+    async def test_events_from_every_configured_account_are_merged(
+        self, fake_calendar, accounts
+    ):
+        accounts.append(_account("work"))
+        fake_calendar.events = [_event(20, "Coffee with Rowan Placeholder")]
+        out = await _tool_search_calendar({"query": "Rowan"})
+        assert "Rowan Placeholder" in out
+        # One rung, queried once per account.
+        assert len(fake_calendar.searches) == 2
+
+
+# ---------------------------------------------------------------------------
+# search_email
+# ---------------------------------------------------------------------------
+
+def _email(days_ago: int, subject: str, sender: str = "rowan@example.invalid"):
+    return SimpleNamespace(
+        sender=sender,
+        to="me@example.invalid",
+        subject=subject,
+        date=_days_ago(days_ago),
+        source_account="personal",
+        body=f"Synthetic body for {subject}.",
+        snippet="",
+    )
+
+
+@pytest.fixture
+def fake_gmail(monkeypatch, accounts):
+    """Stub GmailService, recording the kwargs of every search call.
+
+    Applies after/before the way Gmail would (server-side) so date scoping is
+    exercised, and caps at max_results so the truncation signal is real.
+    """
+    state = SimpleNamespace(messages=[], per_account={}, broken=set(), calls=[])
+
+    class FakeGmailService:
+        def __init__(self, account):
+            self.account = account
+
+        def search(self, keywords=None, from_email=None, to_email=None, after=None,
+                   before=None, max_results=20, include_body=False):
+            state.calls.append({
+                "account": self.account.value, "keywords": keywords,
+                "from_email": from_email, "to_email": to_email, "after": after,
+                "before": before, "max_results": max_results,
+                "include_body": include_body,
+            })
+            if self.account.value in state.broken:
+                raise RuntimeError("synthetic account outage")
+            msgs = state.per_account.get(self.account.value, state.messages)
+            if after:
+                msgs = [m for m in msgs if m.date.date() >= after.date()]
+            if before:
+                msgs = [m for m in msgs if m.date.date() <= before.date()]
+            return list(msgs)[:max_results]
+
+    monkeypatch.setattr("api.services.gmail.GmailService", FakeGmailService)
+    return state
+
+
+class TestEmailDateFilters:
+    async def test_after_and_before_reach_gmail_as_datetimes(self, fake_gmail):
+        fake_gmail.messages = [_email(40, "Nursery paint samples")]
+        await _tool_search_email({"keywords": "nursery", "after": "2026-01-01",
+                                  "before": "2026-02-01"})
+        call = fake_gmail.calls[0]
+        assert call["after"] == datetime(2026, 1, 1)
+        assert call["before"] == datetime(2026, 2, 1)
+
+    async def test_no_dates_means_no_bounds_reach_gmail(self, fake_gmail):
+        """Unscoped must mean all of history, not a silent recent-only window."""
+        await _tool_search_email({"keywords": "nursery"})
+        assert fake_gmail.calls[0]["after"] is None
+        assert fake_gmail.calls[0]["before"] is None
+
+    async def test_old_email_is_reachable_with_no_dates(self, fake_gmail):
+        fake_gmail.messages = [_email(400, "Nursery paint samples")]
+        out = await _tool_search_email({"keywords": "nursery"})
+        assert "Nursery paint samples" in out
+
+    async def test_dates_actually_scope_the_result(self, fake_gmail):
+        fake_gmail.messages = [_email(400, "Old thread"), _email(2, "Recent thread")]
+        out = await _tool_search_email({"after": _ymd_days_ago(30)})
+        assert "Recent thread" in out
+        assert "Old thread" not in out
+
+
+class TestEmailCapAndTruncation:
+    async def test_default_max_results_is_fifteen(self, fake_gmail):
+        await _tool_search_email({"keywords": "nursery"})
+        assert fake_gmail.calls[0]["max_results"] == 15
+
+    async def test_explicit_max_results_is_passed_through(self, fake_gmail):
+        await _tool_search_email({"keywords": "nursery", "max_results": 50})
+        assert fake_gmail.calls[0]["max_results"] == 50
+
+    async def test_truncation_is_disclosed_when_the_cap_is_hit(self, fake_gmail):
+        fake_gmail.messages = [_email(i + 1, f"Thread {i}") for i in range(20)]
+        out = await _tool_search_email({"keywords": "thread"})
+        assert "Capped at 15 per account" in out
+        assert "Raise max_results" in out
+
+    async def test_no_truncation_note_below_the_cap(self, fake_gmail):
+        fake_gmail.messages = [_email(1, "Only thread")]
+        out = await _tool_search_email({"keywords": "thread"})
+        assert "Capped at" not in out
+
+    async def test_truncation_on_one_of_several_accounts_is_disclosed(self, fake_gmail, accounts):
+        accounts.append(_account("work"))
+        fake_gmail.per_account = {
+            "personal": [_email(1, "Only personal thread")],
+            "work": [_email(i + 1, f"Work thread {i}") for i in range(15)],
+        }
+        out = await _tool_search_email({"keywords": "thread"})
+        assert "Capped at 15 per account" in out
+
+    async def test_a_broken_account_does_not_fake_truncation(self, fake_gmail, accounts):
+        accounts.append(_account("work"))
+        fake_gmail.broken = {"work"}
+        fake_gmail.per_account = {"personal": [_email(1, "Only personal thread")]}
+        out = await _tool_search_email({"keywords": "thread"})
+        assert "Only personal thread" in out
+        assert "Capped at" not in out
+
+
+class TestEmailUnparseableDates:
+    async def test_unparseable_after_is_dropped_before_reaching_gmail(self, fake_gmail):
+        fake_gmail.messages = [_email(3, "Nursery paint samples")]
+        out = await _tool_search_email({"keywords": "nursery", "after": "last tuesday"})
+        assert fake_gmail.calls[0]["after"] is None
+        assert "Nursery paint samples" in out
+
+    async def test_unparseable_date_is_disclosed_on_a_hit(self, fake_gmail):
+        fake_gmail.messages = [_email(3, "Nursery paint samples")]
+        out = await _tool_search_email({"keywords": "nursery", "after": "last tuesday"})
+        assert "Ignored unparseable after='last tuesday'" in out
+        assert "NOT scoped" in out
+
+    async def test_unparseable_date_is_disclosed_on_an_empty_result(self, fake_gmail):
+        out = await _tool_search_email({"keywords": "nursery", "before": "sometime"})
+        assert "Ignored unparseable before='sometime'" in out
+
+    async def test_both_unparseable_dates_are_named(self, fake_gmail):
+        fake_gmail.messages = [_email(3, "Nursery paint samples")]
+        out = await _tool_search_email({"keywords": "nursery", "after": "??",
+                                        "before": "2026-13-45"})
+        assert "after='??'" in out
+        assert "before='2026-13-45'" in out
+
+    async def test_a_valid_date_is_not_reported_as_ignored(self, fake_gmail):
+        fake_gmail.messages = [_email(3, "Nursery paint samples")]
+        out = await _tool_search_email({"keywords": "nursery", "after": "2026-01-01"})
+        assert "Ignored unparseable" not in out
+
+
+class TestEmailHonestEmpty:
+    async def test_empty_result_names_the_filters_applied(self, fake_gmail):
+        out = await _tool_search_email({
+            "keywords": "nursery", "from_email": "rowan@example.invalid",
+            "to_email": "me@example.invalid",
+        })
+        assert "keywords='nursery'" in out
+        assert "from='rowan@example.invalid'" in out
+        assert "to='me@example.invalid'" in out
+
+    async def test_empty_result_states_when_no_date_filter_applied(self, fake_gmail):
+        """Without this the model can't tell an unscoped miss from a scoped one."""
+        out = await _tool_search_email({"keywords": "nursery"})
+        assert "no date filter" in out
+
+    async def test_empty_result_names_the_date_span(self, fake_gmail):
+        out = await _tool_search_email({"keywords": "nursery", "after": "2026-01-01",
+                                        "before": "2026-02-01"})
+        assert "dates 2026-01-01" in out
+        assert "2026-02-01" in out
+        assert "no date filter" not in out
+
+    async def test_empty_result_names_a_one_sided_span(self, fake_gmail):
+        out = await _tool_search_email({"keywords": "nursery", "after": "2026-01-01"})
+        assert "dates 2026-01-01" in out
+
+    async def test_empty_result_does_not_suggest_a_backend_fault(self, fake_gmail):
+        out = (await _tool_search_email({"keywords": "nursery"})).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+    async def test_empty_result_after_an_account_outage_still_blames_no_backend(
+        self, fake_gmail
+    ):
+        """Even a genuine per-account failure must not be guessed at in the text."""
+        fake_gmail.broken = {"personal"}
+        out = (await _tool_search_email({"keywords": "nursery"})).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+
+# ---------------------------------------------------------------------------
+# search_slack
+# ---------------------------------------------------------------------------
+
+def _slack_msg(days_ago: int, content: str, *, channel="#synthetic-standup",
+               user="Rowan Placeholder", timestamp=None) -> dict:
+    return {
+        "channel_name": channel,
+        "user_name": user,
+        "timestamp": _days_ago(days_ago).isoformat() if timestamp is None else timestamp,
+        "content": content,
+    }
+
+
+@pytest.fixture
+def fake_slack(monkeypatch):
+    """Stub the Slack indexer, recording the top_k of every search."""
+    state = SimpleNamespace(results=[], calls=[], enabled=True)
+
+    class FakeIndexer:
+        def search(self, query, top_k=20, **kwargs):
+            state.calls.append({"query": query, "top_k": top_k})
+            return list(state.results)[:top_k]
+
+    monkeypatch.setattr("api.services.slack_integration.is_slack_enabled", lambda: state.enabled)
+    monkeypatch.setattr("api.services.slack_indexer.get_slack_indexer", lambda: FakeIndexer())
+    return state
+
+
+class TestSlackTopK:
+    def test_default_top_k_is_twenty(self, fake_slack):
+        _tool_search_slack({"query": "release plan"})
+        assert fake_slack.calls[0]["top_k"] == 20
+
+    def test_explicit_top_k_is_passed_through(self, fake_slack):
+        _tool_search_slack({"query": "release plan", "top_k": 75})
+        assert fake_slack.calls[0]["top_k"] == 75
+
+    def test_truncation_is_disclosed_when_top_k_is_hit(self, fake_slack):
+        fake_slack.results = [_slack_msg(i + 1, f"note {i}") for i in range(25)]
+        out = _tool_search_slack({"query": "note"})
+        assert "Ranked top 20 only" in out
+        assert "Raise top_k" in out
+
+    def test_no_truncation_note_below_top_k(self, fake_slack):
+        fake_slack.results = [_slack_msg(1, "note zero")]
+        out = _tool_search_slack({"query": "note"})
+        assert "Ranked top" not in out
+
+    def test_not_configured_is_reported_plainly(self, fake_slack):
+        fake_slack.enabled = False
+        assert _tool_search_slack({"query": "release plan"}) == "Slack is not configured."
+
+
+class TestSlackDateFilters:
+    def test_dates_post_filter_the_ranked_page(self, fake_slack):
+        fake_slack.results = [
+            _slack_msg(400, "ancient note"),
+            _slack_msg(10, "recent note"),
+        ]
+        out = _tool_search_slack({"query": "note", "after": _ymd_days_ago(30)})
+        assert "recent note" in out
+        assert "ancient note" not in out
+
+    def test_before_bound_includes_the_whole_end_day(self, fake_slack):
+        """before is a date, so a message later that same day must still match."""
+        same_day = datetime.now(timezone.utc).replace(hour=22, minute=30)
+        fake_slack.results = [_slack_msg(0, "late note", timestamp=same_day.isoformat())]
+        out = _tool_search_slack({
+            "query": "note", "before": same_day.strftime("%Y-%m-%d"),
+        })
+        assert "late note" in out
+
+    def test_undateable_message_is_excluded_when_dates_are_given(self, fake_slack):
+        """A message we can't date can't honestly be claimed to be in range."""
+        fake_slack.results = [
+            _slack_msg(1, "undateable note", timestamp="not-a-timestamp"),
+            _slack_msg(1, "dateable note"),
+        ]
+        out = _tool_search_slack({"query": "note", "after": _ymd_days_ago(30)})
+        assert "dateable note" in out
+        assert "undateable note" not in out
+
+    def test_undateable_message_is_kept_when_no_dates_are_given(self, fake_slack):
+        fake_slack.results = [_slack_msg(1, "undateable note", timestamp="not-a-timestamp")]
+        out = _tool_search_slack({"query": "note"})
+        assert "undateable note" in out
+
+    def test_undateable_exclusion_is_disclosed_alongside_hits(self, fake_slack):
+        """Dropping a match silently would understate what the range might hold."""
+        fake_slack.results = [
+            _slack_msg(1, "dateable note"),
+            _slack_msg(1, "undateable note", timestamp="not-a-timestamp"),
+        ]
+        out = _tool_search_slack({"query": "note", "after": _ymd_days_ago(30)})
+        assert "dateable note" in out
+        assert "1 matching message" in out
+        assert "no readable timestamp" in out
+        assert "in range" in out
+
+    def test_no_undateable_note_when_every_match_could_be_dated(self, fake_slack):
+        fake_slack.results = [_slack_msg(1, "dateable note")]
+        out = _tool_search_slack({"query": "note", "after": _ymd_days_ago(30)})
+        assert "no readable timestamp" not in out
+
+    def test_unparseable_date_is_ignored_and_disclosed(self, fake_slack):
+        fake_slack.results = [_slack_msg(400, "ancient note")]
+        out = _tool_search_slack({"query": "note", "after": "last week"})
+        assert "ancient note" in out, "an ignored filter must not silently scope results"
+        assert "Ignored unparseable after='last week'" in out
+        assert "NOT date-scoped" in out
+
+
+class TestSlackHonestEmpty:
+    def test_nothing_indexed_matches_is_named_as_such(self, fake_slack):
+        out = _tool_search_slack({"query": "release plan"})
+        assert "'release plan'" in out
+        assert "nothing indexed matches" in out
+
+    def test_all_matches_outside_the_range_is_a_distinct_branch(self, fake_slack):
+        """Only here does a bigger top_k help — the query did match, the dates cut it."""
+        fake_slack.results = [_slack_msg(400 + i, f"ancient note {i}") for i in range(3)]
+        out = _tool_search_slack({"query": "note", "after": _ymd_days_ago(30)})
+        assert "of 3 top-ranked matches" in out
+        assert _counts_outside_range(out, 3)
+        assert "raising top_k" in out
+
+    def test_out_of_range_and_undateable_are_counted_separately(self, fake_slack):
+        """"Outside the range" is established; "couldn't be dated" is not the same fact."""
+        fake_slack.results = [
+            _slack_msg(400, "ancient note"),
+            _slack_msg(1, "undateable note", timestamp="not-a-timestamp"),
+        ]
+        out = _tool_search_slack({"query": "note", "after": _ymd_days_ago(30)})
+        assert "of 2 top-ranked matches" in out
+        assert _counts_outside_range(out, 1)
+        assert "1 with no readable timestamp" in out
+
+    def test_all_undateable_does_not_claim_they_were_out_of_range(self, fake_slack):
+        fake_slack.results = [
+            _slack_msg(1, f"undateable note {i}", timestamp="not-a-timestamp")
+            for i in range(2)
+        ]
+        out = _tool_search_slack({"query": "note", "after": _ymd_days_ago(30)})
+        assert "2 with no readable timestamp" in out
+        assert "outside that range" not in out
+
+    def test_the_two_empty_branches_are_not_the_same_text(self, fake_slack):
+        after = _ymd_days_ago(30)
+        nothing_indexed = _tool_search_slack({"query": "note", "after": after})
+        fake_slack.results = [_slack_msg(400, "ancient note")]
+        out_of_range = _tool_search_slack({"query": "note", "after": after})
+        assert nothing_indexed != out_of_range
+        assert _counts_outside_range(out_of_range, 1)
+        assert "outside that range" not in nothing_indexed
+        assert "nothing indexed matches" in nothing_indexed
+        assert "nothing indexed matches" not in out_of_range
+
+    def test_out_of_range_empty_names_the_span(self, fake_slack):
+        fake_slack.results = [_slack_msg(400, "ancient note")]
+        out = _tool_search_slack({
+            "query": "note", "after": "2026-01-01", "before": "2026-02-01",
+        })
+        assert "between 2026-01-01" in out
+        assert "2026-02-01" in out
+
+    def test_out_of_range_empty_does_not_suggest_a_backend_fault(self, fake_slack):
+        fake_slack.results = [_slack_msg(400, "ancient note")]
+        out = _tool_search_slack({"query": "note", "after": _ymd_days_ago(30)}).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+    def test_nothing_indexed_empty_does_not_suggest_a_backend_fault(self, fake_slack):
+        """The misdiagnosis guard, with no exceptions.
+
+        This branch used to deny a fault in the words "not that the search
+        failed", which forced a carve-out in this invariant. The wording was
+        changed to "not a sign the search broke" so the guard could stay literal
+        and apply to every empty-result path identically — a blanket ban is a
+        stronger contract than one with a permitted phrase inside it.
+        """
+        out = _tool_search_slack({"query": "release plan"}).lower()
+        for word in FAULT_WORDS:
+            assert word not in out, f"empty result implies a fault: {word!r}"
+
+    def test_empty_result_states_the_coverage_limit_rather_than_a_fault(self, fake_slack):
+        out = _tool_search_slack({"query": "release plan"})
+        assert "have been indexed" in out
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+class TestLadderNote:
+    def test_empty_attempts_has_no_note(self):
+        assert _ladder_note([]) == ""
+
+    def test_single_attempt_has_no_note(self):
+        """One rung means nothing was widened, so nothing to disclose."""
+        assert _ladder_note(["last 90d"]) == ""
+
+    def test_two_attempts_name_the_empty_one(self):
+        assert _ladder_note(["last 90d", "last 365d"]) == (
+            " (nothing in last 90d; widened to last 365d)"
+        )
+
+    def test_three_attempts_list_every_empty_rung(self):
+        note = _ladder_note(["last 90d", "last 365d", "all history"])
+        assert note == " (nothing in last 90d, last 365d; widened to all history)"
+
+    def test_note_never_implies_a_fault(self):
+        note = _ladder_note(["±180d", "±365d", "±1095d"]).lower()
+        for word in FAULT_WORDS:
+            assert word not in note
+
+
+class TestExhaustedNote:
+    def test_no_attempts_is_a_bare_statement(self):
+        assert _exhausted_note("transactions", []) == "No transactions found."
+
+    def test_attempts_are_listed_in_order(self):
+        assert _exhausted_note("transactions", ["last 90d", "all history"]) == (
+            "No transactions found. Searched last 90d, then all history."
+        )
+
+    def test_single_attempt_is_named(self):
+        assert _exhausted_note("calendar events", ["±7d"]) == (
+            "No calendar events found. Searched ±7d."
+        )
+
+    def test_hint_is_appended(self):
+        out = _exhausted_note("transactions", ["last 90d"], "Try dropping the search.")
+        assert out.endswith(" Try dropping the search.")
+
+    def test_hint_without_attempts(self):
+        assert _exhausted_note("transactions", [], "Try again.") == (
+            "No transactions found. Try again."
+        )
+
+    def test_note_never_implies_a_fault(self):
+        out = _exhausted_note("transactions", ["last 90d", "all history"]).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+
+class TestParseYmd:
+    def test_parses_a_well_formed_date(self):
+        assert _parse_ymd("2026-03-14") == datetime(2026, 3, 14)
+
+    @pytest.mark.parametrize("raw", [None, "", "last tuesday", "03/14/2026",
+                                     "2026-13-01", "2026-02-30", "2026-03-14T10:00:00"])
+    def test_unusable_input_yields_none(self, raw):
+        assert _parse_ymd(raw) is None
+
+    @pytest.mark.parametrize("raw", [20260314, 3.14, ["2026-03-14"], object()])
+    def test_non_string_input_yields_none_instead_of_raising(self, raw):
+        """A garbage type must cost the filter, not the whole search."""
+        assert _parse_ymd(raw) is None
+
+    def test_returns_a_naive_datetime(self):
+        """Callers attach tzinfo themselves; a surprise tz would shift bounds."""
+        assert _parse_ymd("2026-03-14").tzinfo is None
+
+
+# ---------------------------------------------------------------------------
+# Tool schema — the model can only use parameters that are advertised
+# ---------------------------------------------------------------------------
+
+class TestToolDefinitions:
+    @pytest.mark.parametrize(
+        "name", ["search_finances", "search_calendar", "search_email", "search_slack"]
+    )
+    def test_tool_is_registered(self, name):
+        assert name in _TOOL_HANDLERS
+        assert any(t["name"] == name for t in TOOL_DEFINITIONS)
+
+    @staticmethod
+    def _schema(name: str) -> dict:
+        return next(t for t in TOOL_DEFINITIONS if t["name"] == name)["input_schema"]
+
+    @pytest.mark.parametrize("name", ["search_email", "search_slack"])
+    def test_date_params_are_advertised(self, name):
+        props = self._schema(name)["properties"]
+        assert "after" in props
+        assert "before" in props
+
+    @pytest.mark.parametrize(
+        "name,param",
+        [("search_finances", "start_date"), ("search_calendar", "days_range")],
+    )
+    def test_widening_is_documented_on_the_scope_param(self, name, param):
+        desc = self._schema(name)["properties"][param]["description"].lower()
+        assert "widen" in desc
+        assert "disables widening" in desc
+
+    def test_email_documents_the_new_default_cap(self, name="search_email"):
+        desc = self._schema(name)["properties"]["max_results"]["description"]
+        assert "15" in desc
+
+    def test_slack_documents_the_new_default_top_k(self):
+        desc = self._schema("search_slack")["properties"]["top_k"]["description"]
+        assert "20" in desc
+
+
+# ---------------------------------------------------------------------------
+# Argument hardening — the model fills these in, so garbled values arrive
+# ---------------------------------------------------------------------------
+
+class TestCalendarDaysRangeValidation:
+    """An invalid days_range must not reach CalendarService.
+
+    It used to: `timedelta(days="30")` raises inside search_events, the
+    per-account handler swallowed it, and the tool reported "No calendar events
+    found. Searched ±30d" — a scoped-looking empty for a search that never
+    validly ran. Invalid values are now treated as *unstated* so the ladder
+    applies, and the drop is disclosed.
+    """
+
+    async def test_numeric_string_is_coerced_and_honored(self, fake_calendar):
+        await _tool_search_calendar({"query": "standup", "days_range": "30"})
+        assert [s["days_back"] for s in fake_calendar.searches] == [30]
+
+    async def test_numeric_string_is_not_reported_as_ignored(self, fake_calendar):
+        out = await _tool_search_calendar({"query": "standup", "days_range": "30"})
+        assert "Ignored days_range" not in out
+
+    async def test_float_is_truncated_and_honored(self, fake_calendar):
+        out = await _tool_search_calendar({"query": "standup", "days_range": 3.9})
+        assert [s["days_back"] for s in fake_calendar.searches] == [3]
+        assert "Ignored days_range" not in out
+
+    @pytest.mark.parametrize("bad", [-30, 0, "soon", "", [], {}, "3.9"])
+    async def test_invalid_range_falls_back_to_the_ladder(self, fake_calendar, bad):
+        """Ignored means widened, not clamped to some nearby number."""
+        out = await _tool_search_calendar({"query": "standup", "days_range": bad})
+        assert [s["days_back"] for s in fake_calendar.searches] == list(
+            _CALENDAR_LADDER_DAYS
+        )
+        assert "Ignored days_range" in out
+
+    async def test_ignored_range_still_reaches_old_events(self, fake_calendar):
+        """The payoff: falling back to the ladder must actually find the data."""
+        fake_calendar.events = [_event(300, "Housewarming at Fig Lane")]
+        out = await _tool_search_calendar({"query": "Housewarming", "days_range": 0})
+        assert "Fig Lane" in out
+
+    async def test_ignored_range_is_disclosed_on_a_hit_too(self, fake_calendar):
+        """A note only on empty results would let a scoped-looking hit mislead."""
+        fake_calendar.events = [_event(20, "Coffee with Rowan Placeholder")]
+        out = await _tool_search_calendar({"query": "Rowan", "days_range": -30})
+        assert "Rowan Placeholder" in out
+        assert "Ignored days_range=-30" in out
+        assert "NOT scoped" in out
+
+    async def test_negative_range_is_not_clamped_to_one_day(self, fake_calendar):
+        """Clamping would invent a ±1d scope the caller never asked for."""
+        await _tool_search_calendar({"query": "standup", "days_range": -30})
+        assert 1 not in [s["days_back"] for s in fake_calendar.searches]
+
+    async def test_absent_range_is_not_an_error(self, fake_calendar):
+        """Omission is the normal case and must not be reported as ignored."""
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Ignored days_range" not in out
+
+    async def test_invalid_range_on_the_date_ref_branch_is_also_disclosed(
+        self, fake_calendar
+    ):
+        """date_ref uses days_range as a forward span, so a bad value matters there too."""
+        out = await _tool_search_calendar({"date_ref": "2026-03-14", "days_range": 0})
+        start, end = fake_calendar.range_calls[0]
+        assert (end - start).days == 1  # falls back to the documented default
+        assert "Ignored days_range=0" in out
+
+    async def test_none_range_is_treated_as_absent(self, fake_calendar):
+        out = await _tool_search_calendar({"query": "standup", "days_range": None})
+        assert [s["days_back"] for s in fake_calendar.searches] == list(
+            _CALENDAR_LADDER_DAYS
+        )
+        assert "Ignored days_range" not in out
+
+
+class TestCalendarAccountFailureDisclosure:
+    """A failing account must not be rendered as an empty calendar.
+
+    An expired token was logged and the tool still said "No calendar events
+    found" — a genuine backend fault dressed as absence, which is exactly the
+    misdiagnosis this change exists to prevent.
+    """
+
+    @pytest.fixture
+    def broken_calendar(self, monkeypatch, accounts):
+        state = SimpleNamespace(events_by_account={}, raising=set())
+
+        class FlakyCalendarService:
+            def __init__(self, account):
+                self.account = account
+
+            def search_events(self, query=None, days_back=30, days_forward=30, **kw):
+                if self.account.value in state.raising:
+                    raise RuntimeError("credentials expired")
+                return list(state.events_by_account.get(self.account.value, []))
+
+            def get_events_in_range(self, start, end):
+                return []
+
+            def get_upcoming_events(self, days=7, max_results=15):
+                return []
+
+        monkeypatch.setattr(
+            "api.services.calendar.CalendarService", FlakyCalendarService
+        )
+        return state
+
+    async def test_total_failure_is_disclosed_not_reported_as_empty(
+        self, broken_calendar, accounts
+    ):
+        broken_calendar.raising = {"personal"}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Could not reach personal" in out
+        assert "not necessarily an empty calendar" in out
+
+    async def test_partial_failure_still_discloses_alongside_results(
+        self, broken_calendar, accounts
+    ):
+        """The dangerous case: real events returned, one account silently missing."""
+        accounts.append(_account("work"))
+        broken_calendar.raising = {"work"}
+        broken_calendar.events_by_account["personal"] = [
+            SimpleNamespace(
+                title="Synthetic standup",
+                start_time=datetime.now(timezone.utc),
+                attendees=[],
+                location="",
+                source_account="personal",
+            )
+        ]
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Synthetic standup" in out
+        assert "Could not reach work" in out
+
+    async def test_healthy_accounts_produce_no_failure_note(
+        self, broken_calendar, accounts
+    ):
+        broken_calendar.raising = set()
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Could not reach" not in out
+
+    async def test_only_the_failing_account_is_named(self, broken_calendar, accounts):
+        accounts.append(_account("work"))
+        broken_calendar.raising = {"work"}
+        out = await _tool_search_calendar({"query": "standup"})
+        reach = out.split("Could not reach", 1)[1]
+        assert "work" in reach
+        assert "personal" not in reach
+
+    async def test_a_real_fault_is_named_rather_than_hidden(
+        self, broken_calendar, accounts
+    ):
+        """The complement of the no-fault-words rule.
+
+        An honest empty must never imply a fault — but a genuine failure must not
+        be scrubbed into one either, or we are back to reporting absence for a
+        calendar we could not read.
+        """
+        broken_calendar.raising = {"personal"}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "incomplete" in out
+        assert any(word in out.lower() for word in FAULT_WORDS)
+
+
+class TestCapNormalization:
+    """max_results/top_k double as the truncation yardstick.
+
+    A None or 0 from the model would both confuse the service layer and silently
+    disable the truncation disclosure that compares against them.
+    """
+
+    @pytest.mark.parametrize(
+        "raw,expected", [(None, 15), (0, 1), (-5, 1), ("25", 25), (99999, 100)]
+    )
+    async def test_email_cap_is_normalised_before_the_service_call(
+        self, fake_gmail, raw, expected
+    ):
+        await _tool_search_email({"keywords": "invoice", "max_results": raw})
+        assert fake_gmail.calls[0]["max_results"] == expected
+
+    @pytest.mark.parametrize(
+        "raw,expected", [(None, 20), (0, 1), (-5, 1), ("25", 25), (99999, 200)]
+    )
+    def test_slack_top_k_is_normalised_before_the_service_call(
+        self, fake_slack, raw, expected
+    ):
+        _tool_search_slack({"query": "release plan", "top_k": raw})
+        assert fake_slack.calls[0]["top_k"] == expected
+
+    def test_zero_top_k_still_searches_rather_than_faking_an_empty(self, fake_slack):
+        """A 0 cap must not manufacture "nothing matches" without looking."""
+        fake_slack.results = [_slack_msg(1, "release plan notes")]
+        out = _tool_search_slack({"query": "release plan", "top_k": 0})
+        assert fake_slack.calls[0]["top_k"] >= 1
+        assert "release plan notes" in out
+
+    def test_normalised_top_k_still_drives_the_truncation_note(self, fake_slack):
+        """The defect: a 0 cap made len(results) == top_k unreachable, so the
+        "there may be more" disclosure silently never fired."""
+        fake_slack.results = [_slack_msg(i + 1, f"note {i}") for i in range(5)]
+        out = _tool_search_slack({"query": "note", "top_k": 0})
+        assert "Ranked top 1 only" in out
+
+    async def test_normalised_email_cap_still_drives_the_truncation_note(
+        self, fake_gmail
+    ):
+        fake_gmail.messages = [_email(i + 1, f"Thread {i}") for i in range(5)]
+        out = await _tool_search_email({"keywords": "thread", "max_results": 0})
+        assert "Capped at 1 per account" in out
+
+    async def test_email_cap_above_the_maximum_is_the_yardstick_used(self, fake_gmail):
+        """Truncation must compare against the capped value, not the raw request."""
+        fake_gmail.messages = [_email(i + 1, f"Thread {i}") for i in range(150)]
+        out = await _tool_search_email({"keywords": "thread", "max_results": 99999})
+        assert "Capped at 100 per account" in out
+
+
+class TestPositiveIntHelper:
+    @pytest.mark.parametrize("raw", [None, "abc", "", [], {}, object(), "3.9", "1e3"])
+    def test_unusable_input_falls_back_to_the_default(self, raw):
+        """int() rejects a decimal *string* even though it truncates a real float."""
+        assert _positive_int(raw, 15, 100) == 15
+
+    @pytest.mark.parametrize("raw", [0, -1, -999, False])
+    def test_non_positive_is_raised_to_one(self, raw):
+        assert _positive_int(raw, 15, 100) == 1
+
+    def test_value_above_maximum_is_capped(self):
+        assert _positive_int(10**9, 15, 100) == 100
+
+    def test_numeric_string_is_accepted(self):
+        assert _positive_int("42", 15, 100) == 42
+
+    def test_float_is_truncated_toward_zero(self):
+        assert _positive_int(7.9, 15, 100) == 7
+
+    def test_value_inside_bounds_is_unchanged(self):
+        assert _positive_int(50, 15, 100) == 50


### PR DESCRIPTION
## What happened

Asking chat for a friend's newborn's name failed with:

> the system shows Sam has 6 iMessage interactions in the last 90 days, but when I try to retrieve the actual message history, nothing comes back. This could be a sync issue or a permissions problem on the backend.

There was no sync issue and no permissions problem. The message was in `data/imessage.db` the whole time — 49 days old, just outside a 30-day window nobody asked for.

## The bug class

Two halves that combine into a false fault report:

1. **A silent scope clamp** — the tool imposes a default window or cap the caller never requested.
2. **An uninformative empty** — `"No X found."` never names what was searched.

The model can't distinguish *data absent* from *I looked in the wrong place*, so it invents an explanation. `person_info` reporting interaction counts over **90 days** while `get_message_history` clamped to **30** gave it two true-but-contradictory facts and nothing to reconcile them with.

## Commit 1 — `get_message_history`

Retrieval was never the constraint: the `person_entity_id` index answers a 1000-message query in **27ms**. Context was, and message count is a poor proxy — a quiet thread's full year is ~250 tokens; 1000 messages of a busy one is ~28k, and this tool had **no truncation at all**.

- Ladder 90d → 1y → all history, stopping at the first window with hits, reporting which came up empty. Near-free by construction: widening only runs on threads too sparse to fill the narrow window.
- Ladder breaks on **either** source, so a recent iMessage can't hide an older WhatsApp thread. Fixes the same 30-day default on the WhatsApp lookback.
- Explicit dates honored exactly — a stated window is intent.
- Budget in **characters**, split across sources with the quiet one donating its share. Cuts align to `### date` headers so no message is shown without the date it belongs under.

## Commit 2 — the other four tools

| Tool | Was | Now |
|---|---|---|
| `transactions` | `now - 30d`, identical two lines | 90d → 1y → all history |
| `search_calendar` | fixed, unstated ±180d | ±180d → ±1y → ±3y |
| `search_email` | **no date params at all**; cap 5 | `after`/`before` exposed; cap 15, disclosed |
| `search_slack` | cap 10, no dates | `after`/`before` post-filter; cap 20, disclosed |

**No retry-on-empty for email or Slack** — this was in the original plan and is wrong. A keyword matching zero emails matches zero at any cap, and Slack is top-k nearest-neighbour with **no score threshold** (verified), so zero means nothing indexed matches. Raising the cap is pointless work. The cap bites in the opposite case — results silently truncated — so those are disclosed instead.

## Defects found in review and fixed

Three found by my own path-by-path testing, two of which an independent adversarial review (Codex) reached separately from the pre-fix diff:

1. **Slack asserted an unestablished fact.** A message whose timestamp failed to parse was dropped via bare `continue`, then the empty text claimed "all N top-ranked matches fall outside that range." Undateable ≠ out-of-range. This was the bug class reappearing *inside its own fix*. Now counted and attributed separately.
2. **Transactions built an inverted range.** With only `end_date`, the ladder counted back from *today* — rung 1 sent `start=2026-05-12, end=2026-03-01`. Impossible, guaranteed zero, then misreported as "nothing in last 90d." Now anchored to `end_date`.
3. **Garbled dates reached the Monarch API** unvalidated. Now normalised and disclosed.

Three more from the adversarial review:

4. **`days_range` reached `timedelta(days=...)` unvalidated** — raised, got swallowed per-account, returned a scoped-looking empty for a search that never validly ran. Now treated as unstated so the ladder applies, and disclosed. Deliberately **not clamped**: turning `-30` into `1` would invent a ±1d scope. Caps clamp; scopes don't.
5. **Swallowed per-account calendar failures** — an expired token was logged and reported as "no events." A real fault dressed as absence. Now disclosed, including on *partial* failure.
6. **Unnormalised caps** — `max_results`/`top_k` double as the truncation yardstick, so `None`/`0` both confused the service and silently disabled the disclosure.

Also folded in: `monarch.get_transactions` capped at 500 undisclosed, so a widened window silently topped out. Now an explicit cap, disclosed. Ordering verified newest-first against the live API, so the cap drops the oldest rows.

## Two suspicions that were wrong

Worth recording, because both would have been plausible bug reports:

- I expected `orderBy: "date"` to be *ascending* (Django convention), which would have made the all-history rung return the oldest 500. Tested against the live API: **newest-first**. Non-issue.
- I expected Slack timestamps might be epoch strings, which would make `fromisoformat` drop every message under a date filter. They're `isoformat()` at `slack_indexer.py:205`. Non-issue.

## Empty-result wording

The Slack branch used to deny a fault in the words "not that the search **failed**", which forced a carve-out in the invariant banning fault language. Rephrased to "not a sign the search broke" so the guard applies literally on every path — a blanket ban is a stronger contract than one with a permitted phrase inside it.


## Commit 3 — two defects the review of commit 2 turned up

Both are the same bug class again, and **one was introduced by commit 2's own fix**.

**`category` is filtered client-side, downstream of the row cap.** `monarch.py` sends limit/search/dates to the API but applies the category filter to the page that comes back. So on a window dense enough to fill the cap, the filter ran over *one page*, not the window — and because rows arrive newest-first, every wider ladder rung re-fetched that same newest page. A category with no recent activity produced "There are no transactions on record in category 'X'" over data that was present. The original misdiagnosis, reintroduced through the cap.

- Filter in the tool rather than pushing it down, so the cap and the filter sit on the same side and the pre-filter count stays knowable.
- **Stop laddering once a rung fills the cap** — wider rungs can't surface anything newer, so continuing burned API calls *and* let the note claim "all history" was searched when it never got past one page.
- A capped miss no longer claims absence at all. A sparse window still reports absence confidently; that path is the honest one and is kept.

**An absurd `days_range` was blamed on the account.** The gate rejected non-ints and values below 1 but had no ceiling. `search_events` does `now - timedelta(days=days_back)`, which raises `OverflowError` past a few million days — landing in the per-account handler that commit 2 taught to speak up, and coming back as "may need re-authorising." A bad argument dressed as expired credentials, newly reachable *because* the handler stopped staying silent. Bounded at 36500 days.

## Final verification

**232 tests** pass sequentially and under `-n 4 --dist loadscope`. Full unit suite: **3617 passed**, no new failures — the 5 remaining reproduce on a stashed clean-tree baseline, and the exact set shifts between runs.

## Verification

The originally-failing call, unchanged, now returns the answer in 6ms. Busy thread capped at ~5k tokens, down from 27.7k uncapped, with source labels and date headers intact.

## Not in this PR

An audit of the rest of the tool surface found 8 more instances, deliberately left out rather than tripling the blast radius. Two verified as accurate and worth filing first:

- **`search_drive`** (high) — `drive.py` defaults to 20, the tool narrows to **5**, and `orderBy="modifiedTime desc"` means *no relevance ranking at all*. It returns the 5 most-recently-modified files containing your query, so old documents are systematically invisible. It also swallows per-account OAuth failures into the same empty.
- **`search_finances` cashflow** (medium-high) — defaults to month-to-date and prints Income/Expenses/Savings Rate with **no window label**. On the 2nd of a month that's two days of data as an unqualified total: a confidently wrong number, which for a finance question is worse than an empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
