### PR TITLE
feat(llm): per-request thinking control and configurable routing target

### DIFF
--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -118,6 +118,25 @@ class _ToolUseBlock:
     type: str = "tool_use"
 
 
+def _reasoning_control_payload(
+    enable_thinking: bool | None, reasoning_effort: str | None
+) -> dict[str, Any]:
+    """Optional per-request reasoning-control fields for the llama-server payload.
+
+    ``enable_thinking`` is sent as ``chat_template_kwargs: {"enable_thinking": ...}``
+    (llama-server's jinja template switch); ``reasoning_effort`` is forwarded
+    as-is. Both are ``None`` by default, in which case this returns ``{}`` —
+    no new keys appear in the request body unless a caller explicitly asks,
+    so an unset call stays byte-identical to the payload before this existed.
+    """
+    extra: dict[str, Any] = {}
+    if enable_thinking is not None:
+        extra["chat_template_kwargs"] = {"enable_thinking": enable_thinking}
+    if reasoning_effort is not None:
+        extra["reasoning_effort"] = reasoning_effort
+    return extra
+
+
 _THINK_OPEN = "<think>"
 _THINK_CLOSE = "</think>"
 
@@ -396,8 +415,15 @@ class LocalLLMClient:
         max_tokens: int = 4096,
         tools: list[dict] | None = None,
         temperature: float | None = None,
+        enable_thinking: bool | None = None,
+        reasoning_effort: str | None = None,
     ) -> LLMResponse:
-        """Synchronous chat completion."""
+        """Synchronous chat completion.
+
+        ``enable_thinking``/``reasoning_effort`` control reasoning for this
+        request only — see ``_reasoning_control_payload``. Both default to
+        ``None`` (unset), which adds no new keys to the request body.
+        """
         all_messages = self._build_messages_list(messages, system)
         payload: dict[str, Any] = {
             "model": "local",
@@ -409,6 +435,7 @@ class LocalLLMClient:
             payload["temperature"] = temperature
         if tools:
             payload["tools"] = _anthropic_tools_to_openai(tools)
+        payload.update(_reasoning_control_payload(enable_thinking, reasoning_effort))
 
         resp = self.sync_client.post("/v1/chat/completions", json=payload)
         resp.raise_for_status()
@@ -423,8 +450,15 @@ class LocalLLMClient:
         max_tokens: int = 4096,
         tools: list[dict] | None = None,
         temperature: float | None = None,
+        enable_thinking: bool | None = None,
+        reasoning_effort: str | None = None,
     ) -> LLMResponse:
-        """Async chat completion."""
+        """Async chat completion.
+
+        ``enable_thinking``/``reasoning_effort`` control reasoning for this
+        request only — see ``_reasoning_control_payload``. Both default to
+        ``None`` (unset), which adds no new keys to the request body.
+        """
         all_messages = self._build_messages_list(messages, system)
         payload: dict[str, Any] = {
             "model": "local",
@@ -436,6 +470,7 @@ class LocalLLMClient:
             payload["temperature"] = temperature
         if tools:
             payload["tools"] = _anthropic_tools_to_openai(tools)
+        payload.update(_reasoning_control_payload(enable_thinking, reasoning_effort))
 
         resp = await self.async_client.post("/v1/chat/completions", json=payload)
         resp.raise_for_status()
@@ -451,6 +486,8 @@ class LocalLLMClient:
         tools: list[dict] | None = None,
         temperature: float | None = None,
         timeout: float | None = None,
+        enable_thinking: bool | None = None,
+        reasoning_effort: str | None = None,
     ) -> AsyncGenerator[dict, None]:
         """Async streaming chat completion.
 
@@ -458,6 +495,10 @@ class LocalLLMClient:
             {"type": "text", "content": "..."}     — text delta
             {"type": "tool_calls", "calls": [...]}  — tool calls (complete)
             {"type": "done", "usage": LLMUsage, "finish_reason": "..."}
+
+        ``enable_thinking``/``reasoning_effort`` control reasoning for this
+        request only — see ``_reasoning_control_payload``. Both default to
+        ``None`` (unset), which adds no new keys to the request body.
 
         Reasoning models may inline chain-of-thought as a leading
         <think>...</think> prefix in the content delta. That's buffered and
@@ -482,6 +523,7 @@ class LocalLLMClient:
             payload["temperature"] = temperature
         if tools:
             payload["tools"] = _anthropic_tools_to_openai(tools)
+        payload.update(_reasoning_control_payload(enable_thinking, reasoning_effort))
 
         request_timeout = httpx.Timeout(timeout or self.timeout, connect=10.0) if timeout else None
         async with self.async_client.stream(
@@ -878,7 +920,7 @@ def _get_local_routing_client() -> LocalLLMClient:
     """
     global _routing_client
     if _routing_client is None:
-        _routing_client = LocalLLMClient()
+        _routing_client = LocalLLMClient(base_url=settings.routing_llm_url)
     return _routing_client
 
 
@@ -936,18 +978,24 @@ async def generate_text(
     max_tokens: int = 2048,
     temperature: float = 0.3,
     timeout: float | None = None,
+    enable_thinking: bool | None = None,
+    reasoning_effort: str | None = None,
 ) -> str:
     """Generate raw text from the local LLM.
 
     Replaces ``OllamaClient.generate(...)`` for routing / validation callers.
     A per-call ``timeout`` uses a transient client so concurrent default-
-    timeout calls aren't affected.
+    timeout calls aren't affected. ``enable_thinking``/``reasoning_effort``
+    are forwarded to ``LocalLLMClient.acreate`` unchanged — see
+    ``_reasoning_control_payload``; both default to ``None`` (unset).
     """
     client = LocalLLMClient(timeout=timeout) if timeout is not None else _get_local_routing_client()
     response = await client.acreate(
         messages=[{"role": "user", "content": prompt}],
         max_tokens=max_tokens,
         temperature=temperature,
+        enable_thinking=enable_thinking,
+        reasoning_effort=reasoning_effort,
     )
     if response.reasoning_starved:
         logger.warning(
@@ -965,17 +1013,23 @@ async def generate_json(
     max_tokens: int = 4096,
     temperature: float = 0.1,
     timeout: float | None = None,
+    enable_thinking: bool | None = None,
+    reasoning_effort: str | None = None,
 ) -> dict:
     """Generate a JSON dict from the local LLM.
 
     Replaces ``OllamaClient.generate_json(...)`` for routing / validation
     callers. Uses a low temperature by default for structured output.
+    ``enable_thinking``/``reasoning_effort`` are forwarded to
+    ``generate_text`` unchanged; both default to ``None`` (unset).
     """
     text = await generate_text(
         prompt,
         max_tokens=max_tokens,
         temperature=temperature,
         timeout=timeout,
+        enable_thinking=enable_thinking,
+        reasoning_effort=reasoning_effort,
     )
     return extract_json(text)
 

--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -984,12 +984,19 @@ async def generate_text(
     """Generate raw text from the local LLM.
 
     Replaces ``OllamaClient.generate(...)`` for routing / validation callers.
-    A per-call ``timeout`` uses a transient client so concurrent default-
-    timeout calls aren't affected. ``enable_thinking``/``reasoning_effort``
-    are forwarded to ``LocalLLMClient.acreate`` unchanged — see
-    ``_reasoning_control_payload``; both default to ``None`` (unset).
+    A per-call ``timeout`` uses a transient client (still pinned to
+    ``settings.routing_llm_url``, same as the cached singleton — a caller
+    passing ``timeout`` must not silently fall back to the main chat model's
+    URL) so concurrent default-timeout calls aren't affected.
+    ``enable_thinking``/``reasoning_effort`` are forwarded to
+    ``LocalLLMClient.acreate`` unchanged — see ``_reasoning_control_payload``;
+    both default to ``None`` (unset).
     """
-    client = LocalLLMClient(timeout=timeout) if timeout is not None else _get_local_routing_client()
+    client = (
+        LocalLLMClient(base_url=settings.routing_llm_url, timeout=timeout)
+        if timeout is not None
+        else _get_local_routing_client()
+    )
     response = await client.acreate(
         messages=[{"role": "user", "content": prompt}],
         max_tokens=max_tokens,

--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -125,9 +125,12 @@ def _reasoning_control_payload(
 
     ``enable_thinking`` is sent as ``chat_template_kwargs: {"enable_thinking": ...}``
     (llama-server's jinja template switch); ``reasoning_effort`` is forwarded
-    as-is. Both are ``None`` by default, in which case this returns ``{}`` —
-    no new keys appear in the request body unless a caller explicitly asks,
-    so an unset call stays byte-identical to the payload before this existed.
+    as-is — llama-server parses it directly (server-common.cpp) and treats
+    ``"none"`` as its own way to disable reasoning, separate from
+    ``enable_thinking``. Both are ``None`` by default, in which case this
+    returns ``{}`` — no new keys appear in the request body unless a caller
+    explicitly asks, so an unset call stays byte-identical to the payload
+    before this existed.
     """
     extra: dict[str, Any] = {}
     if enable_thinking is not None:
@@ -891,10 +894,11 @@ def get_anthropic_llm() -> AnthropicLLMClient:
 
 def reset_local_llm() -> None:
     """Reset all singletons (for testing)."""
-    global _llm_client, _anthropic_client, _routing_client
+    global _llm_client, _anthropic_client, _routing_client, _routing_client_url
     _llm_client = None
     _anthropic_client = None
     _routing_client = None
+    _routing_client_url = None
 
 
 # ============================================================================
@@ -909,6 +913,7 @@ def reset_local_llm() -> None:
 # ============================================================================
 
 _routing_client: LocalLLMClient | None = None
+_routing_client_url: str | None = None  # URL the cached client above was built against
 
 
 def _get_local_routing_client() -> LocalLLMClient:
@@ -917,10 +922,18 @@ def _get_local_routing_client() -> LocalLLMClient:
     Distinct from ``get_local_llm`` because that one switches to Anthropic
     when the backend is set to ``anthropic``; routing/validation should stay
     local even then.
+
+    Cached per resolved URL rather than unconditionally: settings.routing_llm_url
+    is configurable (#566), so if it changes after the first call — an operator
+    edits LIFEOS_LOCAL_ROUTING_LLM_URL, or a test monkeypatches settings mid-process
+    — the client is rebuilt against the new target instead of silently keeping
+    traffic pinned to wherever it first resolved.
     """
-    global _routing_client
-    if _routing_client is None:
-        _routing_client = LocalLLMClient(base_url=settings.routing_llm_url)
+    global _routing_client, _routing_client_url
+    url = settings.routing_llm_url
+    if _routing_client is None or _routing_client_url != url:
+        _routing_client = LocalLLMClient(base_url=url)
+        _routing_client_url = url
     return _routing_client
 
 

--- a/api/services/query_router.py
+++ b/api/services/query_router.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from config.settings import settings
 from api.services.llm_client import (
     generate_text,
     is_local_routing_llm_available,
@@ -417,7 +418,13 @@ class QueryRouter:
             RoutingResult from LLM decision
         """
         prompt = ROUTER_PROMPT.format(query=query)
-        response = await generate_text(prompt)
+        # settings.router_enable_thinking defaults True (current behaviour) —
+        # translated to enable_thinking=None so the request body stays
+        # byte-identical to before this setting existed. Flipping the
+        # default to False (once the correctness A/B in #566 confirms no
+        # regression) is then a one-line config change.
+        enable_thinking = None if settings.router_enable_thinking else False
+        response = await generate_text(prompt, enable_thinking=enable_thinking)
 
         # Try to parse JSON from response
         try:

--- a/config/settings.py
+++ b/config/settings.py
@@ -277,6 +277,52 @@ class Settings(BaseSettings):
         description="HuggingFace GGUF model ID for llama-server"
     )
 
+    # Routing target (query_router, fact filtering, entity-cleanup auto-hide —
+    # see _get_local_routing_client). Optional overrides so routing calls can
+    # eventually point at a distinct llama-server instance/model without
+    # touching the main local_llm_url/local_llm_model used for chat synthesis.
+    # Both empty (default) falls back to those global values — see
+    # routing_llm_url/routing_llm_model — so a fresh clone behaves exactly as
+    # it does today (#566 PR 2).
+    local_routing_llm_url: str = Field(
+        default="",
+        alias="LIFEOS_LOCAL_ROUTING_LLM_URL",
+        description="Optional dedicated llama-server endpoint for routing/"
+                    "validation calls. Empty (default) falls back to "
+                    "LIFEOS_LOCAL_LLM_URL — set this only once a distinct "
+                    "routing server is actually running."
+    )
+    local_routing_llm_model: str = Field(
+        default="",
+        alias="LIFEOS_LOCAL_ROUTING_LLM_MODEL",
+        description="Optional informational label for the routing target's "
+                    "model (mirrors LIFEOS_LLM_MODEL — not sent in requests; "
+                    "the model actually served is whatever "
+                    "LIFEOS_LOCAL_ROUTING_LLM_URL points at). Empty (default) "
+                    "falls back to LIFEOS_LLM_MODEL."
+    )
+    router_enable_thinking: bool = Field(
+        default=True,
+        alias="LIFEOS_ROUTER_ENABLE_THINKING",
+        description="Whether query_router's LLM routing call requests "
+                    "reasoning/thinking from the local model. Default True "
+                    "(current behaviour, unchanged) — measured on the live "
+                    "host at 23-32s per routing call vs 2-9s with thinking "
+                    "off, with substantively identical routing decisions "
+                    "(#566). Left True here pending a broader correctness "
+                    "A/B; flip to False to opt in once confirmed."
+    )
+
+    @property
+    def routing_llm_url(self) -> str:
+        """Resolved routing-target URL: the dedicated override if set, else local_llm_url."""
+        return self.local_routing_llm_url or self.local_llm_url
+
+    @property
+    def routing_llm_model(self) -> str:
+        """Resolved routing-target model label: the dedicated override if set, else local_llm_model."""
+        return self.local_routing_llm_model or self.local_llm_model
+
     # MCP HTTP transport (used by remote agent platforms; local Claude Code keeps stdio)
     mcp_http_port: int = Field(
         default=8765,

--- a/config/settings.py
+++ b/config/settings.py
@@ -278,28 +278,24 @@ class Settings(BaseSettings):
     )
 
     # Routing target (query_router, fact filtering, entity-cleanup auto-hide —
-    # see _get_local_routing_client). Optional overrides so routing calls can
-    # eventually point at a distinct llama-server instance/model without
-    # touching the main local_llm_url/local_llm_model used for chat synthesis.
-    # Both empty (default) falls back to those global values — see
-    # routing_llm_url/routing_llm_model — so a fresh clone behaves exactly as
-    # it does today (#566 PR 2).
+    # see _get_local_routing_client). Optional override so routing calls can
+    # eventually point at a distinct llama-server instance without touching
+    # local_llm_url, which chat synthesis uses. Empty (default) falls back to
+    # that global value — see routing_llm_url — so a fresh clone behaves
+    # exactly as it does today (#566 PR 2). llama-server serves one model per
+    # process and ignores the request's "model" field, so on this
+    # architecture "which model" *is* "which URL" — there is no separate
+    # model-name setting to wire up.
     local_routing_llm_url: str = Field(
         default="",
         alias="LIFEOS_LOCAL_ROUTING_LLM_URL",
         description="Optional dedicated llama-server endpoint for routing/"
                     "validation calls. Empty (default) falls back to "
-                    "LIFEOS_LOCAL_LLM_URL — set this only once a distinct "
-                    "routing server is actually running."
-    )
-    local_routing_llm_model: str = Field(
-        default="",
-        alias="LIFEOS_LOCAL_ROUTING_LLM_MODEL",
-        description="Optional informational label for the routing target's "
-                    "model (mirrors LIFEOS_LLM_MODEL — not sent in requests; "
-                    "the model actually served is whatever "
-                    "LIFEOS_LOCAL_ROUTING_LLM_URL points at). Empty (default) "
-                    "falls back to LIFEOS_LLM_MODEL."
+                    "LIFEOS_LOCAL_LLM_URL. Set this to point routing at a "
+                    "second llama-server that has a different model loaded — "
+                    "that's the actual mechanism for selecting a distinct "
+                    "routing model, since llama-server ignores the request's "
+                    "model field."
     )
     router_enable_thinking: bool = Field(
         default=True,
@@ -317,11 +313,6 @@ class Settings(BaseSettings):
     def routing_llm_url(self) -> str:
         """Resolved routing-target URL: the dedicated override if set, else local_llm_url."""
         return self.local_routing_llm_url or self.local_llm_url
-
-    @property
-    def routing_llm_model(self) -> str:
-        """Resolved routing-target model label: the dedicated override if set, else local_llm_model."""
-        return self.local_routing_llm_model or self.local_llm_model
 
     # MCP HTTP transport (used by remote agent platforms; local Claude Code keeps stdio)
     mcp_http_port: int = Field(

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -73,8 +73,7 @@ Query routing, fact filtering, and entity-cleanup auto-hide decisions always go 
 
 | Variable | Type | Default | Sets |
 |---|---|---|---|
-| `LIFEOS_LOCAL_ROUTING_LLM_URL` | str | — (falls back to `LIFEOS_LOCAL_LLM_URL`) | Dedicated llama-server endpoint for routing/validation calls. Set only once a distinct routing server is actually running elsewhere. |
-| `LIFEOS_LOCAL_ROUTING_LLM_MODEL` | str | — (falls back to `LIFEOS_LLM_MODEL`) | Informational label for the routing target's model. Not sent in requests — the model actually served is whatever `LIFEOS_LOCAL_ROUTING_LLM_URL` points at. |
+| `LIFEOS_LOCAL_ROUTING_LLM_URL` | str | — (falls back to `LIFEOS_LOCAL_LLM_URL`) | Dedicated llama-server endpoint for routing/validation calls. `llama-server` serves one model per process and ignores the request's `model` field, so this URL — pointing at a second `llama-server` with a different model loaded — is the actual mechanism for giving routing a distinct model from chat synthesis. Set only once that second server is actually running. |
 | `LIFEOS_ROUTER_ENABLE_THINKING` | bool | `true` | Whether `query_router`'s LLM routing call requests reasoning from the local model. Measured on the live host: 23-32s/call with thinking on vs. 2-9s with it off, with substantively identical routing decisions. Left `true` (unchanged behaviour) pending a broader correctness A/B — flipping to `false` is a one-line default change once confirmed. |
 
 `LocalLLMClient.create`/`acreate`/`astream` (and the `generate_text`/`generate_json` routing helpers) also accept per-request `enable_thinking` (bool) and `reasoning_effort` (str) keyword arguments, sent as `chat_template_kwargs: {"enable_thinking": ...}` and `reasoning_effort` on the request body. Leaving both unset adds no new keys to the request — existing callers are unaffected.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -67,6 +67,18 @@ Governs chat synthesis, intent classification, and agentic orchestration. The to
 
 **When to change `LIFEOS_LLM_BACKEND`:** the default (`anthropic`) is right for operators without a high-VRAM GPU. Switch to `local` if you have a workstation that can run `llama-server` and want zero marginal cost / no data transit to Anthropic.
 
+### Routing Target and Reasoning Control (#566)
+
+Query routing, fact filtering, and entity-cleanup auto-hide decisions always go through the local llama-server (`_get_local_routing_client`), regardless of `LIFEOS_LLM_BACKEND`. These settings let that routing target — and whether it's asked to reason — be configured independently of the main local LLM used for chat synthesis.
+
+| Variable | Type | Default | Sets |
+|---|---|---|---|
+| `LIFEOS_LOCAL_ROUTING_LLM_URL` | str | — (falls back to `LIFEOS_LOCAL_LLM_URL`) | Dedicated llama-server endpoint for routing/validation calls. Set only once a distinct routing server is actually running elsewhere. |
+| `LIFEOS_LOCAL_ROUTING_LLM_MODEL` | str | — (falls back to `LIFEOS_LLM_MODEL`) | Informational label for the routing target's model. Not sent in requests — the model actually served is whatever `LIFEOS_LOCAL_ROUTING_LLM_URL` points at. |
+| `LIFEOS_ROUTER_ENABLE_THINKING` | bool | `true` | Whether `query_router`'s LLM routing call requests reasoning from the local model. Measured on the live host: 23-32s/call with thinking on vs. 2-9s with it off, with substantively identical routing decisions. Left `true` (unchanged behaviour) pending a broader correctness A/B — flipping to `false` is a one-line default change once confirmed. |
+
+`LocalLLMClient.create`/`acreate`/`astream` (and the `generate_text`/`generate_json` routing helpers) also accept per-request `enable_thinking` (bool) and `reasoning_effort` (str) keyword arguments, sent as `chat_template_kwargs: {"enable_thinking": ...}` and `reasoning_effort` on the request body. Leaving both unset adds no new keys to the request — existing callers are unaffected.
+
 ## Embedding & Search
 
 Encoder model selection and search-pipeline knobs. Decision recorded in [ADR-012](../adr/012-embedding-pipeline.md).

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -461,6 +461,172 @@ class TestParseResponse:
         assert resp.reasoning_starved is True
 
 
+# ---- Reasoning control (#566 PR 2: per-request thinking/reasoning_effort) ----
+
+
+class TestReasoningControlPayloadHelper:
+    """Tests for the ``_reasoning_control_payload`` helper shared by
+    create/acreate/astream."""
+
+    def test_both_unset_returns_empty(self):
+        """The critical backward-compat case: no keys unless a caller asks."""
+        from api.services.llm_client import _reasoning_control_payload
+        assert _reasoning_control_payload(None, None) == {}
+
+    def test_enable_thinking_true(self):
+        from api.services.llm_client import _reasoning_control_payload
+        assert _reasoning_control_payload(True, None) == {
+            "chat_template_kwargs": {"enable_thinking": True}
+        }
+
+    def test_enable_thinking_false(self):
+        from api.services.llm_client import _reasoning_control_payload
+        assert _reasoning_control_payload(False, None) == {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }
+
+    def test_reasoning_effort_passthrough(self):
+        from api.services.llm_client import _reasoning_control_payload
+        assert _reasoning_control_payload(None, "low") == {"reasoning_effort": "low"}
+
+    def test_both_set(self):
+        from api.services.llm_client import _reasoning_control_payload
+        assert _reasoning_control_payload(True, "high") == {
+            "chat_template_kwargs": {"enable_thinking": True},
+            "reasoning_effort": "high",
+        }
+
+
+class TestCreateReasoningControl:
+    """create()/acreate() forward reasoning control into the request body,
+    and the request body is byte-identical to before this feature existed
+    when neither knob is passed."""
+
+    def _client(self):
+        from api.services.llm_client import LocalLLMClient
+        return LocalLLMClient(base_url="http://fake:8080")
+
+    def _fake_sync_client(self):
+        from unittest.mock import MagicMock
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = {"choices": [], "model": "local"}
+        fake_sync_client = MagicMock(is_closed=False)
+        fake_sync_client.post.return_value = fake_resp
+        return fake_sync_client
+
+    def test_create_unset_body_byte_identical(self):
+        """No enable_thinking/reasoning_effort ⇒ no new keys in the request body."""
+        client = self._client()
+        fake_sync_client = self._fake_sync_client()
+        client._sync_client = fake_sync_client
+
+        client.create([{"role": "user", "content": "hi"}])
+
+        args, kwargs = fake_sync_client.post.call_args
+        assert args == ("/v1/chat/completions",)
+        assert kwargs["json"] == {
+            "model": "local",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4096,
+            "stream": False,
+        }
+
+    def test_create_enable_thinking_false(self):
+        client = self._client()
+        fake_sync_client = self._fake_sync_client()
+        client._sync_client = fake_sync_client
+
+        client.create([{"role": "user", "content": "hi"}], enable_thinking=False)
+
+        payload = fake_sync_client.post.call_args.kwargs["json"]
+        assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+    def test_create_reasoning_effort_passthrough(self):
+        client = self._client()
+        fake_sync_client = self._fake_sync_client()
+        client._sync_client = fake_sync_client
+
+        client.create([{"role": "user", "content": "hi"}], reasoning_effort="low")
+
+        payload = fake_sync_client.post.call_args.kwargs["json"]
+        assert payload["reasoning_effort"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_acreate_unset_body_byte_identical(self):
+        from unittest.mock import AsyncMock, MagicMock
+        client = self._client()
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = {"choices": [], "model": "local"}
+        fake_async_client = MagicMock(is_closed=False)
+        fake_async_client.post = AsyncMock(return_value=fake_resp)
+        client._async_client = fake_async_client
+
+        await client.acreate([{"role": "user", "content": "hi"}])
+
+        payload = fake_async_client.post.call_args.kwargs["json"]
+        assert payload == {
+            "model": "local",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4096,
+            "stream": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_acreate_enable_thinking_true(self):
+        from unittest.mock import AsyncMock, MagicMock
+        client = self._client()
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = {"choices": [], "model": "local"}
+        fake_async_client = MagicMock(is_closed=False)
+        fake_async_client.post = AsyncMock(return_value=fake_resp)
+        client._async_client = fake_async_client
+
+        await client.acreate([{"role": "user", "content": "hi"}], enable_thinking=True, reasoning_effort="high")
+
+        payload = fake_async_client.post.call_args.kwargs["json"]
+        assert payload["chat_template_kwargs"] == {"enable_thinking": True}
+        assert payload["reasoning_effort"] == "high"
+
+
+class TestAStreamReasoningControl:
+    """astream() forwards reasoning control the same way create()/acreate() do."""
+
+    def _client_with_capture(self, chunks):
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient(base_url="http://fake:8080")
+        captured = {}
+
+        class _CapturingAsyncClient(_FakeAsyncClient):
+            def stream(self, method, url, **kwargs):
+                captured["kwargs"] = kwargs
+                return super().stream(method, url, **kwargs)
+
+        client._async_client = _CapturingAsyncClient(_FakeSSEResponse(chunks))
+        return client, captured
+
+    @pytest.mark.asyncio
+    async def test_astream_unset_body_byte_identical(self):
+        client, captured = self._client_with_capture([_done_chunk()])
+        _ = [e async for e in client.astream([{"role": "user", "content": "hi"}])]
+        assert captured["kwargs"]["json"] == {
+            "model": "local",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4096,
+            "stream": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_astream_enable_thinking_false(self):
+        client, captured = self._client_with_capture([_done_chunk()])
+        _ = [
+            e async for e in client.astream(
+                [{"role": "user", "content": "hi"}], enable_thinking=False, reasoning_effort="low"
+            )
+        ]
+        assert captured["kwargs"]["json"]["chat_template_kwargs"] == {"enable_thinking": False}
+        assert captured["kwargs"]["json"]["reasoning_effort"] == "low"
+
+
 # ---- Singleton ----
 
 
@@ -638,6 +804,36 @@ class TestRoutingHelpers:
                 text = await mod.generate_text("hi", max_tokens=10)
         assert text == "42"
         assert not any("reasoning starved" in r.message.lower() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_generate_text_forwards_reasoning_control(self, _routing_singleton_reset):
+        """generate_text forwards enable_thinking/reasoning_effort to acreate() unchanged."""
+        from unittest.mock import AsyncMock, MagicMock
+        mod = _routing_singleton_reset
+
+        fake_client = MagicMock()
+        fake_resp = MagicMock(text="ok", reasoning_starved=False)
+        fake_client.acreate = AsyncMock(return_value=fake_resp)
+        with patch.object(mod, "_get_local_routing_client", return_value=fake_client):
+            await mod.generate_text("hi", enable_thinking=False, reasoning_effort="low")
+        kwargs = fake_client.acreate.await_args.kwargs
+        assert kwargs["enable_thinking"] is False
+        assert kwargs["reasoning_effort"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_generate_text_reasoning_control_unset_by_default(self, _routing_singleton_reset):
+        """Callers that don't ask for reasoning control get None through to acreate()."""
+        from unittest.mock import AsyncMock, MagicMock
+        mod = _routing_singleton_reset
+
+        fake_client = MagicMock()
+        fake_resp = MagicMock(text="ok", reasoning_starved=False)
+        fake_client.acreate = AsyncMock(return_value=fake_resp)
+        with patch.object(mod, "_get_local_routing_client", return_value=fake_client):
+            await mod.generate_text("hi")
+        kwargs = fake_client.acreate.await_args.kwargs
+        assert kwargs["enable_thinking"] is None
+        assert kwargs["reasoning_effort"] is None
 
     @pytest.mark.asyncio
     async def test_generate_json_extracts(self, _routing_singleton_reset):

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -735,12 +735,15 @@ class TestExtractJson:
 
 @pytest.fixture
 def _routing_singleton_reset():
-    """Reset the routing-client singleton around each test so mutations don't leak."""
+    """Reset the routing-client singleton (and its cache key) around each
+    test so mutations don't leak."""
     from api.services import llm_client as mod
-    prev = mod._routing_client
+    prev_client, prev_url = mod._routing_client, mod._routing_client_url
     mod._routing_client = None
+    mod._routing_client_url = None
     yield mod
-    mod._routing_client = prev
+    mod._routing_client = prev_client
+    mod._routing_client_url = prev_url
 
 
 class TestRoutingHelpers:
@@ -882,6 +885,27 @@ class TestRoutingHelpers:
             mock_settings.local_llm_timeout = 90
             client = mod._get_local_routing_client()
             assert isinstance(client, mod.LocalLLMClient)
+
+    def test_get_local_routing_client_rebuilds_when_url_changes(self, _routing_singleton_reset):
+        """Regression: the cached routing client must rebuild when
+        settings.routing_llm_url changes mid-process (an operator edits
+        LIFEOS_LOCAL_ROUTING_LLM_URL, or a test monkeypatches settings),
+        not silently keep pointing at wherever it first resolved."""
+        mod = _routing_singleton_reset
+
+        with patch.object(mod, "settings") as mock_settings:
+            mock_settings.routing_llm_url = "http://localhost:8080"
+            first = mod._get_local_routing_client()
+            assert first.base_url == "http://localhost:8080"
+
+            mock_settings.routing_llm_url = "http://routing-box:9090"
+            second = mod._get_local_routing_client()
+            assert second is not first
+            assert second.base_url == "http://routing-box:9090"
+
+            # Same (new) URL on the next call returns the cached instance.
+            third = mod._get_local_routing_client()
+            assert third is second
 
     def test_is_available_swallows_errors(self, _routing_singleton_reset):
         """is_local_routing_llm_available returns False rather than propagating."""

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -764,6 +764,32 @@ class TestRoutingHelpers:
         assert kwargs["temperature"] == 0.5
 
     @pytest.mark.asyncio
+    async def test_generate_text_with_timeout_uses_routing_url(self, _routing_singleton_reset):
+        """Regression: generate_text's ``timeout is not None`` branch builds a
+        transient LocalLLMClient instead of using the cached routing
+        singleton — that transient client must still be pinned to
+        settings.routing_llm_url, not silently fall back to the default
+        local LLM URL. Two of three routing/validation callers pass a
+        timeout (agent_viz_summary, person_facts), so this branch is the
+        common case, not an edge case."""
+        from unittest.mock import AsyncMock, MagicMock
+        mod = _routing_singleton_reset
+
+        fake_instance = MagicMock()
+        fake_resp = MagicMock(text="ok", reasoning_starved=False)
+        fake_instance.acreate = AsyncMock(return_value=fake_resp)
+        with (
+            patch.object(mod, "settings") as mock_settings,
+            patch.object(mod, "LocalLLMClient", return_value=fake_instance) as mock_cls,
+        ):
+            mock_settings.routing_llm_url = "http://routing-box:9090"
+            await mod.generate_text("hi", timeout=30)
+
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["base_url"] == "http://routing-box:9090"
+        assert kwargs["timeout"] == 30
+
+    @pytest.mark.asyncio
     async def test_generate_text_warns_on_reasoning_starvation(self, _routing_singleton_reset, caplog):
         """generate_text logs a distinct warning when the model burned its
         whole budget on reasoning and returned no answer — otherwise this

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -72,6 +72,47 @@ class TestQueryRouter:
             assert "keyword" in result.reasoning.lower()
 
     @pytest.mark.asyncio
+    async def test_route_thinking_setting_default_omits_kwarg(self):
+        """settings.router_enable_thinking defaults True ⇒ the router passes
+        enable_thinking=None to generate_text, so the request body stays
+        unchanged from before this setting existed (#566 PR 2)."""
+        from api.services.query_router import QueryRouter
+
+        with (
+            patch("api.services.query_router.is_local_routing_llm_available", return_value=True),
+            patch(
+                "api.services.query_router.generate_text",
+                AsyncMock(return_value='{"sources": ["vault"], "reasoning": "test"}'),
+            ) as mock_generate_text,
+        ):
+            router = QueryRouter()
+            await router.route("test query")
+            kwargs = mock_generate_text.await_args.kwargs
+            assert kwargs["enable_thinking"] is None
+
+    @pytest.mark.asyncio
+    async def test_route_thinking_disabled_passes_false(self):
+        """When settings.router_enable_thinking is False, the router
+        explicitly requests thinking off — this is the one-line flip a
+        follow-up PR will make once the correctness A/B confirms no
+        regression."""
+        from api.services.query_router import QueryRouter
+
+        with (
+            patch("api.services.query_router.is_local_routing_llm_available", return_value=True),
+            patch("api.services.query_router.settings") as mock_settings,
+            patch(
+                "api.services.query_router.generate_text",
+                AsyncMock(return_value='{"sources": ["vault"], "reasoning": "test"}'),
+            ) as mock_generate_text,
+        ):
+            mock_settings.router_enable_thinking = False
+            router = QueryRouter()
+            await router.route("test query")
+            kwargs = mock_generate_text.await_args.kwargs
+            assert kwargs["enable_thinking"] is False
+
+    @pytest.mark.asyncio
     async def test_route_includes_latency(self):
         """Router result should include latency measurement."""
         from api.services.query_router import QueryRouter

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -72,23 +72,57 @@ class TestQueryRouter:
             assert "keyword" in result.reasoning.lower()
 
     @pytest.mark.asyncio
-    async def test_route_thinking_setting_default_omits_kwarg(self):
-        """settings.router_enable_thinking defaults True ⇒ the router passes
-        enable_thinking=None to generate_text, so the request body stays
-        unchanged from before this setting existed (#566 PR 2)."""
-        from api.services.query_router import QueryRouter
+    async def test_route_thinking_setting_default_payload_byte_identical(self):
+        """settings.router_enable_thinking defaults True ⇒ the actual JSON
+        body sent over HTTP is byte-identical to before
+        LIFEOS_ROUTER_ENABLE_THINKING existed (#566 PR 2).
 
-        with (
-            patch("api.services.query_router.is_local_routing_llm_available", return_value=True),
-            patch(
-                "api.services.query_router.generate_text",
-                AsyncMock(return_value='{"sources": ["vault"], "reasoning": "test"}'),
-            ) as mock_generate_text,
-        ):
-            router = QueryRouter()
-            await router.route("test query")
-            kwargs = mock_generate_text.await_args.kwargs
-            assert kwargs["enable_thinking"] is None
+        Runs the real generate_text -> LocalLLMClient.acreate path (only the
+        httpx client underneath is faked) rather than mocking generate_text
+        itself — a mock-call-shape assertion (enable_thinking=None was
+        passed to generate_text) would still pass even if acreate later
+        started serializing that as chat_template_kwargs:
+        {"enable_thinking": None}; this asserts the wire body directly
+        (#569 review)."""
+        from unittest.mock import AsyncMock, MagicMock
+        from api.services import llm_client as llm_mod
+        from api.services.query_router import QueryRouter, ROUTER_PROMPT
+
+        prev_client, prev_url = llm_mod._routing_client, llm_mod._routing_client_url
+        llm_mod._routing_client = None
+        llm_mod._routing_client_url = None
+        try:
+            fake_resp = MagicMock()
+            fake_resp.json.return_value = {
+                "choices": [{
+                    "message": {"content": '{"sources": ["vault"], "reasoning": "test"}'},
+                    "finish_reason": "stop",
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                "model": "local",
+            }
+            fake_async_client = MagicMock(is_closed=False)
+            fake_async_client.post = AsyncMock(return_value=fake_resp)
+
+            client = llm_mod._get_local_routing_client()
+            client._async_client = fake_async_client
+
+            with patch("api.services.query_router.is_local_routing_llm_available", return_value=True):
+                router = QueryRouter()
+                result = await router.route("test query")
+        finally:
+            llm_mod._routing_client = prev_client
+            llm_mod._routing_client_url = prev_url
+
+        assert "vault" in result.sources
+        payload = fake_async_client.post.call_args.kwargs["json"]
+        assert payload == {
+            "model": "local",
+            "messages": [{"role": "user", "content": ROUTER_PROMPT.format(query="test query")}],
+            "max_tokens": 2048,
+            "temperature": 0.3,
+            "stream": False,
+        }
 
     @pytest.mark.asyncio
     async def test_route_thinking_disabled_passes_false(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -76,24 +76,6 @@ def test_routing_llm_url_override(monkeypatch):
     assert s.routing_llm_url == "http://routing-box:9090"
 
 
-def test_routing_llm_model_falls_back_to_local_llm_model_when_unset(monkeypatch):
-    """Routing target model label defaults to the global local LLM model when
-    unset, so a fresh clone with no override behaves exactly as today."""
-    monkeypatch.delenv("LIFEOS_LOCAL_ROUTING_LLM_MODEL", raising=False)
-    monkeypatch.setenv("LIFEOS_LLM_MODEL", "some-org/base-model-GGUF")
-    from config.settings import Settings
-    s = Settings()
-    assert s.routing_llm_model == "some-org/base-model-GGUF"
-
-
-def test_routing_llm_model_override(monkeypatch):
-    """An explicit LIFEOS_LOCAL_ROUTING_LLM_MODEL wins over local_llm_model."""
-    monkeypatch.setenv("LIFEOS_LOCAL_ROUTING_LLM_MODEL", "some-org/other-model-GGUF")
-    from config.settings import Settings
-    s = Settings()
-    assert s.routing_llm_model == "some-org/other-model-GGUF"
-
-
 def test_router_enable_thinking_defaults_true():
     """Router thinking stays on by default (#566 PR 2 does not flip
     behaviour) — the eventual flip is a one-line default change here."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -58,6 +58,49 @@ def test_local_llm_model_from_env(monkeypatch):
     assert s.local_llm_model == "some-org/qwen3-32b-GGUF"
 
 
+def test_routing_llm_url_falls_back_to_local_llm_url_when_unset(monkeypatch):
+    """Routing target URL defaults to the global local LLM URL when unset, so
+    a fresh clone with no override behaves exactly as today (#566 PR 2)."""
+    monkeypatch.delenv("LIFEOS_LOCAL_ROUTING_LLM_URL", raising=False)
+    monkeypatch.setenv("LIFEOS_LOCAL_LLM_URL", "http://localhost:8080")
+    from config.settings import Settings
+    s = Settings()
+    assert s.routing_llm_url == "http://localhost:8080"
+
+
+def test_routing_llm_url_override(monkeypatch):
+    """An explicit LIFEOS_LOCAL_ROUTING_LLM_URL wins over local_llm_url."""
+    monkeypatch.setenv("LIFEOS_LOCAL_ROUTING_LLM_URL", "http://routing-box:9090")
+    from config.settings import Settings
+    s = Settings()
+    assert s.routing_llm_url == "http://routing-box:9090"
+
+
+def test_routing_llm_model_falls_back_to_local_llm_model_when_unset(monkeypatch):
+    """Routing target model label defaults to the global local LLM model when
+    unset, so a fresh clone with no override behaves exactly as today."""
+    monkeypatch.delenv("LIFEOS_LOCAL_ROUTING_LLM_MODEL", raising=False)
+    monkeypatch.setenv("LIFEOS_LLM_MODEL", "some-org/base-model-GGUF")
+    from config.settings import Settings
+    s = Settings()
+    assert s.routing_llm_model == "some-org/base-model-GGUF"
+
+
+def test_routing_llm_model_override(monkeypatch):
+    """An explicit LIFEOS_LOCAL_ROUTING_LLM_MODEL wins over local_llm_model."""
+    monkeypatch.setenv("LIFEOS_LOCAL_ROUTING_LLM_MODEL", "some-org/other-model-GGUF")
+    from config.settings import Settings
+    s = Settings()
+    assert s.routing_llm_model == "some-org/other-model-GGUF"
+
+
+def test_router_enable_thinking_defaults_true():
+    """Router thinking stays on by default (#566 PR 2 does not flip
+    behaviour) — the eventual flip is a one-line default change here."""
+    from config.settings import Settings
+    assert Settings.model_fields["router_enable_thinking"].default is True
+
+
 def test_specialist_model_default_is_current_alias():
     """#470 regression pin: the specialist-call model must be a model ALIAS,
     never a dated snapshot. The previous pin (claude-sonnet-4-20250514)


### PR DESCRIPTION
PR 2 of 2 for #566. Recreated from #569, which GitHub auto-closed when its stacked base branch (`fix/llm-reasoning-content`, PR #568) was deleted on merge. Same four commits, cherry-picked cleanly onto `main` with no conflicts.

## What this adds

1. **Per-request reasoning control** on `LocalLLMClient` (`create`/`acreate`/`astream` and the `generate_text`/`generate_json` routing helpers): `enable_thinking` emits `chat_template_kwargs: {"enable_thinking": ...}`, `reasoning_effort` is forwarded as-is. Both default to `None` — **unset produces a byte-identical request body**, asserted directly against the serialized JSON.

2. **Configurable routing target.** `LIFEOS_LOCAL_ROUTING_LLM_URL` lets the latency-sensitive routing/validation callers point at a second llama-server, defaulting to the existing global URL so a fresh clone is unaffected.

3. **`LIFEOS_ROUTER_ENABLE_THINKING`**, wired into `query_router`, **defaulting to `True` (current behaviour, unchanged)**. The default flip is deliberately deferred — see below.

## Why the default is not flipped here

Measured on the host against the real `config/prompts/query_router.txt`:

| | thinking on | thinking off |
|---|---|---|
| mean latency | 27.8s | 4.4s |
| completion tokens | 731-1148 | 55-93 |
| routing decisions | — | substantively identical |

That's a 10-19x cut on the routing hot path. It's a behaviour change to a live interactive path, so it belongs in its own PR with its own correctness A/B rather than riding along with the plumbing. Flipping it is a one-line change: `default=True` → `default=False` in `config/settings.py`. The router maps the default to `enable_thinking=None` (not `True`) precisely so the current path stays byte-identical.

## Review history

Adversarially reviewed; four defects found and fixed:

- **Dead config** — `LIFEOS_LOCAL_ROUTING_LLM_MODEL` was never consumed (`LocalLLMClient` hardcodes `"model": "local"`; llama-server serves one model per process and ignores the field). Removed rather than wired up: on this architecture "which routing model" *is* "which URL."
- **`generate_text`'s timeout branch bypassed the routing URL** — real callers pass a timeout (`agent_viz_summary.py:419`, `person_facts.py:1169`/`:1368`), so those would have silently kept hitting the main chat server while the setting claimed otherwise. Regression test verified to fail before the fix.
- **Routing-client cache** now keyed on its resolved URL so a settings change can't leave it stale.
- **Router test asserted the mock boundary**, not the wire format — replaced with a payload-level assertion on the actual serialized JSON.

## Verification

119 passed across `test_llm_client.py` / `test_query_router.py` / `test_settings.py` on the rebuilt branch. Full suite green apart from the 13 documented pre-existing failures (verified identical on unmodified `main`).

Closes #569.