### PR TITLE
fix(tests): isolate settings and slack tests from the local environment

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,17 +11,35 @@ def test_chroma_url_setting():
 
 
 def test_local_llm_autostart_defaults_false():
-    """Local LLM autostart should default to False."""
+    """
+    Local LLM autostart should default to False.
+
+    Asserts the FIELD default, not a live instance. ``Settings()`` reads the
+    local .env, so this used to assert whatever the developer's machine had
+    configured — it failed on any host that sets LIFEOS_LOCAL_LLM_AUTOSTART and
+    passed everywhere else, which is the opposite of what it claims to check.
+    """
     from config.settings import Settings
-    s = Settings()
-    assert s.local_llm_autostart is False
+
+    assert Settings.model_fields["local_llm_autostart"].default is False
 
 
 def test_local_llm_model_default():
-    """Local LLM model should default to gpt-oss-120b."""
+    """
+    The shipped local-LLM default is a deliberate pin — update it here when the
+    default model changes. It drifted silently once already: the assertion
+    still named gpt-oss-120b long after the default moved to Gemma, so this
+    test failed for everyone, including a fresh clone.
+
+    Reads the field default so a host-level LIFEOS_LLM_MODEL override doesn't
+    turn a local config choice into a test failure.
+    """
     from config.settings import Settings
-    s = Settings()
-    assert s.local_llm_model == "ggml-org/gpt-oss-120b-GGUF"
+
+    assert (
+        Settings.model_fields["local_llm_model"].default
+        == "unsloth/gemma-4-26B-A4B-it-GGUF"
+    )
 
 
 def test_local_llm_autostart_from_env(monkeypatch):

--- a/tests/test_slack_sync.py
+++ b/tests/test_slack_sync.py
@@ -1,6 +1,6 @@
 """Tests for SlackSync orchestrator — the daily-vs-full-sync entry points."""
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 @pytest.fixture
@@ -113,6 +113,15 @@ class TestIncrementalSyncCallsSyncUsers:
         # Real store, isolated from the project DB.
         entity_store = SourceEntityStore(db_path=str(tmp_path / "crm.db"))
 
+        # Pin the workspace so source_ids are predictable. slack_integration
+        # reads SLACK_TEAM_ID into a module constant at import time, so whether
+        # this test saw "default" or a real team id depended on whether some
+        # other module had already called load_dotenv() — it passed alone and
+        # failed under xdist purely on import order.
+        workspace_patch = patch(
+            "api.services.slack_sync.get_workspace_id", return_value="default"
+        )
+
         # Mock SlackClient returns one workspace user.
         new_user = SlackUser(
             user_id="U_NEW_HUMAN",
@@ -129,12 +138,13 @@ class TestIncrementalSyncCallsSyncUsers:
 
         # sync_messages is irrelevant for this test — short-circuit it.
         mock_indexer = MagicMock()
-        sync = SlackSync(
-            client=mock_client,
-            indexer=mock_indexer,
-            entity_store=entity_store,
-            interaction_store=MagicMock(),
-        )
+        with workspace_patch:
+            sync = SlackSync(
+                client=mock_client,
+                indexer=mock_indexer,
+                entity_store=entity_store,
+                interaction_store=MagicMock(),
+            )
         sync.sync_messages = MagicMock(return_value={
             "channels_synced": 0, "messages_indexed": 0,
             "interactions_created": 0, "errors": [],


### PR DESCRIPTION
Fixes three of the four long-standing suite failures. All three are environment leaks, not real defects — none of them was catching a bug.

## 1. `test_local_llm_model_default` — a stale pin

Asserted `ggml-org/gpt-oss-120b-GGUF` long after `config/settings.py:275` moved to `unsloth/gemma-4-26B-A4B-it-GGUF`. This one **failed for everyone, including a fresh clone** — it just drifted and was never updated.

Kept as a deliberate pin (it's useful to notice the shipped default changing) but now reads the field default, with a docstring saying to update it when the default moves.

## 2. `test_local_llm_autostart_defaults_false` — asserted the developer's machine

The code default *is* `False`. But `Settings()` reads the local `.env`, so the test asserted whatever the host had configured — failing on any machine that sets `LIFEOS_LOCAL_LLM_AUTOSTART` (yours does, `.env:83`) and passing everywhere else. Exactly backwards for a test claiming to check a default.

Both settings tests now read `Settings.model_fields[...].default`, which is the pattern the `#470` model-alias pins in this same file already use.

## 3. `test_new_workspace_user_persists_to_source_entities` — import-order dependent

The test looks up source_id `default:U_NEW_HUMAN`, but `slack_integration.py:35` reads `SLACK_TEAM_ID` into a **module constant at import time**. Whether that constant was empty depended on whether some other module had already called `load_dotenv()` — so the test passed alone, passed for its own file, and failed under xdist purely on import order.

Reproduced deterministically with `SLACK_TEAM_ID=... pytest <single test>`, then fixed by pinning the workspace explicitly. Setting the env var later can't help, since the constant is bound at import.

## Verification

Ran both files with `SLACK_TEAM_ID`, `LIFEOS_LOCAL_LLM_AUTOSTART`, and `LIFEOS_LLM_MODEL` **deliberately set to hostile values**, and again with a clean environment — 28 pass both ways. That's the property that was missing.

Full unit suite: **4 failures → 1**, 4,236 passed.

## What's deliberately left

`test_p91_data_integrity.py::TestR1CleanDatabase::test_all_vault_files_exist` still fails, correctly. It reports 78 vault interactions pointing at files that no longer exist — a real data inconsistency, not a test bug. Investigated separately; notably 56 of the 78 are notes that were **moved**, not deleted, so it needs re-pointing rather than deletion. Handled in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
