### PR TITLE
fix(sync): make backup snapshots self-contained single files

### DIFF
--- a/api/services/backup_retention.py
+++ b/api/services/backup_retention.py
@@ -270,6 +270,14 @@ def create_snapshot(
         dest = sqlite3.connect(str(backup_path))
         try:
             source.backup(dest)
+            # The snapshot inherits journal_mode from the source, so a WAL-mode
+            # database yields a snapshot that is three files, not one. That is
+            # wrong twice over: retention only tracks ``*.backup`` and would
+            # orphan the -wal/-shm forever, and a snapshot whose committed pages
+            # live in a separate -wal is not safe to copy or restore on its own.
+            # Fold it down to a single self-contained file.
+            dest.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            dest.execute("PRAGMA journal_mode=DELETE")
         finally:
             dest.close()
     finally:

--- a/tests/test_backup_retention.py
+++ b/tests/test_backup_retention.py
@@ -354,3 +354,59 @@ class TestUntieredRetention:
         prune(tmp_path, "crm.db", policy=DEFAULT_POLICY, now=base)
 
         assert len(list(tmp_path.glob("crm.db.*.backup"))) > 2
+
+
+class TestSnapshotIsSelfContained:
+    """
+    A snapshot must be one file, not three.
+
+    ``Connection.backup`` gives the destination the source's journal_mode, so
+    snapshotting a WAL database produced a .backup plus -wal and -shm. Retention
+    only tracks ``*.backup``, so the sidecars were orphaned the moment their
+    parent was pruned — and a snapshot whose committed pages live in a separate
+    -wal is not safe to copy or restore on its own.
+    """
+
+    @staticmethod
+    def _wal_db(path: Path) -> Path:
+        conn = sqlite3.connect(str(path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        conn.execute("INSERT INTO t (v) VALUES ('committed')")
+        conn.commit()
+        conn.close()
+        return path
+
+    def test_no_sidecar_files_are_left_behind(self, tmp_path):
+        out = tmp_path / "b"
+
+        snap = create_snapshot(self._wal_db(tmp_path / "src.db"), out, "src.db")
+
+        assert snap is not None
+        assert not (out / f"{snap.name}-wal").exists()
+        assert not (out / f"{snap.name}-shm").exists()
+        assert [p.name for p in out.iterdir()] == [snap.name]
+
+    def test_snapshot_is_not_in_wal_mode(self, tmp_path):
+        snap = create_snapshot(self._wal_db(tmp_path / "src.db"), tmp_path / "b", "src.db")
+
+        conn = sqlite3.connect(str(snap))
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        assert mode.lower() != "wal"
+
+    def test_data_survives_the_journal_mode_change(self, tmp_path):
+        snap = create_snapshot(self._wal_db(tmp_path / "src.db"), tmp_path / "b", "src.db")
+
+        conn = sqlite3.connect(str(snap))
+        rows = [r[0] for r in conn.execute("SELECT v FROM t")]
+        conn.close()
+        assert rows == ["committed"]
+
+    def test_verifying_a_snapshot_creates_no_sidecars(self, tmp_path):
+        """Read-only opens of a WAL database still spawn -shm; ours must not."""
+        out = tmp_path / "b"
+        snap = create_snapshot(self._wal_db(tmp_path / "src.db"), out, "src.db")
+
+        assert verify_snapshot(snap) is True
+        assert [p.name for p in out.iterdir()] == [snap.name]


### PR DESCRIPTION
Fixes a defect I introduced in #563/#564, caught by the first nightly run that exercised it.

## What last night's sync left on disk

```
crm.db.20260814_033003.backup
crm.db.20260814_033003.backup-shm     ← 32 KB
crm.db.20260814_033003.backup-wal     ← 0 bytes
interactions.db.20260814_033000.backup
interactions.db.20260814_033000.backup-shm
interactions.db.20260814_033000.backup-wal
```

`Connection.backup` gives the destination the **source's** `journal_mode`, so snapshotting a WAL-mode database produces three files instead of one. Confirmed directly — the snapshot reported `journal_mode=wal`.

## Why it matters

**Retention can't see the sidecars.** They don't match `<db>.<timestamp>.backup`, so `parse_backup_timestamp` returns `None` for them:

```
interactions.db.20260814_033000.backup      -> 2026-08-14 03:30:00
interactions.db.20260814_033000.backup-wal  -> None
interactions.db.20260814_033000.backup-shm  -> None
```

Tonight's prune would have deleted the parent and **orphaned its `-wal` and `-shm` permanently**, accumulating a pair per night forever. Nothing was orphaned yet only because the sidecars belong to the two newest snapshots, which are the ones retention keeps.

**And a multi-file snapshot isn't safe to restore alone.** A backup whose committed pages can live in a separate `-wal` is only self-contained by luck. It looked harmless here because the WAL happened to be checkpointed and empty — that is not a property to rely on.

## Fix

Checkpoint and switch the snapshot to `journal_mode=DELETE` before closing it, so one self-contained file lands on disk. This also stops `verify_snapshot` from creating a `-shm`, since read-only opens only spawn one for WAL databases — that `-shm` timestamped 04:56 was my own verification step.

## Verification

Against the real 640 MB `crm.db`:

```
snapshot: crm.db.20260814_153840.backup
  -wal: False   -shm: False
  journal_mode: delete
  person_entities: 15,218
  verify: True
  -shm after verify: False
```

Existing sidecar files on the host were removed by hand.

## Tests

4 added in `TestSnapshotIsSelfContained`, and I confirmed they actually catch the bug rather than merely passing — reverting the fix fails 3 of 4:

- no sidecar files left behind (asserts the directory contains *only* the snapshot)
- the snapshot is not in WAL mode
- data survives the journal-mode change
- verifying a snapshot creates no sidecars

Full unit suite: **4,287 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
