### PR TITLE
fix(sync): don't let an interrupted sleep trip the runtime watchdog

### DIFF
--- a/scripts/run_sync_wrapper.sh
+++ b/scripts/run_sync_wrapper.sh
@@ -61,9 +61,26 @@ for i in $(seq 1 $MAX_RETRIES); do
         SYNC_PID=$!
 
         # Watchdog: SIGTERM after MAX_RUNTIME, SIGKILL 60s later as backstop.
+        #
+        # `sleep` returns early if the subshell catches a signal, and the next
+        # line then kills a sync that has run for minutes rather than hours.
+        # That is not hypothetical: on 2026-08-15 this killed the nightly run
+        # 31 minutes in and logged it as a 21600s timeout, taking out
+        # relationship_discovery and every phase after it. So re-check the wall
+        # clock and go back to sleep unless the deadline has genuinely passed.
+        WATCH_START=$(date +%s)
         (
-            sleep "$MAX_RUNTIME"
-            echo "$(date '+%Y-%m-%d %H:%M:%S') [WRAPPER] Killing stuck sync (PID $SYNC_PID) after ${MAX_RUNTIME}s" >> "$LOG"
+            while :; do
+                sleep "$MAX_RUNTIME"
+                ELAPSED=$(( $(date +%s) - WATCH_START ))
+                if [ "$ELAPSED" -ge "$MAX_RUNTIME" ]; then
+                    break
+                fi
+                # Woken early — log it, since a signal reaching this subshell
+                # means something is stray-signalling the sync's process group.
+                echo "$(date '+%Y-%m-%d %H:%M:%S') [WRAPPER] Watchdog woke early at ${ELAPSED}s (limit ${MAX_RUNTIME}s) — not killing" >> "$LOG"
+            done
+            echo "$(date '+%Y-%m-%d %H:%M:%S') [WRAPPER] Killing stuck sync (PID $SYNC_PID) after ${ELAPSED}s" >> "$LOG"
             kill -TERM "$SYNC_PID" 2>/dev/null
             sleep 60
             kill -KILL "$SYNC_PID" 2>/dev/null


### PR DESCRIPTION
Last night's sync was killed 31 minutes into a run with a **6 hour** limit, and the log blamed a 21600s timeout. This fixes the mechanism that made that possible.

## What happened

```
03:51:15  relationship_discovery starts (normally ~39 min)
04:01:27  Process killed by signal 15 during relationship_discovery
04:01:27  [WRAPPER] Killing stuck sync (PID 3036181) after 21600s
```

Elapsed run time: **31m27s**. `MAX_RUNTIME` is 21600s. The "after 21600s" in the message is just the variable interpolated into the string — it never measured anything.

## Root cause

```bash
sleep "$MAX_RUNTIME"
echo "... Killing stuck sync ..." >> "$LOG"
kill -TERM "$SYNC_PID"
```

`sleep` returns early when the subshell catches a signal, and the next line then kills unconditionally. So **any stray signal reaching the sync's process group becomes an immediate kill**, disguised as a timeout.

An unrelated user-session process (`toshy-sessmon`) logged `Terminated` 58 ms before the sync died, so something did signal the group broadly at 04:01:27. I could not identify the sender — ruled out OOM (no kill logged, 10.9 GB peak against a ~46 GB `MemoryMax`), systemd stopping the unit, suspend/resume (zero events), `logrotate` (config has no postrotate), and autodeploy (started 20 s *after*).

**This PR does not fix the signaller. It makes the sync survive it.**

## Fix

Re-check the wall clock and go back to sleep unless the deadline genuinely passed. An early wake is logged instead of acted on — so the next occurrence produces evidence about the signaller rather than a dead sync.

## Verification

Scratch harness, 30s limit, sleep interrupted at 1s:

```
--- OLD logic ---
  [WRAPPER] Killing stuck sync after 30s
  RESULT: victim KILLED after 1s despite 30s limit
--- NEW logic ---
  [WRAPPER] Watchdog woke early at 1s (limit 30s) — not killing
  RESULT: victim ALIVE — early wake did not kill it
```

## Blast radius of the original bug

`relationship_discovery` failed and every phase after it never ran — `strengths`, `vault_reindex`, `crm_vectorstore`, `google_docs`, `google_sheets`, `entity_cleanup`, `consistency_verify` all left stale.

Worth noting the backup work from #563–#565 behaved correctly under this failure: both snapshots were taken, **retention was skipped because the run failed**, so three of each are retained instead of pruning to two — exactly the night you want the extra copies. And zero WAL sidecars, confirming #565 in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
