### PR TITLE
fix(sync): resolve ambiguous vault moves when every candidate is already covered

### DIFF
--- a/scripts/sync_consistency_verify.py
+++ b/scripts/sync_consistency_verify.py
@@ -474,7 +474,14 @@ def _classify_missing_vault_files() -> dict:
         if not candidates:
             buckets["gone"].append((stale_path, None))
         elif len(candidates) > 1:
-            buckets["ambiguous"].append((stale_path, candidates))
+            if all(c in known_paths for c in candidates):
+                # The move target is unknown, but every candidate already has
+                # its own interactions — so whichever one it was, the history is
+                # already represented and this row is a duplicate either way.
+                # No guess required.
+                buckets["duplicate"].append((stale_path, None))
+            else:
+                buckets["ambiguous"].append((stale_path, candidates))
         elif candidates[0] in known_paths:
             buckets["duplicate"].append((stale_path, candidates[0]))
         else:

--- a/tests/test_consistency_vault_files.py
+++ b/tests/test_consistency_vault_files.py
@@ -100,6 +100,37 @@ class TestClassification:
         assert len(buckets["ambiguous"]) == 1
         assert buckets["duplicate"] == [] and buckets["repoint"] == []
 
+    def test_ambiguous_but_all_candidates_covered_is_a_duplicate(self, vault_env):
+        """
+        The move target is unknown, but every candidate already carries its own
+        interactions — so the history survives whichever one it was, and the
+        stale row is a duplicate either way. Decidable without guessing.
+        """
+        vault, add, _ = vault_env
+        (vault / "Work" / "Notes.md").write_text("one")
+        (vault / "Personal" / "Notes.md").write_text("two")
+        add(str(vault / "Notes.md"))
+        add(str(vault / "Work" / "Notes.md"))
+        add(str(vault / "Personal" / "Notes.md"))
+
+        buckets = _classify_missing_vault_files()
+
+        assert len(buckets["duplicate"]) == 1
+        assert buckets["ambiguous"] == []
+
+    def test_partial_candidate_coverage_stays_ambiguous(self, vault_env):
+        """One uncovered candidate means the row might be its only history."""
+        vault, add, _ = vault_env
+        (vault / "Work" / "Notes.md").write_text("one")
+        (vault / "Personal" / "Notes.md").write_text("two")
+        add(str(vault / "Notes.md"))
+        add(str(vault / "Work" / "Notes.md"))  # Personal/ left uncovered
+
+        buckets = _classify_missing_vault_files()
+
+        assert len(buckets["ambiguous"]) == 1
+        assert buckets["duplicate"] == []
+
     def test_existing_files_are_not_flagged(self, vault_env):
         vault, add, _ = vault_env
         (vault / "Work" / "Present.md").write_text("here")


### PR DESCRIPTION
Follow-up to #558, which deferred every ambiguous vault move to a human. There is a sub-case that needs no human at all.

## The insight

When a stale path's basename matches several files, the move target is a guess — so #558 refused to touch it. But if **every** candidate already carries its own interactions, the history survives whichever one the note moved to. The stale row is a duplicate either way, and no guess is required to say so.

On the live corpus this decides 2 of the 4 remaining cases:

| stale path | candidates | all covered? |
|---|---|---|
| `Personal/Thea Book 3-21.md` | 2 identical copies (845 KB each) | yes → duplicate |
| `Yoni feedback Q3 2025.md` | 2 identical copies (2,337 B each) | yes → duplicate |
| `Untitled 2.md` | 18, scattered across archived projects | no |
| `Untitled 3.md` | 15, same | no |

Partial coverage still defers: if any candidate lacks interactions, the stale row might be that note's only history, and deleting it would lose it.

## Tests

Two added to the classification suite:

- ambiguous **but all candidates covered** → classified duplicate, not ambiguous
- **partial** coverage → stays ambiguous (the guard that keeps this safe)

14 pass in `test_consistency_vault_files.py`.

## Live result

Applied after merge of #558. Vault interactions went 3,022 → 2,950, with dangling references down from 78 to 2. Backup taken beforehand at `data/backups/interactions.db.pre-vault-cleanup.backup`.

The remaining 2 are `Untitled 2.md` and `Untitled 3.md` at the vault root — generic export names matching 18 and 15 archived files respectively, with mixed coverage. They are genuinely unattributable and left for a human decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
