### PR TITLE
fix(chat): stop the remaining tools reporting a clamped scope as missing data

### DIFF
--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -83,7 +83,7 @@ Deletes a calendar event. Requires event_id from search_calendar. ALWAYS confirm
 Saves a persistent memory that will be surfaced in future conversations. Use when the user says "remember that...", "don't forget...", or asks you to remember something. Memories are automatically retrieved when relevant to future queries.
 
 **search_memories:**
-Searches saved memories by keyword. Use to recall previously saved information or check if a memory already exists.
+Searches saved memories by wording and meaning. Use to recall previously saved information or check if a memory already exists. A relevance threshold applies: if the result says candidates came close but cleared no threshold, retry with different wording (or a higher `limit`) before telling the user nothing was saved.
 
 ## When NOT to use tools
 

--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -83,7 +83,7 @@ Deletes a calendar event. Requires event_id from search_calendar. ALWAYS confirm
 Saves a persistent memory that will be surfaced in future conversations. Use when the user says "remember that...", "don't forget...", or asks you to remember something. Memories are automatically retrieved when relevant to future queries.
 
 **search_memories:**
-Searches saved memories by wording and meaning. Use to recall previously saved information or check if a memory already exists. A relevance threshold applies: if the result says candidates came close but cleared no threshold, retry with different wording (or a higher `limit`) before telling the user nothing was saved.
+Searches saved memories by wording and meaning. Use to recall previously saved information or check if a memory already exists. A relevance threshold applies: if the result says candidates scored below the threshold, retry with different wording (or a higher `limit`) before telling the user nothing was saved.
 
 ## When NOT to use tools
 

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -693,8 +693,12 @@ TOOL_DEFINITIONS = [
     {
         "name": "search_memories",
         "description": (
-            "Search saved memories by keyword. Use to recall previously saved information, "
-            "check if a memory already exists, or find specific remembered facts/preferences."
+            "Search saved memories by wording and meaning. Use to recall previously saved "
+            "information, check if a memory already exists, or find specific remembered "
+            "facts/preferences. A relevance threshold applies, so an empty result can mean "
+            "the query wording missed rather than nothing being saved — the result says "
+            "which. When it says candidates came close, retry with different wording or a "
+            "higher limit before telling the user nothing is saved."
         ),
         "input_schema": {
             "type": "object",
@@ -702,6 +706,13 @@ TOOL_DEFINITIONS = [
                 "query": {
                     "type": "string",
                     "description": "Search query for memories.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": (
+                        "Max memories to return (default 10). Raise it when the result "
+                        "says it was capped, or when widening a search that came up short."
+                    ),
                 },
             },
             "required": ["query"],
@@ -1878,17 +1889,87 @@ async def _tool_save_memory(inp: dict) -> str:
     return f"Memory saved: \"{memory.content}\" (id: {memory.id}, category: {memory.category})"
 
 
+# Result cap for memory search. Exposed to the caller so a memory that missed on
+# wording can be reached by widening; also the truncation yardstick, so it has to
+# be a usable positive int however the model fills it in.
+_MEMORY_LIMIT_DEFAULT = 10
+_MEMORY_LIMIT_MAX = 200
+
+
 def _tool_search_memories(inp: dict) -> str:
     from api.services.memory_store import get_memory_store
 
+    query = (inp.get("query") or "").strip()
+    if not query:
+        return "search_memories needs a non-empty query."
+
     store = get_memory_store()
-    memories = store.search_memories(inp["query"], limit=10)
+    limit = _positive_int(inp.get("limit", _MEMORY_LIMIT_DEFAULT), _MEMORY_LIMIT_DEFAULT, _MEMORY_LIMIT_MAX)
+    memories, stats = store.search_memories_detailed(query, limit=limit)
+
+    notes = ""
+    # The corpus bound is a fact about what was checked, never about what exists:
+    # a memory saved before the newest N was not scored at all.
+    if stats.total_saved > stats.searched:
+        notes += (
+            f"\n\n[Scored the {stats.searched} most recently saved memories of "
+            f"{stats.total_saved} saved in total — anything older was not checked, "
+            "so this is not a complete look at everything saved.]"
+        )
+    # stats.matched counts matches before the cap, so this fires only when the
+    # cap actually hid something.
+    if stats.matched > limit:
+        notes += (
+            f"\n\n[Showing {limit} of {stats.matched} matching memories — raise "
+            "`limit` to see the rest.]"
+        )
+    if not stats.semantic_available:
+        notes += (
+            "\n\n[Meaning-based recall is offline for this search, so only word "
+            "overlap was scored — a memory phrased differently from the query may "
+            "have been missed. Retrying in the memory's likely wording helps.]"
+        )
+
     if not memories:
-        return "No matching memories found."
+        if stats.near_misses:
+            # Candidates existed and were scored; only the relevance floors kept
+            # them out. Rewording is the fix, not concluding the memory is gone.
+            return (
+                f"No saved memory cleared the relevance threshold for {query!r}, but "
+                f"{stats.near_misses} came close. Something relevant is likely saved: "
+                "retry with the wording the memory itself probably uses, or with "
+                "fewer, more specific terms." + notes
+            )
+        if stats.total_saved > stats.searched:
+            # The corpus bound cut the search short, so absence was never established.
+            return (
+                f"No match for {query!r} among the {stats.searched} most recently "
+                f"saved memories, of {stats.total_saved} saved in total. Older "
+                "memories were not scored, so this does not establish that the "
+                "thing was never saved." + notes
+            )
+        if stats.total_saved == 0:
+            return (
+                f"Nothing saved matches {query!r} — no memories have been saved yet, "
+                "so there was nothing to search."
+            )
+        if stats.semantic_available:
+            return (
+                f"Nothing saved matches {query!r}. All {stats.total_saved} saved "
+                "memories were scored on both wording and meaning, and none "
+                "matched." + notes
+            )
+        # Meaning was never scored, so only a wording miss was established.
+        return (
+            f"No saved memory matches the wording of {query!r}. All "
+            f"{stats.total_saved} saved memories were checked for word overlap."
+            + notes
+        )
+
     lines = []
     for m in memories:
         lines.append(f"- [{m.category}] {m.content}")
-    return "\n".join(lines)
+    return "\n".join(lines) + notes
 
 
 # -- Workout helpers (fitness bot backend) --

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -849,13 +849,24 @@ async def execute_tool_parallel(name: str, tool_input: dict) -> str:
 # Individual tool handlers
 # ---------------------------------------------------------------------------
 
+# Matches HybridSearch.search's own default. The old default of 10 halved the
+# service default for no stated reason, so a chunk the vault ranked 12th came
+# back as "no vault results" — an empty that described the cap, not the vault.
+_VAULT_TOP_K_DEFAULT = 20
+
+
 def _tool_search_vault(inp: dict) -> str:
     from api.services.hybrid_search import HybridSearch
     hs = HybridSearch()
-    top_k = inp.get("top_k", 10)
-    results = hs.search(inp["query"], top_k=top_k)
+    # Normalised like Slack's top_k: the model fills this in, and a 0 or None
+    # would return nothing and read as an empty vault.
+    top_k = _positive_int(inp.get("top_k", _VAULT_TOP_K_DEFAULT), _VAULT_TOP_K_DEFAULT, 200)
+    query = inp["query"]
+    results = hs.search(query, top_k=top_k)
     if not results:
-        return "No vault results found."
+        # Echo the query: an empty here is a fact about this wording, and the
+        # model needs to see what was asked to try a different one.
+        return f"No vault results found for query {query!r}."
     lines = []
     for i, r in enumerate(results, 1):
         fn = r.get("file_name", "unknown")
@@ -1266,6 +1277,24 @@ def _exhausted_note(noun: str, attempts: list[str], hint: str = "") -> str:
     return f"No {noun} found.{searched}" + (f" {hint}" if hint else "")
 
 
+def _applied_filters(date_start=None, date_end=None, **named) -> list[str]:
+    """The filters actually in effect, for naming in an empty result.
+
+    Mirrors the construction in `_tool_search_email`: a filtered search that
+    found nothing establishes only that the slice is empty, so the reply must
+    describe the slice rather than the whole record. An empty list means nothing
+    was filtered — the one case where "there are none" is a fair thing to say.
+    """
+    applied = [f"{label}={value!r}" for label, value in named.items() if value]
+    if date_start and date_end:
+        applied.append(f"dates {date_start} to {date_end}")
+    elif date_start:
+        applied.append(f"dates from {date_start}")
+    elif date_end:
+        applied.append(f"dates through {date_end}")
+    return applied
+
+
 def _positive_int(raw, default: int, maximum: int) -> int:
     """Coerce a model-supplied count to a usable bound.
 
@@ -1579,6 +1608,20 @@ def _task_list(inp: dict) -> str:
         query=inp.get("query"),
     )
     if not tasks:
+        applied = _applied_filters(
+            status=inp.get("status"), context=inp.get("context"), query=inp.get("query"),
+        )
+        if applied:
+            # Filtered: say which slice was empty. A context spelled differently
+            # from the stored one matches nothing, and reporting that as "no
+            # tasks found" reads as an empty task list.
+            hint = (
+                " The context filter is compared exactly (case-insensitively), so a "
+                "different spelling of it matches nothing."
+                if inp.get("context")
+                else ""
+            )
+            return f"No tasks matched. Filtered on {', '.join(applied)}.{hint}"
         return "No tasks found."
     lines = []
     for t in tasks:
@@ -1974,6 +2017,17 @@ def _workout_list(inp: dict) -> str:
         limit=int(inp.get("limit", 10) or 10),
     )
     if not sessions:
+        applied = _applied_filters(
+            date_start=inp.get("date_start"), date_end=inp.get("date_end"), kind=inp.get("kind"),
+        )
+        if applied:
+            # A filtered miss says nothing about the rest of the log. Asked
+            # "did I train in June", "No sessions logged." reads as "you have no
+            # training history".
+            return (
+                f"No sessions matched. Filtered on {', '.join(applied)} — "
+                "sessions outside those filters may still be logged."
+            )
         return "No sessions logged."
     lines = ["Recent sessions (newest first):"]
     for s in sessions:
@@ -1990,7 +2044,15 @@ def _workout_history(inp: dict) -> str:
     rows = store.exercise_history(exercise, limit=int(inp.get("limit", 20) or 20))
     canonical = store.normalize_exercise(exercise)
     if not rows:
-        return f"No history for {canonical}."
+        # normalize_exercise title-cases anything it has no alias for, so the
+        # name looked up can differ from the name asked about. Say which name was
+        # queried — otherwise a lift logged under another spelling reads as
+        # never performed.
+        normalised = f" (normalised from {exercise.strip()!r})" if canonical != exercise.strip() else ""
+        return (
+            f"No history for exercise {canonical!r}{normalised} — that exact name was "
+            "looked up, so the same work logged under a different name would not appear here."
+        )
     lines = [f"{canonical} — recent sets:"]
     for r in rows:
         w = f" @{_fmt_num(r['weight'])} {r['unit']}" if r["weight"] else ""
@@ -2038,6 +2100,17 @@ def _workout_metrics(inp: dict) -> str:
     label = metric_type.replace("_", " ")
     limit = int(inp.get("limit", 100) or 100)
 
+    # Both query paths below share one empty result. With a window in effect it
+    # must name the window: "No body weight recorded." for a dated query implies
+    # the metric was never recorded at all.
+    dated = _applied_filters(date_start=inp.get("date_start"), date_end=inp.get("date_end"))
+    empty = (
+        f"No {label} matched. Filtered on {', '.join(dated)} — that window only, "
+        f"so {label} may be recorded outside it."
+        if dated
+        else f"No {label} recorded."
+    )
+
     # Cumulative metrics (steps, active energy) arrive from Apple Health as many
     # intraday buckets — sum them to one daily total so the trend is readable.
     if metric_type in _CUMULATIVE_METRICS:
@@ -2045,7 +2118,7 @@ def _workout_metrics(inp: dict) -> str:
             metric_type, start=inp.get("date_start"), end=inp.get("date_end"), limit=limit,
         )
         if not days:
-            return f"No {label} recorded."
+            return empty
         lines = [f"{label} (daily total):"]
         for d in days:
             unit = f" {d['unit']}" if d["unit"] else ""
@@ -2054,7 +2127,7 @@ def _workout_metrics(inp: dict) -> str:
 
     rows = store.list_metrics(metric_type, start=inp.get("date_start"), end=inp.get("date_end"), limit=limit)
     if not rows:
-        return f"No {label} recorded."
+        return empty
     lines = [f"{label}:"]
     for m in rows:
         unit = f" {m.unit}" if m.unit else ""

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -162,18 +162,34 @@ TOOL_DEFINITIONS = [
     {
         "name": "search_drive",
         "description": (
-            "Search Google Drive files (docs, sheets, presentations) across personal and work accounts."
+            "Search Google Drive files (docs, sheets, presentations) across personal "
+            "and work accounts. Drive offers no relevance ranking, so results are "
+            "ordered by modification time and the result says so whenever the "
+            "per-account cap binds — an empty result means no file in the searched "
+            "accounts contains those terms, not a sign the search broke."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Search query (matches file names and content).",
+                    "description": "Search query (matches file content).",
                 },
                 "max_results": {
                     "type": "integer",
-                    "description": "Max files to return per account (default 5).",
+                    "description": (
+                        "Max files to return per account (default 20, max 100). "
+                        "The result discloses when this cap binds."
+                    ),
+                },
+                "order_by": {
+                    "type": "string",
+                    "enum": ["recent", "oldest"],
+                    "description": (
+                        "Modification-time order: 'recent' (default, newest first) "
+                        "or 'oldest'. Use 'oldest' to reach an old document that "
+                        "newer matches would otherwise push past the cap."
+                    ),
                 },
             },
             "required": ["query"],
@@ -1073,30 +1089,139 @@ async def _tool_search_email(inp: dict) -> str:
     return "\n\n---\n".join(lines) + ignored_note + trunc_note
 
 
+# Per-account page size for a Drive search. 20 matches the DriveService default;
+# the old 5 meant any query whose terms also appeared in five newer files could
+# never surface an older one, with nothing in the output to hint at the cut.
+_DRIVE_DEFAULT_RESULTS = 20
+_DRIVE_MAX_RESULTS = 100
+
+# Drive cannot sort by relevance. files.list only accepts the documented sort
+# keys (modifiedTime, name, recency, ...) and, per Google's own search guide,
+# "if you omit the orderBy query parameter, there's no default sort order and
+# the items are returned arbitrarily". So an old document hidden behind newer
+# matches is reached by a bigger page plus an explicit oldest-first option —
+# not by pretending an unordered page is relevance-ranked.
+_DRIVE_ORDERINGS = {
+    "recent": ("modifiedTime desc", "newest-modified first"),
+    "oldest": ("modifiedTime", "oldest-modified first"),
+}
+
+
+def _drive_modified_key(f) -> datetime:
+    """Sort key over DriveFile.modified_time that can't raise mid-merge.
+
+    Files come from several accounts, so a missing or naive timestamp on one of
+    them would otherwise blow up the merge sort — outside the per-account
+    handler, taking the whole search with it.
+    """
+    ts = getattr(f, "modified_time", None)
+    if ts is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+
+
 async def _tool_search_drive(inp: dict) -> str:
     from api.services.drive import DriveService
 
-    max_results = inp.get("max_results", 5)
+    # Read before the loop: this used to be inp["query"] inside the per-account
+    # try, so a missing query raised KeyError once per account and came back as
+    # "Could not reach personal, work" — a malformed argument reported as
+    # expired credentials.
+    query = str(inp.get("query") or "").strip()
+    if not query:
+        return "No Drive search ran: search_drive needs a non-empty query."
+
+    # Normalised, not passed through: max_results is also the yardstick for the
+    # truncation check below, so a None or 0 from the model would both confuse
+    # Drive's pageSize and silently disable that disclosure.
+    max_results = _positive_int(
+        inp.get("max_results", _DRIVE_DEFAULT_RESULTS),
+        _DRIVE_DEFAULT_RESULTS,
+        _DRIVE_MAX_RESULTS,
+    )
+    raw_order = inp.get("order_by")
+    order_key = raw_order if raw_order in _DRIVE_ORDERINGS else "recent"
+    order_by, order_desc = _DRIVE_ORDERINGS[order_key]
+    bad_order = (
+        f"\n\n[Ignored order_by={raw_order!r} — must be one of "
+        f"{', '.join(sorted(_DRIVE_ORDERINGS))}; ordered {order_desc} instead.]"
+        if raw_order is not None and raw_order not in _DRIVE_ORDERINGS
+        else ""
+    )
+
+    # Accounts that raised during the search. An expired token used to be logged
+    # and the tool still said "No drive files found." — a broken connection
+    # rendered as absent data, which is the misdiagnosis this change exists to
+    # stop.
+    failed_accounts: list[str] = []
     all_files = []
+    truncated = False
     for account in get_configured_accounts():
         try:
             drive = DriveService(account)
-            files = drive.search(full_text=inp["query"], max_results=max_results)
+            files = drive.search(
+                full_text=query, max_results=max_results, order_by=order_by
+            )
             all_files.extend(files)
+            # A full page back is the only signal Drive gives that it had more.
+            if len(files) == max_results:
+                truncated = True
         except Exception as e:
             logger.warning(f"Drive {account.value} error: {e}")
+            failed_accounts.append(account.value)
+
+    failed_note = ""
+    if failed_accounts:
+        failed_note = (
+            f"\n\n[Could not reach {', '.join(failed_accounts)} — that account "
+            "errored, so this is an incomplete answer, not necessarily an empty "
+            "Drive. It may need re-authorising.]"
+        )
 
     if not all_files:
-        return "No drive files found."
+        if failed_accounts:
+            return (
+                "No Drive files came back from the accounts that responded."
+                + bad_order
+                + failed_note
+            )
+        # Name what was actually searched. A term that matches nothing matches
+        # nothing at any page size, so there is no retry to make — but the model
+        # needs to see the scope to pick a better query.
+        return (
+            f"No Drive files found. Searched file contents for {query!r} in every "
+            f"configured account, ordered {order_desc}, up to {max_results} files "
+            "per account." + bad_order
+        )
+
+    # Concatenating per-account pages would contradict the ordering the note
+    # claims, so the merged list is re-sorted the same way.
+    all_files.sort(key=_drive_modified_key, reverse=(order_key == "recent"))
+
+    trunc_note = ""
+    if truncated:
+        trunc_note = (
+            f"\n\n[Capped at {max_results} files per account and ordered "
+            f"{order_desc} — more may exist. Drive has no relevance ranking, so "
+            "the cut is by modification time, not match quality: raise "
+            "max_results, narrow the query, or pass order_by='oldest' to reach "
+            "older matches.]"
+        )
 
     lines = []
     for f in all_files:
         acct = f"[{f.source_account}]" if f.source_account else ""
+        modified = ""
+        ts = getattr(f, "modified_time", None)
+        if ts:
+            modified = f" modified {ts.strftime('%Y-%m-%d')}"
         content_preview = ""
         if f.content:
             content_preview = f"\n{f.content[:800]}"
-        lines.append(f"**{f.name}** {acct} ({f.mime_type}){content_preview}")
-    return "\n\n---\n".join(lines)
+        lines.append(
+            f"**{f.name}** {acct} ({f.mime_type}){modified}{content_preview}"
+        )
+    return "\n\n---\n".join(lines) + bad_order + trunc_note + failed_note
 
 
 def _tool_search_slack(inp: dict) -> str:

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -727,8 +727,8 @@ TOOL_DEFINITIONS = [
             "information, check if a memory already exists, or find specific remembered "
             "facts/preferences. A relevance threshold applies, so an empty result can mean "
             "the query wording missed rather than nothing being saved — the result says "
-            "which. When it says candidates came close, retry with different wording or a "
-            "higher limit before telling the user nothing is saved."
+            "which. When it says candidates scored below the threshold, retry with "
+            "different wording or a higher limit before telling the user nothing is saved."
         ),
         "input_schema": {
             "type": "object",
@@ -1196,13 +1196,17 @@ async def _tool_search_drive(inp: dict) -> str:
         _DRIVE_DEFAULT_RESULTS,
         _DRIVE_MAX_RESULTS,
     )
+    # The membership test is guarded: the model writes this argument, and an
+    # order_by=[] would raise TypeError: unhashable type on a bare `in` check —
+    # a malformed argument taken down as a tool crash rather than disclosed.
     raw_order = inp.get("order_by")
-    order_key = raw_order if raw_order in _DRIVE_ORDERINGS else "recent"
+    valid_order = isinstance(raw_order, str) and raw_order in _DRIVE_ORDERINGS
+    order_key = raw_order if valid_order else "recent"
     order_by, order_desc = _DRIVE_ORDERINGS[order_key]
     bad_order = (
         f"\n\n[Ignored order_by={raw_order!r} — must be one of "
         f"{', '.join(sorted(_DRIVE_ORDERINGS))}; ordered {order_desc} instead.]"
-        if raw_order is not None and raw_order not in _DRIVE_ORDERINGS
+        if raw_order is not None and not valid_order
         else ""
     )
 
@@ -1213,7 +1217,9 @@ async def _tool_search_drive(inp: dict) -> str:
     failed_accounts: list[str] = []
     all_files = []
     truncated = False
+    account_count = 0
     for account in get_configured_accounts():
+        account_count += 1
         try:
             drive = DriveService(account)
             files = drive.search(
@@ -1236,6 +1242,17 @@ async def _tool_search_drive(inp: dict) -> str:
         )
 
     if not all_files:
+        # With every account down, nothing was searched, so an absence was never
+        # established. Lead with the fault instead of appending it to a denial —
+        # "nothing came back" followed by a footnote still reads as an answer,
+        # and "the accounts that responded" was none of them.
+        if len(failed_accounts) == account_count and failed_accounts:
+            return (
+                f"Could not search Drive: {', '.join(failed_accounts)} errored, and "
+                "no other account was reachable. This is NOT an empty Drive — "
+                "nothing was actually searched. The account may need "
+                "re-authorising." + bad_order
+            )
         if failed_accounts:
             return (
                 "No Drive files came back from the accounts that responded."
@@ -1774,9 +1791,14 @@ def _lookup_person(inp: dict) -> str:
 async def _briefing_person(inp: dict) -> str:
     from api.services.briefings import get_briefings_service
 
-    # A window is a scope, not a cap: clamping a nonsense value would brief on a
-    # period nobody asked for, so a bad one is treated as unstated (the widening
-    # ladder then applies) and the drop is disclosed.
+    # A window is a scope, not a cap, so clamping is out — but unlike
+    # search_calendar's days_range, an unusable window here is refused outright
+    # rather than treated as unstated. Falling back to the ladder would widen the
+    # briefing past the caller's scope, and this window bounds how much of a
+    # person's history the briefing reads: emails, messages, meetings. Widening
+    # on a malformed argument exposes more personal history than was asked for,
+    # which AGENTS.md §6 says to treat as a privacy concern, and no briefing is
+    # cheaper to correct than the wrong one.
     raw_days = inp.get("interaction_days")
     interaction_days: int | None = None
     if raw_days is not None:
@@ -1786,13 +1808,14 @@ async def _briefing_person(inp: dict) -> str:
             interaction_days = None
         if interaction_days is not None and not 1 <= interaction_days <= _BRIEFING_MAX_DAYS:
             interaction_days = None
-    bad_days = (
-        f"\n\n[Ignored interaction_days={raw_days!r} — must be a whole number of "
-        f"days between 1 and {_BRIEFING_MAX_DAYS}, so this briefing is NOT scoped "
-        "to it.]"
-        if raw_days is not None and interaction_days is None
-        else ""
-    )
+        if interaction_days is None:
+            return (
+                f"No briefing generated: interaction_days={raw_days!r} is not a "
+                f"whole number of days between 1 and {_BRIEFING_MAX_DAYS}. This is "
+                "a bad argument, NOT a thin record — nothing was looked up. "
+                "Widening to the default window would cover more of this person's "
+                "history than was asked for, so re-send a valid window instead."
+            )
 
     svc = get_briefings_service()
     result = await svc.generate_briefing(
@@ -1800,15 +1823,16 @@ async def _briefing_person(inp: dict) -> str:
     )
     status = result.get("status")
     if status == "success":
-        return result.get("briefing", "Briefing generated but empty.") + bad_days
+        return result.get("briefing", "Briefing generated but empty.")
     if status in ("not_found", "limited"):
         # Thin or absent data is an absence, not a fault. Reporting it as a failed
-        # briefing invites the model to blame the backend for a quiet record.
+        # briefing invites the model to blame the backend for a quiet record. When
+        # a source did fail, that message says so itself (see generate_briefing).
         return (
             result.get("message")
             or f"Nothing on record under '{inp['name']}' to brief from."
-        ) + bad_days
-    return f"Briefing failed: {result.get('message', 'unknown error')}" + bad_days
+        )
+    return f"Briefing failed: {result.get('message', 'unknown error')}"
 
 
 def _tool_person_info(inp: dict):
@@ -2202,11 +2226,18 @@ def _tool_search_memories(inp: dict) -> str:
         if stats.near_misses:
             # Candidates existed and were scored; only the relevance floors kept
             # them out. Rewording is the fix, not concluding the memory is gone.
+            #
+            # The claim is deliberately narrow. This count includes any keyword
+            # overlap under min_relevance — one common word shared with a long
+            # query qualifies — so it cannot support "something relevant is
+            # likely saved". It states the two things the count does establish:
+            # candidates were scored, and none cleared a floor.
             return (
-                f"No saved memory cleared the relevance threshold for {query!r}, but "
-                f"{stats.near_misses} came close. Something relevant is likely saved: "
-                "retry with the wording the memory itself probably uses, or with "
-                "fewer, more specific terms." + notes
+                f"No saved memory cleared the relevance threshold for {query!r}. "
+                f"{stats.near_misses} shared some wording with it, or scored near "
+                "the meaning floor, without clearing either — a threshold miss, "
+                "not an established absence. Retry with the wording the memory "
+                "itself probably uses, or with fewer, more specific terms." + notes
             )
         if stats.total_saved > stats.searched:
             # The corpus bound cut the search short, so absence was never established.
@@ -2599,12 +2630,12 @@ _TXN_ROW_CAP = 500
 _CASHFLOW_CATEGORY_CAP = 10
 
 
-def _summary_period(inp: dict) -> tuple[str, str, str, str]:
+def _summary_period(inp: dict) -> tuple[str, str, str, str | None]:
     """Resolve the window a cashflow/budget summary covers.
 
-    Returns ``(start, end, label, dropped_note)``: the two bounds to send, a
-    human label for them, and a disclosure for any unparseable date dropped on
-    the way. The label exists because these summaries default to month-to-date,
+    Returns ``(start, end, label, error)``: the two bounds to send, a human label
+    for them, and a refusal message when the request cannot be honestly answered
+    at all. The label exists because these summaries default to month-to-date,
     and an unlabelled month-to-date total is worse than an empty result — asked
     on the 2nd, it is a two-day figure with a savings rate beside it and nothing
     to cue the reader that the period is partial.
@@ -2615,20 +2646,6 @@ def _summary_period(inp: dict) -> tuple[str, str, str, str]:
     """
     raw_start, raw_end = inp.get("start_date"), inp.get("end_date")
     start_dt, end_dt = _parse_ymd(raw_start), _parse_ymd(raw_end)
-    dropped = [
-        f"{label}={raw!r}"
-        for raw, parsed, label in (
-            (raw_start, start_dt, "start_date"),
-            (raw_end, end_dt, "end_date"),
-        )
-        if raw and not parsed
-    ]
-    dropped_note = (
-        f" [Ignored unparseable {', '.join(dropped)} — dates must be "
-        "YYYY-MM-DD, so this period is NOT the one that was asked for.]"
-        if dropped
-        else ""
-    )
 
     now = datetime.now()
     # A defaulted start counts back from end_date when one was given, not from
@@ -2638,25 +2655,46 @@ def _summary_period(inp: dict) -> tuple[str, str, str, str]:
     start = (start_dt or anchor.replace(day=1)).strftime("%Y-%m-%d")
     end = (end_dt or now).strftime("%Y-%m-%d")
 
+    # An explicitly supplied date that can't be read is refused rather than
+    # dropped. The transactions branch drops one and says so, which is safe there
+    # because every row it prints carries its own date, so a wrong period shows
+    # up in the output. An aggregate has no such cue: the number IS the whole
+    # answer, and a note beside a real total is easily reported without it.
+    unparseable = [
+        f"{label}={raw!r}"
+        for raw, parsed, label in (
+            (raw_start, start_dt, "start_date"),
+            (raw_end, end_dt, "end_date"),
+        )
+        if raw and not parsed
+    ]
+    if unparseable:
+        return start, end, f"{start} to {end}", (
+            f"Cannot summarise this period: could not read "
+            f"{', '.join(unparseable)} — dates must be YYYY-MM-DD. No figures "
+            "were fetched, because a total for some other window reads exactly "
+            "like the one that was asked for. This is a bad date argument, NOT "
+            "an empty period. Re-send the date as YYYY-MM-DD."
+        )
+
     # Anchoring fixes the defaulted case but not a caller-supplied one: a future
     # start_date, or bounds passed the wrong way round, still describe a window
     # that cannot contain anything. Querying it returns zeros that print as a
     # real $0.00 period at 0% — the confidently-wrong-number failure this whole
     # change exists to remove. Refuse it instead of reporting it.
     if start > end:
-        error = (
+        return start, end, f"{start} to {end}", (
             f"Cannot summarise {start} to {end} — the start is after the end, so "
             "that period cannot contain anything. This is a bad date range, NOT "
             "an empty period. Check the order of start_date and end_date."
         )
-        return start, end, f"{start} to {end}", dropped_note, error
 
     label = f"{start} to {end}"
     if start_dt is None and end_dt is None:
         label += " (month-to-date by default, so it may cover only part of the month)"
     elif start_dt is None:
         label += " (start defaulted to the 1st of that month)"
-    return start, end, label, dropped_note, None
+    return start, end, label, None
 
 
 async def _tool_search_finances(inp: dict) -> str:
@@ -2860,7 +2898,7 @@ async def _tool_search_finances(inp: dict) -> str:
         return "\n".join(lines)
 
     elif action == "cashflow":
-        start, end, period, dropped_note, error = _summary_period(inp)
+        start, end, period, error = _summary_period(inp)
         if error:
             return error
         cf = await client.get_cashflow_summary(start_date=start, end_date=end)
@@ -2870,7 +2908,7 @@ async def _tool_search_finances(inp: dict) -> str:
         # Period first: every figure below is only true of that window, and a
         # savings rate reads as a settled fact unless the scope precedes it.
         lines = [
-            f"**Period**: {period}{dropped_note}",
+            f"**Period**: {period}",
             f"**Income**: ${income:,.2f}",
             f"**Expenses**: ${expenses:,.2f}",
             f"**Net Savings**: ${income - expenses:,.2f}",
@@ -2909,7 +2947,7 @@ async def _tool_search_finances(inp: dict) -> str:
         return "\n".join(lines)
 
     elif action == "budgets":
-        start, end, period, dropped_note, error = _summary_period(inp)
+        start, end, period, error = _summary_period(inp)
         if error:
             return error
         budgets = await client.get_budgets(start_date=start, end_date=end)
@@ -2923,10 +2961,10 @@ async def _tool_search_finances(inp: dict) -> str:
                 + " That is a statement about this period, not about whether "
                 "budgets are set up — a period that hasn't populated yet looks "
                 "the same as one with none. Try a different start_date/end_date "
-                "to check another period." + dropped_note
+                "to check another period."
             )
         lines = [
-            f"Budgets for {period}:{dropped_note}",
+            f"Budgets for {period}:",
             "| Category | Budgeted | Actual | Remaining |",
             "|----------|----------|--------|-----------|",
         ]

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -510,7 +510,9 @@ TOOL_DEFINITIONS = [
                         "Start date (YYYY-MM-DD). For transactions, omit to auto-widen "
                         "through 90 days → 1 year → all history, stopping at the first "
                         "window with matches; setting it disables widening. "
-                        "cashflow/budgets default to the 1st of the current month."
+                        "cashflow/budgets default to the 1st of the month end_date "
+                        "falls in (the current month when end_date is omitted) and "
+                        "state the period they cover."
                     ),
                 },
                 "end_date": {
@@ -2215,6 +2217,57 @@ _TXN_LADDER_DAYS = (90, 365, None)
 # so hitting the cap drops the OLDEST rows, not the most recent.
 _TXN_ROW_CAP = 500
 
+# Spending categories shown in a cashflow breakdown, highest amount first.
+# Named so the truncation disclosure can quote it instead of hardcoding 10.
+_CASHFLOW_CATEGORY_CAP = 10
+
+
+def _summary_period(inp: dict) -> tuple[str, str, str, str]:
+    """Resolve the window a cashflow/budget summary covers.
+
+    Returns ``(start, end, label, dropped_note)``: the two bounds to send, a
+    human label for them, and a disclosure for any unparseable date dropped on
+    the way. The label exists because these summaries default to month-to-date,
+    and an unlabelled month-to-date total is worse than an empty result — asked
+    on the 2nd, it is a two-day figure with a savings rate beside it and nothing
+    to cue the reader that the period is partial.
+
+    Both bounds are always filled in. Monarch rejects a one-sided range ("You
+    must specify both a startDate and endDate, not just one of them"), and a
+    period whose end the caller can't see isn't a stated period at all.
+    """
+    raw_start, raw_end = inp.get("start_date"), inp.get("end_date")
+    start_dt, end_dt = _parse_ymd(raw_start), _parse_ymd(raw_end)
+    dropped = [
+        f"{label}={raw!r}"
+        for raw, parsed, label in (
+            (raw_start, start_dt, "start_date"),
+            (raw_end, end_dt, "end_date"),
+        )
+        if raw and not parsed
+    ]
+    dropped_note = (
+        f" [Ignored unparseable {', '.join(dropped)} — dates must be "
+        "YYYY-MM-DD, so this period is NOT the one that was asked for.]"
+        if dropped
+        else ""
+    )
+
+    now = datetime.now()
+    # A defaulted start counts back from end_date when one was given, not from
+    # today: pairing this month's 1st with a past end_date builds an inverted
+    # window that can only report zeros, which then reads as a real $0 month.
+    anchor = end_dt or now
+    start = (start_dt or anchor.replace(day=1)).strftime("%Y-%m-%d")
+    end = (end_dt or now).strftime("%Y-%m-%d")
+
+    label = f"{start} to {end}"
+    if start_dt is None and end_dt is None:
+        label += " (month-to-date by default, so it may cover only part of the month)"
+    elif start_dt is None:
+        label += " (start defaulted to the 1st of that month)"
+    return start, end, label, dropped_note
+
 
 async def _tool_search_finances(inp: dict) -> str:
     from api.services.monarch import get_monarch_client
@@ -2417,14 +2470,13 @@ async def _tool_search_finances(inp: dict) -> str:
         return "\n".join(lines)
 
     elif action == "cashflow":
-        start = inp.get("start_date")
-        end = inp.get("end_date")
-        if not start:
-            now = datetime.now()
-            start = now.replace(day=1).strftime("%Y-%m-%d")
+        start, end, period, dropped_note = _summary_period(inp)
         cf = await client.get_cashflow_summary(start_date=start, end_date=end)
         cats = await client.get_cashflow_by_category(start_date=start, end_date=end)
+        # Period first: every figure below is only true of that window, and a
+        # savings rate reads as a settled fact unless the scope precedes it.
         lines = [
+            f"**Period**: {period}{dropped_note}",
             f"**Income**: ${cf['total_income']:,.2f}",
             f"**Expenses**: ${cf['total_expenses']:,.2f}",
             f"**Net Savings**: ${cf['total_income'] - cf['total_expenses']:,.2f}",
@@ -2432,20 +2484,39 @@ async def _tool_search_finances(inp: dict) -> str:
         ]
         if cats:
             lines.append("\nTop categories:")
-            for c in cats[:10]:
+            for c in cats[:_CASHFLOW_CATEGORY_CAP]:
                 lines.append(f"- {c['category']}: ${c['amount']:,.2f}")
+            # Without this, a category just outside the cut reads as zero spend.
+            if len(cats) > _CASHFLOW_CATEGORY_CAP:
+                lines.append(
+                    f"... and {len(cats) - _CASHFLOW_CATEGORY_CAP} more categories "
+                    "(breakdown truncated to the largest "
+                    f"{_CASHFLOW_CATEGORY_CAP} — the rest are not zero)"
+                )
+        else:
+            lines.append("\nNo categorized spending in this period.")
         return "\n".join(lines)
 
     elif action == "budgets":
-        start = inp.get("start_date")
-        end = inp.get("end_date")
-        if not start:
-            now = datetime.now()
-            start = now.replace(day=1).strftime("%Y-%m-%d")
+        start, end, period, dropped_note = _summary_period(inp)
         budgets = await client.get_budgets(start_date=start, end_date=end)
         if not budgets:
-            return "No budgets found."
-        lines = ["| Category | Budgeted | Actual | Remaining |", "|----------|----------|--------|-----------|"]
+            # The period is always bounded (month-to-date at the widest), so
+            # nothing here establishes that no budgets exist — a month whose
+            # figures haven't populated yet looks identical to an account with
+            # none configured. Say only what was checked.
+            return (
+                _exhausted_note("budgets", [period])
+                + " That is a statement about this period, not about whether "
+                "budgets are set up — a period that hasn't populated yet looks "
+                "the same as one with none. Try a different start_date/end_date "
+                "to check another period." + dropped_note
+            )
+        lines = [
+            f"Budgets for {period}:{dropped_note}",
+            "| Category | Budgeted | Actual | Remaining |",
+            "|----------|----------|--------|-----------|",
+        ]
         for b in budgets:
             lines.append(f"| {b['category']} | ${b['budgeted']:,.2f} | ${b['actual']:,.2f} | ${b['remaining']:,.2f} |")
         return "\n".join(lines)

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -1200,12 +1200,17 @@ async def _tool_search_drive(inp: dict) -> str:
 
     trunc_note = ""
     if truncated:
+        # Point at the other end of the ordering, never the one already used.
+        flip = (
+            "order_by='oldest' to reach older matches"
+            if order_key == "recent"
+            else "order_by='recent' to reach newer matches"
+        )
         trunc_note = (
             f"\n\n[Capped at {max_results} files per account and ordered "
             f"{order_desc} — more may exist. Drive has no relevance ranking, so "
             "the cut is by modification time, not match quality: raise "
-            "max_results, narrow the query, or pass order_by='oldest' to reach "
-            "older matches.]"
+            f"max_results, narrow the query, or pass {flip}.]"
         )
 
     lines = []

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -281,7 +281,10 @@ TOOL_DEFINITIONS = [
             "Look up a person or generate a comprehensive briefing. "
             "Use 'lookup' for any query mentioning a person — returns entity_id, emails, phones, "
             "relationship strength, days since last contact, interaction counts per channel (90 days), "
-            "and known facts. Use 'briefing' for meeting prep or deep dives."
+            "and known facts (highest-confidence first; the output says so when it truncates). "
+            "Use 'briefing' for meeting prep or deep dives — it searches the last 90 days of "
+            "interactions and widens automatically if that window is empty; pass interaction_days "
+            "to pin a specific window instead."
         ),
         "input_schema": {
             "type": "object",
@@ -298,6 +301,15 @@ TOOL_DEFINITIONS = [
                 "email": {
                     "type": "string",
                     "description": "Person's email (optional, improves briefing accuracy).",
+                },
+                "interaction_days": {
+                    "type": "integer",
+                    "description": (
+                        "Briefing only: interaction lookback in days (1-3650). Omit "
+                        "unless the user named a period — omitted means 90 days, "
+                        "widening to a year then all history if that is empty. A "
+                        "value here is honoured exactly, with no widening."
+                    ),
                 },
             },
             "required": ["action", "name"],
@@ -1499,15 +1511,33 @@ def _split_to_budget(imsg_text: str, wa_text: str) -> tuple[str, str, bool]:
 
 # -- People helpers --
 
+# Facts shown by person_info(lookup). Doubles as the yardstick for the truncation
+# disclosure below, so it must be a real number rather than a bare slice.
+_PERSON_FACT_LIMIT = 15
+
+# Upper bound on a caller-supplied briefing window. The interaction index spans
+# about ten years, so anything past this is not a window the data can honour.
+_BRIEFING_MAX_DAYS = 3650
+
+
 def _lookup_person(inp: dict) -> str:
     from api.services.entity_resolver import get_entity_resolver
     from api.services.relationship_summary import get_relationship_summary, format_relationship_context
-    from api.services.person_facts import get_person_fact_store
+    from api.services.person_facts import get_person_fact_store, rank_facts
 
     resolver = get_entity_resolver()
-    result = resolver.resolve(name=inp["name"])
+    name = inp["name"]
+    result = resolver.resolve(name=name)
     if not result or not result.entity:
-        return f"No person found matching '{inp['name']}'."
+        # Name the term searched: the model needs to tell "that spelling didn't
+        # match" from "this person isn't in the index" before it decides whether
+        # to retry, and downstream tools depend on the entity_id this returns.
+        return (
+            f"No person found matching '{name}'. That exact term was searched "
+            "against the people index and nothing matched it closely enough to be "
+            "treated as the same person. Try a fuller name, a different spelling, "
+            "or pass the person's email address."
+        )
 
     entity = result.entity
     parts = [f"**{entity.canonical_name}** (entity_id: {entity.id})"]
@@ -1527,23 +1557,65 @@ def _lookup_person(inp: dict) -> str:
     if rel:
         parts.append(format_relationship_context(rel))
 
-    # Person facts
+    # Person facts. Ranked by confidence rather than the store's category/key
+    # order: an alphabetical cut can drop "family: spouse" for a work fact purely
+    # on spelling, and the model then answers that it doesn't know.
     fact_store = get_person_fact_store()
-    facts = fact_store.get_for_person(entity.id)
+    facts = rank_facts(fact_store.get_for_person(entity.id))
     if facts:
-        fact_lines = [f"- {f.category}: {f.key} = {f.value}" for f in facts[:15]]
-        parts.append("Known facts:\n" + "\n".join(fact_lines))
+        shown = facts[:_PERSON_FACT_LIMIT]
+        header = "Known facts:"
+        if len(facts) > len(shown):
+            header = (
+                f"Known facts ({len(shown)} of {len(facts)} shown, "
+                "highest-confidence first; the rest were truncated for length — "
+                "ask for a specific category to see more):"
+            )
+        parts.append(header + "\n" + "\n".join(
+            f"- {f.category}: {f.key} = {f.value}" for f in shown
+        ))
 
     return "\n\n".join(parts)
 
 
 async def _briefing_person(inp: dict) -> str:
     from api.services.briefings import get_briefings_service
+
+    # A window is a scope, not a cap: clamping a nonsense value would brief on a
+    # period nobody asked for, so a bad one is treated as unstated (the widening
+    # ladder then applies) and the drop is disclosed.
+    raw_days = inp.get("interaction_days")
+    interaction_days: int | None = None
+    if raw_days is not None:
+        try:
+            interaction_days = int(raw_days)
+        except (TypeError, ValueError):
+            interaction_days = None
+        if interaction_days is not None and not 1 <= interaction_days <= _BRIEFING_MAX_DAYS:
+            interaction_days = None
+    bad_days = (
+        f"\n\n[Ignored interaction_days={raw_days!r} — must be a whole number of "
+        f"days between 1 and {_BRIEFING_MAX_DAYS}, so this briefing is NOT scoped "
+        "to it.]"
+        if raw_days is not None and interaction_days is None
+        else ""
+    )
+
     svc = get_briefings_service()
-    result = await svc.generate_briefing(inp["name"], email=inp.get("email"))
-    if result.get("status") == "success":
-        return result.get("briefing", "Briefing generated but empty.")
-    return f"Briefing failed: {result.get('message', 'unknown error')}"
+    result = await svc.generate_briefing(
+        inp["name"], email=inp.get("email"), interaction_days=interaction_days
+    )
+    status = result.get("status")
+    if status == "success":
+        return result.get("briefing", "Briefing generated but empty.") + bad_days
+    if status in ("not_found", "limited"):
+        # Thin or absent data is an absence, not a fault. Reporting it as a failed
+        # briefing invites the model to blame the backend for a quiet record.
+        return (
+            result.get("message")
+            or f"Nothing on record under '{inp['name']}' to brief from."
+        ) + bad_days
+    return f"Briefing failed: {result.get('message', 'unknown error')}" + bad_days
 
 
 def _tool_person_info(inp: dict):

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -2261,12 +2261,25 @@ def _summary_period(inp: dict) -> tuple[str, str, str, str]:
     start = (start_dt or anchor.replace(day=1)).strftime("%Y-%m-%d")
     end = (end_dt or now).strftime("%Y-%m-%d")
 
+    # Anchoring fixes the defaulted case but not a caller-supplied one: a future
+    # start_date, or bounds passed the wrong way round, still describe a window
+    # that cannot contain anything. Querying it returns zeros that print as a
+    # real $0.00 period at 0% — the confidently-wrong-number failure this whole
+    # change exists to remove. Refuse it instead of reporting it.
+    if start > end:
+        error = (
+            f"Cannot summarise {start} to {end} — the start is after the end, so "
+            "that period cannot contain anything. This is a bad date range, NOT "
+            "an empty period. Check the order of start_date and end_date."
+        )
+        return start, end, f"{start} to {end}", dropped_note, error
+
     label = f"{start} to {end}"
     if start_dt is None and end_dt is None:
         label += " (month-to-date by default, so it may cover only part of the month)"
     elif start_dt is None:
         label += " (start defaulted to the 1st of that month)"
-    return start, end, label, dropped_note
+    return start, end, label, dropped_note, None
 
 
 async def _tool_search_finances(inp: dict) -> str:
@@ -2470,35 +2483,58 @@ async def _tool_search_finances(inp: dict) -> str:
         return "\n".join(lines)
 
     elif action == "cashflow":
-        start, end, period, dropped_note = _summary_period(inp)
+        start, end, period, dropped_note, error = _summary_period(inp)
+        if error:
+            return error
         cf = await client.get_cashflow_summary(start_date=start, end_date=end)
         cats = await client.get_cashflow_by_category(start_date=start, end_date=end)
+        income = cf["total_income"]
+        expenses = cf["total_expenses"]
         # Period first: every figure below is only true of that window, and a
         # savings rate reads as a settled fact unless the scope precedes it.
         lines = [
             f"**Period**: {period}{dropped_note}",
-            f"**Income**: ${cf['total_income']:,.2f}",
-            f"**Expenses**: ${cf['total_expenses']:,.2f}",
-            f"**Net Savings**: ${cf['total_income'] - cf['total_expenses']:,.2f}",
-            f"**Savings Rate**: {cf['savings_rate'] * 100:.1f}%" if cf['savings_rate'] <= 1 else f"**Savings Rate**: {cf['savings_rate']:.1f}%",
+            f"**Income**: ${income:,.2f}",
+            f"**Expenses**: ${expenses:,.2f}",
+            f"**Net Savings**: ${income - expenses:,.2f}",
         ]
+        # Derived from the two figures printed above rather than taken from the
+        # upstream field. With no income the rate is undefined, and printing
+        # "0.0%" for it states something untrue; the upstream value's unit is
+        # also ambiguous (a bare -25 could mean -25% or -2500%), and a
+        # magnitude heuristic guesses wrong on negative rates.
+        if income > 0:
+            lines.append(f"**Savings Rate**: {(income - expenses) / income * 100:.1f}%")
+        else:
+            lines.append("**Savings Rate**: n/a (no income in this period)")
+
         if cats:
+            shown = cats[:_CASHFLOW_CATEGORY_CAP]
             lines.append("\nTop categories:")
-            for c in cats[:_CASHFLOW_CATEGORY_CAP]:
+            for c in shown:
                 lines.append(f"- {c['category']}: ${c['amount']:,.2f}")
             # Without this, a category just outside the cut reads as zero spend.
-            if len(cats) > _CASHFLOW_CATEGORY_CAP:
+            if len(cats) > len(shown):
                 lines.append(
-                    f"... and {len(cats) - _CASHFLOW_CATEGORY_CAP} more categories "
-                    "(breakdown truncated to the largest "
-                    f"{_CASHFLOW_CATEGORY_CAP} — the rest are not zero)"
+                    f"... and {len(cats) - len(shown)} more categories not shown "
+                    f"(largest {_CASHFLOW_CATEGORY_CAP} of {len(cats)} listed)"
                 )
+        elif expenses:
+            # Expenses exist but arrived unclassified. Saying "no spending" here
+            # would contradict the Expenses line printed directly above it.
+            lines.append(
+                "\nNo category breakdown came back for this period, though the "
+                "expenses above are non-zero — the breakdown is unavailable, not "
+                "empty."
+            )
         else:
-            lines.append("\nNo categorized spending in this period.")
+            lines.append("\nNo spending in this period.")
         return "\n".join(lines)
 
     elif action == "budgets":
-        start, end, period, dropped_note = _summary_period(inp)
+        start, end, period, dropped_note, error = _summary_period(inp)
+        if error:
+            return error
         budgets = await client.get_budgets(start_date=start, end_date=end)
         if not budgets:
             # The period is always bounded (month-to-date at the widest), so

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -966,12 +966,16 @@ async def _tool_search_calendar(inp: dict) -> str:
     # logged and then reported as "no events" — a real fault dressed up as an
     # empty result, which is the misdiagnosis this whole change exists to stop.
     failed_accounts: list[str] = []
+    account_count = 0
 
     def _fetch(search_range: int | None) -> list:
         """Collect events from every configured account for one window."""
+        nonlocal account_count
         events = []
         failed_accounts.clear()
+        account_count = 0
         for account in get_configured_accounts():
+            account_count += 1
             try:
                 cal = CalendarService(account)
                 if query:
@@ -999,6 +1003,11 @@ async def _tool_search_calendar(inp: dict) -> str:
             windows_tried.append(f"±{days}d")
             if all_events:
                 break
+            # Every account errored, so this rung searched nothing. Widening
+            # cannot help a broken connection, and continuing would let the
+            # note claim three windows were searched when none were.
+            if account_count and len(failed_accounts) == account_count:
+                break
     else:
         # date_ref / upcoming branches set their own range; search_range unused.
         all_events = _fetch(None)
@@ -1011,7 +1020,19 @@ async def _tool_search_calendar(inp: dict) -> str:
             "calendar. It may need re-authorising.]"
         )
 
+    total_failure = bool(failed_accounts) and len(failed_accounts) == account_count
+
     if not all_events:
+        # With every account down, nothing was searched, so an absence was never
+        # established. Lead with the fault instead of appending it to a denial —
+        # "nothing matches" followed by a footnote still reads as an answer.
+        if total_failure:
+            return (
+                f"Could not search the calendar: {', '.join(failed_accounts)} "
+                "errored, and no other account was reachable. This is NOT an "
+                "empty calendar — nothing was actually searched. The account may "
+                "need re-authorising." + bad_range
+            )
         if windows_tried:
             hint = f"Nothing on the calendar matches {query!r} in that span."
             return (

--- a/api/services/briefings.py
+++ b/api/services/briefings.py
@@ -9,17 +9,22 @@ Generates stakeholder briefings by aggregating:
 - Interaction history
 """
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Optional
 from dataclasses import dataclass, field
 
 from config.settings import settings
-from api.services.people import resolve_person_name, PEOPLE_DICTIONARY
+from api.services.people import resolve_person_name
 from api.services.hybrid_search import HybridSearch
 from api.services.task_manager import TaskManager, get_task_manager
 from api.services.synthesizer import get_synthesizer
 from api.services.entity_resolver import EntityResolver, get_entity_resolver
-from api.services.interaction_store import InteractionStore, get_interaction_store
+from api.services.interaction_store import (
+    NO_INTERACTIONS_PREFIX,
+    InteractionStore,
+    format_window_label,
+    get_interaction_store,
+)
 
 # iMessage imports
 try:
@@ -29,6 +34,17 @@ except ImportError:
     HAS_IMESSAGE = False
 
 logger = logging.getLogger(__name__)
+
+# Widening ladder for the briefing's interaction window when the caller stated
+# none. Ninety days is the right first look for meeting prep, but a relationship
+# last touched five months ago is exactly when a briefing is most useful, so an
+# empty narrow window widens instead of being reported as no history at all.
+_INTERACTION_LADDER_DAYS = (90, 365, None)  # None = the store's full window
+
+# Facts below this extraction confidence are kept out of the briefing. The floor
+# is disclosed whenever it drops anything: a silently thinned set of facts reads
+# as the complete set, which is worse than showing none.
+FACT_CONFIDENCE_FLOOR = 0.6
 
 
 @dataclass
@@ -56,6 +72,11 @@ class BriefingContext:
     # v2: Interaction history (formatted markdown)
     interaction_history: str = ""
 
+    # Which lookback windows the interaction search actually used, oldest attempt
+    # first, so an empty result can name its scope instead of implying absence.
+    interaction_windows_tried: list[str] = field(default_factory=list)
+    interaction_lookup_failed: bool = False  # a real fault, not an empty record
+
     # iMessage history (formatted markdown)
     imessage_history: str = ""
 
@@ -67,6 +88,7 @@ class BriefingContext:
 
     # v3: CRM enrichment
     person_facts: list[dict] = field(default_factory=list)  # Extracted facts
+    facts_withheld_low_confidence: int = 0  # dropped by FACT_CONFIDENCE_FLOOR
     aliases: list[str] = field(default_factory=list)        # Known aliases
     relationship_strength: float = 0.0                       # 0-100 scale
     tags: list[str] = field(default_factory=list)           # User-defined tags
@@ -123,7 +145,8 @@ Generate a briefing in this exact format:
 
 ### Interaction Timeline
 [If interaction history is available, summarize recent touchpoints: emails, meetings, note mentions]
-[If not available, omit this section]
+[If the Interaction History section reports an empty window, state which window was searched and that nothing turned up in it — do not generalise that to the person having no record, and do not contradict the Last interaction date above]
+[If it was not searched at all, omit this section]
 
 ### Recent Context
 - [2-4 bullet points of key recent information from notes]
@@ -143,7 +166,9 @@ Generate a briefing in this exact format:
 ---
 Sources: [list source files]
 
-Keep it concise and actionable. Focus on what {user_name} needs to know for their next interaction."""
+Keep it concise and actionable. Focus on what {user_name} needs to know for their next interaction.
+
+Scope rule: the sections above state the windows and thresholds they searched. Never turn an empty or partial section into a claim about what exists — say what was checked. If a section reports facts withheld or a widened window, carry that caveat into the briefing."""
 
 
 class BriefingsService:
@@ -202,13 +227,21 @@ class BriefingsService:
                 logger.debug(f"IMessageStore not available: {e}")
         return self._imessage_store
 
-    def gather_context(self, person_name: str, email: Optional[str] = None) -> Optional[BriefingContext]:
+    def gather_context(
+        self,
+        person_name: str,
+        email: Optional[str] = None,
+        interaction_days: Optional[int] = None,
+    ) -> Optional[BriefingContext]:
         """
         Gather all context about a person.
 
         Args:
             person_name: Name to look up (will be resolved)
             email: Optional email for better resolution (v2)
+            interaction_days: Caller's interaction lookback in days. A stated
+                window is intent and is honoured exactly; with none, the
+                _INTERACTION_LADDER_DAYS ladder widens until something is found.
 
         Returns:
             BriefingContext with all gathered data, or None if person unknown
@@ -256,9 +289,11 @@ class BriefingsService:
         # v3: Get PersonFacts (extracted facts about this person)
         if context.entity_id:
             try:
-                from api.services.person_facts import get_person_fact_store
+                from api.services.person_facts import get_person_fact_store, rank_facts
                 fact_store = get_person_fact_store()
-                facts = fact_store.get_for_person(context.entity_id)
+                facts = rank_facts(fact_store.get_for_person(context.entity_id))
+                kept = [f for f in facts if (f.confidence or 0.0) >= FACT_CONFIDENCE_FLOOR]
+                context.facts_withheld_low_confidence = len(facts) - len(kept)
                 context.person_facts = [
                     {
                         "category": f.category,
@@ -267,20 +302,32 @@ class BriefingsService:
                         "confidence": f.confidence,
                         "confirmed": f.confirmed_by_user,
                     }
-                    for f in facts if f.confidence >= 0.6
+                    for f in kept
                 ]
                 logger.debug(f"Loaded {len(context.person_facts)} facts for {person_name}")
             except Exception as e:
                 logger.warning(f"Could not get person facts: {e}")
 
-        # Get interaction history from v2 InteractionStore (if available and entity found)
+        # Get interaction history from v2 InteractionStore (if available and entity
+        # found). A stated window is answered exactly; otherwise walk the ladder so
+        # a quiet quarter doesn't get reported as a person with no history.
         if self.interaction_store and context.entity_id:
-            try:
-                context.interaction_history = self.interaction_store.format_interaction_history(
-                    context.entity_id, days_back=90, limit=20
-                )
-            except Exception as e:
-                logger.warning(f"Could not get interaction history: {e}")
+            windows = (interaction_days,) if interaction_days else _INTERACTION_LADDER_DAYS
+            for days in windows:
+                try:
+                    formatted = self.interaction_store.format_interaction_history(
+                        context.entity_id, days_back=days, limit=20
+                    )
+                except Exception as e:
+                    # A store that errors is a fault, not an empty record, and must
+                    # never be summarised as "nothing found".
+                    logger.warning(f"Could not get interaction history: {e}")
+                    context.interaction_lookup_failed = True
+                    break
+                context.interaction_windows_tried.append(format_window_label(days))
+                if formatted and not formatted.startswith(NO_INTERACTIONS_PREFIX):
+                    context.interaction_history = formatted
+                    break
 
         # Get iMessage history (if available and entity found)
         if self.imessage_store and context.entity_id:
@@ -358,19 +405,93 @@ class BriefingsService:
 
         return "\n".join(lines)
 
-    async def generate_briefing(self, person_name: str, email: Optional[str] = None) -> dict:
+    def _format_interaction_section(self, context: BriefingContext) -> str:
+        """Interaction history for the prompt, or a statement of what was searched.
+
+        The old collapse to "_No interaction history available._" is what let a
+        briefing assert a blank over years of record: it discarded the window the
+        search actually used. Every branch here names its scope instead.
+        """
+        if context.interaction_lookup_failed:
+            return (
+                "_The interaction index could not be read for this person. That is "
+                "a genuine fault on this source, so this briefing is missing it — "
+                "say so plainly rather than treating it as an empty record._"
+            )
+
+        if context.interaction_history:
+            tried = context.interaction_windows_tried
+            if len(tried) > 1:
+                return context.interaction_history + (
+                    f"\n\n_(Nothing in {', '.join(tried[:-1])}; widened to "
+                    f"{tried[-1]}, which is the window shown above.)_"
+                )
+            return context.interaction_history
+
+        if not context.interaction_windows_tried:
+            return (
+                "_The interaction index was not searched for this person, so it "
+                "contributes nothing either way here. Use the other sections._"
+            )
+
+        searched = ", then ".join(context.interaction_windows_tried)
+        return (
+            f"_Nothing in the interaction index for {searched}. That names the "
+            f"window searched and nothing more: report it as nothing found in "
+            f"{context.interaction_windows_tried[-1]}, and keep the Last "
+            "interaction date above if one is known._"
+        )
+
+    def _format_facts_section(self, context: BriefingContext) -> str:
+        """Facts for the prompt, grouped by category, with the floor disclosed."""
+        withheld = context.facts_withheld_low_confidence
+        floor_note = (
+            f"\n\n_({withheld} further fact(s) are on record but were withheld: "
+            f"their extraction confidence is below {FACT_CONFIDENCE_FLOOR}. The "
+            "list above is therefore partial.)_"
+            if withheld
+            else ""
+        )
+
+        if not context.person_facts:
+            if withheld:
+                return (
+                    f"_No facts reached the {FACT_CONFIDENCE_FLOOR} confidence "
+                    f"floor. {withheld} lower-confidence fact(s) are on record and "
+                    "were withheld — this is not an absence of facts._"
+                )
+            return "_No facts extracted yet._"
+
+        facts_by_cat: dict[str, list[str]] = {}
+        for fact in context.person_facts:
+            facts_by_cat.setdefault(fact["category"], []).append(f"- {fact['value']}")
+        return "\n".join(
+            f"**{cat.title()}:**\n" + "\n".join(items)
+            for cat, items in facts_by_cat.items()
+        ) + floor_note
+
+    async def generate_briefing(
+        self,
+        person_name: str,
+        email: Optional[str] = None,
+        interaction_days: Optional[int] = None,
+    ) -> dict:
         """
         Generate a stakeholder briefing.
 
         Args:
             person_name: Name of person to brief on
             email: Optional email for better resolution (v2)
+            interaction_days: Optional interaction lookback in days (see
+                gather_context). Honoured exactly when given.
 
         Returns:
             Dict with briefing content and metadata
         """
         # Gather context
-        context = self.gather_context(person_name, email=email)
+        context = self.gather_context(
+            person_name, email=email, interaction_days=interaction_days
+        )
 
         if not context:
             return {
@@ -379,11 +500,29 @@ class BriefingsService:
                 "person_name": person_name,
             }
 
-        # Check if we have any data
-        if not context.related_notes and not context.action_items and not context.email:
+        # Check if we have any data. Interactions and facts count: a person with
+        # years of messages but no vault note is not "limited information", and
+        # bailing here would drop the interaction history the caller asked for.
+        if (
+            not context.related_notes
+            and not context.action_items
+            and not context.email
+            and not context.interaction_history
+            and not context.person_facts
+        ):
+            searched = (
+                " Interaction history was searched over "
+                + ", then ".join(context.interaction_windows_tried)
+                + "."
+                if context.interaction_windows_tried
+                else ""
+            )
             return {
                 "status": "limited",
-                "message": f"I have limited information about {context.resolved_name}. They appear in my records but I don't have detailed notes.",
+                "message": (
+                    f"I have limited information about {context.resolved_name}. They "
+                    f"appear in my records but I don't have detailed notes.{searched}"
+                ),
                 "person_name": context.resolved_name,
                 "sources": context.sources,
             }
@@ -400,8 +539,8 @@ class BriefingsService:
             for item in context.action_items
         ]) or "No action items found."
 
-        # Format interaction history
-        interaction_history = context.interaction_history or "_No interaction history available._"
+        # Format interaction history — states the window when it came up empty
+        interaction_history = self._format_interaction_section(context)
 
         # Format iMessage history
         imessage_history = context.imessage_history or "_No recent messages._"
@@ -416,18 +555,8 @@ class BriefingsService:
         tags_text = ", ".join(context.tags) if context.tags else "None"
         notes_text = context.notes if context.notes else "_No notes._"
 
-        # Format facts by category
-        if context.person_facts:
-            facts_by_cat = {}
-            for fact in context.person_facts:
-                cat = fact["category"]
-                facts_by_cat.setdefault(cat, []).append(f"- {fact['value']}")
-            person_facts_text = "\n".join(
-                f"**{cat.title()}:**\n" + "\n".join(items)
-                for cat, items in facts_by_cat.items()
-            )
-        else:
-            person_facts_text = "_No facts extracted yet._"
+        # Format facts by category, disclosing anything the floor withheld
+        person_facts_text = self._format_facts_section(context)
 
         # Build prompt
         prompt = BRIEFING_PROMPT.format(

--- a/api/services/briefings.py
+++ b/api/services/briefings.py
@@ -289,10 +289,17 @@ class BriefingsService:
         # v3: Get PersonFacts (extracted facts about this person)
         if context.entity_id:
             try:
-                from api.services.person_facts import get_person_fact_store, rank_facts
+                from api.services.person_facts import (
+                    effective_confidence,
+                    get_person_fact_store,
+                    rank_facts,
+                )
                 fact_store = get_person_fact_store()
                 facts = rank_facts(fact_store.get_for_person(context.entity_id))
-                kept = [f for f in facts if (f.confidence or 0.0) >= FACT_CONFIDENCE_FLOOR]
+                # Same effective confidence the ranking uses, so a fact the user
+                # confirmed is never dropped here and then attributed to low
+                # extraction confidence — a claim about something they asserted.
+                kept = [f for f in facts if effective_confidence(f) >= FACT_CONFIDENCE_FLOOR]
                 context.facts_withheld_low_confidence = len(facts) - len(kept)
                 context.person_facts = [
                     {
@@ -517,12 +524,39 @@ class BriefingsService:
                 if context.interaction_windows_tried
                 else ""
             )
-            return {
-                "status": "limited",
-                "message": (
+            # This return happens before _format_facts_section can disclose the
+            # confidence floor, so it carries that caveat itself. Without it a
+            # person whose only facts sit under the floor is reported as having
+            # nothing on record.
+            withheld = (
+                f" {context.facts_withheld_low_confidence} lower-confidence "
+                f"fact(s) are on record, below the {FACT_CONFIDENCE_FLOOR} "
+                "confidence floor, and are not included here."
+                if context.facts_withheld_low_confidence
+                else ""
+            )
+            # Same reason, and the one caveat that must never be summarised as
+            # thin data: the interaction lookup raised, so the history is missing
+            # because that source could not be read. _format_interaction_section
+            # states this on the normal path, which this return never reaches.
+            if context.interaction_lookup_failed:
+                message = (
+                    f"The interaction index could not be read for "
+                    f"{context.resolved_name}, and no notes, tasks, or facts turned "
+                    "up either. The interaction history is absent because that "
+                    "source errored, NOT because there is nothing on record — this "
+                    "is a genuine fault on that source and must be stated as one."
+                    + withheld
+                )
+            else:
+                message = (
                     f"I have limited information about {context.resolved_name}. They "
                     f"appear in my records but I don't have detailed notes.{searched}"
-                ),
+                    + withheld
+                )
+            return {
+                "status": "limited",
+                "message": message,
                 "person_name": context.resolved_name,
                 "sources": context.sources,
             }

--- a/api/services/calendar.py
+++ b/api/services/calendar.py
@@ -285,7 +285,21 @@ class CalendarService:
 
         Returns:
             List of CalendarEvent objects
+
+        Raises:
+            Exception: if credentials cannot be resolved. API-level errors are
+                still swallowed to an empty list (the long-standing contract for
+                the other callers), but an auth failure must reach the caller —
+                see the note below.
         """
+        # Resolved before the try. `service` is a lazy property, so building it
+        # inside the block meant an expired token was caught here and returned as
+        # an empty list — indistinguishable from a genuinely empty calendar. The
+        # per-account failure disclosure in agent_tools could therefore never
+        # fire for the case it exists for, and a broken Google connection was
+        # reported as "nothing on your calendar" after apparently searching
+        # three widening windows.
+        service = self.service
         try:
             request_params = {
                 "calendarId": calendar_id,
@@ -299,7 +313,7 @@ class CalendarService:
             if query:
                 request_params["q"] = query
 
-            result = self.service.events().list(**request_params).execute()
+            result = service.events().list(**request_params).execute()
             items = result.get("items", [])
 
             events = []

--- a/api/services/drive.py
+++ b/api/services/drive.py
@@ -6,7 +6,7 @@ Supports Google Docs, Sheets, and other file types.
 """
 import logging
 from datetime import datetime, timezone
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 from googleapiclient.discovery import build
@@ -115,6 +115,7 @@ class DriveService:
         mime_type: Optional[str] = None,
         folder_id: Optional[str] = None,
         max_results: int = 20,
+        order_by: str = "modifiedTime desc",
     ) -> list[DriveFile]:
         """
         Search Drive files.
@@ -125,6 +126,10 @@ class DriveService:
             mime_type: Filter by MIME type
             folder_id: Search within specific folder
             max_results: Maximum files to return
+            order_by: Drive `orderBy` sort key. Must be one of Drive's documented
+                keys (e.g. "modifiedTime desc", "modifiedTime", "name"). Drive has
+                no relevance key and omitting orderBy returns an arbitrary order,
+                so callers get an explicit sort rather than an unordered page.
 
         Returns:
             List of DriveFile objects
@@ -153,12 +158,18 @@ class DriveService:
 
         query = " and ".join(query_parts)
 
+        # Resolved before the handler below: an expired token raises here, and a
+        # caller must be able to tell "this account is unreachable" from "this
+        # account has no matching files". Swallowing an auth fault into an empty
+        # list makes a broken connection look like absent data.
+        service = self.service
+
         try:
-            result = self.service.files().list(
+            result = service.files().list(
                 q=query,
                 pageSize=max_results,
                 fields="files(id, name, mimeType, modifiedTime, webViewLink, size, parents)",
-                orderBy="modifiedTime desc",
+                orderBy=order_by,
             ).execute()
 
             files = result.get("files", [])

--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -38,6 +38,22 @@ VALID_SOURCE_TYPES = frozenset({
 _MIN_TIMESTAMP = datetime(2000, 1, 1, tzinfo=timezone.utc)
 _MAX_FUTURE_DAYS = 90  # Calendar events can be up to ~30 days out; allow margin
 
+# Opening of the empty-history message. Callers detect emptiness by this prefix
+# rather than by an exact string, so the window named after it can vary.
+NO_INTERACTIONS_PREFIX = "_No interactions found"
+
+
+def format_window_label(days_back: Optional[int]) -> str:
+    """Human phrasing for a lookback window, for messages that must name it.
+
+    None means the store's default window (InteractionConfig.DEFAULT_WINDOW_DAYS,
+    which spans the whole indexed period), so it is described as such rather than
+    as "the specified time period" — a phrase that tells a reader nothing.
+    """
+    if days_back is None:
+        return "the full history on record"
+    return f"the last {days_back} days"
+
 
 def get_interaction_db_path() -> str:
     """Get the path to the interactions database."""
@@ -1394,14 +1410,16 @@ class InteractionStore:
             limit: Maximum interactions
 
         Returns:
-            Formatted markdown string
+            Formatted markdown string. An empty result names the window it
+            searched (see NO_INTERACTIONS_PREFIX) — callers must not restate it
+            as "no history", which claims more than the window established.
         """
         interactions = self.get_for_person(person_id, days_back, limit)
         counts = self.get_interaction_counts(person_id, days_back)
         last = self.get_last_interaction(person_id)
 
         if not interactions:
-            return "_No interactions found in the specified time period._"
+            return f"{NO_INTERACTIONS_PREFIX} in {format_window_label(days_back)}._"
 
         # Build summary line
         total = sum(counts.values())

--- a/api/services/memory_store.py
+++ b/api/services/memory_store.py
@@ -178,7 +178,12 @@ class MemorySearchStats:
     searched: int         # memories actually scored
     corpus_limit: int     # the bound applied to the corpus
     matched: int          # matches found, before the `limit` slice
-    near_misses: int      # scored memories that cleared neither floor but came close
+    # Scored memories that cleared neither floor: keyword overlap under
+    # min_relevance, or a semantic score inside MEMORY_SEMANTIC_NEAR_MISS_MARGIN
+    # of the floor. The keyword half is a weak signal — a single common word in a
+    # long query counts — so a caller may report that candidates were scored and
+    # rejected, but not that a relevant memory is likely saved.
+    near_misses: int
     semantic_available: bool  # False when scoring fell back to keyword-only
 
 
@@ -519,7 +524,7 @@ class MemoryStore:
 
         Same ranking and same results as search_memories; the second element
         reports what was scored, how many matched before `limit` was applied, and
-        how many came close without clearing a floor. Callers that render an
+        how many were scored and rejected by a floor. Callers that render an
         empty result to a user need that to avoid reporting a relevance miss as a
         memory the system lost. See MemorySearchStats.
         """

--- a/api/services/memory_store.py
+++ b/api/services/memory_store.py
@@ -29,6 +29,18 @@ DEFAULT_MEMORIES_PATH = Path.home() / ".lifeos" / "memories.json"
 # keeps vague/unrelated queries from pulling in low-relevance memories. Tunable.
 MEMORY_SEMANTIC_FLOOR = 0.35
 
+# How close to MEMORY_SEMANTIC_FLOOR a score has to be to be reported as a near
+# miss. Reporting only — it never changes which memories are returned. A
+# paraphrase of a saved memory typically lands just under the floor, and the
+# difference between "nothing is saved about this" and "something nearly matched"
+# is what stops an empty search being read as a lost memory.
+MEMORY_SEMANTIC_NEAR_MISS_MARGIN = 0.05
+
+# Search scores the most recently saved memories only. Bounded because semantic
+# recall embeds every memory it scores; when the bound binds it is reported in
+# MemorySearchStats so a miss beyond it is never presented as absence.
+MEMORY_SEARCH_CORPUS_LIMIT = 1000
+
 # Memory categories and their trigger patterns
 CATEGORY_PATTERNS = {
     "people": [
@@ -152,6 +164,22 @@ class Memory:
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
             "is_active": self.is_active,
         }
+
+
+@dataclass
+class MemorySearchStats:
+    """What bounded a memory search, so the caller can disclose it.
+
+    Returned alongside results rather than logged: a bare empty list can't tell
+    "nothing is saved about this" from "something nearly matched but no floor was
+    cleared", and only the first justifies telling the user the memory is gone.
+    """
+    total_saved: int      # active memories in the store, before the corpus bound
+    searched: int         # memories actually scored
+    corpus_limit: int     # the bound applied to the corpus
+    matched: int          # matches found, before the `limit` slice
+    near_misses: int      # scored memories that cleared neither floor but came close
+    semantic_available: bool  # False when scoring fell back to keyword-only
 
 
 class MemoryStore:
@@ -479,12 +507,40 @@ class MemoryStore:
         Returns:
             List of matching Memory objects
         """
-        if not query.strip():
-            return []
+        memories, _stats = self.search_memories_detailed(
+            query, limit=limit, min_relevance=min_relevance
+        )
+        return memories
 
-        memories = self.list_memories(limit=1000)
+    def search_memories_detailed(
+        self, query: str, limit: int = 10, min_relevance: float = 0.15
+    ) -> tuple[list[Memory], MemorySearchStats]:
+        """search_memories, plus the bounds that shaped the result.
+
+        Same ranking and same results as search_memories; the second element
+        reports what was scored, how many matched before `limit` was applied, and
+        how many came close without clearing a floor. Callers that render an
+        empty result to a user need that to avoid reporting a relevance miss as a
+        memory the system lost. See MemorySearchStats.
+        """
+        total_saved = sum(1 for m in self._memories.values() if m.is_active)
+
+        def _stats(searched=0, matched=0, near_misses=0, semantic_available=True):
+            return MemorySearchStats(
+                total_saved=total_saved,
+                searched=searched,
+                corpus_limit=MEMORY_SEARCH_CORPUS_LIMIT,
+                matched=matched,
+                near_misses=near_misses,
+                semantic_available=semantic_available,
+            )
+
+        if not query.strip():
+            return [], _stats()
+
+        memories = self.list_memories(limit=MEMORY_SEARCH_CORPUS_LIMIT)
         if not memories:
-            return []
+            return [], _stats()
 
         by_id = {m.id: m for m in memories}
 
@@ -495,14 +551,21 @@ class MemoryStore:
         term_count = max(len(search_terms), 1)
 
         keyword_scores: dict[str, int] = {}
+        # Memories that overlapped the query but not by enough to clear a floor.
+        # Tracked as ids so a memory caught by both floors is only counted once.
+        near_miss_ids: set[str] = set()
         for memory in memories:
             memory_keywords = set(kw.lower() for kw in memory.keywords)
             content_words = set(memory.content.lower().split())
             all_terms = memory_keywords | content_words
 
             overlap = len(search_terms & all_terms)
-            if overlap > 0 and overlap / term_count >= min_relevance:
+            if overlap == 0:
+                continue
+            if overlap / term_count >= min_relevance:
                 keyword_scores[memory.id] = overlap
+            else:
+                near_miss_ids.add(memory.id)
 
         keyword_ranked = [mid for mid, _ in sorted(keyword_scores.items(), key=lambda x: -x[1])]
 
@@ -510,19 +573,37 @@ class MemoryStore:
 
         # Embedding service unavailable — preserve the original keyword behavior.
         if semantic_scores is None:
-            return [by_id[mid] for mid in keyword_ranked[:limit]]
+            results = [by_id[mid] for mid in keyword_ranked[:limit]]
+            near_miss_ids -= {m.id for m in results}
+            return results, _stats(
+                searched=len(memories),
+                matched=len(keyword_ranked),
+                near_misses=len(near_miss_ids),
+                semantic_available=False,
+            )
 
         semantic_ranked = [
             mid for mid, score in sorted(semantic_scores.items(), key=lambda x: -x[1])
             if score >= MEMORY_SEMANTIC_FLOOR
         ]
+        near_miss_ids.update(
+            mid for mid, score in semantic_scores.items()
+            if MEMORY_SEMANTIC_FLOOR - MEMORY_SEMANTIC_NEAR_MISS_MARGIN <= score < MEMORY_SEMANTIC_FLOOR
+        )
 
         if not semantic_ranked and not keyword_ranked:
-            return []
+            return [], _stats(searched=len(memories), near_misses=len(near_miss_ids))
 
         from api.services.hybrid_search import reciprocal_rank_fusion
         fused = reciprocal_rank_fusion(semantic_ranked, keyword_ranked)
-        return [by_id[mid] for mid, _ in fused[:limit] if mid in by_id]
+        matched = [by_id[mid] for mid, _ in fused if mid in by_id]
+        results = matched[:limit]
+        near_miss_ids -= {m.id for m in results}
+        return results, _stats(
+            searched=len(memories),
+            matched=len(matched),
+            near_misses=len(near_miss_ids),
+        )
 
     def get_relevant_memories(self, query: str, limit: int = 5) -> list[Memory]:
         """

--- a/api/services/person_facts.py
+++ b/api/services/person_facts.py
@@ -119,6 +119,27 @@ class PersonFact:
         )
 
 
+def rank_facts(facts: list["PersonFact"]) -> list["PersonFact"]:
+    """Order facts most-trustworthy-first, for surfaces that show only some.
+
+    The store returns facts sorted by category then key, which is right for a UI
+    that groups them but wrong for anything that truncates: an alphabetical cut
+    drops "family: spouse" for "work: …" purely on spelling, and the reader is
+    told nothing about what fell off. A user-confirmed fact counts as full
+    confidence — the user asserted it, which outranks any extraction score.
+
+    Does not change the store's own ordering; callers opt in.
+    """
+    return sorted(
+        facts,
+        key=lambda f: (
+            -(1.0 if f.confirmed_by_user else (f.confidence or 0.0)),
+            f.category,
+            f.key,
+        ),
+    )
+
+
 class PersonFactStore:
     """
     SQLite-backed storage for person facts.

--- a/api/services/person_facts.py
+++ b/api/services/person_facts.py
@@ -119,24 +119,33 @@ class PersonFact:
         )
 
 
+def effective_confidence(fact: "PersonFact") -> float:
+    """How much a fact is trusted: extraction confidence, or 1.0 if confirmed.
+
+    A user-confirmed fact counts as full confidence — the user asserted it, which
+    outranks any extraction score. Shared by ranking and by confidence floors so
+    the two cannot disagree: they did, and a fact the user had personally
+    confirmed was ranked first, dropped by the briefing's floor, and then
+    reported as withheld for low extraction confidence.
+    """
+    if fact.confirmed_by_user:
+        return 1.0
+    return fact.confidence or 0.0
+
+
 def rank_facts(facts: list["PersonFact"]) -> list["PersonFact"]:
     """Order facts most-trustworthy-first, for surfaces that show only some.
 
     The store returns facts sorted by category then key, which is right for a UI
     that groups them but wrong for anything that truncates: an alphabetical cut
     drops "family: spouse" for "work: …" purely on spelling, and the reader is
-    told nothing about what fell off. A user-confirmed fact counts as full
-    confidence — the user asserted it, which outranks any extraction score.
+    told nothing about what fell off.
 
     Does not change the store's own ordering; callers opt in.
     """
     return sorted(
         facts,
-        key=lambda f: (
-            -(1.0 if f.confirmed_by_user else (f.confidence or 0.0)),
-            f.category,
-            f.key,
-        ),
+        key=lambda f: (-effective_confidence(f), f.category, f.key),
     )
 
 

--- a/api/services/person_indexer.py
+++ b/api/services/person_indexer.py
@@ -83,17 +83,22 @@ def generate_person_document(person: PersonEntity, summary: RelationshipSummary)
         if summary.primary_channel:
             parts.append(f"\nPrimary communication channel: {summary.primary_channel}")
 
-    # Contact recency
-    if summary.days_since_contact < 7:
-        parts.append(f"\nLast contact: within the last week")
+    # Contact recency. The never-contacted sentinel is a marker, not a
+    # measurement: bucketing it lands in the final branch, which would index
+    # "over a year ago" as a searchable claim about someone who was never
+    # contacted at all.
+    if not summary.contact_on_record:
+        parts.append("\nLast contact: none on record")
+    elif summary.days_since_contact < 7:
+        parts.append("\nLast contact: within the last week")
     elif summary.days_since_contact < 30:
-        parts.append(f"\nLast contact: within the last month")
+        parts.append("\nLast contact: within the last month")
     elif summary.days_since_contact < 90:
-        parts.append(f"\nLast contact: within the last 3 months")
+        parts.append("\nLast contact: within the last 3 months")
     elif summary.days_since_contact < 365:
-        parts.append(f"\nLast contact: within the last year")
+        parts.append("\nLast contact: within the last year")
     else:
-        parts.append(f"\nLast contact: over a year ago")
+        parts.append("\nLast contact: over a year ago")
 
     # Aliases (for search matching)
     if person.aliases:

--- a/api/services/relationship_summary.py
+++ b/api/services/relationship_summary.py
@@ -21,6 +21,11 @@ logger = logging.getLogger(__name__)
 # Threshold for considering a channel "recently active"
 RECENT_ACTIVITY_DAYS = 7
 
+# Sentinel stored in days_since_contact when there is no last-contact date at
+# all. It is a marker, not a measurement: rendered as a number it reads as a gap
+# of about 2.7 years, so formatters must ask `contact_on_record` first.
+NEVER_CONTACTED_DAYS = 999
+
 
 @dataclass
 class ChannelActivity:
@@ -62,11 +67,22 @@ class RelationshipSummary:
     # Quick stats
     total_interactions_90d: int = 0
     last_interaction: Optional[datetime] = None
-    days_since_contact: int = 999  # 999 = never contacted
+    days_since_contact: int = NEVER_CONTACTED_DAYS  # sentinel = never contacted
 
     # Optional extras
     facts_count: int = 0
     has_facts: bool = False
+
+    @property
+    def contact_on_record(self) -> bool:
+        """Whether days_since_contact is a real gap rather than the sentinel.
+
+        The date is the authority, not the number: a genuine gap can exceed
+        NEVER_CONTACTED_DAYS, so a large value alone proves nothing either way.
+        """
+        if self.last_interaction is not None:
+            return True
+        return self.days_since_contact != NEVER_CONTACTED_DAYS
 
     def to_dict(self) -> dict:
         """Convert to dict for JSON serialization."""
@@ -162,7 +178,7 @@ def get_relationship_summary(person_id: str) -> Optional[RelationshipSummary]:
     primary = channels[0].source_type if channels else None
 
     # Calculate days since contact
-    days_since = 999
+    days_since = NEVER_CONTACTED_DAYS
     if person.last_seen:
         last_seen = person.last_seen
         if last_seen.tzinfo is None:
@@ -209,8 +225,15 @@ def format_relationship_context(summary: RelationshipSummary) -> str:
     lines = [
         f"## Relationship Context: {summary.person_name}",
         f"- **Strength**: {summary.relationship_strength}/100",
-        f"- **Days since contact**: {summary.days_since_contact}",
     ]
+
+    # Never print the sentinel. A reader (human or model) has no way to tell it
+    # from a real 999-day gap, and stating a fabricated interval is worse than
+    # stating that nothing is on record.
+    if summary.contact_on_record:
+        lines.append(f"- **Days since contact**: {summary.days_since_contact}")
+    else:
+        lines.append("- **Days since contact**: no contact on record")
 
     if summary.active_channels:
         lines.append(f"- **Active channels** (last 7 days): {', '.join(summary.active_channels)}")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1505,17 +1505,33 @@ class LifeOSMCPServer:
             text = "## Communication Gap Analysis\n\n"
             # Show person summaries first
             text += "### Overview\n"
+            # Report the fields the endpoint actually returns. All three names
+            # read here before were absent from the response, so every .get()
+            # fell through to its default: each person was rendered as "999 days
+            # since contact" — a fabricated interval, not a real one — the real
+            # average gap was dropped because it read as 0, and the alert could
+            # never fire. There is no days-since-contact in this response, so
+            # none is invented.
             for s in summaries:
                 name = s.get("person_name", "Unknown")
-                days = s.get("days_since_last_contact", 999)
-                avg = s.get("average_gap_days", 0)
-                current = s.get("current_gap_days", 0)
-                # Flag if current gap is significantly longer than average
-                alert = "⚠️ " if current > avg * 1.5 and current > 14 else ""
-                text += f"- **{name}**: {alert}{days} days since contact"
-                if avg:
-                    text += f" (avg gap: {avg:.0f} days)"
-                text += "\n"
+                avg = s.get("avg_gap_days")
+                longest = s.get("max_gap_days")
+                over = s.get("total_gaps_over_threshold")
+                parts = []
+                if avg is not None:
+                    parts.append(f"avg gap {avg:.0f}d")
+                if longest is not None:
+                    parts.append(f"longest {longest}d")
+                if over:
+                    parts.append(f"{over} over threshold")
+                # Flag someone whose worst gap is far above their own average.
+                alert = (
+                    "⚠️ "
+                    if avg and longest and longest > avg * 1.5 and longest > 14
+                    else ""
+                )
+                detail = " · ".join(parts) if parts else "no gap data"
+                text += f"- **{name}**: {alert}{detail}\n"
             # Show significant gaps
             if gaps:
                 text += "\n### Significant Gaps\n"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1303,10 +1303,18 @@ class LifeOSMCPServer:
                 text += "\n"
                 # Show relationship context for routing decisions
                 strength = p.get("relationship_strength", 0)
+                # 999 is the API's never-contacted sentinel, not a measurement.
+                # Printed as a number it reads as a real gap of about 2.7 years,
+                # so fall back to the date the API actually reports.
                 days = p.get("days_since_contact", 999)
                 active = p.get("active_channels", [])
                 entity_id = p.get("entity_id", "")
-                text += f"  Strength: {strength:.0f}/100 | Last contact: {days} days ago\n"
+                last_contact = (
+                    f"{days} days ago"
+                    if days != 999 or p.get("last_seen")
+                    else "no contact on record"
+                )
+                text += f"  Strength: {strength:.0f}/100 | Last contact: {last_contact}\n"
                 if active:
                     text += f"  Active channels: {', '.join(active)}\n"
                 else:

--- a/tests/test_agent_tools_drive_scope.py
+++ b/tests/test_agent_tools_drive_scope.py
@@ -251,6 +251,27 @@ class TestDriveOrdering:
         out = await _tool_search_drive({"query": "synthetic", "order_by": "recent"})
         assert "Ignored order_by" not in out
 
+    @pytest.mark.parametrize("raw", [[], ["recent"], {}, {"order": "recent"}, 3, 1.5, True])
+    async def test_wrong_typed_ordering_is_disclosed_not_raised(self, fake_drive, raw):
+        """The model writes this argument, so a list or dict arrives.
+
+        `raw_order in _DRIVE_ORDERINGS` raised TypeError: unhashable type on those
+        — a malformed argument taken down as a tool crash instead of being
+        reported. It is now handled exactly like an unknown sort key.
+        """
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        out = await _tool_search_drive({"query": "synthetic", "order_by": raw})
+        assert f"Ignored order_by={raw!r}" in out
+        assert fake_drive.calls[0]["order_by"] == "modifiedTime desc"
+        assert "Synthetic doc" in out
+
+    async def test_wrong_typed_ordering_is_disclosed_on_an_empty_result_too(
+        self, fake_drive
+    ):
+        out = await _tool_search_drive({"query": "nothing", "order_by": []})
+        assert "Ignored order_by=[]" in out
+        assert not any(word in out.lower() for word in FAULT_WORDS)
+
     async def test_merged_accounts_are_sorted_not_concatenated(
         self, fake_drive, accounts
     ):
@@ -331,8 +352,41 @@ class TestDriveAccountFailureDisclosure:
     ):
         fake_drive.broken = {"personal"}
         out = await _tool_search_drive({"query": "comp planning"})
-        assert "Could not reach personal" in out
-        assert "not necessarily an empty Drive" in out
+        assert "personal" in out
+        assert "NOT an empty Drive" in out
+
+    async def test_total_failure_leads_with_the_fault(self, fake_drive, accounts):
+        """A denial with a footnote still reads as an answer."""
+        fake_drive.broken = {"personal"}
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert out.startswith("Could not search Drive")
+
+    async def test_total_failure_does_not_claim_an_absence(self, fake_drive, accounts):
+        """Nothing responded, so "the accounts that responded" was none of them."""
+        fake_drive.broken = {"personal"}
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "No Drive files" not in out
+        assert "accounts that responded" not in out
+
+    async def test_every_account_failing_is_a_total_failure(
+        self, fake_drive, accounts
+    ):
+        """Two accounts, both down — still nothing searched."""
+        accounts.append(_account("work"))
+        fake_drive.broken = {"personal", "work"}
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert out.startswith("Could not search Drive")
+        assert "personal" in out and "work" in out
+
+    async def test_total_failure_still_discloses_a_bad_ordering(
+        self, fake_drive, accounts
+    ):
+        """A bad argument does not stop being wrong because an account broke."""
+        fake_drive.broken = {"personal"}
+        out = await _tool_search_drive(
+            {"query": "comp planning", "order_by": "relevance"}
+        )
+        assert "Ignored order_by='relevance'" in out
 
     async def test_partial_failure_still_discloses_alongside_results(
         self, fake_drive, accounts
@@ -382,8 +436,19 @@ class TestDriveAccountFailureDisclosure:
         """
         fake_drive.broken = {"personal"}
         out = await _tool_search_drive({"query": "synthetic"})
-        assert "incomplete" in out
+        assert "errored" in out
         assert any(word in out.lower() for word in FAULT_WORDS)
+
+    async def test_partial_failure_still_calls_the_answer_incomplete(
+        self, fake_drive, accounts
+    ):
+        """The partial branch keeps its own wording: results, minus one account."""
+        accounts.append(_account("work"))
+        fake_drive.broken = {"work"}
+        fake_drive.per_account = {"personal": [_file(1, "Synthetic personal doc")]}
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert "incomplete" in out
+        assert "not necessarily an empty Drive" in out
 
     async def test_empty_after_a_failure_is_a_distinct_branch(
         self, fake_drive, accounts
@@ -425,6 +490,7 @@ class TestDriveHonestEmpty:
             {"query": "comp planning"},
             {"query": "comp planning", "max_results": 0},
             {"query": "comp planning", "order_by": "relevance"},
+            {"query": "comp planning", "order_by": []},
             {},
             {"query": "   "},
         ],

--- a/tests/test_agent_tools_drive_scope.py
+++ b/tests/test_agent_tools_drive_scope.py
@@ -1,0 +1,616 @@
+"""
+Tests for Drive search scope disclosure in the chat tool surface.
+
+Regression context: same bug class as tests/test_agent_tools_scope_widening.py.
+search_drive asked Drive for only the five most recently modified matches per
+account, said nothing about the cut or the ordering, and swallowed a failing
+account into the same bare "No drive files found." An old document was therefore
+systematically unreachable whenever a handful of newer files also matched, and
+an expired token was indistinguishable from an empty Drive — so chat denied the
+existence of a document that was present and indexed.
+
+These tests pin the fix: a cap that matches the service default and discloses
+itself when it binds, an explicit modification-time ordering (Drive has no
+relevance sort — see _DRIVE_ORDERINGS) so old files stay reachable, per-account
+failures named even when other accounts return files, and an empty result that
+names the scope it searched instead of implying a fault.
+"""
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import api.services.agent_tools as at
+from api.services.agent_tools import (
+    _DRIVE_DEFAULT_RESULTS,
+    _DRIVE_MAX_RESULTS,
+    _DRIVE_ORDERINGS,
+    _positive_int,
+    _tool_search_drive,
+    TOOL_DEFINITIONS,
+    _TOOL_HANDLERS,
+)
+
+pytestmark = pytest.mark.unit
+
+# Phrases that would tell the orchestrator the backend broke. An empty result is
+# a fact about the data, so none of these may appear in one.
+FAULT_WORDS = ("sync issue", "permission", "failed", "error", "unavailable")
+
+
+def _days_ago(n: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=n)
+
+
+def _account(value: str = "personal"):
+    """Stand-in for a GoogleAccount enum member; only `.value` is read."""
+    return SimpleNamespace(value=value)
+
+
+@pytest.fixture
+def accounts(monkeypatch):
+    """One configured Google account. Tests may append more in place."""
+    configured = [_account("personal")]
+    monkeypatch.setattr(at, "get_configured_accounts", lambda: list(configured))
+    return configured
+
+
+def _file(days_ago: int, name: str, account: str = "personal", content: str = ""):
+    """A DriveFile stand-in; the tool reads only these attributes."""
+    return SimpleNamespace(
+        name=name,
+        source_account=account,
+        mime_type="application/vnd.google-apps.document",
+        modified_time=_days_ago(days_ago),
+        content=content,
+    )
+
+
+@pytest.fixture
+def fake_drive(monkeypatch, accounts):
+    """Stub DriveService, recording the kwargs of every search call.
+
+    Applies order_by and max_results the way Drive would (server-side sort, then
+    a single page) so both the ordering and the truncation signal are real rather
+    than assumed.
+    """
+    state = SimpleNamespace(files=[], per_account={}, broken=set(), calls=[])
+
+    class FakeDriveService:
+        def __init__(self, account):
+            self.account = account
+
+        def search(
+            self,
+            name=None,
+            full_text=None,
+            mime_type=None,
+            folder_id=None,
+            max_results=20,
+            order_by="modifiedTime desc",
+        ):
+            state.calls.append({
+                "account": self.account.value, "name": name,
+                "full_text": full_text, "max_results": max_results,
+                "order_by": order_by,
+            })
+            if self.account.value in state.broken:
+                raise RuntimeError("synthetic credentials expired")
+            files = list(state.per_account.get(self.account.value, state.files))
+            files.sort(
+                key=lambda f: f.modified_time,
+                reverse=(order_by == "modifiedTime desc"),
+            )
+            return files[:max_results]
+
+    monkeypatch.setattr("api.services.drive.DriveService", FakeDriveService)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Cap and truncation disclosure
+# ---------------------------------------------------------------------------
+
+class TestDriveCapAndTruncation:
+    async def test_default_cap_matches_the_service_default(self, fake_drive):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        await _tool_search_drive({"query": "synthetic"})
+        assert fake_drive.calls[0]["max_results"] == _DRIVE_DEFAULT_RESULTS == 20
+
+    async def test_explicit_max_results_is_passed_through(self, fake_drive):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        await _tool_search_drive({"query": "synthetic", "max_results": 7})
+        assert fake_drive.calls[0]["max_results"] == 7
+
+    async def test_truncation_is_disclosed_when_the_cap_is_hit(self, fake_drive):
+        fake_drive.files = [_file(i + 1, f"Synthetic doc {i}") for i in range(20)]
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert "Capped at 20 files per account" in out
+        assert "more may exist" in out
+
+    async def test_no_truncation_note_below_the_cap(self, fake_drive):
+        fake_drive.files = [_file(1, "Only doc")]
+        out = await _tool_search_drive({"query": "only"})
+        assert "Capped at" not in out
+
+    async def test_truncation_on_one_of_several_accounts_is_disclosed(
+        self, fake_drive, accounts
+    ):
+        accounts.append(_account("work"))
+        fake_drive.per_account = {
+            "personal": [_file(1, "Only personal doc")],
+            "work": [
+                _file(i + 1, f"Work doc {i}", account="work") for i in range(4)
+            ],
+        }
+        out = await _tool_search_drive({"query": "doc", "max_results": 4})
+        assert "Capped at 4 files per account" in out
+
+    async def test_a_broken_account_does_not_fake_truncation(
+        self, fake_drive, accounts
+    ):
+        """A raising account returns nothing, not a full page."""
+        accounts.append(_account("work"))
+        fake_drive.broken = {"work"}
+        fake_drive.per_account = {"personal": [_file(1, "Only personal doc")]}
+        out = await _tool_search_drive({"query": "doc"})
+        assert "Only personal doc" in out
+        assert "Capped at" not in out
+
+    async def test_capped_result_says_the_cut_is_by_time_not_relevance(
+        self, fake_drive
+    ):
+        """The cut must not read as "these were the best matches".
+
+        Drive ranks nothing; the dropped files may match better than the kept
+        ones, and the note is the only place the model can learn that.
+        """
+        fake_drive.files = [_file(i + 1, f"Synthetic doc {i}") for i in range(5)]
+        out = await _tool_search_drive({"query": "synthetic", "max_results": 5})
+        assert "no relevance ranking" in out
+        assert "order_by='oldest'" in out
+
+
+# ---------------------------------------------------------------------------
+# Ordering — Drive has no relevance sort, so ordering is explicit
+# ---------------------------------------------------------------------------
+
+class TestDriveOrdering:
+    async def test_default_ordering_is_newest_modified_first(self, fake_drive):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        await _tool_search_drive({"query": "synthetic"})
+        assert fake_drive.calls[0]["order_by"] == "modifiedTime desc"
+
+    async def test_old_file_is_reachable_behind_newer_matches(self, fake_drive):
+        """The reported failure: a comp doc from last year, six newer matches.
+
+        At the old cap of 5 the older file was pushed off the page entirely and
+        nothing in the output hinted at it, so chat reported the document absent.
+        """
+        fake_drive.files = [
+            _file(i + 1, f"Synthetic planning note {i}") for i in range(6)
+        ] + [_file(420, "Synthetic comp planning 2025")]
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "Synthetic comp planning 2025" in out
+        assert "Capped at" not in out
+
+    async def test_oldest_ordering_reaches_an_old_file_the_cap_would_hide(
+        self, fake_drive
+    ):
+        """With the cap binding, ordering is the only way to reach the old file."""
+        fake_drive.files = [
+            _file(i + 1, f"Synthetic planning note {i}") for i in range(6)
+        ] + [_file(420, "Synthetic comp planning 2025")]
+        recent = await _tool_search_drive({"query": "comp", "max_results": 3})
+        assert "Synthetic comp planning 2025" not in recent
+
+        oldest = await _tool_search_drive(
+            {"query": "comp", "max_results": 3, "order_by": "oldest"}
+        )
+        assert "Synthetic comp planning 2025" in oldest
+        assert fake_drive.calls[-1]["order_by"] == "modifiedTime"
+
+    async def test_ordering_note_names_the_direction_actually_used(self, fake_drive):
+        fake_drive.files = [_file(i + 1, f"Synthetic doc {i}") for i in range(3)]
+        out = await _tool_search_drive(
+            {"query": "synthetic", "max_results": 3, "order_by": "oldest"}
+        )
+        assert "oldest-modified first" in out
+        assert "newest-modified first" not in out
+
+    async def test_unknown_ordering_falls_back_and_is_disclosed(self, fake_drive):
+        """A made-up sort key must not be sent to Drive, nor silently ignored."""
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        out = await _tool_search_drive(
+            {"query": "synthetic", "order_by": "relevance"}
+        )
+        assert fake_drive.calls[0]["order_by"] == "modifiedTime desc"
+        assert "Ignored order_by='relevance'" in out
+        assert "newest-modified first" in out
+
+    async def test_unknown_ordering_is_disclosed_on_an_empty_result_too(
+        self, fake_drive
+    ):
+        out = await _tool_search_drive({"query": "nothing", "order_by": "relevance"})
+        assert "Ignored order_by='relevance'" in out
+
+    async def test_a_valid_ordering_is_not_reported_as_ignored(self, fake_drive):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        out = await _tool_search_drive({"query": "synthetic", "order_by": "recent"})
+        assert "Ignored order_by" not in out
+
+    async def test_merged_accounts_are_sorted_not_concatenated(
+        self, fake_drive, accounts
+    ):
+        """Two pages joined end to end would contradict the ordering claimed."""
+        accounts.append(_account("work"))
+        fake_drive.per_account = {
+            "personal": [_file(30, "Synthetic older personal doc")],
+            "work": [_file(1, "Synthetic newer work doc", account="work")],
+        }
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert out.index("Synthetic newer work doc") < out.index(
+            "Synthetic older personal doc"
+        )
+
+    async def test_oldest_ordering_reverses_the_merged_order(
+        self, fake_drive, accounts
+    ):
+        accounts.append(_account("work"))
+        fake_drive.per_account = {
+            "personal": [_file(30, "Synthetic older personal doc")],
+            "work": [_file(1, "Synthetic newer work doc", account="work")],
+        }
+        out = await _tool_search_drive({"query": "synthetic", "order_by": "oldest"})
+        assert out.index("Synthetic older personal doc") < out.index(
+            "Synthetic newer work doc"
+        )
+
+    async def test_mixed_timestamp_shapes_do_not_break_the_merge(self, fake_drive):
+        """The merge sort runs outside the per-account handler.
+
+        A naive or missing modified_time from one account would take the whole
+        search down with a TypeError rather than costing one file.
+        """
+        undated = _file(5, "Synthetic undated doc")
+        undated.modified_time = None
+        naive = _file(2, "Synthetic naive doc")
+        naive.modified_time = datetime.now() - timedelta(days=2)
+        fake_drive.per_account = {"personal": [naive, undated, _file(1, "Aware doc")]}
+        # The fake's own sort needs comparable keys; bypass it with a page big
+        # enough that ordering there is irrelevant to what the tool receives.
+        fake_drive.per_account["personal"].sort(key=lambda f: f.name)
+
+        class NoSortDrive:
+            def __init__(self, account):
+                self.account = account
+
+            def search(self, **kw):
+                return list(fake_drive.per_account["personal"])
+
+        with patch("api.services.drive.DriveService", NoSortDrive):
+            out = await _tool_search_drive({"query": "synthetic"})
+        assert "Synthetic undated doc" in out
+        assert "Aware doc" in out
+
+    async def test_modified_date_is_shown_so_the_ordering_is_checkable(
+        self, fake_drive
+    ):
+        stamp = _days_ago(3)
+        fake_drive.files = [_file(3, "Synthetic doc")]
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert f"modified {stamp.strftime('%Y-%m-%d')}" in out
+
+
+# ---------------------------------------------------------------------------
+# Per-account failures — a fault is not an absence
+# ---------------------------------------------------------------------------
+
+class TestDriveAccountFailureDisclosure:
+    """A failing account must not be rendered as an empty Drive.
+
+    An expired token was logged and the tool still said "No drive files found."
+    — a genuine backend fault dressed as absence, which is the misdiagnosis this
+    change exists to prevent.
+    """
+
+    async def test_total_failure_is_disclosed_not_reported_as_empty(
+        self, fake_drive, accounts
+    ):
+        fake_drive.broken = {"personal"}
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "Could not reach personal" in out
+        assert "not necessarily an empty Drive" in out
+
+    async def test_partial_failure_still_discloses_alongside_results(
+        self, fake_drive, accounts
+    ):
+        """The dangerous case: real files returned, one account silently missing."""
+        accounts.append(_account("work"))
+        fake_drive.broken = {"work"}
+        fake_drive.per_account = {"personal": [_file(1, "Synthetic personal doc")]}
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert "Synthetic personal doc" in out
+        assert "Could not reach work" in out
+
+    async def test_healthy_accounts_produce_no_failure_note(
+        self, fake_drive, accounts
+    ):
+        accounts.append(_account("work"))
+        fake_drive.per_account = {
+            "personal": [_file(1, "Synthetic personal doc")],
+            "work": [_file(2, "Synthetic work doc", account="work")],
+        }
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert "Could not reach" not in out
+
+    async def test_healthy_accounts_produce_no_failure_note_when_empty(
+        self, fake_drive, accounts
+    ):
+        accounts.append(_account("work"))
+        out = await _tool_search_drive({"query": "nothing matches this"})
+        assert "Could not reach" not in out
+
+    async def test_only_the_failing_account_is_named(self, fake_drive, accounts):
+        accounts.append(_account("work"))
+        fake_drive.broken = {"work"}
+        out = await _tool_search_drive({"query": "synthetic"})
+        reach = out.split("Could not reach", 1)[1]
+        assert "work" in reach
+        assert "personal" not in reach
+
+    async def test_a_real_fault_is_named_rather_than_hidden(
+        self, fake_drive, accounts
+    ):
+        """The complement of the no-fault-words rule.
+
+        An honest empty must never imply a fault — but a genuine failure must
+        not be scrubbed into one either, or we are back to reporting absence for
+        a Drive we could not read.
+        """
+        fake_drive.broken = {"personal"}
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert "incomplete" in out
+        assert any(word in out.lower() for word in FAULT_WORDS)
+
+    async def test_empty_after_a_failure_is_a_distinct_branch(
+        self, fake_drive, accounts
+    ):
+        """"Nothing found" and "nothing found in what answered" differ."""
+        accounts.append(_account("work"))
+        fake_drive.broken = {"work"}
+        partial = await _tool_search_drive({"query": "synthetic"})
+        fake_drive.broken = set()
+        healthy = await _tool_search_drive({"query": "synthetic"})
+        assert partial != healthy
+        assert "accounts that responded" in partial
+        assert "accounts that responded" not in healthy
+
+
+# ---------------------------------------------------------------------------
+# Honest empty results
+# ---------------------------------------------------------------------------
+
+class TestDriveHonestEmpty:
+    async def test_empty_result_names_the_query(self, fake_drive):
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "'comp planning'" in out
+
+    async def test_empty_result_names_the_cap_and_the_ordering(self, fake_drive):
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "up to 20 files per account" in out
+        assert "newest-modified first" in out
+
+    async def test_empty_result_names_the_explicit_cap_actually_used(
+        self, fake_drive
+    ):
+        out = await _tool_search_drive({"query": "comp planning", "max_results": 3})
+        assert "up to 3 files per account" in out
+
+    @pytest.mark.parametrize(
+        "inp",
+        [
+            {"query": "comp planning"},
+            {"query": "comp planning", "max_results": 0},
+            {"query": "comp planning", "order_by": "relevance"},
+            {},
+            {"query": "   "},
+        ],
+    )
+    async def test_no_empty_result_suggests_a_backend_fault(self, fake_drive, inp):
+        """Blanket ban, no exceptions on the paths where nothing actually broke.
+
+        The one branch deliberately excluded is the raising-account branch, which
+        must name the fault — see test_a_real_fault_is_named_rather_than_hidden.
+        """
+        out = await _tool_search_drive(inp)
+        assert not any(word in out.lower() for word in FAULT_WORDS)
+
+    async def test_missing_query_is_not_blamed_on_the_accounts(self, fake_drive):
+        """query was read inside the per-account try.
+
+        A missing query raised KeyError once per account and came back as
+        "Could not reach personal, work" — a malformed argument reported as
+        expired credentials.
+        """
+        out = await _tool_search_drive({})
+        assert "Could not reach" not in out
+        assert "query" in out
+        assert fake_drive.calls == []
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", 0])
+    async def test_blank_query_never_reaches_drive(self, fake_drive, raw):
+        await _tool_search_drive({"query": raw})
+        assert fake_drive.calls == []
+
+    async def test_query_is_trimmed_before_the_service_call(self, fake_drive):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        await _tool_search_drive({"query": "  comp planning  "})
+        assert fake_drive.calls[0]["full_text"] == "comp planning"
+
+
+# ---------------------------------------------------------------------------
+# Argument hardening — the model fills these in, so garbled values arrive
+# ---------------------------------------------------------------------------
+
+class TestDriveCapNormalization:
+    """max_results doubles as the truncation yardstick.
+
+    A None or 0 from the model would both confuse Drive's pageSize and silently
+    disable the disclosure that the page was cut short.
+    """
+
+    @pytest.mark.parametrize("raw", [None, "not a number"])
+    async def test_uninterpretable_cap_falls_back_to_the_default(
+        self, fake_drive, raw
+    ):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        await _tool_search_drive({"query": "synthetic", "max_results": raw})
+        assert fake_drive.calls[0]["max_results"] == _DRIVE_DEFAULT_RESULTS
+
+    @pytest.mark.parametrize("raw", [0, -5])
+    async def test_non_positive_cap_is_raised_to_one(self, fake_drive, raw):
+        """A cap is clamped, not dropped — unlike a scope.
+
+        A cap of 1 still returns data and the truncation check still works, which
+        is the same treatment search_email and search_slack give theirs.
+        """
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        await _tool_search_drive({"query": "synthetic", "max_results": raw})
+        assert fake_drive.calls[0]["max_results"] == 1
+
+    async def test_numeric_string_is_coerced(self, fake_drive):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        await _tool_search_drive({"query": "synthetic", "max_results": "6"})
+        assert fake_drive.calls[0]["max_results"] == 6
+
+    async def test_absurd_cap_is_clamped(self, fake_drive):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        await _tool_search_drive({"query": "synthetic", "max_results": 10_000})
+        assert fake_drive.calls[0]["max_results"] == _DRIVE_MAX_RESULTS
+
+    async def test_every_cap_the_model_can_send_is_a_positive_int(self, fake_drive):
+        for raw in (None, 0, -1, "0", 3.9, 10_000, "nonsense"):
+            fake_drive.calls.clear()
+            fake_drive.files = [_file(1, "Synthetic doc")]
+            await _tool_search_drive({"query": "synthetic", "max_results": raw})
+            used = fake_drive.calls[0]["max_results"]
+            assert isinstance(used, int) and used > 0
+
+    async def test_normalised_cap_is_the_yardstick_the_note_reports(
+        self, fake_drive
+    ):
+        """The cap sent and the cap compared against must be the same number.
+
+        If the clamped value reached Drive but the raw one drove the check, a cut
+        page would come back looking complete.
+        """
+        fake_drive.files = [_file(i + 1, f"Synthetic doc {i}") for i in range(25)]
+        out = await _tool_search_drive({"query": "synthetic", "max_results": 10_000})
+        sent = fake_drive.calls[0]["max_results"]
+        assert sent == _DRIVE_MAX_RESULTS
+        # 25 files, page of 100: the cap did not bind, so nothing to disclose.
+        assert "Capped at" not in out
+
+        fake_drive.calls.clear()
+        out = await _tool_search_drive({"query": "synthetic", "max_results": 0})
+        assert fake_drive.calls[0]["max_results"] == 1
+        assert "Capped at 1 files per account" in out
+
+    async def test_zero_cap_still_searches_rather_than_faking_an_empty(
+        self, fake_drive
+    ):
+        fake_drive.files = [_file(1, "Synthetic doc")]
+        out = await _tool_search_drive({"query": "synthetic", "max_results": 0})
+        assert "Synthetic doc" in out
+
+    def test_cap_bounds_are_sane(self):
+        assert _positive_int(None, _DRIVE_DEFAULT_RESULTS, _DRIVE_MAX_RESULTS) == 20
+        assert _DRIVE_DEFAULT_RESULTS <= _DRIVE_MAX_RESULTS
+
+
+# ---------------------------------------------------------------------------
+# Tool schema — the model can only use parameters that are advertised
+# ---------------------------------------------------------------------------
+
+class TestDriveToolDefinition:
+    @staticmethod
+    def _schema() -> dict:
+        return next(
+            t for t in TOOL_DEFINITIONS if t["name"] == "search_drive"
+        )["input_schema"]
+
+    def test_tool_is_registered(self):
+        assert "search_drive" in _TOOL_HANDLERS
+        assert any(t["name"] == "search_drive" for t in TOOL_DEFINITIONS)
+
+    def test_documents_the_new_default_cap(self):
+        desc = self._schema()["properties"]["max_results"]["description"]
+        assert "20" in desc
+
+    def test_ordering_option_is_advertised(self):
+        prop = self._schema()["properties"]["order_by"]
+        assert set(prop["enum"]) == set(_DRIVE_ORDERINGS)
+
+    def test_ordering_description_explains_when_to_use_oldest(self):
+        desc = self._schema()["properties"]["order_by"]["description"].lower()
+        assert "oldest" in desc
+        assert "cap" in desc
+
+    def test_description_warns_there_is_no_relevance_ranking(self):
+        desc = next(
+            t for t in TOOL_DEFINITIONS if t["name"] == "search_drive"
+        )["description"].lower()
+        assert "no relevance ranking" in desc
+
+
+# ---------------------------------------------------------------------------
+# Service boundary — the disclosure above depends on faults reaching the tool
+# ---------------------------------------------------------------------------
+
+class TestDriveServiceContract:
+    """DriveService.search() swallows API errors into an empty list.
+
+    That is fine for a bad query, but the credential fetch used to sit inside the
+    same handler, so an expired token returned [] and the tool could not tell an
+    unreachable account from one with no matching files. These pin the boundary
+    the per-account disclosure relies on.
+    """
+
+    def test_auth_failure_propagates_instead_of_returning_empty(self):
+        from api.services.drive import DriveService, GoogleAccount
+
+        with patch(
+            "api.services.drive.get_google_auth",
+            side_effect=RuntimeError("synthetic token expired"),
+        ):
+            service = DriveService(account_type=GoogleAccount.PERSONAL)
+            with pytest.raises(RuntimeError, match="synthetic token expired"):
+                service.search(full_text="comp planning")
+
+    def test_order_by_reaches_the_drive_api(self):
+        from api.services.drive import DriveService, GoogleAccount
+
+        service = DriveService.__new__(DriveService)
+        service.account_type = GoogleAccount.PERSONAL
+        service._service = MagicMock()
+        service._service.files().list().execute.return_value = {"files": []}
+
+        service.search(full_text="comp planning", order_by="modifiedTime")
+
+        kwargs = service._service.files().list.call_args.kwargs
+        assert kwargs["orderBy"] == "modifiedTime"
+
+    def test_default_order_by_is_unchanged_for_existing_callers(self):
+        from api.services.drive import DriveService, GoogleAccount
+
+        service = DriveService.__new__(DriveService)
+        service.account_type = GoogleAccount.PERSONAL
+        service._service = MagicMock()
+        service._service.files().list().execute.return_value = {"files": []}
+
+        service.search(name="Synthetic doc")
+
+        kwargs = service._service.files().list.call_args.kwargs
+        assert kwargs["orderBy"] == "modifiedTime desc"

--- a/tests/test_agent_tools_drive_scope.py
+++ b/tests/test_agent_tools_drive_scope.py
@@ -171,6 +171,17 @@ class TestDriveCapAndTruncation:
         assert "no relevance ranking" in out
         assert "order_by='oldest'" in out
 
+    async def test_capped_result_suggests_the_ordering_not_already_used(
+        self, fake_drive
+    ):
+        """Advising order_by='oldest' to a caller already on 'oldest' is noise."""
+        fake_drive.files = [_file(i + 1, f"Synthetic doc {i}") for i in range(5)]
+        out = await _tool_search_drive(
+            {"query": "synthetic", "max_results": 5, "order_by": "oldest"}
+        )
+        assert "order_by='recent'" in out
+        assert "order_by='oldest'" not in out
+
 
 # ---------------------------------------------------------------------------
 # Ordering — Drive has no relevance sort, so ordering is explicit

--- a/tests/test_agent_tools_empty_filters.py
+++ b/tests/test_agent_tools_empty_filters.py
@@ -1,0 +1,283 @@
+"""
+Tests for filter echoing on empty results from the workout, task, and vault tools.
+
+Regression context (issue #535): same bug class as
+tests/test_agent_tools_scope_widening.py, one notch milder. These three tools
+applied the filters they were given, found nothing in the slice, and then
+described the *whole record* as empty — "No sessions logged.", "No tasks
+found.", "No vault results found." Asked whether any training happened in June,
+the workout log answered that no sessions are logged, which reads as "you have
+no training history"; a lift logged under another name read as never performed;
+a slightly misspelled task context read as an empty task list.
+
+No widening ladder belongs here — these corpora are cheap to re-query. The fix
+is only that the reply stops asserting more than the search established, so
+these tests pin the distinction that motivates the issue: a *filtered* empty
+must name its filters, while an *unfiltered* empty may still say the record is
+empty.
+"""
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+import api.services.fitness_store as fs
+import api.services.hybrid_search as hs_mod
+import api.services.task_manager as tm_mod
+from api.services.agent_tools import (
+    _VAULT_TOP_K_DEFAULT,
+    _applied_filters,
+    _tool_manage_tasks,
+    _tool_manage_workouts,
+    _tool_search_vault,
+)
+from api.services.fitness_store import FitnessStore
+from api.services.task_manager import TaskManager
+
+pytestmark = pytest.mark.unit
+
+# Phrases that would tell the orchestrator the backend broke. An empty result is
+# a fact about the data, so none of these may appear in one.
+FAULT_WORDS = ("sync issue", "permission", "failed", "error", "unavailable")
+
+
+def assert_no_fault_language(text: str) -> None:
+    lowered = text.lower()
+    for word in FAULT_WORDS:
+        assert word not in lowered, f"empty result blames a fault ({word!r}): {text!r}"
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """Real FitnessStore on a temp sqlite db — the service boundary, and the
+    only way to exercise the real normalize_exercise title-casing."""
+    instance = FitnessStore(db_path=str(tmp_path / "fitness.db"))
+    monkeypatch.setattr(fs, "_store_instance", instance)
+    return instance
+
+
+@pytest.fixture
+def tasks(tmp_path, monkeypatch):
+    manager = TaskManager(vault_path=tmp_path / "vault", index_path=tmp_path / "task_index.json")
+    # agent_tools imports get_task_manager lazily from this module, so patching
+    # the module attribute is enough.
+    monkeypatch.setattr(tm_mod, "get_task_manager", lambda: manager)
+    return manager
+
+
+@pytest.fixture
+def fake_vault(monkeypatch):
+    """Stub HybridSearch, recording the top_k the tool actually asked for."""
+    state = SimpleNamespace(calls=[], results=[])
+
+    class FakeHybridSearch:
+        def search(self, query, top_k=20, **kwargs):
+            state.calls.append({"query": query, "top_k": top_k})
+            return list(state.results)
+
+    monkeypatch.setattr(hs_mod, "HybridSearch", FakeHybridSearch)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# manage_workouts — action="list"
+# ---------------------------------------------------------------------------
+
+class TestWorkoutListEmpty:
+    def test_dated_empty_names_the_range_and_does_not_deny_the_log(self, store):
+        out = _tool_manage_workouts({
+            "action": "list", "date_start": "2026-06-01", "date_end": "2026-06-30",
+        })
+        assert "2026-06-01" in out and "2026-06-30" in out
+        # The core claim: a June miss is not evidence the log is empty.
+        assert "No sessions logged" not in out
+        assert_no_fault_language(out)
+
+    def test_dated_empty_while_sessions_exist_outside_the_range(self, store):
+        # The shipped misdiagnosis in miniature: sessions exist, just not in the
+        # window asked about.
+        store.add_session(sets=[{"exercise": "flamingo hold", "reps": 3}], date="2026-01-05")
+        out = _tool_manage_workouts({
+            "action": "list", "date_start": "2026-06-01", "date_end": "2026-06-30",
+        })
+        assert "2026-06-01" in out and "2026-06-30" in out
+        assert "No sessions logged" not in out
+        assert_no_fault_language(out)
+
+    def test_kind_filter_is_echoed(self, store):
+        out = _tool_manage_workouts({"action": "list", "kind": "mobility"})
+        assert "mobility" in out
+        assert "No sessions logged" not in out
+        assert_no_fault_language(out)
+
+    def test_unfiltered_empty_may_state_the_log_is_empty(self, store):
+        # The other direction. With nothing filtered, "no sessions are logged" is
+        # exactly what the search established — this must not collapse into the
+        # filtered wording, or the distinction stops carrying information.
+        out = _tool_manage_workouts({"action": "list"})
+        assert out == "No sessions logged."
+        assert_no_fault_language(out)
+
+
+# ---------------------------------------------------------------------------
+# manage_workouts — action="history"
+# ---------------------------------------------------------------------------
+
+class TestWorkoutHistoryEmpty:
+    def test_states_the_normalised_name_that_was_queried(self, store):
+        # normalize_exercise title-cases anything it has no alias for, so the
+        # name looked up differs from the name asked about. Out of scope to
+        # resolve the alias; in scope to say which name was queried.
+        out = _tool_manage_workouts({"action": "history", "exercise": "flamingo hold"})
+        assert "Flamingo Hold" in out
+        assert "flamingo hold" in out  # the name as asked, so the model sees both
+        assert "normalised from" in out
+        assert_no_fault_language(out)
+
+    def test_already_canonical_name_is_still_stated(self, store):
+        out = _tool_manage_workouts({"action": "history", "exercise": "Flamingo Hold"})
+        assert "Flamingo Hold" in out
+        # Nothing was rewritten, so claiming a normalisation would be noise.
+        assert "normalised from" not in out
+        assert_no_fault_language(out)
+
+    def test_empty_does_not_claim_the_exercise_was_never_done(self, store):
+        store.add_session(sets=[{"exercise": "Flamingo Hold", "reps": 3}], date="2026-06-07")
+        out = _tool_manage_workouts({"action": "history", "exercise": "flamingo holds"})
+        # "Flamingo Holds" (plural) is a different key; the reply must attribute
+        # the miss to the name looked up, not to the work never happening.
+        assert "different name" in out
+        assert_no_fault_language(out)
+
+
+# ---------------------------------------------------------------------------
+# manage_workouts — action="metrics"
+# ---------------------------------------------------------------------------
+
+class TestWorkoutMetricsEmpty:
+    def test_dated_empty_names_the_window(self, store):
+        out = _tool_manage_workouts({
+            "action": "metrics", "metric_type": "body_weight",
+            "date_start": "2026-06-01", "date_end": "2026-06-30",
+        })
+        assert "2026-06-01" in out and "2026-06-30" in out
+        assert "No body weight recorded" not in out
+        assert_no_fault_language(out)
+
+    def test_dated_empty_while_values_exist_outside_the_window(self, store):
+        store.log_metric("body_weight", 171.0, unit="lb", start_at="2026-01-05T07:00:00+00:00")
+        out = _tool_manage_workouts({
+            "action": "metrics", "metric_type": "body_weight",
+            "date_start": "2026-06-01", "date_end": "2026-06-30",
+        })
+        assert "2026-06-01" in out and "2026-06-30" in out
+        assert "No body weight recorded" not in out
+        assert_no_fault_language(out)
+
+    def test_cumulative_dated_empty_names_the_window(self, store):
+        # steps takes the daily-rollup path, which has its own empty return.
+        out = _tool_manage_workouts({
+            "action": "metrics", "metric_type": "steps", "date_start": "2026-06-01",
+        })
+        assert "2026-06-01" in out
+        assert "No steps recorded" not in out
+        assert_no_fault_language(out)
+
+    def test_unfiltered_empty_may_state_the_metric_is_not_recorded(self, store):
+        out = _tool_manage_workouts({"action": "metrics", "metric_type": "body_weight"})
+        assert out == "No body weight recorded."
+        assert_no_fault_language(out)
+
+
+# ---------------------------------------------------------------------------
+# manage_tasks — action="list"
+# ---------------------------------------------------------------------------
+
+class TestTaskListEmpty:
+    def test_filtered_empty_echoes_status_context_and_query(self, tasks):
+        out = _tool_manage_tasks({
+            "action": "list", "status": "done", "context": "Kayak Trip", "query": "portage map",
+        })
+        assert "done" in out
+        assert "Kayak Trip" in out
+        assert "portage map" in out
+        assert "No tasks found" not in out
+        assert_no_fault_language(out)
+
+    def test_context_miss_does_not_read_as_an_empty_task_list(self, tasks):
+        # context is exact case-insensitive equality (loosening it is out of
+        # scope), so a near-miss spelling matches nothing while tasks do exist.
+        tasks.create("Wax the synthetic canoe")
+        out = _tool_manage_tasks({"action": "list", "context": "Kayak Trips"})
+        assert "Kayak Trips" in out
+        assert "No tasks found" not in out
+        assert_no_fault_language(out)
+
+    def test_unfiltered_empty_may_state_there_are_no_tasks(self, tasks):
+        out = _tool_manage_tasks({"action": "list"})
+        assert out == "No tasks found."
+        assert_no_fault_language(out)
+
+
+# ---------------------------------------------------------------------------
+# search_vault
+# ---------------------------------------------------------------------------
+
+class TestSearchVault:
+    def test_default_top_k_is_not_below_the_service_default(self):
+        """Pinned against HybridSearch.search's own signature so the two can't
+        drift apart again — the tool's old default of 10 halved it."""
+        service_default = inspect.signature(hs_mod.HybridSearch.search).parameters["top_k"].default
+        assert _VAULT_TOP_K_DEFAULT >= service_default
+
+    def test_passes_the_default_when_the_caller_states_no_count(self, fake_vault):
+        _tool_search_vault({"query": "kayak portage checklist"})
+        assert fake_vault.calls[0]["top_k"] == _VAULT_TOP_K_DEFAULT
+
+    def test_explicit_top_k_is_honoured(self, fake_vault):
+        _tool_search_vault({"query": "kayak portage checklist", "top_k": 5})
+        assert fake_vault.calls[0]["top_k"] == 5
+
+    def test_unusable_top_k_still_searches_for_something(self, fake_vault):
+        # The model writes this argument; a 0 or None would return nothing and
+        # read as an empty vault.
+        for bad in (0, None, -3):
+            fake_vault.calls.clear()
+            _tool_search_vault({"query": "kayak portage checklist", "top_k": bad})
+            assert fake_vault.calls[0]["top_k"] >= 1
+
+    def test_empty_echoes_the_query(self, fake_vault):
+        out = _tool_search_vault({"query": "kayak portage checklist"})
+        assert "kayak portage checklist" in out
+        assert_no_fault_language(out)
+
+    def test_results_still_render(self, fake_vault):
+        fake_vault.results = [
+            {"file_name": "Kayak Trip Planning.md", "content": "Portage route notes.", "hybrid_score": 0.42},
+        ]
+        out = _tool_search_vault({"query": "kayak portage checklist"})
+        assert "Kayak Trip Planning.md" in out
+        assert "Portage route notes." in out
+
+
+# ---------------------------------------------------------------------------
+# the shared filter-naming helper
+# ---------------------------------------------------------------------------
+
+class TestAppliedFilters:
+    def test_no_filters_is_empty(self):
+        # The empty list is what licenses the "the record is empty" wording.
+        assert _applied_filters() == []
+        assert _applied_filters(status=None, context="") == []
+
+    def test_named_filters_keep_caller_order(self):
+        assert _applied_filters(status="todo", context="Kayak Trip") == [
+            "status='todo'", "context='Kayak Trip'",
+        ]
+
+    def test_one_sided_date_bounds_are_described_as_such(self):
+        assert _applied_filters(date_start="2026-06-01") == ["dates from 2026-06-01"]
+        assert _applied_filters(date_end="2026-06-30") == ["dates through 2026-06-30"]
+        assert _applied_filters(date_start="2026-06-01", date_end="2026-06-30") == [
+            "dates 2026-06-01 to 2026-06-30",
+        ]

--- a/tests/test_agent_tools_finances_period.py
+++ b/tests/test_agent_tools_finances_period.py
@@ -1,0 +1,371 @@
+"""
+Tests for period labelling in the finance summary actions (cashflow, budgets).
+
+Regression context: same bug class as tests/test_agent_tools_scope_widening.py,
+but the harm is inverted. Those tools denied data that was present; these two
+answered confidently with a figure covering a window nobody asked for. Both
+actions defaulted `start_date` to the 1st of the current month and then printed
+Income / Expenses / Net Savings / Savings Rate with no period anywhere in the
+output — on the 2nd of a month, a two-day total with a savings rate beside it
+and nothing to cue the reader that the period was partial. The category
+breakdown was cut to the top ten silently, so the 11th category read as zero
+spend, and an empty budget month reported "No budgets found." as though none
+were configured.
+
+These tests pin the fix: every figure carries its period, the breakdown
+discloses its own cut, an empty budget result names the period it searched
+instead of asserting absence, and an unparseable date is dropped and disclosed.
+"""
+import re
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from api.services.agent_tools import (
+    _CASHFLOW_CATEGORY_CAP,
+    _tool_search_finances,
+)
+
+pytestmark = pytest.mark.unit
+
+# Phrases that would tell the orchestrator the backend broke. An empty result is
+# a fact about the data, so none of these may appear in one.
+FAULT_WORDS = ("sync issue", "permission", "failed", "error", "unavailable")
+
+# Claims an empty budget result must never make: a bounded period being empty
+# says nothing about whether budgets exist at all.
+_CONFIGURED_CLAIM = re.compile(
+    r"no budgets (?:are|were|have been)?\s*(?:configured|set up|set)", re.I
+)
+
+
+def _today() -> str:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def _first_of_this_month() -> str:
+    return datetime.now().replace(day=1).strftime("%Y-%m-%d")
+
+
+@pytest.fixture
+def fake_monarch(monkeypatch):
+    """Stub the Monarch client, recording the bounds of every summary call.
+
+    Raises on a one-sided range exactly as monarchmoney does ("You must specify
+    both a startDate and endDate, not just one of them"), so any code path that
+    sends a bare start_date fails loudly here instead of in production.
+    """
+    state = SimpleNamespace(
+        summary={"total_income": 0.0, "total_expenses": 0.0, "savings": 0.0, "savings_rate": 0.0},
+        categories=[],
+        budgets=[],
+        calls=[],
+    )
+
+    def _record(method, start_date, end_date):
+        if (start_date is None) != (end_date is None):
+            raise AssertionError(
+                f"{method} got a one-sided range ({start_date!r}, {end_date!r}); "
+                "Monarch rejects that outright"
+            )
+        state.calls.append({"method": method, "start": start_date, "end": end_date})
+
+    class FakeMonarchClient:
+        async def get_cashflow_summary(self, start_date=None, end_date=None):
+            _record("cashflow_summary", start_date, end_date)
+            return dict(state.summary)
+
+        async def get_cashflow_by_category(self, start_date=None, end_date=None):
+            _record("cashflow_by_category", start_date, end_date)
+            return [dict(c) for c in state.categories]
+
+        async def get_budgets(self, start_date=None, end_date=None):
+            _record("budgets", start_date, end_date)
+            return [dict(b) for b in state.budgets]
+
+    monkeypatch.setattr("api.services.monarch.get_monarch_client", lambda: FakeMonarchClient())
+    return state
+
+
+async def _cashflow(**inp) -> str:
+    return await _tool_search_finances({"action": "cashflow", **inp})
+
+
+async def _budgets(**inp) -> str:
+    return await _tool_search_finances({"action": "budgets", **inp})
+
+
+def _category(name: str, amount: float) -> dict:
+    return {"category": name, "amount": amount}
+
+
+def _categories(n: int) -> list[dict]:
+    """n synthetic categories, largest first (the real client sorts this way)."""
+    return [_category(f"Category {i:02d}", 1000.0 - i) for i in range(n)]
+
+
+def _budget(category: str, budgeted: float, actual: float) -> dict:
+    return {
+        "category": category,
+        "budgeted": budgeted,
+        "actual": actual,
+        "remaining": budgeted - actual,
+    }
+
+
+class TestCashflowPeriodLabel:
+    """The core fix: no figure is printed without the window it covers."""
+
+    async def test_defaulted_period_is_stated(self, fake_monarch):
+        out = await _cashflow()
+        assert f"**Period**: {_first_of_this_month()} to {_today()}" in out
+
+    async def test_defaulted_period_says_it_is_partial(self, fake_monarch):
+        """A month-to-date total is the confidently-wrong-number case."""
+        out = await _cashflow()
+        assert "month-to-date by default" in out
+        assert "part of the month" in out
+
+    async def test_explicit_period_is_stated(self, fake_monarch):
+        out = await _cashflow(start_date="2026-03-01", end_date="2026-03-31")
+        assert "**Period**: 2026-03-01 to 2026-03-31" in out
+
+    async def test_explicit_period_is_not_labelled_a_default(self, fake_monarch):
+        out = await _cashflow(start_date="2026-03-01", end_date="2026-03-31")
+        assert "default" not in out
+
+    async def test_period_precedes_the_figures(self, fake_monarch):
+        """Scope after the numbers is scope the reader has already skipped."""
+        out = await _cashflow()
+        assert out.index("**Period**") < out.index("**Savings Rate**")
+
+    async def test_explicit_period_is_sent_to_monarch_verbatim(self, fake_monarch):
+        await _cashflow(start_date="2026-03-01", end_date="2026-03-31")
+        assert fake_monarch.calls
+        for call in fake_monarch.calls:
+            assert (call["start"], call["end"]) == ("2026-03-01", "2026-03-31")
+
+    async def test_missing_end_bound_is_filled_in(self, fake_monarch):
+        """Monarch rejects a one-sided range, so the stated end must be real."""
+        await _cashflow(start_date="2026-03-01")
+        for call in fake_monarch.calls:
+            assert (call["start"], call["end"]) == ("2026-03-01", _today())
+
+    async def test_summary_and_breakdown_cover_the_same_window(self, fake_monarch):
+        """A label over two different windows would be a label over neither."""
+        fake_monarch.categories = _categories(3)
+        await _cashflow()
+        bounds = {(c["start"], c["end"]) for c in fake_monarch.calls}
+        assert len(fake_monarch.calls) == 2
+        assert len(bounds) == 1
+
+
+class TestSummaryEndDateAnchor:
+    """A defaulted start counts back from end_date, not from today.
+
+    Pairing this month's 1st with a past end_date builds an inverted window that
+    can only return zeros — which then prints as a real $0.00 month under a
+    period label that reads backwards.
+    """
+
+    async def test_defaulted_start_anchors_to_the_end_date(self, fake_monarch):
+        out = await _cashflow(end_date="2026-03-31")
+        assert "**Period**: 2026-03-01 to 2026-03-31" in out
+
+    async def test_anchored_default_is_disclosed(self, fake_monarch):
+        out = await _cashflow(end_date="2026-03-31")
+        assert "start defaulted to the 1st of that month" in out
+
+    async def test_window_is_never_inverted(self, fake_monarch):
+        await _cashflow(end_date="2026-03-31")
+        assert fake_monarch.calls
+        for call in fake_monarch.calls:
+            assert call["start"] <= call["end"], call
+
+    async def test_budgets_anchor_the_same_way(self, fake_monarch):
+        fake_monarch.budgets = [_budget("Groceries", 600.0, 120.0)]
+        out = await _budgets(end_date="2026-03-31")
+        assert "2026-03-01 to 2026-03-31" in out
+
+
+class TestCashflowBreakdownTruncation:
+    async def test_truncation_is_disclosed_when_the_cap_binds(self, fake_monarch):
+        fake_monarch.categories = _categories(_CASHFLOW_CATEGORY_CAP + 3)
+        out = await _cashflow()
+        assert "and 3 more categories" in out
+        assert "truncated" in out
+
+    async def test_truncated_note_denies_the_zero_reading(self, fake_monarch):
+        """A category just outside the cut otherwise reads as zero spend."""
+        fake_monarch.categories = _categories(_CASHFLOW_CATEGORY_CAP + 1)
+        out = await _cashflow()
+        assert "not zero" in out
+
+    async def test_no_note_when_exactly_at_the_cap(self, fake_monarch):
+        """At the cap nothing was cut, so there is nothing to disclose."""
+        fake_monarch.categories = _categories(_CASHFLOW_CATEGORY_CAP)
+        out = await _cashflow()
+        assert "more categories" not in out
+        assert "truncated" not in out
+
+    async def test_no_note_below_the_cap(self, fake_monarch):
+        fake_monarch.categories = _categories(3)
+        out = await _cashflow()
+        assert "more categories" not in out
+        assert "truncated" not in out
+
+    async def test_kept_categories_are_the_largest(self, fake_monarch):
+        fake_monarch.categories = _categories(_CASHFLOW_CATEGORY_CAP + 2)
+        out = await _cashflow()
+        assert "Category 00" in out
+        assert f"Category {_CASHFLOW_CATEGORY_CAP + 1:02d}" not in out
+
+
+class TestCashflowHonestEmpty:
+    async def test_empty_breakdown_names_the_period(self, fake_monarch):
+        out = await _cashflow()
+        assert "No categorized spending in this period." in out
+        assert f"{_first_of_this_month()} to {_today()}" in out
+
+    async def test_empty_breakdown_does_not_suggest_a_backend_fault(self, fake_monarch):
+        out = (await _cashflow()).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+
+class TestBudgetsHonestEmpty:
+    async def test_empty_result_names_the_defaulted_period(self, fake_monarch):
+        out = await _budgets()
+        assert f"Searched {_first_of_this_month()} to {_today()}" in out
+
+    async def test_empty_result_names_an_explicit_period(self, fake_monarch):
+        out = await _budgets(start_date="2026-03-01", end_date="2026-03-31")
+        assert "Searched 2026-03-01 to 2026-03-31" in out
+
+    async def test_empty_result_does_not_claim_none_are_configured(self, fake_monarch):
+        """The period searched is always bounded, so absence is never established."""
+        out = await _budgets()
+        assert not _CONFIGURED_CLAIM.search(out), out
+
+    async def test_empty_result_separates_the_period_from_the_setup(self, fake_monarch):
+        out = await _budgets()
+        assert "hasn't populated yet" in out
+
+    async def test_empty_result_does_not_suggest_a_backend_fault(self, fake_monarch):
+        out = (await _budgets()).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+    async def test_empty_explicit_period_does_not_suggest_a_backend_fault(self, fake_monarch):
+        out = (await _budgets(start_date="2026-03-01", end_date="2026-03-31")).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+
+class TestBudgetsPopulated:
+    async def test_period_is_stated_above_the_table(self, fake_monarch):
+        fake_monarch.budgets = [_budget("Groceries", 600.0, 120.0)]
+        out = await _budgets()
+        assert f"Budgets for {_first_of_this_month()} to {_today()}" in out
+        assert out.index("Budgets for") < out.index("| Category |")
+
+    async def test_rows_keep_all_four_columns(self, fake_monarch):
+        fake_monarch.budgets = [_budget("Groceries", 600.0, 120.0)]
+        out = await _budgets()
+        assert "| Groceries | $600.00 | $120.00 | $480.00 |" in out
+
+
+class TestSummaryUnparseableDates:
+    async def test_unparseable_start_never_reaches_monarch(self, fake_monarch):
+        await _cashflow(start_date="last month")
+        assert fake_monarch.calls
+        for call in fake_monarch.calls:
+            assert call["start"] == _first_of_this_month()
+
+    async def test_unparseable_start_is_disclosed(self, fake_monarch):
+        out = await _cashflow(start_date="last month")
+        assert "Ignored unparseable start_date='last month'" in out
+
+    async def test_unparseable_end_never_reaches_monarch(self, fake_monarch):
+        await _cashflow(start_date="2026-03-01", end_date="soon")
+        for call in fake_monarch.calls:
+            assert call["end"] == _today()
+
+    async def test_both_unparseable_dates_are_named(self, fake_monarch):
+        out = await _cashflow(start_date="q1", end_date="q2")
+        assert "start_date='q1'" in out
+        assert "end_date='q2'" in out
+
+    async def test_disclosure_says_the_period_is_not_the_one_asked_for(self, fake_monarch):
+        out = await _cashflow(start_date="last month")
+        assert "NOT the one that was asked for" in out
+
+    async def test_no_note_when_dates_are_valid(self, fake_monarch):
+        out = await _cashflow(start_date="2026-03-01", end_date="2026-03-31")
+        assert "Ignored unparseable" not in out
+
+    async def test_no_note_when_dates_are_absent(self, fake_monarch):
+        out = await _cashflow()
+        assert "Ignored unparseable" not in out
+
+    async def test_budgets_disclose_on_a_populated_result(self, fake_monarch):
+        fake_monarch.budgets = [_budget("Groceries", 600.0, 120.0)]
+        out = await _budgets(start_date="whenever")
+        assert "Ignored unparseable start_date='whenever'" in out
+
+    async def test_budgets_disclose_on_an_empty_result(self, fake_monarch):
+        out = await _budgets(end_date="soon")
+        assert "Ignored unparseable end_date='soon'" in out
+
+    async def test_budgets_empty_with_bad_dates_has_no_fault_language(self, fake_monarch):
+        out = (await _budgets(start_date="q1", end_date="q2")).lower()
+        for word in FAULT_WORDS:
+            assert word not in out
+
+    async def test_a_dropped_date_still_leaves_a_valid_window(self, fake_monarch):
+        """Dropping half a range must not produce an inverted or one-sided one."""
+        await _cashflow(start_date="2026-03-01", end_date="nope")
+        for call in fake_monarch.calls:
+            assert call["start"] is not None and call["end"] is not None
+            assert call["start"] <= call["end"], call
+
+
+class TestSummaryFigures:
+    """The figures themselves are unchanged — the period is what was missing."""
+
+    async def test_figures_are_rendered_from_the_summary(self, fake_monarch):
+        fake_monarch.summary = {
+            "total_income": 5000.0,
+            "total_expenses": 3200.0,
+            "savings": 1800.0,
+            "savings_rate": 0.36,
+        }
+        out = await _cashflow()
+        assert "**Income**: $5,000.00" in out
+        assert "**Expenses**: $3,200.00" in out
+        assert "**Net Savings**: $1,800.00" in out
+        assert "**Savings Rate**: 36.0%" in out
+
+
+class TestSummaryDefaultBoundary:
+    """The month-to-date default stays; only its silence was the defect."""
+
+    async def test_default_start_is_the_first_of_the_month(self, fake_monarch):
+        await _cashflow()
+        first = _first_of_this_month()
+        assert first.endswith("-01")
+        for call in fake_monarch.calls:
+            assert call["start"] == first
+
+    async def test_default_end_is_today(self, fake_monarch):
+        await _budgets()
+        assert fake_monarch.calls[0]["end"] == _today()
+
+    async def test_default_window_is_at_most_one_month(self, fake_monarch):
+        await _cashflow()
+        call = fake_monarch.calls[0]
+        span = datetime.strptime(call["end"], "%Y-%m-%d") - datetime.strptime(
+            call["start"], "%Y-%m-%d"
+        )
+        assert timedelta(0) <= span < timedelta(days=31)

--- a/tests/test_agent_tools_finances_period.py
+++ b/tests/test_agent_tools_finances_period.py
@@ -292,59 +292,113 @@ class TestBudgetsPopulated:
         assert "| Groceries | $600.00 | $120.00 | $480.00 |" in out
 
 
-class TestSummaryUnparseableDates:
-    async def test_unparseable_start_never_reaches_monarch(self, fake_monarch):
-        await _cashflow(start_date="last month")
-        assert fake_monarch.calls
-        for call in fake_monarch.calls:
-            assert call["start"] == _first_of_this_month()
+class TestSummaryUnparseableDatesAreRefused:
+    """An unreadable date on an aggregate is refused, not dropped.
 
-    async def test_unparseable_start_is_disclosed(self, fake_monarch):
+    The transactions branch drops one and says so, which is survivable there
+    because every row it prints carries its own date — a wrong period shows up in
+    the output. An aggregate has no such cue: the number IS the whole answer, and
+    a note beside a real total is easily reported without it. So cashflow and
+    budgets make no API call at all when an explicitly supplied date can't be
+    read.
+    """
+
+    async def test_unparseable_start_is_refused(self, fake_monarch):
         out = await _cashflow(start_date="last month")
-        assert "Ignored unparseable start_date='last month'" in out
+        assert "could not read start_date='last month'" in out
+        assert not fake_monarch.calls, "no figures may be fetched for a guessed period"
 
-    async def test_unparseable_end_never_reaches_monarch(self, fake_monarch):
-        await _cashflow(start_date="2026-03-01", end_date="soon")
-        for call in fake_monarch.calls:
-            assert call["end"] == _today()
+    async def test_unparseable_end_is_refused(self, fake_monarch):
+        out = await _cashflow(start_date="2026-03-01", end_date="soon")
+        assert "could not read end_date='soon'" in out
+        assert not fake_monarch.calls
 
     async def test_both_unparseable_dates_are_named(self, fake_monarch):
         out = await _cashflow(start_date="q1", end_date="q2")
         assert "start_date='q1'" in out
         assert "end_date='q2'" in out
 
-    async def test_disclosure_says_the_period_is_not_the_one_asked_for(self, fake_monarch):
+    async def test_refusal_is_named_as_a_bad_argument_not_an_empty_period(
+        self, fake_monarch
+    ):
         out = await _cashflow(start_date="last month")
-        assert "NOT the one that was asked for" in out
+        assert "bad date argument" in out
+        assert "NOT an empty period" in out
 
-    async def test_no_note_when_dates_are_valid(self, fake_monarch):
+    async def test_refusal_says_why_a_note_would_not_have_been_enough(
+        self, fake_monarch
+    ):
+        """The reason this differs from transactions: an aggregate has no cue."""
+        out = await _cashflow(start_date="last month")
+        assert "reads exactly like the one that was asked for" in out
+
+    async def test_refusal_prints_no_figures(self, fake_monarch):
+        fake_monarch.summary = {
+            "total_income": 5000.0, "total_expenses": 3200.0, "savings_rate": 0.36,
+        }
+        out = await _cashflow(start_date="last month")
+        assert "$" not in out
+        assert "Savings Rate" not in out
+
+    async def test_refusal_asks_for_the_expected_format(self, fake_monarch):
+        out = await _cashflow(start_date="last month")
+        assert "YYYY-MM-DD" in out
+
+    async def test_no_refusal_when_dates_are_valid(self, fake_monarch):
         out = await _cashflow(start_date="2026-03-01", end_date="2026-03-31")
-        assert "Ignored unparseable" not in out
+        assert "could not read" not in out
+        assert fake_monarch.calls
 
-    async def test_no_note_when_dates_are_absent(self, fake_monarch):
+    async def test_no_refusal_when_dates_are_absent(self, fake_monarch):
         out = await _cashflow()
-        assert "Ignored unparseable" not in out
+        assert "could not read" not in out
+        assert fake_monarch.calls
 
-    async def test_budgets_disclose_on_a_populated_result(self, fake_monarch):
+    async def test_budgets_refuse_the_same_way(self, fake_monarch):
         fake_monarch.budgets = [_budget("Groceries", 600.0, 120.0)]
         out = await _budgets(start_date="whenever")
-        assert "Ignored unparseable start_date='whenever'" in out
+        assert "could not read start_date='whenever'" in out
+        assert not fake_monarch.calls
+        assert "| Groceries |" not in out
 
-    async def test_budgets_disclose_on_an_empty_result(self, fake_monarch):
+    async def test_budgets_refuse_an_unparseable_end(self, fake_monarch):
         out = await _budgets(end_date="soon")
-        assert "Ignored unparseable end_date='soon'" in out
+        assert "could not read end_date='soon'" in out
+        assert not fake_monarch.calls
 
-    async def test_budgets_empty_with_bad_dates_has_no_fault_language(self, fake_monarch):
-        out = (await _budgets(start_date="q1", end_date="q2")).lower()
-        for word in FAULT_WORDS:
-            assert word not in out
+    async def test_refusal_carries_no_backend_fault_language(self, fake_monarch):
+        """A malformed argument is not a broken backend."""
+        for out in (
+            await _cashflow(start_date="q1", end_date="q2"),
+            await _budgets(start_date="q1", end_date="q2"),
+        ):
+            lowered = out.lower()
+            for word in FAULT_WORDS:
+                assert word not in lowered, f"bad-date refusal implies a fault: {word!r}"
 
-    async def test_a_dropped_date_still_leaves_a_valid_window(self, fake_monarch):
-        """Dropping half a range must not produce an inverted or one-sided one."""
-        await _cashflow(start_date="2026-03-01", end_date="nope")
-        for call in fake_monarch.calls:
-            assert call["start"] is not None and call["end"] is not None
-            assert call["start"] <= call["end"], call
+    async def test_transactions_still_drop_and_disclose(self, fake_monarch, monkeypatch):
+        """The deliberate asymmetry: rows carry their own dates, so a note works.
+
+        Refusing there would remove a working answer; the period is visible on
+        every line printed.
+        """
+        async def _get_transactions(start_date=None, end_date=None, search="", limit=None):
+            return [{
+                "date": "2026-03-04", "merchant": "Synthetic Grocer",
+                "category": "Groceries", "amount": -42.0,
+            }]
+
+        class FakeClient:
+            get_transactions = staticmethod(_get_transactions)
+
+        monkeypatch.setattr(
+            "api.services.monarch.get_monarch_client", lambda: FakeClient()
+        )
+        out = await _tool_search_finances(
+            {"action": "transactions", "start_date": "last month"}
+        )
+        assert "Ignored unparseable start_date='last month'" in out
+        assert "Synthetic Grocer" in out
 
 
 class TestSummaryFigures:

--- a/tests/test_agent_tools_finances_period.py
+++ b/tests/test_agent_tools_finances_period.py
@@ -194,13 +194,19 @@ class TestCashflowBreakdownTruncation:
         fake_monarch.categories = _categories(_CASHFLOW_CATEGORY_CAP + 3)
         out = await _cashflow()
         assert "and 3 more categories" in out
-        assert "truncated" in out
+        assert f"largest {_CASHFLOW_CATEGORY_CAP} of {_CASHFLOW_CATEGORY_CAP + 3}" in out
 
-    async def test_truncated_note_denies_the_zero_reading(self, fake_monarch):
-        """A category just outside the cut otherwise reads as zero spend."""
+    async def test_truncated_note_discloses_without_claiming_amounts(self, fake_monarch):
+        """A category outside the cut must not read as zero spend.
+
+        An earlier version said "the rest are not zero", which the code cannot
+        establish — an omitted category may legitimately be 0. The note now
+        discloses the omission by count and asserts nothing about the amounts.
+        """
         fake_monarch.categories = _categories(_CASHFLOW_CATEGORY_CAP + 1)
         out = await _cashflow()
-        assert "not zero" in out
+        assert "1 more categories not shown" in out
+        assert "not zero" not in out
 
     async def test_no_note_when_exactly_at_the_cap(self, fake_monarch):
         """At the cap nothing was cut, so there is nothing to disclose."""
@@ -225,8 +231,18 @@ class TestCashflowBreakdownTruncation:
 class TestCashflowHonestEmpty:
     async def test_empty_breakdown_names_the_period(self, fake_monarch):
         out = await _cashflow()
-        assert "No categorized spending in this period." in out
+        assert "No spending in this period." in out
         assert f"{_first_of_this_month()} to {_today()}" in out
+
+    async def test_unclassified_expenses_are_not_called_no_spending(self, fake_monarch):
+        """Saying "no spending" here would contradict the Expenses line above it."""
+        fake_monarch.summary = {
+            "total_income": 5000.0, "total_expenses": 1200.0, "savings_rate": 0.76,
+        }
+        fake_monarch.categories = []
+        out = await _cashflow()
+        assert "No spending in this period." not in out
+        assert "unavailable, not" in out
 
     async def test_empty_breakdown_does_not_suggest_a_backend_fault(self, fake_monarch):
         out = (await _cashflow()).lower()
@@ -369,3 +385,85 @@ class TestSummaryDefaultBoundary:
             call["start"], "%Y-%m-%d"
         )
         assert timedelta(0) <= span < timedelta(days=31)
+
+
+class TestImpossibleWindowIsRefused:
+    """A start after the end cannot contain anything, so it must not be queried.
+
+    Anchoring a defaulted start to end_date fixes the defaulted case, but a
+    caller-supplied future start_date — or bounds passed the wrong way round —
+    still describes an impossible window. Querying it returns zeros that print as
+    a real $0.00 period at 0%, which is the confidently-wrong-number failure this
+    whole change exists to remove.
+    """
+
+    async def test_future_start_date_is_refused(self, fake_monarch):
+        future = (datetime.now() + timedelta(days=9)).strftime("%Y-%m-%d")
+        out = await _cashflow(start_date=future)
+        assert "start is after the end" in out
+        assert not fake_monarch.calls, "an impossible window must not be queried"
+
+    async def test_reversed_bounds_are_refused(self, fake_monarch):
+        out = await _cashflow(start_date="2026-09-01", end_date="2026-08-01")
+        assert "start is after the end" in out
+        assert not fake_monarch.calls
+
+    async def test_budgets_refuses_the_same_window(self, fake_monarch):
+        out = await _budgets(start_date="2026-09-01", end_date="2026-08-01")
+        assert "start is after the end" in out
+        assert not fake_monarch.calls
+
+    async def test_refusal_is_named_as_a_bad_range_not_an_empty_period(self, fake_monarch):
+        out = await _cashflow(start_date="2026-09-01", end_date="2026-08-01")
+        assert "NOT an empty period" in out
+        assert "$0.00" not in out
+
+    async def test_refusal_carries_no_fault_language(self, fake_monarch):
+        out = (await _cashflow(start_date="2026-09-01", end_date="2026-08-01")).lower()
+        for word in FAULT_WORDS:
+            assert word not in out, f"bad-range refusal implies a fault: {word!r}"
+
+    async def test_a_valid_window_is_still_queried(self, fake_monarch):
+        out = await _cashflow(start_date="2026-08-01", end_date="2026-08-11")
+        assert "start is after the end" not in out
+        assert fake_monarch.calls
+
+
+class TestSavingsRate:
+    """An undefined rate must not be printed as a number.
+
+    The rate is derived from the two figures printed above it rather than taken
+    from the upstream field: with no income it is undefined, and the upstream
+    value's unit is ambiguous (a bare -25 could mean -25% or -2500%), so a
+    magnitude heuristic guesses wrong on negative rates.
+    """
+
+    async def test_zero_income_reports_not_applicable(self, fake_monarch):
+        fake_monarch.summary = {
+            "total_income": 0.0, "total_expenses": 0.0, "savings_rate": 0,
+        }
+        out = await _cashflow()
+        assert "**Savings Rate**: n/a (no income in this period)" in out
+        assert "0.0%" not in out
+
+    async def test_zero_income_with_spending_reports_not_applicable(self, fake_monarch):
+        fake_monarch.summary = {
+            "total_income": 0.0, "total_expenses": 200.0, "savings_rate": 0,
+        }
+        out = await _cashflow()
+        assert "n/a (no income in this period)" in out
+
+    async def test_rate_is_derived_from_the_printed_figures(self, fake_monarch):
+        fake_monarch.summary = {
+            "total_income": 5000.0, "total_expenses": 1000.0, "savings_rate": 0.99,
+        }
+        out = await _cashflow()
+        # 4000/5000 = 80%, regardless of the upstream field's 0.99.
+        assert "**Savings Rate**: 80.0%" in out
+
+    async def test_overspending_reports_a_negative_rate(self, fake_monarch):
+        fake_monarch.summary = {
+            "total_income": 1000.0, "total_expenses": 1500.0, "savings_rate": -0.5,
+        }
+        out = await _cashflow()
+        assert "**Savings Rate**: -50.0%" in out

--- a/tests/test_agent_tools_memories_scope.py
+++ b/tests/test_agent_tools_memories_scope.py
@@ -1,0 +1,595 @@
+"""
+Tests for scope disclosure in the search_memories tool.
+
+Regression context: same bug class as tests/test_agent_tools_scope_widening.py,
+but this instance lands hardest. The user personally told the assistant to
+remember something, so an empty answer reads as the system having lost it — and
+memory search was the one search on the tool surface with no caller lever at
+all: ten results, two relevance floors and a 1000-memory corpus bound, none of
+them adjustable or disclosed, behind a bare "No matching memories found."
+
+These tests pin the fix: the result cap is caller-supplied and normalised, every
+bound that binds is disclosed, and an empty result says whether nothing is saved
+or whether candidates were scored and fell below the relevance floors — because
+only the first justifies telling the user the memory is gone.
+
+All memory content here is obviously synthetic; this store holds real personal
+data in production and none of it may appear in a test.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from api.services.agent_tools import (
+    _MEMORY_LIMIT_DEFAULT,
+    _MEMORY_LIMIT_MAX,
+    _tool_search_memories,
+    TOOL_DEFINITIONS,
+    _TOOL_HANDLERS,
+)
+from api.services.memory_store import (
+    MemorySearchStats,
+    MemoryStore,
+    MEMORY_SEARCH_CORPUS_LIMIT,
+    MEMORY_SEMANTIC_FLOOR,
+    MEMORY_SEMANTIC_NEAR_MISS_MARGIN,
+)
+
+pytestmark = pytest.mark.unit
+
+# Phrases that would tell the orchestrator the backend broke. An empty result is
+# a fact about the data, so none of these may appear in one.
+FAULT_WORDS = ("sync issue", "permission", "failed", "error", "unavailable")
+
+
+def _memory(content: str, category: str = "preferences", mid: str = None):
+    """Stand-in for a Memory; the tool reads only `.category` and `.content`."""
+    return SimpleNamespace(id=mid or content[:8], category=category, content=content)
+
+
+# Obviously synthetic memories — no real personal values anywhere in this file.
+SYNTHETIC = [
+    _memory("Pat Placeholder prefers decaf after 15:00", "people", mid="m1"),
+    _memory("Synthetic Project Zed ships on 2099-01-01", "facts", mid="m2"),
+    _memory("Keeps replies terse in the sample workspace", "preferences", mid="m3"),
+]
+
+
+@pytest.fixture
+def fake_store(monkeypatch):
+    """Stub the memory store at its service boundary, recording every call.
+
+    Behaves like the real store in the two ways the tool depends on: it slices
+    the match pool to `limit`, and reports the pre-slice match count in the
+    stats, so truncation disclosure is exercised rather than assumed.
+    """
+    state = SimpleNamespace(
+        matches=[],
+        total_saved=None,      # None -> derived from the match pool
+        searched=None,         # None -> derived from the match pool
+        near_misses=0,
+        semantic_available=True,
+        calls=[],
+    )
+
+    class FakeStore:
+        def search_memories_detailed(self, query, limit=10, min_relevance=0.15):
+            state.calls.append(
+                {"query": query, "limit": limit, "min_relevance": min_relevance}
+            )
+            matched = list(state.matches)
+            pool = len(matched)
+            stats = MemorySearchStats(
+                total_saved=pool if state.total_saved is None else state.total_saved,
+                searched=pool if state.searched is None else state.searched,
+                corpus_limit=MEMORY_SEARCH_CORPUS_LIMIT,
+                matched=pool,
+                near_misses=state.near_misses,
+                semantic_available=state.semantic_available,
+            )
+            return matched[:limit], stats
+
+    monkeypatch.setattr(
+        "api.services.memory_store.get_memory_store", lambda *a, **k: FakeStore()
+    )
+    return state
+
+
+def _empties(state) -> list[str]:
+    """Every empty-result string the tool can produce, for blanket assertions."""
+    state.matches = []
+    out = []
+
+    state.total_saved, state.searched, state.near_misses = 0, 0, 0
+    out.append(_tool_search_memories({"query": "synthetic sample topic"}))
+
+    state.total_saved, state.searched, state.near_misses = 4, 4, 0
+    out.append(_tool_search_memories({"query": "synthetic sample topic"}))
+
+    state.near_misses = 2
+    out.append(_tool_search_memories({"query": "synthetic sample topic"}))
+
+    state.total_saved, state.searched, state.near_misses = 1200, 1000, 0
+    out.append(_tool_search_memories({"query": "synthetic sample topic"}))
+
+    state.near_misses = 3
+    out.append(_tool_search_memories({"query": "synthetic sample topic"}))
+
+    state.total_saved, state.searched, state.near_misses = 4, 4, 0
+    state.semantic_available = False
+    out.append(_tool_search_memories({"query": "synthetic sample topic"}))
+    state.semantic_available = True
+
+    out.append(_tool_search_memories({"query": "   "}))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The caller lever — a result cap the model can widen
+# ---------------------------------------------------------------------------
+
+class TestMemoriesLimit:
+    def test_default_limit_is_ten(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        _tool_search_memories({"query": "decaf"})
+        assert fake_store.calls[0]["limit"] == _MEMORY_LIMIT_DEFAULT == 10
+
+    def test_explicit_limit_reaches_the_store(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        _tool_search_memories({"query": "decaf", "limit": 50})
+        assert fake_store.calls[0]["limit"] == 50
+
+    def test_limit_actually_scopes_the_result(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        out = _tool_search_memories({"query": "synthetic", "limit": 1})
+        assert out.count("\n- ") == 0
+        assert SYNTHETIC[0].content in out
+        assert SYNTHETIC[1].content not in out
+
+    def test_query_is_passed_through_stripped(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        _tool_search_memories({"query": "  decaf  "})
+        assert fake_store.calls[0]["query"] == "decaf"
+
+    def test_blank_query_never_reaches_the_store(self, fake_store):
+        out = _tool_search_memories({"query": "   "})
+        assert fake_store.calls == []
+        assert "non-empty query" in out
+
+
+class TestMemoriesLimitNormalisation:
+    """The model writes these, so None/0/-5/"25"/absurd all arrive.
+
+    A bad cap must not reach the store (it doubles as the truncation yardstick,
+    so 0 or None would silently disable the disclosure).
+    """
+
+    @pytest.mark.parametrize("raw", [None, "not-a-number", [], {}])
+    def test_unusable_limit_falls_back_to_the_default(self, fake_store, raw):
+        fake_store.matches = list(SYNTHETIC)
+        _tool_search_memories({"query": "decaf", "limit": raw})
+        assert fake_store.calls[0]["limit"] == _MEMORY_LIMIT_DEFAULT
+
+    @pytest.mark.parametrize("raw", [0, -1, -50])
+    def test_non_positive_limit_is_raised_to_one(self, fake_store, raw):
+        fake_store.matches = list(SYNTHETIC)
+        _tool_search_memories({"query": "decaf", "limit": raw})
+        assert fake_store.calls[0]["limit"] == 1
+
+    def test_absurd_limit_is_capped(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        _tool_search_memories({"query": "decaf", "limit": 10**9})
+        assert fake_store.calls[0]["limit"] == _MEMORY_LIMIT_MAX
+
+    def test_numeric_string_is_accepted(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        _tool_search_memories({"query": "decaf", "limit": "25"})
+        assert fake_store.calls[0]["limit"] == 25
+
+    def test_zero_limit_still_searches_rather_than_faking_an_empty(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        out = _tool_search_memories({"query": "decaf", "limit": 0})
+        assert SYNTHETIC[0].content in out
+
+    def test_normalised_limit_is_the_truncation_yardstick(self, fake_store):
+        """The limit sent to the store is the number truncation compares against.
+
+        A 0 cap normalised to 1 must disclose that 1 of 3 is being shown — the
+        yardstick and the cap can never drift apart.
+        """
+        fake_store.matches = list(SYNTHETIC)
+        out = _tool_search_memories({"query": "decaf", "limit": 0})
+        assert "Showing 1 of 3" in out
+
+    def test_capped_limit_is_the_yardstick_used(self, fake_store):
+        fake_store.matches = [_memory(f"Synthetic sample memory {i}") for i in range(_MEMORY_LIMIT_MAX + 5)]
+        out = _tool_search_memories({"query": "sample", "limit": 10**6})
+        assert f"Showing {_MEMORY_LIMIT_MAX} of {_MEMORY_LIMIT_MAX + 5}" in out
+
+
+# ---------------------------------------------------------------------------
+# Truncation disclosure
+# ---------------------------------------------------------------------------
+
+class TestMemoriesTruncation:
+    def test_truncation_is_disclosed_when_the_cap_binds(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        out = _tool_search_memories({"query": "synthetic", "limit": 2})
+        assert "Showing 2 of 3 matching memories" in out
+        assert "raise" in out.lower()
+
+    def test_no_truncation_note_below_the_cap(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        out = _tool_search_memories({"query": "synthetic", "limit": 10})
+        assert "Showing" not in out
+
+    def test_no_truncation_note_when_matches_exactly_fill_the_cap(self, fake_store):
+        """Exactly `limit` matches means nothing was hidden, so no note."""
+        fake_store.matches = list(SYNTHETIC)
+        out = _tool_search_memories({"query": "synthetic", "limit": 3})
+        assert "Showing" not in out
+
+    def test_no_truncation_note_on_an_empty_result(self, fake_store):
+        fake_store.matches = []
+        fake_store.total_saved = fake_store.searched = 5
+        out = _tool_search_memories({"query": "synthetic"})
+        assert "Showing" not in out
+
+
+# ---------------------------------------------------------------------------
+# The two empty branches — a relevance miss is not a lost memory
+# ---------------------------------------------------------------------------
+
+def _nothing_saved(state, query="synthetic sample topic") -> str:
+    state.matches = []
+    state.total_saved = state.searched = 6
+    state.near_misses = 0
+    return _tool_search_memories({"query": query})
+
+
+def _below_threshold(state, query="synthetic sample topic", near=2) -> str:
+    state.matches = []
+    state.total_saved = state.searched = 6
+    state.near_misses = near
+    return _tool_search_memories({"query": query})
+
+
+class TestMemoriesHonestEmpty:
+    def test_below_threshold_names_the_threshold(self, fake_store):
+        out = _below_threshold(fake_store)
+        assert "relevance threshold" in out
+        assert "2 came close" in out
+
+    def test_below_threshold_suggests_rewording(self, fake_store):
+        out = _below_threshold(fake_store)
+        assert "wording" in out.lower()
+
+    def test_below_threshold_does_not_claim_nothing_is_saved(self, fake_store):
+        """The whole point: candidates existed, so absence was never established."""
+        out = _below_threshold(fake_store)
+        assert "nothing saved" not in out.lower()
+        assert "likely saved" in out.lower()
+
+    def test_nothing_saved_says_so(self, fake_store):
+        out = _nothing_saved(fake_store)
+        assert "Nothing saved matches" in out
+        assert "6 saved" in out
+        assert "wording and meaning" in out
+
+    def test_nothing_saved_does_not_mention_a_threshold(self, fake_store):
+        out = _nothing_saved(fake_store)
+        assert "threshold" not in out.lower()
+
+    def test_the_two_empty_branches_are_not_the_same_text(self, fake_store):
+        assert _nothing_saved(fake_store) != _below_threshold(fake_store)
+
+    def test_empty_store_is_named_as_such(self, fake_store):
+        fake_store.matches = []
+        fake_store.total_saved = fake_store.searched = 0
+        out = _tool_search_memories({"query": "synthetic sample topic"})
+        assert "no memories have been saved yet" in out
+
+    def test_empty_store_text_differs_from_the_scored_empty(self, fake_store):
+        fake_store.matches = []
+        fake_store.total_saved = fake_store.searched = 0
+        empty_store = _tool_search_memories({"query": "synthetic sample topic"})
+        assert empty_store != _nothing_saved(fake_store)
+
+    def test_empty_result_names_the_query(self, fake_store):
+        assert "'synthetic sample topic'" in _nothing_saved(fake_store)
+        assert "'synthetic sample topic'" in _below_threshold(fake_store)
+
+    @pytest.mark.parametrize("index", range(7))
+    def test_no_empty_path_suggests_a_backend_fault(self, fake_store, index):
+        text = _empties(fake_store)[index]
+        lowered = text.lower()
+        assert not any(word in lowered for word in FAULT_WORDS), text
+
+    def test_every_empty_path_is_covered_by_the_fault_check(self, fake_store):
+        assert len(_empties(fake_store)) == 7
+
+
+# ---------------------------------------------------------------------------
+# The corpus bound — a miss beyond it establishes nothing
+# ---------------------------------------------------------------------------
+
+class TestMemoriesCorpusBound:
+    def test_bound_is_disclosed_when_it_binds(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        fake_store.total_saved, fake_store.searched = 1200, 1000
+        out = _tool_search_memories({"query": "synthetic"})
+        assert "1000 most recently saved memories of 1200" in out
+
+    def test_no_bound_note_when_the_whole_corpus_was_scored(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        fake_store.total_saved = fake_store.searched = 40
+        out = _tool_search_memories({"query": "synthetic"})
+        assert "most recently saved" not in out
+
+    def test_capped_empty_does_not_assert_nothing_was_saved(self, fake_store):
+        """A match may sit outside the bound, so absence was never established."""
+        fake_store.matches = []
+        fake_store.total_saved, fake_store.searched = 1200, 1000
+        out = _tool_search_memories({"query": "synthetic sample topic"})
+        assert "nothing saved" not in out.lower()
+        assert "not scored" in out or "not checked" in out
+
+    def test_capped_empty_differs_from_the_full_corpus_empty(self, fake_store):
+        fake_store.matches = []
+        fake_store.total_saved, fake_store.searched = 1200, 1000
+        capped = _tool_search_memories({"query": "synthetic sample topic"})
+        assert capped != _nothing_saved(fake_store)
+
+    def test_capped_empty_still_discloses_near_misses_first(self, fake_store):
+        fake_store.matches = []
+        fake_store.total_saved, fake_store.searched = 1200, 1000
+        fake_store.near_misses = 3
+        out = _tool_search_memories({"query": "synthetic sample topic"})
+        assert "relevance threshold" in out
+        assert "1000 most recently saved memories of 1200" in out
+
+
+# ---------------------------------------------------------------------------
+# Keyword-only fallback — disclosed without blaming the backend
+# ---------------------------------------------------------------------------
+
+class TestMemoriesSemanticFallback:
+    def test_fallback_is_disclosed_on_an_empty_result(self, fake_store):
+        fake_store.matches = []
+        fake_store.total_saved = fake_store.searched = 6
+        fake_store.semantic_available = False
+        out = _tool_search_memories({"query": "synthetic sample topic"})
+        assert "only word overlap was scored" in out
+
+    def test_fallback_is_disclosed_alongside_hits(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        fake_store.semantic_available = False
+        out = _tool_search_memories({"query": "synthetic"})
+        assert SYNTHETIC[0].content in out
+        assert "only word overlap was scored" in out
+
+    def test_fallback_empty_does_not_claim_meaning_was_scored(self, fake_store):
+        """Only a wording miss was established, so that is all it may assert."""
+        fake_store.matches = []
+        fake_store.total_saved = fake_store.searched = 6
+        fake_store.semantic_available = False
+        out = _tool_search_memories({"query": "synthetic sample topic"})
+        sentence = out.split("\n\n[")[0]  # the finding itself, without the notes
+        assert "meaning" not in sentence.lower()
+        assert "wording" in sentence.lower()
+
+    def test_no_fallback_note_when_semantic_recall_ran(self, fake_store):
+        fake_store.matches = list(SYNTHETIC)
+        out = _tool_search_memories({"query": "synthetic"})
+        assert "word overlap" not in out
+
+
+# ---------------------------------------------------------------------------
+# Tool schema — the model can only use a lever that is advertised
+# ---------------------------------------------------------------------------
+
+class TestMemoriesToolDefinition:
+    @staticmethod
+    def _schema() -> dict:
+        return next(
+            t for t in TOOL_DEFINITIONS if t["name"] == "search_memories"
+        )["input_schema"]
+
+    def test_tool_is_registered(self):
+        assert "search_memories" in _TOOL_HANDLERS
+        assert any(t["name"] == "search_memories" for t in TOOL_DEFINITIONS)
+
+    def test_limit_is_advertised(self):
+        props = self._schema()["properties"]
+        assert "limit" in props
+        assert props["limit"]["type"] == "integer"
+
+    def test_limit_documents_the_default_and_widening(self):
+        desc = self._schema()["properties"]["limit"]["description"]
+        assert str(_MEMORY_LIMIT_DEFAULT) in desc
+        assert "capped" in desc.lower()
+
+    def test_limit_is_optional(self):
+        assert self._schema()["required"] == ["query"]
+
+    def test_description_warns_that_an_empty_may_be_a_wording_miss(self):
+        desc = next(
+            t for t in TOOL_DEFINITIONS if t["name"] == "search_memories"
+        )["description"].lower()
+        assert "relevance threshold" in desc
+        assert "wording" in desc
+
+
+# ---------------------------------------------------------------------------
+# Store boundary — the stats the disclosure is built from must be real
+# ---------------------------------------------------------------------------
+
+class _FakeEmbeddingService:
+    """Deterministic embeddings so the semantic floor can be placed exactly."""
+
+    def __init__(self, vectors, default, model_name="fake-embed-model"):
+        self._vectors = vectors
+        self._default = default
+        self.model_name = model_name
+
+    def _lookup(self, text):
+        return list(self._vectors.get(text, self._default))
+
+    def embed_text(self, text):
+        return self._lookup(text)
+
+    def embed_texts(self, texts):
+        return [self._lookup(t) for t in texts]
+
+
+@pytest.fixture
+def store(tmp_path):
+    return MemoryStore(file_path=str(tmp_path / "synthetic_memories.json"))
+
+
+@pytest.fixture
+def keyword_only(monkeypatch):
+    """Force the keyword-only path — no model needed, and no GPU touched."""
+    def _unavailable(*args, **kwargs):
+        raise RuntimeError("embedding service disabled for keyword-only tests")
+    monkeypatch.setattr("api.services.embeddings.get_embedding_service", _unavailable)
+
+
+class TestSearchMemoriesDetailedStats:
+    def test_matches_the_plain_search(self, store, keyword_only):
+        """search_memories must stay a thin wrapper — same results, same order."""
+        store.create_memory("Pat Placeholder prefers decaf after 15:00")
+        store.create_memory("Synthetic Project Zed ships on 2099-01-01")
+        plain = store.search_memories("Placeholder decaf")
+        detailed, _stats = store.search_memories_detailed("Placeholder decaf")
+        assert [m.id for m in plain] == [m.id for m in detailed]
+
+    def test_matched_counts_before_the_limit(self, store, keyword_only):
+        for i in range(5):
+            store.create_memory(f"Synthetic placeholder sample memory number {i}")
+        results, stats = store.search_memories_detailed("placeholder sample", limit=2)
+        assert len(results) == 2
+        assert stats.matched == 5
+
+    def test_keyword_floor_exclusions_are_counted_as_near_misses(self, store, keyword_only):
+        """The exact site the disclosure depends on: a memory that overlapped the
+        query but not by enough is a near miss, not an absence.
+
+        The floor is a ratio of shared terms to query terms, so the same single
+        shared word clears it in a one-word query and misses it in a wordy one.
+        Both are asserted against an explicit min_relevance so the boundary is
+        determinate; the default is pinned in the test below.
+        """
+        store.create_memory("Pat Placeholder prefers decaf after 15:00")
+
+        results, stats = store.search_memories_detailed("placeholder", min_relevance=0.9)
+        assert [m.content for m in results] == ["Pat Placeholder prefers decaf after 15:00"]
+        assert stats.near_misses == 0  # ratio 1.0 — a hit, not a near miss
+
+        results, stats = store.search_memories_detailed(
+            "placeholder wandering unrelated synthetic verbiage padding", min_relevance=0.9
+        )
+        assert results == []
+        assert stats.near_misses == 1
+
+    def test_near_miss_is_reachable_at_the_default_floor(self, store, keyword_only):
+        """Not just at a contrived floor: one shared word in an eight-term query
+        misses the shipped 0.15 default (1/8 = 0.125) and is disclosed as a near
+        miss rather than an absence."""
+        store.create_memory("Pat Placeholder prefers decaf after 15:00")
+        results, stats = store.search_memories_detailed(
+            "placeholder wandering unrelated synthetic verbiage padding thicker phrasing"
+        )
+        assert results == []
+        assert stats.near_misses == 1
+
+    def test_a_returned_memory_is_never_also_a_near_miss(self, store, keyword_only):
+        store.create_memory("Pat Placeholder prefers decaf after 15:00")
+        results, stats = store.search_memories_detailed("Placeholder decaf")
+        assert len(results) == 1
+        assert stats.near_misses == 0
+
+    def test_zero_overlap_is_not_a_near_miss(self, store, keyword_only):
+        store.create_memory("Pat Placeholder prefers decaf after 15:00")
+        results, stats = store.search_memories_detailed("wxyzzy qwertyx")
+        assert results == []
+        assert stats.near_misses == 0
+        assert stats.total_saved == 1
+
+    def test_sub_floor_semantic_score_is_a_near_miss(self, store, monkeypatch):
+        """A paraphrase that lands just under the cosine floor is the motivating
+        case: no shared words, nothing returned, yet something nearly matched."""
+        import math
+        store.create_memory("Keeps replies terse in the sample workspace")
+        near = MEMORY_SEMANTIC_FLOOR - MEMORY_SEMANTIC_NEAR_MISS_MARGIN / 2
+        fake = _FakeEmbeddingService(
+            vectors={
+                "Keeps replies terse in the sample workspace": [near, math.sqrt(1 - near ** 2), 0.0],
+                "wxyzzy qwertyx": [1.0, 0.0, 0.0],
+            },
+            default=[0.0, 0.0, 1.0],
+        )
+        monkeypatch.setattr(
+            "api.services.embeddings.get_embedding_service", lambda *a, **k: fake
+        )
+        results, stats = store.search_memories_detailed("wxyzzy qwertyx")
+        assert results == []
+        assert stats.near_misses == 1
+
+    def test_far_below_the_floor_is_not_a_near_miss(self, store, monkeypatch):
+        import math
+        store.create_memory("Keeps replies terse in the sample workspace")
+        far = MEMORY_SEMANTIC_FLOOR - MEMORY_SEMANTIC_NEAR_MISS_MARGIN - 0.1
+        fake = _FakeEmbeddingService(
+            vectors={
+                "Keeps replies terse in the sample workspace": [far, math.sqrt(1 - far ** 2), 0.0],
+                "wxyzzy qwertyx": [1.0, 0.0, 0.0],
+            },
+            default=[0.0, 0.0, 1.0],
+        )
+        monkeypatch.setattr(
+            "api.services.embeddings.get_embedding_service", lambda *a, **k: fake
+        )
+        results, stats = store.search_memories_detailed("wxyzzy qwertyx")
+        assert results == []
+        assert stats.near_misses == 0
+
+    def test_semantic_outage_is_reported_not_hidden(self, store, keyword_only):
+        store.create_memory("Pat Placeholder prefers decaf after 15:00")
+        _results, stats = store.search_memories_detailed("Placeholder decaf")
+        assert stats.semantic_available is False
+
+    def test_semantic_availability_is_reported_when_scoring_ran(self, store, monkeypatch):
+        store.create_memory("Pat Placeholder prefers decaf after 15:00")
+        fake = _FakeEmbeddingService(vectors={}, default=[0.0, 0.0, 1.0])
+        monkeypatch.setattr(
+            "api.services.embeddings.get_embedding_service", lambda *a, **k: fake
+        )
+        _results, stats = store.search_memories_detailed("Placeholder decaf")
+        assert stats.semantic_available is True
+
+    def test_corpus_bound_is_reported_when_it_binds(self, store, keyword_only, monkeypatch):
+        """total_saved counts everything active; searched counts what was scored."""
+        monkeypatch.setattr("api.services.memory_store.MEMORY_SEARCH_CORPUS_LIMIT", 2)
+        for i in range(4):
+            store.create_memory(f"Synthetic placeholder sample memory number {i}")
+        _results, stats = store.search_memories_detailed("placeholder sample")
+        assert stats.total_saved == 4
+        assert stats.searched == 2
+        assert stats.corpus_limit == 2
+
+    def test_soft_deleted_memories_are_not_counted_as_saved(self, store, keyword_only):
+        keep = store.create_memory("Pat Placeholder prefers decaf after 15:00")
+        gone = store.create_memory("Synthetic Project Zed ships on 2099-01-01")
+        store.delete_memory(gone.id)
+        _results, stats = store.search_memories_detailed("Placeholder decaf")
+        assert stats.total_saved == 1
+        assert stats.searched == 1
+        assert keep.id in store._memories
+
+    def test_blank_query_reports_nothing_searched(self, store, keyword_only):
+        store.create_memory("Pat Placeholder prefers decaf after 15:00")
+        results, stats = store.search_memories_detailed("   ")
+        assert results == []
+        assert stats.searched == 0
+        assert stats.total_saved == 1

--- a/tests/test_agent_tools_memories_scope.py
+++ b/tests/test_agent_tools_memories_scope.py
@@ -258,7 +258,7 @@ class TestMemoriesHonestEmpty:
     def test_below_threshold_names_the_threshold(self, fake_store):
         out = _below_threshold(fake_store)
         assert "relevance threshold" in out
-        assert "2 came close" in out
+        assert "2 shared some wording" in out
 
     def test_below_threshold_suggests_rewording(self, fake_store):
         out = _below_threshold(fake_store)
@@ -268,7 +268,27 @@ class TestMemoriesHonestEmpty:
         """The whole point: candidates existed, so absence was never established."""
         out = _below_threshold(fake_store)
         assert "nothing saved" not in out.lower()
-        assert "likely saved" in out.lower()
+        assert "not an established absence" in out.lower()
+
+    def test_below_threshold_does_not_claim_a_relevant_memory_exists(self, fake_store):
+        """The count cannot support that claim, so the text must not make it.
+
+        A near miss is counted for ANY keyword overlap under min_relevance — one
+        common word shared with a long query qualifies — so "something relevant is
+        likely saved" asserted more than the number establishes. The floors
+        themselves are unchanged; only the claim is.
+        """
+        out = _below_threshold(fake_store, near=1)
+        assert "likely saved" not in out.lower()
+        assert "likely" not in out.lower()
+
+    def test_below_threshold_describes_what_was_actually_counted(self, fake_store):
+        """Both counting rules, stated as the disjunction they are: keyword
+        overlap under the floor, or a semantic score inside the near-miss margin.
+        """
+        out = _below_threshold(fake_store)
+        assert "shared some wording with it, or scored near the meaning floor" in out
+        assert "without clearing either" in out
 
     def test_nothing_saved_says_so(self, fake_store):
         out = _nothing_saved(fake_store)

--- a/tests/test_agent_tools_person_scope.py
+++ b/tests/test_agent_tools_person_scope.py
@@ -47,7 +47,7 @@ from api.services.interaction_store import (
     NO_INTERACTIONS_PREFIX,
     format_window_label,
 )
-from api.services.person_facts import PersonFact, rank_facts
+from api.services.person_facts import PersonFact, effective_confidence, rank_facts
 from api.services.relationship_summary import (
     NEVER_CONTACTED_DAYS,
     ChannelActivity,
@@ -294,6 +294,28 @@ class TestFactRanking:
         fact = _fact("topics", "x", "no score", 0.5)
         fact.confidence = None
         assert rank_facts([fact])[0] is fact
+
+    def test_effective_confidence_is_the_shared_rule(self):
+        """Ranking and the briefing's floor read the same number.
+
+        They did not: ranking treated a confirmed fact as 1.0 while the floor read
+        the raw score, so a fact the user had personally confirmed was ranked
+        first and then withheld as low extraction confidence.
+        """
+        assert effective_confidence(_fact("z", "a", "extracted", 0.42)) == 0.42
+        assert effective_confidence(
+            _fact("z", "a", "user said so", 0.10, confirmed=True)
+        ) == 1.0
+
+    def test_effective_confidence_treats_a_missing_score_as_zero(self):
+        fact = _fact("topics", "x", "no score", 0.5)
+        fact.confidence = None
+        assert effective_confidence(fact) == 0.0
+
+    def test_effective_confidence_of_a_confirmed_fact_ignores_a_missing_score(self):
+        fact = _fact("topics", "x", "user said so", 0.5, confirmed=True)
+        fact.confidence = None
+        assert effective_confidence(fact) == 1.0
 
     def test_input_list_is_not_mutated(self):
         facts = [_fact("a", "one", "low", 0.2), _fact("z", "two", "high", 0.9)]
@@ -621,10 +643,14 @@ def fake_briefing_service(monkeypatch):
 
 
 class TestBriefingToolWindowArgument:
-    """A window is a scope, so a bad one is dropped rather than clamped.
+    """A window is a scope, so a bad one is neither clamped nor widened.
 
-    Clamping would brief on a period nobody asked for; treating it as unstated
-    falls back to the ladder, and the drop is disclosed either way.
+    Clamping would brief on a period nobody asked for. Treating it as unstated —
+    which is what search_calendar does with a bad days_range, harmlessly — is
+    wrong here: the ladder would widen to a year and then to the full history,
+    reading more of this person's emails, messages, and meetings than the caller
+    scoped. Per AGENTS.md §6 that uncertainty is a privacy concern, so an
+    unusable window produces no briefing at all.
     """
 
     async def test_omitted_window_reaches_the_service_as_unstated(
@@ -642,20 +668,43 @@ class TestBriefingToolWindowArgument:
         assert fake_briefing_service.calls[0]["interaction_days"] == 45
 
     @pytest.mark.parametrize(
-        "bad", [0, -30, "soon", 10**9, _BRIEFING_MAX_DAYS + 1, None.__class__]
+        "bad", [0, -30, "soon", 10**9, _BRIEFING_MAX_DAYS + 1, None.__class__, []]
     )
-    async def test_bad_window_is_treated_as_unstated(self, fake_briefing_service, bad):
+    async def test_bad_window_generates_no_briefing(self, fake_briefing_service, bad):
+        """No service call at all — the widening ladder must not run."""
         await _briefing_person({"name": "Marigold Quill", "interaction_days": bad})
-        assert fake_briefing_service.calls[0]["interaction_days"] is None
+        assert fake_briefing_service.calls == []
 
-    async def test_dropped_window_is_disclosed(self, fake_briefing_service):
+    async def test_refusal_names_the_value_and_the_bound(self, fake_briefing_service):
         out = await _briefing_person({"name": "Marigold Quill", "interaction_days": -30})
-        assert "Ignored interaction_days" in out
-        assert "NOT scoped to it" in out
+        assert "interaction_days=-30" in out
+        assert f"between 1 and {_BRIEFING_MAX_DAYS}" in out
+
+    async def test_refusal_names_the_problem_as_a_bad_argument(
+        self, fake_briefing_service
+    ):
+        """The opposite case to an honest empty: this one must not read as one."""
+        out = await _briefing_person({"name": "Marigold Quill", "interaction_days": -30})
+        assert "No briefing generated" in out
+        assert "NOT a thin record" in out
+
+    async def test_refusal_says_why_widening_was_not_the_answer(
+        self, fake_briefing_service
+    ):
+        """The privacy reason, so the model doesn't just retry without a window."""
+        out = await _briefing_person({"name": "Marigold Quill", "interaction_days": -30})
+        assert "more of this person's history than was asked for" in out
+
+    async def test_refusal_carries_no_backend_fault_language(
+        self, fake_briefing_service
+    ):
+        """A malformed argument is not a broken backend."""
+        out = await _briefing_person({"name": "Marigold Quill", "interaction_days": -30})
+        _assert_no_fault_language(out, "bad-window refusal")
 
     async def test_valid_window_is_not_reported_as_ignored(self, fake_briefing_service):
         out = await _briefing_person({"name": "Marigold Quill", "interaction_days": 45})
-        assert "Ignored interaction_days" not in out
+        assert "No briefing generated" not in out
 
     async def test_the_bound_itself_is_accepted(self, fake_briefing_service):
         await _briefing_person(
@@ -798,6 +847,153 @@ class TestBriefingFactConfidenceFloor:
         context = briefing_env.service.gather_context("Marigold Quill")
         section = briefing_env.service._format_facts_section(context)
         _assert_no_fault_language(section, "withheld-facts disclosure")
+
+    def test_a_user_confirmed_fact_clears_the_floor(self, briefing_env):
+        """The floor is about extraction confidence, and the user is not an
+        extractor. Withholding what they personally confirmed, then attributing it
+        to a low extraction score, is a wrong claim about their own assertion."""
+        briefing_env.facts = [
+            _fact("family", "spouse_name", "Spouse is Rowan Quill", 0.1, confirmed=True),
+        ]
+        context = briefing_env.service.gather_context("Marigold Quill")
+        assert context.facts_withheld_low_confidence == 0
+        assert [f["value"] for f in context.person_facts] == ["Spouse is Rowan Quill"]
+
+    def test_a_confirmed_fact_with_no_score_clears_the_floor(self, briefing_env):
+        fact = _fact("family", "spouse_name", "Spouse is Rowan Quill", 0.5, confirmed=True)
+        fact.confidence = None
+        briefing_env.facts = [fact]
+        context = briefing_env.service.gather_context("Marigold Quill")
+        assert context.facts_withheld_low_confidence == 0
+        assert len(context.person_facts) == 1
+
+    async def test_a_confirmed_fact_reaches_the_prompt(self, briefing_env):
+        briefing_env.facts = [
+            _fact("family", "spouse_name", "Spouse is Rowan Quill", 0.1, confirmed=True),
+        ]
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "Spouse is Rowan Quill" in briefing_env.prompt
+        assert "further fact(s)" not in briefing_env.prompt
+
+    def test_an_unconfirmed_low_score_is_still_withheld(self, briefing_env):
+        """The floor still does its job — only the confirmed case is exempt."""
+        briefing_env.facts = [_fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2)]
+        context = briefing_env.service.gather_context("Marigold Quill")
+        assert context.facts_withheld_low_confidence == 1
+        assert context.person_facts == []
+
+    def test_ranking_and_the_floor_agree_on_every_fact(self, briefing_env):
+        """The two sites drifted apart once; nothing kept them together.
+
+        Anything the ranking puts at full confidence must clear the floor, or the
+        briefing ranks a fact first and then drops it.
+        """
+        briefing_env.facts = [
+            _fact("family", "spouse_name", "Spouse is Rowan Quill", 0.05, confirmed=True),
+            _fact("work", "role", "Runs the poetry imprint", 0.9),
+            _fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2),
+        ]
+        context = briefing_env.service.gather_context("Marigold Quill")
+        ranked = rank_facts(briefing_env.facts)
+        kept = [f["value"] for f in context.person_facts]
+        assert kept == [
+            f.value for f in ranked if effective_confidence(f) >= FACT_CONFIDENCE_FLOOR
+        ]
+        assert kept == ["Spouse is Rowan Quill", "Runs the poetry imprint"]
+
+
+class TestBriefingLimitedStatusDisclosesCaveats:
+    """The early "limited information" return happens before the section
+    formatters run, so it has to carry their caveats itself.
+
+    Without that, a briefing whose interaction lookup actually raised reported
+    "limited information … I don't have detailed notes" — a fault rendered as an
+    absence, which is the whole bug class.
+    """
+
+    async def test_a_lookup_fault_is_stated_not_called_thin_data(self, briefing_env):
+        briefing_env.entity_email = None
+        briefing_env.raise_on_history = True
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert result["status"] == "limited"
+        assert "could not be read" in result["message"]
+        assert "NOT because there is nothing on record" in result["message"]
+
+    async def test_a_lookup_fault_names_the_fault_plainly(self, briefing_env):
+        """The opposite case to an honest empty — it must say a source broke."""
+        briefing_env.entity_email = None
+        briefing_env.raise_on_history = True
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "errored" in result["message"]
+        assert any(w in result["message"].lower() for w in FAULT_WORDS)
+
+    async def test_the_fault_message_reaches_the_tool_output_verbatim(
+        self, monkeypatch, briefing_env
+    ):
+        """A "limited" message is passed through as-is, so this is what the
+        orchestrator actually reads."""
+        briefing_env.entity_email = None
+        briefing_env.raise_on_history = True
+        monkeypatch.setattr(
+            briefings, "get_briefings_service", lambda: briefing_env.service
+        )
+        out = await _briefing_person({"name": "Marigold Quill"})
+        assert "could not be read" in out
+
+    async def test_the_fault_message_differs_from_the_thin_record_one(
+        self, briefing_env
+    ):
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = None
+        thin = await briefing_env.service.generate_briefing("Marigold Quill")
+        briefing_env.raise_on_history = True
+        faulted = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert thin["message"] != faulted["message"]
+        assert "limited information" not in faulted["message"]
+
+    async def test_a_thin_record_still_reads_as_an_absence(self, briefing_env):
+        """The complement: with no fault, nothing may imply one."""
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = None
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "limited information" in result["message"]
+        _assert_no_fault_language(result["message"], "thin-record briefing")
+
+    async def test_withheld_facts_are_disclosed_in_the_limited_message(
+        self, briefing_env
+    ):
+        """All facts under the floor looks identical to no facts at all."""
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = None
+        briefing_env.facts = [
+            _fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2),
+            _fact("topics", "rumour2", "Maybe changed jobs", 0.1),
+        ]
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert result["status"] == "limited"
+        assert "2 lower-confidence fact(s)" in result["message"]
+        assert str(FACT_CONFIDENCE_FLOOR) in result["message"]
+
+    async def test_withheld_facts_never_leak_their_content(self, briefing_env):
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = None
+        briefing_env.facts = [_fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2)]
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "Maybe moved to Lowmarsh" not in result["message"]
+
+    async def test_both_caveats_are_carried_together(self, briefing_env):
+        briefing_env.entity_email = None
+        briefing_env.raise_on_history = True
+        briefing_env.facts = [_fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2)]
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "could not be read" in result["message"]
+        assert "1 lower-confidence fact(s)" in result["message"]
+
+    async def test_no_withheld_note_when_the_floor_dropped_nothing(self, briefing_env):
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = None
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "lower-confidence fact(s)" not in result["message"]
 
 
 class TestInteractionStoreEmptyMessage:

--- a/tests/test_agent_tools_person_scope.py
+++ b/tests/test_agent_tools_person_scope.py
@@ -344,6 +344,27 @@ class TestNeverContactedSentinel:
         assert _summary(NEVER_CONTACTED_DAYS, _days_ago(999)).contact_on_record is True
         assert _summary(3, None).contact_on_record is True
 
+    def test_indexed_profile_does_not_invent_a_recency_bucket(self):
+        """The sentinel used to bucket into "over a year ago" — a fabricated
+        interval written into the searchable corpus, where a later retrieval
+        reads it as an established fact.
+        """
+        from api.services.person_entity import PersonEntity
+        from api.services.person_indexer import generate_person_document
+
+        person = PersonEntity(id="person-quill", canonical_name="Marigold Quill")
+        doc = generate_person_document(person, _summary(NEVER_CONTACTED_DAYS, None))
+        assert "over a year ago" not in doc
+        assert "Last contact: none on record" in doc
+
+    def test_indexed_profile_still_buckets_a_real_gap(self):
+        from api.services.person_entity import PersonEntity
+        from api.services.person_indexer import generate_person_document
+
+        person = PersonEntity(id="person-quill", canonical_name="Marigold Quill")
+        doc = generate_person_document(person, _summary(400, _days_ago(400)))
+        assert "over a year ago" in doc
+
 
 # ---------------------------------------------------------------------------
 # person_info action="briefing"

--- a/tests/test_agent_tools_person_scope.py
+++ b/tests/test_agent_tools_person_scope.py
@@ -1,0 +1,862 @@
+"""
+Tests for scope disclosure on the person surface (person_info + briefings).
+
+Regression context: same bug class as tests/test_agent_tools_scope_widening.py.
+The person surface presented narrow or truncated views as complete ones:
+
+- The briefing only ever read 90 days of interactions, the caller could not
+  widen it, and an empty window was collapsed to "no interaction history
+  available" — printed right next to a real last-contact date, so the answer
+  contradicted itself and read as "the records are thin".
+- person_info showed the first 15 facts in alphabetical order with no hint that
+  it had cut anything, so "who is their spouse?" could be answered "I don't
+  know" because `family` sorted past the cut.
+- Briefings dropped facts below a confidence floor without saying so.
+- `days_since_contact` carries 999 as a never-contacted sentinel; printed
+  verbatim it reads as a real gap of about 2.7 years.
+
+These tests pin the fix: widen when the caller stated no window, honour a stated
+one exactly, order and disclose truncated facts, disclose the confidence floor,
+and never render the sentinel as a number.
+
+All people here are obviously synthetic.
+"""
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import api.services.agent_tools as at
+import api.services.briefings as briefings
+import api.services.entity_resolver as entity_resolver_mod
+import api.services.person_facts as person_facts_mod
+import api.services.relationship_summary as rel_mod
+from api.services.agent_tools import (
+    _BRIEFING_MAX_DAYS,
+    _PERSON_FACT_LIMIT,
+    TOOL_DEFINITIONS,
+    _briefing_person,
+    _lookup_person,
+)
+from api.services.briefings import (
+    FACT_CONFIDENCE_FLOOR,
+    _INTERACTION_LADDER_DAYS,
+    BriefingsService,
+)
+from api.services.interaction_store import (
+    NO_INTERACTIONS_PREFIX,
+    format_window_label,
+)
+from api.services.person_facts import PersonFact, rank_facts
+from api.services.relationship_summary import (
+    NEVER_CONTACTED_DAYS,
+    ChannelActivity,
+    RelationshipSummary,
+    format_relationship_context,
+)
+
+pytestmark = pytest.mark.unit
+
+# Phrases that would tell the orchestrator the backend broke. An empty result is
+# a fact about the data, so none of these may appear in one.
+FAULT_WORDS = ("sync issue", "permission", "failed", "error", "unavailable")
+
+# The store's default window; the widest ladder rung resolves to this.
+_FULL_WINDOW_DAYS = 3650
+
+
+def _assert_no_fault_language(text: str, label: str) -> None:
+    lowered = text.lower()
+    for word in FAULT_WORDS:
+        assert word not in lowered, f"{label} implies a fault: {word!r}"
+
+
+def _days_ago(n: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=n)
+
+
+# ---------------------------------------------------------------------------
+# person_info action="lookup"
+# ---------------------------------------------------------------------------
+
+def _fact(category: str, key: str, value: str, confidence: float, confirmed=False):
+    return PersonFact(
+        person_id="person-quill",
+        category=category,
+        key=key,
+        value=value,
+        confidence=confidence,
+        confirmed_by_user=confirmed,
+    )
+
+
+@pytest.fixture
+def fake_person(monkeypatch):
+    """Stub the three service boundaries person_info(lookup) reads.
+
+    Records the name the resolver was asked for, and lets a test set the facts
+    and the relationship summary. `format_relationship_context` is deliberately
+    left real: the sentinel rendering is part of what these tests pin.
+    """
+    state = SimpleNamespace(
+        entity=SimpleNamespace(
+            id="person-quill",
+            canonical_name="Marigold Quill",
+            emails=["marigold.quill@example.invalid"],
+            phone_numbers=[],
+            birthday=None,
+            company="Tidewater Press",
+            position="Editor",
+        ),
+        resolved=True,
+        resolve_calls=[],
+        facts=[],
+        summary=None,
+    )
+
+    class FakeResolver:
+        def resolve(self, name=None, email=None):
+            state.resolve_calls.append({"name": name, "email": email})
+            if not state.resolved:
+                return None
+            return SimpleNamespace(entity=state.entity)
+
+    class FakeFactStore:
+        def get_for_person(self, person_id, include_shared=True):
+            return list(state.facts)
+
+    monkeypatch.setattr(entity_resolver_mod, "get_entity_resolver", lambda: FakeResolver())
+    monkeypatch.setattr(person_facts_mod, "get_person_fact_store", lambda: FakeFactStore())
+    monkeypatch.setattr(rel_mod, "get_relationship_summary", lambda pid: state.summary)
+    return state
+
+
+def _summary(days_since: int, last_interaction: datetime | None) -> RelationshipSummary:
+    return RelationshipSummary(
+        person_id="person-quill",
+        person_name="Marigold Quill",
+        relationship_strength=41.0,
+        channels=[ChannelActivity("gmail", 2, last_interaction, False)],
+        active_channels=[],
+        primary_channel="gmail",
+        total_interactions_90d=2,
+        last_interaction=last_interaction,
+        days_since_contact=days_since,
+    )
+
+
+class TestLookupNoMatch:
+    """A miss must name what was searched, without implying a fault.
+
+    The match threshold itself is unchanged — a loose threshold would merge real
+    people, which is worse than a miss. Only the message improves.
+    """
+
+    def test_names_the_search_term(self, fake_person):
+        fake_person.resolved = False
+        out = _lookup_person({"name": "Thistlewaite Barrowman"})
+        assert "'Thistlewaite Barrowman'" in out
+
+    def test_names_the_term_actually_sent_to_the_resolver(self, fake_person):
+        fake_person.resolved = False
+        _lookup_person({"name": "Thistlewaite Barrowman"})
+        assert [c["name"] for c in fake_person.resolve_calls] == [
+            "Thistlewaite Barrowman"
+        ]
+
+    def test_suggests_a_next_step(self, fake_person):
+        fake_person.resolved = False
+        out = _lookup_person({"name": "Thistlewaite Barrowman"})
+        assert "email" in out.lower()
+
+    def test_miss_carries_no_fault_language(self, fake_person):
+        fake_person.resolved = False
+        out = _lookup_person({"name": "Thistlewaite Barrowman"})
+        _assert_no_fault_language(out, "person lookup miss")
+
+    def test_empty_resolver_result_is_also_a_miss(self, fake_person):
+        """A result object with no entity is the other shape a miss arrives in."""
+        fake_person.resolved = True
+        fake_person.entity = None
+        out = _lookup_person({"name": "Thistlewaite Barrowman"})
+        assert "No person found matching 'Thistlewaite Barrowman'." in out
+
+
+class TestLookupFactOrdering:
+    """Facts are cut by confidence, not by spelling, and the cut is disclosed."""
+
+    def _alphabetically_late_but_certain(self) -> list:
+        """A high-confidence `family` fact buried under low-confidence noise.
+
+        `work`/`travel`/`topics` all sort after `family`, so the pre-fix
+        alphabetical slice kept the noise and dropped the spouse.
+        """
+        noise = [
+            _fact("travel", f"trip_{i:02d}", f"Mentioned a trip to Region {i}", 0.31)
+            for i in range(_PERSON_FACT_LIMIT + 5)
+        ]
+        return noise + [
+            _fact("family", "spouse_name", "Spouse is Rowan Quill", 0.95),
+        ]
+
+    def test_high_confidence_fact_survives_the_cut(self, fake_person):
+        fake_person.facts = self._alphabetically_late_but_certain()
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert "Spouse is Rowan Quill" in out
+
+    def test_facts_are_ordered_by_confidence(self, fake_person):
+        fake_person.facts = [
+            _fact("work", "role", "Runs the poetry imprint", 0.9),
+            _fact("family", "sibling", "Has a sibling in Lowmarsh", 0.4),
+            _fact("topics", "hobby", "Restores fountain pens", 0.7),
+        ]
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert out.index("Runs the poetry imprint") < out.index("Restores fountain pens")
+        assert out.index("Restores fountain pens") < out.index("Has a sibling in Lowmarsh")
+
+    def test_truncation_states_shown_and_total(self, fake_person):
+        total = _PERSON_FACT_LIMIT + 27
+        fake_person.facts = [
+            _fact("topics", f"note_{i:02d}", f"Discussed subject {i}", 0.5)
+            for i in range(total)
+        ]
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert f"{_PERSON_FACT_LIMIT} of {total} shown" in out
+
+    def test_truncation_says_how_the_shown_set_was_chosen(self, fake_person):
+        fake_person.facts = [
+            _fact("topics", f"note_{i:02d}", f"Discussed subject {i}", 0.5)
+            for i in range(_PERSON_FACT_LIMIT + 1)
+        ]
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert "highest-confidence first" in out
+
+    def test_shown_count_matches_the_limit(self, fake_person):
+        fake_person.facts = [
+            _fact("topics", f"note_{i:02d}", f"Discussed subject {i}", 0.5)
+            for i in range(_PERSON_FACT_LIMIT + 9)
+        ]
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert out.count("Discussed subject") == _PERSON_FACT_LIMIT
+
+    def test_no_truncation_note_when_everything_fits(self, fake_person):
+        fake_person.facts = [_fact("work", "role", "Runs the poetry imprint", 0.9)]
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert "Known facts:" in out
+        assert "shown" not in out
+
+    def test_exactly_at_the_limit_is_not_reported_as_truncated(self, fake_person):
+        fake_person.facts = [
+            _fact("topics", f"note_{i:02d}", f"Discussed subject {i}", 0.5)
+            for i in range(_PERSON_FACT_LIMIT)
+        ]
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert "shown" not in out
+
+    def test_low_confidence_facts_are_still_shown_when_they_fit(self, fake_person):
+        """lookup has no confidence floor — only the briefing does."""
+        fake_person.facts = [_fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2)]
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert "Maybe moved to Lowmarsh" in out
+
+
+class TestFactRanking:
+    """rank_facts is the shared ordering; the store's own order is untouched."""
+
+    def test_orders_by_descending_confidence(self):
+        facts = [
+            _fact("a", "one", "low", 0.2),
+            _fact("z", "two", "high", 0.9),
+            _fact("m", "three", "mid", 0.5),
+        ]
+        assert [f.value for f in rank_facts(facts)] == ["high", "mid", "low"]
+
+    def test_user_confirmed_fact_counts_as_full_confidence(self):
+        """The user asserted it, which outranks any extraction score."""
+        facts = [
+            _fact("z", "extracted", "high extraction", 0.95),
+            _fact("a", "confirmed", "user said so", 0.10, confirmed=True),
+        ]
+        ranked = rank_facts(facts)
+        assert ranked[0].value == "user said so"
+
+    def test_ties_fall_back_to_category_then_key(self):
+        facts = [
+            _fact("work", "b", "work b", 0.5),
+            _fact("family", "z", "family z", 0.5),
+            _fact("work", "a", "work a", 0.5),
+        ]
+        assert [f.value for f in rank_facts(facts)] == [
+            "family z", "work a", "work b",
+        ]
+
+    def test_missing_confidence_does_not_raise(self):
+        fact = _fact("topics", "x", "no score", 0.5)
+        fact.confidence = None
+        assert rank_facts([fact])[0] is fact
+
+    def test_input_list_is_not_mutated(self):
+        facts = [_fact("a", "one", "low", 0.2), _fact("z", "two", "high", 0.9)]
+        rank_facts(facts)
+        assert [f.value for f in facts] == ["low", "high"]
+
+
+class TestNeverContactedSentinel:
+    """999 is a marker, not a measurement. It must never reach the output."""
+
+    def test_lookup_states_no_contact_on_record(self, fake_person):
+        fake_person.summary = _summary(NEVER_CONTACTED_DAYS, None)
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert "no contact on record" in out
+
+    def test_lookup_never_prints_the_sentinel(self, fake_person):
+        fake_person.summary = _summary(NEVER_CONTACTED_DAYS, None)
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert str(NEVER_CONTACTED_DAYS) not in out
+
+    def test_never_contacted_carries_no_fault_language(self, fake_person):
+        fake_person.summary = _summary(NEVER_CONTACTED_DAYS, None)
+        out = _lookup_person({"name": "Marigold Quill"})
+        _assert_no_fault_language(out, "never-contacted lookup")
+
+    def test_real_gap_is_still_printed(self, fake_person):
+        fake_person.summary = _summary(41, _days_ago(41))
+        out = _lookup_person({"name": "Marigold Quill"})
+        assert "**Days since contact**: 41" in out
+
+    def test_a_genuine_999_day_gap_is_printed(self):
+        """The date is the authority, not the magnitude.
+
+        A real gap can equal the sentinel, so keying off the number alone would
+        suppress a true 999-day answer — the same class of error inverted.
+        """
+        summary = _summary(NEVER_CONTACTED_DAYS, _days_ago(NEVER_CONTACTED_DAYS))
+        out = format_relationship_context(summary)
+        assert f"**Days since contact**: {NEVER_CONTACTED_DAYS}" in out
+        assert "no contact on record" not in out
+
+    def test_summary_without_a_date_reports_no_contact(self):
+        out = format_relationship_context(_summary(NEVER_CONTACTED_DAYS, None))
+        assert "no contact on record" in out
+
+    def test_contact_on_record_tracks_the_date(self):
+        assert _summary(NEVER_CONTACTED_DAYS, None).contact_on_record is False
+        assert _summary(NEVER_CONTACTED_DAYS, _days_ago(999)).contact_on_record is True
+        assert _summary(3, None).contact_on_record is True
+
+
+# ---------------------------------------------------------------------------
+# person_info action="briefing"
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def briefing_env(monkeypatch):
+    """A BriefingsService with every boundary faked, capturing the prompt.
+
+    The interaction-store fake honours the real contract: an empty window comes
+    back as NO_INTERACTIONS_PREFIX plus the window label, which is what the
+    briefing keys its widening off. `oldest_days = None` means nothing on record.
+    """
+    state = SimpleNamespace(
+        prompt=None,
+        history_calls=[],
+        oldest_days=3,
+        raise_on_history=False,
+        facts=[],
+        notes=[],
+        tasks=[],
+        entity_email="marigold.quill@example.invalid",
+    )
+
+    class FakeInteractionStore:
+        def format_interaction_history(self, person_id, days_back=None, limit=None):
+            state.history_calls.append(
+                {"person_id": person_id, "days_back": days_back, "limit": limit}
+            )
+            if state.raise_on_history:
+                raise RuntimeError("interaction store unreachable")
+            window = _FULL_WINDOW_DAYS if days_back is None else days_back
+            if state.oldest_days is None or state.oldest_days > window:
+                return f"{NO_INTERACTIONS_PREFIX} in {format_window_label(days_back)}._"
+            return (
+                f"**Summary:** 4 interactions | Last: {state.oldest_days} days ago\n"
+                "\n### Recent Activity\n- 📧 Sep 02: Re: Community garden rota"
+            )
+
+    class FakeFactStore:
+        def get_for_person(self, person_id, include_shared=True):
+            return list(state.facts)
+
+    class FakeHybridSearch:
+        def search(self, query=None, top_k=None):
+            return list(state.notes)
+
+    class FakeTaskManager:
+        def list_tasks(self, query=None, status=None):
+            return list(state.tasks)
+
+    class FakeIMessageStore:
+        def get_messages_for_entity(self, entity_id, limit=None):
+            return []
+
+    class FakeResolver:
+        def resolve(self, name=None, email=None):
+            from api.services.person_entity import PersonEntity
+
+            return SimpleNamespace(
+                entity=PersonEntity(
+                    id="person-quill",
+                    canonical_name="Marigold Quill",
+                    display_name="Marigold Quill",
+                    emails=[state.entity_email] if state.entity_email else [],
+                    company="Tidewater Press",
+                    position="Editor",
+                    category="work",
+                    last_seen=_days_ago(150),
+                    sources=["gmail"],
+                )
+            )
+
+    class FakeSynthesizer:
+        async def get_response(self, prompt, max_tokens=None):
+            state.prompt = prompt
+            return "## Marigold Quill — Briefing\n\nSynthesised."
+
+    monkeypatch.setattr(person_facts_mod, "get_person_fact_store", lambda: FakeFactStore())
+    monkeypatch.setattr(briefings, "get_synthesizer", lambda: FakeSynthesizer())
+
+    state.service = BriefingsService(
+        hybrid_search=FakeHybridSearch(),
+        task_manager=FakeTaskManager(),
+        entity_resolver=FakeResolver(),
+        interaction_store=FakeInteractionStore(),
+        imessage_store=FakeIMessageStore(),
+    )
+    return state
+
+
+def _windows(state) -> list:
+    return [c["days_back"] for c in state.history_calls]
+
+
+class TestBriefingInteractionWidening:
+    """A quiet quarter is not an absence of history."""
+
+    async def test_interaction_older_than_the_default_window_is_found(self, briefing_env):
+        briefing_env.oldest_days = 150
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "Community garden rota" in briefing_env.prompt
+
+    async def test_does_not_assert_that_no_history_exists(self, briefing_env):
+        """The exact collapse this issue exists to remove."""
+        briefing_env.oldest_days = 150
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "No interaction history available" not in briefing_env.prompt
+        # The pre-fix 90-day miss reached the prompt as an unnamed window, which
+        # is the same claim wearing different words.
+        assert "the specified time period" not in briefing_env.prompt
+        assert NO_INTERACTIONS_PREFIX not in briefing_env.prompt
+
+    async def test_ladder_rungs_match_the_declared_ladder(self, briefing_env):
+        briefing_env.oldest_days = None
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert _windows(briefing_env) == list(_INTERACTION_LADDER_DAYS)
+
+    async def test_stops_at_the_first_rung_that_hits(self, briefing_env):
+        briefing_env.oldest_days = 3
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert _windows(briefing_env) == [_INTERACTION_LADDER_DAYS[0]]
+
+    async def test_widening_is_disclosed_on_a_hit(self, briefing_env):
+        briefing_env.oldest_days = 150
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "Nothing in the last 90 days" in briefing_env.prompt
+        assert "widened to the last 365 days" in briefing_env.prompt
+
+    async def test_no_widening_note_when_the_first_rung_hits(self, briefing_env):
+        briefing_env.oldest_days = 3
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "widened to" not in briefing_env.prompt
+
+    async def test_context_records_the_windows_tried(self, briefing_env):
+        briefing_env.oldest_days = 150
+        context = briefing_env.service.gather_context("Marigold Quill")
+        assert context.interaction_windows_tried == [
+            "the last 90 days", "the last 365 days",
+        ]
+
+
+class TestBriefingEmptyWindowStatesItsScope:
+    async def test_empty_result_names_every_window_searched(self, briefing_env):
+        briefing_env.oldest_days = None
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        for days in _INTERACTION_LADDER_DAYS:
+            assert format_window_label(days) in briefing_env.prompt
+
+    async def test_empty_result_does_not_collapse_to_no_history(self, briefing_env):
+        briefing_env.oldest_days = None
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "No interaction history available" not in briefing_env.prompt
+        assert "the specified time period" not in briefing_env.prompt
+
+    async def test_empty_window_carries_no_fault_language(self, briefing_env):
+        briefing_env.oldest_days = None
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        section = briefing_env.service._format_interaction_section(
+            briefing_env.service.gather_context("Marigold Quill")
+        )
+        _assert_no_fault_language(section, "empty interaction window")
+
+    async def test_unsearched_index_is_distinguished_from_an_empty_one(self, briefing_env):
+        """No entity resolved means the index was never consulted at all."""
+        context = briefing_env.service.gather_context("Marigold Quill")
+        context.entity_id = None
+        context.interaction_windows_tried = []
+        context.interaction_history = ""
+        section = briefing_env.service._format_interaction_section(context)
+        assert "was not searched" in section
+        _assert_no_fault_language(section, "unsearched interaction index")
+
+    async def test_a_store_fault_is_stated_as_a_fault(self, briefing_env):
+        """The one case that must NOT read as an absence."""
+        briefing_env.raise_on_history = True
+        context = briefing_env.service.gather_context("Marigold Quill")
+        assert context.interaction_lookup_failed is True
+        section = briefing_env.service._format_interaction_section(context)
+        assert "could not be read" in section
+
+
+class TestBriefingCallerSuppliedWindow:
+    async def test_stated_window_is_honoured_exactly(self, briefing_env):
+        briefing_env.oldest_days = 150
+        await briefing_env.service.generate_briefing(
+            "Marigold Quill", interaction_days=30
+        )
+        assert _windows(briefing_env) == [30]
+
+    async def test_stated_window_is_not_widened(self, briefing_env):
+        briefing_env.oldest_days = 150
+        await briefing_env.service.generate_briefing(
+            "Marigold Quill", interaction_days=30
+        )
+        assert "widened to" not in briefing_env.prompt
+
+    async def test_empty_stated_window_names_that_window(self, briefing_env):
+        briefing_env.oldest_days = 150
+        await briefing_env.service.generate_briefing(
+            "Marigold Quill", interaction_days=30
+        )
+        assert "the last 30 days" in briefing_env.prompt
+
+    async def test_empty_stated_window_does_not_claim_wider_ones(self, briefing_env):
+        briefing_env.oldest_days = 150
+        await briefing_env.service.generate_briefing(
+            "Marigold Quill", interaction_days=30
+        )
+        assert "the last 365 days" not in briefing_env.prompt
+
+
+class TestBriefingToolSchema:
+    def _person_info(self) -> dict:
+        return next(t for t in TOOL_DEFINITIONS if t["name"] == "person_info")
+
+    def test_schema_advertises_the_window(self):
+        props = self._person_info()["input_schema"]["properties"]
+        assert "interaction_days" in props
+
+    def test_window_is_an_integer_and_optional(self):
+        tool = self._person_info()
+        assert tool["input_schema"]["properties"]["interaction_days"]["type"] == "integer"
+        assert "interaction_days" not in tool["input_schema"]["required"]
+
+    def test_description_states_the_default_and_the_widening(self):
+        desc = self._person_info()["description"]
+        assert "90 days" in desc
+        assert "widens" in desc
+
+    def test_window_description_states_its_bounds(self):
+        prop = self._person_info()["input_schema"]["properties"]["interaction_days"]
+        assert f"1-{_BRIEFING_MAX_DAYS}" in prop["description"]
+
+
+@pytest.fixture
+def fake_briefing_service(monkeypatch):
+    """Capture what the tool passes down to BriefingsService."""
+    state = SimpleNamespace(calls=[], result={"status": "success", "briefing": "## Brief"})
+
+    class FakeService:
+        async def generate_briefing(self, person_name, email=None, interaction_days=None):
+            state.calls.append(
+                {
+                    "person_name": person_name,
+                    "email": email,
+                    "interaction_days": interaction_days,
+                }
+            )
+            return state.result
+
+    monkeypatch.setattr(briefings, "get_briefings_service", lambda: FakeService())
+    return state
+
+
+class TestBriefingToolWindowArgument:
+    """A window is a scope, so a bad one is dropped rather than clamped.
+
+    Clamping would brief on a period nobody asked for; treating it as unstated
+    falls back to the ladder, and the drop is disclosed either way.
+    """
+
+    async def test_omitted_window_reaches_the_service_as_unstated(
+        self, fake_briefing_service
+    ):
+        await _briefing_person({"name": "Marigold Quill"})
+        assert fake_briefing_service.calls[0]["interaction_days"] is None
+
+    async def test_stated_window_is_passed_through(self, fake_briefing_service):
+        await _briefing_person({"name": "Marigold Quill", "interaction_days": 45})
+        assert fake_briefing_service.calls[0]["interaction_days"] == 45
+
+    async def test_numeric_string_is_coerced(self, fake_briefing_service):
+        await _briefing_person({"name": "Marigold Quill", "interaction_days": "45"})
+        assert fake_briefing_service.calls[0]["interaction_days"] == 45
+
+    @pytest.mark.parametrize(
+        "bad", [0, -30, "soon", 10**9, _BRIEFING_MAX_DAYS + 1, None.__class__]
+    )
+    async def test_bad_window_is_treated_as_unstated(self, fake_briefing_service, bad):
+        await _briefing_person({"name": "Marigold Quill", "interaction_days": bad})
+        assert fake_briefing_service.calls[0]["interaction_days"] is None
+
+    async def test_dropped_window_is_disclosed(self, fake_briefing_service):
+        out = await _briefing_person({"name": "Marigold Quill", "interaction_days": -30})
+        assert "Ignored interaction_days" in out
+        assert "NOT scoped to it" in out
+
+    async def test_valid_window_is_not_reported_as_ignored(self, fake_briefing_service):
+        out = await _briefing_person({"name": "Marigold Quill", "interaction_days": 45})
+        assert "Ignored interaction_days" not in out
+
+    async def test_the_bound_itself_is_accepted(self, fake_briefing_service):
+        await _briefing_person(
+            {"name": "Marigold Quill", "interaction_days": _BRIEFING_MAX_DAYS}
+        )
+        assert fake_briefing_service.calls[0]["interaction_days"] == _BRIEFING_MAX_DAYS
+
+
+class TestBriefingToolStatusHandling:
+    """Thin data is an absence; only a real fault may be reported as one."""
+
+    async def test_limited_data_is_not_reported_as_a_failure(
+        self, fake_briefing_service
+    ):
+        fake_briefing_service.result = {
+            "status": "limited",
+            "message": "I have limited information about Marigold Quill.",
+        }
+        out = await _briefing_person({"name": "Marigold Quill"})
+        _assert_no_fault_language(out, "limited briefing")
+
+    async def test_limited_data_keeps_its_own_message(self, fake_briefing_service):
+        fake_briefing_service.result = {
+            "status": "limited",
+            "message": "I have limited information about Marigold Quill.",
+        }
+        out = await _briefing_person({"name": "Marigold Quill"})
+        assert "limited information about Marigold Quill" in out
+
+    async def test_not_found_names_the_person_searched(self, fake_briefing_service):
+        fake_briefing_service.result = {"status": "not_found", "message": ""}
+        out = await _briefing_person({"name": "Thistlewaite Barrowman"})
+        assert "'Thistlewaite Barrowman'" in out
+        _assert_no_fault_language(out, "not-found briefing")
+
+    async def test_a_real_fault_is_still_stated_plainly(self, fake_briefing_service):
+        fake_briefing_service.result = {
+            "status": "error",
+            "message": "synthesiser timed out",
+        }
+        out = await _briefing_person({"name": "Marigold Quill"})
+        assert "Briefing failed" in out
+
+
+class TestBriefingLimitedStatus:
+    """Interactions and facts count as data for the early bail-out.
+
+    Without them a person with years of messages but no vault note got "I have
+    limited information", which threw away the interaction history entirely.
+    """
+
+    async def test_interactions_alone_are_enough_to_brief(self, briefing_env):
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = 3
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert result["status"] == "success"
+
+    async def test_facts_alone_are_enough_to_brief(self, briefing_env):
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = None
+        briefing_env.facts = [_fact("work", "role", "Runs the poetry imprint", 0.9)]
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert result["status"] == "success"
+
+    async def test_a_truly_empty_record_names_what_was_searched(self, briefing_env):
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = None
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        assert result["status"] == "limited"
+        assert "the last 90 days" in result["message"]
+
+    async def test_limited_message_carries_no_fault_language(self, briefing_env):
+        briefing_env.entity_email = None
+        briefing_env.oldest_days = None
+        result = await briefing_env.service.generate_briefing("Marigold Quill")
+        _assert_no_fault_language(result["message"], "limited briefing message")
+
+
+class TestBriefingFactConfidenceFloor:
+    """A floor that thins the set silently presents a partial set as complete."""
+
+    def test_facts_below_the_floor_are_counted(self, briefing_env):
+        briefing_env.facts = [
+            _fact("work", "role", "Runs the poetry imprint", 0.9),
+            _fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2),
+        ]
+        context = briefing_env.service.gather_context("Marigold Quill")
+        assert context.facts_withheld_low_confidence == 1
+        assert len(context.person_facts) == 1
+
+    async def test_withheld_facts_are_disclosed(self, briefing_env):
+        briefing_env.facts = [
+            _fact("work", "role", "Runs the poetry imprint", 0.9),
+            _fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2),
+            _fact("topics", "rumour2", "Maybe changed jobs", 0.1),
+        ]
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "2 further fact(s)" in briefing_env.prompt
+        assert str(FACT_CONFIDENCE_FLOOR) in briefing_env.prompt
+
+    async def test_withheld_facts_never_leak_their_content(self, briefing_env):
+        briefing_env.facts = [
+            _fact("work", "role", "Runs the poetry imprint", 0.9),
+            _fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2),
+        ]
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "Maybe moved to Lowmarsh" not in briefing_env.prompt
+
+    async def test_no_disclosure_when_the_floor_drops_nothing(self, briefing_env):
+        briefing_env.facts = [_fact("work", "role", "Runs the poetry imprint", 0.9)]
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "further fact(s)" not in briefing_env.prompt
+
+    async def test_all_facts_withheld_is_not_reported_as_no_facts(self, briefing_env):
+        briefing_env.facts = [
+            _fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2),
+            _fact("topics", "rumour2", "Maybe changed jobs", 0.1),
+        ]
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "No facts extracted yet" not in briefing_env.prompt
+        assert "2 lower-confidence fact(s)" in briefing_env.prompt
+
+    async def test_no_facts_at_all_still_says_so(self, briefing_env):
+        briefing_env.facts = []
+        await briefing_env.service.generate_briefing("Marigold Quill")
+        assert "No facts extracted yet" in briefing_env.prompt
+
+    async def test_briefing_facts_are_ranked_by_confidence(self, briefing_env):
+        briefing_env.facts = [
+            _fact("work", "role", "Runs the poetry imprint", 0.65),
+            _fact("family", "spouse_name", "Spouse is Rowan Quill", 0.95),
+        ]
+        context = briefing_env.service.gather_context("Marigold Quill")
+        assert [f["value"] for f in context.person_facts] == [
+            "Spouse is Rowan Quill", "Runs the poetry imprint",
+        ]
+
+    async def test_floor_disclosure_carries_no_fault_language(self, briefing_env):
+        briefing_env.facts = [_fact("topics", "rumour", "Maybe moved to Lowmarsh", 0.2)]
+        context = briefing_env.service.gather_context("Marigold Quill")
+        section = briefing_env.service._format_facts_section(context)
+        _assert_no_fault_language(section, "withheld-facts disclosure")
+
+
+class TestInteractionStoreEmptyMessage:
+    """The store's empty message is the contract the briefing widens on."""
+
+    def test_empty_message_names_the_window(self):
+        from api.services.interaction_store import InteractionStore
+
+        store = InteractionStore.__new__(InteractionStore)
+        store.get_for_person = lambda *a, **k: []
+        store.get_interaction_counts = lambda *a, **k: {}
+        store.get_last_interaction = lambda *a, **k: None
+        out = store.format_interaction_history("person-quill", days_back=90)
+        assert "the last 90 days" in out
+        assert out.startswith(NO_INTERACTIONS_PREFIX)
+
+    def test_empty_message_describes_an_unbounded_window(self):
+        from api.services.interaction_store import InteractionStore
+
+        store = InteractionStore.__new__(InteractionStore)
+        store.get_for_person = lambda *a, **k: []
+        store.get_interaction_counts = lambda *a, **k: {}
+        store.get_last_interaction = lambda *a, **k: None
+        out = store.format_interaction_history("person-quill")
+        assert "the full history on record" in out
+
+    def test_empty_message_carries_no_fault_language(self):
+        from api.services.interaction_store import InteractionStore
+
+        store = InteractionStore.__new__(InteractionStore)
+        store.get_for_person = lambda *a, **k: []
+        store.get_interaction_counts = lambda *a, **k: {}
+        store.get_last_interaction = lambda *a, **k: None
+        out = store.format_interaction_history("person-quill", days_back=90)
+        _assert_no_fault_language(out, "empty interaction history")
+
+
+class TestPersonSurfaceEmptiesCarryNoFaultLanguage:
+    """Blanket ban, no exceptions, across every empty path on this surface."""
+
+    def test_lookup_miss(self, fake_person):
+        fake_person.resolved = False
+        _assert_no_fault_language(
+            _lookup_person({"name": "Thistlewaite Barrowman"}), "lookup miss"
+        )
+
+    def test_lookup_with_no_facts_and_no_contact(self, fake_person):
+        fake_person.facts = []
+        fake_person.summary = _summary(NEVER_CONTACTED_DAYS, None)
+        _assert_no_fault_language(
+            _lookup_person({"name": "Marigold Quill"}), "empty lookup"
+        )
+
+    def test_lookup_with_truncated_facts(self, fake_person):
+        fake_person.facts = [
+            _fact("topics", f"note_{i:02d}", f"Discussed subject {i}", 0.5)
+            for i in range(_PERSON_FACT_LIMIT + 4)
+        ]
+        _assert_no_fault_language(
+            _lookup_person({"name": "Marigold Quill"}), "truncated lookup"
+        )
+
+    async def test_briefing_with_an_empty_interaction_index(self, briefing_env):
+        briefing_env.oldest_days = None
+        briefing_env.facts = []
+        context = briefing_env.service.gather_context("Marigold Quill")
+        _assert_no_fault_language(
+            briefing_env.service._format_interaction_section(context),
+            "empty briefing interactions",
+        )
+        _assert_no_fault_language(
+            briefing_env.service._format_facts_section(context), "empty briefing facts"
+        )
+
+    async def test_briefing_tool_on_a_thin_record(self, fake_briefing_service):
+        fake_briefing_service.result = {"status": "limited", "message": ""}
+        _assert_no_fault_language(
+            await _briefing_person({"name": "Marigold Quill"}), "thin briefing"
+        )
+
+    def test_tool_handler_is_still_registered(self):
+        """The tool must remain reachable — a rename here breaks the surface."""
+        assert at._TOOL_HANDLERS["person_info"] is at._tool_person_info

--- a/tests/test_agent_tools_scope_widening.py
+++ b/tests/test_agent_tools_scope_widening.py
@@ -1107,8 +1107,8 @@ class TestCalendarAccountFailureDisclosure:
     ):
         broken_calendar.raising = {"personal"}
         out = await _tool_search_calendar({"query": "standup"})
-        assert "Could not reach personal" in out
-        assert "not necessarily an empty calendar" in out
+        assert "personal" in out
+        assert "NOT an empty calendar" in out
 
     async def test_partial_failure_still_discloses_alongside_results(
         self, broken_calendar, accounts
@@ -1155,7 +1155,7 @@ class TestCalendarAccountFailureDisclosure:
         """
         broken_calendar.raising = {"personal"}
         out = await _tool_search_calendar({"query": "standup"})
-        assert "incomplete" in out
+        assert "errored" in out
         assert any(word in out.lower() for word in FAULT_WORDS)
 
 
@@ -1344,3 +1344,68 @@ class TestCalendarDaysRangeUpperBound:
     async def test_bound_does_not_overflow_timedelta(self):
         """The ceiling must be safely below where timedelta gives out."""
         assert datetime.now(timezone.utc) - timedelta(days=_CALENDAR_MAX_DAYS)
+
+
+class TestCalendarTotalAccountFailure:
+    """With every account down, nothing was searched — so nothing was established.
+
+    `CalendarService._fetch_events` used to resolve its lazy `service` property
+    inside its own `try/except Exception -> return []`, so an expired token came
+    back as an empty list. The per-account disclosure could never fire for the
+    case it exists for, and the widening ladder then reported "Searched ±180d,
+    then ±365d, then ±1095d. Nothing on the calendar matches ..." over a broken
+    connection — three windows it claimed to search and never did.
+    """
+
+    @pytest.fixture
+    def flaky_calendar(self, monkeypatch, accounts):
+        state = SimpleNamespace(raising=set(), events={}, attempts=0)
+
+        class FlakyCalendarService:
+            def __init__(self, account):
+                self.name = account.value
+
+            def search_events(self, query=None, days_back=30, days_forward=30, **kw):
+                state.attempts += 1
+                if self.name in state.raising:
+                    raise RuntimeError("invalid_grant: token expired")
+                return list(state.events.get(self.name, []))
+
+            def get_events_in_range(self, start, end):
+                return []
+
+            def get_upcoming_events(self, days=7, max_results=15):
+                return []
+
+        monkeypatch.setattr(
+            "api.services.calendar.CalendarService", FlakyCalendarService
+        )
+        return state
+
+    def _event(self, title="Synthetic standup"):
+        return SimpleNamespace(
+            title=title,
+            start_time=datetime.now(timezone.utc),
+            attendees=[],
+            location="",
+            source_account="personal",
+        )
+
+    async def test_total_failure_leads_with_the_fault(self, flaky_calendar):
+        flaky_calendar.raising = {"personal"}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert out.startswith("Could not search the calendar")
+
+    async def test_total_failure_does_not_claim_an_absence(self, flaky_calendar):
+        """A denial with a footnote still reads as an answer."""
+        flaky_calendar.raising = {"personal"}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Nothing on the calendar matches" not in out
+        assert "NOT an empty calendar" in out
+
+    async def test_total_failure_stops_the_ladder(self, flaky_calendar):
+        """Widening cannot help a broken connection, and claiming it lies."""
+        flaky_calendar.raising = {"personal"}
+        await _tool_search_calendar({"query": "standup"})
+        assert flaky_calendar.attempts == 1
+


### PR DESCRIPTION
Closes #531, #532, #533, #534, #535.

## What this is

The audited remainder of the bug class fixed in #530: a tool clamps its search scope to a default the caller never asked for, then returns a bare "No X found." that never names what was searched. The model cannot tell *the data is absent* from *I looked in the wrong place*, so it fabricates an explanation. In the original report it told the user a backend sync/permissions fault for a message that was sitting in the database.

Ten audited findings, grouped into five issues. Each was implemented in an isolated worktree, then reviewed — by me line-by-line and by an adversarial reviewer (Codex). **Review found more defects than implementation did**, including several in the fixes themselves.

## The four rules

1. Never assert more than the search established.
2. An explicit scope from the caller is intent — honour it exactly.
3. Disclose every bound that binds.
4. Distinguish a fault from an absence.

## Per tool

**Drive (#531)** — cap 5 → 20 with truncation disclosed; per-account failures surfaced; `order_by` exposed.

The issue's premise was **wrong** and is worth recording: I proposed relevance ordering, but Drive has *no relevance key*, and omitting `orderBy` returns **arbitrary** order. The fix would have traded a documented order for an undocumented one. Instead the cut is disclosed as being by modification time rather than match quality, and `order_by` lets an old file be reached. A file behind more than 20 newer matches is still off the default page — that is the honest ceiling of the API, and the output says so.

**Finances (#532)** — every figure now carries its period.

The issue's premise was also wrong here, in the other direction. It claimed unlabelled month-to-date totals; in fact `monarchmoney` **rejects a one-sided range**, so the month-to-date default sent a bare `start_date` and *raised*. That default could never have worked. This inverts my own severity argument in the issue — I claimed a confidently wrong number is worse than a denial, which is true in general but did not apply to a hard failure.

**Person (#533)** — briefing interaction window is caller-controllable, stated, and widened before giving up; facts ranked by confidence with truncation disclosed; the never-contacted sentinel no longer renders as an interval.

That sentinel reached **four** renderers, not one. The worst was `person_indexer`, which bucketed it numerically and wrote *"Last contact: over a year ago"* into the indexed, searchable profile for someone never contacted — retrieval then reads that as established fact.

**Memories (#534)** — the result limit is now a caller lever and advertised in the schema; truncation and the corpus bound disclosed; "nothing saved matches" separated from "candidates scored below the relevance threshold".

The floors are **not** AND-ed as the issue implied — they are RRF-fused, so clearing *either* admits a memory. That makes a pure paraphrase (missing both) the real failure mode. Floor values were deliberately left alone: lowering them trades false negatives for false positives and needs evidence, not a guess.

**Wording (#535)** — workout, task, and vault empties name their filters instead of denying the whole record. No ladders added; these are cheap corpora and the only defect was overstatement.

## Defects found in review, not implementation

**In already-merged #530:**
- `CalendarService._fetch_events` wrapped everything in `try/except → return []` with `service` as a lazy property inside it, so an expired token was swallowed. The failure disclosure #530 added **could never fire for the case it was written for** — and #530 made it *worse*: the ladder walked three rungs against a dead connection and claimed to have searched all three.

**In the batch's own fixes:**
- Impossible finance windows still reachable via a *future* `start_date` → `$0.00` at 0% printed as a real period.
- Savings rate printed `0.0%` with zero income (undefined, not zero); now derived from the two figures above it, which also removes a unit heuristic that guessed wrong on negative rates.
- "No categorized spending" emitted while a non-zero Expenses line sat directly above it.
- Drive repeated the calendar total-failure bug verbatim.
- An invalid `interaction_days` widened a *personal history* search. This contradicts the batch's own "caps clamp, scopes don't" rule — correct for a calendar search, wrong when widening exposes more personal data. Refusing is the deliberate exception.
- Unparseable finance dates returned real aggregates for an unasked period. Acceptable for transactions (every row shows its date) but not for an aggregate, where the number is the whole answer.
- A **user-confirmed** fact was withheld as "low confidence": the ranker treated confirmed as 1.0 while the floor used raw confidence. Now one shared helper.
- The near-miss count claimed "something relevant is likely saved" on a single shared common word.

**Found while auditing, unrelated to any issue:** `lifeos_communication_gaps` read three field names that do not exist in the response, so every `.get()` defaulted — every person rendered as *"999 days since contact"* with their real gap data discarded. A fabricated fact about a real person, on the MCP surface.

## Verification

- **683 tests** across the ten affected files; **3938 passing** in the full suite.
- 5 remaining failures are the known baseline (machine-specific `.env`, real-vault data checks), verified on a clean tree.
- `test_directory_resolver` failed once and did not reproduce: it passes on main, in isolation, under xdist alongside all new test files, and on a second identical full run. A distribution flake, not this change.
- Lint clean on all changed files.
- Two claims the new code makes were checked rather than assumed: `list_memories` sorts descending **then** slices (so "1000 newest" is true), and cashflow categories are largest-first (so "largest 10 of N" is true). Had either ordered the other way, the disclosure would have been a fresh instance of the bug.

## Deliberately not here

- **#536** — Google API/quota errors (403, 500) are *still* rendered as absence. Only the auth path is fixed; propagating API errors changes a service contract the HTTP routes depend on.
- **#537** — non-empty results still hide their caps on vault and workout paths. #535 was scoped to empties on purpose.

Both filed rather than folded in, to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
