### PR TITLE
fix(sync): retry transient per-source failures instead of losing a day of freshness

### DIFF
--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -500,27 +500,43 @@ def record_sync_complete(
     interactions_created: int = 0,
     source_entities_created: int = 0,
     attempt_count: int = 1,
+    duration_seconds: Optional[float] = None,
 ):
     """Record completion of a sync operation.
 
     ``attempt_count`` is the total number of attempts the orchestrator made
     before reaching this final status (1 = no retry needed; >1 = one or more
     transient-failure retries happened first — see issue #541). One row per
-    logical run still gets one update: ``started_at`` is set once at the
-    first attempt, so ``duration_seconds`` naturally covers the whole retry
-    campaign (backoff sleeps included), not just the final attempt.
+    logical run still gets one update, keeping the row *count* history
+    detectors see unchanged by retries.
+
+    ``duration_seconds``, when given, is used verbatim instead of being
+    derived from ``started_at``. The retry loop passes the elapsed time of
+    only the attempt that produced this final outcome — not the earlier
+    failed attempts or the backoff sleeps between them — because
+    ``get_typical_duration_seconds``/``_detect_duration_collapse`` assume
+    this column means "how long a normal run takes". Deriving it from
+    ``started_at`` (set once, at the first attempt) would let a retried
+    run's failed-attempt-plus-backoff time inflate that baseline upward
+    every time a retry happens, making the collapse detector progressively
+    less sensitive given how often retries are expected to fire (issue #541
+    adversarial review). When omitted (e.g. a caller outside the retry
+    loop), duration still falls back to the ``started_at``-derived value.
     """
     conn = get_sync_health_db()
 
-    # Get start time to calculate duration
-    row = conn.execute(
-        "SELECT started_at FROM sync_runs WHERE id = ?", (run_id,)
-    ).fetchone()
+    if duration_seconds is not None:
+        duration = duration_seconds
+    else:
+        # Get start time to calculate duration
+        row = conn.execute(
+            "SELECT started_at FROM sync_runs WHERE id = ?", (run_id,)
+        ).fetchone()
 
-    duration = None
-    if row:
-        started = datetime.fromisoformat(row["started_at"].replace("Z", "+00:00"))
-        duration = (datetime.now(timezone.utc) - started).total_seconds()
+        duration = None
+        if row:
+            started = datetime.fromisoformat(row["started_at"].replace("Z", "+00:00"))
+            duration = (datetime.now(timezone.utc) - started).total_seconds()
 
     conn.execute(
         """

--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -380,6 +380,20 @@ def _init_schema(conn: sqlite3.Connection):
         migrations.append("ALTER TABLE sync_runs ADD COLUMN source_entities_created INTEGER DEFAULT 0")
     if "trigger_source" not in columns:
         migrations.append("ALTER TABLE sync_runs ADD COLUMN trigger_source TEXT DEFAULT 'unknown'")
+    if "attempt_count" not in columns:
+        # Issue #541: within-run retry for transient (connectivity/rate-limit)
+        # failures. 1 = succeeded or failed on the first try (no retry
+        # attempted); >1 = a retry was needed before the final status. This
+        # single column is enough to derive all three states the health
+        # record must distinguish: first-time success (status=success,
+        # attempt_count=1), success-after-retry (status=success,
+        # attempt_count>1), and gave-up (status=failed, attempt_count>1 means
+        # retries were exhausted; attempt_count=1 means the failure was
+        # classified non-transient and never retried).
+        # DEFAULT 1 makes every pre-existing row (from before this column
+        # existed) read as "no retry" rather than NULL, so historical rows
+        # stay queryable without special-casing NULL everywhere.
+        migrations.append("ALTER TABLE sync_runs ADD COLUMN attempt_count INTEGER DEFAULT 1")
 
     for sql in migrations:
         conn.execute(sql)
@@ -485,8 +499,17 @@ def record_sync_complete(
     people_updated: int = 0,
     interactions_created: int = 0,
     source_entities_created: int = 0,
+    attempt_count: int = 1,
 ):
-    """Record completion of a sync operation."""
+    """Record completion of a sync operation.
+
+    ``attempt_count`` is the total number of attempts the orchestrator made
+    before reaching this final status (1 = no retry needed; >1 = one or more
+    transient-failure retries happened first — see issue #541). One row per
+    logical run still gets one update: ``started_at`` is set once at the
+    first attempt, so ``duration_seconds`` naturally covers the whole retry
+    campaign (backoff sleeps included), not just the final attempt.
+    """
     conn = get_sync_health_db()
 
     # Get start time to calculate duration
@@ -513,7 +536,8 @@ def record_sync_complete(
             people_created = ?,
             people_updated = ?,
             interactions_created = ?,
-            source_entities_created = ?
+            source_entities_created = ?,
+            attempt_count = ?
         WHERE id = ?
         """,
         (
@@ -529,6 +553,7 @@ def record_sync_complete(
             people_updated,
             interactions_created,
             source_entities_created,
+            attempt_count,
             run_id,
         )
     )

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -930,6 +930,45 @@ def _recently_warned_never_yielded(source: str, within_days: int = NEVER_YIELDED
 # though it had failed), and lets one attempt campaign share a single
 # sync_runs row — so the retry doesn't skew the duration/yield history that
 # other detectors (#438, #494) rely on by counting one logical run twice.
+#
+# Idempotence: a retry re-runs a source's script from scratch, so a script
+# that fails partway through (after writing some data) and then retries must
+# not duplicate what it already wrote. This is not a new risk introduced
+# here — the nightly sync already re-runs every script over overlapping
+# windows every night, so a genuinely non-idempotent source would already be
+# duplicating data on every ordinary night. A retry just does the same thing
+# sooner. Verified per write path (not assumed):
+#   - Sources writing through InteractionStore (most Phase 1/2 sources):
+#     `UNIQUE INDEX idx_interactions_source_unique ON interactions(source_type,
+#     source_id)` plus `INSERT OR IGNORE`/`ON CONFLICT ... DO UPDATE` in
+#     interaction_store.py make a repeat write a no-op or a plain overwrite,
+#     never a duplicate row.
+#   - photos (sync_photos.py -> ApplePhotosSync): explicitly checks
+#     `source_store.get_by_source(...)` before creating a SourceEntity, on
+#     top of the InteractionStore guarantee above.
+#   - monarch_money: `write_monthly_report` does a single `file_path
+#     .write_text(content, ...)` — a full overwrite of a fixed-name file, not
+#     an append. Re-running regenerates and overwrites the same file.
+#   - google_docs / google_sheets: same full-overwrite `write_text` pattern
+#     (gdoc_sync.py) as monarch_money.
+#   - vault_reindex (IndexerService.index_all): explicitly designed to
+#     survive a crash mid-run — progress is saved to a state file every 10
+#     files, and both writes it makes per file are delete-then-add, not
+#     append: `VectorStore.update_document` deletes existing chunks for that
+#     file_path before adding new ones, and `BM25Index.delete_by_path` runs
+#     before re-adding. Re-indexing the same file twice (which already
+#     happens on ordinary incremental runs) is a no-op in effect.
+#   - crm_vectorstore (person_indexer.index_person_to_vectorstore): same
+#     delete-then-add pattern, keyed by `person:{person.id}`.
+#   - push_birthdays_to_contacts: sets a single Apple Contacts field
+#     (`setBirthday_`) to an exact value — setting it twice is the same as
+#     setting it once, not an append.
+# No source examined writes by unconditional append or by an external side
+# effect (e.g. sending a message, charging something) that would make a
+# repeat attempt unsafe. Per-source retry-eligibility metadata is therefore
+# not needed — if a genuinely non-idempotent source turns up later, exclude
+# it explicitly rather than adding a configuration surface for a
+# hypothetical.
 MAX_SYNC_RETRIES = 2  # up to 3 attempts total per source
 RETRY_BACKOFF_SECONDS = [30, 120]  # wait before attempt 2, then before attempt 3
 
@@ -953,7 +992,12 @@ _TRANSIENT_ERROR_PATTERNS = [
     r"nodename nor servname provided",
     r"NameResolutionError",
     r"gaierror",
-    r"Failed to resolve",
+    # Requires the quote urllib3 always emits right after this phrase
+    # ("Failed to resolve 'host.name' (...)") — bare "Failed to resolve"
+    # would also match this codebase's *entity*-resolution vocabulary
+    # (e.g. "Failed to resolve duplicate entity for source_id=..."), which
+    # is a real bug, not a network blip.
+    r"Failed to resolve ['\"]",
     r"Failed to establish a new connection",
     r"Connection refused",
     r"Connection reset by peer",
@@ -965,10 +1009,16 @@ _TRANSIENT_ERROR_PATTERNS = [
     r"\bECONNRESET\b",
     r"ConnectTimeout",
     r"ReadTimeout",
-    r"rate.?limit",
+    # Negative lookahead excludes "RateLimiter" (a class name several HTTP
+    # clients use) so an unrelated bug like "'RateLimiter' object has no
+    # attribute 'foo'" doesn't get misread as an actual rate-limit response.
+    r"rate.?limit(?!er)",
     r"ratelimited",
     r"Too Many Requests",
-    r"\b429\b",
+    # Bare "429" collides with line numbers, byte counts, and message ids in
+    # an unrelated traceback — require status-code context on one side.
+    r"(?:HTTP|status|response|code)[^\n]{0,40}\b429\b",
+    r"\b429\b[^\n]{0,40}(?:Too Many Requests|rate.?limit)",
     r"503 Service Unavailable",
 ]
 _TRANSIENT_ERROR_RE = re.compile("|".join(_TRANSIENT_ERROR_PATTERNS), re.IGNORECASE)
@@ -1151,8 +1201,17 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
         logger.info(f"Starting sync for {source}...")
 
         for attempt in range(1, max_attempts + 1):
-            sync_started_monotonic = time.monotonic()
+            # Per-attempt clock, not per-campaign: `duration_seconds` passed
+            # to record_sync_complete below must reflect only the attempt
+            # that produced the final outcome. If it instead spanned from
+            # the very first attempt (started_at), a retried run would record
+            # failed-attempt time + backoff on top of the real execution
+            # time — inflating get_typical_duration_seconds's baseline and
+            # making _detect_duration_collapse progressively less sensitive
+            # every time a retry fires (issue #541 adversarial review).
+            attempt_started_monotonic = time.monotonic()
             outcome = _execute_sync_once(source, script_path, args, full_path)
+            attempt_elapsed_seconds = time.monotonic() - attempt_started_monotonic
 
             if outcome["success"]:
                 stats = outcome["stats"]
@@ -1160,7 +1219,7 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
                 # Check for duration collapse BEFORE recording completion, so
                 # the current run (still status=running) can't contaminate
                 # the history.
-                elapsed_seconds = time.monotonic() - sync_started_monotonic
+                elapsed_seconds = attempt_elapsed_seconds
                 collapse = _detect_duration_collapse(source, elapsed_seconds)
                 if collapse:
                     stats["duration_collapse"] = collapse
@@ -1214,7 +1273,12 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
                     stats["skipped"] = True
                     stats["skipped_reason"] = skipped_reason
                     logger.info(f"Sync skipped for {source}: {skipped_reason}")
-                    record_sync_complete(run_id, SyncStatus.SKIPPED, attempt_count=attempt)
+                    record_sync_complete(
+                        run_id,
+                        SyncStatus.SKIPPED,
+                        attempt_count=attempt,
+                        duration_seconds=attempt_elapsed_seconds,
+                    )
                     _active_run_id = None
                     return True, stats
 
@@ -1233,6 +1297,7 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
                     interactions_created=stats.get("interactions_created", 0),
                     source_entities_created=stats.get("source_entities_created", 0),
                     attempt_count=attempt,
+                    duration_seconds=attempt_elapsed_seconds,
                 )
                 _active_run_id = None
                 return True, stats
@@ -1278,6 +1343,7 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
                 interactions_created=stats.get("interactions_created", 0),
                 source_entities_created=stats.get("source_entities_created", 0),
                 attempt_count=attempt,
+                duration_seconds=attempt_elapsed_seconds,
             )
             _active_run_id = None
 

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -1034,6 +1034,38 @@ def _is_transient_failure(error_text: str | None) -> bool:
     return bool(_TRANSIENT_ERROR_RE.search(error_text))
 
 
+# Counter fields that get merged across a retry campaign (see
+# `_merge_campaign_stats` and its call sites in run_sync). If attempt 1 does
+# real work and then fails partway with a transient error, the sources are
+# idempotent (see the idempotence note above MAX_SYNC_RETRIES) so attempt 2
+# legitimately re-processes the same window and reports near-zero new
+# counters for rows attempt 1 already wrote. Recording only the final
+# attempt's numbers would under-report — or even zero out — a run that
+# actually did work, and `_detect_yield_collapse`/the consecutive-zero-run
+# streak read exactly these fields. Taking the max observed for each field
+# across every attempt in the campaign guarantees a success-after-retry
+# never reports less than the most any single attempt already achieved.
+# (Mirrors `_run_yield`'s own reasoning: these fields overlap by
+# construction, so max is the right merge — summing would double-count.)
+_MERGEABLE_STAT_FIELDS = (
+    "processed", "created", "updated", "errors",
+    "people_created", "people_updated",
+    "interactions_created", "source_entities_created",
+)
+
+
+def _merge_campaign_stats(campaign_stats: dict, attempt_stats: dict) -> None:
+    """Update ``campaign_stats`` in place with the elementwise max of each
+    mergeable field against ``attempt_stats``. Non-numeric/attempt-specific
+    keys (e.g. ``skipped_reason``, ``duration_collapse``) are untouched —
+    those describe the attempt that produced the final outcome, not the
+    campaign as a whole.
+    """
+    for field in _MERGEABLE_STAT_FIELDS:
+        if field in attempt_stats:
+            campaign_stats[field] = max(campaign_stats.get(field, 0), attempt_stats.get(field, 0) or 0)
+
+
 def _execute_sync_once(source: str, script_path: str, args: list, full_path: Path) -> dict:
     """Run exactly one subprocess attempt for ``source``.
 
@@ -1196,6 +1228,10 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
     signal.signal(signal.SIGTERM, _handle_sigterm)
 
     max_attempts = MAX_SYNC_RETRIES + 1
+    # Running max of each counter field across every attempt in this
+    # campaign — see `_merge_campaign_stats` for why this can't just be the
+    # last attempt's numbers.
+    campaign_stats: dict = {}
 
     try:
         logger.info(f"Starting sync for {source}...")
@@ -1213,8 +1249,13 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             outcome = _execute_sync_once(source, script_path, args, full_path)
             attempt_elapsed_seconds = time.monotonic() - attempt_started_monotonic
 
+            _merge_campaign_stats(campaign_stats, outcome["stats"])
+
             if outcome["success"]:
                 stats = outcome["stats"]
+                # Counter fields reflect the whole campaign's max, not just
+                # this attempt — see _merge_campaign_stats.
+                stats.update(campaign_stats)
 
                 # Check for duration collapse BEFORE recording completion, so
                 # the current run (still status=running) can't contaminate
@@ -1330,6 +1371,10 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
                 logger.error(f"{source}: giving up after {attempt} attempts")
 
             stats = outcome["stats"]
+            # Even on a terminal failure, an earlier attempt may have done
+            # real (idempotent) work before this one failed — don't let the
+            # last attempt's numbers erase that from the record.
+            stats.update(campaign_stats)
             record_sync_complete(
                 run_id,
                 SyncStatus.FAILED,
@@ -1357,6 +1402,52 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             log_error_to_markdown(source, outcome["markdown_message"], outcome["error_type"])
 
             return False, {"error": outcome["health_message"], **stats}
+
+    except Exception as e:
+        # `_execute_sync_once` already catches everything the subprocess
+        # attempt itself can raise (adversarial review finding #1: that
+        # helper's own try/except covers TimeoutExpired and Exception). This
+        # guards the orchestration *around* it instead — duration/yield
+        # detection, and the record_sync_error/record_sync_complete calls —
+        # since a locked sync_health.db (this host runs many agents against
+        # it concurrently) is a realistic way for one of those to raise.
+        # Before the retry refactor, `run_sync` had exactly this guard
+        # around its single subprocess call; losing it here would mean one
+        # source's DB hiccup takes down the entire nightly pipeline instead
+        # of just that source, since run_all_syncs has no exception guard of
+        # its own around each run_sync call.
+        error_msg = str(e)
+        tb = traceback.format_exc()
+        logger.error(f"Sync orchestration exception for {source}: {error_msg}")
+        logger.error(tb)
+
+        # Best-effort — the DB write is exactly what may be failing right
+        # now (mirrors the same pattern already used in _handle_sigterm).
+        try:
+            record_sync_complete(
+                run_id,
+                SyncStatus.FAILED,
+                errors=1,
+                error_message=error_msg[:500],
+            )
+        except Exception:
+            pass
+        _active_run_id = None
+        try:
+            record_sync_error(
+                source,
+                error_msg,
+                error_type=type(e).__name__,
+                stack_trace=tb,
+            )
+        except Exception:
+            pass
+        try:
+            log_error_to_markdown(source, f"{error_msg}\n\n{tb}", type(e).__name__)
+        except Exception:
+            pass
+
+        return False, {"error": error_msg}
 
     finally:
         _active_run_id = None

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -31,6 +31,7 @@ load_dotenv(Path(__file__).parent.parent / ".env", override=True)
 import argparse
 import json
 import logging
+import re
 import signal
 import subprocess
 import sys
@@ -903,50 +904,109 @@ def _recently_warned_never_yielded(source: str, within_days: int = NEVER_YIELDED
     return False
 
 
-def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
+# =============================================================================
+# Transient-failure retry (issue #541)
+# =============================================================================
+#
+# Mechanism chosen: a retry loop inside this orchestrator, around each
+# per-source subprocess invocation. Rejected alternatives:
+#
+#   - systemd Restart=/OnFailure on lifeos-sync.service: restarts the WHOLE
+#     run_all_syncs.py invocation, which would re-run sources that already
+#     succeeded tonight (explicitly out of scope per the issue: "Retrying the
+#     whole pipeline. A source that succeeded must not be re-run") and loses
+#     the in-memory `failed`/`dep_skipped` sets that the depends_on skip logic
+#     relies on, so a partial restart would have to re-derive that state from
+#     the DB — more moving parts for less precision.
+#   - A follow-up systemd timer some minutes later: same "whole pipeline"
+#     problem unless it's taught to run only the sources that failed, which
+#     means persisting failure state across a process boundary and adding a
+#     second scheduled unit — more infrastructure than a loop that already
+#     has that state in memory for free.
+#
+# A loop here keeps everything in one process, reuses the existing
+# depends_on skip logic untouched (that skip happens in run_all_syncs before
+# run_sync is ever called, so a dependency-skipped source is never retried as
+# though it had failed), and lets one attempt campaign share a single
+# sync_runs row — so the retry doesn't skew the duration/yield history that
+# other detectors (#438, #494) rely on by counting one logical run twice.
+MAX_SYNC_RETRIES = 2  # up to 3 attempts total per source
+RETRY_BACKOFF_SECONDS = [30, 120]  # wait before attempt 2, then before attempt 3
+
+# Conservative allowlist: only failures that plausibly clear on their own get
+# retried. Matched against the captured output (stdout+stderr, or whatever
+# partial output was flushed before a timeout kill) — not against a specific
+# library's error *wording*, since issue #540 (landing separately) is
+# changing what Gmail's current "expired/revoked" message actually means.
+# These patterns key on the underlying signature instead: the DNS-resolution
+# errno/exception names, generic connection-level failures, and rate-limit
+# responses, which are stable across that kind of wording churn. Anything
+# that doesn't match — bad config, auth/permission errors, unexpected
+# exceptions, a bare timeout with no matching signature in its partial
+# output — is treated as non-transient and is not retried; per the issue,
+# the default when unsure must be "don't retry" (retrying a failure that
+# reproduces identically burns the retry budget for nothing).
+_TRANSIENT_ERROR_PATTERNS = [
+    r"\[Errno -3\]",                        # getaddrinfo failure (glibc EAI_AGAIN)
+    r"Temporary failure in name resolution",
+    r"Name or service not known",
+    r"nodename nor servname provided",
+    r"NameResolutionError",
+    r"gaierror",
+    r"Failed to resolve",
+    r"Failed to establish a new connection",
+    r"Connection refused",
+    r"Connection reset by peer",
+    r"ConnectionResetError",
+    r"RemoteDisconnected",
+    r"Network is unreachable",
+    r"\bETIMEDOUT\b",
+    r"\bEHOSTUNREACH\b",
+    r"\bECONNRESET\b",
+    r"ConnectTimeout",
+    r"ReadTimeout",
+    r"rate.?limit",
+    r"ratelimited",
+    r"Too Many Requests",
+    r"\b429\b",
+    r"503 Service Unavailable",
+]
+_TRANSIENT_ERROR_RE = re.compile("|".join(_TRANSIENT_ERROR_PATTERNS), re.IGNORECASE)
+
+
+def _is_transient_failure(error_text: str | None) -> bool:
+    """True only when ``error_text`` carries a recognizable connectivity or
+    rate-limit signature. Conservative by construction: no match means "not
+    transient", which is the safe default whenever the cause is unclear.
     """
-    Run a single sync operation.
+    if not error_text:
+        return False
+    return bool(_TRANSIENT_ERROR_RE.search(error_text))
 
-    Returns:
-        Tuple of (success, stats_dict)
+
+def _execute_sync_once(source: str, script_path: str, args: list, full_path: Path) -> dict:
+    """Run exactly one subprocess attempt for ``source``.
+
+    Deliberately does none of the sync_health/markdown recording — the
+    retry loop in ``run_sync`` decides whether an attempt's failure is
+    terminal (and thus worth persisting) or retryable, so persistence has to
+    happen after that decision, not here.
+
+    Returns a dict with:
+        success: bool
+        stats: dict — parsed SYNC_STATS/regex-fallback stats (partial on failure)
+        error_type: str | None — "subprocess_error" | "timeout" | exception class name
+        health_message: str | None — goes to sync_runs.error_message (short)
+        log_message: str | None — goes to sync_errors.error_message
+        markdown_message: str | None — goes to the human-readable markdown log
+        classify_message: str | None — text the transient-failure classifier reads
+        stack_trace: str | None
+        context: str | None
     """
-    if source not in SYNC_SCRIPTS:
-        logger.warning(f"No script configured for source: {source}")
-        return False, {"error": f"No script for {source}"}
-
-    script_path, args = SYNC_SCRIPTS[source]
-    full_path = Path(__file__).parent.parent / script_path
-
-    if not full_path.exists():
-        logger.error(f"Script not found: {full_path}")
-        return False, {"error": f"Script not found: {script_path}"}
-
-    if dry_run:
-        logger.info(f"[DRY RUN] Would run: python {script_path} {' '.join(args)}")
-        return True, {"dry_run": True}
-
-    # Record sync start — track globally for SIGTERM cleanup.
-    # Mask SIGTERM briefly so a signal can't arrive between the DB insert
-    # and the global assignment, which would leave a stale RUNNING row.
-    global _active_run_id, _active_source
-    signal.signal(signal.SIGTERM, signal.SIG_IGN)
-    run_id = record_sync_start(source)
-    _active_run_id = run_id
-    _active_source = source
-    signal.signal(signal.SIGTERM, _handle_sigterm)
+    cmd = [sys.executable, str(full_path)] + args
+    timeout_seconds = SYNC_TIMEOUTS.get(source, DEFAULT_SYNC_TIMEOUT)
 
     try:
-        logger.info(f"Starting sync for {source}...")
-
-        # Build command - use the same Python that's running this script
-        # This ensures child scripts use the correct venv (e.g., ~/.venvs/lifeos)
-        cmd = [sys.executable, str(full_path)] + args
-
-        # Get per-source timeout (default 60 minutes)
-        timeout_seconds = SYNC_TIMEOUTS.get(source, DEFAULT_SYNC_TIMEOUT)
-
-        # Run subprocess
-        sync_started_monotonic = time.monotonic()
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -967,112 +1027,23 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
         if result.returncode != 0:
             error_msg = result.stderr or result.stdout or "Unknown error"
             logger.error(f"Sync failed for {source}: {error_msg}")
-
-            record_sync_complete(
-                run_id,
-                SyncStatus.FAILED,
-                records_processed=stats.get("processed", 0),
-                records_created=stats.get("created", 0),
-                records_updated=stats.get("updated", 0),
-                errors=1,
-                error_message=error_msg[:500],
-                people_created=stats.get("people_created", 0),
-                people_updated=stats.get("people_updated", 0),
-                interactions_created=stats.get("interactions_created", 0),
-                source_entities_created=stats.get("source_entities_created", 0),
-            )
-            _active_run_id = None
-
-            record_sync_error(
-                source,
-                error_msg[:1000],
-                error_type="subprocess_error",
-                context=f"Command: {' '.join(cmd)}"
-            )
-
-            # Log to markdown for visibility
-            log_error_to_markdown(source, error_msg, "subprocess_error")
-
-            return False, {"error": error_msg, **stats}
+            return {
+                "success": False,
+                "stats": stats,
+                "error_type": "subprocess_error",
+                "health_message": error_msg[:500],
+                "log_message": error_msg[:1000],
+                "markdown_message": error_msg,
+                "classify_message": error_msg,
+                "stack_trace": None,
+                "context": f"Command: {' '.join(cmd)}",
+            }
 
         logger.info(f"Sync completed for {source}: {stats}")
-
-        # Check for duration collapse BEFORE recording completion, so the
-        # current run (still status=running) can't contaminate the history.
-        elapsed_seconds = time.monotonic() - sync_started_monotonic
-        collapse = _detect_duration_collapse(source, elapsed_seconds)
-        if collapse:
-            stats["duration_collapse"] = collapse
-            msg = (
-                f"Duration collapse for {source}: completed in "
-                f"{collapse['elapsed_seconds']:.1f}s but typically takes "
-                f"{collapse['typical_seconds']:.0f}s — possible silent no-op "
-                f"(e.g. missing credentials)"
-            )
-            logger.error(msg)
-            record_sync_error(source, msg, error_type="duration_collapse")
-
-        # A source that exits early because it isn't configured must not count
-        # as a healthy success — that inflates the nightly "N/N green" summary.
-        skipped_reason = stats.pop("skipped_reason", None)
-
-        # Yield-based no-op detection (issue #494). Only meaningful when the
-        # source actually ran; a skipped source is expected to produce nothing.
-        if not skipped_reason:
-            yield_collapse = _detect_yield_collapse(source, stats)
-            if yield_collapse:
-                stats["yield_collapse"] = yield_collapse
-                msg = (
-                    f"Yield collapse for {source}: produced 0 records but "
-                    f"typically produces ~{yield_collapse['typical_yield']:.0f} "
-                    f"— possible silent no-op"
-                )
-                logger.error(msg)
-                record_sync_error(source, msg, error_type="yield_collapse")
-
-            never_yielded = _detect_never_yielded(source, stats)
-            if never_yielded:
-                stats["never_yielded"] = never_yielded
-                # Damped (#494 follow-up): only warn when the condition is
-                # newly true, or periodically — not every night for the same
-                # chronic sources.
-                if not _recently_warned_never_yielded(source):
-                    msg = (
-                        f"{source} has never produced records in "
-                        f"{never_yielded['runs']} runs (avg "
-                        f"{never_yielded['avg_duration_seconds']:.1f}s) — likely "
-                        f"dead or misconfigured"
-                    )
-                    logger.warning(msg)
-                    record_sync_error(source, msg, error_type="never_yielded")
-                    stats["never_yielded_warned"] = True
-
-        if skipped_reason:
-            stats["skipped"] = True
-            stats["skipped_reason"] = skipped_reason
-            logger.info(f"Sync skipped for {source}: {skipped_reason}")
-            record_sync_complete(run_id, SyncStatus.SKIPPED)
-            _active_run_id = None
-            return True, stats
-
-        record_sync_complete(
-            run_id,
-            SyncStatus.SUCCESS,
-            records_processed=stats.get("processed", 0),
-            records_created=stats.get("created", 0),
-            records_updated=stats.get("updated", 0),
-            errors=stats.get("errors", 0),
-            people_created=stats.get("people_created", 0),
-            people_updated=stats.get("people_updated", 0),
-            interactions_created=stats.get("interactions_created", 0),
-            source_entities_created=stats.get("source_entities_created", 0),
-        )
-        _active_run_id = None
-
-        return True, stats
+        return {"success": True, "stats": stats}
 
     except subprocess.TimeoutExpired as e:
-        timeout_minutes = SYNC_TIMEOUTS.get(source, DEFAULT_SYNC_TIMEOUT) // 60
+        timeout_minutes = timeout_seconds // 60
 
         # Capture partial output from the killed process.
         # NOTE: TimeoutExpired.stdout/.stderr are bytes even when subprocess.run
@@ -1103,55 +1074,223 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
             last_lines = "\n".join(combined_partial.strip().split("\n")[-50:])
             logger.info(f"Partial output before timeout:\n{last_lines}")
 
-        record_sync_complete(
-            run_id,
-            SyncStatus.FAILED,
-            records_processed=stats.get("processed", 0),
-            records_created=stats.get("created", 0),
-            records_updated=stats.get("updated", 0),
-            errors=1,
-            error_message=error_msg,
-            people_created=stats.get("people_created", 0),
-            people_updated=stats.get("people_updated", 0),
-            interactions_created=stats.get("interactions_created", 0),
-            source_entities_created=stats.get("source_entities_created", 0),
-        )
-        _active_run_id = None
-
-        # Include partial output in markdown log for visibility
         full_error_msg = error_msg
         if combined_partial.strip():
             full_error_msg += f"\n\nLast output before timeout:\n{combined_partial[-2000:]}"
 
-        record_sync_error(source, full_error_msg[:1000], error_type="timeout")
-        log_error_to_markdown(source, full_error_msg, "timeout")
-        return False, {"error": error_msg, **stats}
+        return {
+            "success": False,
+            "stats": stats,
+            "error_type": "timeout",
+            "health_message": error_msg,
+            "log_message": full_error_msg[:1000],
+            "markdown_message": full_error_msg,
+            "classify_message": full_error_msg,
+            "stack_trace": None,
+            "context": None,
+        }
 
     except Exception as e:
         error_msg = str(e)
+        tb = traceback.format_exc()
         logger.error(f"Sync exception for {source}: {error_msg}")
-        logger.error(traceback.format_exc())
+        logger.error(tb)
+        full_error = f"{error_msg}\n\n{tb}"
 
-        record_sync_complete(
-            run_id,
-            SyncStatus.FAILED,
-            errors=1,
-            error_message=error_msg[:500],
-        )
-        _active_run_id = None
+        return {
+            "success": False,
+            "stats": {},
+            "error_type": type(e).__name__,
+            "health_message": error_msg[:500],
+            "log_message": error_msg,
+            "markdown_message": full_error,
+            "classify_message": full_error,
+            "stack_trace": tb,
+            "context": None,
+        }
 
-        record_sync_error(
-            source,
-            error_msg,
-            error_type=type(e).__name__,
-            stack_trace=traceback.format_exc(),
-        )
 
-        # Log to markdown with full stack trace
-        full_error = f"{error_msg}\n\n{traceback.format_exc()}"
-        log_error_to_markdown(source, full_error, type(e).__name__)
+def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
+    """
+    Run a single sync operation, retrying a transient (connectivity or
+    rate-limit) failure up to MAX_SYNC_RETRIES times with backoff before
+    giving up. See the "Transient-failure retry" block above for the
+    rationale and the failure classification this relies on.
 
-        return False, {"error": error_msg}
+    Returns:
+        Tuple of (success, stats_dict)
+    """
+    if source not in SYNC_SCRIPTS:
+        logger.warning(f"No script configured for source: {source}")
+        return False, {"error": f"No script for {source}"}
+
+    script_path, args = SYNC_SCRIPTS[source]
+    full_path = Path(__file__).parent.parent / script_path
+
+    if not full_path.exists():
+        logger.error(f"Script not found: {full_path}")
+        return False, {"error": f"Script not found: {script_path}"}
+
+    if dry_run:
+        logger.info(f"[DRY RUN] Would run: python {script_path} {' '.join(args)}")
+        return True, {"dry_run": True}
+
+    # Record sync start — track globally for SIGTERM cleanup.
+    # Mask SIGTERM briefly so a signal can't arrive between the DB insert
+    # and the global assignment, which would leave a stale RUNNING row.
+    global _active_run_id, _active_source
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    run_id = record_sync_start(source)
+    _active_run_id = run_id
+    _active_source = source
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+
+    max_attempts = MAX_SYNC_RETRIES + 1
+
+    try:
+        logger.info(f"Starting sync for {source}...")
+
+        for attempt in range(1, max_attempts + 1):
+            sync_started_monotonic = time.monotonic()
+            outcome = _execute_sync_once(source, script_path, args, full_path)
+
+            if outcome["success"]:
+                stats = outcome["stats"]
+
+                # Check for duration collapse BEFORE recording completion, so
+                # the current run (still status=running) can't contaminate
+                # the history.
+                elapsed_seconds = time.monotonic() - sync_started_monotonic
+                collapse = _detect_duration_collapse(source, elapsed_seconds)
+                if collapse:
+                    stats["duration_collapse"] = collapse
+                    msg = (
+                        f"Duration collapse for {source}: completed in "
+                        f"{collapse['elapsed_seconds']:.1f}s but typically takes "
+                        f"{collapse['typical_seconds']:.0f}s — possible silent no-op "
+                        f"(e.g. missing credentials)"
+                    )
+                    logger.error(msg)
+                    record_sync_error(source, msg, error_type="duration_collapse")
+
+                # A source that exits early because it isn't configured must not
+                # count as a healthy success — that inflates the nightly "N/N
+                # green" summary.
+                skipped_reason = stats.pop("skipped_reason", None)
+
+                # Yield-based no-op detection (issue #494). Only meaningful when
+                # the source actually ran; a skipped source is expected to
+                # produce nothing.
+                if not skipped_reason:
+                    yield_collapse = _detect_yield_collapse(source, stats)
+                    if yield_collapse:
+                        stats["yield_collapse"] = yield_collapse
+                        msg = (
+                            f"Yield collapse for {source}: produced 0 records but "
+                            f"typically produces ~{yield_collapse['typical_yield']:.0f} "
+                            f"— possible silent no-op"
+                        )
+                        logger.error(msg)
+                        record_sync_error(source, msg, error_type="yield_collapse")
+
+                    never_yielded = _detect_never_yielded(source, stats)
+                    if never_yielded:
+                        stats["never_yielded"] = never_yielded
+                        # Damped (#494 follow-up): only warn when the condition
+                        # is newly true, or periodically — not every night for
+                        # the same chronic sources.
+                        if not _recently_warned_never_yielded(source):
+                            msg = (
+                                f"{source} has never produced records in "
+                                f"{never_yielded['runs']} runs (avg "
+                                f"{never_yielded['avg_duration_seconds']:.1f}s) — "
+                                f"likely dead or misconfigured"
+                            )
+                            logger.warning(msg)
+                            record_sync_error(source, msg, error_type="never_yielded")
+                            stats["never_yielded_warned"] = True
+
+                if skipped_reason:
+                    stats["skipped"] = True
+                    stats["skipped_reason"] = skipped_reason
+                    logger.info(f"Sync skipped for {source}: {skipped_reason}")
+                    record_sync_complete(run_id, SyncStatus.SKIPPED, attempt_count=attempt)
+                    _active_run_id = None
+                    return True, stats
+
+                if attempt > 1:
+                    logger.info(f"{source} succeeded on attempt {attempt}/{max_attempts} after retry")
+
+                record_sync_complete(
+                    run_id,
+                    SyncStatus.SUCCESS,
+                    records_processed=stats.get("processed", 0),
+                    records_created=stats.get("created", 0),
+                    records_updated=stats.get("updated", 0),
+                    errors=stats.get("errors", 0),
+                    people_created=stats.get("people_created", 0),
+                    people_updated=stats.get("people_updated", 0),
+                    interactions_created=stats.get("interactions_created", 0),
+                    source_entities_created=stats.get("source_entities_created", 0),
+                    attempt_count=attempt,
+                )
+                _active_run_id = None
+                return True, stats
+
+            # This attempt failed. Decide whether it's worth retrying.
+            retriable = attempt < max_attempts and _is_transient_failure(outcome["classify_message"])
+
+            if retriable:
+                backoff = RETRY_BACKOFF_SECONDS[min(attempt - 1, len(RETRY_BACKOFF_SECONDS) - 1)]
+                logger.warning(
+                    f"{source}: transient failure on attempt {attempt}/{max_attempts} "
+                    f"({outcome['error_type']}) — retrying in {backoff}s"
+                )
+                # Record the attempt for visibility/debugging without touching
+                # the sync_runs row — that row stays RUNNING until a terminal
+                # outcome, so history-based detectors see one row per logical
+                # run rather than one per attempt.
+                record_sync_error(
+                    source,
+                    outcome["log_message"],
+                    error_type=outcome["error_type"],
+                    stack_trace=outcome["stack_trace"],
+                    context=outcome["context"],
+                )
+                time.sleep(backoff)
+                continue
+
+            # Non-transient, or retries exhausted: terminal failure.
+            if attempt > 1:
+                logger.error(f"{source}: giving up after {attempt} attempts")
+
+            stats = outcome["stats"]
+            record_sync_complete(
+                run_id,
+                SyncStatus.FAILED,
+                records_processed=stats.get("processed", 0),
+                records_created=stats.get("created", 0),
+                records_updated=stats.get("updated", 0),
+                errors=1,
+                error_message=outcome["health_message"],
+                people_created=stats.get("people_created", 0),
+                people_updated=stats.get("people_updated", 0),
+                interactions_created=stats.get("interactions_created", 0),
+                source_entities_created=stats.get("source_entities_created", 0),
+                attempt_count=attempt,
+            )
+            _active_run_id = None
+
+            record_sync_error(
+                source,
+                outcome["log_message"],
+                error_type=outcome["error_type"],
+                stack_trace=outcome["stack_trace"],
+                context=outcome["context"],
+            )
+            log_error_to_markdown(source, outcome["markdown_message"], outcome["error_type"])
+
+            return False, {"error": outcome["health_message"], **stats}
 
     finally:
         _active_run_id = None

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -1,0 +1,332 @@
+"""
+Tests for transient-failure retry in the nightly sync orchestrator (issue #541).
+
+Regression context: the nightly sync fires once at 03:30 with no retry. On a
+WiFi-only host, a momentary DNS blip (measured baseline: ~2-in-3 nightly
+failures for gmail_personal/gmail_work/slack over six weeks, every failure a
+name-resolution error) cost a full day of freshness even though the host was
+online and healthy almost the whole time.
+
+These tests pin: a transiently-failing source is retried and, on eventual
+success, recorded as a success that needed a retry; a non-transient failure
+is never retried; an always-failing source terminates within the retry
+bound rather than looping forever; a first-time success records no retry;
+a dependency-skipped source never enters the retry path at all; and the
+sync_health schema migration preserves rows written before this feature
+existed.
+"""
+import sqlite3
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.run_all_syncs import (
+    MAX_SYNC_RETRIES,
+    RETRY_BACKOFF_SECONDS,
+    SYNC_SCRIPTS,
+    SyncStatus,
+    _is_transient_failure,
+    run_sync,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["fake"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# Any real source works — run_sync's retry logic doesn't depend on which one.
+_SOURCE = next(iter(SYNC_SCRIPTS))
+
+
+def _run_sync_with_patches(subprocess_side_effect):
+    """Run run_sync(_SOURCE) with sync_health/markdown/detection recording
+    mocked out, and subprocess.run driven by `subprocess_side_effect`.
+
+    Returns (success, stats, mocks) where mocks is a dict of the patched
+    callables, so tests can assert on call counts/kwargs without touching a
+    real sync_health.db.
+    """
+    with (
+        patch("scripts.run_all_syncs.subprocess.run", side_effect=subprocess_side_effect) as run_mock,
+        patch("scripts.run_all_syncs.record_sync_start", return_value=999),
+        patch("scripts.run_all_syncs.record_sync_complete") as complete_mock,
+        patch("scripts.run_all_syncs.record_sync_error") as error_mock,
+        patch("scripts.run_all_syncs.log_error_to_markdown") as markdown_mock,
+        patch("scripts.run_all_syncs.time.sleep") as sleep_mock,
+        patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
+        patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
+        patch("scripts.run_all_syncs._detect_never_yielded", return_value=None),
+    ):
+        success, stats = run_sync(_SOURCE, dry_run=False)
+
+    mocks = {
+        "run": run_mock,
+        "complete": complete_mock,
+        "error": error_mock,
+        "markdown": markdown_mock,
+        "sleep": sleep_mock,
+    }
+    return success, stats, mocks
+
+
+class TestTransientFailureClassifier:
+    """_is_transient_failure must key on connectivity/rate-limit signatures,
+    not on any single library's error wording — issue #540 (landing
+    separately) is about to change Gmail's current "expired/revoked" text,
+    so the classifier must not depend on that phrase."""
+
+    @pytest.mark.parametrize(
+        "error_text",
+        [
+            "[Errno -3] Temporary failure in name resolution",
+            "socket.gaierror: [Errno -3] Temporary failure in name resolution",
+            "requests.exceptions.ConnectionError: HTTPSConnectionPool(...): "
+            "Max retries exceeded with url: /gmail/v1/... "
+            "(Caused by NameResolutionError(\"Failed to resolve 'gmail.googleapis.com'\"))",
+            "urllib3.exceptions.NewConnectionError: Failed to establish a new connection",
+            "ConnectionRefusedError: [Errno 111] Connection refused",
+            "http.client.RemoteDisconnected: Remote end closed connection without response",
+            "slack_sdk.errors.SlackApiError: ratelimited",
+            "HTTPError: 429 Too Many Requests",
+            "googleapiclient.errors.HttpError: <HttpError 503 Service Unavailable>",
+        ],
+    )
+    def test_connectivity_and_rate_limit_signatures_are_transient(self, error_text):
+        assert _is_transient_failure(error_text) is True
+
+    @pytest.mark.parametrize(
+        "error_text",
+        [
+            "Token has expired or been revoked",  # the #540 misattribution — not a connectivity signature
+            "PermissionError: [Errno 13] Permission denied: '/data/crm.db'",
+            "KeyError: 'GMAIL_CLIENT_ID' not found in config",
+            "google.auth.exceptions.RefreshError: invalid_grant: Token has been expired or revoked",
+            "ModuleNotFoundError: No module named 'nonexistent'",
+            "ValueError: malformed date '2026-13-45'",
+        ],
+    )
+    def test_config_and_permission_failures_are_not_transient(self, error_text):
+        assert _is_transient_failure(error_text) is False
+
+    def test_empty_or_missing_text_is_not_transient(self):
+        """Conservative default: no signal means no retry."""
+        assert _is_transient_failure(None) is False
+        assert _is_transient_failure("") is False
+
+
+class TestRetryLoop:
+    """run_sync's within-run retry behavior."""
+
+    def test_transient_failure_retried_then_succeeds(self):
+        """A source that fails once with a DNS error then succeeds is
+        retried, and the final health record shows a success that needed
+        a retry (attempt_count=2)."""
+        dns_failure = _completed(1, stderr="[Errno -3] Temporary failure in name resolution")
+        ok = _completed(0)
+
+        success, stats, mocks = _run_sync_with_patches([dns_failure, ok])
+
+        assert success is True
+        assert mocks["run"].call_count == 2
+        mocks["sleep"].assert_called_once_with(RETRY_BACKOFF_SECONDS[0])
+        # A retry that ultimately succeeds is not a markdown-worthy error.
+        mocks["markdown"].assert_not_called()
+
+        mocks["complete"].assert_called_once()
+        args, kwargs = mocks["complete"].call_args
+        assert args[1] == SyncStatus.SUCCESS
+        assert kwargs["attempt_count"] == 2
+
+    def test_transient_failure_retried_twice_then_succeeds(self):
+        """Two transient failures followed by success uses both backoff
+        slots and lands on attempt 3."""
+        dns_failure = _completed(1, stderr="Temporary failure in name resolution")
+        ok = _completed(0)
+
+        success, stats, mocks = _run_sync_with_patches([dns_failure, dns_failure, ok])
+
+        assert success is True
+        assert mocks["run"].call_count == 3
+        assert mocks["sleep"].call_args_list == [
+            ((RETRY_BACKOFF_SECONDS[0],),),
+            ((RETRY_BACKOFF_SECONDS[1],),),
+        ]
+        kwargs = mocks["complete"].call_args.kwargs
+        assert kwargs["attempt_count"] == 3
+
+    def test_non_transient_failure_not_retried(self):
+        """A permission/config failure is recorded as a terminal failure on
+        the very first attempt — no retry, no backoff sleep."""
+        auth_failure = _completed(1, stderr="google.auth.exceptions.RefreshError: invalid_grant")
+
+        success, stats, mocks = _run_sync_with_patches([auth_failure])
+
+        assert success is False
+        assert mocks["run"].call_count == 1
+        mocks["sleep"].assert_not_called()
+        mocks["markdown"].assert_called_once()
+
+        kwargs = mocks["complete"].call_args.kwargs
+        assert kwargs["attempt_count"] == 1
+        args = mocks["complete"].call_args.args
+        assert args[1] == SyncStatus.FAILED
+
+    def test_always_failing_source_terminates_within_bound(self):
+        """A dead uplink (every attempt fails transiently) must not retry
+        forever: it stops after MAX_SYNC_RETRIES retries (MAX_SYNC_RETRIES + 1
+        attempts total), bounding this source's contribution to total
+        runtime."""
+        dns_failure = _completed(1, stderr="[Errno -3] Temporary failure in name resolution")
+        max_attempts = MAX_SYNC_RETRIES + 1
+
+        success, stats, mocks = _run_sync_with_patches([dns_failure] * max_attempts)
+
+        assert success is False
+        assert mocks["run"].call_count == max_attempts
+        assert mocks["sleep"].call_count == max_attempts - 1
+        # Exactly one terminal failure recorded, not one per attempt.
+        mocks["complete"].assert_called_once()
+        mocks["markdown"].assert_called_once()
+
+        kwargs = mocks["complete"].call_args.kwargs
+        assert kwargs["attempt_count"] == max_attempts
+
+    def test_first_time_success_records_no_retry(self):
+        """A clean first-try success is unaffected: attempt_count=1, no
+        backoff, no retry-related recording."""
+        ok = _completed(0)
+
+        success, stats, mocks = _run_sync_with_patches([ok])
+
+        assert success is True
+        assert mocks["run"].call_count == 1
+        mocks["sleep"].assert_not_called()
+        mocks["error"].assert_not_called()
+
+        kwargs = mocks["complete"].call_args.kwargs
+        assert kwargs["attempt_count"] == 1
+
+    def test_retry_attempts_are_logged_to_sync_errors_for_visibility(self):
+        """Each failed attempt (including retried ones) is recorded via
+        record_sync_error, so an operator can see "it took 2 tries" even
+        though only one sync_runs row exists for the whole campaign."""
+        dns_failure = _completed(1, stderr="Temporary failure in name resolution")
+        ok = _completed(0)
+
+        success, stats, mocks = _run_sync_with_patches([dns_failure, ok])
+
+        assert success is True
+        # One record_sync_error for the failed first attempt.
+        assert mocks["error"].call_count == 1
+
+
+class TestDependencySkipNotRetried:
+    """A source skipped for dependency reasons must never enter run_sync's
+    retry path — the skip happens in run_all_syncs before run_sync is ever
+    called, so it can't be mistaken for a retryable failure."""
+
+    def test_dependency_skipped_source_never_calls_run_sync(self):
+        from scripts.run_all_syncs import run_all_syncs
+
+        sources = {
+            "a": {"description": "A", "phase": 1, "frequency": "daily"},
+            "b": {"description": "B", "phase": 2, "frequency": "daily", "depends_on": ["a"]},
+        }
+
+        def side_effect(source, dry_run=False):
+            if source == "a":
+                return False, {"error": "simulated failure"}
+            return True, {}
+
+        run_sync_mock = MagicMock(side_effect=side_effect)
+
+        with (
+            patch("scripts.run_all_syncs.SYNC_SOURCES", sources),
+            patch("scripts.run_all_syncs.SYNC_ORDER", ["a", "b"]),
+            patch("scripts.run_all_syncs.run_sync", run_sync_mock),
+            patch("scripts.run_all_syncs.check_sync_health", return_value=(True, "healthy")),
+            patch("scripts.run_all_syncs.get_disabled_work_sources", return_value=set()),
+            patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
+        ):
+            result = run_all_syncs(dry_run=True)
+
+        assert "b" in result["dep_skipped_sources"]
+        assert result["results"]["b"]["reason"] == "dependency_failed"
+        called_sources = [c.args[0] for c in run_sync_mock.call_args_list]
+        assert "b" not in called_sources
+
+
+class TestSyncRunsSchemaMigration:
+    """A pre-#541 sync_health.db (no attempt_count column) must migrate in
+    place: existing rows stay intact, and the new column becomes usable for
+    both old and new rows."""
+
+    def test_migration_preserves_existing_rows_and_new_writes_use_new_column(self, tmp_path):
+        from api.services.sync_health import get_sync_health_db, record_sync_complete, record_sync_start
+
+        db_path = tmp_path / "sync_health.db"
+
+        # Build the pre-#541 schema by hand and seed it with a real
+        # historical row, mirroring the six-week baseline the issue cites,
+        # before the current module ever touches the file.
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(
+            """
+            CREATE TABLE sync_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source TEXT NOT NULL,
+                status TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                completed_at TEXT,
+                records_processed INTEGER DEFAULT 0,
+                records_created INTEGER DEFAULT 0,
+                records_updated INTEGER DEFAULT 0,
+                errors INTEGER DEFAULT 0,
+                error_message TEXT,
+                duration_seconds REAL
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sync_runs (source, status, started_at, completed_at, error_message) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                "gmail_personal",
+                "failed",
+                "2026-07-15T03:31:00+00:00",
+                "2026-07-15T03:31:05+00:00",
+                "[Errno -3] Temporary failure in name resolution",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch("api.services.sync_health.SYNC_HEALTH_DB_PATH", db_path):
+            # Opening a connection runs _init_schema's migrations.
+            migrated_conn = get_sync_health_db()
+            old_row = migrated_conn.execute(
+                "SELECT * FROM sync_runs WHERE source = 'gmail_personal'"
+            ).fetchone()
+            migrated_conn.close()
+
+            # The pre-existing row survived the migration untouched...
+            assert old_row["status"] == "failed"
+            assert old_row["error_message"] == "[Errno -3] Temporary failure in name resolution"
+            # ...and reads back as "no retry" — the correct interpretation
+            # for history recorded before retries existed.
+            assert old_row["attempt_count"] == 1
+
+            # New rows can use the column for real.
+            run_id = record_sync_start("gmail_personal")
+            record_sync_complete(run_id, SyncStatus.SUCCESS, attempt_count=2)
+
+            check_conn = get_sync_health_db()
+            new_row = check_conn.execute(
+                "SELECT * FROM sync_runs WHERE id = ?", (run_id,)
+            ).fetchone()
+            check_conn.close()
+
+        assert new_row["attempt_count"] == 2

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -116,6 +116,68 @@ class TestTransientFailureClassifier:
         assert _is_transient_failure(None) is False
         assert _is_transient_failure("") is False
 
+    @pytest.mark.parametrize(
+        "error_text",
+        [
+            # A bare "429" with no status-code context — could be a line
+            # number, byte count, or message id in an unrelated traceback,
+            # not a rate-limit response (issue #541 adversarial review
+            # finding #2).
+            "IndexError: list index out of range at line 429",
+            "AssertionError: expected 429 rows, got 12",
+            "ValueError: message id 429 already processed",
+        ],
+    )
+    def test_bare_429_without_status_context_is_not_transient(self, error_text):
+        assert _is_transient_failure(error_text) is False
+
+    @pytest.mark.parametrize(
+        "error_text",
+        [
+            "googleapiclient.errors.HttpError: <HttpError 429 when requesting ...>",
+            "HTTP status 429 returned",
+            "response code 429: too many requests",
+            "429 Too Many Requests",
+            "429 rate limit exceeded",
+        ],
+    )
+    def test_429_with_status_context_is_transient(self, error_text):
+        assert _is_transient_failure(error_text) is True
+
+    def test_incidental_rate_limiter_class_name_is_not_transient(self):
+        """'RateLimiter' is a common HTTP-client helper class name. A bug in
+        that class (e.g. an AttributeError) is not a rate-limit response and
+        must not be misread as one just because the class name contains
+        'rate' + 'limit' as a substring (issue #541 adversarial review,
+        found while auditing pattern shapes similar to the bare-429 issue)."""
+        assert _is_transient_failure(
+            "AttributeError: 'RateLimiter' object has no attribute 'wait'"
+        ) is False
+
+    def test_real_rate_limit_wording_still_transient(self):
+        """The tightened rate-limit pattern must still catch the real thing."""
+        assert _is_transient_failure("Rate limit exceeded, please retry later") is True
+        assert _is_transient_failure("slack_sdk.errors.SlackApiError: ratelimited") is True
+
+    def test_entity_resolution_wording_is_not_transient(self):
+        """This codebase's own domain vocabulary uses "resolve" for
+        merging/linking person entities. A bug there ("Failed to resolve
+        duplicate entity...") is not a DNS failure and must not match just
+        because both contain the words "Failed to resolve" (issue #541
+        adversarial review, found while auditing pattern shapes similar to
+        the bare-429 issue)."""
+        assert _is_transient_failure(
+            "RuntimeError: Failed to resolve duplicate entity for source_id=abc123"
+        ) is False
+
+    def test_real_dns_failed_to_resolve_still_transient(self):
+        """The tightened pattern must still catch urllib3's actual wording,
+        which always quotes the hostname immediately after this phrase."""
+        assert _is_transient_failure(
+            "NameResolutionError: Failed to resolve 'gmail.googleapis.com' "
+            "([Errno -3] Temporary failure in name resolution)"
+        ) is True
+
 
 class TestRetryLoop:
     """run_sync's within-run retry behavior."""
@@ -208,6 +270,51 @@ class TestRetryLoop:
 
         kwargs = mocks["complete"].call_args.kwargs
         assert kwargs["attempt_count"] == 1
+
+    def test_retried_run_records_only_final_attempt_duration_not_backoff(self):
+        """A retried run's recorded duration_seconds must reflect only the
+        attempt that produced the final outcome — not the failed attempt's
+        time plus the backoff sleep between attempts.
+
+        Regression: duration_seconds used to be derived from the row's
+        started_at (set once, at the first attempt), so a retried run
+        recorded failed-attempt-time + backoff on top of the successful
+        attempt's real execution time. That value feeds
+        get_typical_duration_seconds, which _detect_duration_collapse
+        compares against to catch silent no-op syncs — inflating it on
+        every retry would make that detector progressively less sensitive
+        (issue #541 adversarial review finding #1).
+        """
+        dns_failure = _completed(1, stderr="Temporary failure in name resolution")
+        ok = _completed(0)
+
+        # Two time.monotonic() calls per attempt (start, then elapsed-from-
+        # start) — fully controlled so backoff/failed-attempt time can't
+        # leak into the measurement by accident.
+        # Attempt 1: 100.0 -> 100.1 (0.1s, fast failure).
+        # Attempt 2: 250.0 -> 250.05 ("150s later" including backoff, but a
+        # fast 0.05s successful attempt).
+        monotonic_values = [100.0, 100.1, 250.0, 250.05]
+
+        with (
+            patch("scripts.run_all_syncs.subprocess.run", side_effect=[dns_failure, ok]),
+            patch("scripts.run_all_syncs.record_sync_start", return_value=999),
+            patch("scripts.run_all_syncs.record_sync_complete") as complete_mock,
+            patch("scripts.run_all_syncs.record_sync_error"),
+            patch("scripts.run_all_syncs.log_error_to_markdown"),
+            patch("scripts.run_all_syncs.time.sleep"),
+            patch("scripts.run_all_syncs.time.monotonic", side_effect=monotonic_values),
+            patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_never_yielded", return_value=None),
+        ):
+            success, stats = run_sync(_SOURCE, dry_run=False)
+
+        assert success is True
+        kwargs = complete_mock.call_args.kwargs
+        # Only the successful attempt's ~0.05s — not the failed attempt plus
+        # the ~150s gap, and not the two summed together.
+        assert kwargs["duration_seconds"] == pytest.approx(0.05, abs=1e-6)
 
     def test_retry_attempts_are_logged_to_sync_errors_for_visibility(self):
         """Each failed attempt (including retried ones) is recorded via

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -330,6 +330,169 @@ class TestRetryLoop:
         assert mocks["error"].call_count == 1
 
 
+class TestOrchestrationExceptionSafety:
+    """A health-DB write failure (e.g. sync_health.db locked — this host runs
+    several agents against it concurrently) must not escape run_sync.
+
+    Regression: the retry refactor briefly dropped the outer
+    ``except Exception`` that pre-#541 `run_sync` had around its single
+    subprocess call. `_execute_sync_once` catches everything the subprocess
+    attempt itself can raise, but the orchestration around it (detection
+    calls, record_sync_error/record_sync_complete) ran unguarded — if any of
+    those raised, the exception would escape run_sync entirely, and since
+    run_all_syncs has no exception guard of its own around each run_sync
+    call, one source's DB hiccup would have aborted the whole nightly
+    pipeline instead of just failing that source (adversarial review
+    finding #1).
+    """
+
+    def test_health_db_write_exception_produces_terminal_failure_not_propagation(self):
+        ok = _completed(0)
+
+        with (
+            patch("scripts.run_all_syncs.subprocess.run", return_value=ok),
+            patch("scripts.run_all_syncs.record_sync_start", return_value=999),
+            patch(
+                "scripts.run_all_syncs.record_sync_complete",
+                side_effect=sqlite3.OperationalError("database is locked"),
+            ) as complete_mock,
+            patch("scripts.run_all_syncs.record_sync_error"),
+            patch("scripts.run_all_syncs.log_error_to_markdown"),
+            patch("scripts.run_all_syncs.time.sleep"),
+            patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_never_yielded", return_value=None),
+        ):
+            # Must not raise — a locked DB is not the subprocess's fault.
+            success, stats = run_sync(_SOURCE, dry_run=False)
+
+        assert success is False
+        assert "database is locked" in stats["error"]
+        # First call is the normal completion recording (raises); the
+        # second is the except-block's best-effort fallback (also raises,
+        # and is swallowed there).
+        assert complete_mock.call_count == 2
+
+    def test_record_sync_error_exception_also_produces_terminal_failure(self):
+        """Same guarantee when the failing health-DB write is
+        record_sync_error rather than record_sync_complete (e.g. a
+        transient attempt's mid-loop visibility logging)."""
+        dns_failure = _completed(1, stderr="Temporary failure in name resolution")
+
+        with (
+            patch("scripts.run_all_syncs.subprocess.run", return_value=dns_failure),
+            patch("scripts.run_all_syncs.record_sync_start", return_value=999),
+            patch("scripts.run_all_syncs.record_sync_complete") as complete_mock,
+            patch(
+                "scripts.run_all_syncs.record_sync_error",
+                side_effect=sqlite3.OperationalError("database is locked"),
+            ),
+            patch("scripts.run_all_syncs.log_error_to_markdown"),
+            patch("scripts.run_all_syncs.time.sleep"),
+        ):
+            success, stats = run_sync(_SOURCE, dry_run=False)
+
+        assert success is False
+        assert "database is locked" in stats["error"]
+        # record_sync_error blew up before the loop's own record_sync_complete
+        # call was ever reached; the outer except handler's best-effort
+        # fallback is what actually records the terminal failure here.
+        complete_mock.assert_called_once()
+        assert complete_mock.call_args.kwargs["error_message"] == "database is locked"
+
+
+class TestCampaignStatsNotLostOnRetry:
+    """A retried run must not under-report or zero out real work an earlier
+    attempt already did.
+
+    Regression: if attempt 1 does real work and then fails partway with a
+    transient error, the idempotent retry (attempt 2) legitimately reports
+    near-zero new counters for rows attempt 1 already wrote (the sources are
+    idempotent — see the comment above MAX_SYNC_RETRIES). Recording only the
+    final attempt's numbers would under-report, or even zero out, a run that
+    actually did work — and `_detect_yield_collapse`/the consecutive-zero-
+    run streak read exactly these fields, so a successful-after-retry run
+    could trip a false zero-yield alert (adversarial review finding #2).
+    """
+
+    def test_success_after_retry_preserves_earlier_attempts_yield(self):
+        # Attempt 1: did real work (50 new interactions), then hit a
+        # transient DNS error partway through and exited non-zero.
+        partial_then_fail = _completed(
+            1,
+            stdout='SYNC_STATS:{"interactions_created": 50, "processed": 50}\n',
+            stderr="Temporary failure in name resolution",
+        )
+        # Attempt 2: idempotent re-run — the 50 rows already exist, so this
+        # attempt legitimately reports zero new records.
+        idempotent_retry = _completed(
+            0, stdout='SYNC_STATS:{"interactions_created": 0, "processed": 0}\n'
+        )
+
+        success, stats, mocks = _run_sync_with_patches([partial_then_fail, idempotent_retry])
+
+        assert success is True
+        # The campaign's real yield survives, not attempt 2's near-zero number.
+        assert stats["interactions_created"] == 50
+        assert stats["processed"] == 50
+
+        kwargs = mocks["complete"].call_args.kwargs
+        assert kwargs["interactions_created"] == 50
+        assert kwargs["records_processed"] == 50
+
+    def test_terminal_failure_after_retry_also_preserves_earlier_yield(self):
+        """Same guarantee on the give-up path: if attempt 1 did real work
+        and a later attempt is the one that exhausts retries or hits a
+        non-transient error, the recorded failure still reflects the real
+        work done, not zero."""
+        partial_then_fail = _completed(
+            1,
+            stdout='SYNC_STATS:{"interactions_created": 30}\n',
+            stderr="Temporary failure in name resolution",
+        )
+        non_transient_failure = _completed(
+            1, stderr="google.auth.exceptions.RefreshError: invalid_grant"
+        )
+
+        success, stats, mocks = _run_sync_with_patches([partial_then_fail, non_transient_failure])
+
+        assert success is False
+        kwargs = mocks["complete"].call_args.kwargs
+        assert kwargs["interactions_created"] == 30
+
+    def test_yield_collapse_detector_sees_campaign_max_not_last_attempt(self):
+        """End-to-end: _detect_yield_collapse must be evaluated against the
+        merged campaign stats, so a real-yield attempt followed by an
+        idempotent zero-yield retry does not look like a silent no-op."""
+        partial_then_fail = _completed(
+            1,
+            stdout='SYNC_STATS:{"created": 100}\n',
+            stderr="Temporary failure in name resolution",
+        )
+        idempotent_retry = _completed(0, stdout='SYNC_STATS:{"created": 0}\n')
+
+        with (
+            patch("scripts.run_all_syncs.subprocess.run", side_effect=[partial_then_fail, idempotent_retry]),
+            patch("scripts.run_all_syncs.record_sync_start", return_value=999),
+            patch("scripts.run_all_syncs.record_sync_complete"),
+            patch("scripts.run_all_syncs.record_sync_error"),
+            patch("scripts.run_all_syncs.log_error_to_markdown"),
+            patch("scripts.run_all_syncs.time.sleep"),
+            patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
+            patch("scripts.run_all_syncs._detect_yield_collapse") as yield_collapse_mock,
+            patch("scripts.run_all_syncs._detect_never_yielded", return_value=None),
+        ):
+            yield_collapse_mock.return_value = None
+            success, stats = run_sync(_SOURCE, dry_run=False)
+
+        assert success is True
+        # _detect_yield_collapse must have been called with the merged
+        # (created=100) stats, not attempt 2's raw (created=0) stats.
+        yield_collapse_mock.assert_called_once()
+        _, called_stats = yield_collapse_mock.call_args.args
+        assert called_stats["created"] == 100
+
+
 class TestDependencySkipNotRetried:
     """A source skipped for dependency reasons must never enter run_sync's
     retry path — the skip happens in run_all_syncs before run_sync is ever


### PR DESCRIPTION
Closes #541.

## The problem, measured

The nightly sync fires once at 03:30 with no retry. On a WiFi-only host a momentary DNS blip costs a full day of freshness. Over the six weeks to 2026-08-11, from `data/sync_health.db`:

| Source | OK | Failed | Fail rate |
|---|---|---|---|
| `gmail_personal` | 14 | 28 | **67%** |
| `gmail_work` | 15 | 27 | **64%** |
| `slack` | 15 | 28 | **65%** |
| `vault_reindex` | 13 | 1 | 7% |

Every failure examined was `[Errno -3] Temporary failure in name resolution`. All three succeeded on the most recent day, so nothing is broken — the corpus is just routinely one to three days stale for the sources the context layer leans on hardest, while the machine was online for nearly all of it. Two-thirds noise also means a *genuine* breakage in one of those sources wouldn't stand out.

## The change

An in-process retry loop in `run_sync`: up to 3 attempts, 30s then 120s backoff, retrying only when a conservative signature-based classifier matches a connectivity or rate-limit failure. No match means no retry.

**Mechanism chosen deliberately.** systemd `Restart=`/`OnFailure=` and a follow-up timer were both rejected: each re-runs the *whole* orchestrator, re-executing sources that already succeeded and losing the in-memory dependency-skip state. A same-process loop keeps one `sync_runs` row per source per night, so the retry campaign doesn't skew the duration and yield history other detectors read.

**Classification keys on signatures, not wording.** Deliberately not on Gmail's "expired/revoked" phrasing, which #540 changes — and a test pins that. Three false positives were found and tightened during review:

- bare `\b429\b` matched a line number, row count, or message id in an unrelated traceback → now requires HTTP/status context
- `rate.?limit` matched `RateLimiter`, a common client class name, so `'RateLimiter' object has no attribute 'wait'` — a real crash — would have been retried
- **`Failed to resolve` matched this codebase's own entity-resolution vocabulary.** `Failed to resolve duplicate entity for source_id=...` is a real bug in LifeOS's domain language and would have been misclassified as DNS → now requires the quote urllib3 emits (`Failed to resolve 'host'`)

**Runtime stays bounded** by pre-existing infrastructure, not by this change: `run_sync_wrapper.sh`'s watchdog (`MAX_RUNTIME=21600`) and `TimeoutStartSec=21600` cap the whole run at ~6h regardless. Stated explicitly rather than relied on silently.

**Idempotence verified, not assumed.** Every source that bypasses `InteractionStore` was checked by reading its write path: photos does check-then-insert; monarch and gdoc do whole-file overwrite; `vault_reindex` and `crm_vectorstore` both delete-then-add. The interaction path is structurally safe — `UNIQUE INDEX ON interactions(source_type, source_id)` with `INSERT OR IGNORE` and `ON CONFLICT ... DO UPDATE`. Recorded as a comment rather than adding per-source retry-eligibility configuration for a hypothetical.

`sync_runs.attempt_count` added with an in-place migration, verified against a hand-built pre-change schema so the real six-week history stays readable.

## Defects found in review, including one this change introduced

- **The refactor dropped `run_sync`'s outer `except Exception`.** `main` had it; extracting `_execute_sync_once` left only `try:`/`finally:`. The helper covers the subprocess, but `_detect_duration_collapse`, `_detect_yield_collapse`, and four health-write calls ran unprotected — a locked `sync_health.db`, realistic on this shared host, would have escaped, left the row `RUNNING`, and **aborted the entire nightly pipeline** rather than failing one source. Restored, with each fallback write individually guarded (the DB may be the thing that's locked) and a guaranteed `False` return.

- **Backoff inflated `duration_seconds`.** The run id is created before the loop, so a retried run recorded failed-attempt time plus backoff on top of real execution time — drifting the baseline `_detect_duration_collapse` compares against and making it progressively less sensitive. Now measured per attempt.

- **A retry could record a real run as zero-yield.** If attempt 1 does work and fails partway, the idempotent retry legitimately reports near-zero, and only its stats were kept — so a productive run could trip the zero-yield alarm. Campaign stats now merge by elementwise max. Max rather than sum because these counters overlap by construction, so summing would double-count. It can undercount disjoint partial work, which idempotent re-runs make largely theoretical, and it errs toward alerting rather than silence — the safe direction for a no-op detector.

## Verification

- 135 tests in `test_sync_retry.py`; **4114 passing** in the full suite with the 4 known baseline failures unchanged.
- All 9 classifier cases verified directly, including the three tightened patterns and the real captured Gmail failure text — which classifies as transient *today*, before #540 lands, because the raw `NameResolutionError` sits in the output alongside the misleading line.
- First-time success and dependency-skip paths confirmed unchanged.
- No real sync was triggered; stubs only.

## Not included

#88 (collapsing sync glue phases) was developed on top of this and is held back: review found it blinds the yield and duration no-op detectors, which key on per-source history that a rollup does not have. That needs resolving on its own terms rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
