### PR TITLE
feat(llm): default thinking OFF on the local orchestrator path

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -309,17 +309,23 @@ class Settings(BaseSettings):
                     "A/B; flip to False to opt in once confirmed."
     )
     local_agent_enable_thinking: bool = Field(
-        default=True,
+        default=False,
         alias="LIFEOS_LOCAL_AGENT_ENABLE_THINKING",
         description="Whether run_agent_loop's tool-round and synthesis calls "
                     "request reasoning/thinking from a LOCAL model (Anthropic "
                     "backend ignores this — see agent_loop._select_client). "
-                    "Default True (current behaviour, unchanged). Measured "
-                    "reasoning starvation on a reasoning-capable local model "
-                    "(Qwen3.8-27B): 4 of 6 questions spent the entire "
-                    "4096-token max_tokens budget on chain-of-thought and "
-                    "returned an empty answer (#567). Flip to False to stop "
-                    "reasoning from starving the answer."
+                    "Default False (#567): measured on the real orchestrator "
+                    "with Gemma 4 26B-A4B, 6 multi-step questions — thinking "
+                    "ON 233.0s mean / 1032 char answers, thinking OFF 72.6s "
+                    "mean / 1714 char answers, 6/6 answered either way. "
+                    "3.2x faster with LONGER answers; time-to-first-token "
+                    "~195s -> ~60s. Answer quality was reviewed side by side "
+                    "on the four most judgement-heavy questions and showed no "
+                    "regression (thinking-off was better on two: it cited "
+                    "task ids and surfaced more recent items). The reasoning "
+                    "budget was crowding out the answer — the same mechanism "
+                    "as the starvation that can empty it entirely on a "
+                    "reasoning-heavy model. Set True to restore reasoning."
     )
 
     @property

--- a/tests/test_agent_loop_thinking.py
+++ b/tests/test_agent_loop_thinking.py
@@ -75,18 +75,26 @@ def _local_client_with_chunks(chunks):
 
 
 @pytest.mark.asyncio
-async def test_local_default_true_omits_enable_thinking_from_wire_body():
-    """settings.local_agent_enable_thinking defaults True -> the orchestrator's
-    outgoing request body to a LOCAL client is byte-identical to before this
-    setting existed (mirrors #566 PR 2's router-level payload assertion) —
-    asserted at the actual wire body, not a mocked call-kwargs shape."""
+async def test_local_thinking_enabled_omits_enable_thinking_from_wire_body():
+    """With thinking ENABLED, the orchestrator's outgoing body to a LOCAL client
+    is byte-identical to before this setting existed (mirrors #566 PR 2's
+    router-level payload assertion) — asserted at the actual wire body, not a
+    mocked call-kwargs shape.
+
+    The setting is patched explicitly rather than relying on the field default:
+    the default flipped to False in #567 once the measurement showed thinking
+    OFF was 3.2x faster with no quality regression, and this test guards the
+    enabled path regardless of which way the default points."""
     from api.services import agent_loop
 
     client, async_client = _local_client_with_chunks([
         {"choices": [{"delta": {"content": "42"}, "finish_reason": None}]},
         _done_chunk(),
     ])
-    with patch.object(agent_loop, "_select_client", return_value=client):
+    with (
+        patch.object(agent_loop, "_select_client", return_value=client),
+        patch.object(agent_loop.settings, "local_agent_enable_thinking", True),
+    ):
         events = [e async for e in agent_loop.run_agent_loop("what is 6x7", max_tool_rounds=1)]
 
     result = next(e["result"] for e in events if e["type"] == "result")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -83,11 +83,16 @@ def test_router_enable_thinking_defaults_true():
     assert Settings.model_fields["router_enable_thinking"].default is True
 
 
-def test_local_agent_enable_thinking_defaults_true():
-    """The orchestrator's local-model thinking control (#567) defaults True —
-    current behaviour, unchanged — mirroring router_enable_thinking (#566)."""
+def test_local_agent_enable_thinking_defaults_false():
+    """The orchestrator's local-model thinking control (#567) defaults False.
+
+    Measured on the real orchestrator (Gemma 4 26B-A4B, 6 multi-step
+    questions): thinking ON 233.0s mean / 1032 char answers vs OFF 72.6s /
+    1714 chars, 6/6 answered either way — 3.2x faster with longer answers and
+    no quality regression on side-by-side review. Pinned so the default can't
+    drift back silently."""
     from config.settings import Settings
-    assert Settings.model_fields["local_agent_enable_thinking"].default is True
+    assert Settings.model_fields["local_agent_enable_thinking"].default is False
 
 
 def test_specialist_model_default_is_current_alias():


### PR DESCRIPTION
Flips `LIFEOS_LOCAL_AGENT_ENABLE_THINKING` to default `False`, following the plumbing added in #571.

## Measured

Real orchestrator (`run_agent_loop(force_local=True)`), Gemma 4 26B-A4B Q8_0, 6 multi-step questions over live data:

| | thinking ON | thinking OFF |
|---|---|---|
| answered | 6/6 | 6/6 |
| **mean latency** | **233.0s** | **72.6s** |
| mean time-to-first-token | ~195s | ~60s |
| mean answer length | 1032 ch | **1714 ch** |

**3.2x faster with longer answers.**

## Quality was reviewed, not inferred

Answer length is a weak proxy for answer quality, so the answers were compared side by side on the four most judgement-heavy questions:

| Question | Verdict |
|---|---|
| Is my week realistically achievable? | Equivalent — both identified the deep-work-vs-meeting-density conflict and the same bottleneck days |
| Which tasks are overdue / prioritise? | **OFF better** — cited task ids, flagged a mid-month timing check, grouped coherently; ON contradicted itself (called a task "quick", then filed it Low Priority) |
| What did I follow up on? | **OFF better** — surfaced items from the last two days rather than reaching back months, and answered the "is there any sign I did it" half explicitly |
| Calendar + which meetings need prep | Void — OFF hit a transient `Server disconnected` blip, not a quality difference; re-ran clean with a full correct listing |

No regression on any of them.

## Why this works

Same mechanism as the routing result in #566 (27.8s → 4.4s, decisions unchanged): the reasoning budget was crowding out the answer. It is the starvation failure #571 warns about, stopping just short of emptying the answer entirely.

## Reversibility

One line back. The setting stays, and #571's starvation warning surfaces the failure mode if reasoning ever does turn out to matter. The Anthropic backend is unaffected — `agent_loop` gates the kwarg on `isinstance(client, LocalLLMClient)`, and that guard has its own regression test driving the real `AnthropicLLMClient`.

## Tests

- `test_local_agent_enable_thinking_defaults_true` → `..._defaults_false`, with the measurement in the docstring so the pin explains itself. **Verified fail-first:** reverting the default makes it fail, restoring makes it pass.
- `test_local_default_true_omits_enable_thinking_from_wire_body` → `test_local_thinking_enabled_omits_...`, now patching the setting explicitly instead of riding on the default, so it guards the enabled path regardless of which way the default points.

91 passed across `test_agent_loop_thinking.py` / `test_settings.py` / `test_llm_client.py`.

Refs #566, #567.
