### PR TITLE
fix(scheduler): reject unknown notification bot names instead of silently using the primary chat

### DIFF
--- a/api/routes/reminders.py
+++ b/api/routes/reminders.py
@@ -84,8 +84,9 @@ class SendMessageRequest(BaseModel):
     text: str = Field(..., min_length=1, description="Message text to send via Telegram")
     bot: Optional[str] = Field(
         default=None,
-        description="Optional bot name to send from (e.g. 'fitness', 'therapy'). "
-                    "Falls back to the primary bot if unset or unrecognised.",
+        description="Optional bot name to send from — a name from the registry "
+                    "(config/telegram_bots.json). Falls back to the primary bot "
+                    "if unset or unrecognised.",
     )
 
 

--- a/api/routes/scheduler.py
+++ b/api/routes/scheduler.py
@@ -127,18 +127,19 @@ def _resolve_action(action: Optional[str], message_type: Optional[str]) -> str:
     return _TYPE_TO_ACTION.get(message_type or "", "notify")
 
 
-def _require_known_bot(bot: Optional[str]) -> None:
-    """Reject a bot name the registry doesn't know (#575).
+def _require_known_bot(bot: Optional[str]) -> Optional[str]:
+    """Reject a bot name the registry doesn't know, else return it (#575).
 
     An orphaned name — usually the residue of a bot rename — otherwise stores
     fine and then silently delivers to the primary chat at every fire. The
     registry is read here, at request time, because it reflects the current
-    environment; empty or unset stays valid and means the primary bot.
+    environment; empty or unset stays valid and means the primary bot. Returns
+    the trimmed name so that is what gets stored.
     """
     from api.services.telegram import validate_bot_name
 
     try:
-        validate_bot_name(bot)
+        return validate_bot_name(bot)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
 
@@ -155,7 +156,7 @@ async def create_schedule(request: CreateScheduleRequest):
     action = _resolve_action(request.action, request.message_type)
     if action not in VALID_ACTIONS:
         raise HTTPException(status_code=400, detail=f"action must be one of {VALID_ACTIONS}")
-    _require_known_bot(request.bot)
+    request.bot = _require_known_bot(request.bot)
 
     store = get_scheduler_store()
     entry = store.create(
@@ -212,7 +213,7 @@ async def get_schedule(schedule_id: str):
 @router.put("/{schedule_id}", response_model=ScheduleResponse)
 async def update_schedule(schedule_id: str, request: UpdateScheduleRequest):
     """Update an existing schedule."""
-    _require_known_bot(request.bot)
+    request.bot = _require_known_bot(request.bot)
     store = get_scheduler_store()
     updates = {k: v for k, v in request.model_dump().items() if v is not None}
     entry = store.update(schedule_id, **updates)

--- a/api/routes/scheduler.py
+++ b/api/routes/scheduler.py
@@ -41,7 +41,8 @@ class CreateScheduleRequest(BaseModel):
     message_content: str = Field(default="", description="Static text or natural-language prompt")
     endpoint_config: Optional[dict] = Field(default=None, description="For endpoint action: {endpoint, method, params}")
     executor: str = Field(default="", description="For agent action: local | cloud | cloud-haiku | cloud-sonnet")
-    bot: str = Field(default="", description="Telegram bot to notify from (e.g. 'fitness', 'therapy'); empty = primary")
+    bot: str = Field(default="", description="Telegram bot to notify from — a name from the "
+                                             "registry (config/telegram_bots.json) or 'primary'; empty = primary")
     enabled: bool = Field(default=True)
     timezone: str = Field(default_factory=lambda: settings.timezone, description="IANA timezone for the schedule")
 
@@ -109,8 +110,9 @@ class SendMessageRequest(BaseModel):
     text: str = Field(..., min_length=1, description="Message text to send via Telegram")
     bot: Optional[str] = Field(
         default=None,
-        description="Optional bot name to send from (e.g. 'fitness', 'therapy'). "
-                    "Falls back to the primary bot if unset or unrecognised.",
+        description="Optional bot name to send from — a name from the registry "
+                    "(config/telegram_bots.json). Falls back to the primary bot "
+                    "if unset or unrecognised.",
     )
 
 
@@ -125,6 +127,22 @@ def _resolve_action(action: Optional[str], message_type: Optional[str]) -> str:
     return _TYPE_TO_ACTION.get(message_type or "", "notify")
 
 
+def _require_known_bot(bot: Optional[str]) -> None:
+    """Reject a bot name the registry doesn't know (#575).
+
+    An orphaned name — usually the residue of a bot rename — otherwise stores
+    fine and then silently delivers to the primary chat at every fire. The
+    registry is read here, at request time, because it reflects the current
+    environment; empty or unset stays valid and means the primary bot.
+    """
+    from api.services.telegram import validate_bot_name
+
+    try:
+        validate_bot_name(bot)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
 # ---------------------------------------------------------------------------
 # Routes (static paths MUST come before {schedule_id} to avoid capture)
 # ---------------------------------------------------------------------------
@@ -137,6 +155,7 @@ async def create_schedule(request: CreateScheduleRequest):
     action = _resolve_action(request.action, request.message_type)
     if action not in VALID_ACTIONS:
         raise HTTPException(status_code=400, detail=f"action must be one of {VALID_ACTIONS}")
+    _require_known_bot(request.bot)
 
     store = get_scheduler_store()
     entry = store.create(
@@ -193,6 +212,7 @@ async def get_schedule(schedule_id: str):
 @router.put("/{schedule_id}", response_model=ScheduleResponse)
 async def update_schedule(schedule_id: str, request: UpdateScheduleRequest):
     """Update an existing schedule."""
+    _require_known_bot(request.bot)
     store = get_scheduler_store()
     updates = {k: v for k, v in request.model_dump().items() if v is not None}
     entry = store.update(schedule_id, **updates)

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -73,7 +73,7 @@ class ScheduleEntry:
     message_content: str = ""  # static text or natural-language prompt
     endpoint_config: Optional[dict] = None  # {endpoint, method, params}
     executor: str = ""  # agent executor tag without '#': local / cloud / cloud-haiku ...
-    bot: str = ""  # Telegram bot name for outbound sends (e.g. "fitness", "therapy"); empty = primary
+    bot: str = ""  # Telegram bot name for outbound sends (registry: config/telegram_bots.json); empty = primary
     enabled: bool = True
     created_at: str = ""
     last_triggered_at: Optional[str] = None
@@ -738,6 +738,23 @@ class SchedulerStore:
         return entry.action
 
 
+def _misroute_notice(bot: str) -> str:
+    """Banner for a schedule whose configured bot can't be resolved (#575).
+
+    Delivery stays fail-open — an orphaned bot name (typically the residue of a
+    bot rename) must never cost a notification, so the send still goes out from
+    the primary bot. This makes that substitution visible in the channel the
+    message lands in instead of only in a log line nobody reads. Generic text:
+    it names the unresolvable bot and nothing else.
+    """
+    from api.services.telegram import is_known_bot
+
+    if is_known_bot(bot):
+        return ""
+    return (f"⚠️ *Routing warning:* this schedule's bot '{bot}' is not configured "
+            f"— delivered from the primary bot instead.\n\n")
+
+
 class SchedulerScheduler:
     """
     Background thread that fires due schedules every 60 seconds.
@@ -982,7 +999,10 @@ class SchedulerScheduler:
 
             if message:
                 from api.services.telegram import send_message_async
-                await send_message_async(f"*{entry.name}*\n\n{message}", bot=entry.bot or None)
+                await send_message_async(
+                    f"{_misroute_notice(entry.bot)}*{entry.name}*\n\n{message}",
+                    bot=entry.bot or None,
+                )
                 self.store.record_run(entry.id, "sent", message[:200])
             else:
                 self.store.record_run(entry.id, "empty", "")
@@ -993,7 +1013,7 @@ class SchedulerScheduler:
             try:
                 from api.services.telegram import send_message_async
                 await send_message_async(
-                    f"*{entry.name}* (failed)\n\n"
+                    f"{_misroute_notice(entry.bot)}*{entry.name}* (failed)\n\n"
                     f"Schedule could not execute: {str(e)[:200]}",
                     bot=entry.bot or None,
                 )

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -749,7 +749,13 @@ def _misroute_notice(bot: str) -> str:
     """
     from api.services.telegram import is_known_bot
 
-    if is_known_bot(bot):
+    try:
+        known = is_known_bot(bot)
+    except Exception:
+        # Reading the registry must never be what loses a notification: this
+        # runs inside the message the send is about to deliver.
+        return ""
+    if known:
         return ""
     return (f"⚠️ *Routing warning:* this schedule's bot '{bot}' is not configured "
             f"— delivered from the primary bot instead.\n\n")

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -71,6 +71,39 @@ def _token_for_bot(bot: Optional[str]) -> Optional[str]:
     return _resolve_bot(bot)[0]
 
 
+def valid_bot_names() -> list[str]:
+    """Names a caller may legitimately route a send to, newest state.
+
+    ``"primary"`` plus whatever the registry (``config/telegram_bots.json``)
+    currently holds. Read on every call rather than cached at import: the
+    ``telegram_bots`` property is uncached and reflects the current
+    environment, and a registry with no specialized bots is a valid state (a
+    fresh clone configures only the primary bot).
+    """
+    return ["primary"] + [cfg.name for cfg in settings.telegram_bots]
+
+
+def is_known_bot(bot: Optional[str]) -> bool:
+    """Whether ``bot`` resolves to a configured bot. Empty means primary."""
+    return not bot or bot in valid_bot_names()
+
+
+def validate_bot_name(bot: Optional[str]) -> None:
+    """Raise ``ValueError`` if ``bot`` names no configured bot.
+
+    Used wherever a bot name is *written* (scheduler create/update) so an
+    orphaned name — the residue of a bot rename — is rejected at the point of
+    entry instead of silently degrading to the primary chat weeks later (#575).
+    Empty or unset stays valid and continues to mean the primary bot.
+    """
+    if is_known_bot(bot):
+        return
+    raise ValueError(
+        f"Unknown Telegram bot '{bot}'. Valid names: "
+        f"{', '.join(valid_bot_names())} (registry: config/telegram_bots.json)"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Message sending
 # ---------------------------------------------------------------------------

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -88,19 +88,26 @@ def is_known_bot(bot: Optional[str]) -> bool:
     return not bot or bot in valid_bot_names()
 
 
-def validate_bot_name(bot: Optional[str]) -> None:
-    """Raise ``ValueError`` if ``bot`` names no configured bot.
+def validate_bot_name(bot: Optional[str]) -> Optional[str]:
+    """Return the name to store, or raise ``ValueError`` if it isn't configured.
 
     Used wherever a bot name is *written* (scheduler create/update) so an
     orphaned name — the residue of a bot rename — is rejected at the point of
     entry instead of silently degrading to the primary chat weeks later (#575).
     Empty or unset stays valid and continues to mean the primary bot.
+
+    Surrounding whitespace is trimmed, so a tool argument that arrived as
+    ``' ledger'`` stores as ``'ledger'`` and resolves at fire time. Case is
+    *not* folded: matching stays exact, in parity with :func:`_resolve_bot`.
     """
+    if bot is not None:
+        bot = bot.strip()
     if is_known_bot(bot):
-        return
+        return bot
     raise ValueError(
-        f"Unknown Telegram bot '{bot}'. Valid names: "
-        f"{', '.join(valid_bot_names())} (registry: config/telegram_bots.json)"
+        f"Unknown Telegram bot '{bot}'. Configured names: "
+        f"{', '.join(valid_bot_names())} — a registry entry "
+        f"(config/telegram_bots.json) counts only once its token env var is set"
     )
 
 

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -35,7 +35,9 @@ source of truth; `data/scheduler_index.json` is a rebuildable cache.
 - **`[bot:: <name>]`** — which Telegram bot delivers the notification (see below); omitted means the primary bot.
 
 Editing a line in Obsidian (changing the cron, toggling the checkbox) is picked
-up within ~2s by the file watcher.
+up within ~2s by the file watcher. Markdown edits are **not** validated — a
+`[bot:: <name>]` typed here is accepted as-is, and the fire-time routing warning
+below is the only safety net.
 
 ## Triggers
 
@@ -63,13 +65,15 @@ to say.
 
 ### Notification bot
 
-A `notify` or `prompt` schedule can name the Telegram bot that delivers it, so
-finance, health, or therapy content lands in its own channel instead of the
-general feed. The valid names are `primary` plus whatever is registered in
-`config/telegram_bots.json` — that registry is the source of truth, and both
-`POST /api/scheduler` and `PUT /api/scheduler/{id}` reject any other name with
-a 422 that lists the accepted ones. Leaving the field unset means the primary
-bot, which is what an installation with no specialized bots configured gets.
+Any schedule except `action:: agent` can name the Telegram bot that delivers it,
+so finance, health, or therapy content lands in its own channel instead of the
+general feed. The valid names are `primary` plus whatever is *configured* —
+`config/telegram_bots.json` is the registry, but an entry there counts only once
+the env var named by its `token_env` is set, so a listed bot with no token is not
+an accepted name. Both `POST /api/scheduler` and `PUT /api/scheduler/{id}` reject
+any other name with a 422 that lists the accepted ones. Leaving the field unset
+means the primary bot, which is what an installation with no specialized bots
+configured gets.
 
 If a stored schedule names a bot the registry no longer has — usually because
 the bot was renamed after the schedule was written — the notification is still

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Scheduler
-> **Last Updated:** 2026-06-21
+> **Last Updated:** 2026-08-17
 > **Audience:** Operators
 
 The Scheduler runs work on a timer. A **schedule** binds a **trigger** (one-off
@@ -32,6 +32,7 @@ source of truth; `data/scheduler_index.json` is a rebuildable cache.
 - **`[tz:: <IANA zone>]`** — interprets the trigger in that timezone (defaults to the configured timezone).
 - **`[action:: …]`** — what fires (see below).
 - **`#executor` tag** — for `action:: agent`, the executor: `#local`, `#cloud`, `#cloud-haiku`, or `#cloud-sonnet`.
+- **`[bot:: <name>]`** — which Telegram bot delivers the notification (see below); omitted means the primary bot.
 
 Editing a line in Obsidian (changing the cron, toggling the checkbox) is picked
 up within ~2s by the file watcher.
@@ -59,6 +60,22 @@ For `notify` and `prompt`, the Telegram message is **suppressed** when the
 result is empty or a sentinel (`NO_MEETING`, `NOTHING_TO_REPORT`, …) — so
 high-frequency schedules like pre-meeting prep stay quiet when there's nothing
 to say.
+
+### Notification bot
+
+A `notify` or `prompt` schedule can name the Telegram bot that delivers it, so
+finance, health, or therapy content lands in its own channel instead of the
+general feed. The valid names are `primary` plus whatever is registered in
+`config/telegram_bots.json` — that registry is the source of truth, and both
+`POST /api/scheduler` and `PUT /api/scheduler/{id}` reject any other name with
+a 422 that lists the accepted ones. Leaving the field unset means the primary
+bot, which is what an installation with no specialized bots configured gets.
+
+If a stored schedule names a bot the registry no longer has — usually because
+the bot was renamed after the schedule was written — the notification is still
+delivered from the primary bot rather than dropped, but the message carries a
+routing warning naming the unresolvable bot so the misroute is visible in the
+channel it lands in.
 
 ### Agent hand-off
 

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** API Gateway
-**Last Updated:** 2026-07-09
+**Last Updated:** 2026-08-17
 
 Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two adjacent catalogs split out for size:
 
@@ -701,6 +701,8 @@ Schedules can also be created, edited, listed, and deleted via natural language 
 
 Create a schedule. Supports `schedule_type` of `once` (ISO datetime) or `cron`, and `action` of `notify` (static text), `prompt` (runs through the chat pipeline), `endpoint` (calls a LifeOS API endpoint), or `agent` (hands off to the agent worker via an `#agent` task, with `executor` = `local`/`cloud`/`cloud-haiku`/`cloud-sonnet`).
 
+`bot` (optional) selects which Telegram bot delivers the notification. Valid values are `primary` and the names registered in `config/telegram_bots.json`; anything else returns **422** with the accepted names. Omit it, or send an empty string, for the primary bot.
+
 ### GET /api/scheduler
 
 List all schedules.
@@ -711,7 +713,7 @@ Get a specific schedule.
 
 ### PUT /api/scheduler/{id}
 
-Update a schedule.
+Update a schedule. An unrecognised `bot` returns **422** and leaves the schedule unchanged.
 
 ### DELETE /api/scheduler/{id}
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1057,22 +1057,6 @@ class LifeOSMCPServer:
             return {"error": f"Request failed: {e}"}
 
     @staticmethod
-    def _validate_schedule_bot(bot: str | None) -> str | None:
-        """Error message if ``bot`` names no configured bot, else ``None``.
-
-        Reuses the same registry-backed check the scheduler routes apply, so an
-        MCP caller and an HTTP caller are told the same thing. Imported lazily,
-        matching the other app-module imports in this server.
-        """
-        try:
-            from api.services.telegram import validate_bot_name
-
-            validate_bot_name(bot)
-        except ValueError as e:
-            return str(e)
-        return None
-
-    @staticmethod
     def _cache_eligible(tool_name: str) -> bool:
         """Tools whose results are safe to cache for 60s within a session.
 
@@ -1101,14 +1085,6 @@ class LifeOSMCPServer:
         # Custom handlers for tools that don't map 1:1 to endpoints
         if tool_name == "lifeos_sync_trigger":
             return self._handle_sync_trigger(arguments)
-
-        # Reject an unknown notification bot before writing the schedule, so an
-        # agent gets the valid names back instead of a schedule that silently
-        # delivers to the primary chat forever (#575).
-        if tool_name in ("lifeos_schedule_create", "lifeos_schedule_update"):
-            error = self._validate_schedule_bot(arguments.get("bot"))
-            if error:
-                return {"error": error}
 
         # Inter-agent tools dispatch through the agent worker's session store
         # (no HTTP round-trip). The caller_session_id arg identifies which

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -748,7 +748,7 @@ class LifeOSMCPServer:
                     "message_content": {"type": "string", "description": "Static text, natural-language prompt, or agent task description"},
                     "endpoint_config": {"type": "object", "description": "For action=endpoint: {endpoint, method, params}"},
                     "executor": {"type": "string", "description": "For action=agent: 'local', 'cloud', 'cloud-haiku', or 'cloud-sonnet'"},
-                    "bot": {"type": "string", "description": "For action=notify/prompt: Telegram bot to send from ('fitness', 'therapy'). Omit for the primary bot."},
+                    "bot": {"type": "string", "description": "For action=notify/prompt: Telegram bot to send from — a name from the registry in config/telegram_bots.json, or 'primary'. Omit for the primary bot."},
                     "enabled": {"type": "boolean", "description": "Whether the schedule is active", "default": True}
                 },
                 "required": ["name", "schedule_type", "schedule_value", "action"]
@@ -767,7 +767,7 @@ class LifeOSMCPServer:
                     "action": {"type": "string", "description": "'notify', 'prompt', 'endpoint', or 'agent'"},
                     "message_content": {"type": "string", "description": "Message text, prompt, or task description"},
                     "executor": {"type": "string", "description": "For action=agent: local | cloud | cloud-haiku | cloud-sonnet"},
-                    "bot": {"type": "string", "description": "For action=notify/prompt: Telegram bot to send from ('fitness', 'therapy'). Omit for the primary bot."},
+                    "bot": {"type": "string", "description": "For action=notify/prompt: Telegram bot to send from — a name from the registry in config/telegram_bots.json, or 'primary'. Omit for the primary bot."},
                     "timezone": {"type": "string", "description": "IANA timezone (e.g., 'America/New_York')"},
                     "enabled": {"type": "boolean", "description": "Whether the schedule is active"}
                 },
@@ -820,8 +820,8 @@ class LifeOSMCPServer:
                     "bot": {
                         "type": "string",
                         "description": (
-                            "Optional bot to send from. Use 'fitness' to send from the fitness bot, "
-                            "'therapy' for the therapy bot. Omit to send from the primary bot."
+                            "Optional bot to send from — a name from the registry in "
+                            "config/telegram_bots.json. Omit to send from the primary bot."
                         ),
                     },
                 },
@@ -1057,6 +1057,22 @@ class LifeOSMCPServer:
             return {"error": f"Request failed: {e}"}
 
     @staticmethod
+    def _validate_schedule_bot(bot: str | None) -> str | None:
+        """Error message if ``bot`` names no configured bot, else ``None``.
+
+        Reuses the same registry-backed check the scheduler routes apply, so an
+        MCP caller and an HTTP caller are told the same thing. Imported lazily,
+        matching the other app-module imports in this server.
+        """
+        try:
+            from api.services.telegram import validate_bot_name
+
+            validate_bot_name(bot)
+        except ValueError as e:
+            return str(e)
+        return None
+
+    @staticmethod
     def _cache_eligible(tool_name: str) -> bool:
         """Tools whose results are safe to cache for 60s within a session.
 
@@ -1085,6 +1101,14 @@ class LifeOSMCPServer:
         # Custom handlers for tools that don't map 1:1 to endpoints
         if tool_name == "lifeos_sync_trigger":
             return self._handle_sync_trigger(arguments)
+
+        # Reject an unknown notification bot before writing the schedule, so an
+        # agent gets the valid names back instead of a schedule that silently
+        # delivers to the primary chat forever (#575).
+        if tool_name in ("lifeos_schedule_create", "lifeos_schedule_update"):
+            error = self._validate_schedule_bot(arguments.get("bot"))
+            if error:
+                return {"error": error}
 
         # Inter-agent tools dispatch through the agent worker's session store
         # (no HTTP round-trip). The caller_session_id arg identifies which

--- a/tests/test_scheduler_bot_validation.py
+++ b/tests/test_scheduler_bot_validation.py
@@ -1,0 +1,353 @@
+"""
+Tests for schedule notification-bot validation (issue #575).
+
+A schedule's ``bot`` field names which Telegram bot delivers its notification.
+Before #575 nothing validated it, so a typo — or a name orphaned by a bot
+rename — was accepted and then silently degraded to the primary bot and the
+primary chat at every fire, putting domain-specific content in the general feed
+with no signal anywhere but a log line.
+
+Three surfaces are covered here:
+- the registry-backed validation helpers in ``api.services.telegram``
+- the scheduler HTTP routes (create + update) and the MCP tool handlers
+- the fire path, which stays fail-open but now marks the misroute in the
+  message it delivers
+
+Every registry in this file is synthetic and patched in; nothing asserts against
+the real bot names, tokens, or chat ids.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _synthetic_bots():
+    """A stand-in registry — deliberately unlike the real one."""
+    from config.settings import TelegramBotConfig
+    return [
+        TelegramBotConfig(name="alerts", token="ALERTS-TOK", chat_id="ALERTS-CHAT"),
+        TelegramBotConfig(name="ledger", token="LEDGER-TOK", chat_id="LEDGER-CHAT"),
+    ]
+
+
+def _patch_registry(bots):
+    """Patch the bot registry the validation path reads at call time."""
+    mock_settings = MagicMock()
+    mock_settings.telegram_bots = bots
+    mock_settings.telegram_bot_token = "PRIMARY-TOK"
+    mock_settings.telegram_chat_id = "PRIMARY-CHAT"
+    return patch("api.services.telegram.settings", mock_settings)
+
+
+# ---------------------------------------------------------------------------
+# Registry-backed helpers
+# ---------------------------------------------------------------------------
+
+class TestValidBotNames:
+    def test_lists_primary_plus_registry(self):
+        from api.services.telegram import valid_bot_names
+        with _patch_registry(_synthetic_bots()):
+            assert valid_bot_names() == ["primary", "alerts", "ledger"]
+
+    def test_empty_registry_still_offers_primary(self):
+        from api.services.telegram import valid_bot_names
+        with _patch_registry([]):
+            assert valid_bot_names() == ["primary"]
+
+    def test_read_at_call_time_not_captured(self):
+        # A rename between calls must be visible immediately — nothing may
+        # snapshot the registry at import time.
+        from api.services.telegram import valid_bot_names
+        with _patch_registry(_synthetic_bots()):
+            assert "alerts" in valid_bot_names()
+        with _patch_registry([]):
+            assert "alerts" not in valid_bot_names()
+
+
+class TestValidateBotName:
+    @pytest.mark.parametrize("bot", [None, "", "primary", "alerts", "ledger"])
+    def test_accepts_empty_primary_and_registered(self, bot):
+        from api.services.telegram import validate_bot_name
+        with _patch_registry(_synthetic_bots()):
+            validate_bot_name(bot)  # does not raise
+
+    def test_rejects_unknown_name_and_lists_options(self):
+        from api.services.telegram import validate_bot_name
+        with _patch_registry(_synthetic_bots()):
+            with pytest.raises(ValueError) as exc:
+                validate_bot_name("orphaned")
+        message = str(exc.value)
+        assert "orphaned" in message
+        assert "primary" in message and "alerts" in message and "ledger" in message
+
+    def test_empty_registry_accepts_unset_but_rejects_a_name(self):
+        # A fresh clone with only a primary bot is a valid state, not a
+        # rejection — but a name it doesn't have is still wrong.
+        from api.services.telegram import validate_bot_name
+        with _patch_registry([]):
+            validate_bot_name("")
+            validate_bot_name("primary")
+            with pytest.raises(ValueError):
+                validate_bot_name("alerts")
+
+    def test_is_known_bot_predicate(self):
+        from api.services.telegram import is_known_bot
+        with _patch_registry(_synthetic_bots()):
+            assert is_known_bot("") is True
+            assert is_known_bot(None) is True
+            assert is_known_bot("primary") is True
+            assert is_known_bot("alerts") is True
+            assert is_known_bot("orphaned") is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP routes
+# ---------------------------------------------------------------------------
+
+class TestSchedulerRoutesBotValidation:
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        from api.main import app
+        return TestClient(app)
+
+    @pytest.fixture
+    def mock_store(self):
+        from api.services.scheduler_store import ScheduleEntry
+        with patch("api.routes.scheduler.get_scheduler_store") as mock:
+            store = mock.return_value
+            entry = ScheduleEntry(
+                id="sch-1", name="Balance check", schedule_type="cron",
+                schedule_value="0 7 * * 1-5", action="notify",
+                message_type="static", message_content="check the balance",
+                bot="ledger",
+            )
+            store.create.return_value = entry
+            store.update.return_value = entry
+            store.get.return_value = entry
+            yield store
+
+    def _create_payload(self, **overrides):
+        payload = {
+            "name": "Balance check", "schedule_type": "cron",
+            "schedule_value": "0 7 * * 1-5", "action": "notify",
+            "message_content": "check the balance",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_create_rejects_unknown_bot_with_valid_options(self, client, mock_store):
+        with _patch_registry(_synthetic_bots()):
+            resp = client.post("/api/scheduler", json=self._create_payload(bot="orphaned"))
+        assert resp.status_code == 422
+        detail = resp.text
+        assert "orphaned" in detail
+        assert "alerts" in detail and "ledger" in detail and "primary" in detail
+        mock_store.create.assert_not_called()
+
+    def test_update_rejects_unknown_bot_and_leaves_schedule_untouched(self, client, mock_store):
+        with _patch_registry(_synthetic_bots()):
+            resp = client.put("/api/scheduler/sch-1", json={"bot": "orphaned"})
+        assert resp.status_code == 422
+        assert "alerts" in resp.text
+        mock_store.update.assert_not_called()
+
+    def test_create_without_bot_succeeds(self, client, mock_store):
+        with _patch_registry(_synthetic_bots()):
+            resp = client.post("/api/scheduler", json=self._create_payload())
+        assert resp.status_code == 200
+        assert mock_store.create.call_args.kwargs["bot"] == ""
+
+    def test_create_with_empty_bot_succeeds(self, client, mock_store):
+        with _patch_registry(_synthetic_bots()):
+            resp = client.post("/api/scheduler", json=self._create_payload(bot=""))
+        assert resp.status_code == 200
+        assert mock_store.create.call_args.kwargs["bot"] == ""
+
+    def test_create_with_primary_succeeds(self, client, mock_store):
+        with _patch_registry(_synthetic_bots()):
+            resp = client.post("/api/scheduler", json=self._create_payload(bot="primary"))
+        assert resp.status_code == 200
+        assert mock_store.create.call_args.kwargs["bot"] == "primary"
+
+    def test_create_with_registered_bot_persists_the_name(self, client, mock_store):
+        with _patch_registry(_synthetic_bots()):
+            resp = client.post("/api/scheduler", json=self._create_payload(bot="ledger"))
+        assert resp.status_code == 200
+        assert mock_store.create.call_args.kwargs["bot"] == "ledger"
+        assert resp.json()["bot"] == "ledger"
+
+    def test_update_with_registered_bot_succeeds(self, client, mock_store):
+        with _patch_registry(_synthetic_bots()):
+            resp = client.put("/api/scheduler/sch-1", json={"bot": "alerts"})
+        assert resp.status_code == 200
+        assert mock_store.update.call_args.kwargs["bot"] == "alerts"
+
+    def test_empty_registry_accepts_a_schedule_without_a_bot(self, client, mock_store):
+        # Fresh clone: only a primary bot configured.
+        with _patch_registry([]):
+            resp = client.post("/api/scheduler", json=self._create_payload())
+        assert resp.status_code == 200
+        mock_store.create.assert_called_once()
+
+    def test_empty_registry_rejects_a_named_bot(self, client, mock_store):
+        with _patch_registry([]):
+            resp = client.post("/api/scheduler", json=self._create_payload(bot="alerts"))
+        assert resp.status_code == 422
+        mock_store.create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# MCP tool handlers
+# ---------------------------------------------------------------------------
+
+class TestMcpScheduleBotValidation:
+    @pytest.fixture
+    def server(self):
+        from mcp_server import LifeOSMCPServer
+        srv = LifeOSMCPServer.__new__(LifeOSMCPServer)
+        srv.client = MagicMock()
+        srv._result_cache = None
+        return srv
+
+    @pytest.mark.parametrize(
+        "tool_name,arguments",
+        [
+            ("lifeos_schedule_create", {
+                "name": "Balance check", "schedule_type": "cron",
+                "schedule_value": "0 7 * * 1-5", "action": "notify",
+                "bot": "orphaned",
+            }),
+            ("lifeos_schedule_update", {"schedule_id": "sch-1", "bot": "orphaned"}),
+        ],
+    )
+    def test_unknown_bot_rejected_without_writing(self, server, tool_name, arguments):
+        with _patch_registry(_synthetic_bots()):
+            result = server._call_api(tool_name, arguments)
+        assert "error" in result
+        assert "orphaned" in result["error"]
+        assert "alerts" in result["error"] and "primary" in result["error"]
+        server.client.post.assert_not_called()
+        server.client.request.assert_not_called()
+
+    def test_registered_bot_passes_through_to_the_api(self, server):
+        response = MagicMock()
+        response.json.return_value = {"id": "sch-2", "name": "Balance check", "bot": "ledger"}
+        server.client.post.return_value = response
+
+        with _patch_registry(_synthetic_bots()):
+            result = server._call_api("lifeos_schedule_create", {
+                "name": "Balance check", "schedule_type": "cron",
+                "schedule_value": "0 7 * * 1-5", "action": "notify", "bot": "ledger",
+            })
+        assert result["bot"] == "ledger"
+        assert server.client.post.call_args.kwargs["json"]["bot"] == "ledger"
+
+    def test_omitted_bot_passes_through(self, server):
+        response = MagicMock()
+        response.json.return_value = {"id": "sch-3", "name": "Ping"}
+        server.client.post.return_value = response
+
+        with _patch_registry([]):
+            result = server._call_api("lifeos_schedule_create", {
+                "name": "Ping", "schedule_type": "cron",
+                "schedule_value": "0 9 * * *", "action": "notify",
+            })
+        assert "error" not in result
+        server.client.post.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Fire path — fail-open delivery, but marked
+# ---------------------------------------------------------------------------
+
+class TestFireTimeMisrouteMarker:
+    @pytest.fixture
+    def scheduler(self, tmp_path):
+        from api.services.scheduler_store import SchedulerStore, SchedulerScheduler
+        store = SchedulerStore(
+            vault_path=tmp_path / "vault",
+            index_path=tmp_path / "scheduler_index.json",
+        )
+        return SchedulerScheduler(store)
+
+    def _entry(self, scheduler, bot):
+        return scheduler.store.create(
+            name="Balance check", schedule_type="cron", schedule_value="0 7 * * 1-5",
+            action="notify", message_type="static",
+            message_content="the balance is fine", bot=bot,
+        )
+
+    @pytest.mark.asyncio
+    async def test_orphaned_bot_still_delivers_with_a_marker(self, scheduler):
+        entry = self._entry(scheduler, "orphaned")
+        with _patch_registry(_synthetic_bots()):
+            with patch("api.services.telegram.send_message_async",
+                       new_callable=AsyncMock, return_value=True) as mock_send:
+                await scheduler._fire_entry(entry)
+
+        mock_send.assert_called_once()
+        sent = mock_send.call_args[0][0]
+        # The notification is never dropped on account of the bad name.
+        assert "the balance is fine" in sent
+        # And the misroute is visible in the channel it lands in.
+        assert "orphaned" in sent
+        assert "not configured" in sent
+        assert scheduler.store.get(entry.id).last_status == "sent"
+
+    @pytest.mark.asyncio
+    async def test_marker_leaks_no_chat_id_or_token(self, scheduler):
+        entry = self._entry(scheduler, "orphaned")
+        with _patch_registry(_synthetic_bots()):
+            with patch("api.services.telegram.send_message_async",
+                       new_callable=AsyncMock, return_value=True) as mock_send:
+                await scheduler._fire_entry(entry)
+
+        sent = mock_send.call_args[0][0]
+        for secret in ("PRIMARY-TOK", "PRIMARY-CHAT", "ALERTS-TOK", "ALERTS-CHAT"):
+            assert secret not in sent
+
+    @pytest.mark.asyncio
+    async def test_registered_bot_delivers_unmarked(self, scheduler):
+        entry = self._entry(scheduler, "ledger")
+        with _patch_registry(_synthetic_bots()):
+            with patch("api.services.telegram.send_message_async",
+                       new_callable=AsyncMock, return_value=True) as mock_send:
+                await scheduler._fire_entry(entry)
+
+        sent = mock_send.call_args[0][0]
+        assert sent == "*Balance check*\n\nthe balance is fine"
+        assert mock_send.call_args.kwargs["bot"] == "ledger"
+
+    @pytest.mark.asyncio
+    async def test_unset_bot_delivers_unmarked_on_an_empty_registry(self, scheduler):
+        entry = self._entry(scheduler, "")
+        with _patch_registry([]):
+            with patch("api.services.telegram.send_message_async",
+                       new_callable=AsyncMock, return_value=True) as mock_send:
+                await scheduler._fire_entry(entry)
+
+        sent = mock_send.call_args[0][0]
+        assert sent == "*Balance check*\n\nthe balance is fine"
+
+    @pytest.mark.asyncio
+    async def test_failure_notification_also_carries_the_marker(self, scheduler):
+        entry = scheduler.store.create(
+            name="Balance check", schedule_type="cron", schedule_value="0 7 * * 1-5",
+            action="endpoint", message_type="endpoint",
+            endpoint_config={"endpoint": "/api/nope"}, bot="orphaned",
+        )
+        with _patch_registry(_synthetic_bots()):
+            with patch.object(scheduler, "_generate_message",
+                             new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+                with patch("api.services.telegram.send_message_async",
+                           new_callable=AsyncMock, return_value=True) as mock_send:
+                    await scheduler._fire_entry(entry)
+
+        mock_send.assert_called_once()
+        sent = mock_send.call_args[0][0]
+        assert "orphaned" in sent and "not configured" in sent
+        assert "boom" in sent
+        assert scheduler.store.get(entry.id).last_status == "failed"

--- a/tests/test_scheduler_bot_validation.py
+++ b/tests/test_scheduler_bot_validation.py
@@ -92,6 +92,21 @@ class TestValidateBotName:
             with pytest.raises(ValueError):
                 validate_bot_name("alerts")
 
+    @pytest.mark.parametrize("bot", [" ledger", "ledger ", "  ledger  "])
+    def test_trims_surrounding_whitespace_and_returns_the_stored_name(self, bot):
+        # Rejecting ' ledger' against a list showing a visually identical
+        # 'ledger' is unhelpful for an LLM-authored tool argument.
+        from api.services.telegram import validate_bot_name
+        with _patch_registry(_synthetic_bots()):
+            assert validate_bot_name(bot) == "ledger"
+
+    def test_does_not_case_fold(self):
+        # Exact matching is deliberate — parity with _resolve_bot.
+        from api.services.telegram import validate_bot_name
+        with _patch_registry(_synthetic_bots()):
+            with pytest.raises(ValueError):
+                validate_bot_name("Ledger")
+
     def test_is_known_bot_predicate(self):
         from api.services.telegram import is_known_bot
         with _patch_registry(_synthetic_bots()):
@@ -185,6 +200,20 @@ class TestSchedulerRoutesBotValidation:
         assert resp.status_code == 200
         assert mock_store.update.call_args.kwargs["bot"] == "alerts"
 
+    def test_create_trims_whitespace_before_storing(self, client, mock_store):
+        # Stored untrimmed, the name would pass validation and then misroute at
+        # fire time — so the write path has to store the trimmed value.
+        with _patch_registry(_synthetic_bots()):
+            resp = client.post("/api/scheduler", json=self._create_payload(bot=" ledger "))
+        assert resp.status_code == 200
+        assert mock_store.create.call_args.kwargs["bot"] == "ledger"
+
+    def test_update_trims_whitespace_before_storing(self, client, mock_store):
+        with _patch_registry(_synthetic_bots()):
+            resp = client.put("/api/scheduler/sch-1", json={"bot": " alerts "})
+        assert resp.status_code == 200
+        assert mock_store.update.call_args.kwargs["bot"] == "alerts"
+
     def test_empty_registry_accepts_a_schedule_without_a_bot(self, client, mock_store):
         # Fresh clone: only a primary bot configured.
         with _patch_registry([]):
@@ -204,6 +233,16 @@ class TestSchedulerRoutesBotValidation:
 # ---------------------------------------------------------------------------
 
 class TestMcpScheduleBotValidation:
+    """The API is the only validator; MCP just surfaces its rejection.
+
+    The MCP server deliberately does *not* pre-check the bot name. Its view of
+    the registry is not the API's: ``config/telegram_bots.json`` is read
+    relative to the process cwd (the stdio child inherits the agent's cwd, not
+    the repo), and a client pointed at a remote ``LIFEOS_API_URL`` has neither
+    the same file nor the token env vars. A local pre-check would reject names
+    the server accepts, so the 422 is allowed to propagate instead.
+    """
+
     @pytest.fixture
     def server(self):
         from mcp_server import LifeOSMCPServer
@@ -211,6 +250,14 @@ class TestMcpScheduleBotValidation:
         srv.client = MagicMock()
         srv._result_cache = None
         return srv
+
+    def _http_422(self, detail):
+        """Make the transport raise the way httpx does on a 422."""
+        import httpx
+        response = MagicMock()
+        response.status_code = 422
+        response.text = f'{{"detail":"{detail}"}}'
+        return httpx.HTTPStatusError("422", request=MagicMock(), response=response)
 
     @pytest.mark.parametrize(
         "tool_name,arguments",
@@ -223,25 +270,38 @@ class TestMcpScheduleBotValidation:
             ("lifeos_schedule_update", {"schedule_id": "sch-1", "bot": "orphaned"}),
         ],
     )
-    def test_unknown_bot_rejected_without_writing(self, server, tool_name, arguments):
-        with _patch_registry(_synthetic_bots()):
-            result = server._call_api(tool_name, arguments)
+    def test_api_rejection_surfaces_as_the_tool_error(self, server, tool_name, arguments):
+        detail = ("Unknown Telegram bot 'orphaned'. Configured names: "
+                  "primary, alerts, ledger")
+        error = self._http_422(detail)
+        server.client.post.side_effect = error
+        server.client.request.side_effect = error
+
+        result = server._call_api(tool_name, arguments)
+
         assert "error" in result
+        assert "422" in result["error"]
+        # The valid options reach the agent verbatim from the API.
         assert "orphaned" in result["error"]
         assert "alerts" in result["error"] and "primary" in result["error"]
-        server.client.post.assert_not_called()
-        server.client.request.assert_not_called()
+        # And the agent sees it as an error, not a successful write.
+        assert server._format_response(tool_name, result).startswith("Error:")
 
-    def test_registered_bot_passes_through_to_the_api(self, server):
+    def test_no_local_precheck_blocks_a_name_the_api_would_accept(self, server):
+        # The regression guarded here: an MCP client whose local registry is
+        # empty (wrong cwd, or a remote API) must still be able to write a bot
+        # name the server knows. A pre-flight check would have hard-rejected it.
         response = MagicMock()
         response.json.return_value = {"id": "sch-2", "name": "Balance check", "bot": "ledger"}
         server.client.post.return_value = response
 
-        with _patch_registry(_synthetic_bots()):
+        with _patch_registry([]):
             result = server._call_api("lifeos_schedule_create", {
                 "name": "Balance check", "schedule_type": "cron",
                 "schedule_value": "0 7 * * 1-5", "action": "notify", "bot": "ledger",
             })
+
+        assert "error" not in result
         assert result["bot"] == "ledger"
         assert server.client.post.call_args.kwargs["json"]["bot"] == "ledger"
 
@@ -331,6 +391,25 @@ class TestFireTimeMisrouteMarker:
 
         sent = mock_send.call_args[0][0]
         assert sent == "*Balance check*\n\nthe balance is fine"
+
+    @pytest.mark.asyncio
+    async def test_send_survives_a_registry_read_that_raises(self, scheduler):
+        # The banner exists to annotate the send; it must never be the thing
+        # that loses it. A malformed registry makes the lookup raise, and the
+        # notification still has to go out.
+        entry = self._entry(scheduler, "orphaned")
+        with patch("api.services.telegram.is_known_bot",
+                   side_effect=RuntimeError("malformed registry")):
+            with patch("api.services.telegram.send_message_async",
+                       new_callable=AsyncMock, return_value=True) as mock_send:
+                await scheduler._fire_entry(entry)
+
+        mock_send.assert_called_once()
+        sent = mock_send.call_args[0][0]
+        assert "the balance is fine" in sent
+        # No banner is better than no message: it degrades, it doesn't abort.
+        assert "not configured" not in sent
+        assert scheduler.store.get(entry.id).last_status == "sent"
 
     @pytest.mark.asyncio
     async def test_failure_notification_also_carries_the_marker(self, scheduler):


### PR DESCRIPTION
## TL;DR

A schedule can name which Telegram bot delivers its notification, but nothing checked that the name existed. A name that didn't match anything — typically one left orphaned by a bot rename — was accepted, kept reporting successful fires, and quietly delivered every notification to the general channel instead. Now an unrecognized name is rejected when the schedule is written, with the accepted names in the error, and a schedule already carrying a bad name still gets delivered but arrives with a visible routing warning naming the bot it could not use. An installation with only a primary bot configured is unaffected.

Closes #575

## Design

The bot registry is the single source of truth and is read at the moment of each check, never captured earlier, because it reflects the current environment and may be empty. An empty registry is a valid configuration — a fresh clone with only a primary bot — so it accepts an unset name and rejects only a name it doesn't have.

**Validation lives in the API and only in the API.** Rejection happens on the scheduler create and update routes. The MCP tools do *not* pre-check: they send the write and let the route's 422 come back as the tool's error. That is a deliberate correction made during review — see below.

Fire-time behavior deliberately stays fail-open: an unresolvable name must never cost a notification, so the send still goes out from the primary bot. Only the silence is fixed — the message gains a warning banner naming the unresolvable bot. The banner is generic text carrying nothing but that name, it appears on both the normal and the failure notification, and building it can never abort the send it annotates. A resolvable name produces no banner at all.

### Why the MCP pre-check was removed

The first cut of this PR validated the bot name inside `mcp_server.py` before its HTTP round-trip. That was wrong, and review caught it: it made the MCP client's view of the registry authoritative over the API's, and the two are not the same view.

- `settings.telegram_bots` reads `Path("config/telegram_bots.json")` — **relative to the process cwd**. The stdio MCP child is spawned with the calling agent's cwd, not the repo, so the registry read returned nothing and `valid_bot_names()` was just `['primary']`. A `lifeos_schedule_create(bot="finance")` that worked before this PR would have been hard-rejected and never written.
- Anchoring the path to the repo root would only half-fix it. A client pointed at a remote `LIFEOS_API_URL` has the tracked registry file but not the token env vars that make an entry count, so it would still reject names the server accepts.

So the pre-check is gone rather than hardened — a net code removal. `_call_api`'s existing `httpx.HTTPStatusError` branch returns `{"error": "API error 422: …Unknown Telegram bot 'x'. Configured names: …"}` and `_format_response` renders it as `Error: …`, which satisfies the issue's MCP acceptance criterion with the API as the one validator.

**One intentional deviation from the issue.** The issue specifies HTTP 422 and suggests Pydantic field validators. Those are mutually exclusive in this app: `api/main.py` registers a global `RequestValidationError` handler that rewrites every Pydantic failure to 400, and it cannot serialize a `ValueError` in the error context, so a field validator returns 500 rather than a rejection. This is pre-existing and reproducible on `POST /api/ask` with a blank question on `main`. The 422 requirement therefore won, and the check sits in the route bodies — which is also where these routes already validate their other enumerated fields.

## Implementation Notes

`api/services/telegram.py` gains three small registry-backed helpers next to the existing `_resolve_bot`, whose contract is untouched: `valid_bot_names`, `is_known_bot`, and `validate_bot_name`. Everything else calls into these. `validate_bot_name` returns the name to store, trimming surrounding whitespace so a tool argument that arrived as `' ledger'` stores as `'ledger'` and resolves at fire time; case is **not** folded, keeping exact-match parity with `_resolve_bot`.

- `api/routes/scheduler.py` — `_require_known_bot` translates a `ValueError` into an `HTTPException(422)` and returns the trimmed name; called in `create_schedule` after the action check and as the first statement of `update_schedule`, so a rejected update never reaches the store and a trimmed name is what gets persisted.
- `mcp_server.py` — tool descriptions only. No validation logic (see Design).
- `api/services/scheduler_store.py` — `_misroute_notice` builds the banner and is prefixed to both `_fire_entry` sends. Its registry lookup is wrapped so a malformed registry degrades to *no banner* rather than raising; it is evaluated inside the f-string before `send_message_async`, so an exception there would otherwise have killed the primary send and then the failure send too, losing the notification outright.
- Stale `'therapy'` citations (the registry name is `therapist`) are replaced with a pointer to `config/telegram_bots.json` in `mcp_server.py` (three tool descriptions), `api/routes/scheduler.py`, `api/routes/reminders.py` (the deprecated twin of the same send model), and the `ScheduleEntry.bot` comment.
- Docs: the scheduler guide gains a "Notification bot" section and the `[bot:: …]` field, notes that the field applies to every action except `agent`, describes the valid set as *configured* bots (a registry entry counts only once its token env var is set), and states that hand-edited markdown is **not** validated — the fire-time banner is the only safety net there. The API reference notes the 422 on both routes.

### Files changed

```
api/routes/reminders.py                |   5 +-
api/routes/scheduler.py                |  27 ++-
api/services/scheduler_store.py        |  32 ++-
api/services/telegram.py               |  40 +++
docs/guides/scheduler.md               |  25 +-
docs/specs/product/api-reference.md    |   6 +-
mcp_server.py                          |   8 +-
tests/test_scheduler_bot_validation.py | 432 +++++++++++++++++++++++++++++++++
8 files changed, 559 insertions(+), 16 deletions(-)
```

## Test evidence

### Automated tests

`tests/test_scheduler_bot_validation.py` is new — **36 tests**, patching the registry to a synthetic two-bot set (`alerts`, `ledger`) so nothing asserts against real bot names or ids. It covers the helpers, create/update rejection and acceptance (unset, empty, `primary`, registered), whitespace trimming on both write routes, the deliberate non-folding of case, the empty-registry accept and reject cases, the MCP surface, and the fire path in five shapes: orphaned name delivers with the marker, registered name delivers without it, unset name on an empty registry delivers without it, the failure notification also carries it, and — new in round 1 — **the send still happens when the registry read raises**. One test asserts the marker leaks no patched token or chat id.

The MCP tests assert the corrected contract: an API 422 surfaces as the tool's error with the valid options intact and renders through `_format_response` as `Error: …`, and a bot name the *local* registry doesn't know still reaches the API — the regression that the deleted pre-check would have caused.

**No existing test was modified.** The only test file in the diff is the new one.

```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" pytest \
    tests/test_scheduler_bot_validation.py tests/test_mcp_server.py tests/test_scheduler_api.py -q
82 passed, 1 warning in 27.64s
```

```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" pytest \
    tests/test_scheduler_api.py tests/test_scheduler_store.py tests/test_scheduler_watcher.py \
    tests/test_persona_api.py tests/test_mcp_server.py tests/test_mcp_http_transport.py \
    tests/test_agent_worker_mcp_exposure.py tests/test_telegram_outbound_routing.py \
    tests/test_telegram_multibot.py tests/test_telegram.py tests/test_reminders_api.py \
    tests/test_scheduler_bot_validation.py -q -n auto --dist loadscope -m "not requires_server"
306 passed, 82 warnings in 21.03s
```

The pre-push hook ran the full unit suite: `3365 passed, 8 skipped` plus `12 passed` server-free browser tests.

### Manual verification

Route rejection, against the **real** registry, in-process via `TestClient` (no server restart — the live service deploys from the canonical checkout, not this worktree). The names listed are the ones committed in the tracked registry file; no tokens or chat ids are involved.

```
=== 1. POST /api/scheduler with an unregistered bot (real registry) ===
422 {'detail': "Unknown Telegram bot 'portfolio-old'. Configured names: primary, fitness, therapist, doctor, finance — a registry entry (config/telegram_bots.json) counts only once its token env var is set"}

=== 2. PUT /api/scheduler/{id} with an unregistered bot ===
422 <- 422 before the 404 lookup: nothing was read or written

=== 3. PUT with a registered name reaches the store (404 = validation passed) ===
404 {'detail': 'Schedule not found'}
```

Case 2 returns 422 rather than the 404 the id would otherwise produce, which shows the rejection lands before the store is touched. Case 3 reaching the 404 shows a valid name passes through.

Fire path, real code and real registry, against a temp store and a mocked send so no live vault or chat is touched:

```
--- bot='portfolio-old' -> send called: True, status: sent
"⚠️ *Routing warning:* this schedule's bot 'portfolio-old' is not configured — delivered from the primary bot instead.\n\n*Portfolio alert*\n\nBalances are within range."

--- bot='finance' -> send called: True, status: sent
'*Portfolio alert*\n\nBalances are within range.'
```

The orphaned schedule still sends and still records `sent` — delivery is never lost — and the message carries the banner. The registered bot's message is byte-identical to the pre-change format, so nothing leaks into the healthy path.

## Review focus

- The 422-versus-field-validator tradeoff in `api/routes/scheduler.py:130` — see Design. Fixing the global handler in `api/main.py` so field validators work at all is a real bug worth its own issue; I deliberately left it alone.
- The banner's wording and placement at `api/services/scheduler_store.py:741`. It is prefixed above the schedule title so it is the first thing read. It uses `*bold*` and no backticks: the send functions already retry without `parse_mode` on any non-200, so a Markdown edge case costs formatting but never the message.
- `api/routes/reminders.py:87` is outside the issue's stated file list. It is the deprecated twin of the send model I fixed in `scheduler.py` and carried the same stale citation; fixing one and not the other seemed worse.
- `docs/specs/product/api-reference.md` still words the valid set as the names "registered in `config/telegram_bots.json`" rather than *configured*. Round 1 scoped that rewording to the rejection message and the scheduler guide; I left the API reference alone rather than widen the change, and am flagging it here instead.
