### PR TITLE
feat(llm): thinking control on the orchestrator path + streaming starvation warning

### DIFF
--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -22,7 +22,7 @@ from api.services.agent_system_prompt import build_system_prompt
 from api.services.agent_tools import TOOL_DEFINITIONS, TOOL_STATUS_MESSAGES, execute_tool_parallel, begin_email_send_turn
 from api.services.synthesizer import build_message_content
 from api.services.perf_trace import trace_span
-from api.services.llm_client import get_local_llm, openai_tool_calls_to_anthropic, LLMUsage
+from api.services.llm_client import get_local_llm, openai_tool_calls_to_anthropic, LLMUsage, LocalLLMClient
 from api.services.resilience import is_retryable_api_error
 from config.settings import settings
 
@@ -462,6 +462,19 @@ async def run_agent_loop(
     system_prompt = build_system_prompt(persona=persona, max_tool_rounds=max_tool_rounds,
                                         voice_rules=voice_rules, personal_context=personal_context)
 
+    # Thinking control (#567): only LocalLLMClient.astream accepts
+    # enable_thinking — AnthropicLLMClient.astream has no such kwarg, and
+    # passing it unconditionally would break the (default) Anthropic backend.
+    # isinstance is the simplest correct gate here: there are exactly two
+    # concrete client classes, agent_loop already branches on which one it
+    # has (_select_client), and a capability protocol would be overkill for
+    # a single kwarg on a two-class module. settings.local_agent_enable_thinking
+    # defaults True (current behaviour) -> mapped to None so the request body
+    # stays byte-identical until an operator opts out.
+    astream_kwargs: dict = {}
+    if isinstance(client, LocalLLMClient):
+        astream_kwargs["enable_thinking"] = None if settings.local_agent_enable_thinking else False
+
     # Bind a fresh per-turn email-draft set. The send gate uses this to refuse
     # sending any draft created during this same turn — sends require the user
     # to confirm in a later turn (draft → confirm → send).
@@ -534,6 +547,7 @@ async def run_agent_loop(
                         system=system_prompt,
                         max_tokens=4096,
                         tools=tools,
+                        **astream_kwargs,
                     ):
                         if event["type"] == "text":
                             text_this_round += event["content"]
@@ -678,6 +692,7 @@ async def run_agent_loop(
                 system=system_prompt,
                 max_tokens=4096,
                 timeout=180,
+                **astream_kwargs,
             ):
                 synthesis_events += 1
                 if event["type"] == "text":

--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -510,10 +510,16 @@ class LocalLLMClient:
         reasoning is only ever a leading prefix. _consume_think_stream does
         NOT also handle a closing-only "</think>" with no preceding opener
         (see its module-level comment) — on this deployment reasoning
-        arrives via the separate ``reasoning_content`` delta field instead,
-        which is simply not read here, so it never reaches a "text" event
-        either. No consumer needs the reasoning text itself, so unlike
-        _parse_response it isn't reassembled or surfaced here.
+        arrives via the separate ``reasoning_content`` delta field instead.
+        That field is only checked for presence (to warn on starvation, see
+        below), never reassembled or surfaced — it still never reaches a
+        "text" event.
+
+        If the stream ends with ``finish_reason == "length"``, reasoning
+        deltas were seen, and no text was ever emitted, the whole token
+        budget was spent on chain-of-thought with no answer to show for it —
+        a warning is logged (not yielded; this never changes what the
+        caller receives).
         """
         all_messages = self._build_messages_list(messages, system)
         payload: dict[str, Any] = {
@@ -537,6 +543,14 @@ class LocalLLMClient:
             tool_calls_acc: dict[int, dict] = {}  # index -> accumulated tool call
             think_buffer = ""  # holds text not yet resolved against the reasoning-prefix rule
             think_phase = "undetermined"
+            # Starvation tracking (#567): reasoning_content deltas are never
+            # surfaced as a "text" event (see docstring), which made the
+            # failure mode silent — a reasoning model can burn its entire
+            # max_tokens budget on chain-of-thought and stream nothing back.
+            # These two flags don't change what's yielded; they only decide
+            # whether to log a warning at "done".
+            reasoning_seen = False
+            text_emitted = False
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):
                     continue
@@ -562,7 +576,15 @@ class LocalLLMClient:
                     think_buffer += delta["content"]
                     emit_text, think_phase, think_buffer = _consume_think_stream(think_buffer, think_phase)
                     if emit_text:
+                        text_emitted = True
                         yield {"type": "text", "content": emit_text}
+
+                # reasoning_content deltas are never turned into text (see
+                # docstring) — tracked only so a starved response (all
+                # reasoning, no answer) can be logged below instead of
+                # silently returning nothing.
+                if delta.get("reasoning_content"):
+                    reasoning_seen = True
 
                 # Tool calls (streamed incrementally)
                 if delta.get("tool_calls"):
@@ -593,8 +615,19 @@ class LocalLLMClient:
                     # leading-prefix rule it's just ordinary text and is
                     # flushed rather than dropped.
                     if think_buffer and think_phase != "in_think":
+                        text_emitted = True
                         yield {"type": "text", "content": think_buffer}
                     think_buffer = ""
+
+                    if not text_emitted and reasoning_seen and finish_reason == "length":
+                        logger.warning(
+                            "Streamed LLM response reasoning starved: spent the "
+                            "entire %d-token max_tokens budget on chain-of-thought "
+                            "and streamed no answer text (finish_reason=length). "
+                            "Disable thinking for this call (enable_thinking=False) "
+                            "or raise max_tokens.",
+                            payload.get("max_tokens", 0),
+                        )
 
                     usage_data = chunk.get("usage", {})
                     usage = LLMUsage(

--- a/config/settings.py
+++ b/config/settings.py
@@ -308,6 +308,19 @@ class Settings(BaseSettings):
                     "(#566). Left True here pending a broader correctness "
                     "A/B; flip to False to opt in once confirmed."
     )
+    local_agent_enable_thinking: bool = Field(
+        default=True,
+        alias="LIFEOS_LOCAL_AGENT_ENABLE_THINKING",
+        description="Whether run_agent_loop's tool-round and synthesis calls "
+                    "request reasoning/thinking from a LOCAL model (Anthropic "
+                    "backend ignores this — see agent_loop._select_client). "
+                    "Default True (current behaviour, unchanged). Measured "
+                    "reasoning starvation on a reasoning-capable local model "
+                    "(Qwen3.8-27B): 4 of 6 questions spent the entire "
+                    "4096-token max_tokens budget on chain-of-thought and "
+                    "returned an empty answer (#567). Flip to False to stop "
+                    "reasoning from starving the answer."
+    )
 
     @property
     def routing_llm_url(self) -> str:

--- a/tests/test_agent_loop_thinking.py
+++ b/tests/test_agent_loop_thinking.py
@@ -1,0 +1,174 @@
+"""
+Tests for thinking control on the orchestrator path (#567, follow-up to #566/#570).
+
+PR #570 added LIFEOS_ROUTER_ENABLE_THINKING for query_router, but run_agent_loop
+had no equivalent — its two client.astream(...) call sites always let a local
+reasoning model think with no way to turn it off. settings.local_agent_enable_thinking
+closes that gap.
+
+The critical constraint: client at those call sites may be either LocalLLMClient
+or AnthropicLLMClient (see agent_loop._select_client). AnthropicLLMClient.astream
+has no enable_thinking parameter — passing it unconditionally breaks the
+(default) cloud backend. These tests cover: the local body stays byte-identical
+at the default, a disabled setting reaches the local body as enable_thinking=False,
+and the Anthropic path is provably never handed the kwarg.
+"""
+import json
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeSSEResponse:
+    """Mimics the httpx streaming response LocalLLMClient.astream reads from."""
+
+    def __init__(self, chunks: list[dict]):
+        self._lines = [f"data: {json.dumps(c)}" for c in chunks] + ["data: [DONE]"]
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+class _FakeStreamCtx:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self._resp
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _CapturingAsyncClient:
+    """Stand-in for httpx.AsyncClient that records each streamed request body."""
+
+    def __init__(self, resp):
+        self.is_closed = False
+        self._resp = resp
+        self.bodies: list[dict] = []
+
+    def stream(self, method, url, **kwargs):
+        self.bodies.append(kwargs["json"])
+        return _FakeStreamCtx(self._resp)
+
+
+def _done_chunk(finish_reason="stop"):
+    return {
+        "choices": [{"delta": {}, "finish_reason": finish_reason}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _local_client_with_chunks(chunks):
+    from api.services.llm_client import LocalLLMClient
+    client = LocalLLMClient(base_url="http://fake:8080")
+    async_client = _CapturingAsyncClient(_FakeSSEResponse(chunks))
+    client._async_client = async_client
+    return client, async_client
+
+
+@pytest.mark.asyncio
+async def test_local_default_true_omits_enable_thinking_from_wire_body():
+    """settings.local_agent_enable_thinking defaults True -> the orchestrator's
+    outgoing request body to a LOCAL client is byte-identical to before this
+    setting existed (mirrors #566 PR 2's router-level payload assertion) —
+    asserted at the actual wire body, not a mocked call-kwargs shape."""
+    from api.services import agent_loop
+
+    client, async_client = _local_client_with_chunks([
+        {"choices": [{"delta": {"content": "42"}, "finish_reason": None}]},
+        _done_chunk(),
+    ])
+    with patch.object(agent_loop, "_select_client", return_value=client):
+        events = [e async for e in agent_loop.run_agent_loop("what is 6x7", max_tool_rounds=1)]
+
+    result = next(e["result"] for e in events if e["type"] == "result")
+    assert result.full_text == "42"
+    assert async_client.bodies, "expected at least one streamed request"
+    for body in async_client.bodies:
+        assert "chat_template_kwargs" not in body
+
+
+@pytest.mark.asyncio
+async def test_local_disabled_setting_sends_enable_thinking_false():
+    """When settings.local_agent_enable_thinking is False, the tool-round
+    request reaching a LOCAL client explicitly turns thinking off."""
+    from api.services import agent_loop
+
+    client, async_client = _local_client_with_chunks([
+        {"choices": [{"delta": {"content": "42"}, "finish_reason": None}]},
+        _done_chunk(),
+    ])
+    with (
+        patch.object(agent_loop, "_select_client", return_value=client),
+        patch.object(agent_loop.settings, "local_agent_enable_thinking", False),
+    ):
+        _ = [e async for e in agent_loop.run_agent_loop("what is 6x7", max_tool_rounds=1)]
+
+    assert async_client.bodies
+    assert async_client.bodies[0]["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+class _MockAnthropicStream:
+    """Minimal async context manager mimicking anthropic's streaming response
+    (same shape as test_agent_loop_caching.py's fixture), so the REAL
+    AnthropicLLMClient.astream can be exercised end-to-end."""
+
+    def __init__(self, final_message, deltas=None):
+        self._final = final_message
+        self._deltas = deltas or []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for d in self._deltas:
+            yield d
+
+    async def get_final_message(self):
+        return self._final
+
+
+@pytest.mark.asyncio
+async def test_anthropic_astream_never_receives_enable_thinking():
+    """Regression guard: AnthropicLLMClient.astream's real signature has no
+    enable_thinking parameter (no **kwargs to swallow it either). If
+    agent_loop's isinstance(client, LocalLLMClient) gate were ever dropped
+    and the kwarg passed unconditionally, this call raises TypeError before
+    ever reaching the (mocked) SDK internals — proving the cloud path,
+    which is the default backend, is unaffected by this feature."""
+    from types import SimpleNamespace
+    from api.services import agent_loop
+    from api.services.llm_client import AnthropicLLMClient
+
+    def _usage():
+        return SimpleNamespace(input_tokens=10, output_tokens=5,
+                               cache_creation_input_tokens=0, cache_read_input_tokens=0)
+
+    def fake_stream(**kwargs):
+        final = SimpleNamespace(content=[], usage=_usage(), stop_reason="end_turn")
+        delta = SimpleNamespace(type="content_block_delta",
+                                delta=SimpleNamespace(text="42"))
+        return _MockAnthropicStream(final, deltas=[delta])
+
+    client = AnthropicLLMClient(api_key="sk-ant-test")
+    client._async_client = SimpleNamespace(messages=SimpleNamespace(stream=fake_stream))
+
+    with patch.object(agent_loop, "_select_client", return_value=client):
+        events = [e async for e in agent_loop.run_agent_loop("what is 6x7", max_tool_rounds=1)]
+
+    result = next(e["result"] for e in events if e["type"] == "result")
+    assert result.full_text == "42"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1147,6 +1147,47 @@ class TestAStreamReasoning:
                 break
         assert events[0] == {"type": "text", "content": "The answer is 42."}
 
+    @pytest.mark.asyncio
+    async def test_starvation_warning_fires_when_budget_exhausted_on_reasoning(self, caplog):
+        """#567: astream ignores reasoning_content deltas entirely, so a
+        reasoning model that burns its whole max_tokens budget on
+        chain-of-thought and never reaches an answer used to fail silently
+        (empty text, no signal). When no text was ever emitted, reasoning
+        deltas WERE seen, and finish_reason=="length", a warning must be
+        logged naming the cause (thinking) and the fix (disable it / raise
+        max_tokens) — without changing what's yielded."""
+        chunks = [
+            {"choices": [{"delta": {"reasoning_content": "thinking, thinking..."}, "finish_reason": None}]},
+            {"choices": [{"delta": {"reasoning_content": "still thinking..."}, "finish_reason": None}]},
+            _done_chunk(finish_reason="length", completion_tokens=4096),
+        ]
+        client = self._client_with_chunks(chunks)
+        with caplog.at_level("WARNING", logger="api.services.llm_client"):
+            events = [e async for e in client.astream([{"role": "user", "content": "hi"}])]
+        text_events = [e for e in events if e["type"] == "text"]
+        assert text_events == []  # yielded content is unchanged — nothing to emit
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("reasoning starved" in w.lower() for w in warnings)
+        assert any("max_tokens" in w or "enable_thinking" in w for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_no_starvation_warning_for_normal_stream(self, caplog):
+        """A normal stream that reaches an answer (or a legitimate empty
+        response that isn't reasoning-starved) never logs the warning."""
+        chunks = [
+            {"choices": [{"delta": {"reasoning_content": "thinking..."}, "finish_reason": None}]},
+            {"choices": [{"delta": {"content": "The answer is 42."}, "finish_reason": None}]},
+            _done_chunk(finish_reason="length", completion_tokens=4096),
+        ]
+        client = self._client_with_chunks(chunks)
+        with caplog.at_level("WARNING", logger="api.services.llm_client"):
+            events = [e async for e in client.astream([{"role": "user", "content": "hi"}])]
+        text = "".join(e["content"] for e in events if e["type"] == "text")
+        assert text == "The answer is 42."
+        warnings = [r.message for r in caplog.records
+                    if r.levelname == "WARNING" and "reasoning starved" in r.message.lower()]
+        assert warnings == []
+
 
 # ---- Anthropic prompt caching (#383 Phase 1) ----
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -83,6 +83,13 @@ def test_router_enable_thinking_defaults_true():
     assert Settings.model_fields["router_enable_thinking"].default is True
 
 
+def test_local_agent_enable_thinking_defaults_true():
+    """The orchestrator's local-model thinking control (#567) defaults True —
+    current behaviour, unchanged — mirroring router_enable_thinking (#566)."""
+    from config.settings import Settings
+    assert Settings.model_fields["local_agent_enable_thinking"].default is True
+
+
 def test_specialist_model_default_is_current_alias():
     """#470 regression pin: the specialist-call model must be a model ALIAS,
     never a dated snapshot. The previous pin (claude-sonnet-4-20250514)


### PR DESCRIPTION
## Summary

Follow-up to #566 / #567. The local agentic path fails on reasoning models because of **reasoning starvation**, not slowness — measured with Qwen3.8-27B on the real `/api/ask/stream` path, 4 of 6 questions burned the entire `max_tokens=4096` budget on chain-of-thought and stored a zero-length answer.

- PR #570 added `LIFEOS_ROUTER_ENABLE_THINKING` for `query_router`, but the orchestrator (`run_agent_loop`) had no equivalent. This adds **`LIFEOS_LOCAL_AGENT_ENABLE_THINKING`** (`settings.local_agent_enable_thinking`), default `True` (current behaviour, unchanged), wired into both `client.astream(...)` call sites in `api/services/agent_loop.py` (tool-round loop and synthesis round).
- `client` at those sites may be `LocalLLMClient` or `AnthropicLLMClient`. `AnthropicLLMClient.astream` has no `enable_thinking` parameter — passing it unconditionally breaks the (default) cloud backend. Gated with `isinstance(client, LocalLLMClient)`: simplest correct option given there are exactly two concrete client classes and `agent_loop` already branches on which one it has (`_select_client`); a capability protocol would be overkill for a single kwarg on a two-class module. When `True`, `None` is passed (not `True`) so the request body stays byte-identical to today.
- PR #568 added a `reasoning_starved` property to `generate_text`/`generate_json`, but `astream` (used by the orchestrator) ignores `reasoning_content` deltas entirely, so this failure mode was silent on the streaming path. `astream` now tracks (without emitting) whether reasoning deltas were seen and whether any text was emitted, and logs a warning at the terminal `done` event when the whole budget was spent on reasoning with `finish_reason == "length"`. No new SSE event — what `astream` yields is unchanged, and reasoning still never reaches a `text` event.

## Test plan

- [x] `settings.local_agent_enable_thinking` defaults `True` (field-default test, mirrors `router_enable_thinking`)
- [x] Default `True` → the local client's outgoing wire body has no `chat_template_kwargs` key (byte-identical to today)
- [x] `False` → `chat_template_kwargs: {"enable_thinking": false}` reaches the local client's wire body
- [x] Regression guard: the REAL `AnthropicLLMClient.astream` is driven end-to-end via `run_agent_loop` — if the kwarg were ever passed unconditionally it raises `TypeError` before touching the SDK (verified by reverting the isinstance gate)
- [x] Starvation warning fires on a synthetic stream (reasoning deltas, no content, `finish_reason="length"`), and does not fire on a normal stream
- [x] Every new test verified fail-first by reverting the guarded behaviour and re-running (isinstance gate, mapping, warning condition, warning presence)
- [x] `HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ./scripts/test.sh` → 4298 passed, 35 skipped; the 13 failures are the pre-existing CRM/vault data-dependent ones, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)