### PR TITLE
fix(sync): detect and repair vault interactions whose note was moved

### DIFF
--- a/scripts/sync_consistency_verify.py
+++ b/scripts/sync_consistency_verify.py
@@ -15,6 +15,8 @@ Checks performed:
   4. Self-loop and hidden-person relationships — always cleaned up
   5. Orphaned CRM records — per-table threshold for relationships, facts,
      overrides, source_entities with invalid person_ids
+  6. Missing vault files — interactions pointing at notes that were moved or
+     deleted; re-points moves, drops duplicates, flags ambiguous cases
 
 Usage:
     python scripts/sync_consistency_verify.py --dry-run          # report only
@@ -416,6 +418,127 @@ def _check_orphaned_crm_records(valid_ids: set, dry_run: bool, fix_threshold: in
     return {"count": total_count, "fixed": total_fixed, "details": details}
 
 
+def _classify_missing_vault_files() -> dict:
+    """
+    Sort vault interactions whose file is gone into what should happen to them.
+
+    Moving a note in Obsidian leaves the old interaction pointing at a path that
+    no longer exists, and the next reindex creates fresh interactions at the new
+    path. So a dangling row is usually a *duplicate*, not lost history — but not
+    always, and blanket-deleting them would destroy the exceptions.
+
+    Returns lists keyed by disposition:
+      duplicate — the note moved and the new path already has interactions;
+                  the old rows are stale copies and can go
+      repoint   — the note moved and nothing points at the new path yet;
+                  deleting these would lose the interaction entirely
+      gone      — no file with that name anywhere in the vault
+      ambiguous — the name matches several files, so the move target is a
+                  guess; left alone for a human
+    """
+    from api.services.interaction_store import get_interaction_db_path
+    from config.settings import settings
+
+    conn = sqlite3.connect(get_interaction_db_path(), timeout=60.0)
+    try:
+        known_paths = {
+            row[0] for row in conn.execute(
+                "SELECT DISTINCT source_id FROM interactions "
+                "WHERE source_type IN ('vault', 'granola') AND source_id IS NOT NULL"
+            )
+        }
+    finally:
+        conn.close()
+
+    missing = [
+        p for p in known_paths
+        if p.startswith("/") and not Path(p).exists()
+    ]
+    buckets = {"duplicate": [], "repoint": [], "gone": [], "ambiguous": []}
+    if not missing:
+        return buckets
+
+    vault_root = Path(settings.vault_path)
+    if not vault_root.is_dir():
+        # Vault not mounted — every path would look missing. Report nothing
+        # rather than propose deleting the entire interaction history.
+        logger.warning("vault path %s not present — skipping vault file check", vault_root)
+        return buckets
+
+    by_name: dict[str, list[str]] = {}
+    for path in vault_root.rglob("*.md"):
+        by_name.setdefault(path.name, []).append(str(path))
+
+    for stale_path in missing:
+        candidates = by_name.get(Path(stale_path).name, [])
+        if not candidates:
+            buckets["gone"].append((stale_path, None))
+        elif len(candidates) > 1:
+            buckets["ambiguous"].append((stale_path, candidates))
+        elif candidates[0] in known_paths:
+            buckets["duplicate"].append((stale_path, candidates[0]))
+        else:
+            buckets["repoint"].append((stale_path, candidates[0]))
+
+    return buckets
+
+
+def _check_missing_vault_files(dry_run: bool, fix_threshold: int) -> dict:
+    """
+    Check 6: vault interactions pointing at files that no longer exist.
+
+    Notes get moved between folders, which silently strands their interactions
+    (78 of 3,022 on the corpus that prompted this). Re-point where the history
+    would otherwise be lost, delete where it is a duplicate of rows already
+    created at the new path, and never guess when the target is ambiguous.
+    """
+    from api.services.interaction_store import get_interaction_db_path
+
+    buckets = _classify_missing_vault_files()
+    deletable = buckets["duplicate"] + buckets["gone"]
+    repointable = buckets["repoint"]
+    count = len(deletable) + len(repointable) + len(buckets["ambiguous"])
+    if count == 0:
+        return {"count": 0, "fixed": 0}
+
+    details = (
+        f"duplicate={len(buckets['duplicate'])}, repoint={len(repointable)}, "
+        f"gone={len(buckets['gone'])}, ambiguous={len(buckets['ambiguous'])}"
+    )
+
+    fixed = 0
+    actionable = len(deletable) + len(repointable)
+    if not dry_run and 0 < actionable <= fix_threshold:
+        conn = sqlite3.connect(get_interaction_db_path(), timeout=60.0)
+        try:
+            # Re-point first: if a later delete ever overlapped, we would rather
+            # have preserved the row than removed it.
+            for stale_path, new_path in repointable:
+                cursor = conn.execute(
+                    "UPDATE interactions SET source_id = ? WHERE source_id = ?",
+                    (new_path, stale_path),
+                )
+                fixed += cursor.rowcount
+            for stale_path, _ in deletable:
+                cursor = conn.execute(
+                    "DELETE FROM interactions WHERE source_id = ?", (stale_path,)
+                )
+                fixed += cursor.rowcount
+            conn.commit()
+        finally:
+            conn.close()
+
+    if buckets["ambiguous"]:
+        logger.warning(
+            "%d vault interactions point at moved notes whose name matches "
+            "several files — resolve these manually: %s",
+            len(buckets["ambiguous"]),
+            ", ".join(p for p, _ in buckets["ambiguous"][:5]),
+        )
+
+    return {"count": count, "fixed": fixed, "details": details}
+
+
 def verify_consistency(dry_run: bool = True, fix_threshold: int = AUTO_FIX_THRESHOLD) -> dict:
     """
     Run all consistency checks.
@@ -439,6 +562,7 @@ def verify_consistency(dry_run: bool = True, fix_threshold: int = AUTO_FIX_THRES
             "stale_merged_relationships": {"count": 0, "fixed": 0},
             "relationship_hygiene": {"count": 0, "fixed": 0, "self_loops": 0, "hidden": 0},
             "orphaned_crm_records": {"count": 0, "fixed": 0},
+            "missing_vault_files": {"count": 0, "fixed": 0},
             "total_issues": 0,
             "total_fixed": 0,
             "auto_fix_skipped": False,
@@ -453,19 +577,22 @@ def verify_consistency(dry_run: bool = True, fix_threshold: int = AUTO_FIX_THRES
     # Clean up self-loops and hidden-person relationships BEFORE orphan check
     rel_hygiene = _check_relationship_hygiene(hidden_ids, valid_ids, dry_run)
     orphaned_crm_records = _check_orphaned_crm_records(valid_ids, dry_run, fix_threshold)
+    # Vault paths drift when notes are moved between folders
+    missing_vault_files = _check_missing_vault_files(dry_run, fix_threshold)
     # Person stats AFTER interaction-modifying checks so counts reflect final state
     person_stats = _check_person_stats(dry_run)
 
     checks = [
         person_stats, orphaned_interactions, hidden_interactions,
         stale_merged_ids, stale_merged_rels, rel_hygiene, orphaned_crm_records,
+        missing_vault_files,
     ]
     total_issues = sum(c["count"] for c in checks)
     total_fixed = sum(c["fixed"] for c in checks)
 
     auto_fix_skipped = any(
         check["count"] > fix_threshold and check["count"] > 0
-        for check in [orphaned_interactions, orphaned_crm_records]
+        for check in [orphaned_interactions, orphaned_crm_records, missing_vault_files]
     )
 
     return {
@@ -476,6 +603,7 @@ def verify_consistency(dry_run: bool = True, fix_threshold: int = AUTO_FIX_THRES
         "stale_merged_relationships": stale_merged_rels,
         "relationship_hygiene": rel_hygiene,
         "orphaned_crm_records": orphaned_crm_records,
+        "missing_vault_files": missing_vault_files,
         "total_issues": total_issues,
         "total_fixed": total_fixed,
         "auto_fix_skipped": auto_fix_skipped,

--- a/tests/test_consistency_vault_files.py
+++ b/tests/test_consistency_vault_files.py
@@ -1,0 +1,186 @@
+"""
+Vault interactions whose file no longer exists.
+
+Moving a note in Obsidian strands its interactions at the old path, and the next
+reindex creates new ones at the new path. A blanket delete would be wrong: on
+the corpus that prompted this, 56 of 78 dangling rows were *moved* notes, not
+deleted ones, and 4 of those had no replacement rows at all — deleting them
+would have destroyed the only record of the interaction.
+"""
+import sqlite3
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from api.services.interaction_store import InteractionStore  # noqa: E402
+from scripts.sync_consistency_verify import (  # noqa: E402
+    _check_missing_vault_files,
+    _classify_missing_vault_files,
+)
+
+
+@pytest.fixture
+def vault_env(tmp_path, monkeypatch):
+    """A temp vault plus an interactions DB wired into the checker."""
+    vault = tmp_path / "vault"
+    (vault / "Work").mkdir(parents=True)
+    (vault / "Personal").mkdir(parents=True)
+
+    db_path = str(tmp_path / "interactions.db")
+    InteractionStore(db_path=db_path)
+
+    monkeypatch.setattr(
+        "api.services.interaction_store.get_interaction_db_path", lambda: db_path
+    )
+    from config.settings import settings
+    monkeypatch.setattr(settings, "vault_path", vault, raising=False)
+
+    def add_interaction(source_id, person_id="p1"):
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "INSERT INTO interactions (id, person_id, timestamp, source_type, "
+            "title, source_id) VALUES (?, ?, '2026-01-01T00:00:00+00:00', "
+            "'vault', 'Note', ?)",
+            (f"i_{source_id}_{person_id}", person_id, source_id),
+        )
+        conn.commit()
+        conn.close()
+
+    def source_ids():
+        conn = sqlite3.connect(db_path)
+        rows = {r[0] for r in conn.execute("SELECT source_id FROM interactions")}
+        conn.close()
+        return rows
+
+    return vault, add_interaction, source_ids
+
+
+class TestClassification:
+    def test_moved_note_with_replacement_rows_is_a_duplicate(self, vault_env):
+        vault, add, _ = vault_env
+        (vault / "Work" / "Standup.md").write_text("moved here")
+        add(str(vault / "Personal" / "Standup.md"))   # stale, file gone
+        add(str(vault / "Work" / "Standup.md"))       # already reindexed
+
+        buckets = _classify_missing_vault_files()
+
+        assert len(buckets["duplicate"]) == 1
+        assert buckets["repoint"] == []
+
+    def test_moved_note_without_replacement_rows_is_repointable(self, vault_env):
+        """Deleting this one would lose the interaction entirely."""
+        vault, add, _ = vault_env
+        (vault / "Work" / "Standup.md").write_text("moved here")
+        add(str(vault / "Personal" / "Standup.md"))
+
+        buckets = _classify_missing_vault_files()
+
+        assert buckets["repoint"] == [
+            (str(vault / "Personal" / "Standup.md"), str(vault / "Work" / "Standup.md"))
+        ]
+
+    def test_deleted_note_is_gone(self, vault_env):
+        vault, add, _ = vault_env
+        add(str(vault / "Work" / "Vanished.md"))
+
+        buckets = _classify_missing_vault_files()
+
+        assert len(buckets["gone"]) == 1
+
+    def test_duplicate_basename_is_ambiguous(self, vault_env):
+        """Two candidates means the move target is a guess — never guess."""
+        vault, add, _ = vault_env
+        (vault / "Work" / "Notes.md").write_text("one")
+        (vault / "Personal" / "Notes.md").write_text("two")
+        add(str(vault / "Notes.md"))
+
+        buckets = _classify_missing_vault_files()
+
+        assert len(buckets["ambiguous"]) == 1
+        assert buckets["duplicate"] == [] and buckets["repoint"] == []
+
+    def test_existing_files_are_not_flagged(self, vault_env):
+        vault, add, _ = vault_env
+        (vault / "Work" / "Present.md").write_text("here")
+        add(str(vault / "Work" / "Present.md"))
+
+        buckets = _classify_missing_vault_files()
+
+        assert all(v == [] for v in buckets.values())
+
+
+class TestSafety:
+    def test_absent_vault_reports_nothing(self, vault_env, monkeypatch, tmp_path):
+        """
+        If the vault isn't mounted every path looks missing. Reporting them
+        would propose deleting the entire interaction history.
+        """
+        vault, add, _ = vault_env
+        add(str(vault / "Work" / "Anything.md"))
+        from config.settings import settings
+        monkeypatch.setattr(settings, "vault_path", tmp_path / "not-mounted", raising=False)
+
+        buckets = _classify_missing_vault_files()
+
+        assert all(v == [] for v in buckets.values())
+
+    def test_above_threshold_reports_but_does_not_fix(self, vault_env):
+        """Matches the script's existing convention for destructive fixes."""
+        vault, add, source_ids = vault_env
+        for i in range(5):
+            add(str(vault / "Work" / f"Gone{i}.md"))
+
+        result = _check_missing_vault_files(dry_run=False, fix_threshold=2)
+
+        assert result["count"] == 5
+        assert result["fixed"] == 0
+        assert len(source_ids()) == 5
+
+    def test_dry_run_changes_nothing(self, vault_env):
+        vault, add, source_ids = vault_env
+        add(str(vault / "Work" / "Gone.md"))
+
+        result = _check_missing_vault_files(dry_run=True, fix_threshold=100)
+
+        assert result["count"] == 1 and result["fixed"] == 0
+        assert len(source_ids()) == 1
+
+
+class TestFixing:
+    def test_repoints_moved_note_instead_of_deleting_it(self, vault_env):
+        vault, add, source_ids = vault_env
+        (vault / "Work" / "Standup.md").write_text("moved here")
+        add(str(vault / "Personal" / "Standup.md"))
+
+        _check_missing_vault_files(dry_run=False, fix_threshold=100)
+
+        assert source_ids() == {str(vault / "Work" / "Standup.md")}
+
+    def test_deletes_stale_duplicates(self, vault_env):
+        vault, add, source_ids = vault_env
+        (vault / "Work" / "Standup.md").write_text("moved here")
+        add(str(vault / "Personal" / "Standup.md"))
+        add(str(vault / "Work" / "Standup.md"))
+
+        _check_missing_vault_files(dry_run=False, fix_threshold=100)
+
+        assert source_ids() == {str(vault / "Work" / "Standup.md")}
+
+    def test_deletes_interactions_for_vanished_notes(self, vault_env):
+        vault, add, source_ids = vault_env
+        add(str(vault / "Work" / "Vanished.md"))
+
+        _check_missing_vault_files(dry_run=False, fix_threshold=100)
+
+        assert source_ids() == set()
+
+    def test_ambiguous_rows_are_left_alone(self, vault_env):
+        vault, add, source_ids = vault_env
+        (vault / "Work" / "Notes.md").write_text("one")
+        (vault / "Personal" / "Notes.md").write_text("two")
+        add(str(vault / "Notes.md"))
+
+        _check_missing_vault_files(dry_run=False, fix_threshold=100)
+
+        assert source_ids() == {str(vault / "Notes.md")}


### PR DESCRIPTION
Fixes the fourth and last suite failure — the only one of the four that was reporting a **real** problem rather than an environment leak.

## Problem

`test_all_vault_files_exist` reports 78 of 3,022 vault interactions pointing at files that no longer exist. Nothing detected this: `consistency_verify` covers person-ID referential integrity across stores, but never checked that a vault `source_id` still resolves to a real file.

The cause is note movement. Moving a note between folders in Obsidian strands its interactions at the old path, and the next reindex creates fresh ones at the new path.

## Why the obvious fix would have been wrong

I nearly deleted all 78. Classifying them first shows why that's destructive:

| disposition | count | meaning |
|---|---|---|
| duplicate | 48 | note moved, new path **already has** rows — old ones are stale copies |
| gone | 22 | no file with that name anywhere in the vault |
| **repoint** | **4** | note moved, **nothing points at the new path yet** |
| **ambiguous** | **4** | name matches several files — the move target is a guess |

**56 of the 78 were moved, not deleted.** For 4 of them, the dangling row is the *only* record of the interaction — deleting it destroys real history. And guessing at the 4 ambiguous ones could mis-attribute a note to the wrong context.

## Approach

Adds check 6 to `sync_consistency_verify.py`:

- **re-point** unambiguous moves
- **delete** stale duplicates and interactions for vanished notes
- **never guess** on ambiguous names — logs a warning naming them for manual review

Ordering matters: re-pointing runs *before* deletion, so if the two sets ever overlapped the row is preserved rather than removed.

Two safety properties:

- Gated by the existing `fix_threshold`, matching the convention for the other destructive checks. On the live corpus 74 actionable rows exceed the default 10, so it reports and defers rather than mass-deleting unattended.
- **Skipped entirely if the vault directory is absent.** An unmounted vault makes every path look missing, which would otherwise propose deleting the entire interaction history.

## Verification

Live dry run classifies all 78 as above and names the 4 ambiguous ones. Confirmed afterwards that the real database was untouched (3,022 distinct, 78 still missing) — worth checking explicitly, since these tests exercise destructive fixes and a failed monkeypatch would have hit production data.

## Tests

12 tests across classification, safety, and repair:

- each disposition classified correctly, and existing files not flagged
- **absent vault reports nothing** — the whole-history-deletion guard
- above threshold: reports, fixes nothing, leaves rows intact
- dry run changes nothing
- moved note is **re-pointed, not deleted**; duplicates and vanished notes are removed; ambiguous rows are left alone

Full unit suite on this branch: 4,244 passed. It's branched off `main`, so the three environment-leak failures fixed in #557 still show here; no new failures. `test_p91 TestR2EntityResolution` also appears — the pre-existing `ORDER BY RANDOM()` flake that fails 3 of 6 runs on clean `main`.

## Note

The 78 rows are still present in the live database — this PR adds the detection and repair, but the actual cleanup exceeds the auto-fix threshold by design and needs a deliberate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
