### PR TITLE
fix(chat): raise and disclose result caps, stop reporting Google API errors as absence

### DIFF
--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -74,7 +74,7 @@ TOOL_DEFINITIONS = [
                 },
                 "top_k": {
                     "type": "integer",
-                    "description": "Number of results to return (default 10)",
+                    "description": "Number of results to return (default 40). A capped result says so — raise this to reach past it.",
                 },
             },
             "required": ["query"],
@@ -817,13 +817,13 @@ TOOL_DEFINITIONS = [
                 "notes": {"type": "string", "description": "Session notes (optional)."},
                 "session_id": {"type": "string", "description": "Target session for 'update' (defaults to most recent)."},
                 "exercise": {"type": "string", "description": "Exercise name for 'history' / 'summary'."},
-                "date_start": {"type": "string", "description": "Window start YYYY-MM-DD (for summary/metrics)."},
-                "date_end": {"type": "string", "description": "Window end YYYY-MM-DD (for summary/metrics)."},
+                "date_start": {"type": "string", "description": "Window start YYYY-MM-DD (for list/summary/metrics)."},
+                "date_end": {"type": "string", "description": "Window end YYYY-MM-DD (for list/summary/metrics)."},
                 "metric_type": {"type": "string", "description": "Metric name for log_metric/metrics, e.g. 'body_weight'."},
                 "value": {"type": "string", "description": "Value: numeric for 'log_metric' (e.g. '178.4'), free text for 'set_profile'."},
                 "unit": {"type": "string", "description": "Metric unit for 'log_metric', e.g. 'lb'."},
                 "key": {"type": "string", "description": "Training-profile key for 'set_profile'."},
-                "limit": {"type": "integer", "description": "Max rows for history/metrics (default 20/100)."},
+                "limit": {"type": "integer", "description": "Max rows for list/history/metrics (default 50/100/365). A capped result says so — raise this to reach past it."},
             },
             "required": ["action"],
         },
@@ -890,17 +890,34 @@ async def execute_tool_parallel(name: str, tool_input: dict) -> str:
 # Individual tool handlers
 # ---------------------------------------------------------------------------
 
-# Matches HybridSearch.search's own default. The old default of 10 halved the
-# service default for no stated reason, so a chunk the vault ranked 12th came
-# back as "no vault results" — an empty that described the cap, not the vault.
-_VAULT_TOP_K_DEFAULT = 20
+# Result cap for a vault search. Chosen against the live index, not guessed:
+# ordinary queries have far more than 20 matches ("meeting notes" 50, "project"
+# 48, "kayak trip" 42, "workout" 29), and the extra ones are free — the pipeline
+# fetches `rerank_candidates` (50) candidates whatever top_k says, so top_k=80
+# was measured to return exactly what top_k=50 does. 20 was throwing away
+# ranked, already-retrieved chunks and calling the remainder the answer.
+#
+# 40 rather than 50 because HybridSearch.search only runs the cross-encoder when
+# more candidates survive than top_k asks for (`len(final_results) > top_k`). A
+# default of 50 would silently switch reranking off, and the char budget below
+# would then drop the tail by RRF order rather than by relevance.
+_VAULT_TOP_K_DEFAULT = 40
+
+# Payload ceiling for the rendered results, in characters, following
+# _MSG_HISTORY_CHAR_BUDGET. Result *count* is a poor cost proxy here: measured
+# over the live index, 50 results cost 15 KB for "therapy" (avg 270 chars of
+# chunk) and 36 KB for "Nathan" (avg 693) — same count, 2.3x the payload. A
+# character budget lets a query with short chunks keep all 40 while a query with
+# full 800-char chunks stays near the ~17 KB worst case the old cap of 20 had.
+_VAULT_CHAR_BUDGET = 24000
 
 
 def _tool_search_vault(inp: dict) -> str:
     from api.services.hybrid_search import HybridSearch
     hs = HybridSearch()
     # Normalised like Slack's top_k: the model fills this in, and a 0 or None
-    # would return nothing and read as an empty vault.
+    # would return nothing and read as an empty vault — and it doubles as the
+    # yardstick for the truncation disclosure below.
     top_k = _positive_int(inp.get("top_k", _VAULT_TOP_K_DEFAULT), _VAULT_TOP_K_DEFAULT, 200)
     query = inp["query"]
     results = hs.search(query, top_k=top_k)
@@ -909,12 +926,40 @@ def _tool_search_vault(inp: dict) -> str:
         # model needs to see what was asked to try a different one.
         return f"No vault results found for query {query!r}."
     lines = []
+    used = 0
     for i, r in enumerate(results, 1):
         fn = r.get("file_name", "unknown")
         content = r.get("content", "")[:800]
         score = r.get("hybrid_score", 0)
-        lines.append(f"[{i}] {fn} (score={score:.2f})\n{content}")
-    return "\n\n---\n".join(lines)
+        block = f"[{i}] {fn} (score={score:.2f})\n{content}"
+        # Whole chunks only, and always at least one: half a chunk sitting under
+        # the next chunk's header would be attributed to the wrong note, which is
+        # worse than dropping it.
+        if lines and used + len(block) > _VAULT_CHAR_BUDGET:
+            break
+        lines.append(block)
+        used += len(block)
+
+    notes = []
+    if len(lines) < len(results):
+        # Raising top_k cannot help here — the budget, not the count, bound.
+        notes.append(
+            f"Payload capped at {_VAULT_CHAR_BUDGET} characters — showing the "
+            f"{len(lines)} highest-ranked of {len(results)} chunks returned. "
+            "Narrow the query to spend the budget on fewer, closer notes."
+        )
+    if len(results) == top_k:
+        # A full page is the only signal the search gives that it had more. Say
+        # so: a truncated set read as complete is worse than an empty one,
+        # because nothing cues the reader to doubt it.
+        notes.append(
+            f"Capped at top_k={top_k} — more matching chunks may exist. Raise "
+            "top_k, or narrow the query, to reach them."
+        )
+    body = "\n\n---\n".join(lines)
+    if not notes:
+        return body
+    return body + "\n\n[" + " ".join(notes) + "]"
 
 
 # Widening ladder for a calendar keyword search with no caller-supplied range.
@@ -2344,14 +2389,36 @@ def _workout_update(inp: dict) -> str:
     return f"Updated — {_summarize_session(session)} (session id: {session.id})"
 
 
+# Session cap for `list`, and the ceiling on a caller-supplied one.
+#
+# 10 was set the day the workout store was written, before it held a month of
+# real training, and it undercounts an ordinary month: the log holds 16 sessions
+# in June 2026 and 18 in its densest 30-day window, so "how did June go" was
+# answered from 10 of 16 with nothing saying so. 50 is the store's own
+# list_sessions default, covers the densest measured month nearly 3x, and covers
+# a full quarter at the June 2026 rate (~16/month) — the widest span worth
+# enumerating session by session.
+#
+# A count is an honest cost proxy at this shape, unlike the vault chunks above:
+# one line per session, measured at ~96 characters over the real log and 172 at
+# worst, so 50 sessions is ~5 KB. The 200 ceiling bounds a caller-supplied
+# request to ~34 KB and still spans the whole 125-session log.
+_WORKOUT_LIST_LIMIT = 50
+_WORKOUT_LIST_MAX = 200
+
+
 def _workout_list(inp: dict) -> str:
     from api.services.fitness_store import get_fitness_store
     store = get_fitness_store()
+    # Normalised, not coerced with int(): the model writes this, and a 0, None or
+    # "twenty" would either raise inside the store or silently disable the
+    # truncation check below, which compares against this same number.
+    limit = _positive_int(inp.get("limit", _WORKOUT_LIST_LIMIT), _WORKOUT_LIST_LIMIT, _WORKOUT_LIST_MAX)
     sessions = store.list_sessions(
         date_start=inp.get("date_start"),
         date_end=inp.get("date_end"),
         kind=inp.get("kind"),
-        limit=int(inp.get("limit", 10) or 10),
+        limit=limit,
     )
     if not sessions:
         applied = _applied_filters(
@@ -2369,7 +2436,24 @@ def _workout_list(inp: dict) -> str:
     lines = ["Recent sessions (newest first):"]
     for s in sessions:
         lines.append(f"  [{s.id}] {_summarize_session(s)}")
+    if len(sessions) == limit:
+        # A full page is the only signal the store gives that it had more. Newest
+        # first, so what is missing is the older end of the span asked about —
+        # exactly what a "how did that month go" question is counting.
+        lines.append(
+            f"[Capped at {limit} sessions, newest first — older sessions may "
+            "also match. Raise limit, or set date_start/date_end, to reach them.]"
+        )
     return "\n".join(lines)
+
+
+# Set cap for `history`. One row is one set of one lift, so 20 was under a month
+# of a twice-weekly lift at the measured 2.3 sets per session (4 at worst) —
+# the wrong unit for "how has this moved", which is asked over months. 100 rows
+# is roughly a year at that rate and ~5 KB (one date, reps and load per line).
+# The 500 ceiling bounds a caller-supplied request to ~27 KB.
+_WORKOUT_HISTORY_LIMIT = 100
+_WORKOUT_HISTORY_MAX = 500
 
 
 def _workout_history(inp: dict) -> str:
@@ -2378,7 +2462,12 @@ def _workout_history(inp: dict) -> str:
     if not exercise:
         return "Error: 'history' needs an 'exercise'."
     store = get_fitness_store()
-    rows = store.exercise_history(exercise, limit=int(inp.get("limit", 20) or 20))
+    # Normalised for the same reason as `list` above — it is also the yardstick
+    # for the truncation check.
+    limit = _positive_int(
+        inp.get("limit", _WORKOUT_HISTORY_LIMIT), _WORKOUT_HISTORY_LIMIT, _WORKOUT_HISTORY_MAX
+    )
+    rows = store.exercise_history(exercise, limit=limit)
     canonical = store.normalize_exercise(exercise)
     if not rows:
         # normalize_exercise title-cases anything it has no alias for, so the
@@ -2397,6 +2486,11 @@ def _workout_history(inp: dict) -> str:
         dur = f" in {_fmt_duration(r.get('duration_seconds'))}" if r.get("duration_seconds") else ""
         sid = f" [{r['session_id']}]" if r.get("session_id") else ""
         lines.append(f"  {r['date']}: {_fmt_num(r['reps'])} reps{w}{rpe}{dur}{sid}")
+    if len(rows) == limit:
+        lines.append(
+            f"[Capped at {limit} sets, newest first — earlier sets of "
+            f"{canonical!r} may also be logged. Raise limit to reach them.]"
+        )
     return "\n".join(lines)
 
 
@@ -2428,6 +2522,17 @@ def _workout_log_metric(inp: dict) -> str:
     return f"Logged {metric_type.replace('_', ' ')}: {_fmt_num(m.value)}{unit}."
 
 
+# Sample cap for `metrics`. A metric question is a trend question, and its
+# natural span is a year: 365 is a year of the cumulative path (one row per day)
+# and about sixteen months of HRV at the measured 275 samples a year, where the
+# old 100 was under four months of either. Body weight, sleep and resting HR
+# arrive at most daily in the real record, so a year of those fits with room.
+# One row is a date and a number, ~30 characters, so 365 rows is ~11 KB and the
+# 1000 ceiling bounds a caller-supplied request to ~30 KB.
+_WORKOUT_METRICS_LIMIT = 365
+_WORKOUT_METRICS_MAX = 1000
+
+
 def _workout_metrics(inp: dict) -> str:
     from api.services.fitness_store import get_fitness_store
     metric_type = inp.get("metric_type")
@@ -2435,7 +2540,11 @@ def _workout_metrics(inp: dict) -> str:
         return "Error: 'metrics' needs a 'metric_type'."
     store = get_fitness_store()
     label = metric_type.replace("_", " ")
-    limit = int(inp.get("limit", 100) or 100)
+    # Normalised for the same reason as `list` above — it is also the yardstick
+    # for the truncation checks.
+    limit = _positive_int(
+        inp.get("limit", _WORKOUT_METRICS_LIMIT), _WORKOUT_METRICS_LIMIT, _WORKOUT_METRICS_MAX
+    )
 
     # Both query paths below share one empty result. With a window in effect it
     # must name the window: "No body weight recorded." for a dated query implies
@@ -2460,6 +2569,14 @@ def _workout_metrics(inp: dict) -> str:
         for d in days:
             unit = f" {d['unit']}" if d["unit"] else ""
             lines.append(f"  {d['date']}: {_fmt_num(d['value'])}{unit}")
+        if len(days) == limit:
+            # Newest first, so the oldest days of the trend are the ones missing —
+            # and a trend read off a silently clipped series is simply wrong.
+            lines.append(
+                f"[Capped at {limit} days, newest first — earlier {label} may "
+                "also be recorded. Raise limit, or set date_start/date_end, to "
+                "reach it.]"
+            )
         return "\n".join(lines)
 
     rows = store.list_metrics(metric_type, start=inp.get("date_start"), end=inp.get("date_end"), limit=limit)
@@ -2469,6 +2586,11 @@ def _workout_metrics(inp: dict) -> str:
     for m in rows:
         unit = f" {m.unit}" if m.unit else ""
         lines.append(f"  {m.start_at[:10]}: {_fmt_num(m.value)}{unit}")
+    if len(rows) == limit:
+        lines.append(
+            f"[Capped at {limit} samples, newest first — earlier {label} may "
+            "also be recorded. Raise limit, or set date_start/date_end, to reach it.]"
+        )
     return "\n".join(lines)
 
 

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -917,6 +917,97 @@ def _tool_search_vault(inp: dict) -> str:
     return "\n\n---\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Google API failure classification (calendar + Drive)
+# ---------------------------------------------------------------------------
+# "Google is rate-limiting these requests, try again shortly" tells the reader
+# their data is almost certainly there. "The search could not complete" does
+# not. Both beat "nothing found", but the difference between them is the
+# difference between waiting and giving up, so the two are reported separately.
+_FAIL_RATE_LIMIT = "rate_limit"
+_FAIL_ERROR = "error"
+
+# Google's machine reason codes for "too many calls", as returned under the
+# classic 403 error format. Verified against the installed googleapiclient
+# rather than assumed — see _google_failure_kind for the exact field shapes.
+# Deliberately excludes dailyLimitExceeded and quotaExceeded: a daily cap will
+# not clear "shortly", so promising that would be worse than saying the search
+# could not complete.
+_RATE_LIMIT_REASONS = frozenset({"ratelimitexceeded", "userratelimitexceeded"})
+
+
+def _google_failure_kind(exc: Exception) -> str:
+    """Classify a Google API exception as a rate limit or a generic failure.
+
+    Returns only a category, never anything derived from the exception: the
+    payload can quote event titles, file names, or the caller's own query, and
+    none of that belongs in tool output.
+
+    The field shapes below were checked against the installed
+    googleapiclient, not inferred from the attribute names:
+
+    - `HttpError.resp` is an `httplib2.Response` and `.status` is an int. A
+      rate limit under Google's newer error format arrives as 429.
+    - `HttpError.reason` is the human-readable *message* ("Rate Limit
+      Exceeded"), NOT the machine reason code. Testing `.reason` against
+      "rateLimitExceeded" never matches — that trap is why this reads
+      `error_details` instead.
+    - `HttpError.error_details` holds the first present of
+      `error.detail`/`error.details`/`error.errors`/`error.message`. For the
+      classic 403 that is the `errors` list, whose entries carry the machine
+      code: `[{"domain": "usageLimits", "reason": "rateLimitExceeded", ...}]`.
+      It can also be a bare string when the body is not JSON, hence the
+      isinstance guards.
+    """
+    from googleapiclient.errors import HttpError
+
+    if not isinstance(exc, HttpError):
+        return _FAIL_ERROR
+
+    raw_status = getattr(getattr(exc, "resp", None), "status", None)
+    try:
+        status = int(raw_status)
+    except (TypeError, ValueError):
+        status = None
+
+    if status == 429:
+        return _FAIL_RATE_LIMIT
+
+    if status == 403:
+        details = getattr(exc, "error_details", None)
+        entries = details if isinstance(details, (list, tuple)) else []
+        for entry in entries:
+            reason = entry.get("reason") if isinstance(entry, dict) else None
+            if isinstance(reason, str) and reason.lower() in _RATE_LIMIT_REASONS:
+                return _FAIL_RATE_LIMIT
+
+    return _FAIL_ERROR
+
+
+def _failure_causes(failures: dict[str, str]) -> str:
+    """Name the failing accounts and the failure category — never the payload.
+
+    `failures` maps account name to a _FAIL_* category. Rate-limited accounts
+    are grouped separately from the rest so the reader learns the data is
+    probably there and the retry is worth making.
+    """
+    limited = [a for a, kind in failures.items() if kind == _FAIL_RATE_LIMIT]
+    errored = [a for a, kind in failures.items() if kind != _FAIL_RATE_LIMIT]
+    parts = []
+    if limited:
+        parts.append(
+            f"Google is rate-limiting {', '.join(limited)}, so the data is very "
+            "likely there and trying again shortly should reach it"
+        )
+    if errored:
+        subject = "those accounts" if len(errored) > 1 else "that account"
+        parts.append(
+            f"{', '.join(errored)} errored, so the search could not complete "
+            f"there and {subject} may need re-authorising"
+        )
+    return "; ".join(parts)
+
+
 # Widening ladder for a calendar keyword search with no caller-supplied range.
 # ±180d covers "did we meet recently"; the wider rungs catch anniversaries and
 # one-off events from previous years that the old fixed ±180d silently hid.
@@ -962,22 +1053,38 @@ async def _tool_search_calendar(inp: dict) -> str:
         else ""
     )
 
-    # Accounts that errored during the search. An expired token used to be
-    # logged and then reported as "no events" — a real fault dressed up as an
-    # empty result, which is the misdiagnosis this whole change exists to stop.
-    failed_accounts: list[str] = []
+    # Accounts that errored during the search, mapped to a failure category. An
+    # expired token used to be logged and then reported as "no events" — a real
+    # fault dressed up as an empty result, which is the misdiagnosis this whole
+    # change exists to stop. Failures accumulate across rungs rather than being
+    # reset per rung: an account that dropped out on the first window is still
+    # missing from the answer, so it still has to be disclosed.
+    failures: dict[str, str] = {}
+    # Accounts that completed at least one window without error. "Nothing was
+    # searched" is only true if this stays empty — an account that answered the
+    # ±180d rung and then failed at ±365d did establish something.
+    searched: set[str] = set()
     account_count = 0
 
     def _fetch(search_range: int | None) -> list:
         """Collect events from every configured account for one window."""
         nonlocal account_count
         events = []
-        failed_accounts.clear()
         account_count = 0
         for account in get_configured_accounts():
             account_count += 1
+            if account.value in failures:
+                # Do not retry a failed account on a wider rung. The ladder
+                # already triples the call volume of a miss (3 rungs × each
+                # configured account), and rate limits are driven by burst
+                # volume: an account that just 429'd will very likely 429 again
+                # and each retry deepens the hole. The existing break below
+                # covers the all-accounts-down case; this covers the partial one,
+                # where another account is still answering and the ladder walks
+                # on without this one.
+                continue
             try:
-                cal = CalendarService(account)
+                cal = CalendarService(account, raise_on_api_error=True)
                 if query:
                     events.extend(cal.search_events(query=query, days_back=search_range, days_forward=search_range))
                 elif date_ref:
@@ -986,9 +1093,10 @@ async def _tool_search_calendar(inp: dict) -> str:
                     events.extend(cal.get_events_in_range(start, end))
                 else:
                     events.extend(cal.get_upcoming_events(days=7, max_results=15))
+                searched.add(account.value)
             except Exception as e:
                 logger.warning(f"Calendar {account.value} error: {e}")
-                failed_accounts.append(account.value)
+                failures[account.value] = _google_failure_kind(e)
         return events
 
     # An explicit days_range is an intentional constraint — answer exactly that
@@ -1003,24 +1111,34 @@ async def _tool_search_calendar(inp: dict) -> str:
             windows_tried.append(f"±{days}d")
             if all_events:
                 break
-            # Every account errored, so this rung searched nothing. Widening
-            # cannot help a broken connection, and continuing would let the
-            # note claim three windows were searched when none were.
-            if account_count and len(failed_accounts) == account_count:
+            # Every account has now errored, so there is nobody left to ask.
+            # Widening cannot help a broken connection, and continuing would let
+            # the note claim three windows were searched when none were.
+            if account_count and len(failures) == account_count:
                 break
     else:
         # date_ref / upcoming branches set their own range; search_range unused.
         all_events = _fetch(None)
 
     failed_note = ""
-    if failed_accounts:
+    if failures:
+        # Say the account was dropped, but only when a wider rung actually ran:
+        # otherwise "Searched ±180d, then ±365d" reads as if every account was
+        # asked in every window.
+        dropped = ""
+        if len(windows_tried) > 1:
+            subject = "They were" if len(failures) > 1 else "It was"
+            dropped = f" {subject} not retried on the wider windows."
         failed_note = (
-            f" [Could not reach {', '.join(failed_accounts)} — that account "
-            "errored, so this is an incomplete answer, not necessarily an empty "
-            "calendar. It may need re-authorising.]"
+            f" [Could not reach {', '.join(failures)}: {_failure_causes(failures)}."
+            f"{dropped} This is an incomplete answer, not necessarily an empty "
+            "calendar.]"
         )
 
-    total_failure = bool(failed_accounts) and len(failed_accounts) == account_count
+    # Not "every account failed" but "no account ever answered": with two
+    # accounts where one returned an empty ±180d window before the other broke,
+    # something *was* searched, and claiming otherwise is its own false report.
+    total_failure = bool(failures) and not searched
 
     if not all_events:
         # With every account down, nothing was searched, so an absence was never
@@ -1028,13 +1146,21 @@ async def _tool_search_calendar(inp: dict) -> str:
         # "nothing matches" followed by a footnote still reads as an answer.
         if total_failure:
             return (
-                f"Could not search the calendar: {', '.join(failed_accounts)} "
-                "errored, and no other account was reachable. This is NOT an "
-                "empty calendar — nothing was actually searched. The account may "
-                "need re-authorising." + bad_range
+                f"Could not search the calendar: {_failure_causes(failures)}. No "
+                "other account was reachable. This is NOT an empty calendar — "
+                "nothing was actually searched." + bad_range
             )
         if windows_tried:
-            hint = f"Nothing on the calendar matches {query!r} in that span."
+            # An account that never answered leaves the absence unestablished, so
+            # the "nothing matches" hint is withheld — the same distinction Drive
+            # draws with its "accounts that responded" branch. The windows are
+            # still named, because the accounts that did answer really searched
+            # them.
+            hint = (
+                ""
+                if failures
+                else f"Nothing on the calendar matches {query!r} in that span."
+            )
             return (
                 _exhausted_note("calendar events", windows_tried, hint)
                 + bad_range
@@ -1210,18 +1336,18 @@ async def _tool_search_drive(inp: dict) -> str:
         else ""
     )
 
-    # Accounts that raised during the search. An expired token used to be logged
-    # and the tool still said "No drive files found." — a broken connection
-    # rendered as absent data, which is the misdiagnosis this change exists to
-    # stop.
-    failed_accounts: list[str] = []
+    # Accounts that raised during the search, mapped to a failure category. An
+    # expired token used to be logged and the tool still said "No drive files
+    # found." — a broken connection rendered as absent data, which is the
+    # misdiagnosis this change exists to stop.
+    failures: dict[str, str] = {}
     all_files = []
     truncated = False
     account_count = 0
     for account in get_configured_accounts():
         account_count += 1
         try:
-            drive = DriveService(account)
+            drive = DriveService(account, raise_on_api_error=True)
             files = drive.search(
                 full_text=query, max_results=max_results, order_by=order_by
             )
@@ -1231,14 +1357,14 @@ async def _tool_search_drive(inp: dict) -> str:
                 truncated = True
         except Exception as e:
             logger.warning(f"Drive {account.value} error: {e}")
-            failed_accounts.append(account.value)
+            failures[account.value] = _google_failure_kind(e)
 
     failed_note = ""
-    if failed_accounts:
+    if failures:
         failed_note = (
-            f"\n\n[Could not reach {', '.join(failed_accounts)} — that account "
-            "errored, so this is an incomplete answer, not necessarily an empty "
-            "Drive. It may need re-authorising.]"
+            f"\n\n[Could not reach {', '.join(failures)}: "
+            f"{_failure_causes(failures)}. This is an incomplete answer, not "
+            "necessarily an empty Drive.]"
         )
 
     if not all_files:
@@ -1246,14 +1372,13 @@ async def _tool_search_drive(inp: dict) -> str:
         # established. Lead with the fault instead of appending it to a denial —
         # "nothing came back" followed by a footnote still reads as an answer,
         # and "the accounts that responded" was none of them.
-        if len(failed_accounts) == account_count and failed_accounts:
+        if len(failures) == account_count and failures:
             return (
-                f"Could not search Drive: {', '.join(failed_accounts)} errored, and "
-                "no other account was reachable. This is NOT an empty Drive — "
-                "nothing was actually searched. The account may need "
-                "re-authorising." + bad_order
+                f"Could not search Drive: {_failure_causes(failures)}. No other "
+                "account was reachable. This is NOT an empty Drive — nothing was "
+                "actually searched." + bad_order
             )
-        if failed_accounts:
+        if failures:
             return (
                 "No Drive files came back from the accounts that responded."
                 + bad_order

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -890,25 +890,27 @@ async def execute_tool_parallel(name: str, tool_input: dict) -> str:
 # Individual tool handlers
 # ---------------------------------------------------------------------------
 
-# Result cap for a vault search. Chosen against the live index, not guessed:
-# ordinary queries have far more than 20 matches ("meeting notes" 50, "project"
-# 48, "kayak trip" 42, "workout" 29), and the extra ones are free — the pipeline
-# fetches `rerank_candidates` (50) candidates whatever top_k says, so top_k=80
-# was measured to return exactly what top_k=50 does. 20 was throwing away
-# ranked, already-retrieved chunks and calling the remainder the answer.
+# Result cap for a vault search. Measured against a real index rather than
+# guessed: ordinary single-word queries return well over 20 matches, and the
+# extra ones are free, because the pipeline fetches `rerank_candidates` (50)
+# candidates whatever top_k says. A cap of 20 was discarding ranked,
+# already-retrieved chunks and presenting the remainder as the answer.
 #
 # 40 rather than 50 because HybridSearch.search only runs the cross-encoder when
 # more candidates survive than top_k asks for (`len(final_results) > top_k`). A
-# default of 50 would silently switch reranking off, and the char budget below
-# would then drop the tail by RRF order rather than by relevance.
+# default at or above `rerank_candidates` would silently switch reranking off,
+# and the char budget below would then drop the tail by RRF order rather than by
+# relevance. _VAULT_TOP_K_MAX is likewise held below that ceiling so a caller
+# cannot cross it either — and so a request can always actually be served.
 _VAULT_TOP_K_DEFAULT = 40
+_VAULT_TOP_K_MAX = 49
 
 # Payload ceiling for the rendered results, in characters, following
 # _MSG_HISTORY_CHAR_BUDGET. Result *count* is a poor cost proxy here: measured
-# over the live index, 50 results cost 15 KB for "therapy" (avg 270 chars of
-# chunk) and 36 KB for "Nathan" (avg 693) — same count, 2.3x the payload. A
-# character budget lets a query with short chunks keep all 40 while a query with
-# full 800-char chunks stays near the ~17 KB worst case the old cap of 20 had.
+# over a real index, the same number of results varied by roughly 2.3x in bytes
+# depending on how long the matched chunks happened to be. A character budget
+# lets a query with short chunks keep the full set, while one with long chunks
+# stays near the worst case the old count-based cap allowed.
 _VAULT_CHAR_BUDGET = 24000
 
 
@@ -918,13 +920,31 @@ def _tool_search_vault(inp: dict) -> str:
     # Normalised like Slack's top_k: the model fills this in, and a 0 or None
     # would return nothing and read as an empty vault — and it doubles as the
     # yardstick for the truncation disclosure below.
-    top_k = _positive_int(inp.get("top_k", _VAULT_TOP_K_DEFAULT), _VAULT_TOP_K_DEFAULT, 200)
+    # Bounded by what the pipeline can actually return, not by an arbitrary
+    # ceiling. A request above `rerank_candidates` could never be served — it
+    # came back at the candidate limit instead, and since the truncation check
+    # compares against the number asked for, a short return read as complete
+    # when it was really ceiling-bound.
+    raw_top_k = inp.get("top_k", _VAULT_TOP_K_DEFAULT)
+    top_k = _positive_int(raw_top_k, _VAULT_TOP_K_DEFAULT, _VAULT_TOP_K_MAX)
+    reduced_note = ""
+    if isinstance(raw_top_k, (int, float, str)):
+        try:
+            if int(raw_top_k) > _VAULT_TOP_K_MAX:
+                reduced_note = (
+                    f" [Asked for top_k={int(raw_top_k)}, reduced to "
+                    f"{_VAULT_TOP_K_MAX} — the search pipeline cannot return more "
+                    "than that for one query, so a larger number would have gone "
+                    "unserved rather than fetched more.]"
+                )
+        except (TypeError, ValueError):
+            pass
     query = inp["query"]
     results = hs.search(query, top_k=top_k)
     if not results:
         # Echo the query: an empty here is a fact about this wording, and the
         # model needs to see what was asked to try a different one.
-        return f"No vault results found for query {query!r}."
+        return f"No vault results found for query {query!r}.{reduced_note}"
     lines = []
     used = 0
     for i, r in enumerate(results, 1):
@@ -943,8 +963,10 @@ def _tool_search_vault(inp: dict) -> str:
     notes = []
     if len(lines) < len(results):
         # Raising top_k cannot help here — the budget, not the count, bound.
+        # The figure names the budget applied to chunk text; separators and this
+        # note itself sit outside it, so the rendered payload is slightly larger.
         notes.append(
-            f"Payload capped at {_VAULT_CHAR_BUDGET} characters — showing the "
+            f"Chunk text capped at {_VAULT_CHAR_BUDGET} characters — showing the "
             f"{len(lines)} highest-ranked of {len(results)} chunks returned. "
             "Narrow the query to spend the budget on fewer, closer notes."
         )
@@ -958,8 +980,8 @@ def _tool_search_vault(inp: dict) -> str:
         )
     body = "\n\n---\n".join(lines)
     if not notes:
-        return body
-    return body + "\n\n[" + " ".join(notes) + "]"
+        return body + reduced_note
+    return body + "\n\n[" + " ".join(notes) + "]" + reduced_note
 
 
 # ---------------------------------------------------------------------------
@@ -970,7 +992,14 @@ def _tool_search_vault(inp: dict) -> str:
 # not. Both beat "nothing found", but the difference between them is the
 # difference between waiting and giving up, so the two are reported separately.
 _FAIL_RATE_LIMIT = "rate_limit"
+_FAIL_AUTH = "auth"
 _FAIL_ERROR = "error"
+
+# Statuses that mean "this account's credentials are the problem". Anything else
+# — a 500, a 503, a transport error — is Google's side or the network, and
+# telling the reader to re-authorise for one of those sends them to fix
+# something that isn't broken.
+_AUTH_FAIL_STATUSES = frozenset({401, 403})
 
 # Google's machine reason codes for "too many calls", as returned under the
 # classic 403 error format. Verified against the installed googleapiclient
@@ -1026,29 +1055,47 @@ def _google_failure_kind(exc: Exception) -> str:
             if isinstance(reason, str) and reason.lower() in _RATE_LIMIT_REASONS:
                 return _FAIL_RATE_LIMIT
 
+    # A credentials problem is the only failure that re-authorising fixes. A 500
+    # or 503 is Google's side and clears on its own, so naming it an auth
+    # problem sends the reader to repair something that is not broken.
+    if status in _AUTH_FAIL_STATUSES:
+        return _FAIL_AUTH
+
     return _FAIL_ERROR
 
 
 def _failure_causes(failures: dict[str, str]) -> str:
     """Name the failing accounts and the failure category — never the payload.
 
-    `failures` maps account name to a _FAIL_* category. Rate-limited accounts
-    are grouped separately from the rest so the reader learns the data is
-    probably there and the retry is worth making.
+    `failures` maps account name to a _FAIL_* category. Each category gets its
+    own clause, because the remedy differs and naming the wrong one sends the
+    reader to fix something that is not broken: a rate limit clears by waiting,
+    a credentials failure needs re-authorising, and a server-side error needs
+    neither. Only what the status actually establishes is claimed.
     """
     limited = [a for a, kind in failures.items() if kind == _FAIL_RATE_LIMIT]
-    errored = [a for a, kind in failures.items() if kind != _FAIL_RATE_LIMIT]
+    auth = [a for a, kind in failures.items() if kind == _FAIL_AUTH]
+    errored = [
+        a for a, kind in failures.items()
+        if kind not in (_FAIL_RATE_LIMIT, _FAIL_AUTH)
+    ]
     parts = []
     if limited:
         parts.append(
             f"Google is rate-limiting {', '.join(limited)}, so the data is very "
             "likely there and trying again shortly should reach it"
         )
-    if errored:
-        subject = "those accounts" if len(errored) > 1 else "that account"
+    if auth:
+        subject = "those accounts" if len(auth) > 1 else "that account"
         parts.append(
-            f"{', '.join(errored)} errored, so the search could not complete "
-            f"there and {subject} may need re-authorising"
+            f"{', '.join(auth)} rejected the credentials, so {subject} likely "
+            "needs re-authorising"
+        )
+    if errored:
+        parts.append(
+            f"{', '.join(errored)} returned an error, so the search could not "
+            "complete there — the cause is on Google's side or the network "
+            "rather than anything to fix here, and it may clear on a retry"
         )
     return "; ".join(parts)
 
@@ -1110,12 +1157,23 @@ async def _tool_search_calendar(inp: dict) -> str:
     # ±180d rung and then failed at ±365d did establish something.
     searched: set[str] = set()
     account_count = 0
+    # Whether any account completed the window most recently attempted, as
+    # opposed to any window at all.
+    rung_responded = False
 
     def _fetch(search_range: int | None) -> list:
-        """Collect events from every configured account for one window."""
-        nonlocal account_count
+        """Collect events from every configured account for one window.
+
+        Sets `rung_responded` for the window just attempted. That is distinct
+        from the cumulative `searched` set: an earlier rung can have succeeded
+        while this one reached nobody, and claiming this window was searched on
+        the strength of an earlier one is exactly the kind of unearned assertion
+        this module exists to avoid.
+        """
+        nonlocal account_count, rung_responded
         events = []
         account_count = 0
+        rung_responded = False
         for account in get_configured_accounts():
             account_count += 1
             if account.value in failures:
@@ -1139,6 +1197,7 @@ async def _tool_search_calendar(inp: dict) -> str:
                 else:
                     events.extend(cal.get_upcoming_events(days=7, max_results=15))
                 searched.add(account.value)
+                rung_responded = True
             except Exception as e:
                 logger.warning(f"Calendar {account.value} error: {e}")
                 failures[account.value] = _google_failure_kind(e)
@@ -1149,11 +1208,15 @@ async def _tool_search_calendar(inp: dict) -> str:
     windows_tried: list[str] = []
     if query and days_range:
         all_events = _fetch(days_range)
-        windows_tried.append(f"±{days_range}d")
+        if rung_responded:
+            windows_tried.append(f"±{days_range}d")
     elif query:
         for days in _CALENDAR_LADDER_DAYS:
             all_events = _fetch(days)
-            windows_tried.append(f"±{days}d")
+            # Only a window some account actually completed goes on the list.
+            # Otherwise the empty-result note names a span nobody looked at.
+            if rung_responded:
+                windows_tried.append(f"±{days}d")
             if all_events:
                 break
             # Every account has now errored, so there is nobody left to ask.
@@ -2517,15 +2580,15 @@ def _workout_update(inp: dict) -> str:
 # Session cap for `list`, and the ceiling on a caller-supplied one.
 #
 # 10 was set the day the workout store was written, before it held a month of
-# real training, and it undercounts an ordinary month: the log holds 16 sessions
-# in June 2026 and 18 in its densest 30-day window, so "how did June go" was
-# answered from 10 of 16 with nothing saying so. 50 is the store's own
-# list_sessions default, covers the densest measured month nearly 3x, and covers
-# a full quarter at the June 2026 rate (~16/month) — the widest span worth
+# real training, and it undercounts an ordinary month: a measured log held more
+# than 10 sessions in a single month, so "how did that month go" was answered
+# from part of the record with nothing saying so. 50 is the store's own
+# list_sessions default, covers the densest measured month several times over,
+# and covers a full quarter at the measured rate — the widest span worth
 # enumerating session by session.
 #
 # A count is an honest cost proxy at this shape, unlike the vault chunks above:
-# one line per session, measured at ~96 characters over the real log and 172 at
+# one line per session, measured at roughly 100 characters and under 200 at
 # worst, so 50 sessions is ~5 KB. The 200 ceiling bounds a caller-supplied
 # request to ~34 KB and still spans the whole 125-session log.
 _WORKOUT_LIST_LIMIT = 50
@@ -2648,12 +2711,12 @@ def _workout_log_metric(inp: dict) -> str:
 
 
 # Sample cap for `metrics`. A metric question is a trend question, and its
-# natural span is a year: 365 is a year of the cumulative path (one row per day)
-# and about sixteen months of HRV at the measured 275 samples a year, where the
-# old 100 was under four months of either. Body weight, sleep and resting HR
-# arrive at most daily in the real record, so a year of those fits with room.
-# One row is a date and a number, ~30 characters, so 365 rows is ~11 KB and the
-# 1000 ceiling bounds a caller-supplied request to ~30 KB.
+# natural span is a year: 365 covers a year of the cumulative path (one row per
+# day) and over a year of the densest measured metric, where the old 100 was
+# under four months of either. The metrics that arrive at most daily fit a year
+# with room to spare. One row is a date and a number, ~30 characters, so 365
+# rows is ~11 KB and the 1000 ceiling bounds a caller-supplied request to
+# ~30 KB.
 _WORKOUT_METRICS_LIMIT = 365
 _WORKOUT_METRICS_MAX = 1000
 

--- a/api/services/calendar.py
+++ b/api/services/calendar.py
@@ -128,14 +128,26 @@ class CalendarService:
     Provides methods to fetch and search calendar events.
     """
 
-    def __init__(self, account_type: GoogleAccount = GoogleAccount.PERSONAL):
+    def __init__(
+        self,
+        account_type: GoogleAccount = GoogleAccount.PERSONAL,
+        *,
+        raise_on_api_error: bool = False,
+    ):
         """
         Initialize calendar service.
 
         Args:
             account_type: Which Google account to use
+            raise_on_api_error: Opt-in failure propagation. False (the default)
+                keeps the long-standing empty-list-on-error contract that every
+                api/routes/ caller depends on; True lets a caller that can report
+                a fault — the chat tools — tell "this account is unreachable"
+                from "this calendar is empty". See the note in _fetch_events for
+                why this is a constructor flag rather than a per-call one.
         """
         self.account_type = account_type
+        self.raise_on_api_error = raise_on_api_error
         self._service = None
 
     @property
@@ -287,10 +299,11 @@ class CalendarService:
             List of CalendarEvent objects
 
         Raises:
-            Exception: if credentials cannot be resolved. API-level errors are
-                still swallowed to an empty list (the long-standing contract for
-                the other callers), but an auth failure must reach the caller —
-                see the note below.
+            Exception: if credentials cannot be resolved (always), or if the
+                Calendar API itself fails and this service was built with
+                raise_on_api_error=True. Without that flag an API failure is
+                still swallowed to an empty list — the long-standing contract
+                for the other callers.
         """
         # Resolved before the try. `service` is a lazy property, so building it
         # inside the block meant an expired token was caught here and returned as
@@ -325,6 +338,19 @@ class CalendarService:
             return events
 
         except Exception as e:
+            # A 403, a 429, a 500 or a quota event is a failure to look, not a
+            # confirmed empty calendar. Propagation is opt-in per instance
+            # because the alternatives all cost more: a strict twin of each
+            # public method would need three of them (get_upcoming_events,
+            # get_events_in_range, search_events), a per-call keyword would need
+            # threading through all three, and a result wrapper would change the
+            # return type every existing caller reads. One constructor flag
+            # covers all three entry points and leaves every caller that does not
+            # ask for it byte-identical. get_calendar_service() deliberately does
+            # not expose the flag, so the instances the routes share through that
+            # cache can never become strict behind a route's back.
+            if self.raise_on_api_error:
+                raise
             logger.error(f"Failed to fetch calendar events: {e}")
             return []
 

--- a/api/services/drive.py
+++ b/api/services/drive.py
@@ -89,14 +89,27 @@ class DriveService:
     Google Drive service for searching and retrieving files.
     """
 
-    def __init__(self, account_type: GoogleAccount = GoogleAccount.PERSONAL):
+    def __init__(
+        self,
+        account_type: GoogleAccount = GoogleAccount.PERSONAL,
+        *,
+        raise_on_api_error: bool = False,
+    ):
         """
         Initialize Drive service.
 
         Args:
             account_type: Which Google account to use
+            raise_on_api_error: Opt-in failure propagation for search(). False
+                (the default) keeps the long-standing empty-list-on-error
+                contract that every api/routes/ caller depends on; True lets a
+                caller that can report a fault — the chat tools — tell "this
+                account is unreachable" from "this account has no matching
+                files". See the note in search() for why this is a constructor
+                flag rather than a per-call one.
         """
         self.account_type = account_type
+        self.raise_on_api_error = raise_on_api_error
         self._service = None
 
     @property
@@ -133,6 +146,13 @@ class DriveService:
 
         Returns:
             List of DriveFile objects
+
+        Raises:
+            Exception: if credentials cannot be resolved (always), or if the
+                Drive API itself fails and this service was built with
+                raise_on_api_error=True. Without that flag an API failure is
+                still swallowed to an empty list — the long-standing contract
+                for the other callers.
         """
         query_parts = []
 
@@ -176,6 +196,15 @@ class DriveService:
             return [self._parse_file(f) for f in files]
 
         except Exception as e:
+            # A 403, a 429, a 500 or a quota event is a failure to look, not a
+            # confirmed empty Drive. Propagation is opt-in per instance rather
+            # than a strict twin of this method, a per-call keyword, or a result
+            # wrapper: one constructor flag leaves every caller that does not ask
+            # for it byte-identical, and get_drive_service() deliberately does
+            # not expose the flag, so the instances the routes share through that
+            # cache can never become strict behind a route's back.
+            if self.raise_on_api_error:
+                raise
             logger.error(f"Failed to search Drive: {e}")
             return []
 

--- a/tests/test_agent_tools_drive_scope.py
+++ b/tests/test_agent_tools_drive_scope.py
@@ -472,7 +472,7 @@ class TestDriveAccountFailureDisclosure:
         """
         fake_drive.broken = {"personal"}
         out = await _tool_search_drive({"query": "synthetic"})
-        assert "errored" in out
+        assert "returned an error" in out
         assert any(word in out.lower() for word in FAULT_WORDS)
 
     async def test_partial_failure_still_calls_the_answer_incomplete(
@@ -563,7 +563,7 @@ class TestDriveAccountFailureDisclosure:
         }
         out = await _tool_search_drive({"query": "comp planning"})
         assert "rate-limiting" not in out
-        assert "could not complete" in out
+        assert "re-authorising" in out
 
     async def test_failure_note_does_not_quote_the_exception(
         self, fake_drive, accounts
@@ -606,7 +606,7 @@ class TestDriveAccountFailureDisclosure:
         out = await _tool_search_drive({"query": "synthetic"})
         assert out.startswith("Could not search Drive")
         assert "rate-limiting personal" in out
-        assert "work errored" in out
+        assert "work returned an error" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_tools_drive_scope.py
+++ b/tests/test_agent_tools_drive_scope.py
@@ -48,6 +48,33 @@ def _account(value: str = "personal"):
     return SimpleNamespace(value=value)
 
 
+def _http_error(status: int, reason_code: str = "", message: str = "Synthetic failure"):
+    """Build a real googleapiclient HttpError with the shape Google returns.
+
+    Not a stand-in: the classifier reads `resp.status` and the machine reason out
+    of `error_details`, and both are derived by HttpError itself from the raw
+    body — so a hand-rolled double would prove nothing about the real thing.
+    `HttpError.reason` is the human *message*, not `reason_code`; that asymmetry
+    is exactly what the classifier has to cope with.
+    """
+    import json
+
+    import httplib2
+    from googleapiclient.errors import HttpError
+
+    error: dict = {"code": status, "message": message}
+    if reason_code:
+        error["errors"] = [
+            {"domain": "usageLimits", "reason": reason_code, "message": message}
+        ]
+    resp = httplib2.Response({"status": status, "reason": message})
+    return HttpError(
+        resp,
+        json.dumps({"error": error}).encode(),
+        uri="https://www.googleapis.com/drive/v3/files",
+    )
+
+
 @pytest.fixture
 def accounts(monkeypatch):
     """One configured Google account. Tests may append more in place."""
@@ -75,11 +102,14 @@ def fake_drive(monkeypatch, accounts):
     a single page) so both the ordering and the truncation signal are real rather
     than assumed.
     """
-    state = SimpleNamespace(files=[], per_account={}, broken=set(), calls=[])
+    state = SimpleNamespace(
+        files=[], per_account={}, broken=set(), errors={}, calls=[], strict_flags=[]
+    )
 
     class FakeDriveService:
-        def __init__(self, account):
+        def __init__(self, account, *, raise_on_api_error=False):
             self.account = account
+            state.strict_flags.append(raise_on_api_error)
 
         def search(
             self,
@@ -95,6 +125,12 @@ def fake_drive(monkeypatch, accounts):
                 "full_text": full_text, "max_results": max_results,
                 "order_by": order_by,
             })
+            # `errors` maps an account to a specific exception instance (an
+            # HttpError, say) so the failure *category* can be exercised;
+            # `broken` is the plain credentials-expired case.
+            specific = state.errors.get(self.account.value)
+            if specific is not None:
+                raise specific
             if self.account.value in state.broken:
                 raise RuntimeError("synthetic credentials expired")
             files = list(state.per_account.get(self.account.value, state.files))
@@ -315,7 +351,7 @@ class TestDriveOrdering:
         fake_drive.per_account["personal"].sort(key=lambda f: f.name)
 
         class NoSortDrive:
-            def __init__(self, account):
+            def __init__(self, account, *, raise_on_api_error=False):
                 self.account = account
 
             def search(self, **kw):
@@ -462,6 +498,115 @@ class TestDriveAccountFailureDisclosure:
         assert partial != healthy
         assert "accounts that responded" in partial
         assert "accounts that responded" not in healthy
+
+    # -- API failures, not just credential failures (issue #536) -------------
+    # The credential path was fixed first, so an expired token surfaced. A 403, a
+    # 429, a 500 or a quota event still died in `DriveService.search`'s
+    # `except Exception: return []` and came back as "no Drive files".
+
+    async def test_the_tool_asks_the_service_to_propagate_failures(
+        self, fake_drive, accounts
+    ):
+        """Without the opt-in flag the service swallows the fault and none of
+        the disclosure below can ever fire."""
+        await _tool_search_drive({"query": "synthetic"})
+        assert fake_drive.strict_flags
+        assert all(fake_drive.strict_flags)
+
+    async def test_api_error_is_reported_as_a_failure_to_search(
+        self, fake_drive, accounts
+    ):
+        fake_drive.errors = {"personal": _http_error(500, "backendError")}
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert out.startswith("Could not search Drive")
+        assert "NOT an empty Drive" in out
+        assert "No Drive files" not in out
+
+    async def test_api_error_says_the_search_could_not_complete(
+        self, fake_drive, accounts
+    ):
+        fake_drive.errors = {"personal": _http_error(500, "backendError")}
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "could not complete" in out
+        assert "rate-limit" not in out.lower()
+
+    @pytest.mark.parametrize(
+        "exc_args",
+        [
+            (429, "", "Quota exceeded for quota metric 'Queries'"),
+            (403, "rateLimitExceeded", "Rate Limit Exceeded"),
+            (403, "userRateLimitExceeded", "User Rate Limit Exceeded"),
+        ],
+    )
+    async def test_rate_limit_is_reported_distinctly(
+        self, fake_drive, accounts, exc_args
+    ):
+        """A rate limit means the files are almost certainly there.
+
+        Google returns it two ways: a 429 under the newer error format, and a 403
+        whose machine reason — in error_details, not in `.reason` — is
+        rateLimitExceeded or userRateLimitExceeded.
+        """
+        fake_drive.errors = {"personal": _http_error(*exc_args)}
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "rate-limiting" in out
+        assert "trying again shortly" in out
+        assert "likely there" in out
+        assert "may need re-authorising" not in out
+
+    async def test_a_plain_403_is_not_mistaken_for_a_rate_limit(
+        self, fake_drive, accounts
+    ):
+        """Insufficient permission is a 403 too, and it will not clear by waiting."""
+        fake_drive.errors = {
+            "personal": _http_error(403, "forbidden", "Insufficient Permission")
+        }
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "rate-limiting" not in out
+        assert "could not complete" in out
+
+    async def test_failure_note_does_not_quote_the_exception(
+        self, fake_drive, accounts
+    ):
+        """Exception text can carry file names or the caller's own query."""
+        fake_drive.errors = {
+            "personal": _http_error(500, "backendError", "Milo Placeholder therapy")
+        }
+        out = await _tool_search_drive({"query": "comp planning"})
+        assert "Milo Placeholder" not in out
+        assert "HttpError" not in out
+        assert "personal" in out
+
+    async def test_partial_failure_returns_the_healthy_results_and_discloses(
+        self, fake_drive, accounts
+    ):
+        accounts.append(_account("work"))
+        fake_drive.errors = {"work": _http_error(429)}
+        fake_drive.per_account = {"personal": [_file(1, "Synthetic personal doc")]}
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert "Synthetic personal doc" in out
+        assert "Could not reach work" in out
+        assert "rate-limiting" in out
+
+    async def test_a_failed_account_is_asked_exactly_once(self, fake_drive, accounts):
+        """Rate limits are burst-driven; a failure must not be re-attempted."""
+        accounts.append(_account("work"))
+        fake_drive.errors = {"work": _http_error(429)}
+        await _tool_search_drive({"query": "synthetic"})
+        assert [c["account"] for c in fake_drive.calls] == ["personal", "work"]
+
+    async def test_both_failure_categories_are_named_separately(
+        self, fake_drive, accounts
+    ):
+        accounts.append(_account("work"))
+        fake_drive.errors = {
+            "personal": _http_error(429),
+            "work": _http_error(500, "backendError"),
+        }
+        out = await _tool_search_drive({"query": "synthetic"})
+        assert out.startswith("Could not search Drive")
+        assert "rate-limiting personal" in out
+        assert "work errored" in out
 
 
 # ---------------------------------------------------------------------------
@@ -691,3 +836,61 @@ class TestDriveServiceContract:
 
         kwargs = service._service.files().list.call_args.kwargs
         assert kwargs["orderBy"] == "modifiedTime desc"
+
+    # -- Opt-in API-failure propagation (issue #536) --------------------------
+
+    @pytest.fixture
+    def service(self):
+        """A real DriveService with a stubbed Google client."""
+        from api.services.drive import DriveService, GoogleAccount
+
+        def _build(**kwargs):
+            svc = DriveService(account_type=GoogleAccount.PERSONAL, **kwargs)
+            svc._service = MagicMock()
+            return svc
+
+        return _build
+
+    def test_api_error_is_swallowed_to_an_empty_list_by_default(self, service):
+        svc = service()
+        svc._service.files().list().execute.side_effect = _http_error(429)
+        assert svc.search(full_text="comp planning") == []
+
+    def test_api_error_propagates_when_the_caller_opts_in(self, service):
+        from googleapiclient.errors import HttpError
+
+        svc = service(raise_on_api_error=True)
+        svc._service.files().list().execute.side_effect = _http_error(429)
+        with pytest.raises(HttpError):
+            svc.search(full_text="comp planning")
+
+    def test_the_flag_does_not_leak_into_the_other_read_paths(self, service):
+        """Only search() is opted in; get_file/get_file_content keep their own
+        contract, which this change is not in scope to touch."""
+        svc = service(raise_on_api_error=True)
+        svc._service.files().get().execute.side_effect = _http_error(500)
+        assert svc.get_file("synthetic-id") is None
+
+    def test_the_singleton_factory_never_hands_out_a_strict_service(self):
+        """Routes share these instances; none of them may start raising."""
+        from api.services.drive import get_drive_service, GoogleAccount
+
+        svc = get_drive_service(GoogleAccount.PERSONAL)
+        assert svc.raise_on_api_error is False
+
+    async def test_the_route_still_returns_an_empty_list_on_api_error(self, service):
+        """The long-standing HTTP contract: 200 with zero files, not a 500."""
+        from api.routes import drive as drive_route
+
+        svc = service()
+        svc._service.files().list().execute.side_effect = _http_error(429)
+        with patch.object(drive_route, "get_drive_service", return_value=svc):
+            result = await drive_route.search_files(
+                q="comp planning",
+                name=None,
+                content=None,
+                account="personal",
+                max_results=20,
+            )
+        assert (result.files, result.count) == ([], 0)
+        assert result.query == "comp planning"

--- a/tests/test_agent_tools_empty_filters.py
+++ b/tests/test_agent_tools_empty_filters.py
@@ -37,6 +37,7 @@ from api.services import agent_tools
 from api.services.agent_tools import (
     _VAULT_CHAR_BUDGET,
     _VAULT_TOP_K_DEFAULT,
+    _VAULT_TOP_K_MAX,
     _WORKOUT_HISTORY_LIMIT,
     _WORKOUT_LIST_LIMIT,
     _WORKOUT_METRICS_LIMIT,
@@ -510,7 +511,7 @@ class TestSearchVaultCap:
         # another, which is why the ceiling is characters and not count.
         fake_vault.results = [vault_chunk(i, content_len=800) for i in range(_VAULT_TOP_K_DEFAULT)]
         out = _tool_search_vault({"query": "kayak portage checklist"})
-        assert f"Payload capped at {_VAULT_CHAR_BUDGET} characters" in out
+        assert f"Chunk text capped at {_VAULT_CHAR_BUDGET} characters" in out
         assert f"of {_VAULT_TOP_K_DEFAULT} chunks returned" in out
         # Both bounds bound here, and both are facts the model needs: the count
         # cap means more exist beyond these 40, the budget means fewer than 40 are
@@ -525,7 +526,7 @@ class TestSearchVaultCap:
         monkeypatch.setattr(agent_tools, "_VAULT_CHAR_BUDGET", 700)
         fake_vault.results = [vault_chunk(i, content_len=300) for i in range(5)]
         out = _tool_search_vault({"query": "kayak portage checklist"})
-        assert "Payload capped at 700 characters" in out
+        assert "Chunk text capped at 700 characters" in out
         assert "of 5 chunks returned" in out
         kept = [i for i in range(5) if f"chunk-{i:03d}" in out]
         # Highest-ranked first, contiguous from the top, and each kept chunk whole.
@@ -565,3 +566,46 @@ class TestAppliedFilters:
         assert _applied_filters(date_start="2026-06-01", date_end="2026-06-30") == [
             "dates 2026-06-01 to 2026-06-30",
         ]
+
+
+class TestVaultUnreachableTopK:
+    """A request the pipeline cannot serve must not read as a complete answer.
+
+    `HybridSearch` fetches `rerank_candidates` candidates regardless of `top_k`,
+    so a larger `top_k` was never served — it came back at the candidate limit.
+    Because the truncation check compares against the number *asked for*, a short
+    return then read as complete when it was really ceiling-bound. The accepted
+    value is now held below that ceiling, which also keeps the cross-encoder on.
+    """
+
+    def test_the_max_stays_below_the_rerank_candidate_ceiling(self):
+        """At or above it, HybridSearch silently stops reranking."""
+        import inspect
+        from api.services.hybrid_search import HybridSearch
+
+        candidates = inspect.signature(HybridSearch.search).parameters[
+            "rerank_candidates"
+        ].default
+        assert _VAULT_TOP_K_MAX < candidates
+        assert _VAULT_TOP_K_DEFAULT < candidates
+
+    def test_an_unreachable_request_is_reduced_and_disclosed(self, fake_vault):
+        out = _tool_search_vault({"query": "kayak", "top_k": 500})
+        assert fake_vault.calls[-1]["top_k"] == _VAULT_TOP_K_MAX
+        assert "reduced to" in out
+        assert "would have gone unserved" in out
+
+    def test_a_reachable_request_is_passed_through_unreduced(self, fake_vault):
+        out = _tool_search_vault({"query": "kayak", "top_k": 12})
+        assert fake_vault.calls[-1]["top_k"] == 12
+        assert "reduced to" not in out
+
+    def test_the_default_is_not_reported_as_reduced(self, fake_vault):
+        out = _tool_search_vault({"query": "kayak"})
+        assert "reduced to" not in out
+
+    def test_a_garbled_top_k_is_not_reported_as_reduced(self, fake_vault):
+        """Absent or unusable is not the same as "you asked for too much"."""
+        for bad in (None, "lots", [], 0):
+            out = _tool_search_vault({"query": "kayak", "top_k": bad})
+            assert "reduced to" not in out, f"{bad!r} reported as a reduction"

--- a/tests/test_agent_tools_empty_filters.py
+++ b/tests/test_agent_tools_empty_filters.py
@@ -15,6 +15,15 @@ is only that the reply stops asserting more than the search established, so
 these tests pin the distinction that motivates the issue: a *filtered* empty
 must name its filters, while an *unfiltered* empty may still say the record is
 empty.
+
+Second half of the same bug class (issue #537): a *non-empty* result that hides
+its own ceiling, which is the more deceptive half — an empty answer invites a
+follow-up, a list that looks complete does not. Two things are pinned below for
+each capped path: the cap is disclosed when it binds (quoting the value actually
+in effect, caller-supplied or not), and the default is large enough for the real
+corpus. The measured facts behind each default are in the code comment beside it
+and restated in the docstring of the test that pins it, so a silent reduction
+fails a test rather than quietly undercounting again.
 """
 import inspect
 from types import SimpleNamespace
@@ -24,8 +33,13 @@ import pytest
 import api.services.fitness_store as fs
 import api.services.hybrid_search as hs_mod
 import api.services.task_manager as tm_mod
+from api.services import agent_tools
 from api.services.agent_tools import (
+    _VAULT_CHAR_BUDGET,
     _VAULT_TOP_K_DEFAULT,
+    _WORKOUT_HISTORY_LIMIT,
+    _WORKOUT_LIST_LIMIT,
+    _WORKOUT_METRICS_LIMIT,
     _applied_filters,
     _tool_manage_tasks,
     _tool_manage_workouts,
@@ -54,6 +68,46 @@ def store(tmp_path, monkeypatch):
     instance = FitnessStore(db_path=str(tmp_path / "fitness.db"))
     monkeypatch.setattr(fs, "_store_instance", instance)
     return instance
+
+
+@pytest.fixture
+def store_limits(store, monkeypatch):
+    """Records the limit each workout query was actually asked for, while the real
+    store still answers.
+
+    Output alone can't distinguish a raised default from a raised note: the cap is
+    both the argument sent to the store and the yardstick the disclosure is keyed
+    on, so both ends need pinning.
+    """
+    calls = []
+
+    def spy(name):
+        original = getattr(store, name)
+
+        def wrapper(*args, **kwargs):
+            calls.append({"query": name, "limit": kwargs.get("limit")})
+            return original(*args, **kwargs)
+
+        return wrapper
+
+    for name in ("list_sessions", "exercise_history", "list_metrics", "daily_metric_totals"):
+        monkeypatch.setattr(store, name, spy(name))
+    return calls
+
+
+def log_sessions(store, count, date="2026-06-10"):
+    for _ in range(count):
+        store.add_session(sets=[{"exercise": "flamingo hold", "reps": 3}], date=date)
+
+
+def vault_chunk(i, content_len=200):
+    """One synthetic result, tagged so a dropped chunk can be told from a kept one."""
+    marker = f"chunk-{i:03d}"
+    return {
+        "file_name": f"Kayak Trip {i:03d}.md",
+        "content": marker + "x" * max(0, content_len - len(marker)),
+        "hybrid_score": 1.0 - i / 1000,
+    }
 
 
 @pytest.fixture
@@ -119,6 +173,52 @@ class TestWorkoutListEmpty:
         assert_no_fault_language(out)
 
 
+class TestWorkoutListCap:
+    def test_default_covers_a_real_month_of_training(self):
+        """Pinned against the corpus: the log holds 16 sessions in June 2026 and 18
+        in its densest 30-day window, so the old default of 10 answered "how did
+        June go" from 10 of 16. Also pinned at or above the store's own
+        list_sessions default, which the tool used to undercut fivefold."""
+        service_default = inspect.signature(fs.FitnessStore.list_sessions).parameters["limit"].default
+        assert _WORKOUT_LIST_LIMIT >= 18
+        assert _WORKOUT_LIST_LIMIT >= service_default
+
+    def test_the_new_default_is_what_the_store_is_asked_for(self, store, store_limits):
+        _tool_manage_workouts({"action": "list"})
+        assert store_limits == [{"query": "list_sessions", "limit": _WORKOUT_LIST_LIMIT}]
+
+    def test_a_full_page_at_the_default_discloses_the_cap(self, store):
+        log_sessions(store, _WORKOUT_LIST_LIMIT)
+        out = _tool_manage_workouts({"action": "list"})
+        assert f"Capped at {_WORKOUT_LIST_LIMIT} sessions" in out
+        assert "older sessions may also match" in out
+        # A full page is not a fault.
+        assert_no_fault_language(out)
+
+    def test_one_below_the_cap_says_nothing(self, store):
+        log_sessions(store, _WORKOUT_LIST_LIMIT - 1)
+        out = _tool_manage_workouts({"action": "list"})
+        assert "Capped at" not in out
+
+    def test_the_disclosure_quotes_the_caller_supplied_cap(self, store):
+        log_sessions(store, 4)
+        out = _tool_manage_workouts({"action": "list", "limit": 3})
+        assert "Capped at 3 sessions" in out
+        # The default is not what bound, so quoting it would misdirect the retry.
+        assert f"Capped at {_WORKOUT_LIST_LIMIT}" not in out
+        assert_no_fault_language(out)
+
+    def test_an_unusable_cap_still_bounds_the_query(self, store, store_limits):
+        # The model writes this argument. A 0 or None reaching the store would
+        # both distort the page and silently disable the truncation check, since
+        # the same number is the yardstick.
+        log_sessions(store, 2)
+        for bad in (0, None, "loads", -4):
+            store_limits.clear()
+            _tool_manage_workouts({"action": "list", "limit": bad})
+            assert store_limits[0]["limit"] >= 1
+
+
 # ---------------------------------------------------------------------------
 # manage_workouts — action="history"
 # ---------------------------------------------------------------------------
@@ -148,6 +248,53 @@ class TestWorkoutHistoryEmpty:
         # the miss to the name looked up, not to the work never happening.
         assert "different name" in out
         assert_no_fault_language(out)
+
+
+class TestWorkoutHistoryCap:
+    def test_default_spans_more_than_a_month_of_one_lift(self):
+        """One row is one set, and sessions in the log carry 2.3 sets on average
+        (4 at worst), so a twice-weekly lift produces roughly 20 sets a month —
+        the old default of 20 could not span a progression question, which is
+        asked over months."""
+        assert _WORKOUT_HISTORY_LIMIT >= 60
+
+    def test_the_new_default_is_what_the_store_is_asked_for(self, store, store_limits):
+        _tool_manage_workouts({"action": "history", "exercise": "flamingo hold"})
+        assert store_limits == [{"query": "exercise_history", "limit": _WORKOUT_HISTORY_LIMIT}]
+
+    def test_a_full_page_at_the_default_discloses_the_cap(self, store):
+        store.add_session(
+            sets=[{"exercise": "flamingo hold", "reps": 3, "count": _WORKOUT_HISTORY_LIMIT}],
+            date="2026-06-10",
+        )
+        out = _tool_manage_workouts({"action": "history", "exercise": "flamingo hold"})
+        assert f"Capped at {_WORKOUT_HISTORY_LIMIT} sets" in out
+        # Names the lift as looked up, so the note can't be read as being about
+        # some other exercise.
+        assert "Flamingo Hold" in out
+        assert_no_fault_language(out)
+
+    def test_one_below_the_cap_says_nothing(self, store):
+        store.add_session(
+            sets=[{"exercise": "flamingo hold", "reps": 3, "count": _WORKOUT_HISTORY_LIMIT - 1}],
+            date="2026-06-10",
+        )
+        out = _tool_manage_workouts({"action": "history", "exercise": "flamingo hold"})
+        assert "Capped at" not in out
+
+    def test_the_disclosure_quotes_the_caller_supplied_cap(self, store):
+        store.add_session(sets=[{"exercise": "flamingo hold", "reps": 3, "count": 5}], date="2026-06-10")
+        out = _tool_manage_workouts({"action": "history", "exercise": "flamingo hold", "limit": 2})
+        assert "Capped at 2 sets" in out
+        assert f"Capped at {_WORKOUT_HISTORY_LIMIT}" not in out
+        assert_no_fault_language(out)
+
+    def test_an_unusable_cap_still_bounds_the_query(self, store, store_limits):
+        store.add_session(sets=[{"exercise": "flamingo hold", "reps": 3}], date="2026-06-10")
+        for bad in (0, None, "all of them"):
+            store_limits.clear()
+            _tool_manage_workouts({"action": "history", "exercise": "flamingo hold", "limit": bad})
+            assert store_limits[0]["limit"] >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +334,66 @@ class TestWorkoutMetricsEmpty:
         out = _tool_manage_workouts({"action": "metrics", "metric_type": "body_weight"})
         assert out == "No body weight recorded."
         assert_no_fault_language(out)
+
+
+class TestWorkoutMetricsCap:
+    def test_default_spans_a_year_of_a_daily_metric(self):
+        """A metric question is a trend question, and its natural span is a year.
+        The cumulative path returns one row per day, and HRV arrives about 275
+        samples a year in the real record, so the old default of 100 clipped both
+        to under four months."""
+        assert _WORKOUT_METRICS_LIMIT >= 365
+
+    def test_the_new_default_is_what_the_store_is_asked_for(self, store, store_limits):
+        _tool_manage_workouts({"action": "metrics", "metric_type": "body_weight"})
+        _tool_manage_workouts({"action": "metrics", "metric_type": "steps"})
+        assert store_limits == [
+            {"query": "list_metrics", "limit": _WORKOUT_METRICS_LIMIT},
+            {"query": "daily_metric_totals", "limit": _WORKOUT_METRICS_LIMIT},
+        ]
+
+    def test_a_full_page_at_the_default_discloses_the_cap(self, store):
+        # A year of daily samples is exactly the case the raised default is for,
+        # so it is worth filling the page for real rather than stubbing it.
+        for i in range(_WORKOUT_METRICS_LIMIT):
+            store.log_metric(
+                "body_weight", 171.0 + i % 4, unit="lb",
+                start_at=f"2026-06-10T{i % 24:02d}:{i % 60:02d}:00+00:00",
+            )
+        out = _tool_manage_workouts({"action": "metrics", "metric_type": "body_weight"})
+        assert f"Capped at {_WORKOUT_METRICS_LIMIT} samples" in out
+        assert "earlier body weight may also be recorded" in out
+        assert_no_fault_language(out)
+
+    def test_one_below_the_cap_says_nothing(self, store):
+        for i in range(4):
+            store.log_metric("body_weight", 171.0, unit="lb", start_at=f"2026-06-1{i}T07:00:00+00:00")
+        out = _tool_manage_workouts({"action": "metrics", "metric_type": "body_weight", "limit": 5})
+        assert "Capped at" not in out
+
+    def test_the_disclosure_quotes_the_caller_supplied_cap(self, store):
+        for i in range(4):
+            store.log_metric("body_weight", 171.0, unit="lb", start_at=f"2026-06-1{i}T07:00:00+00:00")
+        out = _tool_manage_workouts({"action": "metrics", "metric_type": "body_weight", "limit": 2})
+        assert "Capped at 2 samples" in out
+        assert f"Capped at {_WORKOUT_METRICS_LIMIT}" not in out
+        assert_no_fault_language(out)
+
+    def test_the_daily_rollup_path_discloses_its_cap_in_days(self, store):
+        # steps takes the daily-total path, where the cap counts days, not samples
+        # — describing it as samples would understate what is missing.
+        for day in ("08", "09", "10"):
+            store.log_metric("steps", 4200, unit="count", start_at=f"2026-06-{day}T09:00:00+00:00")
+        out = _tool_manage_workouts({"action": "metrics", "metric_type": "steps", "limit": 2})
+        assert "Capped at 2 days" in out
+        assert_no_fault_language(out)
+
+    def test_an_unusable_cap_still_bounds_the_query(self, store, store_limits):
+        store.log_metric("body_weight", 171.0, unit="lb", start_at="2026-06-10T07:00:00+00:00")
+        for bad in (0, None, "everything"):
+            store_limits.clear()
+            _tool_manage_workouts({"action": "metrics", "metric_type": "body_weight", "limit": bad})
+            assert store_limits[0]["limit"] >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +465,83 @@ class TestSearchVault:
         out = _tool_search_vault({"query": "kayak portage checklist"})
         assert "Kayak Trip Planning.md" in out
         assert "Portage route notes." in out
+
+
+class TestSearchVaultCap:
+    def test_default_keeps_what_the_pipeline_already_retrieved(self):
+        """Ordinary queries have far more matches than the old cap of 20 — measured
+        against the live index, "meeting notes" 50, "project" 48, "kayak trip" 42,
+        "workout" 29 — and the extras are free, because the pipeline fetches
+        rerank_candidates candidates whatever top_k says (top_k=80 was measured to
+        return exactly what top_k=50 does)."""
+        assert _VAULT_TOP_K_DEFAULT >= 40
+
+    def test_default_stays_under_the_rerank_candidate_pool(self):
+        """HybridSearch.search only runs the cross-encoder when more candidates
+        survive than top_k asks for, so a default at or above the candidate pool
+        would silently switch reranking off — and then the character budget would
+        drop the tail by RRF order instead of by relevance."""
+        candidates = inspect.signature(hs_mod.HybridSearch.search).parameters["rerank_candidates"].default
+        assert _VAULT_TOP_K_DEFAULT < candidates
+
+    def test_a_full_page_discloses_the_cap(self, fake_vault):
+        fake_vault.results = [vault_chunk(i) for i in range(_VAULT_TOP_K_DEFAULT)]
+        out = _tool_search_vault({"query": "kayak portage checklist"})
+        assert f"Capped at top_k={_VAULT_TOP_K_DEFAULT}" in out
+        assert "more matching chunks may exist" in out
+        # A full page is not a fault.
+        assert_no_fault_language(out)
+
+    def test_one_below_the_cap_says_nothing(self, fake_vault):
+        fake_vault.results = [vault_chunk(i) for i in range(_VAULT_TOP_K_DEFAULT - 1)]
+        out = _tool_search_vault({"query": "kayak portage checklist"})
+        assert "Capped at" not in out
+
+    def test_the_disclosure_quotes_the_caller_supplied_cap(self, fake_vault):
+        fake_vault.results = [vault_chunk(i) for i in range(3)]
+        out = _tool_search_vault({"query": "kayak portage checklist", "top_k": 3})
+        assert "Capped at top_k=3" in out
+        assert f"top_k={_VAULT_TOP_K_DEFAULT}" not in out
+        assert_no_fault_language(out)
+
+    def test_a_page_of_full_length_chunks_is_trimmed_to_the_char_budget(self, fake_vault):
+        # 40 chunks at the 800-char render slice is ~34 KB — measured over the live
+        # index, the same 40 results cost 15 KB for one query and 36 KB for
+        # another, which is why the ceiling is characters and not count.
+        fake_vault.results = [vault_chunk(i, content_len=800) for i in range(_VAULT_TOP_K_DEFAULT)]
+        out = _tool_search_vault({"query": "kayak portage checklist"})
+        assert f"Payload capped at {_VAULT_CHAR_BUDGET} characters" in out
+        assert f"of {_VAULT_TOP_K_DEFAULT} chunks returned" in out
+        # Both bounds bound here, and both are facts the model needs: the count
+        # cap means more exist beyond these 40, the budget means fewer than 40 are
+        # shown.
+        assert f"Capped at top_k={_VAULT_TOP_K_DEFAULT}" in out
+        assert_no_fault_language(out)
+
+    def test_trimming_drops_whole_chunks_from_the_tail(self, fake_vault, monkeypatch):
+        # A chunk shown without its own header would be attributed to the note
+        # above it, so the cut lands between chunks. Budget shrunk rather than
+        # padded so the note's quoted value is checked against a value in effect.
+        monkeypatch.setattr(agent_tools, "_VAULT_CHAR_BUDGET", 700)
+        fake_vault.results = [vault_chunk(i, content_len=300) for i in range(5)]
+        out = _tool_search_vault({"query": "kayak portage checklist"})
+        assert "Payload capped at 700 characters" in out
+        assert "of 5 chunks returned" in out
+        kept = [i for i in range(5) if f"chunk-{i:03d}" in out]
+        # Highest-ranked first, contiguous from the top, and each kept chunk whole.
+        assert kept == list(range(len(kept)))
+        for i in kept:
+            assert vault_chunk(i, content_len=300)["content"] in out
+
+    def test_a_budget_smaller_than_one_chunk_still_returns_a_chunk(self, fake_vault, monkeypatch):
+        # Never trade a truncation note for an empty body: one whole chunk always
+        # survives, however tight the budget.
+        monkeypatch.setattr(agent_tools, "_VAULT_CHAR_BUDGET", 10)
+        fake_vault.results = [vault_chunk(i, content_len=300) for i in range(3)]
+        out = _tool_search_vault({"query": "kayak portage checklist"})
+        assert "chunk-000" in out
+        assert "chunk-001" not in out
+        assert "showing the 1 highest-ranked of 3 chunks returned" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_tools_scope_widening.py
+++ b/tests/test_agent_tools_scope_widening.py
@@ -1202,7 +1202,7 @@ class TestCalendarAccountFailureDisclosure:
         """
         broken_calendar.raising = {"personal"}
         out = await _tool_search_calendar({"query": "standup"})
-        assert "errored" in out
+        assert "returned an error" in out
         assert any(word in out.lower() for word in FAULT_WORDS)
 
     # -- API failures, not just credential failures (issue #536) -------------
@@ -1270,7 +1270,7 @@ class TestCalendarAccountFailureDisclosure:
         }
         out = await _tool_search_calendar({"query": "standup"})
         assert "rate-limiting" not in out
-        assert "could not complete" in out
+        assert "re-authorising" in out
 
     async def test_failure_note_does_not_quote_the_exception(
         self, broken_calendar, accounts
@@ -1389,7 +1389,7 @@ class TestCalendarAccountFailureDisclosure:
         assert "personal" in out and "work" in out
         # Both categories named, neither collapsed into the other.
         assert "rate-limiting personal" in out
-        assert "work errored" in out
+        assert "work returned an error" in out
 
     async def test_the_ladder_stops_once_every_account_has_failed(
         self, broken_calendar, accounts
@@ -1731,3 +1731,88 @@ class TestCalendarTotalAccountFailure:
         await _tool_search_calendar({"query": "standup"})
         assert flaky_calendar.attempts == 1
 
+
+
+class TestFailureAttribution:
+    """The remedy named must be the one the status actually establishes.
+
+    An earlier version grouped every non-rate-limit failure together and always
+    suggested re-authorising. For a 500 or 503 that is a wrong remedy — the fault
+    is on Google's side and clears on its own — so it sent the reader to repair
+    credentials that were working. Same defect class as the rest of this file: a
+    cause asserted that the code had not established.
+    """
+
+    @pytest.fixture
+    def failing_calendar(self, monkeypatch, accounts):
+        state = SimpleNamespace(error=None)
+
+        class FailingCalendarService:
+            def __init__(self, account, *, raise_on_api_error=False):
+                self.strict = raise_on_api_error
+
+            def search_events(self, query=None, days_back=30, days_forward=30, **kw):
+                if self.strict and state.error is not None:
+                    raise state.error
+                return []
+
+            def get_events_in_range(self, start, end):
+                return []
+
+            def get_upcoming_events(self, days=7, max_results=15):
+                return []
+
+        monkeypatch.setattr(
+            "api.services.calendar.CalendarService", FailingCalendarService
+        )
+        return state
+
+    async def _out(self, state, error):
+        state.error = error
+        return await _tool_search_calendar({"query": "standup"})
+
+    @pytest.mark.parametrize("status,reason", [(429, ""), (403, "rateLimitExceeded")])
+    async def test_rate_limit_says_the_data_is_probably_there(
+        self, failing_calendar, status, reason
+    ):
+        out = await self._out(failing_calendar, _http_error(status, reason))
+        assert "rate-limiting" in out
+        assert "re-authorising" not in out
+
+    @pytest.mark.parametrize("status,reason", [(403, "forbidden"), (401, "")])
+    async def test_credential_failure_names_re_authorising(
+        self, failing_calendar, status, reason
+    ):
+        out = await self._out(failing_calendar, _http_error(status, reason))
+        assert "re-authorising" in out
+        assert "rate-limiting" not in out
+
+    @pytest.mark.parametrize("status", [500, 502, 503])
+    async def test_server_error_is_not_blamed_on_credentials(
+        self, failing_calendar, status
+    ):
+        """The specific wrong remedy this class exists to prevent."""
+        out = await self._out(failing_calendar, _http_error(status))
+        assert "re-authorising" not in out
+        assert "Google's side" in out
+
+    async def test_server_error_still_reports_a_failure_not_an_absence(
+        self, failing_calendar
+    ):
+        out = await self._out(failing_calendar, _http_error(503))
+        assert "Nothing on the calendar matches" not in out
+        assert "could not" in out.lower()
+
+    async def test_daily_quota_is_not_promised_to_clear_shortly(
+        self, failing_calendar
+    ):
+        """A daily cap will not clear 'shortly', so it must not read as a rate limit."""
+        out = await self._out(failing_calendar, _http_error(403, "dailyLimitExceeded"))
+        assert "trying again shortly" not in out
+
+    async def test_the_exception_payload_never_reaches_the_output(
+        self, failing_calendar
+    ):
+        secret = "SYNTHETIC-sensitive-payload-do-not-echo"
+        out = await self._out(failing_calendar, _http_error(500, message=secret))
+        assert secret not in out

--- a/tests/test_agent_tools_scope_widening.py
+++ b/tests/test_agent_tools_scope_widening.py
@@ -15,6 +15,7 @@ the scope it searched instead of implying a fault.
 import re
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -64,6 +65,33 @@ def _counts_outside_range(text: str, n: int) -> bool:
 def _account(value: str = "personal"):
     """Stand-in for a GoogleAccount enum member; only `.value` is read."""
     return SimpleNamespace(value=value)
+
+
+def _http_error(status: int, reason_code: str = "", message: str = "Synthetic failure"):
+    """Build a real googleapiclient HttpError with the shape Google returns.
+
+    Not a stand-in: the classifier reads `resp.status` and the machine reason out
+    of `error_details`, and both are derived by HttpError itself from the raw
+    body — so a hand-rolled double would prove nothing about the real thing.
+    `HttpError.reason` is the human *message*, not `reason_code`; that asymmetry
+    is exactly what the classifier has to cope with.
+    """
+    import json
+
+    import httplib2
+    from googleapiclient.errors import HttpError
+
+    error: dict = {"code": status, "message": message}
+    if reason_code:
+        error["errors"] = [
+            {"domain": "usageLimits", "reason": reason_code, "message": message}
+        ]
+    resp = httplib2.Response({"status": status, "reason": message})
+    return HttpError(
+        resp,
+        json.dumps({"error": error}).encode(),
+        uri="https://www.googleapis.com/calendar/v3/calendars/primary/events",
+    )
 
 
 @pytest.fixture
@@ -370,11 +398,14 @@ def _event(days_ago: int, title: str, **extra):
 @pytest.fixture
 def fake_calendar(monkeypatch, accounts):
     """Stub CalendarService, recording the days_back of every search attempt."""
-    state = SimpleNamespace(events=[], searches=[], range_calls=[], upcoming_calls=[])
+    state = SimpleNamespace(
+        events=[], searches=[], range_calls=[], upcoming_calls=[], strict_flags=[]
+    )
 
     class FakeCalendarService:
-        def __init__(self, account):
+        def __init__(self, account, *, raise_on_api_error=False):
             self.account = account
+            state.strict_flags.append(raise_on_api_error)
 
         def search_events(self, query=None, attendee=None, days_back=30,
                           days_forward=30, calendar_id="primary"):
@@ -1080,13 +1111,29 @@ class TestCalendarAccountFailureDisclosure:
 
     @pytest.fixture
     def broken_calendar(self, monkeypatch, accounts):
-        state = SimpleNamespace(events_by_account={}, raising=set())
+        """Per-account failures.
+
+        `raising` names accounts that fail with a plain credentials error;
+        `errors` maps an account to a specific exception instance (an HttpError,
+        say) so the failure *category* can be exercised. `calls` records every
+        attempt so a rung that should have been skipped is observable.
+        """
+        state = SimpleNamespace(
+            events_by_account={}, raising=set(), errors={}, calls=[], strict_flags=[]
+        )
 
         class FlakyCalendarService:
-            def __init__(self, account):
+            def __init__(self, account, *, raise_on_api_error=False):
                 self.account = account
+                state.strict_flags.append(raise_on_api_error)
 
             def search_events(self, query=None, days_back=30, days_forward=30, **kw):
+                state.calls.append(
+                    {"account": self.account.value, "days_back": days_back}
+                )
+                specific = state.errors.get(self.account.value)
+                if specific is not None:
+                    raise specific
                 if self.account.value in state.raising:
                     raise RuntimeError("credentials expired")
                 return list(state.events_by_account.get(self.account.value, []))
@@ -1157,6 +1204,281 @@ class TestCalendarAccountFailureDisclosure:
         out = await _tool_search_calendar({"query": "standup"})
         assert "errored" in out
         assert any(word in out.lower() for word in FAULT_WORDS)
+
+    # -- API failures, not just credential failures (issue #536) -------------
+    # The credential path was fixed first, so an expired token surfaced. A 403, a
+    # 429, a 500 or a quota event still died in
+    # `CalendarService._fetch_events`'s `except Exception: return []` and came
+    # back as "nothing on your calendar".
+
+    async def test_the_tool_asks_the_service_to_propagate_failures(
+        self, broken_calendar, accounts
+    ):
+        """Without the opt-in flag the service swallows the fault and none of
+        the disclosure below can ever fire."""
+        await _tool_search_calendar({"query": "standup"})
+        assert broken_calendar.strict_flags
+        assert all(broken_calendar.strict_flags)
+
+    async def test_api_error_is_reported_as_a_failure_to_search(
+        self, broken_calendar, accounts
+    ):
+        broken_calendar.errors = {"personal": _http_error(500, "backendError")}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert out.startswith("Could not search the calendar")
+        assert "NOT an empty calendar" in out
+        assert "Nothing on the calendar matches" not in out
+
+    async def test_api_error_says_the_search_could_not_complete(
+        self, broken_calendar, accounts
+    ):
+        broken_calendar.errors = {"personal": _http_error(500, "backendError")}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "could not complete" in out
+        assert "rate-limit" not in out.lower()
+
+    @pytest.mark.parametrize(
+        "exc_args",
+        [
+            (429, "", "Quota exceeded for quota metric 'Queries'"),
+            (403, "rateLimitExceeded", "Rate Limit Exceeded"),
+            (403, "userRateLimitExceeded", "User Rate Limit Exceeded"),
+        ],
+    )
+    async def test_rate_limit_is_reported_distinctly(
+        self, broken_calendar, accounts, exc_args
+    ):
+        """A rate limit means the data is almost certainly there.
+
+        Google returns it two ways: a 429 under the newer error format, and a 403
+        whose machine reason — in error_details, not in `.reason` — is
+        rateLimitExceeded or userRateLimitExceeded.
+        """
+        broken_calendar.errors = {"personal": _http_error(*exc_args)}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "rate-limiting" in out
+        assert "trying again shortly" in out
+        assert "likely there" in out
+        assert "may need re-authorising" not in out
+
+    async def test_a_plain_403_is_not_mistaken_for_a_rate_limit(
+        self, broken_calendar, accounts
+    ):
+        """Insufficient permission is a 403 too, and it will not clear by waiting."""
+        broken_calendar.errors = {
+            "personal": _http_error(403, "forbidden", "Insufficient Permission")
+        }
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "rate-limiting" not in out
+        assert "could not complete" in out
+
+    async def test_failure_note_does_not_quote_the_exception(
+        self, broken_calendar, accounts
+    ):
+        """Exception text can carry event titles, attendees, or the query."""
+        broken_calendar.errors = {
+            "personal": _http_error(500, "backendError", "Milo Placeholder therapy")
+        }
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Milo Placeholder" not in out
+        assert "HttpError" not in out
+        assert "personal" in out
+
+    async def test_a_failed_account_is_not_retried_on_wider_rungs(
+        self, broken_calendar, accounts
+    ):
+        """The ladder triples call volume on a miss, and rate limits are burst-driven.
+
+        A 429 on the ±180d rung must not be answered by two more calls to the
+        same account. The healthy account still walks the whole ladder.
+        """
+        accounts.append(_account("work"))
+        broken_calendar.errors = {"work": _http_error(429)}
+        await _tool_search_calendar({"query": "standup"})
+        work_calls = [c for c in broken_calendar.calls if c["account"] == "work"]
+        personal_calls = [
+            c for c in broken_calendar.calls if c["account"] == "personal"
+        ]
+        assert len(work_calls) == 1
+        assert work_calls[0]["days_back"] == _CALENDAR_LADDER_DAYS[0]
+        assert [c["days_back"] for c in personal_calls] == list(_CALENDAR_LADDER_DAYS)
+
+    async def test_a_dropped_account_is_still_disclosed_on_the_last_rung(
+        self, broken_calendar, accounts
+    ):
+        """Dropping it from later rungs must not drop it from the answer."""
+        accounts.append(_account("work"))
+        broken_calendar.errors = {"work": _http_error(429)}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Could not reach work" in out
+        assert "It was not retried on the wider windows." in out
+
+    async def test_a_partial_failure_withholds_the_nothing_matches_claim(
+        self, broken_calendar, accounts
+    ):
+        """One account never answered, so the absence was never established.
+
+        The windows are still named — the account that did answer really searched
+        them — but "nothing on the calendar matches" is an assertion the search
+        did not earn.
+        """
+        accounts.append(_account("work"))
+        broken_calendar.errors = {"work": _http_error(429)}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Nothing on the calendar matches" not in out
+        assert "Searched ±180d, then ±365d, then ±1095d." in out
+        assert "incomplete answer" in out
+
+    async def test_a_clean_empty_still_makes_the_claim(self, broken_calendar, accounts):
+        """The complement: with every account answering, the absence is real."""
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Nothing on the calendar matches 'standup' in that span." in out
+        assert not any(word in out.lower() for word in FAULT_WORDS)
+
+    async def test_the_drop_is_not_claimed_when_no_wider_rung_ran(
+        self, broken_calendar, accounts
+    ):
+        """First rung hit, so there were no wider windows to skip."""
+        accounts.append(_account("work"))
+        broken_calendar.errors = {"work": _http_error(429)}
+        broken_calendar.events_by_account["personal"] = [
+            _event(20, "Synthetic standup")
+        ]
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "wider windows" not in out
+        assert "Could not reach work" in out
+
+    async def test_partial_failure_returns_the_healthy_results_and_discloses(
+        self, broken_calendar, accounts
+    ):
+        accounts.append(_account("work"))
+        broken_calendar.errors = {"work": _http_error(429)}
+        broken_calendar.events_by_account["personal"] = [
+            _event(20, "Synthetic standup")
+        ]
+        out = await _tool_search_calendar({"query": "standup"})
+        assert "Synthetic standup" in out
+        assert "Could not reach work" in out
+        assert "rate-limiting" in out
+
+    async def test_one_account_failing_is_not_a_total_failure(
+        self, broken_calendar, accounts
+    ):
+        """The other account searched every window and found nothing.
+
+        That empty is real, so the output must not claim nothing was searched —
+        but it must still say the answer is incomplete.
+        """
+        accounts.append(_account("work"))
+        broken_calendar.errors = {"work": _http_error(500, "backendError")}
+        out = await _tool_search_calendar({"query": "standup"})
+        assert not out.startswith("Could not search the calendar")
+        assert "nothing was actually searched" not in out
+        assert "incomplete answer" in out
+
+    async def test_every_account_failing_is_a_total_failure(
+        self, broken_calendar, accounts
+    ):
+        accounts.append(_account("work"))
+        broken_calendar.errors = {
+            "personal": _http_error(429),
+            "work": _http_error(500, "backendError"),
+        }
+        out = await _tool_search_calendar({"query": "standup"})
+        assert out.startswith("Could not search the calendar")
+        assert "personal" in out and "work" in out
+        # Both categories named, neither collapsed into the other.
+        assert "rate-limiting personal" in out
+        assert "work errored" in out
+
+    async def test_the_ladder_stops_once_every_account_has_failed(
+        self, broken_calendar, accounts
+    ):
+        accounts.append(_account("work"))
+        broken_calendar.errors = {
+            "personal": _http_error(429),
+            "work": _http_error(500, "backendError"),
+        }
+        await _tool_search_calendar({"query": "standup"})
+        assert len(broken_calendar.calls) == 2
+
+
+class TestCalendarServiceApiErrorContract:
+    """The disclosure above depends on API faults reaching the tool.
+
+    `CalendarService._fetch_events` wraps its request in
+    `try/except Exception: return []`. That is the contract every api/routes/
+    caller depends on, so propagation is opt-in per instance rather than removed.
+    """
+
+    @pytest.fixture
+    def service(self):
+        """A real CalendarService with a stubbed Google client."""
+        from api.services.calendar import CalendarService
+        from api.services.google_auth import GoogleAccount
+
+        def _build(**kwargs):
+            svc = CalendarService(account_type=GoogleAccount.PERSONAL, **kwargs)
+            svc._service = MagicMock()
+            return svc
+
+        return _build
+
+    def test_api_error_is_swallowed_to_an_empty_list_by_default(self, service):
+        svc = service()
+        svc._service.events().list().execute.side_effect = _http_error(429)
+        assert svc.get_upcoming_events(days=7) == []
+
+    def test_api_error_propagates_when_the_caller_opts_in(self, service):
+        from googleapiclient.errors import HttpError
+
+        svc = service(raise_on_api_error=True)
+        svc._service.events().list().execute.side_effect = _http_error(429)
+        with pytest.raises(HttpError):
+            svc.get_upcoming_events(days=7)
+
+    def test_every_entry_point_honours_the_flag(self, service):
+        """One constructor flag has to cover all three public read paths."""
+        from googleapiclient.errors import HttpError
+
+        svc = service(raise_on_api_error=True)
+        svc._service.events().list().execute.side_effect = _http_error(500)
+        with pytest.raises(HttpError):
+            svc.search_events(query="standup")
+        with pytest.raises(HttpError):
+            svc.get_events_in_range(_days_ago(5), _days_ago(1))
+        with pytest.raises(HttpError):
+            svc.get_upcoming_events(days=7)
+
+    def test_the_singleton_factory_never_hands_out_a_strict_service(self):
+        """Routes share these instances; none of them may start raising."""
+        from api.services.calendar import get_calendar_service
+        from api.services.google_auth import GoogleAccount
+
+        svc = get_calendar_service(GoogleAccount.PERSONAL)
+        assert svc.raise_on_api_error is False
+
+    async def test_the_route_still_returns_an_empty_list_on_api_error(self, service):
+        """The long-standing HTTP contract: 200 with zero events, not a 500."""
+        from api.routes import calendar as calendar_route
+
+        svc = service()
+        svc._service.events().list().execute.side_effect = _http_error(429)
+        with patch.object(
+            calendar_route, "get_calendar_service", return_value=svc
+        ):
+            upcoming = await calendar_route.get_upcoming_events(
+                days=7, account="personal", max_results=50
+            )
+            searched = await calendar_route.search_events(
+                q="standup",
+                attendee=None,
+                account="personal",
+                days_back=30,
+                days_forward=30,
+            )
+        assert (upcoming.events, upcoming.count) == ([], 0)
+        assert (searched.events, searched.count) == ([], 0)
 
 
 class TestCapNormalization:
@@ -1362,7 +1684,7 @@ class TestCalendarTotalAccountFailure:
         state = SimpleNamespace(raising=set(), events={}, attempts=0)
 
         class FlakyCalendarService:
-            def __init__(self, account):
+            def __init__(self, account, *, raise_on_api_error=False):
                 self.name = account.value
 
             def search_events(self, query=None, days_back=30, days_forward=30, **kw):


### PR DESCRIPTION
Closes #536, closes #537.

The last two findings from the audit of the scope-disclosure bug class. Both were deliberately held out of #538 to keep it reviewable; both turned out to be worth more than their original severity suggested.

## #537 — the caps were nobody's decision

Traced through git history: vault `top_k=10` was set in the February commit that *created* the agentic chat pipeline, workout `limit=10` in the June commit that *created* the workout store. Neither was a judgement about what makes a good answer — they are token-economy guesses from before the corpora had any data in them, which is the same root cause as the 30-day message window in #530.

The issue originally put cap *values* out of scope and only asked for disclosure. That was wrong: a note saying "capped at 10" makes a 10-of-16 answer honest without making it useful. Both halves are here.

| Path | Was | Now | Basis |
|---|---|---|---|
| vault `top_k` | 20 | **40** + a character budget | Ordinary single-word queries return well over 20; the extras are already fetched and free |
| workout `list` | 10 | **50** | A measured month exceeded 10. Also the store's own default — the tool had been undercutting its own service 5× |
| workout `history` | 20 | **100** | One row per set; 20 was under a month for a question asked over months |
| workout `metrics` | 100 | **365** | A metric question is a trend question; 100 was under four months |

A character budget is used for vault only. The same result *count* varied ~2.3× in bytes depending on chunk length, so count is the wrong cost proxy there — the same trap `get_message_history` hit. Workout rows measured near-uniform, so counts are honest for those.

**The landmine:** raising vault to 50 — the obvious choice — would have **silently disabled the cross-encoder reranker**. The rerank step is guarded by `len(final_results) > top_k` and `final_results` can never exceed `rerank_candidates` (50), so at `top_k >= 50` the condition is unsatisfiable and reranking just stops. No error, no log line, quietly worse results. Hence 40, with the caller ceiling held at 49 and a test pinning both below `rerank_candidates`.

## #536 — Google API errors were reported as absence

Only the credential path was fixed previously. A 403, 429, 500 or quota event still returned an empty list, so a genuine fault was rendered as "nothing on your calendar".

Both services gained a **keyword-only `raise_on_api_error=False`** constructor flag. Default preserves the empty-list-on-error contract that `api/routes/` depends on; only the agent tools opt in. Keyword-only means none of the 24 existing positional call sites can trip it, and `get_calendar_service()`/`get_drive_service()` deliberately do not expose it — so the instances the routes share through that cache can never turn strict behind a route's back.

**This is also partly our own doing.** The widening ladder from #530 triples calendar calls on a miss (3 rungs × 2 accounts = 6 where there were 2), and rate limits are driven by burst volume. So a rate-limited account is now dropped from later rungs rather than retried blind, and a total failure aborts the ladder — 2 calls instead of 6.

Failure causes are attributed rather than lumped: a rate limit says the data is very likely still there and a retry will reach it; a credentials failure says re-authorise; a server error says the cause is on Google's side and neither applies. `dailyLimitExceeded` is deliberately excluded from the rate-limit class, because a daily cap will not clear "shortly".

## Defects found in review, not implementation

Four from the adversarial pass, all verified before acting:

- **A server error was reported as a credentials problem.** Every non-rate-limit failure shared one clause ending "may need re-authorising", so a 500 sent the reader to fix credentials that worked.
- **A vault request above the candidate ceiling read as complete.** It came back at the limit, and since the truncation check compares against the number *asked for*, the short return looked like the whole answer.
- **A ladder rung that reached nobody was still claimed as searched.** Two accounts answer an empty first rung and both fail the second: the cumulative "searched" set is non-empty, so it is not a total failure, yet the note named the wider window anyway.
- **The budget figure did not match the rendered payload** — separators and the note sit outside it.

## A privacy issue I caused

I instructed the implementer to justify each cap in a code comment and "ground each choice in the corpus". It did exactly that, faithfully — and put real vault query terms, the user's name, and real workout counts and dates into source comments bound for permanent git history, against the synthetic-data rule in AGENTS.md. Caught by the adversarial pass. The reasoning and the measurements are kept in generalised form; the specifics are gone.

## Verification

- **406 tests** across the affected files, sequential and under xdist; **4018 passing** in the full suite.
- 4 remaining failures are the known baseline, verified on a clean tree.
- Route contract checked directly: `_fetch_events` returns `[]` when lenient and raises when strict, against a client raising `HttpError(429)`.
- All six failure statuses (429, 403 rate-limit, 403 auth, 401, 500, 503) verified to name the correct remedy and no other.
- All four ladder/account-drop combinations traced: both fail rung 1; one fails while the other walks on; a failure on a later rung; results plus a failure. Each message is true and each call count minimal.
- Verified no exception payload reaches user-visible output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
