### PR TITLE
fix(agent-tools): correct manage_tasks filter hints for the chat path

### DIFF
--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -367,8 +367,11 @@ TOOL_DEFINITIONS = [
                 "context": {
                     "type": "string",
                     "description": (
-                        "Context/category (e.g. 'Work', 'Personal', 'Inbox'). Used as "
-                        "a filter for 'list' and as the target context for 'update'. "
+                        "Context/category. Contexts are vault-defined, not a fixed set, "
+                        "and most tasks sit in 'Inbox'. Used as a filter for 'list' and "
+                        "as the target context for 'update'. As a filter it matches "
+                        "exactly (case-insensitively), so a context that is not in use "
+                        "returns nothing — omit it unless you know the value exists. "
                         "Ignored on 'create' — new tasks always land in Inbox."
                     ),
                 },
@@ -394,8 +397,13 @@ TOOL_DEFINITIONS = [
                 "status": {
                     "type": "string",
                     "description": (
-                        "Filter by status (for list): 'todo', 'done', 'in_progress', etc. "
-                        "Also accepted on update to change status."
+                        "Filter by status (for list), matched exactly and case-sensitively: "
+                        "'todo', 'done', 'in_progress', 'cancelled', 'deferred', 'blocked', "
+                        "'urgent'. Omitting it returns tasks of EVERY status, and in an "
+                        "established vault most tasks are done or cancelled — so pass "
+                        "'todo' for open/outstanding work rather than listing unfiltered "
+                        "and sorting it out afterwards. Also accepted on update to change "
+                        "status."
                     ),
                 },
                 "query": {

--- a/tests/test_agent_tools_tasks.py
+++ b/tests/test_agent_tools_tasks.py
@@ -92,3 +92,42 @@ class TestUnknownAction:
     def test_unknown_action(self, tm):
         out = _tool_manage_tasks({"action": "nope"})
         assert out.startswith("Error:")
+
+
+class TestManageTasksFilterDocs:
+    """The `manage_tasks` schema is what the orchestrator reads before calling the
+    tool, and a bad filter hint fails silently — the call succeeds and returns the
+    wrong slice. Two regressions cost real accuracy in model benchmarking:
+
+    - `context` offered 'Work'/'Personal' as filter examples. Contexts are
+      vault-defined and most tasks are in 'Inbox', so a model that trusted the
+      example filtered to zero rows.
+    - `status` did not say what omitting it does. Unfiltered `list` returns every
+      status uncapped; in an established vault that is mostly done/cancelled, and
+      summarising it yields a partial open-task list stated as complete.
+    """
+
+    @pytest.fixture
+    def props(self):
+        from api.services.agent_tools import TOOL_DEFINITIONS
+        tool = next(t for t in TOOL_DEFINITIONS if t["name"] == "manage_tasks")
+        return tool["input_schema"]["properties"]
+
+    def test_context_does_not_advertise_values_no_vault_need_have(self, props):
+        desc = props["context"]["description"]
+        assert "'Work'" not in desc and "'Personal'" not in desc
+        assert "Inbox" in desc
+
+    def test_context_warns_unknown_filter_matches_nothing(self, props):
+        desc = props["context"]["description"].lower()
+        assert "omit" in desc
+        assert "returns nothing" in desc or "not in use" in desc
+
+    def test_status_enumerates_values_and_warns_about_omitting(self, props):
+        desc = props["status"]["description"]
+        for value in ("todo", "done", "in_progress", "cancelled",
+                      "deferred", "blocked", "urgent"):
+            assert value in desc
+        lowered = desc.lower()
+        assert "every status" in lowered
+        assert "cancelled" in lowered and "todo" in lowered


### PR DESCRIPTION
Follow-up to #581, same defect (#580) on the surface that actually matters.

## Why #581 was not enough

#581 fixed the MCP tool schema. The **orchestrator never reads it** — the agentic
chat path builds its catalog from `agent_tools.TOOL_DEFINITIONS`, a separate
definition with a consolidated `manage_tasks` tool. I caught this while setting up
the retest, before running it: the benchmark exercises `run_agent_loop`, so a rerun
against #581 alone would have measured nothing.

#581 still stands on its own — Claude Code and Managed Agents reach tasks over MCP.

## The two hints

Both fail silently: the call succeeds and returns the wrong slice.

- **`context`** advertised `(e.g. 'Work', 'Personal', 'Inbox')` as filter values.
  Contexts are vault-defined and most tasks sit in `Inbox`, so a model that trusts
  the example filters to zero rows.
- **`status`** said `'todo', 'done', 'in_progress', etc.` without saying what
  omitting it does. Unfiltered `list` returns every status, **uncapped** — in an
  established vault mostly done/cancelled.

Observed in the #567 evaluation: a model filtered by a plausible context, correctly
followed the existing "compared exactly (case-insensitively)" recovery hint,
re-listed unfiltered, and reported **2 of 6** open tasks as the complete list. Every
step succeeded; only the answer was wrong.

Worth noting the recovery hint in `_task_list` already works — the model quoted it
and acted on it. The gap was purely that nothing steered it to `status='todo'`.

## Tests

3 tests pin the schema (`TestManageTasksFilterDocs`), **all fail without this
change** — verified by stashing the source and keeping the tests.

Unit suite: **4361 passed**. The 13 failures are pre-existing on clean `origin/main`
(data-dependent CRM/entity tests needing a populated `crm.db`), confirmed failing
without this change rather than assumed.

## Not done

No result cap on `list`. That is a behaviour change to a tool definition and stays
behind "ask first" per AGENTS.md — flagging, not bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)