### PR TITLE
feat(skills): add model-eval — benchmark local models at their best

### DIFF
--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: model-eval
+description: Benchmark a candidate local model against the incumbent for LifeOS, each tuned to its best. Use when evaluating a new model (any family) as a replacement for the local orchestrator/router, or re-testing one after upstream fixes.
+argument-hint: [candidate-gguf-or-hf-repo] [--routing-only|--execution-only]
+---
+
+# Model Evaluation
+
+Arguments: `$ARGUMENTS`
+
+Compare a candidate local model against the incumbent **with both tuned to their best**,
+then judge fitness for LifeOS specifically. The point is not "which model is smarter" —
+it is "which produces better grounded answers over *this* tool surface at acceptable
+latency."
+
+> **The one rule that matters.** In the Qwen3.8-27B evaluation, four separate "this model
+> fails" verdicts were reached. **Three were misconfiguration** (`--mmproj`, thinking left
+> on, a 32K context) and the fourth was **half a LifeOS tool-schema bug**. Budget your time
+> accordingly: tuning and harness verification is most of the work. Benchmarking an
+> untuned model produces confident, wrong conclusions.
+
+---
+
+## Phase 0 — Tune before you measure
+
+Do all of this *before* recording a single number. Each item below cost a full wasted
+benchmark round when skipped.
+
+### Context window — check first, it silently voids results
+The agentic loop accumulates tool results across rounds; a request that fits at round 1
+will not at round 5. Symptom: `request (N tokens) exceeds the available context size`,
+returning HTTP 400 mid-run. Two of five questions died this way at `-c 32768` and the
+whole run was void.
+
+Set context as large as VRAM allows and **verify by running the longest question**, not by
+reading the model card. Fall back stepwise (`131072 → 65536 → …`) if the server refuses to
+start — a too-large `-c` fails at load, which is loud and safe.
+
+### Reasoning level — not a boolean, and per-path
+Modern models expose graded effort (`xhigh`/`medium`/`low`, plus `--reasoning-budget N`)
+and/or `chat_template_kwargs: {"enable_thinking": false}`. Only ever testing on/off hides
+the setting that works.
+
+**Reasoning is a prefix the answer competes with, not an addition to it.** A starved answer
+looks like a model failure and is not.
+
+The optimal level *differs by path* — do not assume one setting fits both:
+
+| Path | Setting | Why |
+|---|---|---|
+| Router (`query_router._llm_route`) | thinking **off** | Classification; CoT adds nothing. 8x faster, correctness unchanged. |
+| Agentic loop (`agent_loop.run_agent_loop`) | **some** reasoning | Needs it to terminate cleanly; fully off ran to the token cap. `low` gave 6/6 natural stops where the default gave 4-of-6 empty. |
+
+### Speculative decoding / multi-token prediction
+If the GGUF ships MTP/`nextn` tensors, they are **off unless requested**:
+`--spec-type draft-mtp --spec-default --reasoning-preserve` (no separate draft model —
+it drafts from the model's own head).
+
+**Do not read `blk.N.nextn.* unused tensor -- ignoring` as "unsupported".** That warning
+means *you did not pass the flag*. Reading it as an upstream gap cost a full round and a
+wrong entry in the issue. With the flag the log reads `creating MTP draft context against
+the target model`. Worth ~30% decode.
+
+Diminishing returns are real: draft depth 6 measured *slower* than the default 3. Sweep,
+don't assume.
+
+### Projector (`--mmproj`) — load-bearing in a non-obvious way
+On text-only work the projector inflated reasoning ~6x (1557 vs 245 tokens, identical
+`-c`). Tempting to drop it. **Do not drop it without testing the agentic path** — the
+incumbent without `--mmproj` runs away to the token cap on *execution* while looking fine
+on routing. Validate any projector change on execution, not routing.
+
+### Environment parity
+`ROCBLAS_USE_HIPBLASLT=1` is set for the incumbent by systemd. A manual launch without it
+is not a fair comparison. Check the unit file for anything else before hand-rolling a
+server.
+
+---
+
+## Phase 1 — Verify the harness hits the surface you think it does
+
+**LifeOS has two independent tool catalogs.** Fixing one does not affect the other:
+
+| Surface | Source of tool schemas | Used by |
+|---|---|---|
+| Agentic chat | `api/services/agent_tools.py` → `TOOL_DEFINITIONS` | `run_agent_loop` — web chat, Telegram, voice, **and the execution benchmark** |
+| MCP | route OpenAPI spec → `mcp_server._build_input_schema` | Claude Code, Managed Agents |
+
+A fix to the MCP schema will not move an `agent_loop` benchmark by one character. Confirm
+which catalog your harness exercises before running anything, and re-verify after any
+"fix" you make between rounds.
+
+### The tool surface confounds the model comparison
+A misleading tool description **punishes the better instruction-follower**. Observed: the
+schema advertised context values (`'Work'`, `'Personal'`) that no vault had, and said
+nothing about what omitting `status` does. The model that trusted the schema filtered to
+zero rows, fell back to an unfiltered call returning every task of every status, and
+reported a partial list confidently. The model that ignored the hint guessed
+`status='todo'` and was right.
+
+**Before concluding model A retrieves worse than model B, read the tool descriptions both
+of them read.** Retrieval failures are tool-surface bugs until proven otherwise.
+
+---
+
+## Phase 2 — Benchmark design
+
+### Two axes, different currencies
+- **Routing** — classification against labelled cases. Currency: *latency + correctness*.
+  Use the real `config/prompts/query_router.txt`.
+- **Execution** — multi-step agentic questions through `run_agent_loop`. Currency:
+  *answer quality*. This is the one users wait on and the one that decides the verdict.
+
+Gate on **both**. An early decision rule here gated only routing latency and would have
+green-lit a model 3.4x slower on execution.
+
+### Score qualitatively, never binary
+Several questions "passed" a pass/fail check while being empty, off-topic, or confidently
+wrong. Read the answers. Specifically check:
+
+- **Grounding** — does it match reality? Anchor to a ground truth pulled straight from the
+  API (`curl /api/tasks?status=todo` → N) rather than judging plausibility.
+- **Completeness vs confidence** — the worst failure is a *partial* answer stated as
+  complete ("only two open tasks left — everything else is done"). Rank that far below an
+  honest "I couldn't find X."
+- **Did it answer the question asked?** One model produced an excellent answer to a
+  *different* question in the set.
+- **Signal vs padding** — an answer listing calendar events and notification chatter as
+  "waiting on a reply" is worse than a shorter, correct one. Length is not quality.
+
+### Run discipline
+- **Sequentially, one model resident at a time.** Concurrent runs contend for bandwidth
+  and produced a 729.5s / 31-char artifact that nearly became a finding.
+- **N ≥ 3 trials per question**, compare medians. These runs are stochastic: between two
+  rounds the incumbent's answers dropped 1838→527 and 800→248 chars on questions the
+  intervening change could not possibly affect. **A single run per cell cannot separate a
+  real delta from variance** — with N=1, report direction and caveat it, never a scorecard.
+- **Re-run both models** after any change to prompts or tool schemas. The incumbent's
+  baseline moves too.
+
+---
+
+## Phase 3 — Red flags that mean "re-examine the setup", not "write the verdict"
+
+| Signal | Almost always means |
+|---|---|
+| N queries landing at *exactly* the client timeout | timeout budget, not model speed |
+| Different questions returning *identical* output lengths | hit a token cap |
+| Empty answer with `reasoning_content` populated | reasoning starvation — raise budget or lower effort |
+| HTTP 400 partway through a multi-round run | context window |
+| A result contradicting a pre-registered estimate by >3x | harness bug |
+| Model narrates a tool problem ("the filter matched literally") | **believe it** — it is describing a real schema/tool defect |
+
+That last one is the cheapest signal available and was ignored once. Models often
+diagnose the tool surface correctly in their own output.
+
+---
+
+## Phase 4 — Decision rule
+
+Pre-register the bar **before** running, and write it down. Then:
+
+1. Both paths tuned to their best, verified by the Phase 0 checks.
+2. Routing within ~1.5x of incumbent latency, correctness ≥ incumbent.
+3. Execution: quality ≥ incumbent on median-of-N, and latency within a factor the user has
+   agreed to wait.
+4. If ambiguous — **report, do not swap.** Ambiguity plus a large latency penalty is a no.
+
+Do not swap on speed alone, and do not swap on prose quality alone. LifeOS's job is
+grounded retrieval and synthesis over personal data; a model that writes better but
+retrieves worse is the wrong trade.
+
+---
+
+## Phase 5 — Operational safety
+
+The box is a single always-on host running the live API. Do not destabilize it.
+
+- **Never run two models at once.** Stop the incumbent, run the candidate, restore.
+- **Restore from an `EXIT` trap**, so a crash, a bad load, or a kill still puts the
+  incumbent back. Verify `/health` after restore, and check `systemctl is-active`.
+- **`kill -9` fallback** — a llama-server survived a plain `kill` and held ~17 GB of VRAM
+  until reaped by hand. Wait on the PID, then escalate.
+- **Test suites CPU-only:** `HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES=""`.
+  Embedding load alone has locked up the GPU and rebooted this host.
+- **sudo:** `restart` is *not* allowlisted for `lifeos-llm` — use `stop` then `start`.
+  Other units allow restart. Claude Code's `!` prefix has no TTY, so nothing interactive.
+- **Never edit `.env`** for an experiment — it is a symlink into a Syncthing-synced dir.
+  Pass settings as launch flags or monkeypatch in the harness.
+- **Self-matching `pgrep`** — a waiter loop containing its own search string matches
+  itself and never exits. Match on something the waiter does not contain.
+
+## Scripts
+
+`scripts/swap_and_run.sh` — stop incumbent → start candidate (with context fallback) →
+run the question set → always restore. `scripts/qrun.py` — runs the question set through
+the real `run_agent_loop`, patching per-path reasoning settings.
+
+Both take the model path and label as arguments; neither hardcodes a model family.
+
+## Reporting
+
+Post measurements to a tracking issue, and **keep personal data out of it** — this repo is
+public. Counts and latencies are fine; task text, contact names, and email subjects are
+not. Score tables and mechanism descriptions carry the argument without the content.
+
+State plainly which round each conclusion came from, and retract superseded ones by name —
+several verdicts in the Qwen evaluation were reversed, and an issue thread that only
+accumulates claims becomes unusable.
+
+## Log of false starts (Qwen3.8-27B, Aug 2026)
+
+Each of these produced a confident wrong conclusion. They are the reason Phase 0 exists.
+
+| # | Concluded | Actually was | Cost |
+|---|---|---|---|
+| 1 | "Cannot meet the latency contract — 9/12 routing timeouts" | Thinking left ON. Off: 24.65s → 1.3-3.0s | full round |
+| 2 | "llama.cpp drops the MTP head — wait for upstream" | Never passed `--spec-type draft-mtp`. The `unused tensor` warning means the flag is missing | full round + wrong issue entry |
+| 3 | "Fails 2 of 5 execution questions" | `-c 32768` too small for 5 rounds of accumulated tool results; HTTP 400 mid-run | full round |
+| 4 | "Removing `--mmproj` is a free 1.8x win" | True on routing, breaks the incumbent's agentic termination | retracted before shipping |
+| 5 | "Retrieves worse — found 2 of 6 open tasks" | Substantially a tool-schema bug that punished the model for trusting it | skewed the verdict |
+| 6 | "Quality is config-dependent, not bandwidth-dependent" | Ran both models concurrently; contention produced 729.5s / 31-char output | redone sequentially |
+| 7 | Filed the schema bug against `_fallback_schemas()` | That path never reaches a model; the live schema comes from the OpenAPI spec | one wasted PR scope |
+| 8 | Fixed the MCP schema, planned to re-benchmark | The benchmark uses `agent_tools.TOOL_DEFINITIONS`; MCP fix moves nothing | caught before re-running |
+
+Two meta-lessons:
+
+- **The candidate was blamed four times and was substantially the cause zero times.** When
+  a well-reviewed model performs far below its reputation, the prior should be
+  misconfiguration, not a bad model.
+- **Fixing the confound does not automatically flip the verdict.** After the schema fix the
+  candidate's retrieval measurably improved (0 → 4 of 6 open tasks named on one question),
+  and it still lost on latency. Fix the confound so the comparison is *fair*, not to make a
+  preferred model win.
+
+## Related
+
+- `docs/specs/technical/agent-worker.md`, `docs/specs/technical/architecture.md`
+- Worked example, including every reversal: GitHub issue #567

--- a/.claude/skills/model-eval/scripts/qrun.py
+++ b/.claude/skills/model-eval/scripts/qrun.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Run the execution question set against whatever is serving :8080.
+
+Exercises the REAL agentic path (`agent_loop.run_agent_loop`), so results
+reflect the tool catalog in `agent_tools.TOOL_DEFINITIONS` — NOT the MCP
+schema. If you changed MCP tool definitions, this harness will not see it.
+
+One model resident at a time. Never run two of these concurrently: bandwidth
+contention on a unified-memory box produces artifacts that look like model
+failures.
+
+Usage: qrun.py <label> <off|low>
+  off  -> enable_thinking=False   (router-style; classification)
+  low  -> reasoning_effort="low"  (agentic; enough to terminate cleanly)
+
+Env: OUT_DIR (default cwd), LIFEOS_ROOT (default ~/Code/LifeOS)
+"""
+import asyncio
+import json
+import os
+import sys
+import time
+
+ROOT = os.environ.get("LIFEOS_ROOT", os.path.expanduser("~/Code/LifeOS"))
+sys.path.insert(0, ROOT)
+
+LABEL = sys.argv[1] if len(sys.argv) > 1 else "candidate"
+MODE = sys.argv[2] if len(sys.argv) > 2 else "low"
+OUT_DIR = os.environ.get("OUT_DIR", ".")
+OUT = os.path.join(OUT_DIR, f"q_{LABEL}.json")
+
+from api.services import llm_client as llm_mod  # noqa: E402
+
+# Per-request reasoning control, applied without touching .env (which is a
+# Syncthing symlink and must not be edited for an experiment).
+_orig = llm_mod.LocalLLMClient.astream
+
+
+def _patched(self, *a, **kw):
+    if MODE == "low":
+        kw["reasoning_effort"] = "low"
+        kw.pop("enable_thinking", None)
+    else:
+        kw["enable_thinking"] = False
+        kw.pop("reasoning_effort", None)
+    return _orig(self, *a, **kw)
+
+
+llm_mod.LocalLLMClient.astream = _patched
+
+from api.services.agent_loop import run_agent_loop  # noqa: E402
+
+# Multi-step questions that require driving several tools and synthesising.
+# Keep them stable across rounds — changing the set invalidates comparison
+# with every previous run.
+QUESTIONS = [
+    "Look at my open tasks and my calendar this week and tell me whether the week is realistically achievable.",
+    "What did I say I would follow up on recently, and is there any sign I actually did it?",
+    "Which of my open tasks are overdue, and which should I prioritize today?",
+    "Find anything from the last two weeks that looks like it's waiting on a reply from me.",
+    "Summarize what I've been working on this week based on my notes and tasks.",
+]
+
+
+async def main():
+    rows = []
+    print(f"  === {LABEL} (mode={MODE}) ===", flush=True)
+    for q in QUESTIONS:
+        t0 = time.time()
+        txt = ""
+        err = None
+        try:
+            async for ev in run_agent_loop(q, force_local=True, max_tool_rounds=5):
+                if ev.get("type") == "text":
+                    txt += ev.get("content") or ""
+        except Exception as e:  # noqa: BLE001
+            err = f"{type(e).__name__}: {e}"
+            txt = f"[ERROR] {err}"
+        el = round(time.time() - t0, 1)
+        rows.append({"q": q, "text": txt, "elapsed": el, "chars": len(txt), "error": err})
+        json.dump(rows, open(OUT, "w"), indent=2)
+        # A 400 here almost always means the context window is too small for the
+        # accumulated tool results — the run is void, not the model bad.
+        flag = "  <-- CHECK CONTEXT" if err and "400" in str(err) else ""
+        print(f"  {el:7.1f}s {len(txt):5d} ch  {q[:46]}{flag}", flush=True)
+    print(f"wrote {OUT}")
+    if any(r["error"] for r in rows):
+        print("!! errors present — do NOT score this run until resolved")
+
+
+asyncio.run(main())

--- a/.claude/skills/model-eval/scripts/swap_and_run.sh
+++ b/.claude/skills/model-eval/scripts/swap_and_run.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Swap :8080 from the incumbent (lifeos-llm) to a candidate GGUF, run the
+# execution question set, then ALWAYS restore the incumbent.
+#
+# The restore runs from an EXIT trap, so a benchmark crash, a failed model load,
+# or a kill still puts the live service back.
+#
+# Usage: swap_and_run.sh <model.gguf> <label> [reasoning-mode] [extra llama-server args...]
+#   reasoning-mode: off | low   (passed through to qrun.py; default: low)
+#
+# Env:
+#   LLAMA_BIN   llama-server binary (default: ~/llama.cpp/build/bin/llama-server)
+#   OUT_DIR     where results land  (default: a mktemp dir, printed on exit)
+#   CTX_LIST    context sizes to try, largest first (default: "131072 65536 32768")
+set -uo pipefail
+
+MODEL="${1:?usage: swap_and_run.sh <model.gguf> <label> [off|low] [extra args...]}"
+LABEL="${2:?missing label}"
+MODE="${3:-low}"
+shift 3 2>/dev/null || shift 2
+EXTRA=("$@")
+
+LLAMA_BIN="${LLAMA_BIN:-$HOME/llama.cpp/build/bin/llama-server}"
+OUT_DIR="${OUT_DIR:-$(mktemp -d -t model-eval-XXXX)}"
+CTX_LIST="${CTX_LIST:-131072 65536 32768}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PID=""
+
+log(){ echo "[$(date +%T)] $*"; }
+
+restore(){
+  log "=== RESTORE ==="
+  if [ -n "$PID" ]; then
+    kill "$PID" 2>/dev/null
+    for _ in $(seq 1 20); do kill -0 "$PID" 2>/dev/null || break; sleep 2; done
+    # A plain kill has been survived before, holding VRAM. Escalate.
+    kill -0 "$PID" 2>/dev/null && { log "candidate survived SIGTERM; SIGKILL"; kill -9 "$PID" 2>/dev/null; }
+  fi
+  for _ in $(seq 1 20); do curl -sf --max-time 2 http://localhost:8080/health >/dev/null 2>&1 || break; sleep 2; done
+  sleep 3
+  # NOTE: `restart` is not sudo-allowlisted for lifeos-llm; start only.
+  sudo -n systemctl start lifeos-llm 2>&1 | tail -1
+  for _ in $(seq 1 90); do
+    curl -sf --max-time 3 http://localhost:8080/health >/dev/null 2>&1 && { log "RESTORE OK — incumbent back"; return 0; }
+    sleep 5
+  done
+  log "!!! RESTORE FAILED — check 'systemctl status lifeos-llm' by hand"
+  return 1
+}
+trap restore EXIT
+
+[ -f "$MODEL" ] || { log "no such model: $MODEL"; exit 1; }
+[ -x "$LLAMA_BIN" ] || { log "no llama-server at $LLAMA_BIN (set LLAMA_BIN)"; exit 1; }
+log "results -> $OUT_DIR"
+
+log "stopping incumbent (lifeos-llm)"
+sudo -n systemctl stop lifeos-llm 2>&1 | tail -1
+for _ in $(seq 1 30); do curl -sf --max-time 2 http://localhost:8080/health >/dev/null 2>&1 || break; sleep 2; done
+sleep 5
+
+# Largest context that will actually load. Too-large fails at load — loud and safe —
+# whereas too-small fails mid-run with HTTP 400 and silently voids the results.
+for CTX in $CTX_LIST; do
+  log "trying -c $CTX"
+  # ROCBLAS_USE_HIPBLASLT=1 matches what systemd sets for the incumbent; without it
+  # the comparison is not fair.
+  ROCBLAS_USE_HIPBLASLT=1 setsid nohup "$LLAMA_BIN" -m "$MODEL" \
+    -ngl 99 -fa on --jinja --no-mmap -c "$CTX" \
+    --host 0.0.0.0 --port 8080 "${EXTRA[@]}" \
+    > "$OUT_DIR/server-c$CTX.log" 2>&1 < /dev/null &
+  PID=$!
+  UP=0
+  for _ in $(seq 1 150); do
+    curl -sf --max-time 3 http://localhost:8080/health >/dev/null 2>&1 && { UP=1; break; }
+    kill -0 "$PID" 2>/dev/null || break
+    sleep 5
+  done
+  [ "$UP" = 1 ] && { log "up at -c $CTX (pid $PID)"; echo "$CTX" > "$OUT_DIR/ctx_used.txt"; break; }
+  log "  -c $CTX failed to start (likely VRAM); trying smaller"
+  grep -iE "error|alloc|out of memory" "$OUT_DIR/server-c$CTX.log" | tail -3
+  kill -9 "$PID" 2>/dev/null; PID=""; sleep 8
+done
+[ -n "$PID" ] || { log "no context size worked"; exit 1; }
+
+# Confirm MTP actually engaged if it was requested — the flag is easy to forget,
+# and its absence looks like "the model is slow" rather than "a flag is missing".
+if printf '%s\n' "${EXTRA[@]}" | grep -q draft-mtp; then
+  grep -qi "MTP draft context" "$OUT_DIR/server-c$(cat "$OUT_DIR/ctx_used.txt").log" \
+    && log "MTP: engaged" || log "MTP: WARNING — requested but not confirmed in log"
+fi
+
+log "running question set (label=$LABEL mode=$MODE)"
+OUT_DIR="$OUT_DIR" PYTHONUNBUFFERED=1 \
+  "${LIFEOS_PY:-$HOME/.venvs/lifeos/bin/python}" "$HERE/qrun.py" "$LABEL" "$MODE" \
+  > "$OUT_DIR/q_$LABEL.out" 2>&1
+log "done (exit $?) — results in $OUT_DIR"


### PR DESCRIPTION
Turns the Qwen3.8-27B evaluation (#567) into a repeatable procedure, so the next
model swap is fast and the same cul-de-sacs are not re-entered.

## Why

Across that evaluation I concluded "this model fails" **four times**:

| Concluded | Actually was |
|---|---|
| Can't meet the latency contract (9/12 routing timeouts) | Thinking left ON — off gave 24.65s → 1.3-3.0s |
| llama.cpp drops the MTP head, wait for upstream | Never passed `--spec-type draft-mtp`; the `unused tensor` warning *is* the missing flag |
| Fails 2 of 5 execution questions | `-c 32768` too small for 5 rounds of tool results — HTTP 400 mid-run, run void |
| Retrieves worse (2 of 6 open tasks) | Substantially a tool-schema bug (#580) that punished the model for trusting it |

The candidate was blamed four times and was the cause approximately zero times.
**Benchmarking an untuned model produces confident, wrong conclusions**, so the skill
front-loads tuning and harness verification before any number is recorded.

## What it encodes

- **Phase 0 — tune first.** Context window (fails *silently*, mid-run, voiding results),
  graded reasoning levels and why the optimum **differs between router and agentic loop**,
  MTP flags, the `--mmproj` trap (dropping it looks free on routing and breaks agentic
  termination), environment parity with what systemd sets.
- **Phase 1 — which surface am I testing?** LifeOS has **two independent tool catalogs**
  (`agent_tools.TOOL_DEFINITIONS` vs the MCP schema). I fixed one and nearly re-benchmarked
  against a path it does not touch. Also: a misleading tool description **punishes the
  better instruction-follower**, so retrieval failures are tool-surface bugs until proven
  otherwise.
- **Phase 2 — design.** Routing vs execution as separate currencies (an early rule gated
  only routing latency and would have green-lit a model 3.4x slower where users wait),
  qualitative scoring over pass/fail, ground truth pulled from the API, sequential runs
  only, and **N ≥ 3** — between two rounds the incumbent's answers moved 1838→527 chars on
  a question the intervening change could not affect.
- **Phase 3 — red flags** that mean re-examine the setup: exact-timeout clustering,
  identical output lengths (token cap), empty answer with reasoning present, mid-run 400s.
  Including: when the model narrates a tool problem, **believe it**.
- **Phase 4/5 — pre-registered decision rule and host safety:** EXIT-trap restore,
  `kill -9` fallback (a killed server held ~17 GB VRAM), CPU-only env for test suites,
  the `lifeos-llm` sudo quirk, and never editing `.env` (Syncthing symlink).
- **A table of all 8 false starts** with what each actually was.

## Scripts

`swap_and_run.sh` (stop incumbent → start candidate with context fallback → run → always
restore) and `qrun.py` (question set through the real `run_agent_loop`). Parameterised
over model path and label — no model family, no personal paths, no vault content.
Both syntax-checked; PII- and hardcoded-path-scanned.

## Note

Honest caveat carried into the skill rather than buried: fixing the confound did **not**
flip the verdict. The candidate's retrieval measurably improved afterwards (0 → 4 of 6 open
tasks named on one question) and it still lost on latency. Fix confounds to make the
comparison fair, not to make a preferred model win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)