### PR TITLE
fix(tasks): document lifeos_task_list filter params for MCP callers

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -182,11 +182,43 @@ def _build_preflight_preview(request: CreateTaskRequest) -> PreflightPreviewResp
 
 @router.get("", response_model=TaskListResponse)
 async def list_tasks(
-    status: Optional[str] = None,
-    context: Optional[str] = None,
-    tag: Optional[str] = None,
-    due_before: Optional[str] = None,
-    query: Optional[str] = None,
+    status: Optional[str] = Query(
+        None,
+        description=(
+            "Filter by status, matched exactly and case-sensitively. Valid values: "
+            "todo, done, in_progress, cancelled, deferred, blocked, urgent. Omit to "
+            "return every status — in an established vault most tasks are done or "
+            "cancelled, so pass status='todo' for open/outstanding work."
+        ),
+    ),
+    context: Optional[str] = Query(
+        None,
+        description=(
+            "Filter by context, matched exactly but case-insensitively. Contexts are "
+            "vault-defined (one markdown file each) and default to 'Inbox'; there is "
+            "no fixed set. A context that is not in use returns zero tasks, so omit "
+            "this filter unless you know the value exists."
+        ),
+    ),
+    tag: Optional[str] = Query(
+        None,
+        description=(
+            "Filter by tag, case-insensitive, with or without a leading '#'."
+        ),
+    ),
+    due_before: Optional[str] = Query(
+        None,
+        description=(
+            "Only tasks whose due date is on or before this date (YYYY-MM-DD). "
+            "Tasks with no due date are excluded."
+        ),
+    ),
+    query: Optional[str] = Query(
+        None,
+        description=(
+            "Fuzzy text search over task descriptions (e.g. 'taxes' matches '1099')."
+        ),
+    ),
 ):
     """
     List and filter tasks.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -872,8 +872,8 @@ class LifeOSMCPServer:
             "lifeos_task_list": {
                 "type": "object",
                 "properties": {
-                    "status": {"type": "string", "description": "Filter by status (todo, done, in_progress, cancelled, deferred, blocked, urgent)"},
-                    "context": {"type": "string", "description": "Filter by context (Work, Personal, etc.)"},
+                    "status": {"type": "string", "description": "Filter by status, exact and case-sensitive (todo, done, in_progress, cancelled, deferred, blocked, urgent). Omit to return every status; pass todo for open work."},
+                    "context": {"type": "string", "description": "Filter by context, exact but case-insensitive. Contexts are vault-defined and default to 'Inbox'; a context not in use returns zero tasks."},
                     "tag": {"type": "string", "description": "Filter by tag"},
                     "due_before": {"type": "string", "description": "Tasks due before date (YYYY-MM-DD)"},
                     "query": {"type": "string", "description": "Fuzzy text search across task descriptions"}

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1287,3 +1287,36 @@ class TestEdgeCases:
 
         tasks = task_manager.list_tasks()
         assert len(tasks) == 2
+
+
+class TestListFilterSemanticsMatchDocs:
+    """The `/api/tasks` query-parameter descriptions make specific promises to
+    LLM callers (see api/routes/tasks.py). These pin the promises to behaviour
+    so the docs cannot drift into lying — a wrong filter hint silently returns
+    the wrong task set rather than erroring, which is how a model ends up
+    confidently reporting a partial list.
+    """
+
+    def test_context_filter_is_case_insensitive(self, populated_manager):
+        """Docs say context is matched case-insensitively."""
+        assert len(populated_manager.list_tasks(context="work")) == 3
+        assert len(populated_manager.list_tasks(context="WORK")) == 3
+
+    def test_status_filter_is_case_sensitive(self, populated_manager):
+        """Docs warn status is case-SENSITIVE, unlike context."""
+        assert len(populated_manager.list_tasks(status="todo")) == 5
+        assert populated_manager.list_tasks(status="Todo") == []
+
+    def test_unused_context_returns_empty_not_everything(self, populated_manager):
+        """A context nobody uses yields zero tasks — it does not fall back to
+        returning the unfiltered set."""
+        assert populated_manager.list_tasks(context="Nonexistent") == []
+
+    def test_due_before_is_inclusive_and_drops_undated(self, populated_manager):
+        """Docs say 'on or before', and that undated tasks are excluded."""
+        on_boundary = populated_manager.list_tasks(due_before="2025-02-10")
+        assert any(t.due_date == "2025-02-10" for t in on_boundary)
+
+        # Fixture has 5 tasks, only 2 with due dates.
+        assert len(populated_manager.list_tasks(due_before="2099-01-01")) == 2
+        assert all(t.due_date is not None for t in populated_manager.list_tasks(due_before="2099-01-01"))

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -277,3 +277,47 @@ class TestTasksAPI:
         ]
         for f in expected_fields:
             assert f in data, f"Missing field: {f}"
+
+
+class TestListTasksParameterDocs:
+    """The MCP tool schema for `lifeos_task_list` is generated from this route's
+    OpenAPI spec (mcp_server._build_input_schema). Bare `Optional[str] = None`
+    params produce the placeholder "Query parameter: <name>", which tells a model
+    nothing about valid values — so it guesses a context (0 rows) or omits status
+    (every status, mostly done/cancelled) and reports a partial list as complete.
+    """
+
+    @pytest.fixture
+    def params(self):
+        from api.main import app
+        spec = app.openapi()["paths"]["/api/tasks"]["get"]["parameters"]
+        return {p["name"]: p.get("description", "") for p in spec}
+
+    def test_no_param_falls_back_to_placeholder_description(self, params):
+        assert set(params) == {"status", "context", "tag", "due_before", "query"}
+        for name, desc in params.items():
+            assert desc, f"{name} has no description; MCP would emit a placeholder"
+            assert "Query parameter:" not in desc
+
+    def test_status_description_enumerates_valid_values(self, params):
+        desc = params["status"]
+        for value in ("todo", "done", "in_progress", "cancelled",
+                      "deferred", "blocked", "urgent"):
+            assert value in desc
+        # The failure mode was omitting status entirely and summarising everything.
+        assert "todo" in desc and "omit" in desc.lower()
+
+    def test_context_description_warns_unused_values_return_nothing(self, params):
+        desc = params["context"].lower()
+        assert "zero" in desc or "no tasks" in desc
+        assert "inbox" in desc
+
+    def test_fallback_schema_does_not_invent_context_values(self):
+        """The offline fallback must not advertise contexts that no vault has."""
+        import mcp_server
+        schema = mcp_server.LifeOSMCPServer._fallback_schemas(
+            mcp_server.LifeOSMCPServer.__new__(mcp_server.LifeOSMCPServer)
+        )["lifeos_task_list"]
+        context_desc = schema["properties"]["context"]["description"]
+        assert "Work, Personal" not in context_desc
+        assert "Inbox" in context_desc


### PR DESCRIPTION
Closes #580.

## The defect is not the one I originally filed

#580 blamed the `"Filter by context (Work, Personal, etc.)"` string in
`mcp_server._fallback_schemas()`. That text **never reaches a model** — the live
schema is generated from the route's OpenAPI spec. What models actually received:

```
status:  "Query parameter: status"
context: "Query parameter: context"
```

`_build_input_schema` propagates `param.get("description")` and falls back to that
placeholder when the spec has none — and every filter param was a bare
`Optional[str] = None`, so FastAPI emitted none. It also drops `enum`, so valid
values could not surface that way either.

## Why it produces confidently wrong answers

Nothing errors. A caller guesses a plausible context (`"Personal"`), gets zero rows
because contexts are vault-defined and default to `Inbox`, retries unfiltered, and
receives **every task of every status** — uncapped, and in an established vault
mostly done/cancelled. Summarising that yields a partial open-task list stated as
complete. Both calls "succeed".

This surfaced in the #567 model evaluation and skewed it: a model that trusted the
schema failed, while one that ignored it and guessed `status="todo"` succeeded.

## The fix

`Query(description=...)` on all five params, documenting the semantics as they
actually are — including two asymmetries verified against `task_manager.list_tasks`:

- `status` is matched **case-sensitively**; `context` is **case-insensitive**
- `due_before` is **inclusive** (`<=`) and **excludes undated tasks**

Also removes the invented example from the fallback schema, so the offline path
does not advertise contexts no vault necessarily has.

**Descriptions only — no behaviour change.** The generated schema now reads:

> `status`: Filter by status, matched exactly and case-sensitively. Valid values:
> todo, done, … Omit to return every status — in an established vault most tasks
> are done or cancelled, so pass status='todo' for open/outstanding work.

## Tests

- 4 pin the generated schema (`TestListTasksParameterDocs`) — **all fail without this change**, verified by stashing the source and keeping the tests
- 4 pin the filter semantics the descriptions promise (`TestListFilterSemanticsMatchDocs`) so the docs cannot drift into lying. These pass before and after by design — they are guards, not regression proof, since existing behaviour is unchanged

Full unit suite: **4358 passed**. 13 failures are pre-existing on clean `origin/main`
(data-dependent CRM/entity tests that need a populated `crm.db`); each was confirmed
failing without this change rather than assumed.

## Deliberately not done

Items (2) and (3) from #580 — defaulting to open tasks, and capping results with a
`truncated` signal — are behaviour changes to a tool definition, which AGENTS.md
puts behind "ask first". Flagging rather than bundling.

Noted, not changed: `lifeos_task_create` carries the same `(Work, Personal, Finance)`
examples, but there they are harmless — it has `"default": "Inbox"`, and creating a
new context file is intended behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)