### PR TITLE
fix(home): give the card grid room and let it reflow

### DIFF
--- a/web/home.html
+++ b/web/home.html
@@ -35,9 +35,17 @@
             padding: 2rem;
         }
 
+        /* Sized so four cards sit at roughly the width three had at 600px.
+           The card count grew when Journal was added; keeping the old
+           container squeezed every card to ~132px and wrapped the
+           descriptions into five two-word lines. */
         .container {
             text-align: center;
-            max-width: 600px;
+            /* `width` is load-bearing, not redundant with max-width: body is a
+               centred flex column, so this is a flex item sized to its content
+               unless told otherwise, and max-width alone never engaged. */
+            width: 100%;
+            max-width: 820px;
         }
 
         .logo {
@@ -58,7 +66,11 @@
 
         .cards {
             display: grid;
-            grid-template-columns: repeat(4, 1fr);
+            /* auto-fit rather than a fixed column count: a hard `repeat(4,
+               1fr)` re-crams the cards at every viewport between the mobile
+               breakpoint and full width, and silently mis-lays-out the grid
+               the next time a card is added or removed. */
+            grid-template-columns: repeat(auto-fit, minmax(165px, 1fr));
             gap: 1.5rem;
         }
 


### PR DESCRIPTION
fix(home): give the card grid room and let it reflow

The home page gained a fourth card (Journal) while the container stayed at
600px, so each card rendered ~132px wide and the descriptions wrapped into
five two-word lines. Three cards had ~184px each before.

Widened to 820px, which restores roughly the original per-card width at
four cards. Needed `width: 100%` alongside it: body is a centred flex
column, so .container was a flex item sized to its content and max-width
alone never engaged — with only max-width set, the grid still collapsed to
2x2 at full width.

Also swapped the fixed `repeat(4, 1fr)` for `repeat(auto-fit,
minmax(165px, 1fr))`. The hard column count re-crammed the cards at every
viewport between the 500px breakpoint and full width, and would have
silently mis-laid-out the grid the next time a card was added or removed —
which is exactly how this regression arrived.

Verified: 4 columns at 1280px, 3 at 700px, 1 at 430px, no horizontal
overflow at any of them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)