### PR TITLE
feat(llm): default thinking OFF on the router path

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -298,15 +298,24 @@ class Settings(BaseSettings):
                     "model field."
     )
     router_enable_thinking: bool = Field(
-        default=True,
+        default=False,
         alias="LIFEOS_ROUTER_ENABLE_THINKING",
         description="Whether query_router's LLM routing call requests "
-                    "reasoning/thinking from the local model. Default True "
-                    "(current behaviour, unchanged) — measured on the live "
-                    "host at 23-32s per routing call vs 2-9s with thinking "
-                    "off, with substantively identical routing decisions "
-                    "(#566). Left True here pending a broader correctness "
-                    "A/B; flip to False to opt in once confirmed."
+                    "reasoning/thinking from the local model. Default False "
+                    "(#566/#567). The broader correctness A/B this was "
+                    "waiting on has now run: 12 labelled cases through the "
+                    "real QueryRouter._llm_route — thinking ON 24.65s mean, "
+                    "OFF 3.00s mean (8.2x), with IDENTICAL correctness "
+                    "(11/12 both ways, and the single miss is the same in "
+                    "both modes — a pre-existing router limitation on "
+                    "general-knowledge queries, unrelated to thinking). "
+                    "Decisions agreed on 9/12; of the 3 that differed, "
+                    "thinking-off selected FEWER irrelevant sources on 2 "
+                    "(no vault search for 'did anyone message me', none for "
+                    "'draft a reply to an email') and one justified extra "
+                    "(people, for a query naming a person). Routing is "
+                    "source classification — it does not benefit from "
+                    "chain-of-thought. Set True to restore reasoning."
     )
     local_agent_enable_thinking: bool = Field(
         default=False,

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -72,10 +72,15 @@ class TestQueryRouter:
             assert "keyword" in result.reasoning.lower()
 
     @pytest.mark.asyncio
-    async def test_route_thinking_setting_default_payload_byte_identical(self):
-        """settings.router_enable_thinking defaults True ⇒ the actual JSON
-        body sent over HTTP is byte-identical to before
-        LIFEOS_ROUTER_ENABLE_THINKING existed (#566 PR 2).
+    async def test_route_thinking_enabled_payload_byte_identical(self):
+        """With thinking ENABLED, the actual JSON body sent over HTTP is
+        byte-identical to before LIFEOS_ROUTER_ENABLE_THINKING existed
+        (#566 PR 2).
+
+        The setting is patched explicitly rather than relying on the field
+        default: the default flipped to False in #566/#567 once the 12-case
+        A/B showed identical correctness at 8.2x the speed. This guards the
+        enabled path regardless of which way the default points.
 
         Runs the real generate_text -> LocalLLMClient.acreate path (only the
         httpx client underneath is faked) rather than mocking generate_text
@@ -87,6 +92,7 @@ class TestQueryRouter:
         from unittest.mock import AsyncMock, MagicMock
         from api.services import llm_client as llm_mod
         from api.services.query_router import QueryRouter, ROUTER_PROMPT
+        from api.services.query_router import settings as qr_settings
 
         prev_client, prev_url = llm_mod._routing_client, llm_mod._routing_client_url
         llm_mod._routing_client = None
@@ -107,7 +113,10 @@ class TestQueryRouter:
             client = llm_mod._get_local_routing_client()
             client._async_client = fake_async_client
 
-            with patch("api.services.query_router.is_local_routing_llm_available", return_value=True):
+            with (
+                patch("api.services.query_router.is_local_routing_llm_available", return_value=True),
+                patch.object(qr_settings, "router_enable_thinking", True),
+            ):
                 router = QueryRouter()
                 result = await router.route("test query")
         finally:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -76,11 +76,16 @@ def test_routing_llm_url_override(monkeypatch):
     assert s.routing_llm_url == "http://routing-box:9090"
 
 
-def test_router_enable_thinking_defaults_true():
-    """Router thinking stays on by default (#566 PR 2 does not flip
-    behaviour) — the eventual flip is a one-line default change here."""
+def test_router_enable_thinking_defaults_false():
+    """query_router's thinking control (#566) defaults False.
+
+    12 labelled cases through the real QueryRouter._llm_route: thinking ON
+    24.65s mean vs OFF 3.00s (8.2x), IDENTICAL correctness 11/12 both ways —
+    the single miss is the same in both modes. Of the 3 decisions that
+    differed, thinking-off picked fewer irrelevant sources on 2. Pinned so
+    the default can't drift back silently."""
     from config.settings import Settings
-    assert Settings.model_fields["router_enable_thinking"].default is True
+    assert Settings.model_fields["router_enable_thinking"].default is False
 
 
 def test_local_agent_enable_thinking_defaults_false():


### PR DESCRIPTION
Flips `LIFEOS_ROUTER_ENABLE_THINKING` to default `False`, completing the pair with #573 (orchestrator path).

This setting shipped in #570 deliberately left at `True`, "pending a broader correctness A/B". That A/B has now run.

## Measured — production path, real decisions

12 labelled cases through the real `QueryRouter._llm_route`:

| | thinking ON | thinking OFF |
|---|---|---|
| **mean latency** | **24.65s** | **3.00s** |
| fully correct | 11/12 | 11/12 |
| decision agreement | — | 9/12 |

**8.2x faster at identical correctness.** The single miss — "who won the World Cup in 2022" routed to `vault` instead of `web` — is **the same in both modes**: a pre-existing router limitation on general-knowledge queries, unrelated to thinking.

## The three differing decisions, reviewed individually

| Query | ON | OFF | Assessment |
|---|---|---|---|
| "find the budget spreadsheet *[person]* shared in March" | drive, gmail | drive, gmail, **people** | OFF adds `people` — justified, the query names a person |
| "did anyone **message** me about the offsite" | gmail, people, slack, **vault** | gmail, people, slack | **OFF better** — notes aren't messages |
| "**draft a reply** to the last email from …" | gmail, **vault** | gmail | **OFF better** — no reason to search notes to reply to an email |

On two of three, thinking-off selected *fewer irrelevant sources*, which also reduces downstream fetching. None is a regression.

## Why

Routing is source classification — it doesn't benefit from chain-of-thought, and the discarded reasoning was costing ~22s on **every chat query**.

## Tests

- `test_router_enable_thinking_defaults_true` → `..._defaults_false`, measurement in the docstring. **Verified fail-first:** reverting the default fails it, restoring passes.
- `test_route_thinking_setting_default_payload_byte_identical` → `test_route_thinking_enabled_payload_byte_identical`, now patching the setting explicitly instead of riding on the default, so it guards the enabled path either way.

48 passed across `test_query_router.py` / `test_settings.py` / `test_agent_loop_thinking.py`.

Refs #566, #567.
