### PR TITLE
feat(sync): keep 2 verified backups, and only prune after a clean run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -344,6 +344,9 @@ LIFEOS_RELATIONSHIP_FOLDER=Relationship
 
 # Directory for database backups (use fast storage like NVMe for large backups)
 # LIFEOS_BACKUP_PATH=/path/to/nvme/lifeos-backups
+# Nightly snapshots retained per database (interactions.db, crm.db).
+# Pruned only after a fully successful sync whose newest snapshot verifies.
+# LIFEOS_BACKUP_KEEP=2
 
 # =============================================================================
 # WORK INTEGRATIONS (optional - DISABLED by default)

--- a/api/services/backup_retention.py
+++ b/api/services/backup_retention.py
@@ -99,6 +99,11 @@ class RetentionPolicy:
     week_days: int = 7
     month_days: int = 30
     quarter_days: int = 90
+    #: When False, keep exactly the ``daily_keep`` most recent snapshots and
+    #: drop everything older — no weekly/monthly/quarterly tail. The tiered
+    #: policy never forgets anything entirely, which is the right trade for a
+    #: small database and the wrong one for a 640 MB store snapshotted nightly.
+    tiered: bool = True
 
 
 #: A shared, immutable default. ``frozen=True`` on ``RetentionPolicy`` is
@@ -158,7 +163,7 @@ def prune(
 
     # Tiers 2/3/4: bucket the older ones; keep the newest in each bucket.
     seen_buckets: set[tuple[str, int]] = set()
-    for ts, path in candidates[policy.daily_keep:]:
+    for ts, path in ([] if not policy.tiered else candidates[policy.daily_keep:]):
         age_days = (now - ts).total_seconds() / 86400.0
         if age_days < policy.weekly_horizon_days:
             bucket = ("week", int(age_days // policy.week_days))
@@ -181,6 +186,43 @@ def prune(
     return removed
 
 
+def verify_snapshot(path: Path) -> bool:
+    """Is this snapshot a readable, structurally intact SQLite database?
+
+    Gates retention: a snapshot that fails here must never be counted as a
+    replacement for an older one. Running ``integrity_check`` is cheap next to
+    the cost of discovering, weeks later, that the only surviving backups are
+    all copies of a broken file.
+
+    This checks that the *file* is sound, not that its contents are correct —
+    no amount of page-level verification can tell you the sync wrote sensible
+    data. Retention is additionally gated on the sync succeeding for that.
+    """
+    import sqlite3
+
+    if not path.exists() or path.stat().st_size == 0:
+        logger.error(f"Backup verification failed: {path} missing or empty")
+        return False
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            if conn.execute("PRAGMA integrity_check").fetchone()[0] != "ok":
+                logger.error(f"Backup verification failed: {path} failed integrity_check")
+                return False
+            tables = conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table'"
+            ).fetchone()[0]
+            if not tables:
+                logger.error(f"Backup verification failed: {path} contains no tables")
+                return False
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.error(f"Backup verification failed: {path} could not be read: {e}")
+        return False
+    return True
+
+
 def create_snapshot(
     db_path: Path,
     backup_dir: Path,
@@ -188,6 +230,7 @@ def create_snapshot(
     *,
     policy: RetentionPolicy = DEFAULT_POLICY,
     now: Optional[datetime] = None,
+    prune_after: bool = True,
 ) -> Optional[Path]:
     """Snapshot a live SQLite database, then prune older snapshots.
 
@@ -204,9 +247,14 @@ def create_snapshot(
             which is what keeps retention per-database
         policy: Retention tiers to apply afterwards
         now: Timestamp for the filename; defaults to the current time
+        prune_after: Prune older snapshots once this one verifies. Pass False
+            to defer pruning until the caller knows the run it is protecting
+            actually succeeded — see ``prune_verified``.
 
     Returns:
-        Path to the new snapshot, or None if the source database is absent.
+        Path to the new snapshot, or None if the source database is absent or
+        the snapshot failed verification (in which case nothing is pruned and
+        the bad file is removed).
     """
     import sqlite3
 
@@ -227,11 +275,54 @@ def create_snapshot(
     finally:
         source.close()
 
+    if not verify_snapshot(backup_path):
+        # Never let a broken snapshot displace a good one. Drop it and leave
+        # existing backups untouched.
+        try:
+            backup_path.unlink()
+        except OSError as e:
+            logger.warning(f"Could not remove failed backup {backup_path}: {e}")
+        return None
+
     logger.info(f"Created {db_basename} backup: {backup_path}")
+
+    if prune_after:
+        prune_verified(backup_dir, db_basename, policy=policy, now=now)
+    return backup_path
+
+
+def prune_verified(
+    backup_dir: Path,
+    db_basename: str,
+    *,
+    policy: RetentionPolicy = DEFAULT_POLICY,
+    now: Optional[datetime] = None,
+) -> list[Path]:
+    """Prune, but only while at least one surviving snapshot verifies.
+
+    Tight retention is only safe if the copy being kept is known good. This
+    checks the newest snapshot before removing anything; if it fails, nothing
+    is pruned and the older backups stay, however many there are. Keeping too
+    many files is recoverable, keeping only broken ones is not.
+    """
+    survivors = sorted(
+        (p for p in backup_dir.glob(f"{db_basename}.*.backup")
+         if parse_backup_timestamp(p.name, db_basename)),
+        key=lambda p: parse_backup_timestamp(p.name, db_basename),
+        reverse=True,
+    )
+    if not survivors:
+        return []
+    if not verify_snapshot(survivors[0]):
+        logger.error(
+            f"Newest {db_basename} backup failed verification — skipping "
+            "retention so existing backups are preserved"
+        )
+        return []
 
     removed = prune(backup_dir, db_basename, policy=policy, now=now)
     if removed:
         logger.info(
             f"Backup retention pruned {len(removed)} old {db_basename} backup(s)"
         )
-    return backup_path
+    return removed

--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -1218,37 +1218,22 @@ class InteractionStore:
 
     def create_backup(self) -> Optional[Path]:
         """
-        Create a backup of interactions.db and prune old ones via the
-        tiered retention policy in ``_prune_backups``.
+        Create a verified backup of interactions.db and prune old ones.
 
         Returns:
-            Path to backup file if created, None if no db to backup
+            Path to backup file, or None if there is no db to back up or the
+            snapshot failed verification (in which case nothing is pruned).
         """
-        import shutil
-
-        db_path = Path(self.db_path)
-        if not db_path.exists():
-            logger.warning("No interactions.db to backup")
-            return None
-
-        backup_dir = Path(settings.backup_path)
-        backup_dir.mkdir(parents=True, exist_ok=True)
-
-        # Filename construction goes through the same helper the pruner
-        # uses to parse, so any future schema tweak stays in sync.
-        backup_path = backup_dir / _backup_filename(datetime.now())
-
         try:
-            shutil.copy2(db_path, backup_path)
-            logger.info(f"Created interactions backup: {backup_path}")
-
-            removed = _prune_backups(backup_dir)
-            if removed:
-                logger.info(
-                    f"Backup retention pruned {len(removed)} old backup(s)"
-                )
-
-            return backup_path
+            # Delegates to the shared helper so interactions.db gets the same
+            # treatment as every other store: a WAL-safe online-backup snapshot
+            # rather than a file copy, and verification before anything older
+            # is discarded.
+            return _backup_retention.create_snapshot(
+                Path(self.db_path),
+                Path(settings.backup_path),
+                _BACKUP_DB_BASENAME,
+            )
         except Exception as e:
             logger.error(f"Failed to create backup: {e}")
             # Record backup failure for nightly alert

--- a/config/settings.py
+++ b/config/settings.py
@@ -828,6 +828,15 @@ class Settings(BaseSettings):
         description="Directory for database backups (use fast storage like NVMe)"
     )
 
+    backup_keep: int = Field(
+        default=2,
+        alias="LIFEOS_BACKUP_KEEP",
+        description="Nightly snapshots retained per database. Older ones are "
+                    "pruned only after a fully successful sync whose newest "
+                    "snapshot passes an integrity check, so a run of failures "
+                    "cannot rotate away the last good copy."
+    )
+
     # Claude Code orchestration
     claude_binary: str = Field(
         default="claude",

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,7 +1,7 @@
 # Configuration Guide
 
 **Status:** Complete
-**Last Updated:** 2026-08-09
+**Last Updated:** 2026-08-13
 **Audience:** Operators
 
 **This is the single authoritative reference for every `LIFEOS_*` environment variable and the third-party service variables (`ANTHROPIC_API_KEY`, `OLLAMA_*`, `SLACK_*`, `TELEGRAM_*`, `MONARCH_*`) that LifeOS reads.** Other guides reference this file rather than restating defaults — when documentation conflicts, this file wins (and `config/settings.py` wins over both, since the code is the source of truth).
@@ -25,6 +25,7 @@ Each section corresponds roughly to a section in [`config/settings.py`](../../co
 | `LIFEOS_CHROMA_PATH` | path | `./data/chromadb` | Where ChromaDB persists its data. |
 | `LIFEOS_CODE_DIR` | path | `~/Code` | Parent directory containing LifeOS and (optionally) other projects. Used by `/claude` orchestrator path resolution. |
 | `LIFEOS_BACKUP_PATH` | path | `./data/backups` | Where backup archives are written. |
+| `LIFEOS_BACKUP_KEEP` | int | `2` | Nightly snapshots retained per database. Older ones are pruned only after a fully successful sync whose newest snapshot passes an integrity check, so repeated failures cannot rotate away the last good copy. |
 | `TAILNET_HTTPS_URL` | str | — | Your machine's Tailscale HTTPS URL (no port), e.g. `https://<your-machine>.<tailnet>.ts.net`. Used by `scripts/setup-tailscale.sh` status output, and returned as `secure_url` by `GET /api/chat/config` so `/chat` can offer a one-tap link here when the mic is blocked by an insecure context. **Open `/chat` on this URL for voice** — the mic requires HTTPS. |
 | `LIFEOS_VOICE_GATEWAY_URL` | str | `http://127.0.0.1:9788` | whisper-relay base URL; LifeOS reverse-proxies `/api/voice/*` here (ADR-016). |
 

--- a/docs/specs/technical/data-and-sync.md
+++ b/docs/specs/technical/data-and-sync.md
@@ -184,6 +184,25 @@ Configure `LIFEOS_ALERT_EMAIL` in `.env` to receive notifications when sync step
 | Relationships | `data/crm.db` | Person-to-person edges | Relationship discovery |
 | iMessage | `data/imessage.db` | Message export cache | iMessage sync |
 | Gmail Skip Cache | `data/gmail_skip_cache.db` | Message IDs already judged marketing, per account | Gmail sync |
+
+### Backups
+
+`interactions.db` and `crm.db` are snapshotted to `LIFEOS_BACKUP_PATH` before
+the nightly sync runs, using SQLite's online backup API so a live WAL-mode
+database is captured consistently.
+
+Retention keeps `LIFEOS_BACKUP_KEEP` snapshots per database (default 2), and is
+deliberately conservative about when it deletes:
+
+- **Pruning is deferred to the end of the run**, and skipped entirely if any
+  source failed. A snapshot is only known to be a usable rollback point once
+  the run it protects has finished cleanly, so a string of failing nights
+  cannot rotate away the last good copy.
+- **The newest snapshot must pass an integrity check** before anything older is
+  removed. A snapshot that fails verification is deleted immediately and prunes
+  nothing.
+- Files that don't match the `<db>.<timestamp>.backup` convention are ignored,
+  so hand-named copies kept for safekeeping survive.
 | Task Index | `data/task_index.json` | Parsed task cache | Task CRUD, file watcher |
 | Scheduler | `LifeOS/Scheduler/Inbox.md` (source) + `data/scheduler_index.json` (cache) | Schedules (trigger + action) | Scheduler store, file watcher |
 | Memories | `~/.lifeos/memories.json` | User-saved memories | Memory CRUD |

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -1575,50 +1575,88 @@ def _parse_sync_output(output: str) -> dict:
     return stats
 
 
-def backup_interactions():
-    """Create interactions backup before sync operations."""
-    from api.services.interaction_store import InteractionStore
-    logger.info("Creating pre-sync interactions backup...")
-    store = InteractionStore()
-    backup_path = store.create_backup()
-    if backup_path:
-        logger.info(f"Interactions backup: {backup_path}")
-    return backup_path
+def _retention_policy():
+    """Retention for nightly snapshots: keep N, no long tail."""
+    from api.services.backup_retention import RetentionPolicy
+    from config.settings import settings
+    return RetentionPolicy(daily_keep=max(1, settings.backup_keep), tiered=False)
 
 
-def backup_crm():
-    """Create a crm.db backup before sync operations.
+#: Databases snapshotted before the nightly sync. interactions.db holds the
+#: per-person interaction history; crm.db holds people, source entities and
+#: relationships. Both are rewritten destructively by nightly phases.
+def _backup_targets():
+    from api.services.interaction_store import get_interaction_db_path
+    from api.utils.db_paths import get_crm_db_path
+    return [
+        ("interactions.db", get_interaction_db_path()),
+        ("crm.db", get_crm_db_path()),
+    ]
 
-    crm.db holds person_entities, source_entities, relationships and facts, and
-    several nightly phases write to it destructively — entity_cleanup hides
-    entities, consistency_verify deletes orphans, relationship_discovery
-    rewrites edge weights wholesale. It went unbacked while interactions.db was
-    snapshotted nightly, leaving no rollback path (#562).
+
+def backup_databases():
+    """Snapshot interactions.db and crm.db before sync operations.
+
+    Pruning is deliberately deferred to ``prune_backups_after_success``. A
+    snapshot taken now is only known to be a *usable* rollback point once the
+    run it protects has finished cleanly, so nothing older is discarded until
+    then — a string of failing nights must not rotate away the last good copy.
 
     A failure here is reported but never aborts the sync: losing a backup is
-    worse than not syncing, but not worse than skipping the night's data.
+    bad, losing the night's data is worse.
     """
     from pathlib import Path as _Path
 
     from api.services import backup_retention
-    from api.utils.db_paths import get_crm_db_path
     from config.settings import settings
 
-    logger.info("Creating pre-sync crm backup...")
-    try:
-        backup_path = backup_retention.create_snapshot(
-            _Path(get_crm_db_path()),
-            _Path(settings.backup_path),
-            "crm.db",
-        )
-        if backup_path:
-            logger.info(f"CRM backup: {backup_path}")
-        return backup_path
-    except Exception as e:
-        logger.error(f"Failed to create crm backup: {e}")
-        from api.services.notifications import record_failure
-        record_failure("backup_storage", f"CRM backup failed: {e}", severity="warning")
-        return None
+    paths = []
+    for basename, db_path in _backup_targets():
+        logger.info(f"Creating pre-sync {basename} backup...")
+        try:
+            backup_path = backup_retention.create_snapshot(
+                _Path(db_path),
+                _Path(settings.backup_path),
+                basename,
+                policy=_retention_policy(),
+                prune_after=False,
+            )
+            if backup_path:
+                logger.info(f"{basename} backup: {backup_path}")
+                paths.append(backup_path)
+            else:
+                from api.services.notifications import record_failure
+                record_failure(
+                    "backup_storage",
+                    f"{basename} backup missing or failed verification",
+                    severity="warning",
+                )
+        except Exception as e:
+            logger.error(f"Failed to create {basename} backup: {e}")
+            from api.services.notifications import record_failure
+            record_failure("backup_storage", f"{basename} backup failed: {e}", severity="warning")
+    return paths
+
+
+def prune_backups_after_success():
+    """Apply retention once the run has completed without failures.
+
+    Two conditions must hold before an old snapshot is discarded: the sync
+    succeeded, and the newest snapshot passes an integrity check. Either one
+    failing leaves every existing backup in place.
+    """
+    from pathlib import Path as _Path
+
+    from api.services import backup_retention
+    from config.settings import settings
+
+    for basename, _ in _backup_targets():
+        try:
+            backup_retention.prune_verified(
+                _Path(settings.backup_path), basename, policy=_retention_policy(),
+            )
+        except Exception as e:
+            logger.warning(f"Retention for {basename} failed: {e}")
 
 
 def run_all_syncs(
@@ -1694,10 +1732,10 @@ def run_all_syncs(
         except Exception as e:
             logger.warning(f"Could not open Photos.app: {e}")
 
-    # Create interactions and CRM backups before any syncs
+    # Snapshot interactions.db and crm.db before any syncs. Retention runs at
+    # the end, and only if this run succeeds.
     if not dry_run:
-        backup_interactions()
-        backup_crm()
+        backup_databases()
 
     # Suppress CRITICAL alerts during sync (ChromaDB may have transient SQLite issues
     # during heavy indexing). 4 hours covers even the longest full reindex.
@@ -1854,6 +1892,19 @@ def run_all_syncs(
     if never_yielded_sources:
         logger.warning(f"Never produced records: {', '.join(never_yielded_sources)}")
     logger.info("=" * 60)
+
+    # Apply backup retention only now, and only if nothing failed. Tonight's
+    # snapshot is only worth keeping *instead of* an older one once the run it
+    # protects has finished cleanly; otherwise the older copies are the more
+    # trustworthy ones and all of them stay.
+    if not dry_run:
+        if failed:
+            logger.warning(
+                f"Skipping backup retention — {len(failed)} source(s) failed, "
+                "so existing backups are preserved"
+            )
+        else:
+            prune_backups_after_success()
 
     # Check overall health
     is_healthy, health_msg = check_sync_health()

--- a/tests/test_backup_retention.py
+++ b/tests/test_backup_retention.py
@@ -19,6 +19,8 @@ from api.services.backup_retention import (
     create_snapshot,
     parse_backup_timestamp,
     prune,
+    prune_verified,
+    verify_snapshot,
 )
 
 
@@ -242,3 +244,113 @@ class TestCreateSnapshot:
         create_snapshot(src, out, "crm.db")
 
         assert manual.exists()
+
+
+class TestVerificationGatesRetention:
+    """
+    Tight retention is only safe if the copy being kept is known good (#562).
+
+    With a long tail, a corrupt snapshot was survivable — older tiers remained.
+    Keeping only a couple means a bad snapshot could be the last one standing,
+    so verification has to gate the delete.
+    """
+
+    @staticmethod
+    def _db(path: Path) -> Path:
+        conn = sqlite3.connect(str(path))
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        conn.execute("INSERT INTO t (id) VALUES (1)")
+        conn.commit()
+        conn.close()
+        return path
+
+    def test_verify_accepts_a_real_database(self, tmp_path):
+        assert verify_snapshot(self._db(tmp_path / "ok.db")) is True
+
+    def test_verify_rejects_corrupt_empty_and_missing(self, tmp_path):
+        corrupt = tmp_path / "corrupt.db"
+        corrupt.write_bytes(b"this is not a sqlite database, not even close")
+        empty = tmp_path / "empty.db"
+        empty.touch()
+
+        assert verify_snapshot(corrupt) is False
+        assert verify_snapshot(empty) is False
+        assert verify_snapshot(tmp_path / "absent.db") is False
+
+    def test_verify_rejects_a_database_with_no_tables(self, tmp_path):
+        """A snapshot of nothing is not a usable rollback point."""
+        blank = tmp_path / "blank.db"
+        sqlite3.connect(str(blank)).close()
+
+        assert verify_snapshot(blank) is False
+
+    def test_corrupt_newest_snapshot_blocks_pruning(self, tmp_path):
+        """The whole point: a bad backup must not displace good ones."""
+        out = tmp_path / "b"
+        out.mkdir()
+        base = datetime(2026, 1, 1)
+        olds = [_touch_backup(out, "crm.db", base - timedelta(days=10 + i)) for i in range(5)]
+        for p in olds:
+            self._db(p)
+        newest = out / backup_filename("crm.db", base)
+        newest.write_bytes(b"truncated garbage")
+
+        removed = prune_verified(
+            out, "crm.db", policy=RetentionPolicy(daily_keep=2, tiered=False), now=base,
+        )
+
+        assert removed == []
+        assert all(p.exists() for p in olds)
+
+    def test_good_newest_snapshot_allows_pruning(self, tmp_path):
+        out = tmp_path / "b"
+        out.mkdir()
+        base = datetime(2026, 1, 1)
+        for i in range(5):
+            self._db(_touch_backup(out, "crm.db", base - timedelta(days=10 + i)))
+        self._db(out / backup_filename("crm.db", base))
+
+        removed = prune_verified(
+            out, "crm.db", policy=RetentionPolicy(daily_keep=2, tiered=False), now=base,
+        )
+
+        assert removed
+        assert len(list(out.glob("crm.db.*.backup"))) == 2
+
+    def test_failed_snapshot_is_deleted_and_prunes_nothing(self, tmp_path, monkeypatch):
+        """A snapshot that cannot be verified leaves no trace and no damage."""
+        out = tmp_path / "b"
+        out.mkdir()
+        existing = self._db(_touch_backup(out, "crm.db", datetime(2025, 1, 1)))
+        monkeypatch.setattr(
+            "api.services.backup_retention.verify_snapshot", lambda p: False
+        )
+
+        result = create_snapshot(self._db(tmp_path / "crm.db"), out, "crm.db")
+
+        assert result is None
+        assert existing.exists()
+        assert len(list(out.glob("crm.db.*.backup"))) == 1
+
+
+class TestUntieredRetention:
+    """`tiered=False` keeps exactly N and drops the long tail."""
+
+    def test_keeps_only_the_n_most_recent(self, tmp_path):
+        base = datetime(2026, 1, 1)
+        for i in range(12):
+            _touch_backup(tmp_path, "crm.db", base - timedelta(days=i * 40))
+
+        prune(tmp_path, "crm.db", policy=RetentionPolicy(daily_keep=2, tiered=False), now=base)
+
+        assert len(list(tmp_path.glob("crm.db.*.backup"))) == 2
+
+    def test_tiered_default_still_keeps_a_tail(self, tmp_path):
+        """Regression guard: the default policy is unchanged."""
+        base = datetime(2026, 1, 1)
+        for i in range(12):
+            _touch_backup(tmp_path, "crm.db", base - timedelta(days=i * 40))
+
+        prune(tmp_path, "crm.db", policy=DEFAULT_POLICY, now=base)
+
+        assert len(list(tmp_path.glob("crm.db.*.backup"))) > 2

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -193,7 +193,8 @@ def _run_llm_test(
         patch("scripts.run_all_syncs.check_sync_health", return_value=(True, "healthy")),
         patch("scripts.run_all_syncs.get_disabled_work_sources", return_value=set()),
         patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
-        patch("scripts.run_all_syncs.backup_interactions"),
+        patch("scripts.run_all_syncs.backup_databases"),
+        patch("scripts.run_all_syncs.prune_backups_after_success") as prune_mock,
         patch("scripts.run_all_syncs.send_sync_summary_telegram"),
         patch("scripts.run_all_syncs.reap_orphan_sync_runs", return_value=0),
         patch("scripts.run_all_syncs.detect_silent_source_entity_drift", return_value=[]),
@@ -214,7 +215,7 @@ def _run_llm_test(
 
         result = run_all_syncs(dry_run=False, force=True)
 
-    return result, run_sync_mock, stop_mock, start_mock
+    return result, run_sync_mock, stop_mock, start_mock, prune_mock
 
 
 class TestLLMMemoryGating:
@@ -223,7 +224,7 @@ class TestLLMMemoryGating:
     def test_llm_stopped_when_memory_insufficient(self):
         """LLM is stopped when GPU memory is below threshold."""
         from scripts.run_all_syncs import _EMBEDDING_MEMORY_THRESHOLD_MB
-        result, _, stop_mock, start_mock = _run_llm_test(
+        result, _, stop_mock, start_mock, _ = _run_llm_test(
             llm_running=True, gpu_memory_mb=_EMBEDDING_MEMORY_THRESHOLD_MB - 1000,
         )
 
@@ -233,7 +234,7 @@ class TestLLMMemoryGating:
     def test_llm_not_stopped_when_memory_sufficient(self):
         """LLM stays running when GPU memory is above threshold."""
         from scripts.run_all_syncs import _EMBEDDING_MEMORY_THRESHOLD_MB
-        result, _, stop_mock, start_mock = _run_llm_test(
+        result, _, stop_mock, start_mock, _ = _run_llm_test(
             llm_running=True, gpu_memory_mb=_EMBEDDING_MEMORY_THRESHOLD_MB + 10_000,
         )
 
@@ -243,7 +244,7 @@ class TestLLMMemoryGating:
     def test_llm_not_stopped_when_not_running(self):
         """No action taken when LLM is not running."""
         from scripts.run_all_syncs import _EMBEDDING_MEMORY_THRESHOLD_MB
-        result, _, stop_mock, start_mock = _run_llm_test(
+        result, _, stop_mock, start_mock, _ = _run_llm_test(
             llm_running=False, gpu_memory_mb=_EMBEDDING_MEMORY_THRESHOLD_MB - 1000,
         )
 
@@ -253,7 +254,7 @@ class TestLLMMemoryGating:
     def test_llm_restarted_after_last_embedding_source(self):
         """LLM is restarted after the last embedding source, not the first."""
         from scripts.run_all_syncs import _EMBEDDING_MEMORY_THRESHOLD_MB
-        result, run_sync_mock, stop_mock, start_mock = _run_llm_test(
+        result, run_sync_mock, stop_mock, start_mock, _ = _run_llm_test(
             llm_running=True, gpu_memory_mb=_EMBEDDING_MEMORY_THRESHOLD_MB - 1000,
         )
 
@@ -268,7 +269,7 @@ class TestLLMMemoryGating:
 
     def test_llm_not_stopped_when_memory_unknown(self):
         """LLM is stopped (conservative) when sysfs returns None."""
-        result, _, stop_mock, start_mock = _run_llm_test(
+        result, _, stop_mock, start_mock, _ = _run_llm_test(
             llm_running=True, gpu_memory_mb=None,
         )
 
@@ -277,7 +278,7 @@ class TestLLMMemoryGating:
     def test_internal_keys_not_in_results(self):
         """Internal _llm_* keys are not leaked in the result dict."""
         from scripts.run_all_syncs import _EMBEDDING_MEMORY_THRESHOLD_MB
-        result, _, _, _ = _run_llm_test(
+        result, _, _, _, _ = _run_llm_test(
             llm_running=True, gpu_memory_mb=_EMBEDDING_MEMORY_THRESHOLD_MB - 1000,
         )
 
@@ -291,7 +292,7 @@ class TestLLMMemoryGating:
         from scripts import run_all_syncs as module
         from scripts.run_all_syncs import _EMBEDDING_MEMORY_THRESHOLD_MB
 
-        result, _, stop_mock, start_mock = _run_llm_test(
+        result, _, stop_mock, start_mock, _ = _run_llm_test(
             llm_running=True, gpu_memory_mb=_EMBEDDING_MEMORY_THRESHOLD_MB - 1000,
         )
 
@@ -309,7 +310,7 @@ class TestSystemRAMPreFlight:
 
     def test_embeddings_skipped_when_ram_low(self):
         """Embedding sources are skipped when system RAM is below threshold."""
-        result, run_sync_mock, _, _ = _run_llm_test(
+        result, run_sync_mock, _, _, _ = _run_llm_test(
             llm_running=False, gpu_memory_mb=50_000, system_ram_mb=2000,
         )
 
@@ -324,7 +325,7 @@ class TestSystemRAMPreFlight:
 
     def test_embeddings_run_when_ram_sufficient(self):
         """Embedding sources run normally when system RAM is above threshold."""
-        result, run_sync_mock, _, _ = _run_llm_test(
+        result, run_sync_mock, _, _, _ = _run_llm_test(
             llm_running=False, gpu_memory_mb=50_000, system_ram_mb=16_000,
         )
 
@@ -334,7 +335,7 @@ class TestSystemRAMPreFlight:
 
     def test_non_embedding_sources_unaffected_by_low_ram(self):
         """Non-embedding sources still run even when RAM is low."""
-        result, run_sync_mock, _, _ = _run_llm_test(
+        result, run_sync_mock, _, _, _ = _run_llm_test(
             llm_running=False, gpu_memory_mb=50_000, system_ram_mb=2000,
         )
 
@@ -345,7 +346,7 @@ class TestSystemRAMPreFlight:
     def test_low_ram_with_llm_running_skips_embeddings_without_stopping_llm(self):
         """When LLM is running but RAM is low, embedding sources are skipped
         and the LLM is NOT stopped (no point stopping it only to skip the work)."""
-        result, run_sync_mock, stop_mock, start_mock = _run_llm_test(
+        result, run_sync_mock, stop_mock, start_mock, _ = _run_llm_test(
             llm_running=True, gpu_memory_mb=2000, system_ram_mb=2000,
         )
 
@@ -366,7 +367,7 @@ class TestSystemRAMPreFlight:
 
     def test_ram_check_unknown_allows_embeddings(self):
         """When RAM check returns None (unsupported OS), embeddings proceed."""
-        result, run_sync_mock, _, _ = _run_llm_test(
+        result, run_sync_mock, _, _, _ = _run_llm_test(
             llm_running=False, gpu_memory_mb=50_000, system_ram_mb=None,
         )
 
@@ -883,3 +884,62 @@ class TestSkippedMarker:
         from scripts.run_all_syncs import _parse_sync_output
 
         assert _parse_sync_output("normal sync output\n").get("skipped_reason") is None
+
+
+class TestBackupRetentionGating:
+    """
+    Retention must not run when the sync failed (#562).
+
+    Snapshots are taken before the sync; whether they are a usable rollback
+    point is only known once the run finishes. Pruning on a failed night could
+    rotate away the last good copy exactly when it is most needed.
+    """
+
+    def test_clean_run_prunes(self):
+        _, _, _, _, prune_mock = _run_llm_test(fail_sources=set())
+
+        prune_mock.assert_called_once()
+
+    def test_failed_source_skips_pruning(self):
+        _, _, _, _, prune_mock = _run_llm_test(fail_sources={"source_a"})
+
+        prune_mock.assert_not_called()
+
+    def test_backups_are_still_taken_on_a_failing_run(self):
+        """
+        Only the *deletion* is gated. A failing night still gets its snapshot —
+        that is the run most likely to need one.
+        """
+        from scripts.run_all_syncs import run_all_syncs
+
+        fake_restart = MagicMock(returncode=0, stdout="", stderr="")
+        with (
+            patch("scripts.run_all_syncs.SYNC_SOURCES", LLM_TEST_SYNC_SOURCES),
+            patch("scripts.run_all_syncs.SYNC_ORDER", LLM_TEST_SYNC_ORDER),
+            patch("scripts.run_all_syncs.run_sync",
+                  MagicMock(side_effect=_make_run_sync_side_effect({"source_a"}))),
+            patch("scripts.run_all_syncs.check_sync_health", return_value=(True, "healthy")),
+            patch("scripts.run_all_syncs.get_disabled_work_sources", return_value=set()),
+            patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
+            patch("scripts.run_all_syncs.backup_databases") as backup_mock,
+            patch("scripts.run_all_syncs.prune_backups_after_success") as prune_mock,
+            patch("scripts.run_all_syncs.send_sync_summary_telegram"),
+            patch("scripts.run_all_syncs.reap_orphan_sync_runs", return_value=0),
+            patch("scripts.run_all_syncs.detect_silent_source_entity_drift", return_value=[]),
+            patch("scripts.run_all_syncs.subprocess.run", return_value=fake_restart),
+            patch("urllib.request.urlopen"),
+            patch("scripts.run_all_syncs._is_llm_running", return_value=False),
+            patch("scripts.run_all_syncs._get_available_gpu_memory_mb", return_value=20000),
+            patch("scripts.run_all_syncs._get_available_system_ram_mb", return_value=16000),
+            patch("scripts.run_all_syncs._start_llm"),
+            patch("scripts.run_all_syncs.get_sync_health") as health_mock,
+        ):
+            mock_health = MagicMock()
+            mock_health.hours_since_sync = 24.0
+            mock_health.last_status = "SUCCESS"
+            health_mock.return_value = mock_health
+
+            run_all_syncs(dry_run=False, force=True)
+
+        backup_mock.assert_called_once()
+        prune_mock.assert_not_called()


### PR DESCRIPTION
Cuts nightly backup retention to 2 per database — but the number is the easy part. Cutting it is only safe if the copy being kept is known good, so this adds two gates rather than just lowering a constant.

## Why

The tiered policy never fully forgets anything (5 daily, then weekly/monthly/quarterly survivors). Reasonable for one 300 MB database; poor once `crm.db` (640 MB) joined nightly. Steady state was heading for **~24 GB**.

## Gate 1 — verification

- A snapshot is `integrity_check`ed before it counts as a replacement. One that fails is **deleted immediately and prunes nothing**, so a broken file can never displace a good one.
- `prune_verified()` re-checks the newest surviving snapshot before removing anything. If that fails, **everything stays**, however many files there are.

Keeping too many files is recoverable. Keeping only broken ones is not.

## Gate 2 — sync success

Snapshots are still taken **before** the sync — a failing night is exactly when a rollback point matters. But pruning is deferred to the end of the run and skipped entirely if any source failed.

Whether tonight's snapshot is a *usable* rollback point isn't known until the run it protects finishes cleanly, so a string of failing nights can no longer rotate away the last good copy.

Demonstrated end to end: 5 deferred snapshots → failed run leaves all 5 → successful run prunes to 2.

## Both databases, one path

`interactions.db` was still using `shutil.copy2`, which can capture a torn WAL-mode database out from under an active writer. It now delegates to the shared helper and picks up the online backup API and verification with it — the "similar behavior for others" part of the ask.

## Config

`LIFEOS_BACKUP_KEEP`, default 2. Hand-named files like `crm.db.pre-upgrade.backup` are still ignored by the pruner. Documented in `configuration.md`, `.env.example`, and a new Backups section in `data-and-sync.md`.

## The tradeoff, stated plainly

**2 nights means corruption that survives two clean syncs is unrecoverable from local backups.** The success gate catches loud failures, not silent ones — a sync that "succeeds" while writing bad data will still rotate. If that risk matters more than ~19 GB of disk, raise `LIFEOS_BACKUP_KEEP`; 5 restores roughly the old daily tier at a fraction of the old total.

## Tests

**+11**, covering the properties rather than the plumbing:

- verification accepts a real DB; rejects corrupt, empty, missing, and table-less files
- **a corrupt newest snapshot blocks pruning entirely** — the core safety property
- a good newest snapshot allows it, down to exactly N
- a failed snapshot is deleted and leaves existing backups untouched
- `tiered=False` keeps exactly N; the tiered default still keeps a tail (regression guard)
- clean run prunes; **failed source skips pruning**; **a failing run still takes its backup** — only the deletion is gated

Full unit suite: **4,283 passed, 0 failed.**

One self-inflicted break along the way: renaming `backup_interactions` → `backup_databases` broke 12 tests that patched the old name. Updated the patch target and the harness rather than keeping a compatibility alias — the function genuinely changed responsibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
