### PR TITLE
perf(gmail): fetch messages in batched, quota-aware round-trips

### DIFF
--- a/api/services/gmail.py
+++ b/api/services/gmail.py
@@ -428,14 +428,17 @@ class GmailService:
                 try:
                     batch.execute()
                 except Exception as e:
+                    # A whole-batch failure usually means no callback ran, but a
+                    # partial one is possible — don't re-fetch what already landed.
+                    unfinished = [m for m in pending if m not in results]
                     if self._is_rate_limit_error(e):
-                        rate_limited = list(pending)
+                        rate_limited = unfinished
                     else:
                         logger.warning(
-                            f"Gmail batch request failed for {len(pending)} "
+                            f"Gmail batch request failed for {len(unfinished)} "
                             f"messages, falling back to individual fetches: {e}"
                         )
-                        failed = list(pending)
+                        failed = unfinished
 
                 fallback_ids.extend(failed)
 

--- a/api/services/gmail.py
+++ b/api/services/gmail.py
@@ -13,14 +13,14 @@ import re
 # Set a default socket timeout for all network operations (30 seconds)
 # This prevents Gmail API calls from hanging indefinitely
 socket.setdefaulttimeout(30)
-from datetime import datetime, timezone
-from dataclasses import dataclass, field
-from typing import Optional
-from email.utils import parsedate_to_datetime
+from datetime import datetime, timezone  # noqa: E402
+from dataclasses import dataclass, field  # noqa: E402
+from typing import Optional  # noqa: E402
+from email.utils import parsedate_to_datetime  # noqa: E402
 
-from googleapiclient.discovery import build
+from googleapiclient.discovery import build  # noqa: E402
 
-from api.services.google_auth import get_google_auth, GoogleAccount
+from api.services.google_auth import get_google_auth, GoogleAccount  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -330,6 +330,147 @@ class GmailService:
         # All retries exhausted
         logger.error(f"Failed to get message {message_id} after {max_retries} retries: {last_error}")
         return None
+
+    @staticmethod
+    def _is_rate_limit_error(exception) -> bool:
+        """True if an exception is Gmail telling us to slow down."""
+        status = getattr(getattr(exception, "resp", None), "status", None)
+        if status in (429, 403):
+            # 403 covers both quota exhaustion and genuine permission errors;
+            # only the former mentions a rate/quota reason.
+            text = str(exception).lower()
+            return "ratelimit" in text or "quota" in text or "userratelimit" in text
+        return False
+
+    def get_messages_batch(
+        self,
+        message_ids: list[str],
+        include_body: bool = False,
+        batch_size: int = 50,
+        seconds_per_message: float = 0.04,
+        max_retries: int = 5,
+    ) -> dict[str, EmailMessage]:
+        """
+        Fetch many messages using the Gmail batch endpoint.
+
+        One HTTP round-trip carries up to ``batch_size`` message fetches
+        instead of one, and one pause covers the whole batch rather than each
+        message. The pause matters most: at the default 0.1s per-call delay,
+        fetching 13k messages individually spends ~22 minutes asleep before
+        any network time counts (#552).
+
+        Pacing is deliberate. The per-call sleep this replaces was also, by
+        accident, the thing keeping us under Gmail's per-user quota. Removing
+        it without a replacement exhausts the quota partway through a large
+        mailbox, so batches are paced to ``seconds_per_message`` per message.
+
+        Rate-limit errors back off and retry the whole chunk rather than
+        falling back to individual fetches: once the quota is gone, retrying
+        each message separately is a thundering herd that makes it worse.
+        Only non-quota failures fall back to ``get_message()``, which carries
+        its own retry logic.
+
+        Args:
+            message_ids: Gmail message IDs to fetch
+            include_body: Whether to fetch full bodies
+            batch_size: Messages per HTTP round-trip (Gmail's ceiling is 100,
+                but 50 measured faster — larger batches trip throttling)
+            seconds_per_message: Pacing budget; a chunk is spaced out to at
+                least ``batch_size * seconds_per_message`` seconds
+            max_retries: Backoff attempts per chunk before giving up on it
+
+        Returns:
+            Mapping of message_id -> EmailMessage, omitting any that failed.
+            Callers must not assume every requested id is present.
+        """
+        format_type = "full" if include_body else "metadata"
+        metadata_headers = (
+            ["Subject", "From", "To", "Cc", "Date"] if not include_body else None
+        )
+        chunk_interval = batch_size * seconds_per_message
+
+        results: dict[str, EmailMessage] = {}
+        fallback_ids: list[str] = []
+
+        for start in range(0, len(message_ids), batch_size):
+            chunk = message_ids[start:start + batch_size]
+            pending = list(chunk)
+
+            for attempt in range(max_retries + 1):
+                rate_limited: list[str] = []
+                failed: list[str] = []
+
+                def callback(request_id, response, exception):
+                    if exception is not None:
+                        if self._is_rate_limit_error(exception):
+                            rate_limited.append(request_id)
+                        else:
+                            failed.append(request_id)
+                        return
+                    parsed = self._parse_message(response, include_body)
+                    if parsed:
+                        results[request_id] = parsed
+
+                batch = self.service.new_batch_http_request()
+                for message_id in pending:
+                    batch.add(
+                        self.service.users().messages().get(
+                            userId="me",
+                            id=message_id,
+                            format=format_type,
+                            metadataHeaders=metadata_headers,
+                        ),
+                        request_id=message_id,
+                        callback=callback,
+                    )
+
+                started = time.time()
+                try:
+                    batch.execute()
+                except Exception as e:
+                    if self._is_rate_limit_error(e):
+                        rate_limited = list(pending)
+                    else:
+                        logger.warning(
+                            f"Gmail batch request failed for {len(pending)} "
+                            f"messages, falling back to individual fetches: {e}"
+                        )
+                        failed = list(pending)
+
+                fallback_ids.extend(failed)
+
+                if not rate_limited:
+                    # Pace the next chunk, crediting time already spent on the wire.
+                    time.sleep(max(0.0, chunk_interval - (time.time() - started)))
+                    break
+
+                if attempt == max_retries:
+                    logger.error(
+                        f"Gmail batch: {len(rate_limited)} messages still rate "
+                        f"limited after {max_retries} retries, giving up on them"
+                    )
+                    break
+
+                pending = rate_limited
+                backoff = (2 ** attempt) + 1.0  # 2s, 3s, 5s, 9s, 17s
+                logger.warning(
+                    f"Gmail rate limit hit on {len(pending)} messages, "
+                    f"backing off {backoff:.0f}s (attempt {attempt + 1}/{max_retries})"
+                )
+                time.sleep(backoff)
+
+        for message_id in fallback_ids:
+            message = self.get_message(message_id, include_body=include_body)
+            if message:
+                results[message_id] = message
+
+        if fallback_ids:
+            logger.info(
+                f"Gmail batch: {len(fallback_ids)} of {len(message_ids)} messages "
+                "needed an individual retry"
+            )
+
+        return results
 
     def _parse_message(self, msg: dict, include_body: bool = False) -> Optional[EmailMessage]:
         """

--- a/scripts/sync_gmail_calendar_interactions.py
+++ b/scripts/sync_gmail_calendar_interactions.py
@@ -208,6 +208,28 @@ def sync_gmail_interactions(
         processed = 0
 
         logger.info(f"Starting to process messages (existing base IDs: {len(existing_base_ids)})...")
+
+        # Pre-fetch every message we haven't seen, in batched round-trips.
+        #
+        # Marketing mail is discarded below without ever producing an
+        # interaction row, so it never lands in existing_base_ids and is
+        # re-fetched every night for the full window. On the personal account
+        # that is ~13k messages, and fetching them one at a time cost ~42 min
+        # per run — most of it the per-call rate-limit sleep (#552).
+        new_message_ids = [
+            m["id"] for m in messages if m["id"] not in existing_base_ids
+        ]
+        logger.info(
+            f"  {len(messages) - len(new_message_ids)} already synced, "
+            f"{len(new_message_ids)} to fetch"
+        )
+        fetched_emails = gmail.get_messages_batch(
+            new_message_ids, include_body=False
+        )
+        logger.info(
+            f"  Fetched {len(fetched_emails)}/{len(new_message_ids)} new messages"
+        )
+
         checked = 0
         for msg_data in messages:
             message_id = msg_data["id"]
@@ -228,13 +250,10 @@ def sync_gmail_interactions(
                 stats['already_exists'] += 1
                 continue
 
-            # Log when fetching new message
-            if checked <= 5:
-                logger.info(f"    Fetching new message {message_id[:8]}...")
-
             try:
-                # Fetch message details (metadata only for speed)
-                email = gmail.get_message(message_id, include_body=False)
+                # Already fetched above; a miss means the batch (and its
+                # individual retry) failed for this message.
+                email = fetched_emails.get(message_id)
                 if not email:
                     stats['errors'] += 1
                     continue

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -14,17 +14,19 @@ import pytest
 
 # All tests in this file use mocks (unit tests)
 pytestmark = pytest.mark.unit
-from datetime import datetime, timezone
-from unittest.mock import Mock, patch, MagicMock
-import base64
+from datetime import datetime, timezone  # noqa: E402
+from unittest.mock import patch, MagicMock  # noqa: E402
+import base64  # noqa: E402
 
-from api.services.gmail import (
+from googleapiclient.errors import HttpError  # noqa: E402
+
+from api.services.gmail import (  # noqa: E402
     GmailService,
     EmailMessage,
     DraftMessage,
     build_gmail_query,
 )
-from api.services.google_auth import GoogleAccount
+from api.services.google_auth import GoogleAccount  # noqa: E402
 
 
 class TestEmailMessage:
@@ -164,7 +166,7 @@ class TestGmailService:
         gmail_service._service.users().messages().list().execute.return_value = mock_messages
         gmail_service._service.users().messages().get().execute.return_value = mock_detail
 
-        messages = gmail_service.search(from_email="kevin@example.com")
+        gmail_service.search(from_email="kevin@example.com")
 
         # Should have called with from: in query
         call_args = gmail_service._service.users().messages().list.call_args
@@ -207,6 +209,215 @@ class TestGmailService:
         # Rate limit should be set
         assert hasattr(gmail_service, 'rate_limit_delay')
         assert gmail_service.rate_limit_delay >= 0
+
+
+class TestGetMessagesBatch:
+    """
+    Batched message fetching.
+
+    Fetching one at a time cost ~42 min per nightly run on a busy mailbox,
+    dominated by the per-call rate-limit sleep (#552).
+    """
+
+    @pytest.fixture
+    def mock_auth_service(self):
+        mock = MagicMock()
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock.get_credentials.return_value = mock_creds
+        return mock
+
+    @pytest.fixture
+    def gmail_service(self, mock_auth_service):
+        with patch('api.services.gmail.get_google_auth', return_value=mock_auth_service):
+            with patch('api.services.gmail.build') as mock_build:
+                mock_service = MagicMock()
+                mock_build.return_value = mock_service
+                service = GmailService(account_type=GoogleAccount.PERSONAL)
+                service._service = mock_service
+                return service
+
+    @staticmethod
+    def _raw(message_id):
+        return {
+            "id": message_id,
+            "threadId": f"thread_{message_id}",
+            "snippet": "Quarterly planning notes",
+            "payload": {
+                "headers": [
+                    {"name": "Subject", "value": f"Subject {message_id}"},
+                    {"name": "From", "value": "Dana Reyes <dana@example.com>"},
+                    {"name": "Date", "value": "Tue, 7 Jan 2026 10:00:00 -0800"},
+                ]
+            },
+        }
+
+    def _install_batch(self, gmail_service, fail_ids=()):
+        """Make new_batch_http_request() drive callbacks like the real client."""
+        added = []
+
+        class FakeBatch:
+            def add(self, request, request_id=None, callback=None):
+                added.append((request_id, callback))
+
+            def execute(_self):
+                for request_id, callback in added:
+                    if request_id in fail_ids:
+                        callback(request_id, None, Exception("boom"))
+                    else:
+                        callback(request_id, TestGetMessagesBatch._raw(request_id), None)
+                added.clear()
+
+        gmail_service._service.new_batch_http_request.side_effect = lambda: FakeBatch()
+        return added
+
+    def test_returns_all_requested_messages(self, gmail_service):
+        """Every id resolves to a parsed message keyed by its id."""
+        self._install_batch(gmail_service)
+        ids = [f"msg{i}" for i in range(5)]
+
+        result = gmail_service.get_messages_batch(ids)
+
+        assert set(result) == set(ids)
+        assert result["msg0"].sender == "dana@example.com"
+        assert result["msg3"].subject == "Subject msg3"
+
+    def test_uses_one_round_trip_per_batch_size(self, gmail_service):
+        """120 messages at batch_size=50 is 3 round-trips, not 120."""
+        self._install_batch(gmail_service)
+        ids = [f"msg{i}" for i in range(120)]
+
+        gmail_service.get_messages_batch(ids, batch_size=50)
+
+        assert gmail_service._service.new_batch_http_request.call_count == 3
+
+    def test_failed_message_falls_back_to_individual_fetch(self, gmail_service):
+        """A per-message failure retries individually rather than being dropped."""
+        self._install_batch(gmail_service, fail_ids={"msg1"})
+        gmail_service._service.users().messages().get().execute.return_value = self._raw("msg1")
+
+        result = gmail_service.get_messages_batch(["msg0", "msg1", "msg2"])
+
+        assert set(result) == {"msg0", "msg1", "msg2"}
+
+    def test_whole_batch_failure_falls_back(self, gmail_service):
+        """If execute() raises, the chunk is retried individually, not lost."""
+        class ExplodingBatch:
+            def add(self, *a, **kw):
+                pass
+
+            def execute(self):
+                raise Exception("transport died")
+
+        gmail_service._service.new_batch_http_request.side_effect = lambda: ExplodingBatch()
+        gmail_service._service.users().messages().get().execute.return_value = self._raw("msg0")
+
+        result = gmail_service.get_messages_batch(["msg0"])
+
+        assert "msg0" in result
+
+    def test_empty_input_makes_no_requests(self, gmail_service):
+        """No ids means no round-trips."""
+        self._install_batch(gmail_service)
+
+        assert gmail_service.get_messages_batch([]) == {}
+        assert gmail_service._service.new_batch_http_request.call_count == 0
+
+    @staticmethod
+    def _quota_error():
+        """An HttpError shaped like Gmail's quota-exhaustion response."""
+        resp = MagicMock()
+        resp.status = 403
+        return HttpError(
+            resp,
+            b'{"error": {"message": "Quota exceeded for quota metric '
+            b'\'Queries\'", "errors": [{"reason": "rateLimitExceeded"}]}}',
+        )
+
+    def test_rate_limited_messages_retry_as_a_batch_not_individually(self, gmail_service):
+        """
+        Quota errors back off and re-run the chunk.
+
+        Falling back to individual fetches here is a thundering herd: the quota
+        is already gone, so thousands of single requests make it worse. This is
+        not hypothetical — it exhausted the live quota during development.
+        """
+        calls = {"n": 0}
+
+        class FlakyBatch:
+            def __init__(self):
+                self.items = []
+
+            def add(self, request, request_id=None, callback=None):
+                self.items.append((request_id, callback))
+
+            def execute(_self):
+                calls["n"] += 1
+                first_attempt = calls["n"] == 1
+                for request_id, callback in _self.items:
+                    if first_attempt:
+                        callback(request_id, None, TestGetMessagesBatch._quota_error())
+                    else:
+                        callback(request_id, TestGetMessagesBatch._raw(request_id), None)
+
+        gmail_service._service.new_batch_http_request.side_effect = lambda: FlakyBatch()
+
+        with patch('api.services.gmail.time.sleep'):
+            result = gmail_service.get_messages_batch(["msg0", "msg1"])
+
+        assert set(result) == {"msg0", "msg1"}
+        assert calls["n"] == 2, "should have retried as a batch"
+        # The individual endpoint must not have been used for quota errors.
+        gmail_service._service.users().messages().get().execute.assert_not_called()
+
+    def test_gives_up_after_max_retries(self, gmail_service):
+        """Persistent quota exhaustion stops rather than looping forever."""
+        class AlwaysLimited:
+            def add(self, request, request_id=None, callback=None):
+                self._id, self._cb = request_id, callback
+
+            def execute(_self):
+                _self._cb(_self._id, None, TestGetMessagesBatch._quota_error())
+
+        gmail_service._service.new_batch_http_request.side_effect = lambda: AlwaysLimited()
+
+        with patch('api.services.gmail.time.sleep'):
+            result = gmail_service.get_messages_batch(["msg0"], max_retries=2)
+
+        assert result == {}
+        assert gmail_service._service.new_batch_http_request.call_count == 3
+
+    def test_non_quota_error_still_falls_back_individually(self, gmail_service):
+        """A one-off failure is worth an individual retry; quota exhaustion isn't."""
+        self._install_batch(gmail_service, fail_ids={"msg1"})
+        gmail_service._service.users().messages().get().execute.return_value = self._raw("msg1")
+
+        with patch('api.services.gmail.time.sleep'):
+            result = gmail_service.get_messages_batch(["msg0", "msg1"])
+
+        assert set(result) == {"msg0", "msg1"}
+
+    def test_batches_are_paced(self, gmail_service):
+        """Chunks are spaced out — the per-call sleep was what kept us under quota."""
+        self._install_batch(gmail_service)
+
+        with patch('api.services.gmail.time.sleep') as mock_sleep:
+            gmail_service.get_messages_batch(
+                [f"msg{i}" for i in range(4)], batch_size=2, seconds_per_message=0.5,
+            )
+
+        # Two chunks, each paced to batch_size * seconds_per_message = 1.0s.
+        assert mock_sleep.call_count == 2
+        assert all(0 < c.args[0] <= 1.0 for c in mock_sleep.call_args_list)
+
+    def test_rate_limit_detection_ignores_plain_permission_errors(self, gmail_service):
+        """A 403 that isn't about quota is a real error, not a signal to back off."""
+        resp = MagicMock()
+        resp.status = 403
+        denied = HttpError(resp, b'{"error": {"message": "Insufficient permission"}}')
+
+        assert gmail_service._is_rate_limit_error(denied) is False
+        assert gmail_service._is_rate_limit_error(self._quota_error()) is True
 
 
 class TestGmailAPI:


### PR DESCRIPTION
Refs #552 — **partial fix.** Cuts `gmail_personal` from ~48.6 min to ~18.2 min, short of the issue's <5 min target. See *Why this doesn't hit the target* below.

## Problem

`gmail_personal` spent ~42 min of every nightly run — 40% of the whole sync — producing 350 records. Marketing mail is fetched and *then* discarded, so it never produces an interaction row, never lands in `existing_base_ids`, and is re-fetched every night for the full 30-day window: ~13,158 messages, one API round-trip each.

## What changed

`GmailService.get_messages_batch()` carries up to 50 fetches per HTTP round-trip, and the sync script pre-fetches new messages through it.

Two things this had to get right, both found the hard way during testing:

**Pacing.** The 0.1s per-call sleep being replaced was also, by accident, what kept us under Gmail's per-user quota. My first version dropped it and **exhausted the live quota partway through the mailbox**. Batches are now paced per message (`seconds_per_message=0.04`).

**Backoff.** Quota errors retry the whole chunk with exponential backoff instead of falling back to individual fetches. That fallback is a thundering herd — the quota is already gone, so thousands of single requests make it worse. Only non-quota failures fall back to `get_message()`. A plain 403 permission error is correctly *not* treated as a rate limit.

## Verification (live API)

| pacing | result |
|---|---|
| unpaced | quota exhaustion mid-run |
| `0.04` | 499/499 fetched, **18.2 min** extrapolated |
| `0.06` | 400/400 fetched, 19.6 min |
| `0.10` | 400/400 fetched, 30.9 min |

No message losses across rate-limit events — backoff recovered every one. Separately, 40 messages fetched both ways were byte-identical on sender, sender_name, subject, date, to, cc, and snippet, so this is a pure performance change.

## Why this doesn't hit the <5 min target

Gmail's per-user quota, not the client, is the binding constraint. Sustained throughput tops out near 80 ms/msg however the fetches are packed — `0.04` and `0.06` pacing land within 1.4 min of each other, and going gentler is strictly worse. Fetching 13k messages nightly cannot be made fast; the only way under 5 min is to **stop fetching them**, which needs the skip cache deferred from #552 as a schema change. Leaving #552 open for that.

## The query-level exclusion is rejected

The other half of #552 was `-category:promotions -category:social -category:updates`. I measured it before implementing, and it is **not safe**:

| account | volume dropped | of sampled drops, share `is_marketing_email` would have KEPT |
|---|---|---|
| personal | 39% | 8% |
| work | 56% | **48%** |

Casualties included `comments-noreply@docs.google.com` (Doc comments), `drive-shares-dm-noreply@google.com`, `stratechery.com`, and real human senders. Narrowing to `-category:promotions` alone was no better — still 36-61% legitimate among drops, while removing only 2% of personal volume. Gmail's categories simply do not align with `is_marketing_email`.

## Tests

Ten tests in `TestGetMessagesBatch`, including the failure modes above:

- all requested ids returned and parsed
- 120 ids at `batch_size=50` is 3 round-trips, not 120
- rate-limited messages retry **as a batch**, and the individual endpoint is asserted *not* called
- persistent quota exhaustion gives up after `max_retries` instead of looping
- non-quota failures still fall back individually
- batches are paced
- a non-quota 403 is not misread as a rate limit
- empty input makes no requests

Full unit suite: 4,226 passed, with exactly the 4 failures present on clean `main` (`test_settings` ×2, `test_slack_sync`, `test_p91` R1). Zero new.

## Note on unrelated lint

`api/services/gmail.py` and `tests/test_gmail.py` carried pre-existing ruff violations (E402 from the intentional `socket.setdefaulttimeout()` and `pytestmark` placement, plus an unused `Mock` import and an unused assignment) that only surfaced once these files were staged. Added `# noqa: E402` markers matching the existing convention in `entity_resolver.py` and `crm.py`, and cleared the two dead symbols — the pre-commit hook is mandatory and the files could not otherwise be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
