### PR TITLE
chore(crm): audit remaining unverifiable vault links, document Gmail skip cache

### DIFF
--- a/docs/specs/technical/data-and-sync.md
+++ b/docs/specs/technical/data-and-sync.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Data Pipeline
-> **Last Updated:** 2026-08-09
+> **Last Updated:** 2026-08-13
 
 How LifeOS ingests and stores data from multiple sources.
 
@@ -124,7 +124,8 @@ All data syncing is consolidated into a single daily sync with proper phase orde
                === PHASE 7: Consistency Verification ===
                Verify cross-store data consistency after all syncs complete
                └─ Consistency verify (check orphans, stale merged IDs, cached
-                 counts; auto-fixes below a threshold)
+                 counts, vault files that moved or vanished; auto-fixes below
+                 a threshold)
 
 ~03:16         Unified sync complete
 07:00          Post-sync health check (API server)
@@ -182,6 +183,7 @@ Configure `LIFEOS_ALERT_EMAIL` in `.env` to receive notifications when sync step
 | Interactions | `data/interactions.db` | Interactions per person | People v2 sync, Slack sync |
 | Relationships | `data/crm.db` | Person-to-person edges | Relationship discovery |
 | iMessage | `data/imessage.db` | Message export cache | iMessage sync |
+| Gmail Skip Cache | `data/gmail_skip_cache.db` | Message IDs already judged marketing, per account | Gmail sync |
 | Task Index | `data/task_index.json` | Parsed task cache | Task CRUD, file watcher |
 | Scheduler | `LifeOS/Scheduler/Inbox.md` (source) + `data/scheduler_index.json` (cache) | Schedules (trigger + action) | Scheduler store, file watcher |
 | Memories | `~/.lifeos/memories.json` | User-saved memories | Memory CRUD |
@@ -205,6 +207,24 @@ All sync scripts in `scripts/` follow the pattern:
 | `apple_data_import.py` | Import Apple ecosystem data (contacts, phone, iMessage, photos, WhatsApp) from the Mac Mini export | Apple Data Agent export (Linux only) |
 | `sync_phone_calls.py` | Sync phone calls (not in nightly `SYNC_ORDER` — runs via the separate FDA cron on macOS) | Apple Data Agent export |
 | `sync_slack.py` | Sync Slack users, DMs, and member channels | Slack API |
+
+**Gmail fetch cost.** A message is judged marketing only after it is fetched, and
+a discarded message writes no interaction row — so the "already seen" set derived
+from `interactions` cannot remember it, and it would be re-fetched every night for
+its whole look-back window. Two mechanisms keep that bounded:
+
+- **Batched fetches.** `GmailService.get_messages_batch()` carries many message
+  fetches per HTTP round-trip. Batches are paced per message and back off on
+  quota errors by retrying the whole chunk — retrying each message individually
+  once the quota is exhausted only deepens the hole.
+- **Skip cache.** `data/gmail_skip_cache.db` records the IDs each account has
+  already judged to be marketing, so they are fetched once rather than nightly.
+  Entries are keyed by `(account, message_id)` — Gmail IDs are unique only within
+  a mailbox — and pruned well past the look-back window.
+
+A cached skip is not re-evaluated while its entry lives. To apply changed rules
+from `config/marketing_patterns` to already-skipped mail, delete the database
+file; the next run re-fetches and re-evaluates the whole window.
 
 ### Apple Data Agent
 
@@ -268,7 +288,7 @@ Runs in this order (see [iMessage Sync Ordering](#imessage-sync-ordering) below)
 
 | Script | Purpose | Data Source |
 |--------|---------|-------------|
-| `sync_consistency_verify.py` | Cross-store consistency check (orphans, stale merged IDs, cached counts) and auto-fix | `data/crm.db`, `data/interactions.db` |
+| `sync_consistency_verify.py` | Cross-store consistency check (orphans, stale merged IDs, cached counts, vault files that moved or vanished) and auto-fix | `data/crm.db`, `data/interactions.db` |
 
 ### Unified Sync Runner
 
@@ -448,7 +468,7 @@ The unified sync runner (`run_all_syncs.py`) executes `SYNC_ORDER` in this order
 22. `entity_cleanup` - Auto-hide obvious non-human entities
 
 **Phase 7: Consistency Verification**
-23. `consistency_verify` - Cross-store consistency check (orphans, stale merged IDs, cached counts) and auto-fix
+23. `consistency_verify` - Cross-store consistency check (orphans, stale merged IDs, cached counts, vault files that moved or vanished) and auto-fix
 
 **Automated via systemd (Linux) / launchd (macOS):**
 - Service: `lifeos-sync` (systemd) or `com.lifeos.crm-sync` (launchd)

--- a/tests/test_p91_data_integrity.py
+++ b/tests/test_p91_data_integrity.py
@@ -90,7 +90,14 @@ class TestR2EntityResolution:
     # created when a name was present can outlive the text that justified it.
     # The point of the ceiling is to catch *new* bad links without pretending
     # the existing backlog is clean. Lower it when links are cleaned up.
-    MAX_UNVERIFIABLE_LINKS = 47
+    #
+    # The remainder was audited individually: it is dominated by one close
+    # family member appearing across journal and therapy notes that discuss
+    # her without naming her. The links resolution actually got wrong — vault
+    # mentions attached to people whose name is an initial plus a surname,
+    # which matched any extracted name sharing that letter (#551) — were
+    # removed, along with two non-person entities parsed out of note text.
+    MAX_UNVERIFIABLE_LINKS = 28
 
     @staticmethod
     def _declared_people(content: str) -> list[str]:


### PR DESCRIPTION
Clears the two remaining loose ends: auditing the unverifiable vault links individually, and documenting the Gmail skip cache.

## 1. Audited the 47 unverifiable links

Rather than treating them as one undifferentiated backlog, I classified each:

| group | count |
|---|---|
| vault mentions on people whose name is an initial + surname | 17 |
| granola notes whose body was rewritten after indexing | 15 |
| other | 15 |

**The first group is #551 residue, and the evidence is unambiguous.** Those entities are *real people* whose names were parsed from email local parts — `e.moodyroberts@gmail.com` → "E Moodyroberts" — each with genuine gmail and calendar history. The resolver matched any extracted name sharing that first letter, so they ended up linked to:

```
implement-address.md      (a Claude Code skill file)
Chapter 26.md / 32.md     (book chapters)
Politics & History.md, defense-brief.md, Ryn & Maple Squad.md
```

— documents that declare **no people at all**. Removed those 19 links and **kept the people**; the entities are fine, the links were not.

Also removed two entities that aren't people, parsed out of note text: `Crowdskout company number` and `Cobra`, one vault interaction each.

**What remains is legitimate.** The residual 28 is dominated by one close family member appearing across journal and therapy notes that discuss her without naming her (16 of 28). Those links are correct and simply unverifiable from note text — which is why the ceiling drops to **28, not zero**. I did not read those notes beyond confirming the file paths.

Unverifiable links across the whole effort: **91 → 79** (junk entity purge) → **47** (variant-awareness) → **28** (this audit).

## 2. Documented the Gmail skip cache

Added to `data-and-sync.md`:

- `data/gmail_skip_cache.db` in the Data Stores table
- a short "Gmail fetch cost" note covering *why* it exists (a message is judged marketing only after it's fetched, and a discarded message writes no interaction row, so the interactions-derived skip set can never remember it), the batching/quota-backoff behavior, the `(account, message_id)` key, and pruning
- the invalidation rule: delete the file to re-evaluate already-skipped mail after changing `marketing_patterns`

Also corrected the `consistency_verify` description in three places — it still described only "orphans, stale merged IDs, cached counts" and omitted the vault-file check added in #558.

## Verification

- Ceiling verified deterministic across 5 consecutive runs.
- Full unit suite: **4,266 passed, 0 failed.**
- `interactions.db` backed up to `data/backups/interactions.db.pre-link-audit.backup` before deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
