### PR TITLE
perf(gmail): remember discarded messages so they are fetched once, not nightly

### DIFF
--- a/api/services/gmail_skip_cache.py
+++ b/api/services/gmail_skip_cache.py
@@ -1,0 +1,141 @@
+"""
+Remembers Gmail messages that were fetched and deliberately discarded.
+
+The Gmail sync decides a message is marketing only *after* fetching it, and a
+discarded message never produces an interaction row. Since the sync's
+"already seen" set is derived from the interactions table, promotional mail was
+invisible to it and got re-fetched every night for the full 30-day window —
+~13k messages on a busy personal account, dominating the nightly run (#552).
+
+This is a sidecar sync-state database, following the pattern already used by
+``data/slack_sync_timestamps.db`` and ``data/imessage.db``'s ``sync_state``:
+bookkeeping about what a sync has done, kept out of the main data model.
+
+Caching a skip decision means it is not re-evaluated while the entry lives. If
+the marketing rules in ``config/marketing_patterns`` change and you want them
+applied to already-skipped mail, delete the database file — the next run
+re-fetches and re-evaluates everything in the window.
+"""
+import logging
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# Entries are pruned well past any realistic sync window (the nightly run looks
+# back 30 days), so a message ages out of the query before it ages out of here.
+DEFAULT_RETENTION_DAYS = 90
+
+
+def get_gmail_skip_cache_path() -> str:
+    """Path to the skip-cache database, creating its parent directory."""
+    db_dir = Path(settings.chroma_path).parent
+    db_dir.mkdir(parents=True, exist_ok=True)
+    return str(db_dir / "gmail_skip_cache.db")
+
+
+class GmailSkipCache:
+    """Per-account record of message IDs already judged not worth keeping."""
+
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path = db_path or get_gmail_skip_cache_path()
+        self._init_db()
+
+    def _init_db(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            # Keyed by (account, message_id): Gmail ids are only unique within a
+            # mailbox, and the same sync process handles several accounts.
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS skipped_messages (
+                    account TEXT NOT NULL,
+                    message_id TEXT NOT NULL,
+                    skipped_at TEXT NOT NULL,
+                    reason TEXT,
+                    PRIMARY KEY (account, message_id)
+                )
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_skipped_at
+                ON skipped_messages(skipped_at)
+            """)
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_skipped_ids(self, account: str) -> set[str]:
+        """Every message id previously skipped for this account."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.execute(
+                "SELECT message_id FROM skipped_messages WHERE account = ?",
+                (account,),
+            )
+            return {row[0] for row in cursor.fetchall()}
+        finally:
+            conn.close()
+
+    def record_skipped(
+        self,
+        account: str,
+        message_ids: Iterable[str],
+        reason: str = "marketing",
+    ) -> int:
+        """
+        Remember that these messages were fetched and discarded.
+
+        Returns the number of ids written. Re-recording an existing id is a
+        no-op rather than an error, so a partial run is safe to repeat.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        rows = [(account, message_id, now, reason) for message_id in message_ids]
+        if not rows:
+            return 0
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.executemany(
+                "INSERT OR IGNORE INTO skipped_messages "
+                "(account, message_id, skipped_at, reason) VALUES (?, ?, ?, ?)",
+                rows,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return len(rows)
+
+    def prune(self, retention_days: int = DEFAULT_RETENTION_DAYS) -> int:
+        """
+        Drop entries older than the retention window.
+
+        Without this the cache grows without bound, and an entry is useless once
+        the message has fallen out of the sync's look-back window.
+        """
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=retention_days)
+        ).isoformat()
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.execute(
+                "DELETE FROM skipped_messages WHERE skipped_at < ?", (cutoff,)
+            )
+            conn.commit()
+            return cursor.rowcount
+        finally:
+            conn.close()
+
+
+_skip_cache: Optional[GmailSkipCache] = None
+
+
+def get_gmail_skip_cache() -> GmailSkipCache:
+    """Get or create the singleton skip cache."""
+    global _skip_cache
+    if _skip_cache is None:
+        _skip_cache = GmailSkipCache()
+    return _skip_cache

--- a/scripts/sync_gmail_calendar_interactions.py
+++ b/scripts/sync_gmail_calendar_interactions.py
@@ -31,6 +31,7 @@ from api.services.google_auth import GoogleAccount
 from api.services.entity_resolver import get_entity_resolver
 from api.services.person_entity import get_person_entity_store
 from api.services.interaction_store import get_interaction_db_path
+from api.services.gmail_skip_cache import get_gmail_skip_cache
 from api.services.source_entity import (
     get_source_entity_store,
     create_gmail_source_entity,
@@ -155,6 +156,17 @@ def sync_gmail_interactions(
             existing_base_ids.add(base_id)
     logger.info(f"Found {len(existing)} existing gmail interactions ({len(existing_base_ids)} unique message IDs)")
 
+    # Messages previously fetched and discarded as marketing. They produce no
+    # interaction row, so existing_base_ids alone can never remember them and
+    # they were re-fetched every night for their whole 30-day life (#552).
+    skip_cache = get_gmail_skip_cache()
+    if not dry_run:
+        pruned = skip_cache.prune()
+        if pruned:
+            logger.info(f"Pruned {pruned} expired skip-cache entries")
+    previously_skipped = skip_cache.get_skipped_ids(account_type.value)
+    logger.info(f"Skip cache holds {len(previously_skipped)} known-marketing message IDs")
+
     gmail = GmailService(account_type=account_type)
     after_date = datetime.now(timezone.utc) - timedelta(days=days_back)
     before_date = datetime.now(timezone.utc) - timedelta(days=before_days) if before_days else None
@@ -217,11 +229,13 @@ def sync_gmail_interactions(
         # that is ~13k messages, and fetching them one at a time cost ~42 min
         # per run — most of it the per-call rate-limit sleep (#552).
         new_message_ids = [
-            m["id"] for m in messages if m["id"] not in existing_base_ids
+            m["id"] for m in messages
+            if m["id"] not in existing_base_ids
+            and m["id"] not in previously_skipped
         ]
         logger.info(
-            f"  {len(messages) - len(new_message_ids)} already synced, "
-            f"{len(new_message_ids)} to fetch"
+            f"  {len(messages) - len(new_message_ids)} already synced or "
+            f"known-marketing, {len(new_message_ids)} to fetch"
         )
         fetched_emails = gmail.get_messages_batch(
             new_message_ids, include_body=False
@@ -230,6 +244,7 @@ def sync_gmail_interactions(
             f"  Fetched {len(fetched_emails)}/{len(new_message_ids)} new messages"
         )
 
+        newly_skipped: list[str] = []
         checked = 0
         for msg_data in messages:
             message_id = msg_data["id"]
@@ -250,6 +265,12 @@ def sync_gmail_interactions(
                 stats['already_exists'] += 1
                 continue
 
+            # Judged marketing on an earlier run — never fetched, so there is
+            # nothing in fetched_emails and this is not an error.
+            if message_id in previously_skipped:
+                stats['marketing_skipped'] += 1
+                continue
+
             try:
                 # Already fetched above; a miss means the batch (and its
                 # individual retry) failed for this message.
@@ -261,6 +282,7 @@ def sync_gmail_interactions(
                 # Skip marketing/promotional emails (check both email and sender name)
                 if is_marketing_email(email.sender, email.sender_name):
                     stats['marketing_skipped'] += 1
+                    newly_skipped.append(message_id)
                     continue
 
                 # Resolve the sender
@@ -477,6 +499,16 @@ def sync_gmail_interactions(
 
         if not dry_run:
             conn.commit()
+            # Remember this run's discards so tomorrow doesn't re-fetch them.
+            # Written after the interaction commit: a crash in between costs a
+            # redundant fetch next run, which is exactly today's behaviour, and
+            # is far safer than recording a skip for a message we never stored.
+            if newly_skipped:
+                skip_cache.record_skipped(account_type.value, newly_skipped)
+                logger.info(
+                    f"Recorded {len(newly_skipped)} newly skipped marketing "
+                    "messages in the skip cache"
+                )
 
     except Exception as e:
         logger.error(f"Failed to sync Gmail: {e}")

--- a/tests/test_gmail_skip_cache.py
+++ b/tests/test_gmail_skip_cache.py
@@ -1,0 +1,96 @@
+"""
+Tests for the Gmail skip cache.
+
+The cache exists because marketing mail is discarded without producing an
+interaction row, so the sync's "already seen" set could never remember it and
+re-fetched ~13k messages every night (#552).
+"""
+import pytest
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+pytestmark = pytest.mark.unit
+
+from api.services.gmail_skip_cache import GmailSkipCache  # noqa: E402
+
+
+@pytest.fixture
+def cache(tmp_path):
+    return GmailSkipCache(db_path=str(tmp_path / "skip.db"))
+
+
+class TestRecordAndRead:
+    def test_records_and_returns_ids(self, cache):
+        cache.record_skipped("personal", ["msg1", "msg2"])
+
+        assert cache.get_skipped_ids("personal") == {"msg1", "msg2"}
+
+    def test_accounts_are_isolated(self, cache):
+        """
+        Gmail ids are only unique within a mailbox, and one sync process handles
+        several accounts — a personal skip must not suppress a work message.
+        """
+        cache.record_skipped("personal", ["shared_id"])
+
+        assert cache.get_skipped_ids("work") == set()
+        assert cache.get_skipped_ids("personal") == {"shared_id"}
+
+    def test_recording_twice_is_a_noop(self, cache):
+        """A partial run must be safe to repeat."""
+        cache.record_skipped("personal", ["msg1"])
+        cache.record_skipped("personal", ["msg1", "msg2"])
+
+        assert cache.get_skipped_ids("personal") == {"msg1", "msg2"}
+
+    def test_empty_write_is_harmless(self, cache):
+        assert cache.record_skipped("personal", []) == 0
+        assert cache.get_skipped_ids("personal") == set()
+
+    def test_unknown_account_is_empty_not_an_error(self, cache):
+        assert cache.get_skipped_ids("never_synced") == set()
+
+
+class TestPruning:
+    def _backdate(self, cache, message_id, days):
+        stamp = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+        conn = sqlite3.connect(cache.db_path)
+        conn.execute(
+            "UPDATE skipped_messages SET skipped_at = ? WHERE message_id = ?",
+            (stamp, message_id),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_prunes_only_expired_entries(self, cache):
+        """Unbounded growth is the failure mode pruning exists to prevent."""
+        cache.record_skipped("personal", ["old", "recent"])
+        self._backdate(cache, "old", days=120)
+
+        removed = cache.prune(retention_days=90)
+
+        assert removed == 1
+        assert cache.get_skipped_ids("personal") == {"recent"}
+
+    def test_retention_covers_the_sync_window(self, cache):
+        """
+        An entry must outlive the 30-day look-back window, or a message would
+        be re-fetched while still in range — the bug this cache fixes.
+        """
+        cache.record_skipped("personal", ["msg1"])
+        self._backdate(cache, "msg1", days=31)
+
+        cache.prune(retention_days=90)
+
+        assert cache.get_skipped_ids("personal") == {"msg1"}
+
+    def test_prune_on_empty_cache(self, cache):
+        assert cache.prune() == 0
+
+
+class TestPersistence:
+    def test_survives_reopen(self, tmp_path):
+        """The whole point is remembering across nightly runs."""
+        path = str(tmp_path / "skip.db")
+        GmailSkipCache(db_path=path).record_skipped("personal", ["msg1"])
+
+        assert GmailSkipCache(db_path=path).get_skipped_ids("personal") == {"msg1"}

--- a/tests/test_gmail_sync_skip_cache.py
+++ b/tests/test_gmail_sync_skip_cache.py
@@ -1,0 +1,149 @@
+"""
+The Gmail sync must not re-fetch mail it already judged to be marketing.
+
+Discarded messages produce no interaction row, so the sync's existing_base_ids
+set could never remember them: ~13k messages were re-fetched every night for
+their whole 30-day life, costing ~42 min per run (#552).
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+pytestmark = pytest.mark.unit
+
+from api.services.gmail import EmailMessage  # noqa: E402
+from api.services.gmail_skip_cache import GmailSkipCache  # noqa: E402
+from api.services.google_auth import GoogleAccount  # noqa: E402
+
+
+def _email(message_id, sender, sender_name="Sender"):
+    from datetime import datetime, timezone
+    return EmailMessage(
+        message_id=message_id,
+        thread_id=f"t_{message_id}",
+        subject="Subject",
+        sender=sender,
+        sender_name=sender_name,
+        date=datetime.now(timezone.utc),
+        snippet="snippet",
+        source_account="personal",
+    )
+
+
+@pytest.fixture
+def sync_env(tmp_path):
+    """Run the Gmail sync against isolated databases with a mocked API."""
+    from api.services.interaction_store import InteractionStore
+
+    cache = GmailSkipCache(db_path=str(tmp_path / "skip.db"))
+    interactions_path = str(tmp_path / "interactions.db")
+    InteractionStore(db_path=interactions_path)  # creates the real schema
+
+    gmail = MagicMock()
+    # Two promotional messages and one real one.
+    listed = [{"id": "promo1"}, {"id": "promo2"}, {"id": "real1"}]
+    gmail.service.users().messages().list().execute.return_value = {"messages": listed}
+    gmail.get_messages_batch.side_effect = lambda ids, **kw: {
+        mid: _email(
+            mid,
+            "deals@mailchimp.com" if mid.startswith("promo") else "dana@example.com",
+        )
+        for mid in ids
+    }
+
+    with patch("scripts.sync_gmail_calendar_interactions.GmailService", return_value=gmail), \
+         patch("scripts.sync_gmail_calendar_interactions.get_gmail_skip_cache", return_value=cache), \
+         patch("scripts.sync_gmail_calendar_interactions.get_interaction_db_path",
+               return_value=interactions_path), \
+         patch("scripts.sync_gmail_calendar_interactions.get_source_entity_store",
+               return_value=MagicMock()), \
+         patch("scripts.sync_gmail_calendar_interactions.get_entity_resolver") as resolver:
+        resolver.return_value.resolve.return_value = MagicMock(
+            entity=MagicMock(id="person1"), confidence=1.0, match_type="email_exact",
+        )
+        yield gmail, cache
+
+
+def _run(**kwargs):
+    from scripts.sync_gmail_calendar_interactions import sync_gmail_interactions
+    return sync_gmail_interactions(
+        account_type=GoogleAccount.PERSONAL, dry_run=False, days_back=30, **kwargs
+    )
+
+
+class TestSkipCacheIntegration:
+    def test_first_run_fetches_everything_and_records_discards(self, sync_env):
+        gmail, cache = sync_env
+
+        stats = _run()
+
+        fetched = gmail.get_messages_batch.call_args.args[0]
+        assert set(fetched) == {"promo1", "promo2", "real1"}
+        assert stats["marketing_skipped"] == 2
+        # The discards are remembered for next time.
+        assert cache.get_skipped_ids("personal") == {"promo1", "promo2"}
+
+    def test_second_run_does_not_refetch_known_marketing(self, sync_env):
+        """The whole point: yesterday's promotional mail costs nothing today."""
+        gmail, cache = sync_env
+        _run()
+        gmail.get_messages_batch.reset_mock()
+
+        stats = _run()
+
+        fetched = gmail.get_messages_batch.call_args.args[0]
+        assert "promo1" not in fetched and "promo2" not in fetched
+        # Still counted as skipped, so the stats stay honest.
+        assert stats["marketing_skipped"] == 2
+
+    def test_cached_skips_are_not_counted_as_errors(self, sync_env):
+        """
+        A cached skip is never fetched, so it is absent from the batch result.
+        Treating that absence as a fetch failure would fake an error every night.
+        """
+        gmail, cache = sync_env
+        _run()
+
+        stats = _run()
+
+        assert stats["errors"] == 0
+
+    def test_dry_run_does_not_write_to_the_cache(self, sync_env):
+        gmail, cache = sync_env
+        from scripts.sync_gmail_calendar_interactions import sync_gmail_interactions
+
+        sync_gmail_interactions(
+            account_type=GoogleAccount.PERSONAL, dry_run=True, days_back=30,
+        )
+
+        assert cache.get_skipped_ids("personal") == set()
+
+    def test_legitimate_mail_is_never_cached_as_skipped(self, sync_env):
+        """
+        The cache must only ever suppress discards. Caching a real sender would
+        silently drop them from the CRM forever.
+        """
+        gmail, cache = sync_env
+
+        stats = _run()
+
+        assert "real1" not in cache.get_skipped_ids("personal")
+        assert stats["inserted"] > 0, "the legitimate message should be stored"
+
+    def test_steady_state_fetches_nothing(self, sync_env):
+        """
+        With every message either stored or cached, a run costs no fetches at
+        all — this is what takes the nightly run from ~42 min to seconds.
+        """
+        gmail, cache = sync_env
+        _run()
+        gmail.get_messages_batch.reset_mock()
+
+        _run()
+
+        fetched = gmail.get_messages_batch.call_args.args[0]
+        assert fetched == []


### PR DESCRIPTION
Closes #552 — the remaining half, after #555 batched the fetches.

## Why batching wasn't enough

#555 took `gmail_personal` from ~48.6 min to ~18.2 min, but couldn't go further: Gmail's per-user quota caps sustained throughput near 80 ms/msg however the requests are packed. The only way to be faster is to **not fetch**.

The root cause is an ordering problem. A message is judged marketing only *after* it's fetched, and a discarded message never produces an interaction row. Since `existing_base_ids` is built from the interactions table, promotional mail was permanently invisible to it — re-fetched every night for its whole 30-day life.

## Approach

A sidecar sync-state database, `data/gmail_skip_cache.db`, recording which message IDs each account has already judged to be marketing. This follows the existing pattern for sync bookkeeping (`data/slack_sync_timestamps.db`, `imessage.db`'s `sync_state`, `gsheet_sync.db`'s `synced_rows`) rather than touching the main data model.

Design points worth reviewing:

- **Keyed by `(account, message_id)`** — Gmail IDs are only unique within a mailbox, and one sync process handles several accounts. A personal skip must not suppress a work message.
- **Pruned after 90 days** — well past the 30-day look-back, so a message ages out of the *query* before it ages out of the cache. Without pruning the table grows without bound.
- **Written after the interaction commit** — a crash in between costs a redundant fetch next run, which is exactly today's behaviour. The reverse order could record a skip for a message that was never stored, losing it permanently.
- **Dry runs never write**, and never prune.

## Effect

| | fetches per night |
|---|---|
| before | 13,158 |
| after (first run) | 13,158 — one-time, populates the cache |
| after (steady state) | ~450 genuinely-new messages |

The first run still pays ~18 min once. From the second night on the fetch phase is seconds.

## Tradeoff

Caching a skip means it is not re-evaluated while the entry lives. If the rules in `config/marketing_patterns` change and should apply to already-skipped mail, deleting the database file makes the next run re-fetch and re-evaluate the whole window. This is documented in the module docstring rather than left for someone to rediscover.

## Tests

15 tests across two files.

`test_gmail_skip_cache.py` — the store itself: record/read, **account isolation** (a shared ID in two mailboxes), idempotent re-recording, pruning only expired entries, retention outlasting the 30-day window, and persistence across reopen.

`test_gmail_sync_skip_cache.py` — the wiring, which is the risky part. Runs the real `sync_gmail_interactions` against isolated databases with a mocked API:

- first run fetches all three messages and records the two discards
- **second run does not re-fetch known marketing**
- cached skips are **not counted as fetch errors** — they're absent from the batch result by design, and treating that as failure would fake an error every night
- dry run writes nothing
- legitimate mail is **never** cached as skipped (caching a real sender would silently drop them from the CRM forever)
- steady state fetches nothing at all

Full unit suite: 4,248 passed, with exactly the 4 failures present on clean `main` and zero new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
