### PR TITLE
fix(crm): require last-name corroboration for single-letter initial matches

### DIFF
--- a/api/services/entity_resolver.py
+++ b/api/services/entity_resolver.py
@@ -401,8 +401,16 @@ class EntityResolver:
                 elif is_first_initial and entity_first_lower.startswith(query_first_lower):
                     score += 10  # Initial prefix match
                     first_matched = True
-                elif len(entity_first_lower) == 1 and query_first_lower.startswith(entity_first_lower):
-                    score += 10  # Entity has initial, query has full name
+                elif (
+                    len(entity_first_lower) == 1
+                    and not is_first_name_only
+                    and query_first_lower.startswith(entity_first_lower)
+                ):
+                    # Entity has initial, query has full name ("J Smith" <- "John Smith").
+                    # Requires a last name in the query to corroborate: without one the
+                    # whole match rests on a single shared letter, so an entity stored
+                    # as "A Reader" swallowed every name starting with "a" (#551).
+                    score += 10
                     first_matched = True
                 elif are_name_variants(query_first_lower, entity_first_lower):
                     score += 20  # Nickname match (Ben/Benjamin, Mike/Michael)

--- a/tests/test_entity_resolver.py
+++ b/tests/test_entity_resolver.py
@@ -486,6 +486,50 @@ class TestParseName:
         assert result.last == "Wilhelm"
 
 
+class TestSingleLetterFirstNameEntity:
+    """
+    An entity whose first name is a single letter must not swallow every query
+    sharing that initial.
+
+    "A Reader" matched ADP, ACP, and ADS, Inc. — all promoted to
+    first_name_context_clear and silently linked, because the entire match
+    rested on one shared letter (#551).
+    """
+
+    def test_first_name_only_query_does_not_match_on_initial_alone(self, temp_store):
+        """Without a last name to corroborate, a shared initial is not a match."""
+        temp_store.add(PersonEntity(
+            canonical_name="A Reader",
+            last_seen=datetime.now() - timedelta(days=5),
+        ))
+        resolver = EntityResolver(temp_store)
+
+        for query in ("ADP", "ACP", "ADS, Inc.", "Andrew"):
+            assert resolver.resolve_by_name(query) is None, f"{query} should not match"
+
+    def test_matching_last_name_still_resolves_from_initial(self, temp_store):
+        """The legitimate case survives: 'J Smith' is still found by 'John Smith'."""
+        temp_store.add(PersonEntity(
+            canonical_name="J Smith",
+            last_seen=datetime.now() - timedelta(days=5),
+        ))
+        resolver = EntityResolver(temp_store)
+
+        result = resolver.resolve_by_name("John Smith")
+        assert result is not None
+        assert result.entity.canonical_name == "J Smith"
+
+    def test_non_matching_last_name_does_not_resolve(self, temp_store):
+        """A last name that disagrees is not corroboration."""
+        temp_store.add(PersonEntity(
+            canonical_name="J Smith",
+            last_seen=datetime.now() - timedelta(days=5),
+        ))
+        resolver = EntityResolver(temp_store)
+
+        assert resolver.resolve_by_name("John Walker") is None
+
+
 class TestStructuredNameMatching:
     """Tests for the new structured name matching in _score_candidates."""
 


### PR DESCRIPTION
Closes #551

## Problem

A `PersonEntity` whose first name is a single letter acted as a magnet — **any** query name beginning with that letter matched it, producing silent false-positive CRM links.

Reproduced against the live resolver before the fix:

```
'ADP'       -> A Reader+Ffeb  (first_name_context_clear, conf=0.51)
'ACP'       -> A Reader+Ffeb  (first_name_context_clear, conf=0.51)
'ADS, Inc.' -> A Reader+Ffeb  (first_name_context_clear, conf=0.51)
'Zqx'       -> None                      # control: different initial
'A'         -> None                      # control
```

Three unrelated corporate senders resolving to one person.

## Root cause

`api/services/entity_resolver.py:404`:

```python
elif len(entity_first_lower) == 1 and query_first_lower.startswith(entity_first_lower):
    score += 10  # Entity has initial, query has full name
    first_matched = True
```

The rule is sound for `J Smith` ← `John Smith`, **when a last name corroborates it**. For a first-name-only query there is no last name to check, so the whole match rests on one shared letter — roughly a 1-in-26 collision against every incoming name.

`first_matched = True` then satisfies the first-name-only guard, the candidate survives to the ambiguity check, and as the only candidate above threshold it is promoted to `first_name_context_clear` and linked.

## Approach

Require a last name in the query before the initial-prefix rule can set `first_matched`. Queries with a last name are unaffected — and a *disagreeing* last name was already handled by the existing `score >= 20` threshold, since the initial alone contributes only 10.

This tightens the rule rather than removing it: 75 rows in `person_entities` have a single-letter first name, and while many are junk, some look like real people known by initials (`M P`, `T H`), so initial-based matching still needs to work.

## Verification

- The three false positives now resolve to `None`.
- `link_source_entities` dry run over the live corpus: **6 newly linked → 0**. All 6 were false positives against the same junk entity, so nothing legitimate was lost.

## Tests

Three regression tests in `TestSingleLetterFirstNameEntity`:

- a first-name-only query does not match on a shared initial alone (`ADP`, `ACP`, `ADS, Inc.`, `Andrew` vs. an `A Reader` entity)
- the legitimate case still resolves — `J Smith` is still found by `John Smith`
- a disagreeing last name does not resolve

`tests/test_entity_resolver.py`: 50 passed, including all pre-existing tests — confirming no regression in legitimate initial-based matching.

Full unit suite: 4,218 passed, with the same 4 failures present on clean `main` (`test_settings` ×2, `test_slack_sync`, `test_p91` R1).

## Note on a flaky test

`test_p91_data_integrity.py::TestR2EntityResolution::test_vault_interactions_mention_linked_person` appears in some runs. It is **not** caused by this change — it samples live data with `ORDER BY RANDOM() LIMIT 20`, so it fails whenever the sample happens to include a pre-existing bad link. On clean `main` it fails 3 of 6 runs in isolation. Flagging rather than fixing: a ~50% random gate is worth addressing separately, and the bad links it catches are the very class this PR reduces.

## Follow-up (not in scope)

`A Reader+Ffeb` (`person_entities` id `4480b56f-43fe-4f86-8489-7ca4873e8a61`) is a junk entity. With this fix it no longer attracts matches, but purging it and its siblings is data cleanup and deliberately left separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
