### PR TITLE
feat(mcp): expose manage_workouts on the MCP surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,7 @@ Quick-reference guardrails for all contributors. These complement the Developmen
 | `api/services/perf_trace.py` | Request-level performance tracing (spans, SQLite) |
 | `api/routes/perf.py` | Performance trace query API |
 | `api/services/agent_worker/` | Autonomous worker for `#agent`-tagged tasks (local Gemma or cloud Claude via Managed Agents) |
-| `mcp_server.py` | MCP server — stdio for Claude Code + HTTP transport for Managed Agents (62 tools: 54 from `CURATED_ENDPOINTS` plus 8 `lifeos_agent_*` tools registered separately by `_register_inter_agent_tools()` from `INTER_AGENT_TOOL_SCHEMAS`) |
+| `mcp_server.py` | MCP server — stdio for Claude Code + HTTP transport for Managed Agents (64 tools: 56 from `CURATED_ENDPOINTS` plus 8 `lifeos_agent_*` tools registered separately by `_register_inter_agent_tools()` from `INTER_AGENT_TOOL_SCHEMAS`) |
 | `tests/test_perf_benchmark.py` | Benchmark suite for query performance and quality |
 
 | Script | Purpose |

--- a/api/routes/fitness.py
+++ b/api/routes/fitness.py
@@ -1,12 +1,15 @@
 """
 Fitness API routes.
 
-Currently just the authenticated Apple Health ingest endpoint (#333) — the
-on-device HealthBridge app POSTs its payload here over Tailscale, and it lands
-in fitness.db via the same ingest core the nightly file importer uses.
+The authenticated Apple Health ingest endpoint (#333) — the on-device
+HealthBridge app POSTs its payload here over Tailscale, and it lands in
+fitness.db via the same ingest core the nightly file importer uses — plus
+`/workouts` (#603), the REST surface behind the `lifeos_workout_manage` MCP
+tool so external clients can log/query the fitness bot's own store.
 """
 import hmac
 import logging
+from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field, ValidationError
@@ -76,3 +79,74 @@ async def health_ingest(request: Request):
     result = ingest_health(payload.model_dump())
     logger.info(f"Health ingest: {result}")
     return result
+
+
+# ---------------------------------------------------------------------------
+# manage_workouts over REST (#603) — the MCP surface has no in-process agent
+# loop to call, so this exposes the same action-dispatch tool over HTTP. It
+# calls the exact `_tool_manage_workouts` dispatcher the native orchestrator
+# uses, so both paths write through the same FitnessStore with no separate
+# implementation to drift out of sync.
+# ---------------------------------------------------------------------------
+
+class WorkoutSetInput(BaseModel):
+    """One exercise entry for the 'log'/'update' actions."""
+    exercise: Optional[str] = Field(default=None, description="Exercise name (normalized server-side).")
+    reps: Optional[int] = Field(default=None, description="Reps per set — also the count for timed work.")
+    weight: Optional[float] = Field(default=None, description="Load.")
+    unit: Optional[str] = Field(default=None, description="'lb'/'kg' for weighted sets, or a counted-work unit ('steps', 'm').")
+    count: Optional[int] = Field(default=None, description="Number of identical sets (default 1).")
+    rpe: Optional[float] = Field(default=None, description="Rate of perceived exertion.")
+    duration_seconds: Optional[int] = Field(default=None, description="Elapsed time in seconds for timed work.")
+    notes: Optional[str] = Field(default=None, description="Per-exercise note, e.g. cardio distance ('4 mi').")
+
+
+class ManageWorkoutsRequest(BaseModel):
+    """Mirrors the `manage_workouts` orchestrator tool's input (agent_tools.py)."""
+    action: str = Field(
+        description="log | update | list | history | summary | log_metric | "
+                    "metrics | get_profile | set_profile | readiness"
+    )
+    sets: Optional[list[WorkoutSetInput]] = Field(
+        default=None,
+        description="Exercises for log/update — a JSON array, one entry per distinct "
+                    "exercise/load, each {exercise, reps, weight, unit, count, rpe, "
+                    "duration_seconds, notes}.",
+    )
+    date: Optional[str] = Field(default=None, description="Session date YYYY-MM-DD (log/update). Omit on log to use today.")
+    kind: Optional[str] = Field(default=None, description="strength | cardio | mobility | sport | other.")
+    title: Optional[str] = Field(default=None, description="Session title, e.g. 'Push day'.")
+    notes: Optional[str] = Field(default=None, description="Session notes.")
+    session_id: Optional[str] = Field(default=None, description="Target session for 'update' (defaults to most recent).")
+    exercise: Optional[str] = Field(default=None, description="Exercise name for 'history' / 'summary'.")
+    date_start: Optional[str] = Field(default=None, description="Window start YYYY-MM-DD (list/summary/metrics).")
+    date_end: Optional[str] = Field(default=None, description="Window end YYYY-MM-DD (list/summary/metrics).")
+    metric_type: Optional[str] = Field(default=None, description="Metric name for log_metric/metrics, e.g. 'body_weight'.")
+    value: Optional[str] = Field(default=None, description="Numeric for 'log_metric', free text for 'set_profile'.")
+    unit: Optional[str] = Field(default=None, description="Metric unit for 'log_metric', e.g. 'lb'.")
+    key: Optional[str] = Field(default=None, description="Training-profile key for 'set_profile'.")
+    limit: Optional[int] = Field(default=None, description="Max rows for list/history/metrics — an integer (default varies by action).")
+
+
+@router.post("/workouts")
+async def manage_workouts_endpoint(body: ManageWorkoutsRequest):
+    """Log or query the fitness bot's workout log and metrics.
+
+    Thin transport wrapper around `_tool_manage_workouts` — same store, same
+    formatting, same error strings ("Error: ...") as the native agent loop.
+
+    A dispatcher failure is raised as a 4xx rather than returned as a 200
+    body: the native orchestrator reads the "Error: ..." prose directly, but
+    an MCP/HTTP caller checks structured success, not prose inside a
+    structurally-successful response. Wrapping a failed write in a 200 is
+    exactly the false-confirmation shape this endpoint exists to eliminate —
+    both mcp_server.py's `tools/call` and the agent worker's `ToolRegistry`
+    already key off "error"/non-2xx to decide isError, so raising here is
+    what makes a failed log actually surface as a failure at both layers.
+    """
+    from api.services.agent_tools import _tool_manage_workouts
+    inp = body.model_dump(exclude_none=True)
+    result = _tool_manage_workouts(inp)
+    if result.startswith("Error"):
+        raise HTTPException(status_code=400, detail=result)
+    return {"result": result}

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -9,6 +9,7 @@ import contextvars
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 from zoneinfo import ZoneInfo
 
 from api.services.google_auth import resolve_account, get_configured_accounts
@@ -2618,12 +2619,90 @@ def _summarize_session(session) -> str:
     return f"{session.date}: {body}"
 
 
+# Validation for `log`/`update` (#603 review). This is the trust boundary for
+# both call paths into `_tool_manage_workouts` — the native orchestrator's own
+# tool-calling loop and the REST/MCP surface both pass raw, model-authored
+# dicts through here, so a garbage or destructive write can't reach the store
+# regardless of which caller sent it. Bounds are generous (real training, not
+# a client-side allowlist) — they exist to catch nonsense, not to constrain
+# legitimate values.
+_VALID_WORKOUT_KINDS = {"strength", "cardio", "mobility", "sport", "other"}
+_MAX_REPS = 1000
+_MAX_WEIGHT = 2000  # lb/kg — heaviest plausible loaded lift
+_MAX_RPE = 10
+_MAX_DURATION_SECONDS = 24 * 60 * 60  # a full day
+_MAX_SET_COUNT = 50  # identical sets folded into one entry
+_MAX_SETS_PER_CALL = 200  # distinct entries in one log/update call
+
+
+def _validate_workout_date(raw) -> Optional[str]:
+    """None if `raw` is a valid 'YYYY-MM-DD' date (or absent), else an error."""
+    if not raw:
+        return None
+    try:
+        datetime.strptime(raw, "%Y-%m-%d")
+    except (TypeError, ValueError):
+        return f"Error: 'date' must be YYYY-MM-DD, got {raw!r}."
+    return None
+
+
+def _validate_workout_kind(raw) -> Optional[str]:
+    """None if `raw` is a known session kind (or absent/blank), else an error."""
+    if not raw:
+        return None
+    if raw not in _VALID_WORKOUT_KINDS:
+        return f"Error: 'kind' must be one of {sorted(_VALID_WORKOUT_KINDS)}, got {raw!r}."
+    return None
+
+
+def _validate_workout_sets(sets: list) -> Optional[str]:
+    """None if every entry in `sets` is a well-formed set, else the first error.
+
+    Rejects the shapes a fuzzed or careless caller sends: a blank/missing
+    exercise, an entry with no measure at all (reps/weight/duration), and
+    out-of-range or wrong-typed numbers — before any of it reaches the store.
+    """
+    if len(sets) > _MAX_SETS_PER_CALL:
+        return f"Error: too many sets ({len(sets)}, max {_MAX_SETS_PER_CALL})."
+    for i, s in enumerate(sets):
+        if not isinstance(s, dict):
+            return f"Error: set {i} must be an object."
+        exercise = s.get("exercise")
+        if not exercise or not str(exercise).strip():
+            return f"Error: set {i} is missing a non-empty 'exercise'."
+        reps, weight, duration = s.get("reps"), s.get("weight"), s.get("duration_seconds")
+        if reps is None and weight is None and duration is None:
+            return f"Error: set {i} ({exercise!r}) has no reps, weight, or duration_seconds — nothing to log."
+        for field, val, lo, hi in (
+            ("reps", reps, 1, _MAX_REPS),
+            ("weight", weight, 0, _MAX_WEIGHT),
+            ("duration_seconds", duration, 1, _MAX_DURATION_SECONDS),
+        ):
+            if val is None:
+                continue
+            if isinstance(val, bool) or not isinstance(val, (int, float)) or not (lo <= val <= hi):
+                return f"Error: set {i} ({exercise!r}) has an invalid '{field}': {val!r}."
+        rpe = s.get("rpe")
+        if rpe is not None and (isinstance(rpe, bool) or not isinstance(rpe, (int, float)) or not (0 <= rpe <= _MAX_RPE)):
+            return f"Error: set {i} ({exercise!r}) has an invalid 'rpe': {rpe!r} (must be 0-{_MAX_RPE})."
+        count = s.get("count")
+        if count is not None and (isinstance(count, bool) or not isinstance(count, int) or not (1 <= count <= _MAX_SET_COUNT)):
+            return f"Error: set {i} ({exercise!r}) has an invalid 'count': {count!r} (must be 1-{_MAX_SET_COUNT})."
+    return None
+
+
 def _workout_log(inp: dict) -> str:
     from api.services.fitness_store import get_fitness_store
     store = get_fitness_store()
     sets = inp.get("sets") or []
     if not sets:
         return "Error: 'log' needs at least one entry in 'sets'."
+    if err := _validate_workout_sets(sets):
+        return err
+    if err := _validate_workout_date(inp.get("date")):
+        return err
+    if err := _validate_workout_kind(inp.get("kind")):
+        return err
     session = store.add_session(
         sets=sets,
         date=inp.get("date"),
@@ -2638,6 +2717,19 @@ def _workout_log(inp: dict) -> str:
 def _workout_update(inp: dict) -> str:
     from api.services.fitness_store import get_fitness_store
     store = get_fitness_store()
+    sets = inp.get("sets")
+    if sets is not None:
+        # `sets=[]` would otherwise reach `update_session`, which treats "sets
+        # provided" (even empty) as "replace the sets" — silently deleting the
+        # session's existing sets. Reject before anything is touched.
+        if not sets:
+            return "Error: 'update' with 'sets' needs at least one entry — pass sets to replace them, or omit 'sets' to leave them unchanged."
+        if err := _validate_workout_sets(sets):
+            return err
+    if err := _validate_workout_date(inp.get("date")):
+        return err
+    if err := _validate_workout_kind(inp.get("kind")):
+        return err
     session = store.update_session(
         session_id=inp.get("session_id"),
         target="latest",
@@ -2645,7 +2737,7 @@ def _workout_update(inp: dict) -> str:
         kind=inp.get("kind"),
         title=inp.get("title"),
         notes=inp.get("notes"),
-        sets=inp.get("sets"),
+        sets=sets,
     )
     if not session:
         return "Error: no session to update (none logged yet, or session_id not found)."

--- a/docs/specs/product/mcp-tools.md
+++ b/docs/specs/product/mcp-tools.md
@@ -104,6 +104,14 @@ Schedules can also be managed via natural language chat. See [Scheduler Guide](.
 
 The legacy `lifeos_reminder_*` tools remain registered as deprecated aliases.
 
+### Fitness Tools
+
+The fitness persona's central capability — logging a workout — routed through natural language chat on the native backend. See [config/personas/fitness.md](../../../config/personas/fitness.md).
+
+| Tool | Description |
+|------|-------------|
+| `lifeos_workout_manage` | Log/query workouts and fitness metrics (log, update, list, history, summary, log_metric, metrics, get_profile, set_profile, readiness) |
+
 ### Photos Tools
 | Tool | Description |
 |------|-------------|
@@ -516,6 +524,31 @@ Get current budget status from Monarch Money.
 | end_date | string | No | End date (YYYY-MM-DD), defaults to today |
 
 **Returns:** List of budgets with category, budgeted amount, actual spending, and remaining balance.
+
+### lifeos_workout_manage
+
+Log and query the fitness bot's workout log and metrics — the same store and dispatcher (`manage_workouts`) the native orchestrator uses, exposed over REST so external MCP clients can log a workout too.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| action | string | Yes | log \| update \| list \| history \| summary \| log_metric \| metrics \| get_profile \| set_profile \| readiness |
+| sets | array | No | Exercises for log/update — one entry per distinct exercise/load: `{exercise, reps, weight, unit, count, rpe, duration_seconds, notes}` |
+| date | string | No | Session date YYYY-MM-DD (log/update). Omit on log to use today |
+| kind | string | No | strength \| cardio \| mobility \| sport \| other |
+| title | string | No | Session title |
+| notes | string | No | Session notes |
+| session_id | string | No | Target session for 'update' (defaults to most recent) |
+| exercise | string | No | Exercise name for 'history' / 'summary' |
+| date_start | string | No | Window start YYYY-MM-DD (list/summary/metrics) |
+| date_end | string | No | Window end YYYY-MM-DD (list/summary/metrics) |
+| metric_type | string | No | Metric name for log_metric/metrics, e.g. 'body_weight' |
+| value | string | No | Numeric for 'log_metric', free text for 'set_profile' |
+| unit | string | No | Metric unit for 'log_metric', e.g. 'lb' |
+| key | string | No | Training-profile key for 'set_profile' |
+| limit | integer | No | Max rows for list/history/metrics |
+
+**Returns:** `{"result": "<plain-text confirmation or error>"}` — the same string the native orchestrator gets from this tool (e.g. `Logged — 2026-08-19: Bench Press 8 @135 lb (session id: ...)`).
 
 ---
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -290,6 +290,16 @@ CURATED_ENDPOINTS = {
         "description": "Full investment portfolio (Schwab + 401k + TSP): total value, tax buckets, top holdings with cost basis. Prefer over monarch_accounts for net-worth or portfolio questions.",
         "method": "GET"
     },
+    "/api/fitness/workouts:POST": {
+        "name": "lifeos_workout_manage",
+        "description": (
+            "Log and query workouts/fitness metrics (fitness bot backend). action: "
+            "log/update/list/history/summary/log_metric/metrics/get_profile/"
+            "set_profile/readiness."
+        ),
+        "method": "POST",
+        "path": "/api/fitness/workouts"
+    },
     "/api/tasks:POST": {
         "name": "lifeos_task_create",
         "description": "Create a task (Obsidian markdown). Supports context, priority, due_date, tags. With dry_run=true + #agent tag, returns preflight routing + cost estimate instead of creating.",
@@ -467,6 +477,29 @@ class LifeOSMCPServer:
 
         return None
 
+    @staticmethod
+    def _unwrap_optional(schema: dict) -> dict:
+        """Unwrap a nullable `anyOf` schema down to its real, non-null branch.
+
+        Pydantic v2 renders `Optional[X]` as `anyOf: [<X's schema>, {"type":
+        "null"}]` with no top-level `type` — every optional field in this
+        codebase's request models takes this shape. Reading only the
+        top-level `type` (the old behavior) silently falls back to a default,
+        so `sets: Optional[list[...]]` was advertised as `"type": "string"`
+        and a schema-following MCP client couldn't build the array a workout
+        log needs. A schema that already has a top-level `type` (a required
+        field) passes through unchanged; unwrapping returns the branch as-is
+        so its `items` (and any nested `$ref` inside it) survive intact —
+        only the outer null-wrapper is peeled off, nothing inside is resolved
+        further.
+        """
+        if "type" in schema:
+            return schema
+        for branch in schema.get("anyOf", []):
+            if branch.get("type") != "null":
+                return branch
+        return schema
+
     def _build_input_schema(self, endpoint_spec: dict, schemas: dict, method: str, path: str) -> dict:
         """Build JSON Schema for tool input from OpenAPI endpoint spec."""
         properties = {}
@@ -476,11 +509,13 @@ class LifeOSMCPServer:
         for param in endpoint_spec.get("parameters", []):
             if param.get("in") == "query":
                 name = param["name"]
-                param_schema = param.get("schema", {"type": "string"})
+                param_schema = self._unwrap_optional(param.get("schema", {"type": "string"}))
                 properties[name] = {
                     "type": param_schema.get("type", "string"),
                     "description": param.get("description", f"Query parameter: {name}")
                 }
+                if "items" in param_schema:
+                    properties[name]["items"] = param_schema["items"]
                 if param.get("required"):
                     required.append(name)
 
@@ -509,10 +544,13 @@ class LifeOSMCPServer:
 
             # Merge body properties into tool schema
             for prop_name, prop_schema in body_schema.get("properties", {}).items():
+                resolved = self._unwrap_optional(prop_schema)
                 properties[prop_name] = {
-                    "type": prop_schema.get("type", "string"),
+                    "type": resolved.get("type", "string"),
                     "description": prop_schema.get("description", f"Request field: {prop_name}")
                 }
+                if "items" in resolved:
+                    properties[prop_name]["items"] = resolved["items"]
                 if prop_schema.get("default") is not None:
                     properties[prop_name]["default"] = prop_schema["default"]
 
@@ -1882,6 +1920,12 @@ class LifeOSMCPServer:
         elif tool_name == "lifeos_task_delete":
             return f"Task deleted (ID: {data.get('id', data.get('task_id', 'unknown'))})"
 
+        elif tool_name == "lifeos_workout_manage":
+            # The endpoint already returns the same plain-text confirmation/
+            # error string the native orchestrator gets from this tool — pass
+            # it straight through instead of re-wrapping it as JSON.
+            return data.get("result", json.dumps(data, indent=2))
+
         # Default: return formatted JSON
         return json.dumps(data, indent=2)
 
@@ -1928,6 +1972,13 @@ def dispatch(server: "LifeOSMCPServer", request: dict) -> dict | None:
             data = server._call_api(tool_name, arguments)
             formatted = server._format_response(tool_name, data)
             result = {"content": [{"type": "text", "text": formatted}]}
+            # Same "error" key convention the agent worker's ToolRegistry
+            # already uses to decide is_error (api/services/agent_worker/tools.py)
+            # — set it here too so an MCP client that checks the structured
+            # `isError` field, not just the formatted prose, can tell a failed
+            # tool call from a successful one (MCP tool-result spec).
+            if isinstance(data, dict) and "error" in data:
+                result["isError"] = True
             return None if is_notification else _ok(request_id, result)
 
         # Unknown method

--- a/tests/test_agent_tools_workouts.py
+++ b/tests/test_agent_tools_workouts.py
@@ -1,9 +1,10 @@
 """
 Tests for the manage_workouts orchestrator tool (issue #320).
 
-The fitness bot logs/queries via this tool (not the MCP server). Verifies the
-dispatcher, the log/update/history/summary/metric/profile actions, and the
-compact session summary the bot echoes back.
+The fitness bot logs/queries via this tool on the native orchestrator path;
+`POST /api/fitness/workouts` (#603) calls this same dispatcher for the MCP
+surface. Verifies the dispatcher, the log/update/history/summary/metric/
+profile actions, and the compact session summary the bot echoes back.
 """
 import pytest
 
@@ -36,6 +37,20 @@ class TestDispatch:
     def test_log_requires_sets(self, temp_store):
         out = _tool_manage_workouts({"action": "log", "sets": []})
         assert out.startswith("Error")
+
+    def test_update_with_empty_sets_preserves_existing_sets(self, temp_store):
+        """#603 review (BLOCKER): 'update' with sets=[] must not delete the
+        session's existing sets. Previously this returned 200/"Updated —
+        (no sets)" and the stored session's sets became [] — a silent data
+        loss reported as a success."""
+        _tool_manage_workouts({"action": "log", "sets": [{"exercise": "bench", "reps": 8, "weight": 135}]})
+        session_id = temp_store.get_latest_session().id
+        out = _tool_manage_workouts({"action": "update", "sets": []})
+        assert out.startswith("Error")
+        session = temp_store.get_session(session_id)
+        assert len(session.sets) == 1
+        assert session.sets[0].exercise == "Bench Press"
+        assert session.sets[0].reps == 8 and session.sets[0].weight == 135
 
     def test_update_targets_latest(self, temp_store):
         _tool_manage_workouts({"action": "log", "sets": [{"exercise": "bench", "reps": 8, "weight": 135}]})
@@ -207,3 +222,88 @@ class TestDurationThroughTool:
         })
         out = _tool_manage_workouts({"action": "history", "exercise": "stairs"})
         assert "in 7:01" in out
+
+
+class TestSetValidation:
+    """#603 review (MAJOR): the write path accepted garbage — an empty
+    exercise, no measure at all, negative numbers, an out-of-range RPE, an
+    unparseable date. Every case here must be rejected before it reaches the
+    store, for both 'log' and 'update'."""
+
+    def _assert_rejected_and_nothing_stored(self, temp_store, inp):
+        out = _tool_manage_workouts(inp)
+        assert out.startswith("Error"), out
+        assert temp_store.list_sessions() == []
+
+    def test_empty_set_object_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store, {"action": "log", "sets": [{}]}
+        )
+
+    def test_missing_exercise_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store, {"action": "log", "sets": [{"reps": 8, "weight": 135}]}
+        )
+
+    def test_null_exercise_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store, {"action": "log", "sets": [{"exercise": None, "reps": 8, "weight": 135}]}
+        )
+
+    def test_negative_reps_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store, {"action": "log", "sets": [{"exercise": "bench", "reps": -8, "weight": 135}]}
+        )
+
+    def test_negative_weight_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store, {"action": "log", "sets": [{"exercise": "bench", "reps": 8, "weight": -135}]}
+        )
+
+    def test_negative_duration_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store, {"action": "log", "sets": [{"exercise": "run", "duration_seconds": -5}]}
+        )
+
+    def test_out_of_range_rpe_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store,
+            {"action": "log", "sets": [{"exercise": "bench", "reps": 8, "weight": 135, "rpe": 99}]},
+        )
+
+    def test_invalid_date_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store,
+            {"action": "log", "date": "not-a-date", "sets": [{"exercise": "bench", "reps": 8, "weight": 135}]},
+        )
+
+    def test_unknown_kind_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store,
+            {"action": "log", "kind": "bogus", "sets": [{"exercise": "bench", "reps": 8, "weight": 135}]},
+        )
+
+    def test_excessive_count_rejected(self, temp_store):
+        self._assert_rejected_and_nothing_stored(
+            temp_store,
+            {"action": "log", "sets": [{"exercise": "bench", "reps": 8, "weight": 135, "count": 10_000}]},
+        )
+
+    def test_valid_set_still_logs(self, temp_store):
+        """The validation must not reject legitimate entries."""
+        out = _tool_manage_workouts({
+            "action": "log",
+            "sets": [{"exercise": "bench", "reps": 8, "weight": 135, "rpe": 8.5, "count": 3}],
+        })
+        assert out.startswith("Logged —")
+        assert temp_store.get_latest_session() is not None
+
+    def test_update_applies_same_validation(self, temp_store):
+        """The 'update' path shares the same validation as 'log' — garbage
+        sets must not overwrite a valid session."""
+        _tool_manage_workouts({"action": "log", "sets": [{"exercise": "bench", "reps": 8, "weight": 135}]})
+        session_id = temp_store.get_latest_session().id
+        out = _tool_manage_workouts({"action": "update", "sets": [{"reps": -8}]})
+        assert out.startswith("Error")
+        session = temp_store.get_session(session_id)
+        assert session.sets[0].reps == 8 and session.sets[0].weight == 135

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -135,6 +135,52 @@ def test_tools_call_dispatches_to_handler(client: TestClient, bearer_token: str)
 
 
 @pytest.mark.unit
+def test_tools_call_sets_is_error_on_tool_failure(client: TestClient, bearer_token: str, monkeypatch):
+    """#603 review (MAJOR): a tool-level failure must surface as MCP
+    `isError: true`, not just as prose inside a structurally-successful
+    JSON-RPC result — the same "error" key convention the agent worker's
+    ToolRegistry already uses (api/services/agent_worker/tools.py) to decide
+    is_error, applied here so an MCP client reading the structured field
+    (not just the formatted text) can also tell success from failure."""
+    monkeypatch.setattr(
+        mcp_server.LifeOSMCPServer, "_call_api",
+        lambda self, name, args: {"error": "boom"},
+    )
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {"name": "lifeos_workout_manage", "arguments": {"action": "log", "sets": []}},
+        },
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["isError"] is True
+
+
+@pytest.mark.unit
+def test_tools_call_omits_is_error_on_success(client: TestClient, bearer_token: str):
+    """A successful call (no "error" key in the tool's data) must not carry
+    `isError` at all — confirms the new field is failure-only, not a blanket
+    addition that could confuse existing callers."""
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {"name": "lifeos_search", "arguments": {"query": "hello"}},
+        },
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert resp.status_code == 200
+    assert "isError" not in resp.json()["result"]
+
+
+@pytest.mark.unit
 def test_notification_returns_202_no_body(client: TestClient, bearer_token: str):
     """JSON-RPC notifications (no id) get 202 Accepted per MCP streamable-HTTP spec."""
     resp = client.post(

--- a/tests/test_workout_mcp_route.py
+++ b/tests/test_workout_mcp_route.py
@@ -1,0 +1,272 @@
+"""
+Tests for the workout MCP surface (#603).
+
+The fitness persona's core instruction — log first, report after, never ask
+for confirmation before logging — was previously uncarryable through the MCP
+surface: `manage_workouts` had no exposed equivalent under any name. This
+covers the new `POST /api/fitness/workouts` endpoint and its curated MCP
+tool `lifeos_workout_manage`:
+
+1. The tool is registered and discoverable on the MCP surface.
+2. A workout logged through the MCP/REST path lands in the exact same
+   FitnessStore a natively-logged one does (asserting the stored row, not
+   just a success response — the failure mode at issue is a false "Logged").
+3. No other curated tool or persona's tool availability changed.
+"""
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.services.fitness_store as fs
+from api.services.fitness_store import FitnessStore
+from api.routes import fitness as fitness_route
+
+pytestmark = pytest.mark.unit
+
+MCP_SERVER_PATH = Path(__file__).parent.parent / "mcp_server.py"
+
+
+def _load_mcp_module():
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _server_built_from_live_spec():
+    """A LifeOSMCPServer with `.tools` built from this checkout's live
+    OpenAPI spec, in-process — no HTTP round-trip, no running server."""
+    from api.main import app
+    openapi_spec = app.openapi()
+    module = _load_mcp_module()
+    with patch.object(module.LifeOSMCPServer, "_load_openapi_spec", lambda self: None):
+        server = module.LifeOSMCPServer()
+    server.openapi_spec = openapi_spec
+    server._build_tools_from_spec()
+    return server
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    store = FitnessStore(db_path=str(tmp_path / "fitness.db"))
+    monkeypatch.setattr(fs, "_store_instance", store)  # get_fitness_store() -> this
+    app = FastAPI()
+    app.include_router(fitness_route.router)
+    client = TestClient(app)
+    return client, store
+
+
+# ---------------------------------------------------------------------------
+# 1. Registered and discoverable on the MCP surface
+# ---------------------------------------------------------------------------
+
+class TestMCPRegistration:
+    def test_curated_endpoint_present(self):
+        module = _load_mcp_module()
+        cfg = next(
+            (c for c in module.CURATED_ENDPOINTS.values() if c["name"] == "lifeos_workout_manage"),
+            None,
+        )
+        assert cfg is not None, "lifeos_workout_manage missing from CURATED_ENDPOINTS"
+        assert cfg["method"] == "POST"
+        assert cfg.get("path", "").endswith("/api/fitness/workouts")
+
+    def test_tool_discoverable_with_action_required(self):
+        """Built from this checkout's live OpenAPI spec (in-process, no server)."""
+        from api.main import app
+        openapi_spec = app.openapi()
+
+        module = _load_mcp_module()
+        with patch.object(module.LifeOSMCPServer, "_load_openapi_spec", lambda self: None):
+            server = module.LifeOSMCPServer()
+        server.openapi_spec = openapi_spec
+        server._build_tools_from_spec()
+
+        tool = next((t for t in server.tools if t["name"] == "lifeos_workout_manage"), None)
+        assert tool is not None, "lifeos_workout_manage not discovered from the OpenAPI spec"
+        schema = tool["inputSchema"]
+        assert schema["type"] == "object"
+        assert "action" in schema["properties"]
+        assert schema.get("required") == ["action"]
+
+    def test_format_response_passes_result_through_as_plain_text(self):
+        """The formatter should echo the tool's own confirmation/error string
+        rather than re-wrapping it as JSON, matching what the native
+        orchestrator sees from the same dispatcher."""
+        module = _load_mcp_module()
+        server = module.LifeOSMCPServer()
+        formatted = server._format_response(
+            "lifeos_workout_manage",
+            {"result": "Logged — 2026-06-07: Bench Press 135×8 (session id: abc123)"},
+        )
+        assert formatted == "Logged — 2026-06-07: Bench Press 135×8 (session id: abc123)"
+
+
+# ---------------------------------------------------------------------------
+# 2. Same store as the native path
+# ---------------------------------------------------------------------------
+
+class TestSharedStore:
+    def test_log_via_route_writes_a_real_row(self, env):
+        """The write must be real, not just a success string — check the
+        store directly rather than trusting the response body."""
+        client, store = env
+        resp = client.post(
+            "/api/fitness/workouts",
+            json={"action": "log", "sets": [{"exercise": "bench", "reps": 8, "weight": 135}]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["result"].startswith("Logged")
+
+        session = store.get_latest_session()
+        assert session is not None
+        assert session.sets[0].exercise == "Bench Press"
+        assert session.sets[0].reps == 8
+        assert session.sets[0].weight == 135
+
+    def test_lands_in_same_store_the_native_tool_reads(self, env):
+        """A session logged via the route must be visible to the exact
+        dispatcher the native orchestrator calls — proving both paths share
+        one store rather than two independent ones."""
+        client, store = env
+        client.post(
+            "/api/fitness/workouts",
+            json={"action": "log", "sets": [{"exercise": "squats", "reps": 5, "weight": 185}]},
+        )
+        from api.services.agent_tools import _tool_manage_workouts
+        out = _tool_manage_workouts({"action": "history", "exercise": "squats"})
+        assert store.get_latest_session().id in out
+
+    def test_log_without_sets_is_a_real_error_not_a_false_confirmation(self, env):
+        """No path may report a workout as logged without a write. An empty
+        `sets` must come back as a 4xx, not a structurally-successful 200
+        with an 'Error: ...' string buried in the body (#603 review MAJOR —
+        a 200 there is legible only to a caller that reads the prose, which
+        is exactly the false-confirmation shape this issue exists to close)."""
+        client, store = env
+        resp = client.post("/api/fitness/workouts", json={"action": "log", "sets": []})
+        assert 400 <= resp.status_code < 500
+        assert "Error" in resp.json()["detail"]
+        assert store.list_sessions() == []
+
+    def test_update_targets_the_session_the_route_just_logged(self, env):
+        client, store = env
+        client.post(
+            "/api/fitness/workouts",
+            json={"action": "log", "sets": [{"exercise": "bench", "reps": 8, "weight": 135}]},
+        )
+        resp = client.post(
+            "/api/fitness/workouts",
+            json={"action": "update", "sets": [{"exercise": "bench", "reps": 8, "weight": 145}]},
+        )
+        assert resp.json()["result"].startswith("Updated")
+        assert store.get_latest_session().sets[0].weight == 145
+
+    def test_readiness_action_reachable_over_the_route(self, env):
+        """The persona's recommendation flow also needs `readiness`, not
+        just `log` — confirm the full action set is reachable, not a
+        logging-only subset."""
+        client, _ = env
+        resp = client.post("/api/fitness/workouts", json={"action": "readiness"})
+        assert resp.status_code == 200
+        assert "Readiness snapshot" in resp.json()["result"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Nothing else moved
+# ---------------------------------------------------------------------------
+
+class TestNoUnrelatedChange:
+    def test_curated_endpoint_count(self):
+        """Pins the new total (56 = the pre-existing 55 + this one) so a
+        future change to this count is a deliberate, reviewed edit."""
+        module = _load_mcp_module()
+        assert len(module.CURATED_ENDPOINTS) == 56
+
+    def test_other_tools_unaffected(self):
+        module = _load_mcp_module()
+        names = {c["name"] for c in module.CURATED_ENDPOINTS.values()}
+        # Spot-check a sample from unrelated categories — none of this PR's
+        # changes should have touched their registration.
+        for expected in ("lifeos_task_create", "lifeos_calendar_upcoming", "lifeos_monarch_accounts"):
+            assert expected in names
+
+    def test_agentic_loop_tool_count_unchanged(self):
+        """manage_workouts already existed in the native agentic-loop tool
+        set (#320) — this PR only adds an MCP-side route to it, so the
+        agentic-loop tool count must not move."""
+        from api.services.agent_tools import TOOL_DEFINITIONS
+        assert len(TOOL_DEFINITIONS) == 21
+
+
+# ---------------------------------------------------------------------------
+# 4. Generated schema reports real types, not the anyOf-null fallback
+# ---------------------------------------------------------------------------
+
+class TestSchemaTypeAccuracy:
+    """#603 review (MAJOR): FastAPI/Pydantic v2 renders every Optional field
+    as `anyOf: [<real schema>, {"type": "null"}]` with no top-level `type`.
+    The old generator read only the top-level `type` and silently defaulted
+    to "string", so `sets` (a JSON array of objects) and `limit` (an integer)
+    were both advertised to MCP clients as `"type": "string"`. A schema-
+    following external client could not construct the array a workout log
+    needs — the capability looked present on the tool list and was actually
+    unusable, which alone defeats the point of this issue."""
+
+    def test_sets_reports_array_with_items(self):
+        server = _server_built_from_live_spec()
+        tool = next(t for t in server.tools if t["name"] == "lifeos_workout_manage")
+        sets_schema = tool["inputSchema"]["properties"]["sets"]
+        assert sets_schema["type"] == "array"
+        assert "items" in sets_schema  # the per-entry shape must survive, not just the outer type
+
+    def test_limit_reports_integer(self):
+        server = _server_built_from_live_spec()
+        tool = next(t for t in server.tools if t["name"] == "lifeos_workout_manage")
+        assert tool["inputSchema"]["properties"]["limit"]["type"] == "integer"
+
+    def test_required_action_field_still_reports_string(self):
+        """`action` has no Optional wrapper (it's required) — confirm the
+        anyOf-unwrap didn't regress the already-correct, non-nullable case."""
+        server = _server_built_from_live_spec()
+        tool = next(t for t in server.tools if t["name"] == "lifeos_workout_manage")
+        assert tool["inputSchema"]["properties"]["action"]["type"] == "string"
+
+    def test_other_curated_tool_optional_array_also_fixed(self):
+        """The same anyOf-null shape affects other curated tools' Optional
+        array fields (e.g. task tags) — confirm the generator fix is general,
+        not special-cased to fitness."""
+        server = _server_built_from_live_spec()
+        tool = next(t for t in server.tools if t["name"] == "lifeos_task_create")
+        tags_schema = tool["inputSchema"]["properties"].get("tags")
+        assert tags_schema is not None
+        assert tags_schema["type"] == "array"
+
+
+# ---------------------------------------------------------------------------
+# 5. No persona instruction leaked into the tool description
+# ---------------------------------------------------------------------------
+
+class TestNoPersonaLeakInDescription:
+    """#603 review (MAJOR): `ToolRegistry` exposes the full curated catalog
+    to every persona, so a persona-specific instruction ("log first, never
+    ask for confirmation") baked into this tool's *description* would change
+    behavior for every non-fitness persona too. That instruction already
+    lives in config/personas/fitness.md, where it applies to the right
+    surface — the MCP description must stay capability-only."""
+
+    def test_description_has_no_confirmation_instruction(self):
+        module = _load_mcp_module()
+        cfg = next(c for c in module.CURATED_ENDPOINTS.values() if c["name"] == "lifeos_workout_manage")
+        desc = cfg["description"].lower()
+        assert "confirm" not in desc
+        assert "never ask" not in desc
+
+    def test_instruction_still_lives_in_the_fitness_persona(self):
+        persona_path = Path(__file__).parent.parent / "config" / "personas" / "fitness.md"
+        text = persona_path.read_text().lower()
+        assert "never ask for confirmation" in text


### PR DESCRIPTION
The fitness persona instructs the assistant to log a workout **before** replying and never ask for confirmation — but `manage_workouts` had no MCP equivalent. A backend reached through MCP (now the default `/chat` backend) received an instruction it could not carry out, which is worse than a missing feature: the user believes the set is logged, the log *is* the product, and a model told to log first and unable to do so is under real pressure to claim it did.

Adds `POST /api/fitness/workouts`, a thin wrapper around the same `_tool_manage_workouts` dispatcher the native orchestrator uses, registered as the curated MCP tool `lifeos_workout_manage`. Both paths call the identical function and write through the same `FitnessStore`, so there is no second implementation to drift.

This crosses AGENTS.md's "ask first" line on MCP tool definitions, and was explicitly authorized.

## Review round — one blocker, four majors

An adversarial review reproduced each by issuing real requests. None were caught by the original green suite.

- **Blocker — `update` with `sets: []` destroyed the workout and returned "Updated".** Rejected now at the *dispatcher* boundary, leaving `fitness_store.update_session`'s native semantics untouched for existing callers. The behavior was pre-existing; this issue is what made it reachable by an external model.
- **A failed write was a structurally successful tool call.** The route returned HTTP 200 with `{"result": "Error: ..."}`, which MCP wrapped as a JSON-RPC `result` with no `isError` — legible only to a model reading prose inside a success. That is precisely the false confirmation this issue exists to prevent. Now a 400, with `isError` set at the MCP layer. Notably the `isError` convention already existed and was already tested; it simply never fired, because this was the only curated route returning errors inside a 200.
- **The generated MCP schema lied about argument types.** Pydantic renders `Optional[X]` as `anyOf`, and the generator read only the top-level `type`, so `sets` was advertised as `"string"`. A schema-following client could not construct the array — the capability would have been present and unusable. Fixed generally via `_unwrap_optional`, not special-cased. The blast-radius check found this was never fitness-specific: `CreateTaskRequest.tags`, `UpdateTaskRequest.tags`, `UpdateEventRequest.attendees`, `PersonUpdateRequest.tags`, and a CRM boolean were all mistyped too, and now report correctly.
- **No input validation on a write tool reachable by an external backend.** Empty exercises, negative reps, `rpe: 99`, and `date: "not-a-date"` were all stored and echoed as logged. Shared validators now guard both the log and update paths.
- **Persona behavior had leaked into a global tool description.** "Log first — never ask for confirmation" was read by *every* MCP caller, violating this issue's own "no other persona changes" criterion. The description is capability-only; the instruction stays in `config/personas/fitness.md`, where it applies to the right surface.

One pre-existing test that asserted the old 200-with-error behavior was updated, since that was the exact behavior being fixed.

## Tests

**3547 passed, 8 skipped** (main: 3515) — +32, of which 21 came from this review round. Each fix has a test that fails without it.

Also corrects a count that had already drifted: `AGENTS.md` read 54 curated tools when the real number was 55, because #600 added `lifeos_turn_context` without updating it — within a day of #589 correcting those counts.

Closes #603