### PR TITLE
fix(crm): stop re-queuing blocklisted entities for rematching

### DIFF
--- a/api/services/source_entity.py
+++ b/api/services/source_entity.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 from api.utils.datetime_utils import make_aware as _make_aware
 from api.utils.db_paths import get_crm_db_path
+from config.marketing_patterns import is_blocklisted_domain
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,19 @@ SOURCE_TYPES = {
     "phone",
     "photos",
 }
+
+def _is_blocklisted_entity(entity: "SourceEntity") -> bool:
+    """
+    True if this entity's observed email is on a marketing blocklist.
+
+    Such entities can never resolve to a person, so re-attempting them is pure
+    waste — and because the linking script recorded a match attempt on every
+    skip, they were re-queued under backoff forever and permanently inflated
+    the reported capped backlog (#550). Entities with no observed_email are
+    never blocklisted; they may still be matchable by name or phone.
+    """
+    return bool(entity.observed_email) and is_blocklisted_domain(entity.observed_email)
+
 
 # Link status values
 LINK_STATUS_AUTO = "auto"  # Automatically linked
@@ -973,6 +987,7 @@ class SourceEntityStore:
         limit: int = 1000,
         backoff_multiplier: int = 3,
         max_capped_per_run: Optional[int] = 200,
+        exclude_blocklisted: bool = True,
     ) -> list[SourceEntity]:
         """
         Get unlinked entities eligible for re-matching.
@@ -1014,6 +1029,10 @@ class SourceEntityStore:
             backoff_multiplier: Growth factor applied per attempt past max_attempts
             max_capped_per_run: Max capped (attempt_count >= max_attempts) entities
                 to include per call. None disables the cap.
+            exclude_blocklisted: Drop entities whose observed_email is on a
+                blocklisted (marketing) domain. Being blocklisted is a permanent
+                property of the address, not a match that failed and deserves a
+                retry, so these are never eligible (#550).
 
         Returns:
             List of SourceEntity objects eligible for re-matching
@@ -1048,6 +1067,9 @@ class SourceEntityStore:
             candidates = [SourceEntity.from_row(row) for row in cursor.fetchall()]
         finally:
             conn.close()
+
+        if exclude_blocklisted:
+            candidates = [e for e in candidates if not _is_blocklisted_entity(e)]
 
         now = datetime.now(timezone.utc)
         normal: list[SourceEntity] = []
@@ -1120,6 +1142,7 @@ class SourceEntityStore:
         self,
         source_type: Optional[str] = None,
         max_attempts: int = 3,
+        exclude_blocklisted: bool = True,
     ) -> int:
         """
         Count unlinked entities that have hit ``max_attempts`` or more.
@@ -1129,9 +1152,14 @@ class SourceEntityStore:
         sync stats so a saturated backlog is visible (#507) instead of
         looking identical to "nothing to do".
 
+        Blocklisted entities are excluded by default so the number tracks work
+        that can actually drain. Counting them made the metric useless: they
+        were 70% of the reported backlog and could never be linked (#550).
+
         Args:
             source_type: Optional filter by source type
             max_attempts: Attempt count considered "capped"
+            exclude_blocklisted: Skip entities on blocklisted marketing domains
 
         Returns:
             Count of unlinked entities with match_attempt_count >= max_attempts
@@ -1140,21 +1168,28 @@ class SourceEntityStore:
         try:
             if source_type:
                 cursor = conn.execute("""
-                    SELECT COUNT(*) FROM source_entities
+                    SELECT observed_email FROM source_entities
                     WHERE canonical_person_id IS NULL
                       AND source_type = ?
                       AND match_attempt_count >= ?
                 """, (source_type, max_attempts))
             else:
                 cursor = conn.execute("""
-                    SELECT COUNT(*) FROM source_entities
+                    SELECT observed_email FROM source_entities
                     WHERE canonical_person_id IS NULL
                       AND match_attempt_count >= ?
                 """, (max_attempts,))
 
-            return cursor.fetchone()[0]
+            emails = [row[0] for row in cursor.fetchall()]
         finally:
             conn.close()
+
+        if not exclude_blocklisted:
+            return len(emails)
+        return sum(
+            1 for email in emails
+            if not (email and is_blocklisted_domain(email))
+        )
 
     def delete(self, entity_id: str) -> bool:
         """Delete a source entity."""

--- a/api/services/source_entity.py
+++ b/api/services/source_entity.py
@@ -41,6 +41,7 @@ SOURCE_TYPES = {
     "photos",
 }
 
+
 def _is_blocklisted_entity(entity: "SourceEntity") -> bool:
     """
     True if this entity's observed email is on a marketing blocklist.

--- a/scripts/link_source_entities.py
+++ b/scripts/link_source_entities.py
@@ -180,12 +180,13 @@ def link_source_entities(
             st = entity.source_type
             stats['by_source'][st] = stats['by_source'].get(st, 0) + 1
 
-            # Check if email domain is blocklisted
+            # Backstop only — the store already filters blocklisted entities out
+            # of the eligible pool. Deliberately no record_match_attempt() here:
+            # bumping the count re-queued these under backoff forever, and since
+            # the blocklist is a permanent property of the address there is
+            # nothing for a retry to discover (#550).
             if entity.observed_email and is_blocklisted_domain(entity.observed_email):
                 stats['blocklist_skipped'] += 1
-                # Record attempt so we don't keep trying
-                if not dry_run:
-                    source_store.record_match_attempt(entity.id)
                 continue
 
             try:

--- a/tests/test_source_entity.py
+++ b/tests/test_source_entity.py
@@ -391,6 +391,94 @@ class TestRematchingEligibility:
         assert store.count_capped_backlog(max_attempts=3) == 3
 
 
+class TestBlocklistedExcludedFromRematching:
+    """
+    Blocklisted marketing addresses must never enter the rematching pool.
+
+    They can never resolve to a person, but the linking script recorded a match
+    attempt on every skip, so they were re-queued under backoff forever and made
+    up 70% of the reported capped backlog (#550).
+    """
+
+    # A marketing ESP domain, not a personal address.
+    BLOCKLISTED_EMAIL = "campaign@mailchimp.com"
+
+    def _set_attempts(self, store, entity_id, count, days_ago):
+        attempted = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+        conn = sqlite3.connect(store.db_path)
+        conn.execute(
+            "UPDATE source_entities SET match_attempt_count = ?, match_attempted_at = ? "
+            "WHERE id = ?",
+            (count, attempted, entity_id),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_blocklisted_entity_excluded_from_pool(self, store):
+        """A blocklisted entity is never returned for rematching."""
+        blocked = SourceEntity(
+            source_type="gmail",
+            source_id="promo1",
+            observed_email=self.BLOCKLISTED_EMAIL,
+        )
+        store.add(blocked)
+        self._set_attempts(store, blocked.id, count=3, days_ago=60)
+
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3,
+        )
+        assert blocked.id not in [e.id for e in results]
+
+    def test_non_blocklisted_entity_still_eligible(self, store):
+        """The filter is targeted — an ordinary address is unaffected."""
+        ordinary = SourceEntity(
+            source_type="gmail",
+            source_id="real1",
+            observed_email="sam@example.com",
+        )
+        store.add(ordinary)
+        self._set_attempts(store, ordinary.id, count=3, days_ago=60)
+
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3,
+        )
+        assert ordinary.id in [e.id for e in results]
+
+    def test_entity_without_email_still_eligible(self, store):
+        """No observed_email means not blocklisted — may still match on name/phone."""
+        no_email = SourceEntity(source_type="imessage", source_id="sms1")
+        store.add(no_email)
+        self._set_attempts(store, no_email.id, count=3, days_ago=60)
+
+        results = store.get_unlinked_for_rematching(
+            min_days_since_attempt=30, max_attempts=3,
+        )
+        assert no_email.id in [e.id for e in results]
+
+    def test_capped_backlog_excludes_blocklisted(self, store):
+        """The reported backlog counts only work that can actually drain."""
+        blocked = SourceEntity(
+            source_type="gmail",
+            source_id="promo2",
+            observed_email=self.BLOCKLISTED_EMAIL,
+        )
+        store.add(blocked)
+        self._set_attempts(store, blocked.id, count=3, days_ago=1)
+
+        ordinary = SourceEntity(
+            source_type="gmail",
+            source_id="real2",
+            observed_email="sam@example.com",
+        )
+        store.add(ordinary)
+        self._set_attempts(store, ordinary.id, count=3, days_ago=1)
+
+        assert store.count_capped_backlog(max_attempts=3) == 1
+        assert store.count_capped_backlog(
+            max_attempts=3, exclude_blocklisted=False,
+        ) == 2
+
+
 class TestLinkMethod:
     """Tests for link_method provenance tracking."""
 


### PR DESCRIPTION
Closes #550

## Problem

`link_source_entities` reported a `capped_backlog` of 1,673 that never drained. It was not a backlog draining slowly — it was a permanent floor. 1,177 of those entities (70%) were blocklisted marketing addresses that can never be linked to a person.

`scripts/link_source_entities.py` skipped them, but called `record_match_attempt()` on the way out. That bumped `match_attempt_count` and set `match_attempted_at`, re-entering the entity into the eligible pool under exponential backoff — forever. Every run fetched them, scored them eligible, skipped them, and re-queued them.

The attempt-count distribution showed the cycle with no drain:

| `match_attempt_count` | entities |
|---|---|
| 3 | 876 |
| 4 | 797 |
| 5+ | 0 |

## Approach

Filter blocklisted entities out of the eligible pool at the store level, rather than letting them in and skipping them per-run:

- `get_unlinked_for_rematching()` drops them from the candidate set.
- `count_capped_backlog()` excludes them, so the metric tracks work that can actually drain.
- The `record_match_attempt()` call that caused the churn is removed. The blocklist check in the script stays as a backstop, but no longer mutates state.

Both methods take `exclude_blocklisted: bool = True` so the old behavior is still reachable for diagnostics.

No schema change — the blocklist is evaluated from `observed_email` via the existing `config.marketing_patterns.is_blocklisted_domain`. The unlinked pool is 1,740 rows, so filtering in Python after the SQL fetch is cheap.

## Verification

Live corpus, `--max-capped-per-run 100000` dry run:

| metric | before | after |
|---|---|---|
| `capped_backlog` | 1,673 | **496** |
| eligible for matching | 798 | **73** |
| blocklist skips per run | 725 | **0** |

The 73 remaining are genuine retry candidates.

## Tests

Four regression tests in `TestBlocklistedExcludedFromRematching`:

- blocklisted entity is excluded from the rematching pool
- an ordinary address is still eligible (the filter is targeted, not broad)
- an entity with no `observed_email` is still eligible — it may match on name or phone
- `count_capped_backlog` excludes blocklisted, and `exclude_blocklisted=False` still counts them

`tests/test_source_entity.py`: 40 passed.

Full unit suite: 4,219 passed. The failures present are pre-existing on `main` — I baselined a clean `main` at 4 failures (`test_settings` ×2, `test_slack_sync`, `test_p91` R1) and this branch adds none. Two `test_mcp_server` failures and one `test_p91` R2 failure appeared in one run only, do not reproduce, and pass consistently in isolation — they read the live API and vault, which other agents and the nightly sync mutate concurrently.

## Notes

Only read paths are touched; no data was mutated during verification (dry runs only).

Related: #507 introduced the per-run cap and the `capped_backlog` metric that made this visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
