### PR TITLE
fix(sync): make a failed write legible to the model that called it

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -7,6 +7,7 @@ Provides:
 - Configuration info
 """
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional
 import logging
@@ -223,13 +224,23 @@ async def trigger_calendar_sync(days_past: int = 30, days_future: int = 30) -> C
         )
     except Exception as e:
         logger.error(f"Calendar sync failed: {e}")
-        return CalendarSyncResponse(
-            status="error",
-            events_indexed=0,
-            errors=[str(e)],
-            elapsed_seconds=0,
-            last_sync=""
-        )
+        # A plain JSONResponse, not a CalendarSyncResponse, so the extra
+        # top-level "error" key survives instead of being filtered out by
+        # response_model validation. #609: the request was served, but the
+        # sync itself failed, and this stays a 200 for that reason (#614
+        # tracks whether that should change) — the caller still needs to be
+        # able to tell success from failure without parsing prose, and
+        # `mcp_server.py: dispatch()` and the agent worker's ToolRegistry
+        # already flag any tool result as an error generically whenever the
+        # body carries a top-level "error" key.
+        return JSONResponse(content={
+            "status": "error",
+            "events_indexed": 0,
+            "errors": [str(e)],
+            "elapsed_seconds": 0,
+            "last_sync": "",
+            "error": str(e),
+        })
 
 
 @router.post("/calendar/start")

--- a/api/routes/photos.py
+++ b/api/routes/photos.py
@@ -4,12 +4,11 @@ Apple Photos API endpoints for LifeOS.
 Provides endpoints for querying Photos face recognition data
 and syncing to LifeOS CRM.
 """
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import FileResponse, Response
+from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
 from config.settings import settings
@@ -287,11 +286,21 @@ async def trigger_photo_sync(
                     f"created {stats.get('interactions_created', 0)} interactions"
         )
     except Exception as e:
-        return SyncResponse(
-            success=False,
-            stats={"error": str(e)},
-            message=f"Sync failed: {e}"
-        )
+        # A plain JSONResponse, not a SyncResponse, so a top-level "error"
+        # key can ride alongside the existing fields instead of being
+        # filtered out by response_model validation. #609: the request was
+        # served, but the sync itself failed, and this stays a 200 for that
+        # reason (#614 tracks whether that should change) — the caller
+        # still needs to be able to tell success from failure without
+        # parsing prose, and `mcp_server.py: dispatch()` and the agent
+        # worker's ToolRegistry already flag any tool result as an error
+        # generically whenever the body carries a top-level "error" key.
+        return JSONResponse(content={
+            "success": False,
+            "stats": {"error": str(e)},
+            "message": f"Sync failed: {e}",
+            "error": str(e),
+        })
 
 
 def _get_thumbnail_path(uuid: str) -> Path | None:
@@ -512,7 +521,7 @@ async def open_photo_in_app(uuid: str):
                 capture_output=True,
                 timeout=5,
             )
-            return {"success": True, "message": f"Opened thumbnail (original in iCloud)"}
+            return {"success": True, "message": "Opened thumbnail (original in iCloud)"}
         except Exception:
             pass  # Fall through to Photos app
 

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-08-19
+> **Last Updated:** 2026-08-21
 
 Codebase organization and module structure for efficient navigation.
 
@@ -297,6 +297,97 @@ def my_function():
     conn = sqlite3.connect(get_crm_db_path())
     # ...
 ```
+
+---
+
+## Write Endpoint Failure Contract
+
+**Guarantee:** a curated write endpoint must never report a failure inside an
+HTTP 2xx without a top-level `error` key — a caller (human, MCP client, or
+the agent worker) must be able to tell success from failure from the status
+code or that key alone, without parsing prose. This was violated once (#603,
+`fitness.py`) and the class of defect was audited end to end for #609.
+
+**How it's enforced, mechanically:**
+
+- MCP surface (`mcp_server.py: dispatch()`) sets `result["isError"] = True`
+  whenever a tool's `_call_api()` result is a dict containing an `"error"`
+  key. `_call_api()` derives that key either from `resp.raise_for_status()`
+  raising on a non-2xx, **or** from a 2xx JSON body that already carries a
+  top-level `"error"` key (the latter matters for `lifeos_sync_trigger`,
+  whose custom handler — `_handle_sync_trigger` — passes a 2xx body through
+  unmodified rather than routing it through `_call_api`'s own try/except; see
+  `test_sync_trigger_2xx_with_embedded_error_sets_is_error`). Either way this
+  is generic and correct for any tool **only if** the underlying route
+  actually raises on failure or embeds a top-level `error` key.
+- Agent worker (`api/services/agent_worker/tools.py: ToolRegistry.dispatch`)
+  routes MCP-backed tools through that same `_call_api`/`_format_response`
+  pair and derives `ToolResult.is_error` identically (`"error" in data`,
+  proved tool-name-agnostic by `test_registry_lifeos_tool_error_surfaced` in
+  `tests/test_agent_worker_tools.py`) — it inherits both the guarantee and
+  any exemption to it, with no code of its own to go stale.
+- Native chat/Hermes orchestrator (`api/services/agent_loop.py`) never calls
+  the HTTP layer — it dispatches in-process through
+  `api/services/agent_tools.py`, where every handler returns a plain string
+  and a failure is required to start with the literal `"Error:"`.
+  `agent_loop.py` derives the Anthropic `tool_result.is_error` field from that
+  prefix (`tool_result_str.startswith("Error:")`), which becomes the
+  structured signal the model actually receives.
+
+Both HTTP-facing mechanisms are correct by construction; they only fail when
+a *route* returns 2xx with a failure embedded in the body without a
+top-level `error` key. The table below is the audit of every curated write
+endpoint against that condition, plus which of the three mechanisms above
+actually consumes it — an endpoint can be honest while every consumer of it
+is blind, which is how the incident that prompted #609 happened. This is
+what makes the guarantee above true rather than aspirational (docs/AGENTS.md:
+no document may claim an unenforced guarantee).
+
+| MCP tool | Route | Status | Consumers | Regression coverage |
+|---|---|---|---|---|
+| `lifeos_vault_write` | `POST /api/vault/write` | Safe — `OSError` → `HTTPException(500)` | MCP, worker (no native-loop equivalent) | `tests/test_vault_write_route.py` |
+| `lifeos_memories_create` | `POST /api/memories` | Safe — unhandled exception → default 500 | MCP, worker, native (`_tool_save_memory`) | `tests/test_memories_api.py` |
+| `lifeos_person_update` | `PATCH /api/crm/people/{id}` | Safe — 404 on missing person | MCP, worker (no native-loop equivalent) | `tests/test_crm_api.py::test_update_person_not_found` |
+| `lifeos_person_fact_update/confirm/delete` | `{PUT,POST,DELETE} .../facts/{id}[/confirm]` | Safe — 404/400 on missing or mismatched fact | MCP, worker (no native-loop equivalent) | `tests/test_crm_api.py::test_{update,confirm,delete}_fact_not_found` |
+| `lifeos_gmail_draft` | `POST /api/gmail/drafts` | Safe — 500 on a `None` draft; broad `except` re-raises as `HTTPException` | MCP, worker, native (`_tool_create_email_draft`) | `tests/test_gmail.py::test_create_draft_failure_returns_500` |
+| `lifeos_gmail_send` | `POST /api/gmail/send` | Safe — 409 (send gate) / 500 | MCP, worker, native (`_tool_send_email_draft`) | `tests/test_gmail.py::test_send_draft_failure_returns_500` |
+| `lifeos_reminder_create/update/delete` | `{POST,PUT,DELETE} /api/reminders[/{id}]` | Safe — 400/404 | MCP, worker; native covers create only (deprecated `_reminder_create` alias — no native update/delete) | `tests/test_reminders_api.py` |
+| `lifeos_telegram_send` | `POST /api/reminders/send` | Safe — 400 not configured / 500 send failure | MCP, worker (no native-loop equivalent) | `tests/test_reminders_api.py` |
+| `lifeos_schedule_create/update/delete` | `{POST,PUT,DELETE} /api/scheduler[/{id}]` | Safe — 400/404 | MCP, worker, native (`_schedule_create/_update/_delete`) | `tests/test_scheduler_api.py` |
+| `lifeos_sync_trigger` (`source=vault`) | `POST /api/admin/reindex` | Safe — reports enqueue state honestly, never claims completion | MCP, worker (no native-loop equivalent — see note below) | `tests/test_admin.py` |
+| `lifeos_sync_trigger` (`source=calendar`) | `POST /api/admin/calendar/sync` | **Fixed for #609.** `except Exception` now returns a `JSONResponse` with a top-level `"error"` key alongside the existing fields (status stays 200 — the request *was* served; whether a total sync failure should instead be non-2xx is a separate, deliberate question tracked as #614). | MCP, worker (no native-loop equivalent) | `tests/test_calendar_indexer.py::test_trigger_calendar_sync_failure_carries_top_level_error`, `tests/test_mcp_server.py::test_sync_trigger_2xx_with_embedded_error_sets_is_error` |
+| `lifeos_sync_trigger` (`source=contacts`, `slack`) | `POST /api/crm/{contacts,slack}/sync` | Safe — raise `HTTPException` on failure | MCP, worker (no native-loop equivalent) | `tests/test_crm_api.py` |
+| `lifeos_sync_trigger` (`source=photos`) | `POST /api/photos/sync` | **Fixed for #609.** Same mechanism as the calendar case — the error previously lived only nested inside `stats["error"]`, invisible to the generic top-level check; now also present at the top level (status stays 200, same #614 note as above). | MCP, worker (no native-loop equivalent) | `tests/test_photos_sync_api.py::test_sync_failure_carries_top_level_error` |
+| `lifeos_sync_trigger` (`source=gmail`, `imessage`, `phone`, `facetime`, `linkedin`) | `POST /api/crm/sources/{type}/sync` | Stub — always returns `{"status": "queued"}`; no sync is actually implemented yet, so there is no failure path to mis-report. Not a #609 defect. | MCP, worker (no native-loop equivalent) | — |
+| `lifeos_workout_manage` | `POST /api/fitness/workouts` | Safe — fixed in #603 | MCP, worker, native (`_tool_manage_workouts`) | `tests/test_workout_mcp_route.py` |
+| `lifeos_task_create/update/complete/delete` | `{POST,PUT,DELETE} /api/tasks[/{id}[/complete]]` | Safe — unhandled exception → 500; not-found → 404 | MCP, worker, native covers create/update/complete (`_task_create/_update/_complete`) — no native delete | `tests/test_tasks_api.py::test_create_task_failure_is_never_success_shaped` (create); 404 cases elsewhere in the same file |
+| `lifeos_calendar_create/update/delete` | `{POST,PUT,DELETE} /api/calendar/events[/{id}]` | Safe — 401/500 | MCP, worker, native (`_tool_create/update/delete_calendar_event`) | `tests/test_calendar_api.py::TestCalendarWriteFailures` |
+
+Every `lifeos_sync_trigger` row has no native-loop equivalent because that
+loop has no sync-trigger-shaped tool at all — see the paragraph below.
+
+Native-tool-loop write handlers in `api/services/agent_tools.py` (`_task_*`,
+`_reminder_create`, `_schedule_*`, `_tool_create_email_draft`,
+`_tool_send_email_draft`, `_tool_*_calendar_event`, `_tool_save_memory`,
+`_workout_*`) were each checked for a path that returns success-shaped text
+on failure; none exists — every failure either propagates as an exception
+(caught by `execute_tool`/`execute_tool_parallel`'s `except Exception` →
+`"Error: {e}"`) or is an explicit `"Error: ..."`-prefixed string.
+
+The table above is a point-in-time audit; it does not by itself catch a
+*future* write endpoint that reintroduces the anti-pattern.
+`tests/test_mcp_server.py::TestWriteEndpointNeverReturnsSuccessShapedFailure`
+closes that gap mechanically: it enumerates every curated write endpoint
+straight from `CURATED_ENDPOINTS` (plus the sub-routes `_handle_sync_trigger`
+fans `lifeos_sync_trigger` out to) and statically flags any `except` block
+that returns normally without raising, setting an explicit non-2xx status,
+or embedding a top-level `error` key, so a newly added endpoint with this
+shape fails a test that already exists rather than needing a new one. It is
+a static approximation, not a substitute for the failure-injection tests
+cited in the table above.
+`tests/test_mcp_server.py::TestMCPServerToolDiscovery::test_task_create_tags_advertised_as_array`
+separately pins the specific schema mistyping (`tags` as `string` instead of
+`array`) that #603 fixed and #609 traced the original incident to.
 
 ---
 

--- a/tests/test_calendar_api.py
+++ b/tests/test_calendar_api.py
@@ -2,15 +2,15 @@
 Tests for Calendar API endpoints.
 """
 import pytest
-
-# These tests use TestClient which initializes the app (slow)
-pytestmark = pytest.mark.slow
 from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
 from datetime import datetime, timezone
 
 from api.main import app
 from api.services.calendar import CalendarEvent
+
+# These tests use TestClient which initializes the app (slow)
+pytestmark = pytest.mark.slow
 
 
 client = TestClient(app)
@@ -126,3 +126,30 @@ class TestCalendarSearchEndpoint:
             data = response.json()
             assert "count" in data
             assert isinstance(data["count"], int)
+
+
+class TestCalendarWriteFailures:
+    """#609: a failed create/update/delete must be a non-2xx, never a 200
+    that merely omits the fields a successful write would have."""
+
+    def test_create_event_failure_returns_500(self, mock_calendar_service):
+        mock_calendar_service.create_event.side_effect = Exception("Google API error")
+        with patch('api.routes.calendar.get_calendar_service', return_value=mock_calendar_service):
+            response = client.post("/api/calendar/events", json={
+                "title": "Standup",
+                "start_time": "2026-01-07T10:00:00Z",
+                "end_time": "2026-01-07T10:30:00Z",
+            })
+            assert response.status_code == 500
+
+    def test_update_event_failure_returns_500(self, mock_calendar_service):
+        mock_calendar_service.update_event.side_effect = Exception("Google API error")
+        with patch('api.routes.calendar.get_calendar_service', return_value=mock_calendar_service):
+            response = client.put("/api/calendar/events/evt-1", json={"title": "New title"})
+            assert response.status_code == 500
+
+    def test_delete_event_failure_returns_500(self, mock_calendar_service):
+        mock_calendar_service.delete_event.side_effect = Exception("Google API error")
+        with patch('api.routes.calendar.get_calendar_service', return_value=mock_calendar_service):
+            response = client.delete("/api/calendar/events/evt-1")
+            assert response.status_code == 500

--- a/tests/test_calendar_indexer.py
+++ b/tests/test_calendar_indexer.py
@@ -5,7 +5,7 @@ Tests calendar event indexing and scheduling functionality.
 """
 import pytest
 from unittest.mock import patch, MagicMock
-from datetime import datetime, timedelta
+from datetime import datetime
 
 # Mark all tests in this module as unit tests
 pytestmark = pytest.mark.unit
@@ -201,6 +201,21 @@ class TestCalendarAdminEndpoints:
         data = response.json()
         assert data["status"] == "success"
         assert data["events_indexed"] == 50
+
+    def test_trigger_calendar_sync_failure_carries_top_level_error(self, client, mock_indexer):
+        """#609: a sync failure stays a 200 (the request WAS served — see
+        #614 for whether that should change) but must carry a top-level
+        `error` key, since `mcp_server.py: dispatch()` and the agent
+        worker's `ToolRegistry` both key off exactly that to flag a result
+        as failed. Without it, this failure was reported as success-shaped."""
+        mock_indexer.sync.side_effect = RuntimeError("calendar API unreachable")
+        response = client.post("/api/admin/calendar/sync")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "error"
+        assert "error" in data
+        assert "calendar API unreachable" in data["error"]
 
     def test_start_calendar_scheduler(self, client, mock_indexer):
         """Should start the calendar scheduler with time-based schedule by default."""

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -77,6 +77,14 @@ class TestPersonEndpoints:
         response = client.get("/api/crm/people/invalid-id-12345")
         assert response.status_code == 404
 
+    def test_update_person_not_found(self, client):
+        """#609: PATCH /people/{id} for a missing person is a 404, never a
+        200 that merely omits the update."""
+        response = client.patch(
+            "/api/crm/people/invalid-id-12345", json={"notes": "test"}
+        )
+        assert response.status_code == 404
+
 
 class TestPersonTimeline:
     """Tests for person timeline endpoints."""
@@ -150,6 +158,30 @@ class TestPersonFacts:
         assert response.status_code == 200
         data = response.json()
         assert "facts" in data
+
+    def test_update_fact_not_found(self, client, sample_person_id):
+        """#609: PUT .../facts/{id} for a missing fact is a 404, never a
+        200 that merely omits the update."""
+        response = client.put(
+            f"/api/crm/people/{sample_person_id}/facts/invalid-fact-12345",
+            json={"value": "test"},
+        )
+        assert response.status_code == 404
+
+    def test_confirm_fact_not_found(self, client, sample_person_id):
+        """#609: POST .../facts/{id}/confirm for a missing fact is a 404."""
+        response = client.post(
+            f"/api/crm/people/{sample_person_id}/facts/invalid-fact-12345/confirm"
+        )
+        assert response.status_code == 404
+
+    def test_delete_fact_not_found(self, client, sample_person_id):
+        """#609: DELETE .../facts/{id} for a missing fact is a 404, never a
+        200 'deleted' for a fact that was never there."""
+        response = client.delete(
+            f"/api/crm/people/{sample_person_id}/facts/invalid-fact-12345"
+        )
+        assert response.status_code == 404
 
 
 class TestContactSources:

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -631,6 +631,27 @@ class TestGmailDraftAPI:
             assert "gmail_url" in data
             assert "drafts" in data["gmail_url"]
 
+    def test_create_draft_failure_returns_500(self, mock_gmail_service):
+        """#609: a failed draft creation must be a non-2xx, not a 200 body
+        that merely omits the fields a successful draft would have."""
+        from fastapi.testclient import TestClient
+        from api.main import app
+
+        mock_gmail_service.create_draft.return_value = None
+
+        with patch('api.routes.gmail.get_gmail_service', return_value=mock_gmail_service):
+            client = TestClient(app)
+            response = client.post(
+                "/api/gmail/drafts",
+                json={
+                    "to": "recipient@example.com",
+                    "subject": "Test Subject",
+                    "body": "Test body content",
+                }
+            )
+
+            assert response.status_code == 500
+
     def test_create_draft_requires_to(self, mock_gmail_service):
         """Should require 'to' field."""
         from fastapi.testclient import TestClient

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -130,6 +130,36 @@ class TestMCPServerToolDiscovery:
         for expected in expected_tools:
             assert expected in tool_names, f"Missing tool: {expected}"
 
+    def test_task_create_tags_advertised_as_array(self, openapi_spec):
+        """Regression for #609: the incident that prompted this issue traced
+        back to `lifeos_task_create`'s `tags` field being advertised as
+        `"type": "string"` before #603's `_unwrap_optional` fix. A
+        schema-following model sent a string, the write 400'd, and (per the
+        incident) the failure wasn't surfaced as such. `_unwrap_optional` is
+        exactly the code that could regress and reintroduce the mistyping —
+        pin the schema shape directly so a regression is caught here instead
+        of by another incident.
+        """
+        import importlib.util
+        from unittest.mock import patch
+        spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        with patch.object(module.LifeOSMCPServer, "_load_openapi_spec", lambda self: None):
+            server = module.LifeOSMCPServer()
+        server.openapi_spec = openapi_spec
+        server._build_tools_from_spec()
+
+        task_create_tool = next(t for t in server.tools if t["name"] == "lifeos_task_create")
+        tags_schema = task_create_tool["inputSchema"]["properties"]["tags"]
+        assert tags_schema.get("type") == "array", (
+            f"lifeos_task_create's 'tags' field is advertised as "
+            f"{tags_schema.get('type')!r}, not 'array' — a schema-following "
+            f"model will send the wrong shape and the write will 400"
+        )
+        assert "items" in tags_schema, "'tags' array schema is missing 'items'"
+
 
 class TestMCPServerAPICalls:
     """Test that MCP server correctly calls the API."""
@@ -597,3 +627,306 @@ def test_investments_route_404_matches_mcp_not_synced_branch(tmp_path, monkeypat
     with pytest.raises(HTTPException) as ei:
         inv_route._load("summary.json")
     assert "not synced" in str(ei.value.detail).lower()
+
+
+# ---------------------------------------------------------------------------
+# _handle_sync_trigger (#609) — the custom_handler for lifeos_sync_trigger.
+# It bypasses the generic _call_api HTTP wrapper, so its own error-signaling
+# needs its own coverage rather than inheriting the generic tests above.
+# ---------------------------------------------------------------------------
+
+def _fresh_server():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.LifeOSMCPServer()
+
+
+@pytest.mark.unit
+def test_sync_trigger_missing_source_is_an_error():
+    result = _fresh_server()._handle_sync_trigger({})
+    assert "error" in result
+
+
+@pytest.mark.unit
+def test_sync_trigger_unknown_source_is_an_error():
+    result = _fresh_server()._handle_sync_trigger({"source": "not-a-real-source"})
+    assert "error" in result
+
+
+@pytest.mark.unit
+def test_sync_trigger_known_source_routes_to_the_right_endpoint():
+    from unittest.mock import MagicMock
+    server = _fresh_server()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"status": "started"}
+    fake_response.raise_for_status = MagicMock()
+    fake.post.return_value = fake_response
+    server.client = fake
+
+    result = server._handle_sync_trigger({"source": "vault"})
+    assert result == {"status": "started"}
+    called_url = fake.post.call_args[0][0]
+    assert called_url.endswith("/api/admin/reindex")
+
+
+@pytest.mark.unit
+def test_sync_trigger_downstream_non_2xx_is_an_error():
+    """A downstream route that correctly raises on failure (the safe
+    pattern every other curated write endpoint follows) must still surface
+    as {"error": ...} here — this is what lets dispatch() set `isError`
+    generically for every sync source without source-specific handling."""
+    import httpx
+    from unittest.mock import MagicMock
+    server = _fresh_server()
+    fake = MagicMock()
+    fake_response = MagicMock(status_code=500)
+    fake_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "boom", request=MagicMock(), response=fake_response
+    )
+    fake.post.return_value = fake_response
+    server.client = fake
+
+    result = server._handle_sync_trigger({"source": "vault"})
+    assert "error" in result
+
+
+@pytest.mark.unit
+def test_sync_trigger_2xx_with_embedded_error_sets_is_error():
+    """#609: `POST /api/admin/calendar/sync` and `POST /api/photos/sync`
+    report a failed sync as a 200 carrying a top-level `error` key rather
+    than a non-2xx (the request was served; the sync failed — see #614 for
+    whether that should change). `_handle_sync_trigger` passes a 2xx body
+    through unmodified, so it needs no source-specific handling for this —
+    but prove the full chain end to end rather than assuming: a 200 whose
+    body already carries `error` must still flip `dispatch()`'s `isError`,
+    exactly like `test_tools_call_sets_is_error_on_tool_failure` in
+    test_mcp_http_transport.py proves for the generic (non-sync-trigger)
+    case."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    server = module.LifeOSMCPServer.__new__(module.LifeOSMCPServer)
+    fake = MagicMock()
+    fake_response = MagicMock(status_code=200)
+    fake_response.raise_for_status = MagicMock()  # 2xx: does not raise
+    fake_response.json.return_value = {
+        "status": "error",
+        "events_indexed": 0,
+        "errors": ["calendar API unreachable"],
+        "elapsed_seconds": 0,
+        "last_sync": "",
+        "error": "calendar API unreachable",
+    }
+    fake.post.return_value = fake_response
+    server.client = fake
+
+    result = module.dispatch(
+        server,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "lifeos_sync_trigger", "arguments": {"source": "calendar"}},
+        },
+    )
+    assert result["result"]["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# #609: generic, code-driven safety net over every curated write endpoint.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestWriteEndpointNeverReturnsSuccessShapedFailure:
+    """Enumerates write endpoints from the code — CURATED_ENDPOINTS plus the
+    sub-routes `_handle_sync_trigger` fans `lifeos_sync_trigger` out to,
+    since that tool has no direct path of its own — rather than hardcoding
+    today's list, so a newly added write endpoint that returns a failure
+    inside a 2xx gets caught here without needing a new test.
+
+    Flags any `except` block in a route handler that returns normally
+    (implicit or explicit 2xx) instead of raising or setting an explicit
+    non-2xx status — the exact shape #603 fixed in `fitness.py` and #609
+    found in two sync routes. This is a static approximation of the real
+    guarantee, not a substitute for the failure-injection tests elsewhere in
+    this suite (e.g. `test_create_task_failure_is_never_success_shaped`) —
+    it exists so *future* endpoints get some coverage by construction.
+    """
+
+    # No current exemptions: `POST /api/admin/calendar/sync` and
+    # `POST /api/photos/sync` were fixed for #609 by adding a top-level
+    # `error` key to their failure body (see docs/specs/technical/
+    # architecture.md, "Write Endpoint Failure Contract") rather than
+    # changing their status code — whether a total sync failure should be
+    # non-2xx instead is a separate, deliberate question tracked as #614.
+    # Add an entry here (with a tracking issue and a doc note) only for a
+    # deliberately accepted gap — never to silence a finding.
+    _KNOWN_EXEMPTIONS: set[tuple[str, str]] = set()
+
+    @staticmethod
+    def _load_mcp_module():
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def _curated_write_paths(self, module):
+        """(method, path) pairs for every write endpoint reachable through
+        the MCP surface."""
+        from unittest.mock import MagicMock
+
+        pairs = set()
+        for key, config in module.CURATED_ENDPOINTS.items():
+            if config["method"] == "GET" or config.get("custom_handler"):
+                continue
+            pairs.add((config["method"], config.get("path", key.split(":")[0])))
+
+        # lifeos_sync_trigger has no direct path — _handle_sync_trigger fans
+        # it out at runtime based on `source`. Drive the real routing logic
+        # for every valid source instead of re-typing its route_map, so a
+        # change there is picked up automatically.
+        server = module.LifeOSMCPServer.__new__(module.LifeOSMCPServer)
+        for source in (
+            "vault", "calendar", "contacts", "slack", "photos",
+            "gmail", "imessage", "phone", "facetime", "linkedin",
+        ):
+            fake_client = MagicMock()
+            server.client = fake_client
+            server._handle_sync_trigger({"source": source})
+            url = fake_client.post.call_args[0][0]
+            path = "/" + url.split("://", 1)[-1].split("/", 1)[-1]
+            pairs.add(("POST", path))
+        return pairs
+
+    @staticmethod
+    def _resolve_route(method: str, curated_path: str):
+        """Find the FastAPI route matching `curated_path`, treating any
+        route path parameter as a wildcard — curated paths sometimes name a
+        param differently than the route itself (e.g. `{entity_id}` in
+        CURATED_ENDPOINTS vs `{person_id}` on the actual CRM route), and a
+        sync-trigger URL carries a concrete value (e.g. `gmail`) where the
+        route has a param (`{source_type}`)."""
+        from api.main import app
+
+        curated_segments = curated_path.strip("/").split("/")
+        for route in app.routes:
+            if method not in getattr(route, "methods", set()):
+                continue
+            route_segments = route.path.strip("/").split("/")
+            if len(route_segments) != len(curated_segments):
+                continue
+            if all(
+                a == b or b.startswith("{")
+                for a, b in zip(curated_segments, route_segments)
+            ):
+                return route
+        return None
+
+    @staticmethod
+    def _except_blocks_return_success_shaped(func) -> list[str]:
+        """Describe every `except` block in `func` that returns normally
+        without either raising, setting an explicit non-2xx status, or
+        carrying a top-level `error` key in the response body — the AC's
+        "non-2xx status *or* top-level error" (#609 review discussion),
+        which is what let #609 fix the two sync-trigger routes by adding an
+        additive `error` key instead of changing their status code."""
+        import ast
+        import inspect
+        import textwrap
+
+        src = textwrap.dedent(inspect.getsource(func))
+        func_node = ast.parse(src).body[0]
+
+        def is_explicit_error_status(value_node) -> bool:
+            if not isinstance(value_node, ast.Call):
+                return False
+            callee = value_node.func
+            name = callee.id if isinstance(callee, ast.Name) else getattr(callee, "attr", "")
+            if name == "HTTPException":
+                return True
+            if name in ("JSONResponse", "Response", "PlainTextResponse", "ORJSONResponse"):
+                return any(kw.arg == "status_code" for kw in value_node.keywords)
+            return False
+
+        def dict_has_top_level_error_key(d) -> bool:
+            return isinstance(d, ast.Dict) and any(
+                isinstance(k, ast.Constant) and k.value == "error"
+                for k in d.keys if k is not None
+            )
+
+        def has_top_level_error_key(value_node) -> bool:
+            """True for a bare `{"error": ...}` dict literal, or one passed
+            as `content=`/positionally to a Response-constructing call (e.g.
+            `JSONResponse(content={"error": ..., ...})`). Deliberately
+            top-level only — a dict literal nested inside another kwarg
+            (e.g. the old `SyncResponse(stats={"error": ...})` shape) does
+            NOT count, since that key wasn't visible to a caller checking
+            the body's own top level."""
+            if dict_has_top_level_error_key(value_node):
+                return True
+            if isinstance(value_node, ast.Call):
+                candidates = list(value_node.args) + [
+                    kw.value for kw in value_node.keywords if kw.arg in (None, "content")
+                ]
+                return any(dict_has_top_level_error_key(c) for c in candidates)
+            return False
+
+        findings = []
+        for node in ast.walk(func_node):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            if any(isinstance(n, ast.Raise) for n in ast.walk(node)):
+                continue  # some branch of this handler raises — treat as safe
+            for n in ast.walk(node):
+                if isinstance(n, ast.Return) and n.value is not None:
+                    if not is_explicit_error_status(n.value) and not has_top_level_error_key(n.value):
+                        findings.append(ast.dump(n.value)[:120])
+        return findings
+
+    def test_no_curated_write_endpoint_swallows_a_failure_into_a_2xx(self):
+        module = self._load_mcp_module()
+        pairs = self._curated_write_paths(module)
+        assert pairs, "no curated write endpoints discovered — enumeration is broken"
+
+        unexpected_unsafe = []
+        for method, path in pairs:
+            route = self._resolve_route(method, path)
+            if route is None:
+                continue
+            findings = self._except_blocks_return_success_shaped(route.endpoint)
+            if findings and (method, path) not in self._KNOWN_EXEMPTIONS \
+                    and (method, route.path) not in self._KNOWN_EXEMPTIONS:
+                unexpected_unsafe.append((method, route.path, findings))
+
+        assert not unexpected_unsafe, (
+            "curated write endpoint(s) return a failure inside a 2xx (the "
+            f"#603/#609 anti-pattern): {unexpected_unsafe}. If this is "
+            "intentional, add it to _KNOWN_EXEMPTIONS with a tracking issue "
+            "and document the exemption in "
+            "docs/specs/technical/architecture.md."
+        )
+
+    def test_known_exemptions_are_still_exempt_and_documented(self):
+        """Guards the exemption list itself: once a listed exemption's route
+        is fixed to raise instead of returning success-shaped, this fails —
+        so the entry (and the doc's exemption note) gets removed instead of
+        silently going stale."""
+        for method, path in self._KNOWN_EXEMPTIONS:
+            route = self._resolve_route(method, path)
+            assert route is not None, (
+                f"exempted route {method} {path} no longer exists — remove "
+                "the stale exemption"
+            )
+            findings = self._except_blocks_return_success_shaped(route.endpoint)
+            assert findings, (
+                f"{method} {path} no longer matches the exempted anti-pattern "
+                "— remove it from _KNOWN_EXEMPTIONS and its note in "
+                "docs/specs/technical/architecture.md"
+            )

--- a/tests/test_memories_api.py
+++ b/tests/test_memories_api.py
@@ -82,6 +82,20 @@ class TestMemoriesAPI:
         # FastAPI returns 422 by default, but LifeOS validation error handler returns 400
         assert response.status_code == 400
 
+    def test_create_memory_failure_is_never_success_shaped(self, mock_memory_store):
+        """#609: a store write failure must be a non-2xx, never a 200 with
+        the created memory's own shape."""
+        from fastapi.testclient import TestClient
+        from api.main import app
+
+        mock_memory_store.create_memory.side_effect = OSError("disk write failed")
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(
+            "/api/memories",
+            json={"content": "Remember Erika spelling", "synthesize": False}
+        )
+        assert not (200 <= response.status_code < 300)
+
     def test_list_memories(self, client, mock_memory_store):
         """Should return list of memories."""
         from datetime import datetime

--- a/tests/test_photos_sync_api.py
+++ b/tests/test_photos_sync_api.py
@@ -1,0 +1,60 @@
+"""
+Tests for the Apple Photos sync endpoint (POST /api/photos/sync).
+"""
+import pytest
+from unittest.mock import patch, PropertyMock
+
+pytestmark = pytest.mark.unit
+
+
+class TestPhotosSyncEndpoint:
+    """Tests for POST /api/photos/sync."""
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        from api.main import app
+        return TestClient(app)
+
+    @pytest.fixture
+    def photos_enabled(self):
+        """Photos routes gate on `settings.photos_enabled`, a property
+        derived from whether the Photos library file exists on disk — force
+        it on so the sync handler itself gets exercised."""
+        from config.settings import Settings
+        with patch.object(
+            Settings, "photos_enabled", new_callable=PropertyMock, return_value=True
+        ):
+            yield
+
+    def test_sync_success(self, client, photos_enabled):
+        """A successful sync should not carry a top-level `error` key."""
+        with patch(
+            "api.services.apple_photos_sync.sync_apple_photos",
+            return_value={"person_matches": 3, "interactions_created": 5},
+        ):
+            response = client.post("/api/photos/sync")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert "error" not in data
+
+    def test_sync_failure_carries_top_level_error(self, client, photos_enabled):
+        """#609: a sync failure stays a 200 (the request WAS served — see
+        #614 for whether that should change) but must carry a top-level
+        `error` key, since `mcp_server.py: dispatch()` and the agent
+        worker's `ToolRegistry` both key off exactly that to flag a result
+        as failed. Previously the failure detail only lived nested inside
+        `stats["error"]`, invisible to that generic check."""
+        with patch(
+            "api.services.apple_photos_sync.sync_apple_photos",
+            side_effect=RuntimeError("Photos library locked"),
+        ):
+            response = client.post("/api/photos/sync")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert "error" in data
+        assert "Photos library locked" in data["error"]

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -5,7 +5,7 @@ Tests CRUD endpoints with mocked store and Telegram.
 """
 import pytest
 from datetime import datetime, timezone, timedelta
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, AsyncMock
 
 pytestmark = pytest.mark.unit
 
@@ -77,6 +77,23 @@ class TestRemindersAPI:
             "message_content": "Hi",
         })
         assert response.status_code == 400
+
+    def test_create_reminder_failure_is_never_success_shaped(self, mock_reminder_store):
+        """#609: a store write failure must be a non-2xx, never a 200 with
+        the created reminder's own shape."""
+        from fastapi.testclient import TestClient
+        from api.main import app
+
+        mock_reminder_store.create.side_effect = OSError("disk write failed")
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/api/reminders", json={
+            "name": "Morning Briefing",
+            "schedule_type": "cron",
+            "schedule_value": "30 7 * * 1-5",
+            "message_type": "static",
+            "message_content": "hi",
+        })
+        assert not (200 <= response.status_code < 300)
 
     def test_list_reminders(self, client, mock_reminder_store):
         response = client.get("/api/reminders")

--- a/tests/test_scheduler_api.py
+++ b/tests/test_scheduler_api.py
@@ -73,6 +73,19 @@ class TestSchedulerAPI:
         })
         assert resp.status_code == 400
 
+    def test_create_failure_is_never_success_shaped(self, mock_store):
+        """#609: a store write failure must be a non-2xx, never a 200 with
+        the created schedule's own shape."""
+        from fastapi.testclient import TestClient
+        from api.main import app
+
+        mock_store.create.side_effect = OSError("disk write failed")
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/api/scheduler", json={
+            "name": "X", "schedule_type": "cron", "schedule_value": "0 9 * * *", "action": "notify",
+        })
+        assert not (200 <= resp.status_code < 300)
+
     def test_create_invalid_action(self, client, mock_store):
         resp = client.post("/api/scheduler", json={
             "name": "X", "schedule_type": "cron", "schedule_value": "0 9 * * *",

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -85,6 +85,24 @@ class TestTasksAPI:
         })
         assert response.status_code in (400, 422)  # Validation error
 
+    def test_create_task_failure_is_never_success_shaped(self, mock_task_manager):
+        """#609: if the write itself fails (disk error, index corruption,
+        whatever `TaskManager.create` raises for), the caller must see a
+        non-2xx status — never a 200 with the created task's own shape,
+        which is the false-confirmation pattern this issue exists to close.
+
+        Uses `raise_server_exceptions=False` because this route has no
+        try/except of its own — it relies on FastAPI's default unhandled-
+        exception -> 500 behavior, which the default TestClient re-raises
+        into the test instead of returning, for debuggability."""
+        from fastapi.testclient import TestClient
+        from api.main import app
+
+        mock_task_manager.create.side_effect = OSError("disk write failed")
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/api/tasks", json={"description": "Pull 1099 from Schwab"})
+        assert not (200 <= response.status_code < 300)
+
     # --- DRY RUN (#138) ---
 
     def test_dry_run_with_agent_tag_returns_preflight_preview(self, client, mock_task_manager):


### PR DESCRIPTION
## Problem

A Hermes session reported writing tasks to the vault inbox. The tasks were not there.

The specific instance is already explained and fixed: before #603, the MCP schema advertised `CreateTaskRequest.tags` as `string`, so a schema-following model sent a string, received a 400, and reported success anyway. **This PR closes the class, not the instance.**

## The audit

`docs/specs/technical/architecture.md` gains a "Write Endpoint Failure Contract" section auditing all 17 curated write tools, with a **Consumers** column naming which of {MCP, worker, native tool loop} actually detects each endpoint's failure.

That column is the point. `tasks.py` was always honest — it raises `HTTPException` — and the bug still happened, because the schema lied upstream and no consumer flagged the result. An audit of endpoint *shapes* alone would have marked that row clean and missed the defect entirely.

## Two more endpoints with the #603 anti-pattern

Both reachable via `lifeos_sync_trigger`:

- `POST /api/admin/calendar/sync` — `except Exception` returned `CalendarSyncResponse(status="error", ...)` at HTTP 200.
- `POST /api/photos/sync` — same shape, with the error nested inside `stats["error"]` where no generic top-level check could see it.

Both now return a `JSONResponse` carrying a **top-level `error` key** alongside the existing fields. `JSONResponse` specifically, so `response_model` validation cannot filter the extra key out, and a success can never carry `"error": null` as a false positive.

**Status codes deliberately stay 200.** The criterion accepts a non-2xx status *or* a top-level error, and 200-with-an-explicit-error breaks no existing caller — the request *was* served; the sync failed. This endpoint family already returns legitimately degraded outcomes at 200 (`indexer.sync()`'s `partial` status), left untouched. Whether a total failure should instead be non-2xx is a separate contract decision with a consumer migration, tracked as **#614** — not a side effect of a legibility fix.

## No consumer code needed changing — verified, not assumed

`_handle_sync_trigger` passes a 2xx body through unmodified, so `dispatch()`'s existing generic `"error" in data` check already flips `isError`. `ToolRegistry.dispatch` derives `is_error` from the identical check. Both are now pinned by tests rather than trusted.

## The durability guarantee

`TestWriteEndpointNeverReturnsSuccessShapedFailure` enumerates write endpoints from `CURATED_ENDPOINTS` plus the sub-routes `_handle_sync_trigger` fans out to — driven by *calling* that routing logic, not a re-typed copy — resolves each to its real FastAPI route, and AST-scans for the anti-pattern.

- `_KNOWN_EXEMPTIONS` is **empty**: both endpoints were fixed rather than waived, so any future addition to it is a deliberate, visible act.
- A meta-assertion fails if the enumeration itself discovers nothing, so the test cannot pass vacuously.

**Proved empirically, not asserted:** reverting `admin.py`'s fix made the test fail, and separately adding a brand-new `CURATED_ENDPOINTS` entry with a fresh route carrying the anti-pattern was also caught. Both reverted; `mcp_server.py` has zero diff.

Also pins that `tags` is advertised as an array — the exact mistyping behind the original incident, which `_unwrap_optional` could regress.

## Verification

- Unit: 3562 passed / 8 skipped (baseline 3547 + 15 new)
- Server-free browser set: passed
- The #603 MCP error-shape tests continue to pass unmodified.

Incidental: three pre-existing ruff findings in `photos.py` and `test_calendar_indexer.py` (unused imports, an f-string with no placeholder). The pre-commit hook lints whole staged files, so they blocked the commit either way.

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)