### PR TITLE
feat(sync): back up crm.db before the nightly sync

### DIFF
--- a/api/services/backup_retention.py
+++ b/api/services/backup_retention.py
@@ -179,3 +179,59 @@ def prune(
             except OSError as e:
                 logger.warning(f"Could not remove old backup {path}: {e}")
     return removed
+
+
+def create_snapshot(
+    db_path: Path,
+    backup_dir: Path,
+    db_basename: str,
+    *,
+    policy: RetentionPolicy = DEFAULT_POLICY,
+    now: Optional[datetime] = None,
+) -> Optional[Path]:
+    """Snapshot a live SQLite database, then prune older snapshots.
+
+    Uses SQLite's online backup API rather than a file copy. The nightly sync
+    runs while the API server is serving requests, and copying a WAL-mode
+    database out from under an active writer can capture a torn state — the
+    main DB file without the committed pages still sitting in the -wal.
+    ``Connection.backup`` takes a transactionally consistent snapshot instead.
+
+    Args:
+        db_path: Database to snapshot
+        backup_dir: Directory to write into (created if absent)
+        db_basename: Basename used by the filename convention and the pruner,
+            which is what keeps retention per-database
+        policy: Retention tiers to apply afterwards
+        now: Timestamp for the filename; defaults to the current time
+
+    Returns:
+        Path to the new snapshot, or None if the source database is absent.
+    """
+    import sqlite3
+
+    if not db_path.exists():
+        logger.warning(f"No {db_basename} to backup")
+        return None
+
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = backup_dir / backup_filename(db_basename, now or datetime.now())
+
+    source = sqlite3.connect(str(db_path))
+    try:
+        dest = sqlite3.connect(str(backup_path))
+        try:
+            source.backup(dest)
+        finally:
+            dest.close()
+    finally:
+        source.close()
+
+    logger.info(f"Created {db_basename} backup: {backup_path}")
+
+    removed = prune(backup_dir, db_basename, policy=policy, now=now)
+    if removed:
+        logger.info(
+            f"Backup retention pruned {len(removed)} old {db_basename} backup(s)"
+        )
+    return backup_path

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -1586,6 +1586,41 @@ def backup_interactions():
     return backup_path
 
 
+def backup_crm():
+    """Create a crm.db backup before sync operations.
+
+    crm.db holds person_entities, source_entities, relationships and facts, and
+    several nightly phases write to it destructively — entity_cleanup hides
+    entities, consistency_verify deletes orphans, relationship_discovery
+    rewrites edge weights wholesale. It went unbacked while interactions.db was
+    snapshotted nightly, leaving no rollback path (#562).
+
+    A failure here is reported but never aborts the sync: losing a backup is
+    worse than not syncing, but not worse than skipping the night's data.
+    """
+    from pathlib import Path as _Path
+
+    from api.services import backup_retention
+    from api.utils.db_paths import get_crm_db_path
+    from config.settings import settings
+
+    logger.info("Creating pre-sync crm backup...")
+    try:
+        backup_path = backup_retention.create_snapshot(
+            _Path(get_crm_db_path()),
+            _Path(settings.backup_path),
+            "crm.db",
+        )
+        if backup_path:
+            logger.info(f"CRM backup: {backup_path}")
+        return backup_path
+    except Exception as e:
+        logger.error(f"Failed to create crm backup: {e}")
+        from api.services.notifications import record_failure
+        record_failure("backup_storage", f"CRM backup failed: {e}", severity="warning")
+        return None
+
+
 def run_all_syncs(
     sources: list[str] = None,
     dry_run: bool = False,
@@ -1659,10 +1694,10 @@ def run_all_syncs(
         except Exception as e:
             logger.warning(f"Could not open Photos.app: {e}")
 
-    # Create interactions backup before any syncs
-    # (person entities backup happens automatically on save)
+    # Create interactions and CRM backups before any syncs
     if not dry_run:
         backup_interactions()
+        backup_crm()
 
     # Suppress CRITICAL alerts during sync (ChromaDB may have transient SQLite issues
     # during heavy indexing). 4 hours covers even the longest full reindex.

--- a/tests/test_backup_retention.py
+++ b/tests/test_backup_retention.py
@@ -5,6 +5,7 @@ The integration tests over ``interaction_store._prune_backups`` live in
 same code path via the legacy alias. These tests target the helper
 directly so any other store can adopt it with confidence.
 """
+import sqlite3
 from dataclasses import FrozenInstanceError
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -15,6 +16,7 @@ from api.services.backup_retention import (
     DEFAULT_POLICY,
     RetentionPolicy,
     backup_filename,
+    create_snapshot,
     parse_backup_timestamp,
     prune,
 )
@@ -142,3 +144,101 @@ class TestNoOps:
         # in-place mutation by a caller can't bleed into other callers.
         with pytest.raises(FrozenInstanceError):
             DEFAULT_POLICY.daily_keep = 99  # type: ignore[misc]
+
+
+class TestCreateSnapshot:
+    """Snapshotting a live database (#562 — crm.db had no backup at all)."""
+
+    @staticmethod
+    def _db(path: Path, rows: int = 3) -> Path:
+        conn = sqlite3.connect(str(path))
+        conn.execute("CREATE TABLE people (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.executemany(
+            "INSERT INTO people (name) VALUES (?)", [(f"person{i}",) for i in range(rows)]
+        )
+        conn.commit()
+        conn.close()
+        return path
+
+    def test_snapshot_copies_the_data(self, tmp_path):
+        src = self._db(tmp_path / "crm.db")
+        out = tmp_path / "backups"
+
+        snap = create_snapshot(src, out, "crm.db")
+
+        assert snap is not None and snap.exists()
+        conn = sqlite3.connect(str(snap))
+        assert conn.execute("SELECT COUNT(*) FROM people").fetchone()[0] == 3
+        conn.close()
+
+    def test_snapshot_is_consistent_with_an_open_writer(self, tmp_path):
+        """
+        A file copy of a live WAL database can capture a torn state — the main
+        file without committed pages still in the -wal. The online backup API
+        must not.
+        """
+        src = self._db(tmp_path / "crm.db")
+        writer = sqlite3.connect(str(src))
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("INSERT INTO people (name) VALUES ('committed_via_wal')")
+        writer.commit()
+        try:
+            snap = create_snapshot(src, tmp_path / "backups", "crm.db")
+        finally:
+            writer.close()
+
+        conn = sqlite3.connect(str(snap))
+        names = {r[0] for r in conn.execute("SELECT name FROM people")}
+        conn.close()
+        assert "committed_via_wal" in names
+
+    def test_missing_source_returns_none(self, tmp_path):
+        assert create_snapshot(tmp_path / "absent.db", tmp_path / "b", "crm.db") is None
+
+    def test_creates_backup_dir(self, tmp_path):
+        src = self._db(tmp_path / "crm.db")
+        out = tmp_path / "nested" / "backups"
+
+        assert create_snapshot(src, out, "crm.db") is not None
+        assert out.is_dir()
+
+    def test_uses_canonical_filename(self, tmp_path):
+        src = self._db(tmp_path / "crm.db")
+        ts = datetime(2026, 8, 13, 3, 30, 0)
+
+        snap = create_snapshot(src, tmp_path / "b", "crm.db", now=ts)
+
+        assert snap.name == backup_filename("crm.db", ts)
+        assert parse_backup_timestamp(snap.name, "crm.db") == ts
+
+    def test_prunes_only_its_own_basename(self, tmp_path):
+        """
+        Retention stays per-database: snapshotting crm.db must not evict
+        interactions.db backups sharing the directory.
+        """
+        src = self._db(tmp_path / "crm.db")
+        out = tmp_path / "backups"
+        out.mkdir()
+        base = datetime(2026, 1, 1)
+        # Clustered a day apart so they share a retention bucket and are
+        # genuinely eligible for pruning; spread out, each would be kept.
+        for i in range(10):
+            _touch_backup(out, "crm.db", base - timedelta(days=400 + i))
+        survivor = _touch_backup(out, "interactions.db", base - timedelta(days=900))
+
+        create_snapshot(src, out, "crm.db", now=base)
+
+        assert survivor.exists()
+        assert len(list(out.glob("crm.db.*.backup"))) < 11
+
+    def test_leaves_manual_backups_alone(self, tmp_path):
+        """Operators drop hand-named files here; retention must not eat them."""
+        src = self._db(tmp_path / "crm.db")
+        out = tmp_path / "backups"
+        out.mkdir()
+        manual = out / "crm.db.pre-junk-entity-purge.backup"
+        manual.touch()
+
+        create_snapshot(src, out, "crm.db")
+
+        assert manual.exists()


### PR DESCRIPTION
Closes #562

## Problem

`scripts/run_all_syncs.py` snapshotted `interactions.db` and nothing else. `crm.db` — `person_entities`, `source_entities`, `relationships`, `person_facts`, `link_overrides` — had **no rollback path at all**, despite several nightly phases writing to it destructively:

- `entity_cleanup` auto-hides entities
- `consistency_verify` deletes orphaned relationships, facts and overrides
- `relationship_discovery` rewrote **540,379 rows** on the most recent run

Found while hand-purging a junk entity: the only `crm.db` snapshot on the box was one I took manually for that operation.

## Approach

`backup_retention` was already parameterised by `db_basename` for exactly this case — its own docstring names `crm.db` — so this is wiring, not new policy. Snapshots use the shared filename convention, which is what keeps pruning per-database and leaves hand-named files like `crm.db.pre-upgrade.backup` alone.

**Online backup API, not `shutil.copy2`.** The sync runs while the API server is serving requests, and copying a WAL-mode database out from under an active writer can capture the main file without committed pages still sitting in the `-wal`. `Connection.backup()` takes a transactionally consistent snapshot. The existing interactions path has the same exposure — flagged in #562, not changed here, since it's pre-existing and out of scope.

**Failures never abort the sync.** Reported through the same `backup_storage` alert channel as an interactions backup failure. Losing a night's data is worse than losing a backup.

## Verification against the live database

```
Created crm.db backup: .../crm.db.20260813_211021.backup
elapsed: 2.3s
integrity: ok
person_entities: 15,212   source_entities: 494,623   relationships: 544,798
```

The pre-existing manual `crm.db.pre-junk-entity-purge.backup` was left untouched, confirming retention still ignores non-canonical names.

**Disk:** ~640 MB per snapshot, so the default policy settles near 16 GB — 4% of current free space (403 GB). Called out explicitly since it's a meaningful step up from the interactions-only footprint.

## Tests

7 added in `TestCreateSnapshot`:

- snapshot contains the data; canonical filename round-trips through the parser
- **consistent with an open WAL writer** — the failure mode motivating the online backup API
- missing source returns `None`; backup dir is created if absent
- **pruning stays per-database** — snapshotting `crm.db` doesn't evict `interactions.db` backups sharing the directory
- **hand-named manual backups survive** retention

One of these initially failed and the test was wrong, not the code: I'd spaced the fixture files 100 days apart, so each landed in its own quarterly bucket and nothing was eligible for pruning. Clustering them a day apart makes the assertion meaningful.

Full unit suite: **4,273 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
