### PR TITLE
fix(auth,imessage): stop naming causes and identities more confidently than the evidence

### DIFF
--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -1763,13 +1763,23 @@ _MSG_HISTORY_CHAR_BUDGET = 24000
 
 
 def _tool_get_message_history(inp: dict) -> str:
-    from api.services.imessage import query_person_messages, resolve_entity_id
+    from api.services.imessage import query_person_messages, resolve_entity_id_confidence
     from api.services.interaction_store import get_interaction_store
 
     entity_id = inp["entity_id"]
-    resolved_id = resolve_entity_id(entity_id)
+    resolved_id, ambiguous_match = resolve_entity_id_confidence(entity_id)
     if not resolved_id:
         return f"Could not resolve person '{entity_id}'. Use person_info first."
+
+    # A fuzzy_ambiguous resolution means two+ candidates scored close enough
+    # together that the top pick isn't reliably the right person — flag it
+    # rather than returning someone else's messages as a confident match.
+    ambiguous_note = (
+        f" ('{entity_id}' matched more than one person about equally well — "
+        "this may be the wrong person; confirm with person_info)"
+        if ambiguous_match
+        else ""
+    )
 
     start_date = inp.get("start_date")
     end_date = inp.get("end_date")
@@ -1859,15 +1869,17 @@ def _tool_get_message_history(inp: dict) -> str:
                     if search_term
                     else "."
                 )
+                + ambiguous_note
             )
         window_desc = " to ".join(x for x in (start_date, end_date) if x)
         return (
             f"No messages found in the requested window ({window_desc})"
             + (f" for {search_term!r}" if search_term else "")
             + ". Retry without start_date/end_date to search all history."
+            + ambiguous_note
         )
 
-    widened_note = _ladder_note(windows_tried)
+    widened_note = _ladder_note(windows_tried) + ambiguous_note
 
     # Build output. The budget is split across sources rather than applied to the
     # assembled string: the sections are grouped by source, not interleaved by

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -1772,14 +1772,20 @@ def _tool_get_message_history(inp: dict) -> str:
         return f"Could not resolve person '{entity_id}'. Use person_info first."
 
     # A fuzzy_ambiguous resolution means two+ candidates scored close enough
-    # together that the top pick isn't reliably the right person — flag it
-    # rather than returning someone else's messages as a confident match.
-    ambiguous_note = (
-        f" ('{entity_id}' matched more than one person about equally well — "
-        "this may be the wrong person; confirm with person_info)"
-        if ambiguous_match
-        else ""
-    )
+    # together that the top pick isn't reliably the right person. Disclosure
+    # alone isn't a fix here — a warning appended after the fact doesn't stop
+    # someone's private messages from already being in the model's context,
+    # attributable to whichever person the caller actually meant. Refuse the
+    # query outright: entity_id is documented to come from person_info, which
+    # returns a UUID, so a slug is a fallback and refusing an uncertain one
+    # only costs the caller one extra call.
+    if ambiguous_match:
+        return (
+            f"'{entity_id}' matched more than one person about equally well — "
+            "not resolving to avoid returning the wrong person's messages. "
+            "Use person_info to find the exact person, then pass their UUID "
+            "as entity_id."
+        )
 
     start_date = inp.get("start_date")
     end_date = inp.get("end_date")
@@ -1869,17 +1875,15 @@ def _tool_get_message_history(inp: dict) -> str:
                     if search_term
                     else "."
                 )
-                + ambiguous_note
             )
         window_desc = " to ".join(x for x in (start_date, end_date) if x)
         return (
             f"No messages found in the requested window ({window_desc})"
             + (f" for {search_term!r}" if search_term else "")
             + ". Retry without start_date/end_date to search all history."
-            + ambiguous_note
         )
 
-    widened_note = _ladder_note(windows_tried) + ambiguous_note
+    widened_note = _ladder_note(windows_tried)
 
     # Build output. The budget is split across sources rather than applied to the
     # assembled string: the sections are grouped by source, not interleaved by

--- a/api/services/google_auth.py
+++ b/api/services/google_auth.py
@@ -11,6 +11,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
+from google.auth import exceptions as google_auth_exceptions
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -61,6 +62,80 @@ def get_configured_accounts() -> list[GoogleAccount]:
         if (config_dir / f"credentials-{account.value}.json").exists():
             accounts.append(account)
     return accounts
+
+
+# Refresh-failure categories, mirroring _google_failure_kind/_failure_causes in
+# agent_tools.py: classify what actually happened before naming a remedy,
+# because a connectivity failure and a genuine rejection call for opposite
+# actions — retry vs. re-authenticate — and naming the wrong one sends the
+# operator to fix something that isn't broken (and costs an interactive
+# browser session on a headless box for nothing).
+_REFRESH_FAIL_CONNECTIVITY = "connectivity"
+_REFRESH_FAIL_REJECTED = "rejected"
+_REFRESH_FAIL_UNKNOWN = "unknown"
+
+_AUTHENTICATE_SCRIPT = "~/.venvs/lifeos/bin/python scripts/authenticate_google.py"
+
+
+def _classify_refresh_failure(exc: Exception) -> str:
+    """Classify a `Credentials.refresh()` exception before naming a remedy.
+
+    Never derives anything from the exception's text — it can carry tokens —
+    only its type is inspected.
+
+    - `google.auth.exceptions.TransportError` is what
+      `google.auth.transport.requests.Request.__call__` raises for *any*
+      `requests.exceptions.RequestException` it catches — connection refused,
+      timeout, and DNS/name-resolution failure alike (`requests`/`urllib3`
+      raise a `ConnectionError` wrapping a `NameResolutionError` for the
+      latter; none of these are HTTP-level distinctions). None of those cases
+      ever reached Google, so the credentials were never evaluated.
+    - `google.auth.exceptions.RefreshError` is what
+      `google.oauth2._client._handle_error_response` raises when the token
+      endpoint itself returns a non-200 response — a genuine rejection by
+      the identity provider (e.g. a revoked or expired refresh token).
+    - Anything else is unrecognised; say the refresh failed without
+      asserting which of the above happened.
+    """
+    if isinstance(exc, google_auth_exceptions.TransportError):
+        return _REFRESH_FAIL_CONNECTIVITY
+    if isinstance(exc, google_auth_exceptions.RefreshError):
+        return _REFRESH_FAIL_REJECTED
+    return _REFRESH_FAIL_UNKNOWN
+
+
+def _headless_auth_failure_message(account: str, refresh_failure_kind: Optional[str]) -> str:
+    """Name the failing account and the remedy the failure actually establishes.
+
+    `refresh_failure_kind` is None when no refresh was attempted (no stored
+    token, or an expired token with no refresh_token) — that case keeps its
+    original wording since it isn't the misattribution this classifies.
+    """
+    if refresh_failure_kind == _REFRESH_FAIL_CONNECTIVITY:
+        return (
+            f"Could not reach Google to refresh the OAuth token for the "
+            f"{account} account — this looks like a network or DNS problem, "
+            f"not a credentials problem. The token itself is untested, not "
+            f"known to be invalid. Re-authenticating will not help; retry "
+            f"once connectivity is restored."
+        )
+    if refresh_failure_kind == _REFRESH_FAIL_REJECTED:
+        return (
+            f"Google rejected the OAuth token refresh for the {account} "
+            f"account and it cannot be refreshed in a headless environment. "
+            f"Run interactively: {_AUTHENTICATE_SCRIPT}"
+        )
+    if refresh_failure_kind == _REFRESH_FAIL_UNKNOWN:
+        return (
+            f"Token refresh for the {account} account failed and cannot be "
+            f"retried in a headless environment. The cause is not "
+            f"established — this may or may not be a credentials problem."
+        )
+    return (
+        f"Google OAuth token for {account} account is expired/revoked "
+        f"and cannot be refreshed in a headless environment. "
+        f"Run interactively: {_AUTHENTICATE_SCRIPT}"
+    )
 
 
 class GoogleAuthService:
@@ -129,6 +204,7 @@ class GoogleAuthService:
                 self._credentials = None
 
         # Check if we need to refresh or re-authenticate
+        refresh_failure_kind: Optional[str] = None
         if self._credentials:
             if self._credentials.valid:
                 return self._credentials
@@ -140,15 +216,27 @@ class GoogleAuthService:
                     self._save_token(self._credentials)
                     return self._credentials
                 except Exception as e:
-                    logger.warning(f"Token refresh failed (may be revoked): {e}")
+                    refresh_failure_kind = _classify_refresh_failure(e)
+                    if refresh_failure_kind == _REFRESH_FAIL_CONNECTIVITY:
+                        logger.warning(
+                            f"Token refresh for {self.account_type.value} account could not "
+                            f"reach Google (connectivity failure, token not evaluated): {e}"
+                        )
+                    elif refresh_failure_kind == _REFRESH_FAIL_REJECTED:
+                        logger.warning(
+                            f"Token refresh for {self.account_type.value} account was rejected "
+                            f"by Google: {e}"
+                        )
+                    else:
+                        logger.warning(
+                            f"Token refresh for {self.account_type.value} account failed: {e}"
+                        )
                     # Fall through to re-authenticate
 
         # Need to authenticate via browser — fail fast if headless
         if os.environ.get("LIFEOS_HEADLESS", "").lower() in ("1", "true", "yes") or not sys.stdin.isatty():
             raise RuntimeError(
-                f"Google OAuth token for {self.account_type.value} account is expired/revoked "
-                f"and cannot be refreshed in a headless environment. "
-                f"Run interactively: ~/.venvs/lifeos/bin/python scripts/authenticate_google.py"
+                _headless_auth_failure_message(self.account_type.value, refresh_failure_kind)
             )
 
         logger.info(f"Initiating OAuth flow for {self.account_type.value} account")

--- a/api/services/google_auth.py
+++ b/api/services/google_auth.py
@@ -96,6 +96,21 @@ def _classify_refresh_failure(exc: Exception) -> str:
       the identity provider (e.g. a revoked or expired refresh token).
     - Anything else is unrecognised; say the refresh failed without
       asserting which of the above happened.
+
+    This does not check `exc.__cause__`/`__context__` for a chained
+    TransportError under a RefreshError, and that is deliberate, not an
+    oversight: verified against the installed google-auth (2.48.0) that no
+    such chain exists. `google.oauth2._client._token_endpoint_request_no_throw`
+    calls `request(...)` (the transport call that raises TransportError) with
+    no try/except around it at all, so a transport failure there propagates
+    as a bare TransportError straight out of `Credentials.refresh()`. Every
+    `raise exceptions.RefreshError(...)` in that module (`_handle_error_response`,
+    `_handle_refresh_grant_response`, and the id-token variants) instead
+    originates from parsing or validating the token endpoint's *response body*
+    — a non-200 status, or a missing/malformed field in an otherwise-received
+    response — never from catching a transport exception. So a network
+    failure cannot surface here disguised as a RefreshError; if a future
+    google-auth release changes that, this classifier would need revisiting.
     """
     if isinstance(exc, google_auth_exceptions.TransportError):
         return _REFRESH_FAIL_CONNECTIVITY
@@ -217,19 +232,27 @@ class GoogleAuthService:
                     return self._credentials
                 except Exception as e:
                     refresh_failure_kind = _classify_refresh_failure(e)
+                    # Log the classification and the exception's type only —
+                    # never str(e) and no exc_info. An OAuth refresh exception
+                    # is precisely where a token or response payload can show
+                    # up, and log_redaction.py only filters `bot\d+:...`
+                    # patterns, not this. The classification is the useful
+                    # signal; the payload was never what made this diagnostic.
                     if refresh_failure_kind == _REFRESH_FAIL_CONNECTIVITY:
                         logger.warning(
                             f"Token refresh for {self.account_type.value} account could not "
-                            f"reach Google (connectivity failure, token not evaluated): {e}"
+                            f"reach Google (connectivity failure, token not evaluated); "
+                            f"exception type: {type(e).__name__}"
                         )
                     elif refresh_failure_kind == _REFRESH_FAIL_REJECTED:
                         logger.warning(
                             f"Token refresh for {self.account_type.value} account was rejected "
-                            f"by Google: {e}"
+                            f"by Google; exception type: {type(e).__name__}"
                         )
                     else:
                         logger.warning(
-                            f"Token refresh for {self.account_type.value} account failed: {e}"
+                            f"Token refresh for {self.account_type.value} account failed; "
+                            f"exception type: {type(e).__name__}"
                         )
                     # Fall through to re-authenticate
 

--- a/api/services/imessage.py
+++ b/api/services/imessage.py
@@ -1001,7 +1001,16 @@ def resolve_entity_id_confidence(entity_id: str) -> tuple[Optional[str], bool]:
     in response to a request about another — e.g. get_message_history, which
     this resolution feeds on every call — should use this function directly
     and disclose the uncertainty instead of presenting the match as certain.
+
+    `entity_id` is filled in by an LLM tool call, so None, non-string types,
+    and empty/whitespace strings all arrive in practice. `uuid.UUID(...)`
+    raises TypeError on None and AttributeError on a non-string (no
+    `.replace()`) rather than the ValueError this function otherwise expects
+    for "not a UUID" — so those are rejected up front as simply unresolved,
+    the same outcome a caller gets for any other name that doesn't match.
     """
+    if not isinstance(entity_id, str) or not entity_id.strip():
+        return None, False
     try:
         uuid_mod.UUID(entity_id)
         return entity_id, False

--- a/api/services/imessage.py
+++ b/api/services/imessage.py
@@ -872,28 +872,6 @@ def get_imessage_store(storage_path: str = "./data/imessage.db") -> IMessageStor
     return _imessage_store
 
 
-def resolve_entity_id(entity_id: str) -> Optional[str]:
-    """Resolve an entity_id that may be a UUID or a name slug (e.g. 'john-doe') to a UUID."""
-    import uuid
-    # If it's already a valid UUID, pass through
-    try:
-        uuid.UUID(entity_id)
-        return entity_id
-    except ValueError:
-        pass
-    # Treat as a name slug: "john-doe" -> "john doe", then search
-    try:
-        from api.services.people_aggregator import get_people_aggregator
-        agg = get_people_aggregator()
-        name_query = entity_id.replace("-", " ")
-        results = agg.search(name_query)
-        if results:
-            return results[0].id
-    except Exception:
-        pass
-    return None
-
-
 def sync_imessages() -> dict:
     """
     Convenience function for nightly sync.
@@ -1009,11 +987,24 @@ def sync_and_join_imessages() -> dict:
     }
 
 
-def resolve_entity_id(entity_id: str) -> Optional[str]:  # noqa: F811 - pre-existing duplicate of the definition above; this entity_resolver-based one wins. Flagged as follow-up.
-    """If entity_id isn't a UUID, try resolving it as a person name."""
+def resolve_entity_id_confidence(entity_id: str) -> tuple[Optional[str], bool]:
+    """Resolve a UUID or name slug (e.g. 'john-doe') to a person's UUID.
+
+    Returns `(resolved_id, ambiguous)`. `ambiguous` is True when
+    `entity_resolver.resolve()` reported `match_type="fuzzy_ambiguous"` — two
+    or more candidates scored close enough together that the top pick isn't
+    reliably the right person (confidence is reduced accordingly, but the
+    bare id alone can't carry that).
+
+    `resolve_entity_id()` below discards this flag for callers that only ever
+    need the id. A caller whose output could expose one person's private data
+    in response to a request about another — e.g. get_message_history, which
+    this resolution feeds on every call — should use this function directly
+    and disclose the uncertainty instead of presenting the match as certain.
+    """
     try:
         uuid_mod.UUID(entity_id)
-        return entity_id
+        return entity_id, False
     except ValueError:
         from api.services.entity_resolver import get_entity_resolver
         resolver = get_entity_resolver()
@@ -1021,8 +1012,19 @@ def resolve_entity_id(entity_id: str) -> Optional[str]:  # noqa: F811 - pre-exis
         name = entity_id.replace("-", " ")
         result = resolver.resolve(name=name)
         if result and result.entity:
-            return result.entity.id
-        return None
+            return result.entity.id, result.match_type == "fuzzy_ambiguous"
+        return None, False
+
+
+def resolve_entity_id(entity_id: str) -> Optional[str]:
+    """If entity_id isn't a UUID, try resolving it as a person name.
+
+    Thin wrapper over `resolve_entity_id_confidence()` — see that function's
+    docstring if the caller's output could expose the wrong person's data on
+    an ambiguous match.
+    """
+    resolved_id, _ambiguous = resolve_entity_id_confidence(entity_id)
+    return resolved_id
 
 
 def query_person_messages(

--- a/tests/test_agent_tools_message_history.py
+++ b/tests/test_agent_tools_message_history.py
@@ -173,29 +173,42 @@ class TestHonestEmpty:
 class TestAmbiguousResolution:
     """resolve_entity_id_confidence's second element (#346): when
     entity_resolver reports `fuzzy_ambiguous` (two-plus candidates scored close
-    enough together that the top pick isn't reliably right), the tool must say
-    so rather than silently returning what may be the wrong person's messages.
+    enough together that the top pick isn't reliably right), the tool must
+    refuse the query outright rather than returning what may be the wrong
+    person's private messages with a warning attached — a warning read after
+    the fact doesn't undo content already in the model's context.
     """
 
-    def test_ambiguous_match_is_disclosed_alongside_results(self, fake_sources):
+    def test_ambiguous_match_is_refused_not_disclosed(self, fake_sources):
         fake_sources.ambiguous = True
         fake_sources.imessages = [(_days_ago(3), "hello")]
         out = _tool_get_message_history({"entity_id": ENTITY})
         assert "matched more than one person" in out
+        assert "hello" not in out
 
-    def test_confident_match_carries_no_ambiguity_note(self, fake_sources):
+    def test_ambiguous_match_never_queries_either_source(self, fake_sources):
+        """No message content may reach the tool's output at all — assert the
+        underlying sources were never even queried, not just that the reply
+        omits them."""
+        fake_sources.ambiguous = True
+        fake_sources.imessages = [(_days_ago(3), "hello")]
+        fake_sources.whatsapp = [(_days_ago(3), "wa hello")]
+        _tool_get_message_history({"entity_id": ENTITY})
+        assert fake_sources.attempts == []
+
+    def test_ambiguous_match_names_the_term_and_the_remedy(self, fake_sources):
+        fake_sources.ambiguous = True
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert ENTITY in out
+        assert "person_info" in out
+        assert "UUID" in out
+
+    def test_confident_match_is_not_refused(self, fake_sources):
         fake_sources.ambiguous = False
         fake_sources.imessages = [(_days_ago(3), "hello")]
         out = _tool_get_message_history({"entity_id": ENTITY})
         assert "matched more than one person" not in out
-
-    def test_ambiguous_match_is_disclosed_even_on_empty_result(self, fake_sources):
-        """An ambiguous resolution with zero messages is still worth flagging —
-        the wrong person may simply have no history, which reads as innocuous
-        without the note."""
-        fake_sources.ambiguous = True
-        out = _tool_get_message_history({"entity_id": ENTITY})
-        assert "matched more than one person" in out
+        assert "hello" in out
 
 
 class TestBudget:

--- a/tests/test_agent_tools_message_history.py
+++ b/tests/test_agent_tools_message_history.py
@@ -39,11 +39,15 @@ def fake_sources(monkeypatch):
     """Stub both message sources so windowing is tested without real data.
 
     Records the start_date of every attempt so the widening ladder is visible.
+    `state.ambiguous` defaults to False (a confident resolution); set it to
+    True in a test to simulate entity_resolver reporting `fuzzy_ambiguous`.
     """
-    state = SimpleNamespace(imessages=[], whatsapp=[], attempts=[])
+    state = SimpleNamespace(imessages=[], whatsapp=[], attempts=[], ambiguous=False)
 
     def fake_resolve(entity_id):
-        return entity_id if entity_id == ENTITY else None
+        if entity_id == ENTITY:
+            return entity_id, state.ambiguous
+        return None, False
 
     def fake_query(entity_id, search_term=None, start_date=None, end_date=None, limit=100):
         state.attempts.append(start_date)
@@ -72,7 +76,7 @@ def fake_sources(monkeypatch):
                 if ts >= bound
             ][:limit]
 
-    monkeypatch.setattr("api.services.imessage.resolve_entity_id", fake_resolve)
+    monkeypatch.setattr("api.services.imessage.resolve_entity_id_confidence", fake_resolve)
     monkeypatch.setattr("api.services.imessage.query_person_messages", fake_query)
     monkeypatch.setattr(
         "api.services.interaction_store.get_interaction_store", lambda: FakeStore()
@@ -164,6 +168,34 @@ class TestHonestEmpty:
         fake_sources.imessages = [(_days_ago(5), "hello")]
         out = _tool_get_message_history({"entity_id": ENTITY, "search_term": "zzqqx"})
         assert "without search_term" in out
+
+
+class TestAmbiguousResolution:
+    """resolve_entity_id_confidence's second element (#346): when
+    entity_resolver reports `fuzzy_ambiguous` (two-plus candidates scored close
+    enough together that the top pick isn't reliably right), the tool must say
+    so rather than silently returning what may be the wrong person's messages.
+    """
+
+    def test_ambiguous_match_is_disclosed_alongside_results(self, fake_sources):
+        fake_sources.ambiguous = True
+        fake_sources.imessages = [(_days_ago(3), "hello")]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "matched more than one person" in out
+
+    def test_confident_match_carries_no_ambiguity_note(self, fake_sources):
+        fake_sources.ambiguous = False
+        fake_sources.imessages = [(_days_ago(3), "hello")]
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "matched more than one person" not in out
+
+    def test_ambiguous_match_is_disclosed_even_on_empty_result(self, fake_sources):
+        """An ambiguous resolution with zero messages is still worth flagging —
+        the wrong person may simply have no history, which reads as innocuous
+        without the note."""
+        fake_sources.ambiguous = True
+        out = _tool_get_message_history({"entity_id": ENTITY})
+        assert "matched more than one person" in out
 
 
 class TestBudget:

--- a/tests/test_google_auth_failure_attribution.py
+++ b/tests/test_google_auth_failure_attribution.py
@@ -1,0 +1,302 @@
+"""
+Tests for Google credential-refresh failure attribution (#540).
+
+Regression context: a DNS failure reaching oauth2.googleapis.com during a
+routine token refresh was caught by a bare `except Exception`, logged as
+"Token refresh failed (may be revoked)", and then reported to a headless
+operator as an expired/revoked token that needed an interactive re-auth run.
+The token was valid the whole time — the network was down. This is the
+top-line error on a sync job that fails most nights, so it's the first thing
+an operator reads, and it pointed at the wrong fix (and would have cost an
+interactive browser session on a headless box for nothing).
+
+These tests pin the fix: a transport/DNS failure during refresh must be
+reported as a connectivity problem (token untested, no re-auth suggested); a
+genuine rejection by the identity provider must still say re-auth is needed
+and name the script; an unrecognised failure must say the refresh failed
+without asserting the token is invalid. The valid-credential path must be
+unchanged, and no raw exception text (which can carry tokens) may reach the
+raised message.
+"""
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.auth import exceptions as google_auth_exceptions
+
+from api.services.google_auth import (
+    GoogleAccount,
+    GoogleAuthService,
+    _classify_refresh_failure,
+    _headless_auth_failure_message,
+    _REFRESH_FAIL_CONNECTIVITY,
+    _REFRESH_FAIL_REJECTED,
+    _REFRESH_FAIL_UNKNOWN,
+)
+
+pytestmark = pytest.mark.unit
+
+# A synthetic refresh-token-shaped string. If this ever showed up in a raised
+# message it would mean raw exception text leaked into operator-facing output.
+_SYNTHETIC_SECRET = "1//synthetic-refresh-token-should-never-leak"
+
+
+@pytest.fixture
+def temp_config_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def credentials_file(temp_config_dir):
+    """A synthetic OAuth client-secret file — never a real credential."""
+    creds = {
+        "installed": {
+            "client_id": "synthetic-test.apps.googleusercontent.com",
+            "client_secret": "synthetic-secret",
+            "redirect_uris": ["http://localhost"],
+        }
+    }
+    path = temp_config_dir / "credentials-personal.json"
+    path.write_text(json.dumps(creds))
+    return path
+
+
+def _service(credentials_file, temp_config_dir, account=GoogleAccount.PERSONAL):
+    """Build a service whose token file exists — get_credentials() only loads
+    (and potentially refreshes) a token when `token_path.exists()`, so an
+    absent file would skip the refresh attempt these tests exist to cover.
+    The content is never actually parsed: `Credentials` itself is mocked.
+    """
+    token_path = temp_config_dir / f"token-{account.value}.json"
+    token_path.write_text(json.dumps({"token": "synthetic-placeholder"}))
+    return GoogleAuthService(
+        credentials_path=str(credentials_file),
+        token_path=str(token_path),
+        account_type=account,
+    )
+
+
+def _expired_creds(refresh_side_effect):
+    """Stand-in for an expired-but-refreshable Credentials object."""
+    creds = MagicMock()
+    creds.valid = False
+    creds.expired = True
+    creds.refresh_token = _SYNTHETIC_SECRET
+    creds.refresh.side_effect = refresh_side_effect
+    return creds
+
+
+class TestClassifyRefreshFailure:
+    """The classifier reads only the exception's type, never its text."""
+
+    def test_transport_error_is_connectivity(self):
+        exc = google_auth_exceptions.TransportError(_SYNTHETIC_SECRET)
+        assert _classify_refresh_failure(exc) == _REFRESH_FAIL_CONNECTIVITY
+
+    def test_transport_error_wrapping_dns_failure_is_connectivity(self):
+        """A name-resolution failure never reaches Google. google-auth wraps every
+        requests.exceptions.RequestException — a DNS-caused ConnectionError
+        included — into the same TransportError type, so it lands in the same
+        connectivity bucket as a plain connection-refused or timeout."""
+        dns_cause = ConnectionError(
+            "Synthetic NameResolutionError: nodename nor servname provided"
+        )
+        exc = google_auth_exceptions.TransportError(dns_cause)
+        assert _classify_refresh_failure(exc) == _REFRESH_FAIL_CONNECTIVITY
+
+    def test_refresh_error_is_rejected(self):
+        """RefreshError is what the token endpoint itself raises on a non-200
+        response — a genuine rejection, not a network problem."""
+        exc = google_auth_exceptions.RefreshError(
+            "invalid_grant: Token has been expired or revoked."
+        )
+        assert _classify_refresh_failure(exc) == _REFRESH_FAIL_REJECTED
+
+    def test_unrecognised_exception_is_unknown(self):
+        assert (
+            _classify_refresh_failure(ValueError("synthetic odd failure"))
+            == _REFRESH_FAIL_UNKNOWN
+        )
+
+
+class TestHeadlessFailureMessage:
+    """The raised message names a cause and a remedy per category, never raw
+    exception text, and always names the account."""
+
+    def test_connectivity_names_account_and_does_not_suggest_reauth(self):
+        msg = _headless_auth_failure_message("personal", _REFRESH_FAIL_CONNECTIVITY)
+        assert "personal" in msg
+        assert "authenticate_google.py" not in msg
+        assert "expired" not in msg.lower()
+        assert "revoked" not in msg.lower()
+
+    def test_rejected_names_account_and_the_script(self):
+        msg = _headless_auth_failure_message("work", _REFRESH_FAIL_REJECTED)
+        assert "work" in msg
+        assert "authenticate_google.py" in msg
+
+    def test_unknown_does_not_assert_invalid_and_names_no_script(self):
+        msg = _headless_auth_failure_message("work2", _REFRESH_FAIL_UNKNOWN)
+        assert "work2" in msg
+        assert "expired" not in msg.lower()
+        assert "revoked" not in msg.lower()
+        assert "authenticate_google.py" not in msg
+
+    def test_no_refresh_attempted_keeps_original_wording(self):
+        """None means no refresh was attempted at all (no token, or an expired
+        token with no refresh_token) — a different situation than a refresh
+        that ran and failed, so it keeps the pre-existing remedy."""
+        msg = _headless_auth_failure_message("personal", None)
+        assert "personal" in msg
+        assert "authenticate_google.py" in msg
+
+
+class TestGetCredentialsHeadlessAttribution:
+    """End-to-end through GoogleAuthService.get_credentials() in a headless
+    context, for each failure class in turn."""
+
+    def _run(self, credentials_file, temp_config_dir, refresh_exc, account=GoogleAccount.PERSONAL, monkeypatch=None):
+        service = _service(credentials_file, temp_config_dir, account)
+        monkeypatch.setenv("LIFEOS_HEADLESS", "true")
+        with patch("api.services.google_auth.Credentials") as mock_creds_class:
+            mock_creds_class.from_authorized_user_file.return_value = _expired_creds(refresh_exc)
+            with pytest.raises(RuntimeError) as exc_info:
+                service.get_credentials()
+        return str(exc_info.value)
+
+    def test_dns_failure_reports_connectivity_not_revocation(
+        self, credentials_file, temp_config_dir, monkeypatch
+    ):
+        dns_cause = ConnectionError("Synthetic NameResolutionError for oauth2.googleapis.com")
+        exc = google_auth_exceptions.TransportError(dns_cause)
+        msg = self._run(credentials_file, temp_config_dir, exc, monkeypatch=monkeypatch)
+
+        assert "personal" in msg
+        assert "expired" not in msg.lower()
+        assert "revoked" not in msg.lower()
+        assert "authenticate_google.py" not in msg
+        assert _SYNTHETIC_SECRET not in msg
+
+    def test_generic_transport_failure_reports_connectivity(
+        self, credentials_file, temp_config_dir, monkeypatch
+    ):
+        """A plain connection-refused/timeout — not DNS-specific — lands in the
+        same connectivity bucket with the same remedy."""
+        exc = google_auth_exceptions.TransportError("Synthetic connection timed out")
+        msg = self._run(credentials_file, temp_config_dir, exc, monkeypatch=monkeypatch)
+
+        assert "personal" in msg
+        assert "expired" not in msg.lower()
+        assert "revoked" not in msg.lower()
+        assert "authenticate_google.py" not in msg
+
+    def test_provider_rejection_reports_reauth(
+        self, credentials_file, temp_config_dir, monkeypatch
+    ):
+        exc = google_auth_exceptions.RefreshError(
+            "invalid_grant: Token has been expired or revoked."
+        )
+        msg = self._run(
+            credentials_file, temp_config_dir, exc,
+            account=GoogleAccount.WORK, monkeypatch=monkeypatch,
+        )
+
+        assert "work" in msg
+        assert "authenticate_google.py" in msg
+        assert _SYNTHETIC_SECRET not in msg
+
+    def test_unexpected_failure_does_not_assert_revocation(
+        self, credentials_file, temp_config_dir, monkeypatch
+    ):
+        exc = ValueError("synthetic unrecognised failure")
+        msg = self._run(credentials_file, temp_config_dir, exc, monkeypatch=monkeypatch)
+
+        assert "personal" in msg
+        assert "expired" not in msg.lower()
+        assert "revoked" not in msg.lower()
+        assert _SYNTHETIC_SECRET not in msg
+
+    def test_account_name_distinguishes_a_two_account_setup(
+        self, credentials_file, temp_config_dir, monkeypatch
+    ):
+        """The account must appear in every message so a two-account setup
+        identifies which one failed."""
+        exc = google_auth_exceptions.TransportError("Synthetic DNS failure")
+        personal_msg = self._run(credentials_file, temp_config_dir, exc, monkeypatch=monkeypatch)
+
+        work_creds_file = temp_config_dir / "credentials-work.json"
+        work_creds_file.write_text(credentials_file.read_text())
+        work_msg = self._run(
+            work_creds_file, temp_config_dir, exc,
+            account=GoogleAccount.WORK, monkeypatch=monkeypatch,
+        )
+
+        assert "personal" in personal_msg and "work account" not in personal_msg
+        assert "work account" in work_msg
+
+
+class TestValidCredentialPathUnchanged:
+    """A valid, unexpired token must be returned untouched — no classification,
+    no logging about refresh failures, no exception raised."""
+
+    def test_valid_credentials_returned_without_refresh_attempt(
+        self, credentials_file, temp_config_dir
+    ):
+        service = _service(credentials_file, temp_config_dir)
+
+        with patch("api.services.google_auth.Credentials") as mock_creds_class:
+            mock_creds = MagicMock()
+            mock_creds.valid = True
+            mock_creds.expired = False
+            mock_creds_class.from_authorized_user_file.return_value = mock_creds
+
+            result = service.get_credentials()
+
+        assert result is mock_creds
+        mock_creds.refresh.assert_not_called()
+
+    def test_valid_credentials_returned_even_when_headless(
+        self, credentials_file, temp_config_dir, monkeypatch
+    ):
+        monkeypatch.setenv("LIFEOS_HEADLESS", "true")
+        service = _service(credentials_file, temp_config_dir)
+
+        with patch("api.services.google_auth.Credentials") as mock_creds_class:
+            mock_creds = MagicMock()
+            mock_creds.valid = True
+            mock_creds.expired = False
+            mock_creds_class.from_authorized_user_file.return_value = mock_creds
+
+            result = service.get_credentials()
+
+        assert result is mock_creds
+
+    def test_successful_refresh_returns_credentials_without_raising(
+        self, credentials_file, temp_config_dir, monkeypatch
+    ):
+        """A refresh that succeeds outright must behave exactly as before —
+        including in a headless context, since success never reaches the
+        classifier."""
+        monkeypatch.setenv("LIFEOS_HEADLESS", "true")
+        service = _service(credentials_file, temp_config_dir)
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.expired = True
+        mock_creds.refresh_token = _SYNTHETIC_SECRET
+        mock_creds.to_json.return_value = json.dumps({"token": "synthetic-refreshed-token"})
+
+        def _refresh(request):
+            mock_creds.valid = True
+
+        mock_creds.refresh.side_effect = _refresh
+
+        with patch("api.services.google_auth.Credentials") as mock_creds_class:
+            mock_creds_class.from_authorized_user_file.return_value = mock_creds
+            result = service.get_credentials()
+
+        assert result is mock_creds
+        mock_creds.refresh.assert_called_once()

--- a/tests/test_google_auth_failure_attribution.py
+++ b/tests/test_google_auth_failure_attribution.py
@@ -121,6 +121,25 @@ class TestClassifyRefreshFailure:
             == _REFRESH_FAIL_UNKNOWN
         )
 
+    def test_refresh_error_with_a_chained_transport_cause_is_still_rejected(self):
+        """Documents, rather than guards against, a scenario verified not to
+        occur in the installed google-auth (2.48.0): every RefreshError raise
+        site in google.oauth2._client originates from parsing the token
+        endpoint's response body, never from catching a transport exception,
+        so a network failure cannot surface disguised as a RefreshError. This
+        pins what the classifier does today if that ever changed upstream —
+        isinstance(TransportError) is checked first, but a RefreshError is not
+        a TransportError subclass, so a __cause__ chain is never consulted and
+        the exception classifies by its own type regardless of what caused
+        it."""
+        exc = google_auth_exceptions.RefreshError("invalid_grant")
+        try:
+            raise google_auth_exceptions.TransportError("synthetic transport failure")
+        except google_auth_exceptions.TransportError as transport_exc:
+            exc.__cause__ = transport_exc
+
+        assert _classify_refresh_failure(exc) == _REFRESH_FAIL_REJECTED
+
 
 class TestHeadlessFailureMessage:
     """The raised message names a cause and a remedy per category, never raw
@@ -236,6 +255,59 @@ class TestGetCredentialsHeadlessAttribution:
 
         assert "personal" in personal_msg and "work account" not in personal_msg
         assert "work account" in work_msg
+
+
+class TestLogLinesDoNotLeakExceptionText:
+    """The refresh-failure log lines must never interpolate str(e) — an OAuth
+    refresh exception is precisely where a token or response payload can
+    appear, and log_redaction.py only filters `bot\\d+:...` patterns (the
+    Telegram-token leak it was built for), not an arbitrary OAuth payload.
+    The classification and the exception's type name are the diagnostic
+    signal; the payload never was.
+    """
+
+    def _run_and_capture(self, credentials_file, temp_config_dir, refresh_exc, caplog, monkeypatch):
+        service = _service(credentials_file, temp_config_dir)
+        monkeypatch.setenv("LIFEOS_HEADLESS", "true")
+        with patch("api.services.google_auth.Credentials") as mock_creds_class:
+            mock_creds_class.from_authorized_user_file.return_value = _expired_creds(refresh_exc)
+            with caplog.at_level("WARNING", logger="api.services.google_auth"):
+                with pytest.raises(RuntimeError):
+                    service.get_credentials()
+        return caplog.records
+
+    def test_connectivity_failure_log_omits_exception_text(
+        self, credentials_file, temp_config_dir, monkeypatch, caplog
+    ):
+        exc = google_auth_exceptions.TransportError(_SYNTHETIC_SECRET)
+        records = self._run_and_capture(credentials_file, temp_config_dir, exc, caplog, monkeypatch)
+        joined = "\n".join(r.getMessage() for r in records)
+
+        assert _SYNTHETIC_SECRET not in joined
+        assert "TransportError" in joined
+        assert all(r.exc_info is None for r in records)
+
+    def test_rejected_failure_log_omits_exception_text(
+        self, credentials_file, temp_config_dir, monkeypatch, caplog
+    ):
+        exc = google_auth_exceptions.RefreshError(_SYNTHETIC_SECRET)
+        records = self._run_and_capture(credentials_file, temp_config_dir, exc, caplog, monkeypatch)
+        joined = "\n".join(r.getMessage() for r in records)
+
+        assert _SYNTHETIC_SECRET not in joined
+        assert "RefreshError" in joined
+        assert all(r.exc_info is None for r in records)
+
+    def test_unknown_failure_log_omits_exception_text(
+        self, credentials_file, temp_config_dir, monkeypatch, caplog
+    ):
+        exc = ValueError(_SYNTHETIC_SECRET)
+        records = self._run_and_capture(credentials_file, temp_config_dir, exc, caplog, monkeypatch)
+        joined = "\n".join(r.getMessage() for r in records)
+
+        assert _SYNTHETIC_SECRET not in joined
+        assert "ValueError" in joined
+        assert all(r.exc_info is None for r in records)
 
 
 class TestValidCredentialPathUnchanged:

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -359,6 +359,31 @@ class TestResolveEntityId:
         assert resolve_entity_id("robin-doe") == self.ENTITY_ID
 
 
+class TestResolveEntityIdMalformedInput:
+    """entity_id is filled in by an LLM tool call, so None, non-string types,
+    and empty/whitespace strings all arrive in practice. Before the guard,
+    `uuid.UUID(None)` raised TypeError and `uuid.UUID(123)`/`uuid.UUID([])`/
+    `uuid.UUID({})` raised AttributeError (no `.replace()`) — neither is the
+    ValueError this function otherwise treats as "not a UUID, try the
+    resolver" — so the tool crashed instead of returning its normal
+    could-not-resolve response.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_entity_id", [None, 123, [], {}, "", "   "],
+    )
+    def test_malformed_entity_id_does_not_raise(self, bad_entity_id, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "api.services.entity_resolver.get_entity_resolver",
+            lambda: calls.append(True),
+        )
+        assert resolve_entity_id_confidence(bad_entity_id) == (None, False)
+        assert resolve_entity_id(bad_entity_id) is None
+        # None of these should even reach the resolver.
+        assert calls == []
+
+
 class TestIMessageRecord:
     """Tests for IMessageRecord dataclass."""
 

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -5,6 +5,7 @@ import pytest
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 from api.services.imessage import (
     IMessageStore,
@@ -12,6 +13,8 @@ from api.services.imessage import (
     apple_timestamp_to_datetime,
     datetime_to_apple_timestamp,
     extract_text_from_attributed_body,
+    resolve_entity_id,
+    resolve_entity_id_confidence,
 )
 
 
@@ -255,6 +258,105 @@ class TestQueryMessagesDateFilters:
             entity_id="entity-date", start_date="not-a-date"
         )
         assert len(msgs) == 4
+
+
+class TestResolveEntityId:
+    """resolve_entity_id / resolve_entity_id_confidence (#346).
+
+    imessage.py used to define resolve_entity_id twice: a people_aggregator-
+    based version and an entity_resolver-based version that silently shadowed
+    it (the second definition wins in Python). These tests pin the surviving,
+    entity_resolver-based behavior, and the confidence signal it now surfaces
+    separately — a bare id can't tell a confident match from an ambiguous one.
+    """
+
+    ENTITY_ID = "11111111-2222-3333-4444-555555555555"
+
+    def test_valid_uuid_passes_through_without_resolving(self, monkeypatch):
+        """A UUID never needs the resolver — hitting it would be wasted work
+        and, if the resolver were ever wrong, could substitute an unrelated
+        person for an id that was already correct."""
+        calls = []
+        monkeypatch.setattr(
+            "api.services.entity_resolver.get_entity_resolver",
+            lambda: calls.append(True),
+        )
+        assert resolve_entity_id(self.ENTITY_ID) == self.ENTITY_ID
+        assert calls == []
+
+    def test_valid_uuid_confidence_is_never_ambiguous(self):
+        resolved_id, ambiguous = resolve_entity_id_confidence(self.ENTITY_ID)
+        assert resolved_id == self.ENTITY_ID
+        assert ambiguous is False
+
+    def test_name_slug_resolves_via_entity_resolver(self, monkeypatch):
+        result = SimpleNamespace(
+            entity=SimpleNamespace(id=self.ENTITY_ID), match_type="name_exact"
+        )
+        monkeypatch.setattr(
+            "api.services.entity_resolver.get_entity_resolver",
+            lambda: SimpleNamespace(resolve=lambda **kw: result),
+        )
+        assert resolve_entity_id("robin-doe") == self.ENTITY_ID
+
+    def test_name_slug_converts_hyphens_to_spaces(self, monkeypatch):
+        seen = {}
+
+        def fake_resolve(**kwargs):
+            seen.update(kwargs)
+            return SimpleNamespace(
+                entity=SimpleNamespace(id=self.ENTITY_ID), match_type="name_exact"
+            )
+
+        monkeypatch.setattr(
+            "api.services.entity_resolver.get_entity_resolver",
+            lambda: SimpleNamespace(resolve=fake_resolve),
+        )
+        resolve_entity_id("robin-alex-doe")
+        assert seen["name"] == "robin alex doe"
+
+    def test_no_match_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            "api.services.entity_resolver.get_entity_resolver",
+            lambda: SimpleNamespace(resolve=lambda **kw: None),
+        )
+        assert resolve_entity_id("nobody-here") is None
+        assert resolve_entity_id_confidence("nobody-here") == (None, False)
+
+    def test_confident_exact_match_is_not_ambiguous(self, monkeypatch):
+        result = SimpleNamespace(
+            entity=SimpleNamespace(id=self.ENTITY_ID), match_type="name_exact"
+        )
+        monkeypatch.setattr(
+            "api.services.entity_resolver.get_entity_resolver",
+            lambda: SimpleNamespace(resolve=lambda **kw: result),
+        )
+        resolved_id, ambiguous = resolve_entity_id_confidence("robin-doe")
+        assert resolved_id == self.ENTITY_ID
+        assert ambiguous is False
+
+    def test_fuzzy_ambiguous_match_is_flagged(self, monkeypatch):
+        """entity_resolver.resolve() can return match_type='fuzzy_ambiguous'
+        (confidence reduced to 0.7) when two candidates scored too close to
+        call. resolve_entity_id() discards this entirely — making an uncertain
+        match indistinguishable from an exact one — so callers whose output
+        can expose the wrong person's data must use the confidence variant."""
+        result = SimpleNamespace(
+            entity=SimpleNamespace(id=self.ENTITY_ID),
+            match_type="fuzzy_ambiguous",
+            confidence=0.7,
+            disambiguation_applied=True,
+        )
+        monkeypatch.setattr(
+            "api.services.entity_resolver.get_entity_resolver",
+            lambda: SimpleNamespace(resolve=lambda **kw: result),
+        )
+        resolved_id, ambiguous = resolve_entity_id_confidence("robin-doe")
+        assert resolved_id == self.ENTITY_ID
+        assert ambiguous is True
+        # resolve_entity_id() still returns just the id for callers that don't
+        # need the confidence signal.
+        assert resolve_entity_id("robin-doe") == self.ENTITY_ID
 
 
 class TestIMessageRecord:


### PR DESCRIPTION
Closes #540, closes #346.

Two instances of the same defect: code that names a cause, or resolves an identity, more confidently than the evidence supports.

## #540 — a network outage reported as a revoked token

A DNS failure reaching `oauth2.googleapis.com` was caught by a bare `except Exception`, then reported as *"token is expired/revoked — run interactively."* The token was fine; the network was down. This was the **top-line error on a nightly job failing roughly two nights in three**, so it was the first thing read when email stopped syncing, and it sent the operator to repair working credentials on a headless box.

Failures are now classified **by exception type, never text** — exception text can carry tokens. `google.auth` `TransportError` → connectivity, `RefreshError` → provider rejection, anything else → unknown. Each names only the remedy its category establishes:

> **connectivity:** "…this looks like a network or DNS problem, not a credentials problem. The token itself is untested, not known to be invalid. Re-authenticating will not help; retry once connectivity is restored."

The no-token and no-refresh-token paths keep their original wording — a different situation, not this misattribution.

**One question worth recording:** could `google-auth` raise `RefreshError` wrapping a chained `TransportError`? The classifier ignores `__cause__`, so if so, a network failure would be called a provider rejection — the original bug via a narrower path. Traced every `RefreshError` raise site in the installed 2.48.0: all originate from parsing the token endpoint's *response*, and the transport call has no surrounding try/except, so a transport failure can only surface as a bare `TransportError`. Recorded in a docstring with a pinning test in case that changes upstream.

## #346 — a duplicate definition, and a discarded confidence signal

`imessage.py` defined `resolve_entity_id` twice, the second shadowing the first with a `# noqa: F811` admitting it. The dead one (people_aggregator-based) is removed; the live one (entity_resolver-based) is kept, since it is what every real caller already ran.

The more interesting half: `entity_resolver.resolve` can return `match_type="fuzzy_ambiguous"` with confidence cut to 0.7 — and that signal was being thrown away. This function decides **whose private messages a chat query returns**, so an uncertain fuzzy match was indistinguishable from an exact one.

`resolve_entity_id_confidence()` now returns `(id, ambiguous)`. On an ambiguous match the message-history tool **does not query at all** — it names the ambiguous term and redirects to `person_info`. An earlier version returned the messages with a warning appended, which is not sufficient: by the time the warning is read the content is already in context and can be relayed against the wrong name. Refusing costs the caller one extra call; the tool's contract already expects a UUID from `person_info`.

Scoped as a latent gap, not an observed bug — the ambiguity path exists in the resolver but was not demonstrated firing in practice. `MIN_MATCH_SCORE` and the resolver's own logic are untouched.

## Defects found in review

Three from the adversarial pass, all verified before acting:

- **An ambiguous match still returned the messages** (privacy) — now refuses, as above.
- **The new log lines interpolated the exception** (privacy). Precedented here specifically: this repo leaked Telegram bot tokens into logs at roughly 93,800 occurrences before it was caught, and the redaction filter added afterward only matches `bot\d+:` — an OAuth payload would pass straight through. Now logs the classified kind and `type(e).__name__`, never `str(e)`.
- **Non-string `entity_id` crashed** — `None` raised `TypeError`, `123`/`[]`/`{}` raised `AttributeError`, only `ValueError` was caught. These come from an LLM, so all four arrive.

## A latent hole in existing tests

`tests/test_agent_tools_message_history.py`'s fixture patched `resolve_entity_id`, and its `ENTITY` constant is a valid UUID — so resolution **short-circuited before the mock ever mattered**. Those tests passed by coincidence rather than because the fake worked, meaning the resolution path was never actually exercised. Fixed and pinned.

## Verification

- 81 tests across the affected files; **4089 passing** in the full suite.
- 5 remaining failures are the known baseline, unchanged from before this branch.
- Entity resolution verified against the real 641MB CRM, not a worktree copy: a name slug resolves to the right UUID, an unknown one returns `(None, False)`.
- Confirmed `get_message_history` still returns the message that started this whole line of work, since this branch changes the resolution path feeding it.
- Verified no exception payload reaches any log line or user-facing message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
