### PR TITLE
feat(chat): a turn's lifetime is owned by the server, not the connection

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -210,6 +210,21 @@ async def lifespan(app: FastAPI):
 
     yield  # Application runs here
 
+    # Shutdown: drain in-flight chat turns (#611). A turn's task now runs
+    # independently of its SSE reader, so a shutdown here (e.g. a mid-turn
+    # auto-redeploy, #437) would otherwise just kill it via task
+    # cancellation at process exit with no chance to persist anything —
+    # this cancels every turn explicitly and awaits its own partial-persist
+    # handling first, so a redeploy stores an honest partial instead of
+    # silently losing the turn. Runs before the other shutdown blocks below
+    # since those don't depend on it and a turn task may itself touch
+    # services (the conversation/usage stores) that should still be up.
+    try:
+        from api.services.chat_turns import get_turn_registry
+        await get_turn_registry().shutdown()
+    except Exception as e:
+        logger.error(f"Failed to drain in-flight chat turns: {e}")
+
     # Shutdown: Stop services
     if _calendar_indexer:
         _calendar_indexer.stop_scheduler()

--- a/api/routes/_proxy.py
+++ b/api/routes/_proxy.py
@@ -5,6 +5,8 @@ Keeps the security-relevant header-filtering and timeout in one place so the
 voice, agent, and hermes proxies stay in lockstep.
 """
 
+import asyncio
+import json
 import logging
 from typing import Callable, Optional
 
@@ -13,6 +15,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from config.settings import settings
+from api.services.chat_turns import get_turn_registry
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +37,23 @@ HOP_BY_HOP = frozenset({
 def filter_headers(headers) -> dict:
     """Drop hop-by-hop (and inbound auth) headers before forwarding."""
     return {k: v for k, v in headers.items() if k.lower() not in HOP_BY_HOP}
+
+
+def _sniff_modality(raw_body: bytes) -> str:
+    """Best-effort read of the request's `modality` field (#611), straight
+    off the same raw pre-transform body `transform_body`/`make_observer`
+    already receive — generic across whatever backend uses this router, not
+    Hermes-specific. Used only to gate a relayed turn out of detachment the
+    same way the native path does (see ChatTurn.reader()'s voice gate);
+    anything unparseable defaults to "text" rather than raising, since a
+    malformed body is `transform_body`'s problem to reject, not this one's."""
+    try:
+        data = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return "text"
+    if not isinstance(data, dict):
+        return "text"
+    return "voice" if (data.get("modality") or "").strip().lower() == "voice" else "text"
 
 
 def make_backend_router(
@@ -88,6 +108,21 @@ def make_backend_router(
     needed" gate means Hermes (which already buffers for the envelope)
     doesn't pay for a second `request.body()` read, and Agent (neither hook
     set) still never buffers.
+
+    `make_observer` being set ALSO gates a second behavior (#611): the
+    upstream drain runs as a registry-owned background pump
+    (`api/services/chat_turns.py`) rather than the browser-facing generator
+    itself, so a disconnect no longer aborts it mid-relay — the pump keeps
+    draining upstream and calls `observer.observe()`/`finalize()` exactly as
+    before, now from its own `finally` instead of the response generator's.
+    The client-visible bytes and their order are unaffected either way: the
+    browser reads from a `ChatTurn.reader()` that receives the identical
+    sequence of chunks the plain `relay()` below would have yielded it. This
+    is why Agent (no observer, ever) is untouched by #611 — detaching a
+    relay nothing persists would only spend money with nothing to show for
+    it — and why an observer that returns `None` for a given request (a
+    `make_observer` configured but declining to observe this one) falls
+    through to the plain, still-client-tied `relay()` for that request.
     """
     router = APIRouter(prefix=prefix, tags=[tag])
 
@@ -131,6 +166,45 @@ def make_backend_router(
             await client.aclose()
             logger.warning("%s backend request failed: %s", backend_label, exc)
             raise HTTPException(status_code=502, detail=f"{backend_label} backend unreachable: {exc}")
+
+        if observer is not None:
+            # Registry-owned pump (#611): gated on `observer` (not just
+            # `make_observer` being configured) — this is the ONLY backend
+            # with something to persist for THIS request; if `make_observer`
+            # returned None (e.g. an unparseable body it chose not to raise
+            # on) there's nothing to gain from detaching, so that case falls
+            # through to the plain `relay()` below unchanged. The Agent
+            # backend never sets `make_observer` at all, so `observer` is
+            # always None there and it always takes the plain path —
+            # detaching would only spend money on a relay nothing observes.
+            turn = get_turn_registry().create(
+                conversation_id=None, modality=_sniff_modality(raw_body),
+            )
+            if hasattr(observer, "bind_turn"):
+                observer.bind_turn(turn)
+
+            async def _pump():
+                try:
+                    async for chunk in upstream.aiter_raw():
+                        # Observe before emitting (#592 review, preserved) —
+                        # see make_backend_router's docstring above for why
+                        # the order matters for an early client disconnect.
+                        observer.observe(chunk)
+                        await turn.emit(chunk)
+                finally:
+                    observer.finalize()
+                    await upstream.aclose()
+                    await client.aclose()
+                    get_turn_registry().pop(turn)
+                    await turn.close()
+
+            turn.task = asyncio.create_task(_pump())
+            return StreamingResponse(
+                turn.reader(),
+                status_code=upstream.status_code,
+                headers=filter_headers(upstream.headers),
+                media_type=upstream.headers.get("content-type"),
+            )
 
         async def relay():
             try:

--- a/api/routes/_proxy.py
+++ b/api/routes/_proxy.py
@@ -56,6 +56,24 @@ def _sniff_modality(raw_body: bytes) -> str:
     return "voice" if (data.get("modality") or "").strip().lower() == "voice" else "text"
 
 
+def _sniff_client_turn_id(raw_body: bytes) -> Optional[str]:
+    """Best-effort read of the request's opaque `client_turn_id` field
+    (#611 review), the same way `_sniff_modality` reads `modality` — off
+    the raw pre-transform body, generic across whatever backend uses this
+    router. `None` for anything missing, wrong-typed, or unparseable;
+    length/character validation already happened at the native
+    `AskStreamRequest` layer (this is Hermes's own copy of that same
+    request), so this is a plain read, not re-validation."""
+    try:
+        data = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    client_turn_id = data.get("client_turn_id")
+    return client_turn_id if isinstance(client_turn_id, str) and client_turn_id else None
+
+
 def make_backend_router(
     *, prefix, tag, backend_label, url_attr, token_attr, client_factory,
     transform_body: Optional[Callable[[bytes], bytes]] = None,
@@ -177,8 +195,17 @@ def make_backend_router(
             # backend never sets `make_observer` at all, so `observer` is
             # always None there and it always takes the plain path —
             # detaching would only spend money on a relay nothing observes.
+            # Supersede (#611 review): a reused client_turn_id cancels
+            # whatever turn is still holding it, same as the native path —
+            # a stale/duplicate key resolves to the newest claimant, never
+            # a stray old one.
+            client_turn_id = _sniff_client_turn_id(raw_body)
+            if client_turn_id:
+                get_turn_registry().cancel_by_client_turn_id(client_turn_id)
             turn = get_turn_registry().create(
-                conversation_id=None, modality=_sniff_modality(raw_body),
+                conversation_id=None,
+                modality=_sniff_modality(raw_body),
+                client_turn_id=client_turn_id,
             )
             if hasattr(observer, "bind_turn"):
                 observer.bind_turn(turn)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -384,6 +384,31 @@ class AskStreamRequest(BaseModel):
     # resolve a persona, or pick a model; omitted (the default) reproduces
     # today's tagging ("lifeos") exactly.
     backend: Optional[str] = None
+    # Opaque, client-generated turn key (#611 review). `conversation_id`
+    # alone can't cancel a turn before its first SSE frame ever arrives —
+    # the request that started it carries `conversation_id: None` for a
+    # brand-new conversation, and the real id only shows up in the
+    # `conversation_id` SSE event. That's exactly the window a voice
+    # barge-in on a first turn falls into, so `POST /api/chat/cancel`
+    # accepts this key too. The client mints it (any opaque string works —
+    # not required to be a UUID) before sending; the server never generates
+    # or returns one. Optional and additive: omitting it changes nothing.
+    client_turn_id: Optional[str] = None
+
+    @field_validator("client_turn_id")
+    @classmethod
+    def validate_client_turn_id(cls, v):
+        # Opaque bounded string, not a trusted identifier — bounded to stop
+        # something huge or control-character-laden from reaching the
+        # in-memory registry key space. Not assumed to be a UUID: whatever
+        # scheme a client uses to generate a locally-unique key is fine.
+        if v is None:
+            return v
+        if len(v) > 200:
+            raise ValueError(f"client_turn_id exceeds 200 chars (got {len(v)})")
+        if any(ord(c) < 0x20 or ord(c) == 0x7f for c in v):
+            raise ValueError("client_turn_id must not contain control characters")
+        return v
 
     @field_validator("persona")
     @classmethod
@@ -536,12 +561,21 @@ async def ask_stream(request: AskStreamRequest):
     # the voice gate); text/unset turns survive the client leaving, voice
     # turns keep today's disconnect-cancels semantics.
     _modality = (request.modality or "").strip().lower() or "text"
-    # Supersede (#611): a new turn on a conversation that already has one in
-    # flight cancels the old one first — asking again is itself a stop
-    # gesture, and it prevents a stale reply landing after a newer question.
+    # Supersede (#611): a new turn on a conversation OR client_turn_id that
+    # already has one in flight cancels the old one first — asking again is
+    # itself a stop gesture, and it prevents a stale reply landing after a
+    # newer question. Checking client_turn_id too closes the same gap the
+    # explicit cancel endpoint closes (#611 review): a reused/duplicate key
+    # supersedes rather than silently colliding with an unrelated turn.
     if request.conversation_id:
         get_turn_registry().cancel_conversation(request.conversation_id)
-    turn = get_turn_registry().create(conversation_id=request.conversation_id, modality=_modality)
+    if request.client_turn_id:
+        get_turn_registry().cancel_by_client_turn_id(request.client_turn_id)
+    turn = get_turn_registry().create(
+        conversation_id=request.conversation_id,
+        modality=_modality,
+        client_turn_id=request.client_turn_id,
+    )
 
     async def _content(text: str) -> None:
         """Emit a `content` SSE frame AND accumulate it into `partial_text`
@@ -1058,6 +1092,44 @@ async def ask_stream(request: AskStreamRequest):
             "Connection": "keep-alive",
         }
     )
+
+
+class ChatCancelRequest(BaseModel):
+    """Cancel a chat turn by its client-supplied key (#611 review)."""
+    client_turn_id: str
+
+    @field_validator("client_turn_id")
+    @classmethod
+    def validate_client_turn_id(cls, v):
+        if not v:
+            raise ValueError("client_turn_id cannot be empty")
+        if len(v) > 200:
+            raise ValueError(f"client_turn_id exceeds 200 chars (got {len(v)})")
+        if any(ord(c) < 0x20 or ord(c) == 0x7f for c in v):
+            raise ValueError("client_turn_id must not contain control characters")
+        return v
+
+
+@router.post("/chat/cancel")
+async def chat_cancel(request: ChatCancelRequest):
+    """Cancel a chat turn (native or Hermes-relayed) by `client_turn_id` —
+    the key the client mints and sends on `POST /api/ask/stream`, BEFORE it
+    has a `conversation_id` to cancel by (#611 review). This closes the
+    "first-turn barge-in" gap `POST /api/conversations/{id}/cancel` alone
+    can't: a request that hasn't reached its first SSE frame yet has no
+    conversation id, but the client already has the key it generated.
+
+    There is no 404 here — unlike the conversation-scoped endpoint, there's
+    no existing resource to validate against (a `client_turn_id` might
+    legitimately never have been claimed, e.g. the turn already finished
+    and was popped from the registry, or the key was never used). `200` +
+    `cancelled: false` covers every "nothing to cancel" case; this must
+    never be a 4xx, since a gateway that fires its cancel POST slightly
+    ahead of the turn actually finishing needs that to read as success, not
+    an error.
+    """
+    cancelled = get_turn_registry().cancel_by_client_turn_id(request.client_turn_id)
+    return {"ok": True, "cancelled": cancelled}
 
 
 class HandoffRequest(BaseModel):

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -33,6 +33,7 @@ from config.settings import settings
 from api.services.google_auth import GoogleAccount
 from api.services.perf_trace import start_trace, trace_span, finish_trace, _current_trace
 from api.services.agent_system_prompt import build_turn_context
+from api.services.chat_turns import get_turn_registry, TRUNCATION_MARKER, truncation_routing
 
 logger = logging.getLogger(__name__)
 
@@ -529,11 +530,42 @@ async def ask_stream(request: AskStreamRequest):
         _effective_pid = next((b.name for b in settings.telegram_bots if b.persona == request.persona), None)
     personal_context = settings.personal_context(_effective_pid or "")
 
-    async def generate():
+    # #611: the turn's lifetime is owned by the server from here on, not by
+    # this SSE connection. `modality` decides how a disconnect behaves once
+    # the turn task is running (see ChatTurn.reader() in chat_turns.py for
+    # the voice gate); text/unset turns survive the client leaving, voice
+    # turns keep today's disconnect-cancels semantics.
+    _modality = (request.modality or "").strip().lower() or "text"
+    # Supersede (#611): a new turn on a conversation that already has one in
+    # flight cancels the old one first — asking again is itself a stop
+    # gesture, and it prevents a stale reply landing after a newer question.
+    if request.conversation_id:
+        get_turn_registry().cancel_conversation(request.conversation_id)
+    turn = get_turn_registry().create(conversation_id=request.conversation_id, modality=_modality)
+
+    async def _content(text: str) -> None:
+        """Emit a `content` SSE frame AND accumulate it into `partial_text`
+        (#611) — the running "what has the user actually seen so far" used
+        to persist an honest partial if this turn is interrupted. Reset to
+        "" on `self_correction`, mirroring `ask-stream.js`'s `fullContent`:
+        `agent_result.full_text` only gains a round's text at round end, so
+        it is NOT what was actually streamed and isn't safe to use here."""
+        nonlocal partial_text
+        partial_text += text
+        await turn.emit(f"data: {json.dumps({'type': 'content', 'content': text})}\n\n")
+
+    partial_text = ""
+
+    async def _run_turn():
+        nonlocal partial_text
+        # Pre-initialized outside the try (a plain assignment can't itself be
+        # interrupted) so the except/finally clauses below always have a
+        # defined `conversation_id`, even if a cancellation lands before the
+        # branch that would otherwise set it for a brand-new conversation.
+        conversation_id = turn.conversation_id
         try:
             # Get or create conversation
             store = get_store()
-            conversation_id = request.conversation_id
 
             if not conversation_id:
                 # Create new conversation, tagged with the selected persona so
@@ -546,6 +578,11 @@ async def ask_stream(request: AskStreamRequest):
                     backend=request.backend or "lifeos",
                 )
                 conversation_id = conv.id
+                # #611: bind the turn to its conversation id now that one
+                # exists, so it becomes cancellable/supersedable by that id.
+                # (An id supplied in the request was already bound at
+                # creation, in ask_stream(), before this task started.)
+                get_turn_registry().bind(turn, conversation_id)
                 # Generate title from question
                 title = generate_title(request.question)
                 store.update_title(conversation_id, title)
@@ -555,7 +592,7 @@ async def ask_stream(request: AskStreamRequest):
             start_trace(conversation_id, request.question)
 
             # Send conversation ID to client
-            yield f"data: {json.dumps({'type': 'conversation_id', 'conversation_id': conversation_id})}\n\n"
+            await turn.emit(f"data: {json.dumps({'type': 'conversation_id', 'conversation_id': conversation_id})}\n\n")
 
             # Save user message
             store.add_message(conversation_id, "user", request.question)
@@ -566,7 +603,7 @@ async def ask_stream(request: AskStreamRequest):
             _stripped = request.question.strip()
             if _stripped.lower() == "/agent" or _stripped.lower().startswith("/agent "):
                 async for _ev in _handle_agent_slash(_stripped, conversation_id, store):
-                    yield _ev
+                    await turn.emit(_ev)
                 return
 
             # Model picker → "Claude Code": the toolbar model dropdown can pin a
@@ -580,9 +617,9 @@ async def ask_stream(request: AskStreamRequest):
             # not an LLM turn). The frontend treats an explicit pick as its own
             # handoff opt-in, bypassing the persona capability gate (#359).
             if (request.model_override or "").strip().lower() == "claude_code":
-                yield f"data: {json.dumps({'type': 'routing', 'sources': ['claude_code'], 'reasoning': 'Model picker → Claude Code', 'latency_ms': 0})}\n\n"
-                yield f"data: {json.dumps({'type': 'claude_intent', 'task': request.question, 'engine': 'claude_code'})}\n\n"
-                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'routing', 'sources': ['claude_code'], 'reasoning': 'Model picker → Claude Code', 'latency_ms': 0})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'claude_intent', 'task': request.question, 'engine': 'claude_code'})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                 return
 
             # Orchestrating personas (e.g. doctor) run as a Claude Code session,
@@ -601,7 +638,7 @@ async def ask_stream(request: AskStreamRequest):
                     f"{persona_preamble}\n\n---\n\nThe user just sent this via the "
                     f"{request.persona_id} surface:\n\n{request.question}"
                 )
-                yield f"data: {json.dumps({'type': 'routing', 'sources': ['claude_code'], 'reasoning': f'Orchestrating persona ({request.persona_id}) → Claude Code session', 'latency_ms': 0})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'routing', 'sources': ['claude_code'], 'reasoning': f'Orchestrating persona ({request.persona_id}) → Claude Code session', 'latency_ms': 0})}\n\n")
                 try:
                     _spawn = await asyncio.to_thread(
                         spawn_claude_code_session, SessionStore(), spawn_prompt,
@@ -632,12 +669,12 @@ async def ask_stream(request: AskStreamRequest):
                     )
                 else:
                     ack = f"⚠️ Couldn't start the session: {_spawn.get('error', 'spawn failed')}"
-                yield f"data: {json.dumps({'type': 'content', 'content': ack})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'content', 'content': ack})}\n\n")
                 store.add_message(conversation_id, "assistant", ack, routing={
                     "reasoning": f"orchestrating persona {request.persona_id} → claude_code",
                     "sources": ["claude_code"],
                 })
-                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                 return
 
             # Get conversation history for context in follow-up questions
@@ -686,28 +723,35 @@ async def ask_stream(request: AskStreamRequest):
                                         "created_reminder": {"id": reminder.id, "name": reminder.name},
                                     }
                                     for chunk in response_text:
-                                        yield f"data: {json.dumps({'type': 'content', 'content': chunk})}\n\n"
+                                        await _content(chunk)
                                         await asyncio.sleep(0.005)
                                     store.add_message(conversation_id, "assistant", response_text, routing=routing_metadata)
-                                    yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                                    # Persisted in full above — clear the accumulator so a
+                                    # cancellation on the way out (e.g. during the emit/return
+                                    # below) can't re-persist it as if it were only a partial
+                                    # (#611: would otherwise double-write this message).
+                                    partial_text = ""
+                                    await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                                     return
                             else:
                                 response_text = f"Selected reminder: **\"{reminder.name}\"**"
 
                             for chunk in response_text:
-                                yield f"data: {json.dumps({'type': 'content', 'content': chunk})}\n\n"
+                                await _content(chunk)
                                 await asyncio.sleep(0.005)
                             store.add_message(conversation_id, "assistant", response_text)
-                            yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                            partial_text = ""  # already persisted in full -- see comment above
+                            await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                             return
                 else:
                     # Invalid number
                     response_text = f"Please enter a number between 1 and {len(conv_context.pending_selection_items)}."
                     for chunk in response_text:
-                        yield f"data: {json.dumps({'type': 'content', 'content': chunk})}\n\n"
+                        await _content(chunk)
                         await asyncio.sleep(0.005)
                     store.add_message(conversation_id, "assistant", response_text)
-                    yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                    partial_text = ""  # already persisted in full -- see comment above
+                    await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                     return
 
             # Explicit engine handoff (#305 part b): the user named a CLI engine
@@ -719,9 +763,9 @@ async def ask_stream(request: AskStreamRequest):
             _engine, _engine_task = parse_engine_directive(request.question)
             if _engine:
                 _label = "Codex" if _engine == "codex" else "Claude Code"
-                yield f"data: {json.dumps({'type': 'routing', 'sources': [_engine], 'reasoning': f'User-directed handoff to {_label}', 'latency_ms': 0})}\n\n"
-                yield f"data: {json.dumps({'type': 'claude_intent', 'task': _engine_task, 'engine': _engine})}\n\n"
-                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'routing', 'sources': [_engine], 'reasoning': f'User-directed handoff to {_label}', 'latency_ms': 0})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'claude_intent', 'task': _engine_task, 'engine': _engine})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                 return
 
             # Intent classification for special dispatch cases only.
@@ -735,20 +779,21 @@ async def ask_stream(request: AskStreamRequest):
                 # ---- AMBIGUOUS: could be task or reminder ----
                 print("DETECTED AMBIGUOUS TASK/REMINDER INTENT")
                 response_text = "Should I add this as a **to-do** in your task list, or set a **timed reminder** to ping you about it, or both?"
-                yield f"data: {json.dumps({'type': 'routing', 'sources': ['clarification'], 'reasoning': 'Ambiguous task/reminder', 'latency_ms': 0})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'routing', 'sources': ['clarification'], 'reasoning': 'Ambiguous task/reminder', 'latency_ms': 0})}\n\n")
                 for chunk in response_text:
-                    yield f"data: {json.dumps({'type': 'content', 'content': chunk})}\n\n"
+                    await _content(chunk)
                     await asyncio.sleep(0.005)
                 store.add_message(conversation_id, "assistant", response_text)
-                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                partial_text = ""  # already persisted in full -- see comment above
+                await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                 return
 
             elif action_intent and action_intent.category == "claude":
                 # ---- CLAUDE CODE: requires terminal/filesystem/browser ----
                 print("DETECTED CLAUDE INTENT - delegating to Claude Code")
-                yield f"data: {json.dumps({'type': 'routing', 'sources': ['claude_code'], 'reasoning': 'Action requires terminal/filesystem/browser access', 'latency_ms': 0})}\n\n"
-                yield f"data: {json.dumps({'type': 'claude_intent', 'task': request.question, 'engine': 'claude_code'})}\n\n"
-                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'routing', 'sources': ['claude_code'], 'reasoning': 'Action requires terminal/filesystem/browser access', 'latency_ms': 0})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'claude_intent', 'task': request.question, 'engine': 'claude_code'})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                 return
 
             # --- REMOVED: legacy compose/task/reminder handlers ---
@@ -834,9 +879,9 @@ async def ask_stream(request: AskStreamRequest):
                 # context.
                 from api.services.agent_loop import _original_request
                 _handoff_task = _original_request(conversation_history, request.question)
-                yield f"data: {json.dumps({'type': 'routing', 'sources': [orchestrator_model], 'reasoning': f'Escalation ladder → {_label}', 'latency_ms': 0})}\n\n"
-                yield f"data: {json.dumps({'type': 'claude_intent', 'task': _handoff_task, 'engine': orchestrator_model})}\n\n"
-                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'routing', 'sources': [orchestrator_model], 'reasoning': f'Escalation ladder → {_label}', 'latency_ms': 0})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'claude_intent', 'task': _handoff_task, 'engine': orchestrator_model})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                 return
             if escalated:
                 logger.info("escalating chat turn to %s (user-directed or refusal+pushback)", orchestrator_model)
@@ -865,7 +910,7 @@ async def ask_stream(request: AskStreamRequest):
                 f'Agentic loop — escalated to {orchestrator_model}'
                 if escalated else f'Agentic loop ({orchestrator_model})'
             )
-            yield f"data: {json.dumps({'type': 'routing', 'sources': ['agent'], 'reasoning': _routing_reason, 'latency_ms': 0})}\n\n"
+            await turn.emit(f"data: {json.dumps({'type': 'routing', 'sources': ['agent'], 'reasoning': _routing_reason, 'latency_ms': 0})}\n\n")
 
             # Consume the async generator from the agent loop
             agent_result = None
@@ -882,17 +927,25 @@ async def ask_stream(request: AskStreamRequest):
                 force_local=force_local,
             ):
                 if event["type"] == "text":
-                    yield f"data: {json.dumps({'type': 'content', 'content': event['content']})}\n\n"
+                    await _content(event['content'])
                 elif event["type"] == "status":
-                    yield f"data: {json.dumps({'type': 'status', 'message': event['message']})}\n\n"
+                    await turn.emit(f"data: {json.dumps({'type': 'status', 'message': event['message']})}\n\n")
                 elif event["type"] == "self_correction":
-                    yield f"data: {json.dumps({'type': 'self_correction'})}\n\n"
+                    # #611: what was streamed so far is superseded by the
+                    # self-corrected retry that follows — mirrors
+                    # ask-stream.js's `fullContent = ''` reset, and matters
+                    # here because `agent_result.full_text` only gains a
+                    # round's text at round end, so it is NOT what the user
+                    # actually saw and isn't safe to persist on a
+                    # cancellation that lands mid-correction.
+                    partial_text = ""
+                    await turn.emit(f"data: {json.dumps({'type': 'self_correction'})}\n\n")
                 elif event["type"] == "result":
                     agent_result = event["result"]
 
             if agent_result is None:
-                yield f"data: {json.dumps({'type': 'error', 'message': 'Agent loop returned no result'})}\n\n"
-                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'error', 'message': 'Agent loop returned no result'})}\n\n")
+                await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
                 return
 
             # Record usage
@@ -905,7 +958,7 @@ async def ask_stream(request: AskStreamRequest):
                     cost_usd=agent_result.total_cost_usd,
                     conversation_id=conversation_id,
                 )
-                yield f"data: {json.dumps({'type': 'usage', 'input_tokens': agent_result.total_input_tokens, 'output_tokens': agent_result.total_output_tokens, 'cost_usd': agent_result.total_cost_usd, 'model': agent_result.model})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'usage', 'input_tokens': agent_result.total_input_tokens, 'output_tokens': agent_result.total_output_tokens, 'cost_usd': agent_result.total_cost_usd, 'model': agent_result.model})}\n\n")
 
             # Build source list from tool calls
             sources = []
@@ -929,7 +982,7 @@ async def ask_stream(request: AskStreamRequest):
                     })
 
             if request.include_sources and sources:
-                yield f"data: {json.dumps({'type': 'sources', 'sources': sources})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'sources', 'sources': sources})}\n\n")
 
             # Save assistant response
             routing_metadata = {
@@ -944,21 +997,61 @@ async def ask_stream(request: AskStreamRequest):
                 sources=sources,
                 routing=routing_metadata,
             )
+            # Persisted in full above (the authoritative agent_result.full_text,
+            # not the streamed partial_text) -- clear the accumulator so a
+            # cancellation on the way out below can't re-persist it as a
+            # truncated duplicate of the message just written (#611).
+            partial_text = ""
             print(f"Saved assistant response ({len(agent_result.full_text)} chars, {len(agent_result.tool_calls_log)} tool calls)")
 
             # Finish performance trace and emit it
             perf_trace = finish_trace()
             if perf_trace:
-                yield f"data: {json.dumps({'type': 'perf_trace', 'trace_id': perf_trace.trace_id, 'total_ms': round(perf_trace.total_ms, 1), 'spans': [{'name': s.name, 'duration_ms': s.duration_ms, 'parent': s.parent} for s in perf_trace.spans]})}\n\n"
+                await turn.emit(f"data: {json.dumps({'type': 'perf_trace', 'trace_id': perf_trace.trace_id, 'total_ms': round(perf_trace.total_ms, 1), 'spans': [{'name': s.name, 'duration_ms': s.duration_ms, 'parent': s.parent} for s in perf_trace.spans]})}\n\n")
 
-            yield f"data: {json.dumps({'type': 'done'})}\n\n"
+            await turn.emit(f"data: {json.dumps({'type': 'done'})}\n\n")
 
+        except asyncio.CancelledError:
+            # #611: the client disconnected (survivable turn, now cancelled
+            # by an explicit /cancel, a supersede, the detached-lifetime
+            # deadline, or a shutdown drain), or this is a voice turn whose
+            # disconnect immediately cancels it (see ChatTurn.reader()'s
+            # voice gate). Persist whatever the user had already seen rather
+            # than losing it outright — marked so it's never mistaken for a
+            # finished reply.
+            if conversation_id and partial_text:
+                store.add_message(
+                    conversation_id, "assistant", partial_text + TRUNCATION_MARKER,
+                    routing=truncation_routing(turn.cancel_reason or "cancelled"),
+                )
+            finish_trace()
+            raise
         except Exception as e:
             finish_trace()  # Clean up trace on error
-            yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
+            if conversation_id and partial_text:
+                # #611: a genuine mid-stream error (e.g. the agent loop
+                # itself raised) used to leave NOTHING persisted even though
+                # partial_text had already reached the browser -- an
+                # invisible truncation with no signal anything went wrong.
+                # Persist it, marked, same as an explicit cancellation.
+                store.add_message(
+                    conversation_id, "assistant", partial_text + TRUNCATION_MARKER,
+                    routing=truncation_routing("stream_error"),
+                )
+            await turn.emit(f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n")
+        finally:
+            get_turn_registry().pop(turn)
+            await turn.close()
 
+    # #611: start the turn as a background task NOW -- it owns its own
+    # lifetime from here on -- and hand StreamingResponse a reader over its
+    # queue rather than the turn's own generator. A connected client's frame
+    # sequence is unaffected (emit() backpressures exactly like a bare
+    # `yield` did), but closing this reader (a disconnect) no longer stops
+    # the task underneath it.
+    turn.task = asyncio.create_task(_run_turn())
     return StreamingResponse(
-        generate(),
+        turn.reader(),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -6,6 +6,7 @@ Manages conversation threads with persistence.
 import json
 import asyncio
 import logging
+from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException
@@ -18,6 +19,7 @@ from api.services.conversation_store import (
 from api.services.hybrid_search import HybridSearch
 from api.services.synthesizer import construct_prompt, get_synthesizer
 from api.services.query_router import QueryRouter
+from api.services.chat_turns import get_turn_registry
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +59,16 @@ class PendingQuestionResponse(BaseModel):
     kind: str  # clarification | goal_approval | followup
 
 
+class ActiveTurnResponse(BaseModel):
+    """A chat turn (#611) currently running for this conversation — server-
+    side, regardless of whether any client is watching it. Lets a
+    reconnecting client show "still working..." and reach the Stop
+    affordance even after a reload."""
+    turn_id: str
+    conversation_id: str
+    started_at: str
+
+
 class ConversationDetailResponse(BaseModel):
     """Response with full conversation including messages."""
     id: str
@@ -75,6 +87,10 @@ class ConversationDetailResponse(BaseModel):
     # uses this to STOP once the session is done and nothing awaits an answer —
     # otherwise the 4s poll would run forever after the session finishes.
     agent_session_active: bool = False
+    # Present iff a #611 chat turn is currently in flight for this
+    # conversation (native or Hermes-relayed) — absent/None otherwise,
+    # including for an ordinary completed turn.
+    active_turn: Optional[ActiveTurnResponse] = None
 
 
 class ConversationListResponse(BaseModel):
@@ -205,7 +221,45 @@ async def get_conversation(conversation_id: str):
         ],
         pending_question=pending_question,
         agent_session_active=agent_session_active,
+        active_turn=_active_turn_response(conversation_id),
     )
+
+
+def _active_turn_response(conversation_id: str) -> Optional[ActiveTurnResponse]:
+    """The in-flight #611 turn for this conversation, if any, as the
+    response shape. `None` for a conversation with no turn registered, or
+    whose registered turn has already finished (its task exists but is
+    done) — a narrow window that closes as soon as the task's own `finally`
+    pops the registry entry."""
+    turn = get_turn_registry().get_by_conversation(conversation_id)
+    if turn is None or turn.task is None or turn.task.done():
+        return None
+    return ActiveTurnResponse(
+        turn_id=turn.turn_id,
+        conversation_id=turn.conversation_id,
+        started_at=datetime.fromtimestamp(turn.started_at).isoformat(),
+    )
+
+
+@router.post("/{conversation_id}/cancel")
+async def cancel_conversation_turn(conversation_id: str):
+    """Stop a #611 chat turn in flight for this conversation, if any (native
+    or Hermes-relayed — both register in the same turn registry).
+
+    404 if the conversation itself doesn't exist; otherwise 200 with
+    `cancelled: false` when nothing was in flight (already finished, or
+    never started) — cancelling a turn that isn't running is a no-op, not
+    an error. A repeated cancel while the first is still tearing down
+    reports `cancelled: true` again (harmless — cancelling an
+    already-cancelling task is a no-op); once the turn's task actually
+    finishes and its `finally` pops the registry entry, a further cancel
+    reports `false`.
+    """
+    store = get_store()
+    if store.get_conversation(conversation_id) is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    cancelled = get_turn_registry().cancel_conversation(conversation_id)
+    return {"ok": True, "cancelled": cancelled}
 
 
 @router.delete("/{conversation_id}", status_code=204)

--- a/api/routes/hermes_proxy.py
+++ b/api/routes/hermes_proxy.py
@@ -36,6 +36,7 @@ from config.settings import settings  # noqa: F401
 from api.routes._proxy import TIMEOUT, make_backend_router
 from api.routes.chat import AskStreamRequest
 from api.services.agent_system_prompt import build_turn_context
+from api.services.chat_turns import TRUNCATION_MARKER, get_turn_registry, truncation_routing
 from api.services.conversation_store import get_store
 from api.services.usage_store import get_usage_store
 
@@ -188,6 +189,20 @@ class _HermesTurnPersister:
     partial `usage` event (missing/wrong-typed model or token counts) is
     ignored rather than raised; a well-formed event with no `cost_usd` is
     recorded with a zero cost rather than an invented one.
+
+    #611: `_proxy.py`'s pump now runs as a detached, registry-owned
+    background task, so `finalize()` fires on the REAL end of the turn (the
+    upstream connection closing) rather than on an early client disconnect —
+    a disconnected browser no longer truncates what gets persisted here (see
+    `bind_turn()`). What can still genuinely truncate a Hermes turn is the
+    upstream connection itself ending before a `done` event ever arrived
+    (Hermes crashed, was killed, or the connection dropped mid-turn) — this
+    class can't tell that apart from an ordinary network hiccup on its own,
+    so it tracks only whether `done` was observed and lets `finalize()`
+    decide: seen it, persist verbatim (as always); never saw it, append
+    `TRUNCATION_MARKER` and mark `routing.truncated` — the same visible
+    signal the native path gives a cancelled/errored turn, via the same
+    `truncation_routing()` helper.
     """
 
     _FRAME_SEP = b"\n\n"
@@ -204,6 +219,31 @@ class _HermesTurnPersister:
         self._usage_input_tokens = 0
         self._usage_output_tokens = 0
         self._usage_cost_usd = 0.0
+        # #611: whether a `done` event was ever observed -- see the class
+        # docstring's #611 paragraph. finalize() treats "never saw done" as
+        # a genuine truncation, distinct from #592's disconnect-truncation
+        # (which #611 eliminated for this class).
+        self._done_seen = False
+        # #611: the ChatTurn this persister's turn is registered under, once
+        # `_proxy.py`'s detached pump has one to hand it (bind_turn() is
+        # called right after construction, before any observe()). Kept so
+        # `_handle_event` can register the turn's conversation id with the
+        # shared registry the moment it's observed -- the same "learn the id
+        # from the first SSE frame" pattern the native path uses for a
+        # brand-new conversation, just triggered by an observed frame here
+        # instead of a locally-created row.
+        self._turn = None
+
+    def bind_turn(self, turn) -> None:
+        """Hook `_proxy.py`'s detached pump calls once it creates this
+        turn's `ChatTurn` — see the class docstring. If a `conversation_id`
+        was somehow already observed before this call (shouldn't happen in
+        practice: bind_turn() runs immediately after construction, before
+        the pump's first `observe()`), bind it immediately rather than
+        waiting for a `conversation_id` event that will never arrive again."""
+        self._turn = turn
+        if self._conversation_id is not None:
+            get_turn_registry().bind(turn, self._conversation_id)
 
     def observe(self, chunk: bytes) -> None:
         """Non-blocking, in-memory-only frame reassembly — see the class
@@ -262,10 +302,21 @@ class _HermesTurnPersister:
                     )
                 else:
                     self._conversation_id = conv_id
+                    # #611: the turn becomes cancellable/supersedable by this
+                    # id the moment it's known -- before this, it exists
+                    # (the pump is already running) but isn't reachable by
+                    # conversation id yet, a sub-second window acceptable
+                    # per the #611 design.
+                    if self._turn is not None:
+                        get_turn_registry().bind(self._turn, conv_id)
         elif etype == "content":
             content = event.get("content")
             if isinstance(content, str):
                 self._content_parts.append(content)
+        elif etype == "done":
+            # #611: the backend's own signal that this turn ran to a normal
+            # completion -- see the class docstring's #611 paragraph.
+            self._done_seen = True
         elif etype == "usage" and not self._usage_captured:
             # Not "seen once" like conversation_id above: a malformed usage
             # event (below) leaves `_usage_captured` False, so a later
@@ -293,10 +344,10 @@ class _HermesTurnPersister:
         self._usage_cost_usd = cost_usd
 
     def finalize(self) -> None:
-        """Write this turn to the stores, once each. Runs after the relay
-        has already handed off every byte it's going to (normal completion
-        or an early client disconnect), so it's the only place in this
-        class a blocking store call is allowed to happen.
+        """Write this turn to the stores, once each. Runs after the pump has
+        drained upstream to its real end (#611 — no longer just "however far
+        the browser stuck around for"), so it's the only place in this class
+        a blocking store call is allowed to happen.
 
         Conversation persistence and usage persistence are independent: a
         turn with no `conversation_id`/content still records usage if a
@@ -304,6 +355,17 @@ class _HermesTurnPersister:
         """
         if self._conversation_id is not None and self._content_parts:
             conv_id = self._conversation_id
+            content = "".join(self._content_parts)
+            # #611: no `done` event ever arrived -- the upstream connection
+            # ended (or is still running when this fires, e.g. a
+            # cancellation) without confirming the turn actually finished.
+            # Mark it the same way the native path marks a cancelled/errored
+            # turn, so a genuinely truncated Hermes reply is never presented
+            # as if it were whole.
+            routing = None
+            if not self._done_seen:
+                content += TRUNCATION_MARKER
+                routing = truncation_routing("stream_error")
             try:
                 store = get_store()
                 store.create_conversation(
@@ -314,7 +376,7 @@ class _HermesTurnPersister:
                 logger.warning("hermes turn persistence: failed to create conversation %r", conv_id, exc_info=True)
             else:
                 try:
-                    store.add_message(conv_id, "assistant", "".join(self._content_parts))
+                    store.add_message(conv_id, "assistant", content, routing=routing)
                 except Exception:
                     logger.warning("hermes turn persistence: failed to save assistant reply", exc_info=True)
 

--- a/api/services/chat_turns.py
+++ b/api/services/chat_turns.py
@@ -56,9 +56,23 @@ class ChatTurn:
     `conversation_id` SSE frame it observes).
     """
 
-    def __init__(self, turn_id: str, conversation_id: Optional[str], modality: str = "text"):
+    def __init__(
+        self,
+        turn_id: str,
+        conversation_id: Optional[str],
+        modality: str = "text",
+        client_turn_id: Optional[str] = None,
+    ):
         self.turn_id = turn_id
         self.conversation_id = conversation_id
+        # Opaque, client-generated key (#611 review) — known to the client
+        # BEFORE it ever sends the request, unlike `conversation_id` (which
+        # doesn't exist yet for a brand-new conversation) or `turn_id`
+        # (server-generated, never sent to the client). This is what makes a
+        # turn cancellable before its first SSE frame arrives — the gap that
+        # matters most for voice barge-in, where the interruption is
+        # frequently within the first second of a reply.
+        self.client_turn_id = client_turn_id
         self.modality = modality
         self.started_at = time.time()
         self.detached_at: Optional[float] = None
@@ -179,18 +193,35 @@ class ChatTurn:
 
 class TurnRegistry:
     """Process-global (but instance-per-test-via-`reset_turn_registry`)
-    lookup of in-flight turns, keyed both by their own id and by the
-    conversation they belong to."""
+    lookup of in-flight turns, keyed by their own id, the conversation they
+    belong to, and (#611 review) an opaque client-supplied key."""
 
     def __init__(self):
         self._by_turn_id: dict[str, ChatTurn] = {}
         self._by_conversation_id: dict[str, str] = {}
+        self._by_client_turn_id: dict[str, str] = {}
 
-    def create(self, conversation_id: Optional[str], modality: str = "text") -> ChatTurn:
-        turn = ChatTurn(str(uuid.uuid4()), conversation_id, modality)
+    def create(
+        self,
+        conversation_id: Optional[str],
+        modality: str = "text",
+        client_turn_id: Optional[str] = None,
+    ) -> ChatTurn:
+        turn = ChatTurn(str(uuid.uuid4()), conversation_id, modality, client_turn_id)
         self._by_turn_id[turn.turn_id] = turn
         if conversation_id:
             self._by_conversation_id[conversation_id] = turn.turn_id
+        if client_turn_id:
+            # Known at creation time (the client generated it before
+            # sending), unlike conversation_id for a brand-new conversation
+            # — no separate bind() step needed. A collision with an
+            # in-flight turn's client_turn_id is handled by the caller via
+            # supersede (cancel_by_client_turn_id) before create() runs, the
+            # same pattern conversation_id supersede already uses; this
+            # dict simply always reflects the CURRENT holder of a given key,
+            # so a stale/replayed key can only ever reach whichever turn
+            # most recently claimed it, never one further back.
+            self._by_client_turn_id[client_turn_id] = turn.turn_id
         return turn
 
     def bind(self, turn: ChatTurn, conversation_id: str) -> None:
@@ -200,7 +231,10 @@ class TurnRegistry:
         binds it when the first `conversation_id` SSE frame is observed. In
         both cases there's a sub-second window before the bind where the
         turn exists but isn't yet reachable by conversation id (so it can't
-        be cancelled or superseded) — acceptable per the #611 design."""
+        be cancelled or superseded) — acceptable per the #611 design.
+        `client_turn_id`, if the client sent one, closes exactly this gap:
+        it's known and registered from the moment `create()` runs, before
+        this bind ever happens."""
         turn.conversation_id = conversation_id
         self._by_conversation_id[conversation_id] = turn.turn_id
 
@@ -208,14 +242,21 @@ class TurnRegistry:
         turn_id = self._by_conversation_id.get(conversation_id)
         return self._by_turn_id.get(turn_id) if turn_id else None
 
+    def get_by_client_turn_id(self, client_turn_id: str) -> Optional[ChatTurn]:
+        turn_id = self._by_client_turn_id.get(client_turn_id)
+        return self._by_turn_id.get(turn_id) if turn_id else None
+
     def pop(self, turn: ChatTurn) -> None:
         """Remove a finished turn. Called from the turn task's own
-        `finally`. Only clears the conversation_id mapping if it still
-        points at THIS turn — a supersede may already have replaced it with
-        a newer turn's id, and this must not clobber that."""
+        `finally`. Only clears the conversation_id/client_turn_id mappings
+        if they still point at THIS turn — a supersede may already have
+        replaced either with a newer turn's id, and this must not clobber
+        that (the same guard, applied to both keys)."""
         self._by_turn_id.pop(turn.turn_id, None)
         if turn.conversation_id and self._by_conversation_id.get(turn.conversation_id) == turn.turn_id:
             self._by_conversation_id.pop(turn.conversation_id, None)
+        if turn.client_turn_id and self._by_client_turn_id.get(turn.client_turn_id) == turn.turn_id:
+            self._by_client_turn_id.pop(turn.client_turn_id, None)
         deadline_task = turn._deadline_task
         if deadline_task is not None and not deadline_task.done():
             deadline_task.cancel()
@@ -226,6 +267,17 @@ class TurnRegistry:
         supersede (a new turn on a conversation that already has one running
         cancels it first — asking again IS a stop gesture)."""
         turn = self.get_by_conversation(conversation_id)
+        if turn is None:
+            return False
+        return turn.request_cancel(reason)
+
+    def cancel_by_client_turn_id(self, client_turn_id: str, reason: str = "cancelled") -> bool:
+        """Cancel whatever turn is in flight under this client-supplied key
+        (#611 review). This is the key a client has BEFORE it ever gets a
+        `conversation_id` back — closing the "first-turn barge-in" gap
+        `cancel_conversation` alone can't: a request that hasn't reached its
+        first SSE frame yet has no conversation id to cancel by."""
+        turn = self.get_by_client_turn_id(client_turn_id)
         if turn is None:
             return False
         return turn.request_cancel(reason)

--- a/api/services/chat_turns.py
+++ b/api/services/chat_turns.py
@@ -1,0 +1,283 @@
+"""Turn lifecycle registry (#611).
+
+A chat turn's lifetime is owned by the server, not the SSE connection that
+happened to be watching it when it started. `ChatTurn` decouples the two:
+the turn's own task (`_run_turn` in `api/routes/chat.py`, or the Hermes pump
+in `api/routes/hermes_proxy.py`) emits frames into a bounded queue and runs
+to completion regardless of whether anything is reading it; `reader()` is
+the generator handed to `StreamingResponse`, and closing it — what happens
+when a browser disconnects — detaches without touching the task.
+
+`TurnRegistry` is the shared, process-global lookup (`turn_id -> ChatTurn`
+and `conversation_id -> turn_id`) that makes a turn cancellable by
+conversation id from `POST /api/conversations/{id}/cancel`, bounds a
+detached turn's lifetime, and lets `api/main.py`'s shutdown drain every
+turn still running before the process exits.
+"""
+
+import asyncio
+import logging
+import time
+import uuid
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Appended to whatever text a turn managed to produce before it was
+# interrupted (cancelled, hit its detached-lifetime deadline, was cancelled
+# by a shutdown drain, or died on a genuine stream error) — visible, no
+# client change needed, so a truncated reply is never mistaken for a
+# finished one (the #611 problem statement: "a partial answer... looks like
+# a complete answer that trails away").
+TRUNCATION_MARKER = "\n\n_[cut off — the turn ended before it finished]_"
+
+
+def truncation_routing(reason: str) -> dict:
+    """The `routing` fragment recorded alongside a `TRUNCATION_MARKER`-suffixed
+    message. `reason` is one of "cancelled" | "deadline" | "shutdown" |
+    "stream_error"."""
+    return {"truncated": True, "truncation_reason": reason}
+
+
+# Sentinel pushed into a turn's queue to make `reader()`'s `while True` loop
+# exit normally once the turn has finished (successfully, cancelled, or
+# errored) — distinct from any real frame, including an empty one.
+_SENTINEL = object()
+
+
+class ChatTurn:
+    """One turn's server-side lifetime.
+
+    `turn_id`/`conversation_id` identify it; `conversation_id` may be `None`
+    at construction (a brand-new conversation doesn't have an id yet) and is
+    filled in later via `TurnRegistry.bind()` once the id is known — either
+    immediately (an existing conversation) or mid-run (the native path
+    creates the id itself; the Hermes pump learns it from the first
+    `conversation_id` SSE frame it observes).
+    """
+
+    def __init__(self, turn_id: str, conversation_id: Optional[str], modality: str = "text"):
+        self.turn_id = turn_id
+        self.conversation_id = conversation_id
+        self.modality = modality
+        self.started_at = time.time()
+        self.detached_at: Optional[float] = None
+        self.reader_attached = True
+        self.finalized = False
+        # Set by whoever initiates a cancellation (the /cancel endpoint, a
+        # supersede, the deadline watcher, or registry.shutdown()) BEFORE
+        # calling task.cancel(), so the task's `except asyncio.CancelledError`
+        # handler can record why. Falls back to "cancelled" if unset (the
+        # voice-modality immediate-cancel-on-disconnect path below never sets
+        # it, since a disconnect there is exactly the same gesture as an
+        # explicit cancel).
+        self.cancel_reason: Optional[str] = None
+        self.task: Optional[asyncio.Task] = None
+        self._deadline_task: Optional[asyncio.Task] = None
+        # maxsize=1: while a reader is attached, `emit()` blocks until that
+        # frame has been consumed — the same backpressure a bare `yield`
+        # gives a StreamingResponse today. This is what keeps a connected
+        # turn's frame sequence byte-identical to before #611; it is not
+        # needed once detached (emit() short-circuits instead of queuing,
+        # see below).
+        self._queue: "asyncio.Queue[Any]" = asyncio.Queue(maxsize=1)
+
+    async def emit(self, frame: Any) -> None:
+        """Send one frame (an SSE `data: ...` string on the native path, a
+        raw upstream byte chunk on the Hermes pump) to the reader.
+
+        While attached this awaits exactly the backpressure a bare `yield`
+        gave the old generator. Once detached, frames are dropped rather
+        than queued: nobody will ever call `reader()` again for this turn,
+        so queuing would either block the producer forever (bounded queue,
+        nothing draining it) or grow without bound (unbounded one) for a
+        turn that could otherwise run for the full detached-lifetime
+        deadline.
+        """
+        if not self.reader_attached:
+            return
+        await self._queue.put(frame)
+
+    async def reader(self):
+        """The generator handed to `StreamingResponse`. Its `GeneratorExit` —
+        raised here, at the suspended `await self._queue.get()`, when
+        Starlette closes this generator on client disconnect — detaches the
+        turn. It must NEVER cancel `self.task`: the task keeps running to
+        completion server-side regardless, which is the entire point of
+        #611. `finally` runs on every exit path (normal drain via the
+        sentinel, or GeneratorExit), so `not self.finalized` is what tells
+        the two apart: by the time the sentinel is queued the task has
+        already finalized, so a normal drain never re-arms anything here.
+        """
+        try:
+            while True:
+                item = await self._queue.get()
+                if item is _SENTINEL:
+                    break
+                yield item
+        finally:
+            self.reader_attached = False
+            if not self.finalized:
+                self.detached_at = time.time()
+                if self.modality == "voice":
+                    # LEAD'S DECISION (#611): whisper-relay's adapter
+                    # (voice_gateway/adapters/lifeos.py in the whisper-relay
+                    # repo) deliberately abandons this stream as its cancel
+                    # gesture on barge-in/hangup (raises `LifeOSCancelled`).
+                    # If a voice turn detached instead of being cancelled,
+                    # every interruption would silently run to completion and
+                    # bill for a full reply the operator cut off on purpose —
+                    # a behavior regression AND a spend regression on the
+                    # surface used most from mobile. So a voice-modality
+                    # turn keeps today's disconnect-cancels semantics until
+                    # whisper-relay calls the explicit cancel endpoint
+                    # instead of just walking away.
+                    if self.task is not None and not self.task.done():
+                        self.task.cancel()
+                else:
+                    get_turn_registry().arm_deadline(self)
+
+    def request_cancel(self, reason: str) -> bool:
+        """Cancel this turn's task, recording why. Returns False (no-op) if
+        there's no task or it's already finished."""
+        if self.task is None or self.task.done():
+            return False
+        self.cancel_reason = reason
+        self.task.cancel()
+        return True
+
+    async def close(self) -> None:
+        """Wake up `reader()` if it's still attached and waiting, and mark
+        this turn done taking frames. Called from the turn task's own
+        `finally` — always, on every exit path — never from `reader()`.
+
+        If nothing is attached, there is nothing to wake: `reader()` has
+        already returned (that's what "detached" means), so nobody will
+        ever call `self._queue.get()` again. Blocking on `put()` in that
+        case — e.g. a detached turn whose last `emit()` left one real frame
+        sitting in the (maxsize=1) queue, un-drained — would wait forever
+        for room that can never open up.
+        """
+        self.finalized = True
+        if not self.reader_attached:
+            return
+        try:
+            self._queue.put_nowait(_SENTINEL)
+        except asyncio.QueueFull:
+            # A reader is still attached but hasn't drained the last real
+            # frame yet — wait for it to, so it's guaranteed to see the
+            # sentinel and exit its loop normally rather than hanging until
+            # GC. `reader()` runs as a separate task (the ASGI server
+            # driving the StreamingResponse), so it can still disconnect
+            # while this wait is in flight — bounded rather than unbounded,
+            # so that narrow race can't leak this task forever.
+            try:
+                await asyncio.wait_for(self._queue.put(_SENTINEL), timeout=5.0)
+            except asyncio.TimeoutError:
+                pass
+
+
+class TurnRegistry:
+    """Process-global (but instance-per-test-via-`reset_turn_registry`)
+    lookup of in-flight turns, keyed both by their own id and by the
+    conversation they belong to."""
+
+    def __init__(self):
+        self._by_turn_id: dict[str, ChatTurn] = {}
+        self._by_conversation_id: dict[str, str] = {}
+
+    def create(self, conversation_id: Optional[str], modality: str = "text") -> ChatTurn:
+        turn = ChatTurn(str(uuid.uuid4()), conversation_id, modality)
+        self._by_turn_id[turn.turn_id] = turn
+        if conversation_id:
+            self._by_conversation_id[conversation_id] = turn.turn_id
+        return turn
+
+    def bind(self, turn: ChatTurn, conversation_id: str) -> None:
+        """(Re)point the conversation_id -> turn_id mapping once a turn's
+        conversation id becomes known after creation — the native path binds
+        it as soon as a brand-new conversation is created; the Hermes pump
+        binds it when the first `conversation_id` SSE frame is observed. In
+        both cases there's a sub-second window before the bind where the
+        turn exists but isn't yet reachable by conversation id (so it can't
+        be cancelled or superseded) — acceptable per the #611 design."""
+        turn.conversation_id = conversation_id
+        self._by_conversation_id[conversation_id] = turn.turn_id
+
+    def get_by_conversation(self, conversation_id: str) -> Optional[ChatTurn]:
+        turn_id = self._by_conversation_id.get(conversation_id)
+        return self._by_turn_id.get(turn_id) if turn_id else None
+
+    def pop(self, turn: ChatTurn) -> None:
+        """Remove a finished turn. Called from the turn task's own
+        `finally`. Only clears the conversation_id mapping if it still
+        points at THIS turn — a supersede may already have replaced it with
+        a newer turn's id, and this must not clobber that."""
+        self._by_turn_id.pop(turn.turn_id, None)
+        if turn.conversation_id and self._by_conversation_id.get(turn.conversation_id) == turn.turn_id:
+            self._by_conversation_id.pop(turn.conversation_id, None)
+        deadline_task = turn._deadline_task
+        if deadline_task is not None and not deadline_task.done():
+            deadline_task.cancel()
+
+    def cancel_conversation(self, conversation_id: str, reason: str = "cancelled") -> bool:
+        """Cancel whatever turn is in flight for this conversation, if any.
+        Used both by the explicit `POST /{id}/cancel` endpoint and by
+        supersede (a new turn on a conversation that already has one running
+        cancels it first — asking again IS a stop gesture)."""
+        turn = self.get_by_conversation(conversation_id)
+        if turn is None:
+            return False
+        return turn.request_cancel(reason)
+
+    def arm_deadline(self, turn: ChatTurn) -> None:
+        """Start the clock on a just-detached turn's bounded lifetime. Reads
+        the timeout fresh from settings (not captured at import time) so
+        tests can monkeypatch it per-case, matching the pattern
+        `api/routes/_proxy.py` already uses for its own settings fields."""
+        from config.settings import settings
+
+        timeout = settings.detached_turn_timeout_seconds
+
+        async def _watch():
+            try:
+                await asyncio.sleep(timeout)
+            except asyncio.CancelledError:
+                return
+            if not turn.finalized:
+                turn.request_cancel("deadline")
+
+        turn._deadline_task = asyncio.create_task(_watch())
+
+    async def shutdown(self) -> None:
+        """Cancel every in-flight turn and await its finalization. Called
+        from `api/main.py`'s lifespan shutdown so a mid-turn auto-redeploy
+        (#437) stores an honest partial instead of silently losing the
+        turn."""
+        turns = list(self._by_turn_id.values())
+        tasks = []
+        for turn in turns:
+            if turn.task is not None and not turn.task.done():
+                turn.cancel_reason = "shutdown"
+                turn.task.cancel()
+                tasks.append(turn.task)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+_registry: Optional[TurnRegistry] = None
+
+
+def get_turn_registry() -> TurnRegistry:
+    global _registry
+    if _registry is None:
+        _registry = TurnRegistry()
+    return _registry
+
+
+def reset_turn_registry() -> None:
+    """Test-only: replace the global registry with a fresh, empty one — the
+    same pattern `conversation_store.reset_conversation_store()` uses —
+    so turns from one test can never leak into the next."""
+    global _registry
+    _registry = TurnRegistry()

--- a/config/settings.py
+++ b/config/settings.py
@@ -167,6 +167,19 @@ class Settings(BaseSettings):
         description="Optional bearer token for the Hermes text backend"
     )
 
+    # Bounded lifetime for a chat turn that has detached from its client (#611):
+    # a disconnect no longer stops generation, but an abandoned turn still needs
+    # a ceiling so it can't run forever with nobody watching. Matches the read
+    # timeout the proxy already gives a voice/agent/hermes turn (api/routes/
+    # _proxy.py's TIMEOUT), so a detached turn's own clock (which starts at
+    # detach, not at turn start) doesn't cut it off any earlier than a connected
+    # one already tolerates.
+    detached_turn_timeout_seconds: float = Field(
+        default=300.0,
+        alias="LIFEOS_DETACHED_TURN_TIMEOUT_SECONDS",
+        description="How long a chat turn may keep running after its client disconnects before it's cancelled"
+    )
+
     # Default /chat input mode. Off (text) by default so a fresh clone without a
     # voice gateway isn't dropped onto a non-functional dock; set true to make
     # voice the default. A ?mode= URL param or a stored preference still wins.

--- a/docs/adr/019-turn-owned-by-server.md
+++ b/docs/adr/019-turn-owned-by-server.md
@@ -1,0 +1,264 @@
+# ADR-019: A Turn's Lifetime Is Owned by the Server, Not the Connection
+
+**Status:** Complete
+**Last Updated:** 2026-08-21
+**Decision:** Accepted
+
+## Context
+
+Closing the chat page or app mid-response used to abandon the turn. The SSE
+connection *was* the turn: `/api/ask/stream`'s `generate()` was a plain async
+generator with no `finally` block, so the `GeneratorExit`/`CancelledError`
+Starlette delivers at the suspended `yield` on client disconnect killed
+generation within milliseconds. Nothing was persisted — not even the partial
+text the user had already seen stream past. The same was true of the Hermes
+proxy's relay loop before #592, and #592's fix (a read-only tee that
+persists whatever arrived before the relay ended) only closed half the gap:
+it stops a partial reply from being *lost*, but it can't make the reply
+*complete*, because the relay itself still died with the connection.
+
+This was the wrong contract for how the assistant is used. A tool-using turn
+can run over a minute, and on mobile, interruption is routine rather than
+exceptional — a phone locks, an app backgrounds, a network switches from
+wifi to cellular. Each of those discarded work the user asked for, and on
+the Anthropic (API-billed) backend, work already paid for.
+
+Three constraints shaped the fix:
+
+1. **Cancellation must remain possible.** Today, closing the page *is* the
+   cancel gesture. Decoupling the turn from the connection without adding an
+   explicit stop path would make a runaway tool loop unstoppable — a real
+   problem on a paid backend.
+2. **Voice is a special case.** whisper-relay's adapter deliberately
+   abandons the LifeOS stream as its cancel gesture on barge-in and hangup
+   (`LifeOSCancelled`). If a voice turn silently survived that abandonment,
+   every interruption would run to completion and bill for a reply the
+   operator explicitly cut off — on the surface used most from a phone.
+3. **[ADR-018](018-api-spend-requires-consent.md)'s posture must hold.**
+   ADR-018 established that LifeOS never spends API credits without the
+   operator's consent. Keeping a turn alive after its client leaves is a new
+   way to keep spending on an API-billed engine without a live human
+   watching — the tradeoff isn't "no more spend without consent" (the
+   consent already happened when the turn was started) but it does add a
+   new *duration* the operator isn't directly present for, which needs a
+   ceiling of its own (see Decision 4 below).
+
+## Decision
+
+**A chat turn's lifetime is owned by the server from the moment it starts.
+The SSE stream is a live view of a turn in progress, not its lifeline.**
+
+`api/services/chat_turns.py` introduces `ChatTurn` + `TurnRegistry`:
+
+- The turn's own logic (`_run_turn()` in `api/routes/chat.py`, or a
+  registry-owned pump in `api/routes/_proxy.py` for the Hermes backend) runs
+  as an `asyncio.Task`, independent of any reader.
+- `emit()` sends a frame into a small bounded queue; while a reader is
+  attached this backpressures exactly as a bare `yield` did, so a connected
+  client's byte sequence is unchanged.
+- `reader()` is the generator handed to `StreamingResponse`. Its
+  `GeneratorExit` — fired when the browser disconnects — detaches the queue
+  (frames are dropped rather than queued from then on) but **never cancels
+  the task**. The task keeps running to completion regardless.
+
+Four supporting decisions close the constraints above:
+
+1. **An explicit cancel path exists.** `POST /api/conversations/{id}/cancel`
+   stops whatever turn is in flight for that conversation — keyed by
+   conversation id, since every client already has one from the first SSE
+   event, so no new header or event type was needed. A Stop button in the
+   composer calls it while a turn is loading. A new turn on a conversation
+   that already has one running cancels the old one first (supersede) —
+   asking again is itself a stop gesture, and it prevents a stale reply
+   landing after a newer question.
+2. **Voice turns are gated out of detachment.** `ChatTurn.reader()` checks
+   `modality`: a voice-modality turn's disconnect cancels the task
+   immediately, reproducing today's behavior exactly, rather than arming the
+   survive-and-finish path every other turn gets. This is deliberately a
+   narrower fix than the ideal end state (correct barge-in **and**
+   survive-hangup) — that requires whisper-relay to call the cancel endpoint
+   explicitly instead of just walking away, which is a coordinated,
+   cross-repo follow-up, not part of this change.
+3. **Every interrupted turn is marked, never presented as whole.** Whatever
+   text a turn produced before being cancelled, hitting its deadline, being
+   caught in a shutdown drain, or dying to a genuine stream error is
+   persisted with a visible `TRUNCATION_MARKER` and `routing.truncated`,
+   rather than either being lost (the old behavior) or looking like a
+   complete answer that just trails off (the risk #592 called out and this
+   ADR fully closes).
+4. **A detached turn still has a ceiling.** `LIFEOS_DETACHED_TURN_TIMEOUT_SECONDS`
+   (default 300s, matching the proxy's own upstream read timeout) starts a
+   clock at the moment of detachment — not at turn start, so a turn that's
+   still being watched is never affected by it. If a detached turn hasn't
+   finished by then, it's cancelled the same way an explicit `/cancel` would.
+   `api/main.py`'s lifespan shutdown cancels every in-flight turn and awaits
+   its own partial-persist handling, so a mid-turn auto-redeploy stores an
+   honest partial instead of silently losing the turn outright.
+
+**Scope**: the native path and the Hermes proxy share the same registry in
+one change (splitting them would mean reviewing the same machinery twice).
+The Agent backend is untouched — it has no persistence tee, so detaching it
+would only spend money with nothing to show for it; the gate is literally
+"does something observe this relay," which is false for Agent today.
+
+**Not built**: stream resume/replay from a byte offset (the additive
+`active_turn` field on `GET /api/conversations/{id}` plus polling is enough
+for "is a turn still running" without replaying bytes); a durable turn table
+surviving a process restart (the shutdown drain is a smaller, sufficient
+answer); routing turns through the existing job queue
+(`api/services/job_queue.py` is cross-process and thread-backed, with no
+path back to a live SSE connection — solving a bigger problem than this
+one); a global concurrency cap (the deadline, supersede, and the task's own
+`finally` already bound how many turns can pile up on a single-operator
+box); per-turn token ceilings (`max_tool_rounds` and `max_tokens` already
+bound a native turn's cost).
+
+## Rationale
+
+- **The reader is not the turn.** Conflating "someone is watching" with "the
+  work should happen" was the root bug. Separating them into a task (does
+  the work) and a queue-backed reader (shows the work) is the smallest
+  change that fixes it, and it composes: cancellation, deadlines, and
+  shutdown all become "stop the task," not special cases of streaming logic.
+- **Keying cancellation on conversation id, not a new turn id, avoids
+  surface-area growth.** `X-LifeOS-Turn-ID` already exists with a different
+  meaning (the Gmail send-gate header, `api/routes/gmail.py`). Every
+  client — native and Hermes alike — already receives a conversation id as
+  the first SSE event, so reusing it needed no new header, no new event
+  type, and no CORS `expose_headers` change.
+- **The voice gate is a deliberate, temporary asymmetry, not an oversight.**
+  Fixing #611 without it would have been a silent regression on exactly the
+  surface (mobile voice) the underlying bug report came from — it would
+  have converted "the operator interrupted the assistant" into "the
+  assistant kept talking (and billing) anyway." The gate is explicit,
+  commented with why, and pinned by a test, so it's a decision on record
+  rather than an implicit dependency on old behavior.
+- **A visible truncation marker beats either extreme.** Before #592, an
+  interrupted turn vanished. After #592 but before #611, it could look
+  complete when it wasn't — arguably worse. Marking it is strictly better
+  than either: the user (or a later reader of the thread) can tell what
+  happened.
+
+## Alternatives Considered
+
+### Resume/replay the stream from an offset on reconnect
+
+Let a reconnecting client ask for "everything since byte N" and replay it.
+
+**Rejected because:** the acceptance criteria only require that the
+*finished* reply be readable after reopening the conversation — a plain
+`GET` already does that once the turn persists. Replay adds a second
+consumption path (live tail vs. historical read) for a benefit (watching a
+turn's live output resume mid-stream after a reconnect) nobody asked for.
+`active_turn` + polling gives "is it still running" cheaply if that's ever
+wanted later, without committing to replay semantics now.
+
+### A durable turn table that survives a process restart
+
+Persist turn state to SQLite so a turn could, in principle, resume after the
+server itself restarts.
+
+**Rejected because:** an in-memory `asyncio.Task` cannot survive a process
+restart regardless of what's on disk — resuming would mean re-issuing the
+underlying LLM/tool calls, not resuming a suspended coroutine, which is a
+different and much larger feature (checkpointed agent state). The shutdown
+drain (cancel + honest partial) is the correct-sized answer to "the process
+is about to exit": lose the least, not pretend to lose nothing.
+
+### Route turns through the existing job queue
+
+`api/services/job_queue.py` already runs background work reliably across
+process boundaries.
+
+**Rejected because:** it's thread-backed and has no path to stream results
+back to a *specific still-open* HTTP connection — it's built for
+fire-and-forget work polled later, not for "keep serving this live SSE
+response." Building that path would mean re-deriving most of what
+`ChatTurn`/`TurnRegistry` already provide, at more complexity, to reuse
+infrastructure that solves a different problem.
+
+### A global concurrency cap on in-flight turns
+
+Bound the number of detached turns directly, independent of the deadline.
+
+**Rejected because:** this is a single-operator box. The deadline (300s
+default) plus supersede (asking again cancels the old turn) plus the task's
+own `finally` already bound the population in practice; a cap would be
+solving for a multi-tenant failure mode that doesn't exist here yet. If that
+changes, a cap is a small, separable addition — not a reason to hold up this
+change.
+
+## Consequences
+
+### Positive
+
+- A tool-using turn survives the interruptions mobile use makes routine
+  (locking the phone, backgrounding the app, a network handoff), and the
+  full answer is there when the conversation is reopened.
+- A turn that's cut off — for any reason — is never mistaken for a complete
+  one; `routing.truncated` also gives the UI a place to hang a "this was cut
+  off" affordance later if it wants one.
+- An unwatched, runaway turn has both a ceiling (the deadline) and an
+  explicit off switch (`/cancel`), so decoupling the turn from the
+  connection doesn't reintroduce "impossible to stop."
+- Persistence is exactly-once by construction: it lives in one place inside
+  the turn's own task, which runs regardless of how many times a client
+  connects, disconnects, or reconnects — there is no code path that can
+  double-write.
+
+### Negative
+
+- **A disconnected turn now keeps running, and keeps costing, for up to the
+  deadline.** This is the deliberate tradeoff #611 exists to make (the
+  problem was turns dying too early, not living too long), but it is a real
+  change in worst-case spend per abandoned turn on the Anthropic backend,
+  bounded by `max_tool_rounds`/`max_tokens` and now also by the 300s
+  deadline.
+- **Voice barge-in is only correctly free of this tradeoff via the gate,
+  not via a general solution.** Until whisper-relay is updated to call
+  `/cancel` explicitly, voice's "abandon the stream to cancel" gesture stays
+  a special case in `ChatTurn.reader()` rather than the one true cancel
+  path every modality shares.
+- **The Hermes persister's truncation reason is coarser than the native
+  path's.** `_HermesTurnPersister` only knows whether a `done` event was
+  observed, not *why* a turn was cut short, so every Hermes truncation
+  currently reports `truncation_reason: "stream_error"` — the native path's
+  finer `cancelled`/`deadline`/`shutdown`/`stream_error` distinction doesn't
+  cross the process boundary.
+- **A cancelled native turn's usage isn't recorded.** `AgentResult`'s token
+  counts are only available at the end of a completed run; a cancelled turn
+  has none to record. This is a known, deliberately deferred gap (filed
+  separately), not an oversight.
+
+## Related Documents
+
+### Design Context
+
+- [ADR-018](018-api-spend-requires-consent.md) — the consent posture this
+  change adds a new *duration* to, bounded by the detached-turn deadline
+- [Client surfaces](../specs/technical/client-surfaces.md) — the SSE
+  contract this ADR keeps byte-identical for a connected client
+
+### Specifications
+
+- [Client surfaces](../specs/technical/client-surfaces.md) — `/cancel`,
+  `active_turn`, and the truncation marker as part of the HTTP contract
+
+### Operational
+
+- [Configuration](../guides/configuration.md) —
+  `LIFEOS_DETACHED_TURN_TIMEOUT_SECONDS`
+
+### Code References
+
+- `api/services/chat_turns.py` — `ChatTurn`, `TurnRegistry`,
+  `TRUNCATION_MARKER`, `truncation_routing()`
+- `api/routes/chat.py` — `ask_stream()`'s turn creation/supersede,
+  `_run_turn()`'s emit/cancel/finally handling
+- `api/routes/_proxy.py` — `make_backend_router()`'s registry-owned pump,
+  gated on `make_observer`
+- `api/routes/hermes_proxy.py` — `_HermesTurnPersister.bind_turn()`, the
+  `done`-observed truncation signal
+- `api/routes/conversations.py` — `cancel_conversation_turn()`,
+  `active_turn`
+- `api/main.py` — the lifespan shutdown drain

--- a/docs/adr/019-turn-owned-by-server.md
+++ b/docs/adr/019-turn-owned-by-server.md
@@ -63,14 +63,25 @@ The SSE stream is a live view of a turn in progress, not its lifeline.**
 
 Four supporting decisions close the constraints above:
 
-1. **An explicit cancel path exists.** `POST /api/conversations/{id}/cancel`
-   stops whatever turn is in flight for that conversation — keyed by
-   conversation id, since every client already has one from the first SSE
-   event, so no new header or event type was needed. A Stop button in the
+1. **An explicit cancel path exists, keyed two ways.** `POST
+   /api/conversations/{id}/cancel` stops whatever turn is in flight for that
+   conversation, since every client already has that id from the first SSE
+   event — no new header or event type was needed. A Stop button in the
    composer calls it while a turn is loading. A new turn on a conversation
    that already has one running cancels the old one first (supersede) —
    asking again is itself a stop gesture, and it prevents a stale reply
-   landing after a newer question.
+   landing after a newer question. Review (the whisper-relay maintainer)
+   found a hole in that alone: a brand-new conversation's id doesn't exist
+   until the `conversation_id` SSE event arrives, so a client racing to
+   cancel *before* that — the common shape of a voice barge-in, which often
+   lands within the first second — has nothing to cancel by. `POST
+   /api/ask/stream` therefore also accepts an optional, client-generated
+   `client_turn_id` (opaque, bounded, not assumed to be a UUID), indexed by
+   the registry alongside `conversation_id` from the moment the turn is
+   created; `POST /api/chat/cancel` cancels by that key alone. Reusing a
+   `client_turn_id` supersedes, exactly like `conversation_id` does — a
+   stale or duplicate key always resolves to whichever turn currently holds
+   it, never a stray earlier one.
 2. **Voice turns are gated out of detachment.** `ChatTurn.reader()` checks
    `modality`: a voice-modality turn's disconnect cancels the task
    immediately, reproducing today's behavior exactly, rather than arming the
@@ -120,12 +131,19 @@ bound a native turn's cost).
   the work) and a queue-backed reader (shows the work) is the smallest
   change that fixes it, and it composes: cancellation, deadlines, and
   shutdown all become "stop the task," not special cases of streaming logic.
-- **Keying cancellation on conversation id, not a new turn id, avoids
-  surface-area growth.** `X-LifeOS-Turn-ID` already exists with a different
-  meaning (the Gmail send-gate header, `api/routes/gmail.py`). Every
-  client — native and Hermes alike — already receives a conversation id as
-  the first SSE event, so reusing it needed no new header, no new event
-  type, and no CORS `expose_headers` change.
+- **Keying cancellation on conversation id (plus a client-generated key),
+  not a new server-minted turn id, avoids surface-area growth.**
+  `X-LifeOS-Turn-ID` already exists with a different meaning (the Gmail
+  send-gate header, `api/routes/gmail.py`). Every client — native and
+  Hermes alike — already receives a conversation id as the first SSE
+  event, so reusing it needed no new header, no new event type, and no
+  CORS `expose_headers` change. `client_turn_id` closes the one real gap
+  (cancelling before that first event) as a request-body field instead — a
+  server-minted id returned via a new SSE event or header was considered
+  and rejected specifically because either would break the byte-identity
+  guarantee a connected client already relies on; a body field costs no
+  frame and the client knows its own key before the server could mint one
+  anyway.
 - **The voice gate is a deliberate, temporary asymmetry, not an oversight.**
   Fixing #611 without it would have been a silent regression on exactly the
   surface (mobile voice) the underlying bug report came from — it would

--- a/docs/adr/019-turn-owned-by-server.md
+++ b/docs/adr/019-turn-owned-by-server.md
@@ -247,6 +247,20 @@ change.
   counts are only available at the end of a completed run; a cancelled turn
   has none to record. This is a known, deliberately deferred gap (filed
   separately), not an oversight.
+- **A task cancelled before its first scheduled step never runs its
+  `finally` at all — a real `asyncio` behavior, not something introduced
+  here.** If `TurnRegistry.shutdown()` (or an explicit cancel) ever ran in
+  the exact same event-loop tick as a turn's own `create_task()`, before
+  that task had taken even one step, cancelling it would skip
+  `_run_turn()`'s `finally` entirely — no partial persisted, no registry
+  cleanup for that turn. In practice this can't happen: by the time
+  anything could reach for that turn, it has already taken at least one
+  step (creating the conversation row, emitting the `conversation_id`
+  frame), so the window is theoretical, not reachable through any real
+  request/shutdown ordering. Documented here rather than engineered
+  around, since `shutdown()` — cancelling every registered turn in one
+  pass — is exactly the kind of code a future change might run earlier in
+  a turn's life than today's callers do.
 
 ## Related Documents
 

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -20,6 +20,7 @@ This directory contains Architecture Decision Records (ADRs) — immutable recor
 - `016-voice-gateway-reverse-proxy.md` — Voice gateway reverse-proxied through LifeOS
 - `017-retire-ollama-llama-server-routing.md` — Ollama retired; query routing moved onto the shared llama-server runtime (supersedes 006)
 - `018-api-spend-requires-consent.md` — LifeOS never picks an API-billed engine on its own (amends 008)
+- `019-turn-owned-by-server.md` — a chat turn's lifetime is owned by the server, not the SSE connection watching it
 
 ## Key Principles
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -32,6 +32,7 @@ Each section corresponds roughly to a section in [`config/settings.py`](../../co
 | `LIFEOS_AGENT_BACKEND_TOKEN` | str | *(empty)* | Optional bearer token for the Agent text backend, added server-side (never exposed to the browser). |
 | `LIFEOS_HERMES_BACKEND_URL` | str | *(empty)* | Hermes text backend base URL, proxied the same way at `/api/hermes/ask/stream` (#587). Empty disables the `/chat` Hermes option; with no stored backend preference, `/chat` defaults to Hermes when it's configured and reachable, else LifeOS. Deliberately absent from `.env.example`. |
 | `LIFEOS_HERMES_BACKEND_TOKEN` | str | *(empty)* | Optional bearer token for the Hermes text backend, added server-side. |
+| `LIFEOS_DETACHED_TURN_TIMEOUT_SECONDS` | float | `300.0` | How long a chat turn (native or Hermes-relayed) may keep running after its client disconnects before it's cancelled (#611). The clock starts at disconnect, not at turn start, so a turn that stays watched is never affected by it. Matches the proxy's own upstream read timeout (`api/routes/_proxy.py`'s `TIMEOUT`), so a detached turn isn't cut off any earlier than a connected one already tolerates. |
 
 **Tailscale Serve (phone /chat + voice):** run once after install, then enable the user unit so it survives reboot:
 
@@ -398,6 +399,7 @@ LIFEOS_ALERT_EMAIL=you@example.com
 - [Claude Code Orchestration](claude-code-orchestration.md) — `/claude` setup; references the `LIFEOS_CLAUDE_*` vars in operator-flow context.
 - [Doctor Bot](doctor-bot.md) — The self-repair orchestration bot; setup of its `TELEGRAM_DOCTOR_*` vars and the repair flow.
 - [ADR-009: LIFEOS_LLM_BACKEND toggle](../adr/009-llm-backend-toggle.md) — Why the synthesis backend is operator-configurable.
+- [ADR-019: A Turn's Lifetime Is Owned by the Server](../adr/019-turn-owned-by-server.md) — Why `LIFEOS_DETACHED_TURN_TIMEOUT_SECONDS` exists.
 - [ADR-012: Embedding Pipeline](../adr/012-embedding-pipeline.md) — Why `LIFEOS_EMBEDDING_MODEL` is overridable; the OOM-protection knobs.
 - [API Reference](../specs/product/api-reference.md) — Gmail send endpoint behavior controlled by the draft send cooldown.
 - [`config/settings.py`](../../config/settings.py) — The source of truth; this guide should track it.

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -79,9 +79,11 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 | `claude_intent` | `task`, `engine` (`claude_code` \| `codex`) | CLI engine handoff; HTTP clients POST `/api/chat/handoff` |
 | `error` | `message` | Fatal error for this turn |
 | `usage` | `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `cost_usd` | Token usage and cost |
-| `done` | — | Stream complete (optional; HTTP stream close also finalizes) |
+| `done` | — | Stream complete |
 
 **Wire format:** lines `data: {json}\n`. Clients may ignore `routing`, `sources`, `usage`, and `done` if they handle stream close.
+
+**A disconnect no longer stops the turn (#611).** The turn keeps running server-side and persists its complete reply once done — closing the tab, backgrounding the app, or a network switch no longer loses the answer. `POST /api/conversations/{id}/cancel` stops it explicitly; `GET /api/conversations/{id}`'s `active_turn` field reports whether one is still running. `modality: "voice"` is the one exception — a voice turn's disconnect still cancels it immediately, matching pre-#611 behavior, because whisper-relay uses abandoning the stream as its deliberate barge-in/hangup cancel gesture. See [client-surfaces.md § Turn lifetime and cancellation](../technical/client-surfaces.md#turn-lifetime-and-cancellation-611) for the full contract.
 
 **Pipeline routing (in order of priority):**
 1. **Ambiguous task/reminder** — asks user for clarification (task vs reminder vs both).
@@ -194,7 +196,7 @@ Spawn a CLI engine worker session when the orchestrator emits `claude_intent` on
 - `POST /api/voice/turn/stream` — multipart voice turn (`audio` or `transcript`, plus `backend`, `persona_id`, `conversation_id`) → SSE turn events (`started` / `transcript` / `status_audio` / `response` / `main_audio` / `done` / `error` / `cancelled`); the `done` data is authoritative. Proxied to `LIFEOS_VOICE_GATEWAY_URL` (whisper-relay). Also `POST /api/voice/turn/{turn_id}/cancel` and `GET /api/voice/audio/{turn_id}/{clip_id}`.
 - `POST /api/agent/ask/stream` — text turn for the "Agent" backend; same SSE as [`POST /api/ask/stream`](#post-apiaskstream) but no handoff and no persona. Proxied to `LIFEOS_AGENT_BACKEND_URL` with a bearer token added **server-side** (never exposed to the browser). `GET /api/agent/status` → `{"available": bool}` (drives the UI selector).
 - `POST /api/hermes/ask/stream` — text turn for the "Hermes" backend; same SSE and proxy behavior as the Agent backend above (same factory, `LIFEOS_HERMES_BACKEND_URL`), but the persona picker stays visible client-side, and the route resolves the selected persona and per-turn context and attaches them to the forwarded body as a `lifeos_context` envelope (`{schema_version, modality, persona: {id, label, preamble, voice_rules, orchestrates}, turn: {...}}`, `turn` a sibling of `persona` per [`GET /api/chat/turn-context`](#get-apichatturn-context)) — a cross-repo contract with `nbramia/hermes` pinned on issue #590. Rejects with 400 (before forwarding) on malformed JSON, an unknown `persona_id`, or an orchestrating persona (`doctor`) reaching the route — that last case is a backstop, not the user path: the client diverts an orchestrating persona's turn to [`POST /api/ask/stream`](#post-apiaskstream) instead of here in the first place (#596), tagging the conversation it creates with `backend: "hermes"` so it still shows up in this backend's thread list. `GET /api/hermes/status` → `{"available": bool}`. See [client-surfaces.md](../technical/client-surfaces.md) § "The `lifeos_context` envelope" for the full schema.
-- **Hermes turns are persisted** (#592), unlike the Agent backend: the route tees the relayed SSE bytes to the browser unchanged and, in parallel, reconstructs the turn from the `conversation_id` and `content` events it already emits (same shapes the native `POST /api/ask/stream` uses) — adopting the id Hermes minted, creating the conversation row (tagged `persona_id` + `backend: "hermes"`) on first sight of it, and storing the user question and assembled assistant reply as two messages. A stream that ends before completion still persists whatever assistant content arrived; a persistence failure is logged and never breaks the turn. This is why `GET /api/conversations?backend=hermes` and the sidebar now show Hermes history at all.
+- **Hermes turns are persisted** (#592) **and survive a client disconnect** (#611), unlike the Agent backend: the route tees the relayed SSE bytes to the browser unchanged and, in parallel, reconstructs the turn from the `conversation_id` and `content` events it already emits (same shapes the native `POST /api/ask/stream` uses) — adopting the id Hermes minted, creating the conversation row (tagged `persona_id` + `backend: "hermes"`) on first sight of it, and storing the user question and assembled assistant reply as two messages. Since #611 the upstream drain runs as a background pump independent of the browser connection, so a disconnect no longer cuts a Hermes turn short either — it persists the *complete* reply, not just whatever had streamed so far. A turn whose upstream connection genuinely ends before a `done` event ever arrived still gets a truncation marker + `routing.truncated` (see [client-surfaces.md](../technical/client-surfaces.md#turn-lifetime-and-cancellation-611)). A persistence failure is logged and never breaks the turn. This is why `GET /api/conversations?backend=hermes` and the sidebar now show Hermes history at all.
 - **Hermes usage is captured too** (#595), by the same tee: a relayed `usage` event (`input_tokens`, `output_tokens`, `cost_usd`, `model` — the same shape the native path emits) is recorded to the usage store on turn completion, tagged with the conversation id. The cost is recorded **verbatim** from that event, never recomputed — the cost calculator only knows Anthropic pricing and would misprice a non-Anthropic upstream model (Hermes runs DeepSeek via Fireworks). A `usage` event with no `cost_usd` records a zero cost rather than a guess; a turn with no `usage` event writes no row; a malformed one (missing/wrong-typed model or token counts) is ignored. Conversation persistence and usage persistence are independent — neither gates the other. Since this is the same event shape and client handler (`web/chat/ask-stream.js`'s `data.type === 'usage'` branch) the native path already uses, the browser's session-cost display updates with **no client change**. The Agent backend has no equivalent — it isn't tee'd at all, so its turns stay invisible to the usage store. See [client-surfaces.md](../technical/client-surfaces.md) § "Hermes turn persistence" for the observer internals.
 
 See [client-surfaces.md](../technical/client-surfaces.md) and [ADR-016](../../adr/016-voice-gateway-reverse-proxy.md).
@@ -567,13 +569,27 @@ Get conversation with messages. Access by id is **not** persona-scoped — any v
       "routing": null
     }
   ],
-  "pending_question": null
+  "pending_question": null,
+  "active_turn": null
 }
 ```
 
 `role` is `user` or `assistant`.
 
 `pending_question` is present only while a spawned **orchestrating-persona** session (e.g. `doctor`) started from this conversation is awaiting an answer — `{ "session_id": "...", "question": "...", "kind": "..." }` — and is `null`/absent otherwise. `kind` is `goal_approval` (a `[GOAL]` awaiting approval) or `followup` (a `[CLARIFY]`). The client renders an answer affordance when it's present and posts to `/answer` below.
+
+`active_turn` (#611) is present only while a chat turn is running server-side for this conversation — native or Hermes-relayed alike — and `null` otherwise: `{ "turn_id": "...", "conversation_id": "...", "started_at": "2026-08-21T09:14:22" }`. Lets a client that reconnects mid-turn show "still working..." and reach the cancel affordance below. A completed turn's message carries no marker on it in the normal case; an *interrupted* one (cancelled, timed out, caught in a server shutdown, or a genuine stream error) has its content suffixed with a visible cut-off marker and `routing: {"truncated": true, "truncation_reason": "cancelled" | "deadline" | "shutdown" | "stream_error"}` — see [client-surfaces.md § Turn lifetime and cancellation](../technical/client-surfaces.md#turn-lifetime-and-cancellation-611).
+
+### POST /api/conversations/{id}/cancel
+
+Stop a chat turn in flight for this conversation (#611) — native or Hermes-relayed. Since a disconnect no longer stops a turn on its own, this is the explicit way to do it (also used internally when a new turn on the same conversation supersedes an old one still running).
+
+**Response:**
+```json
+{ "ok": true, "cancelled": true }
+```
+
+`cancelled` is `false` when nothing was in flight (already finished, or never started) — not an error. **Errors:** `404` no such conversation.
 
 ### POST /api/conversations/{id}/answer
 

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -65,6 +65,7 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 - `persona` (optional, internal) — raw preamble text used by the in-process Telegram client. Mutually exclusive with `persona_id` (sending both returns **400**); HTTP clients should use `persona_id`.
 - `model_override` (optional) — pins the model for **this turn**. `"sonnet"` / `"opus"` (or a full model id) run the turn on that cloud model; `"gemma"` / `"local"` run it on the local llama-server; `"auto"` or omitted uses the default orchestrator (Haiku) with escalation — which climbs only to non-API engines (`claude_code` / `codex` / `local`), so a cloud model is reached only by an explicit pick here or a user-directed "escalate to opus" in the message. An explicit pick takes precedence over auto-escalation. Honored on the Anthropic backend; unknown values fall back to `auto`. Drives the web chat model picker.
 - `backend` (optional) — tags a **newly created** conversation for sidebar filtering (see `?backend=` on [`GET /api/conversations`](#get-apiconversations)). This is the only thing it does: it never changes routing, model selection, or persona resolution. Omitted, it tags `"lifeos"` (today's behavior, unchanged). The web client sets it to `"hermes"` only when diverting an orchestrating persona's turn from a Hermes-selected composer to this endpoint (#596) — that persona's spawn is LifeOS-native and has no Hermes equivalent, so the turn lands here regardless of the selected backend, and this field keeps the resulting conversation visible in the Hermes-filtered sidebar rather than vanishing into the `lifeos` bucket.
+- `client_turn_id` (optional, #611) — an opaque key the **client** generates before sending the request, used to cancel this turn via [`POST /api/chat/cancel`](#post-apichatcancel). Closes a gap `conversation_id` alone can't: a brand-new conversation's id doesn't exist until the `conversation_id` SSE event arrives, so a client that wants to cancel before then (the common voice barge-in case) has nothing to cancel by unless it minted this key itself. Bounded to 200 chars, no control characters; not required to be a UUID — any locally-unique string works. Reusing the same key on a later request supersedes (cancels) whichever turn currently holds it, the same as reusing `conversation_id` does. Purely additive — omitting it changes nothing about the turn.
 
 **Response:** Server-Sent Events stream with event types:
 
@@ -83,7 +84,7 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 
 **Wire format:** lines `data: {json}\n`. Clients may ignore `routing`, `sources`, `usage`, and `done` if they handle stream close.
 
-**A disconnect no longer stops the turn (#611).** The turn keeps running server-side and persists its complete reply once done — closing the tab, backgrounding the app, or a network switch no longer loses the answer. `POST /api/conversations/{id}/cancel` stops it explicitly; `GET /api/conversations/{id}`'s `active_turn` field reports whether one is still running. `modality: "voice"` is the one exception — a voice turn's disconnect still cancels it immediately, matching pre-#611 behavior, because whisper-relay uses abandoning the stream as its deliberate barge-in/hangup cancel gesture. See [client-surfaces.md § Turn lifetime and cancellation](../technical/client-surfaces.md#turn-lifetime-and-cancellation-611) for the full contract.
+**A disconnect no longer stops the turn (#611).** The turn keeps running server-side and persists its complete reply once done — closing the tab, backgrounding the app, or a network switch no longer loses the answer. Two ways to cancel it explicitly: `POST /api/conversations/{id}/cancel` (by conversation id) and [`POST /api/chat/cancel`](#post-apichatcancel) (by `client_turn_id`, for a turn that hasn't reached its first SSE frame yet). `GET /api/conversations/{id}`'s `active_turn` field reports whether one is still running. `modality: "voice"` is the one exception — a voice turn's disconnect still cancels it immediately, matching pre-#611 behavior, because whisper-relay uses abandoning the stream as its deliberate barge-in/hangup cancel gesture. See [client-surfaces.md § Turn lifetime and cancellation](../technical/client-surfaces.md#turn-lifetime-and-cancellation-611) for the full contract.
 
 **Pipeline routing (in order of priority):**
 1. **Ambiguous task/reminder** — asks user for clarification (task vs reminder vs both).
@@ -160,6 +161,22 @@ Read-only per-turn context: the current date/time, the relative-time-resolution 
 - `personal_context` is non-empty only for the `therapist` persona (and only once `LIFEOS_PARTNER_NAME`/`LIFEOS_THERAPIST_PATTERNS` are configured); empty string for every other persona.
 - `existing_tags` is `[]` when there are no tags or the task manager is unreachable — a normal degraded case, not an error.
 - This is the exact shape embedded as `lifeos_context.turn` in the Hermes envelope — see [client-surfaces.md](../technical/client-surfaces.md) § "The `lifeos_context` envelope" — both come from the same function call, so they cannot diverge.
+
+### POST /api/chat/cancel
+
+Cancel a chat turn (native or Hermes-relayed) by `client_turn_id` (#611) — the key the client generated and sent on [`POST /api/ask/stream`](#post-apiaskstream), before it necessarily had a `conversation_id` to cancel by instead. This is the endpoint for the "cancel before the first SSE frame arrives" case (e.g. a voice barge-in on a first turn); once a conversation id is known, `POST /api/conversations/{id}/cancel` works too, and either can supersede the same turn.
+
+**Request:**
+```json
+{ "client_turn_id": "some-opaque-client-generated-key" }
+```
+
+**Response:**
+```json
+{ "ok": true, "cancelled": true }
+```
+
+`cancelled` is `false` when nothing was in flight under that key (never claimed, already finished, or already cancelled) — never an error; there's no resource to 404 on here (unlike the conversation-scoped endpoint), since an unknown or expired key legitimately has nothing to report. Calling this while the turn's SSE reader is still attached works correctly — the reader gets a clean end-of-stream rather than an error, and a client that then also disconnects sees a no-op, not a second finalize. **Errors:** `422` empty/oversized (>200 chars)/control-character `client_turn_id` (standard FastAPI request validation).
 
 ### POST /api/chat/handoff
 

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -26,7 +26,7 @@ Voice transport in the same GitHub org: [github.com/nbramia/whisper-relay](https
 
 The gateway connects to LifeOS at `LIFEOS_BASE_URL` for orchestration (ask/stream, handoff). Persona listing and conversation CRUD are **LifeOS-owned** — consumed by `/chat` directly, not through whisper-relay.
 
-**LifeOS endpoints the gateway calls** (shapes: [api-reference.md](../product/api-reference.md)): `POST /api/ask/stream`, `POST /api/chat/handoff`. At startup it may call `GET /api/personas` server-side for handoff capability caching (not exposed to browsers).
+**LifeOS endpoints the gateway calls** (shapes: [api-reference.md](../product/api-reference.md)): `POST /api/ask/stream`, `POST /api/chat/handoff`. At startup it may call `GET /api/personas` server-side for handoff capability caching (not exposed to browsers). `POST /api/chat/cancel` (`client_turn_id`, #611) exists for the gateway to adopt as its explicit stop path — tracked as `whisper-relay#37`, not yet started — but is not called today: voice still relies on cancel-on-disconnect (see "Turn lifetime and cancellation" below) until that lands.
 
 **Persona contract** (shared by web and voice; lets a thin client expose LifeOS's multi-bot personas without reading LifeOS config):
 
@@ -101,6 +101,35 @@ proxy; the Agent backend is unaffected (below).
   exist. A new `POST /api/ask/stream` (or the Hermes equivalent) naming a
   conversation that already has a turn in flight cancels the old one first
   (supersede) — asking again is itself a stop gesture.
+- **`client_turn_id` and `POST /api/chat/cancel` (#611 review — closes the
+  first-turn barge-in gap).** `conversation_id` alone can't cancel a turn
+  before its first SSE frame arrives: a brand-new conversation's id doesn't
+  exist until the `conversation_id` event, so a client racing to cancel
+  before then — the common case for a voice barge-in, which tends to land
+  within the first second — has nothing to cancel by. `POST
+  /api/ask/stream` accepts an optional `client_turn_id`: an opaque,
+  client-generated key (bounded to 200 chars, no control characters — not
+  assumed to be a UUID), known before the request is even sent. The
+  registry indexes turns by it in addition to `conversation_id`, and `POST
+  /api/chat/cancel` (body: `{"client_turn_id": "..."}`) cancels by that key
+  alone. Reusing a `client_turn_id` on a later request supersedes the turn
+  currently holding it, mirroring `conversation_id` supersede — a stale or
+  duplicate key always resolves to its current claimant, never a stray
+  earlier turn. Returning a server-minted turn id in a new SSE event or
+  header was considered and rejected: either would break the byte-identity
+  guarantee a connected client already relies on (no new frame, no new
+  header); a request-body field costs nothing and the client knows its own
+  key earlier than the server could mint one anyway.
+- **Cancelling a turn whose reader is still attached is a supported,
+  explicitly-tested ordering** (#611 review) — not just "cancel after
+  disconnect." A gateway that fires its cancel POST from an event handler
+  rather than its SSE read loop (to avoid the latency of checking a flag
+  between reads) can have that POST arrive *before* the client actually
+  stops reading. Cancelling in that ordering works correctly: the
+  still-attached reader gets a clean end-of-stream (no exception), and a
+  disconnect that follows afterward is a no-op — not a second finalize.
+  Cancelling an already-finished (or already-cancelled) turn is `200` +
+  `cancelled: false`, never a 4xx — a gateway treats that as success.
 - **`GET /api/conversations/{id}`** gains an additive `active_turn` field:
   `{turn_id, conversation_id, started_at}` while a turn is in flight for
   that conversation, `null` otherwise. Lets a reconnecting client show

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -74,6 +74,55 @@ With #361, LifeOS `/chat` is the unified text+voice client. Voice *transport* st
 
 Web chat implements voice mode in `web/chat/voice.js` — tap-to-talk turn lifecycle (Voice|Text toggle, SSE `done` data, sequential audio, cancel via `AbortController`), same-origin via the reverse proxy. Mode persists in `sessionStorage` (`lifeos:chat:voice_mode`).
 
+## Turn lifetime and cancellation (#611)
+
+A chat turn's lifetime is owned by the server, not the SSE connection watching
+it — see [ADR-019](../../adr/019-turn-owned-by-server.md) for the full
+rationale. This applies to the native (`lifeos`) backend and the Hermes
+proxy; the Agent backend is unaffected (below).
+
+- **A client disconnecting no longer stops the turn.** Closing the tab,
+  backgrounding the app, or a network switch used to kill generation within
+  milliseconds and lose the reply outright. Now the turn keeps running
+  server-side and persists the complete reply, readable via `GET
+  /api/conversations/{id}` once it's reopened. A connected client's frame
+  sequence and bytes are unaffected — this is purely about what happens
+  *after* a disconnect.
+- **Exception: voice.** whisper-relay's adapter deliberately abandons the
+  LifeOS/Hermes stream as its cancel gesture on barge-in and hangup. A turn
+  with `modality: "voice"` therefore keeps the *old* disconnect-cancels
+  behavior — a voice-modality disconnect cancels the turn immediately,
+  exactly as before #611 — until whisper-relay is updated to call the
+  cancel endpoint below explicitly instead of just walking away.
+- **`POST /api/conversations/{id}/cancel`** stops whatever turn is in
+  flight for that conversation, native or Hermes-relayed alike. `{ok:
+  true, cancelled: true|false}` — `false` when nothing was running (already
+  finished, or never started); `404` if the conversation itself doesn't
+  exist. A new `POST /api/ask/stream` (or the Hermes equivalent) naming a
+  conversation that already has a turn in flight cancels the old one first
+  (supersede) — asking again is itself a stop gesture.
+- **`GET /api/conversations/{id}`** gains an additive `active_turn` field:
+  `{turn_id, conversation_id, started_at}` while a turn is in flight for
+  that conversation, `null` otherwise. Lets a reconnecting client show
+  "still working..." and reach the cancel affordance even after a reload.
+- **A cut-off turn is always marked, never presented as whole.** Whatever
+  text a turn produced before being cancelled, hitting its
+  `LIFEOS_DETACHED_TURN_TIMEOUT_SECONDS` deadline (default 300s, clock
+  starts at disconnect), being caught in a server shutdown drain, or dying
+  to a genuine stream error is persisted with a trailing, visible marker
+  (`"\n\n_[cut off — the turn ended before it finished]_"`) and a
+  `routing.truncated: true` / `routing.truncation_reason` on the stored
+  message (`"cancelled"` | `"deadline"` | `"shutdown"` | `"stream_error"`
+  on the native path; Hermes can only tell "a `done` event never arrived"
+  from "it did," so every Hermes truncation reports `"stream_error"`).
+  Neither field is new SSE wire protocol — they only ever appear on the
+  persisted message read back via `GET /api/conversations/{id}`, not on any
+  `data:` event.
+- **Byte identity for a connected client is unchanged.** No new SSE event
+  type and no new header were added — cancellation is keyed on
+  `conversation_id`, which every client already receives as the first SSE
+  event on both the native and Hermes paths.
+
 ## Text Backends
 
 `/chat` (and voice, via the gateway) targets one of three text backends, carried as an optional `backend` field (`lifeos` | `agent` | `hermes`, omitted/`lifeos` reproducing pre-#361 behavior exactly). Each gets its own section below because their capabilities genuinely differ — treat no statement in one backend's section as implying anything about another's.
@@ -84,7 +133,7 @@ The native orchestrator (`POST /api/ask/stream`, documented above and in [api-re
 
 ### Agent
 
-`agent` is the OpenClaw voice-adapter, reached at `LIFEOS_AGENT_BACKEND_URL` (optional bearer token) and proxied at `POST /api/agent/ask/stream` — LifeOS **adds the bearer server-side** so it never reaches the browser, and `GET /api/agent/status` reports whether it's configured (drives the UI selector). It speaks the same `/api/ask/stream` SSE contract as the native path. It has **no personas at all** — `persona_id` is never sent, so the persona and model pickers are both hidden while it's selected, no persona is ever diverted (nothing to divert), and no per-turn context is attached. It has **no handoff**. The route (`api/routes/agent_proxy.py`) is a pure byte relay (`request.stream()`, unbuffered — no `transform_body`, no `make_observer`), so its behavior is byte-for-byte what it was before Hermes existed. Its conversation history is **not** LifeOS-owned: nothing here persists it, so switching to `agent` shows a fresh view even though the stored conversation id is retained for continuity with whatever does own that history upstream. Because it isn't tee'd at all, its turns are also invisible to the usage store — unlike Hermes, below.
+`agent` is the OpenClaw voice-adapter, reached at `LIFEOS_AGENT_BACKEND_URL` (optional bearer token) and proxied at `POST /api/agent/ask/stream` — LifeOS **adds the bearer server-side** so it never reaches the browser, and `GET /api/agent/status` reports whether it's configured (drives the UI selector). It speaks the same `/api/ask/stream` SSE contract as the native path. It has **no personas at all** — `persona_id` is never sent, so the persona and model pickers are both hidden while it's selected, no persona is ever diverted (nothing to divert), and no per-turn context is attached. It has **no handoff**. The route (`api/routes/agent_proxy.py`) is a pure byte relay (`request.stream()`, unbuffered — no `transform_body`, no `make_observer`), so its behavior is byte-for-byte what it was before Hermes existed. Its conversation history is **not** LifeOS-owned: nothing here persists it, so switching to `agent` shows a fresh view even though the stored conversation id is retained for continuity with whatever does own that history upstream. Because it isn't tee'd at all, its turns are also invisible to the usage store — unlike Hermes, below. **It's also unaffected by #611** (turn-survives-disconnect): the registry-owned pump is gated on `make_observer` being set, and Agent never sets it, so a disconnected Agent-backend turn still stops exactly as before — detaching a relay nothing persists would only spend money with nothing to show for it.
 
 **These are properties of the Agent backend specifically, not of "external backends" generally** — Hermes, below, shares only some of them.
 
@@ -92,9 +141,13 @@ The native orchestrator (`POST /api/ask/stream`, documented above and in [api-re
 
 `hermes` is an agent harness reached as a gateway (#587), at `LIFEOS_HERMES_BACKEND_URL` (optional bearer token), proxied at `POST /api/hermes/ask/stream` with the same server-side bearer injection and a `GET /api/hermes/status` availability check. Both proxies are built by the same `make_backend_router()` factory in `api/routes/_proxy.py`; `agent_proxy.py` and `hermes_proxy.py` each just name their own settings fields and `_client()` test seam. Hermes has **no handoff** either — but unlike Agent, it keeps the persona picker visible, carries spoken-style rules on voice turns, receives the orchestrator's auto-injected turn context, and its history **is** LifeOS-owned. Its route (`api/routes/hermes_proxy.py`) buffers the request body (`transform_body`) to resolve the selected persona and attach it as the `lifeos_context` envelope below — the only text-backend proxy that does. Orchestrating personas never reach this route: they're diverted client-side to `POST /api/ask/stream` instead (#596, above), because the spawn they trigger is LifeOS-native and Hermes has no equivalent.
 
-#### Hermes turn persistence (#592) and usage capture (#595)
+#### Hermes turn persistence (#592, survives disconnect since #611) and usage capture (#595)
 
-Unlike the Agent backend, whose history genuinely lives elsewhere, Hermes turns are persisted into the same conversation store the native path uses, and their usage/cost is recorded into the same usage store. `make_backend_router()`'s relay loop (`api/routes/_proxy.py`) accepts an optional `make_observer` hook: given the same raw request body `transform_body` already buffers, it returns a `_HermesTurnPersister` (`api/routes/hermes_proxy.py`) whose `observe(chunk)` is called with a copy of each chunk immediately *before* that chunk is yielded to the browser (so an early client disconnect — which raises `GeneratorExit` at the `yield` — can never skip a chunk the tee hasn't seen yet), and whose `finalize()` runs whenever the relay ends — normal completion or an early disconnect alike. The persister reassembles SSE frames from the observed bytes (a chunk is a network read, not a frame, so frames can split across chunk boundaries) and reacts to the event types the native path emits: on the first `conversation_id` event it adopts that id via `ConversationStore.create_conversation(conv_id=..., persona_id=..., backend="hermes")` (existing rows are returned unchanged, so a continuing thread doesn't get re-tagged) and stores the user's question; `content` events accumulate into the assistant reply, written on `finalize()` — including whatever arrived if the stream died mid-turn; a `usage` event (`input_tokens`, `output_tokens`, `cost_usd`, `model`) is captured and, on `finalize()`, written to `UsageStore.record_usage()` tagged with the conversation id — **cost is recorded verbatim, never recomputed** (Hermes runs DeepSeek via Fireworks; LifeOS's calculator only knows Anthropic pricing), and a cost-less event records a zero cost rather than an invented one. Conversation persistence and usage persistence are independent: a turn with no `usage` event writes no usage row (and vice versa), and each is retried/skipped on its own. A malformed or partial `usage` event (missing/wrong-typed model or token counts) is ignored entirely. Every store call is wrapped so a persistence failure is logged and swallowed, never surfacing as a broken turn. The Agent proxy passes neither `transform_body` nor `make_observer`, so its relay is byte-for-byte what it was before this hook existed.
+Unlike the Agent backend, whose history genuinely lives elsewhere, Hermes turns are persisted into the same conversation store the native path uses, and their usage/cost is recorded into the same usage store. `make_backend_router()`'s relay loop (`api/routes/_proxy.py`) accepts an optional `make_observer` hook: given the same raw request body `transform_body` already buffers, it returns a `_HermesTurnPersister` (`api/routes/hermes_proxy.py`) whose `observe(chunk)` is called with a copy of each chunk immediately *before* that chunk is handed onward (never altered — the byte sequence a connected client sees is unaffected), and whose `finalize()` runs once, when the turn truly ends. **Since #611**, `make_observer` being set also gates a second behavior: the upstream drain runs as a registry-owned background pump (`api/services/chat_turns.py`) rather than the browser-facing generator itself, so a client disconnect no longer cuts the drain short — `finalize()` now fires on the pump's own real end, not on whatever the browser happened to still be attached for. The Agent proxy passes neither `transform_body` nor `make_observer`, so it's untouched by this — it never detaches, and its relay stays byte-for-byte what it was before either hook existed.
+
+The persister reassembles SSE frames from the observed bytes (a chunk is a network read, not a frame, so frames can split across chunk boundaries) and reacts to the event types the native path emits: on the first `conversation_id` event it adopts that id via `ConversationStore.create_conversation(conv_id=..., persona_id=..., backend="hermes")` (existing rows are returned unchanged, so a continuing thread doesn't get re-tagged) and stores the user's question, and — since #611 — binds the turn into the shared registry under that id, making it reachable by `POST /api/conversations/{id}/cancel` from that point on; `content` events accumulate into the assistant reply, written on `finalize()` — including whatever arrived if the pump ends early; a `usage` event (`input_tokens`, `output_tokens`, `cost_usd`, `model`) is captured and, on `finalize()`, written to `UsageStore.record_usage()` tagged with the conversation id — **cost is recorded verbatim, never recomputed** (Hermes runs DeepSeek via Fireworks; LifeOS's calculator only knows Anthropic pricing), and a cost-less event records a zero cost rather than an invented one. Conversation persistence and usage persistence are independent: a turn with no `usage` event writes no usage row (and vice versa), and each is retried/skipped on its own. A malformed or partial `usage` event (missing/wrong-typed model or token counts) is ignored entirely. Every store call is wrapped so a persistence failure is logged and swallowed, never surfacing as a broken turn.
+
+**Truncation (#611):** the persister tracks only whether a `done` event was ever observed. `finalize()` without one appends the same truncation marker and `routing.truncated`/`routing.truncation_reason: "stream_error"` the native path uses (see "Turn lifetime and cancellation" above) — the upstream connection ending before `done` arrived (a crash, a kill, a dropped connection) is the only signal available to this side; unlike the native path, Hermes truncation always reports `"stream_error"` regardless of the underlying cause.
 
 #### Usage and cost reporting (external backends) — #595
 
@@ -166,6 +219,8 @@ The `turn` object above — identical in shape to the response body of [`GET /ap
 | Orchestrating personas | Runs natively (spawns a background session) | N/A — never selectable | Diverted client-side to LifeOS (#596); never actually forwarded to Hermes |
 | Per-turn model selection | Yes (`model_override`: Auto/Sonnet/Opus/Gemma/Claude Code) | No — picker hidden | No — picker hidden; model choice is the harness's call, not LifeOS's |
 | Conversation history LifeOS-owned | Yes (always has been) | No | Yes, since #592 (tee-persisted) |
+| Survives a client disconnect (#611) | Yes (voice modality excepted — see above) | No — untouched, no observer to persist a detached turn's output | Yes (voice modality excepted — same gate) |
+| Explicit cancel (`POST .../cancel`, #611) | Yes | Yes (the endpoint doesn't distinguish backends — but nothing detaches here to cancel) | Yes |
 
 ### Default backend selection
 
@@ -195,6 +250,9 @@ Since #592, `restoreBackendConversation()` renders the stored conversation on a 
 ---
 
 ## Related Documents
+
+### Design Context
+- [ADR-019: A Turn's Lifetime Is Owned by the Server, Not the Connection](../../adr/019-turn-owned-by-server.md) — why a disconnect no longer stops a turn, the voice exception, and the tradeoffs
 
 ### Specifications
 - [API Reference](../product/api-reference.md) — Canonical endpoint and SSE shapes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,6 +359,26 @@ def _isolate_gmail_draft_ledger(tmp_path, monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_turn_registry():
+    """Reset the #611 chat-turn registry (`api/services/chat_turns.py`)
+    before and after every test.
+
+    It's a process-wide singleton holding live `asyncio.Task`s — a turn left
+    registered by one test (e.g. one that starts `ask_stream()` and never
+    lets its background task finish) would otherwise leak into the next
+    test's registry lookups, and a still-running task from a torn-down test
+    could touch a store another test has already swapped out. Mirrors
+    ``_isolate_conversation_store_db`` above for the same singleton-leakage
+    reason.
+    """
+    from api.services import chat_turns
+
+    chat_turns.reset_turn_registry()
+    yield
+    chat_turns.reset_turn_registry()
+
+
 @pytest.fixture(scope="session")
 def embedding_service():
     """

--- a/tests/test_chat_turn_cancel.py
+++ b/tests/test_chat_turn_cancel.py
@@ -1,0 +1,229 @@
+"""#611: the explicit cancellation path (`POST /api/conversations/{id}/cancel`),
+`active_turn` surfacing on `GET /api/conversations/{id}`, and supersede (a new
+turn on a conversation that already has one in flight cancels the old one
+first).
+
+Uses a lightweight app (just the chat + conversations routers, no lifespan)
+against a real ConversationStore/UsageStore on throwaway dbs — the same
+pattern tests/test_hermes_proxy.py and tests/test_persona_api.py already use
+for this router, so these don't pay for the full app's startup.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from api.routes import chat, conversations
+from api.services import chat_turns
+from api.services.conversation_store import ConversationStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _fresh_turn_registry():
+    chat_turns.reset_turn_registry()
+    yield
+    chat_turns.reset_turn_registry()
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    s = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+    monkeypatch.setattr(chat, "get_store", lambda: s)
+    monkeypatch.setattr(conversations, "get_store", lambda: s)
+    return s
+
+
+@pytest.fixture
+def api_client():
+    """A callable `(method, path) -> Response` — each call opens and closes
+    its own short-lived httpx.AsyncClient (ASGITransport is stateless/cheap),
+    so a test can make several requests without hitting httpx's "can't
+    reopen a closed client" guard that a single shared `async with` would."""
+    app = FastAPI()
+    app.include_router(conversations.router)
+
+    async def _call(method, path):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+            return await c.request(method, path)
+
+    return _call
+
+
+async def _drive_until(gen, min_events):
+    events = []
+    async for raw in gen:
+        text = raw.decode() if isinstance(raw, bytes) else raw
+        for line in text.split("\n"):
+            if line.startswith("data: "):
+                events.append(json.loads(line[len("data: "):]))
+        if len(events) >= min_events:
+            break
+    return events
+
+
+def _fake_agent_loop_holding_at(hold: asyncio.Event, first_chunk="Hello "):
+    async def fake_loop(**kwargs):
+        yield {"type": "text", "content": first_chunk}
+        await hold.wait()
+        yield {"type": "text", "content": "unreachable"}
+        yield {"type": "result", "result": SimpleNamespace(
+            total_input_tokens=1, total_output_tokens=1, total_cost_usd=0.0,
+            model="m", tool_calls_log=[], full_text=first_chunk + "unreachable",
+        )}
+    return fake_loop
+
+
+async def _start_turn_and_disconnect(monkeypatch, question="tell me something", hold=None):
+    """Start a real ask_stream() turn, pull events until the first content
+    chunk, then disconnect (close the reader) -- leaving a detached,
+    still-running turn behind, exactly like test_chat_turn_survives_disconnect.py."""
+    import api.services.agent_loop as agent_loop_mod
+
+    hold = hold or asyncio.Event()
+    monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_agent_loop_holding_at(hold))
+
+    async def fake_classify(*a, **k):
+        return None
+    monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+    request = chat.AskStreamRequest(question=question)
+    response = await chat.ask_stream(request)
+    gen = response.body_iterator
+    events = await _drive_until(gen, 3)  # conversation_id, routing, content
+    conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+    await gen.aclose()
+    return conversation_id, hold
+
+
+class TestCancelEndpoint:
+    async def test_404_for_unknown_conversation(self, api_client, store):
+        resp = await api_client("POST", "/api/conversations/does-not-exist/cancel")
+        assert resp.status_code == 404
+
+    async def test_200_cancelled_false_when_nothing_in_flight(self, api_client, store):
+        conv = store.create_conversation()
+        resp = await api_client("POST", f"/api/conversations/{conv.id}/cancel")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "cancelled": False}
+
+    async def test_cancels_an_unwatched_detached_turn_and_persists_partial(
+        self, api_client, store, monkeypatch,
+    ):
+        conversation_id, hold = await _start_turn_and_disconnect(monkeypatch)
+
+        # Nobody is reading the SSE stream any more (disconnected above) --
+        # the turn is running unwatched. Cancel it via the real endpoint.
+        resp = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        # The registry entry is popped once the task's own finally runs;
+        # await it directly here (not via the endpoint) to deterministically
+        # wait for that teardown before asserting on persisted rows.
+        if turn is not None and turn.task is not None:
+            with pytest.raises(asyncio.CancelledError):
+                await turn.task
+
+        messages = store.get_messages(conversation_id)
+        assert [(m.role, m.content) for m in messages[:1]] == [("user", "tell me something")]
+        assert len(messages) == 2
+        assert messages[1].role == "assistant"
+        assert "Hello " in messages[1].content
+        assert "cut off" in messages[1].content
+        assert messages[1].routing == {"truncated": True, "truncation_reason": "cancelled"}
+
+        # A second cancel of the same (now-finished) conversation reports
+        # nothing left in flight.
+        resp2 = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp2.json() == {"ok": True, "cancelled": False}
+
+
+class TestActiveTurnField:
+    async def test_present_while_running_absent_once_finished(
+        self, api_client, store, monkeypatch,
+    ):
+        conversation_id, hold = await _start_turn_and_disconnect(monkeypatch)
+
+        resp = await api_client("GET", f"/api/conversations/{conversation_id}")
+        assert resp.status_code == 200
+        active = resp.json()["active_turn"]
+        assert active is not None
+        assert active["conversation_id"] == conversation_id
+        assert active["turn_id"]
+        assert active["started_at"]
+
+        # Let the turn finish, then the field must be gone.
+        hold.set()
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        await turn.task
+
+        resp2 = await api_client("GET", f"/api/conversations/{conversation_id}")
+        assert resp2.json()["active_turn"] is None
+
+    async def test_absent_for_a_conversation_with_no_turn(self, api_client, store):
+        conv = store.create_conversation()
+        resp = await api_client("GET", f"/api/conversations/{conv.id}")
+        assert resp.json()["active_turn"] is None
+
+
+class TestSupersede:
+    async def test_new_turn_on_conversation_cancels_the_old_one_first(self, store, monkeypatch):
+        """A second POST /api/ask/stream naming a conversation that already
+        has a turn in flight cancels the old one before starting the new
+        one -- asking again is itself a stop gesture. Both rows land, in
+        order, the first marked as cut off."""
+        import api.services.agent_loop as agent_loop_mod
+
+        hold_first = asyncio.Event()
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_agent_loop_holding_at(hold_first, "first partial "))
+
+        first_request = chat.AskStreamRequest(question="first question")
+        first_response = await chat.ask_stream(first_request)
+        first_gen = first_response.body_iterator
+        first_events = await _drive_until(first_gen, 3)
+        conversation_id = next(e["conversation_id"] for e in first_events if e.get("type") == "conversation_id")
+        await first_gen.aclose()  # detach, but the first turn keeps running
+
+        first_turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        assert first_turn is not None
+
+        # A second, fully-synchronous fake loop for the superseding turn.
+        async def fake_loop_2(**kwargs):
+            yield {"type": "text", "content": "second full answer"}
+            yield {"type": "result", "result": SimpleNamespace(
+                total_input_tokens=2, total_output_tokens=2, total_cost_usd=0.0,
+                model="m", tool_calls_log=[], full_text="second full answer",
+            )}
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop_2)
+
+        second_request = chat.AskStreamRequest(question="second question", conversation_id=conversation_id)
+        second_response = await chat.ask_stream(second_request)
+        second_gen = second_response.body_iterator
+        async for _ in second_gen:
+            pass  # drain fully -- this fake loop finishes immediately
+
+        # The first turn was cancelled by the supersede, not left running.
+        with pytest.raises(asyncio.CancelledError):
+            await first_turn.task
+
+        messages = store.get_messages(conversation_id)
+        contents = [(m.role, m.content, m.routing) for m in messages]
+        assert contents[0] == ("user", "first question", None)
+        assert contents[1][0] == "assistant"
+        assert "first partial " in contents[1][1]
+        assert "cut off" in contents[1][1]
+        assert contents[1][2] == {"truncated": True, "truncation_reason": "cancelled"}
+        assert contents[2] == ("user", "second question", None)
+        assert contents[3] == ("assistant", "second full answer", {
+            "sources": [], "reasoning": "agentic (claude-haiku-4-5)", "tool_rounds": 0,
+        })

--- a/tests/test_chat_turn_cancel.py
+++ b/tests/test_chat_turn_cancel.py
@@ -23,13 +23,6 @@ from api.services.conversation_store import ConversationStore
 pytestmark = pytest.mark.unit
 
 
-@pytest.fixture(autouse=True)
-def _fresh_turn_registry():
-    chat_turns.reset_turn_registry()
-    yield
-    chat_turns.reset_turn_registry()
-
-
 @pytest.fixture
 def store(tmp_path, monkeypatch):
     s = ConversationStore(db_path=str(tmp_path / "conversations.db"))

--- a/tests/test_chat_turn_cancel.py
+++ b/tests/test_chat_turn_cancel.py
@@ -33,16 +33,19 @@ def store(tmp_path, monkeypatch):
 
 @pytest.fixture
 def api_client():
-    """A callable `(method, path) -> Response` — each call opens and closes
-    its own short-lived httpx.AsyncClient (ASGITransport is stateless/cheap),
-    so a test can make several requests without hitting httpx's "can't
-    reopen a closed client" guard that a single shared `async with` would."""
+    """A callable `(method, path, **kw) -> Response` — each call opens and
+    closes its own short-lived httpx.AsyncClient (ASGITransport is
+    stateless/cheap), so a test can make several requests without hitting
+    httpx's "can't reopen a closed client" guard that a single shared
+    `async with` would. Mounts both routers so `/api/conversations/*` and
+    `/api/chat/cancel` are both reachable."""
     app = FastAPI()
     app.include_router(conversations.router)
+    app.include_router(chat.router)
 
-    async def _call(method, path):
+    async def _call(method, path, **kw):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
-            return await c.request(method, path)
+            return await c.request(method, path, **kw)
 
     return _call
 
@@ -220,3 +223,327 @@ class TestSupersede:
         assert contents[3] == ("assistant", "second full answer", {
             "sources": [], "reasoning": "agentic (claude-haiku-4-5)", "tool_rounds": 0,
         })
+
+
+class TestClientTurnIdCancel:
+    """#611 review (whisper-relay maintainer): `conversation_id` alone can't
+    cancel a turn before its first SSE frame ever arrives -- a brand-new
+    conversation's id doesn't exist until the `conversation_id` event, and
+    that's exactly the window a first-turn voice barge-in falls into. A
+    client-generated `client_turn_id`, known before the request is even
+    sent, closes that gap. `POST /api/chat/cancel` accepts it."""
+
+    async def test_cancels_before_any_sse_frame_ever_arrives(self, store, monkeypatch):
+        import api.services.agent_loop as agent_loop_mod
+
+        hang_forever = asyncio.Event()
+
+        async def fake_loop(**kwargs):
+            await hang_forever.wait()  # would hang forever if not cancelled
+            yield {"type": "text", "content": "unreachable"}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(question="hi", client_turn_id="barge-in-key-1")
+        await chat.ask_stream(request)
+        # Deliberately never touch response.body_iterator -- no SSE frame,
+        # not even `conversation_id`, has been read. The only thing the
+        # caller has is the key it minted before sending the request.
+
+        turn = chat_turns.get_turn_registry().get_by_client_turn_id("barge-in-key-1")
+        assert turn is not None
+        assert turn.conversation_id is None  # not yet bound -- this is the whole point
+
+        cancelled = chat_turns.get_turn_registry().cancel_by_client_turn_id("barge-in-key-1")
+        assert cancelled is True
+
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task
+
+    async def test_cancel_endpoint_accepts_client_turn_id(self, api_client, store, monkeypatch):
+        import api.services.agent_loop as agent_loop_mod
+
+        hang_forever = asyncio.Event()
+
+        async def fake_loop(**kwargs):
+            await hang_forever.wait()
+            yield {"type": "text", "content": "unreachable"}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(question="hi", client_turn_id="barge-in-key-2")
+        await chat.ask_stream(request)
+
+        resp = await api_client("POST", "/api/chat/cancel", json={"client_turn_id": "barge-in-key-2"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        turn = chat_turns.get_turn_registry().get_by_client_turn_id("barge-in-key-2")
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task
+
+        # No such conversation exists to 404 on -- an unknown/expired key is
+        # just "nothing to cancel", 200, never a 4xx.
+        resp2 = await api_client("POST", "/api/chat/cancel", json={"client_turn_id": "never-existed"})
+        assert resp2.status_code == 200
+        assert resp2.json() == {"ok": True, "cancelled": False}
+
+    async def test_empty_client_turn_id_is_rejected_not_a_silent_noop(self, api_client, store):
+        # FastAPI's standard pydantic-validation-failure status (422) --
+        # loudly rejected, not silently treated as "nothing to cancel".
+        resp = await api_client("POST", "/api/chat/cancel", json={"client_turn_id": ""})
+        assert resp.status_code == 422
+
+    async def test_oversized_client_turn_id_rejected_on_ask_stream(self, store):
+        with pytest.raises(Exception):  # pydantic ValidationError
+            chat.AskStreamRequest(question="hi", client_turn_id="x" * 201)
+
+    async def test_control_character_client_turn_id_rejected_on_ask_stream(self, store):
+        with pytest.raises(Exception):
+            chat.AskStreamRequest(question="hi", client_turn_id="abc\x00def")
+
+    async def test_a_reused_client_turn_id_supersedes_the_old_turn(self, store, monkeypatch):
+        """Reusing the same client_turn_id on a second request (e.g. a retry)
+        cancels the first turn rather than leaving two turns registered
+        under the one key -- the same supersede semantics conversation_id
+        already gets."""
+        import api.services.agent_loop as agent_loop_mod
+
+        hang_forever = asyncio.Event()
+
+        async def fake_loop_1(**kwargs):
+            await hang_forever.wait()
+            yield {"type": "text", "content": "unreachable"}
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop_1)
+
+        first = chat.AskStreamRequest(question="first", client_turn_id="dup-key")
+        await chat.ask_stream(first)
+        first_turn = chat_turns.get_turn_registry().get_by_client_turn_id("dup-key")
+        assert first_turn is not None
+
+        async def fake_loop_2(**kwargs):
+            yield {"type": "text", "content": "second answer"}
+            yield {"type": "result", "result": SimpleNamespace(
+                total_input_tokens=1, total_output_tokens=1, total_cost_usd=0.0,
+                model="m", tool_calls_log=[], full_text="second answer",
+            )}
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop_2)
+
+        second = chat.AskStreamRequest(question="second", client_turn_id="dup-key")
+        second_response = await chat.ask_stream(second)
+        async for _ in second_response.body_iterator:
+            pass
+
+        with pytest.raises(asyncio.CancelledError):
+            await first_turn.task
+
+        # "dup-key" now resolves to the SECOND turn, not the first -- the
+        # scoping guarantee: a reused key always reaches its current
+        # claimant, never a stray earlier one.
+        current = chat_turns.get_turn_registry().get_by_client_turn_id("dup-key")
+        assert current is None  # the second turn already finished and was popped
+
+    async def test_client_turn_id_and_conversation_id_are_independently_scoped(self, store, monkeypatch):
+        """Two different, unrelated turns -- one reachable only by
+        conversation_id, one only by client_turn_id -- and cancelling one
+        must never touch the other."""
+        import api.services.agent_loop as agent_loop_mod
+
+        hold_a = asyncio.Event()
+        hold_b = asyncio.Event()
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        # Turn A: has a conversation_id (existing conversation), no client_turn_id.
+        conv = store.create_conversation()
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_agent_loop_holding_at(hold_a, "A "))
+        request_a = chat.AskStreamRequest(question="a", conversation_id=conv.id)
+        response_a = await chat.ask_stream(request_a)
+        await _drive_until(response_a.body_iterator, 2)  # routing, "A "
+
+        # Turn B: only a client_turn_id, no conversation_id yet.
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_agent_loop_holding_at(hold_b, "B "))
+        request_b = chat.AskStreamRequest(question="b", client_turn_id="only-b")
+        await chat.ask_stream(request_b)
+        # Don't touch response_b.body_iterator -- B intentionally has no
+        # conversation_id bound yet.
+
+        turn_a = chat_turns.get_turn_registry().get_by_conversation(conv.id)
+        turn_b = chat_turns.get_turn_registry().get_by_client_turn_id("only-b")
+        assert turn_a is not None and turn_b is not None
+        assert turn_a is not turn_b
+
+        # Let B's task actually take its first step before cancelling it --
+        # a task cancelled before it's ever run never executes its
+        # `finally` at all (a real asyncio behavior, not specific to this
+        # code), which would make the "pop() cleared the mapping" assertion
+        # below pass for the wrong reason. A real turn always has at least
+        # one `await turn.emit(...)` before anything could try to cancel it.
+        await asyncio.sleep(0)
+
+        # Cancelling B by its client_turn_id must not affect A.
+        assert chat_turns.get_turn_registry().cancel_by_client_turn_id("only-b") is True
+        with pytest.raises(asyncio.CancelledError):
+            await turn_b.task
+        assert not turn_a.task.done()
+
+        # And a lookup of A by conversation_id must never resolve through B's key.
+        assert chat_turns.get_turn_registry().get_by_conversation(conv.id) is turn_a
+        assert chat_turns.get_turn_registry().get_by_client_turn_id("only-b") is None
+
+        # Clean up A explicitly (its reader was only partially drained,
+        # never closed, so its emit() would otherwise block forever with
+        # nobody consuming the queue) -- the test's assertions are already
+        # done; this just avoids leaking a permanently-blocked task.
+        chat_turns.get_turn_registry().cancel_conversation(conv.id)
+        with pytest.raises(asyncio.CancelledError):
+            await turn_a.task
+
+
+class TestCancelOrderingsAroundAnAttachedReader:
+    """#611 review (whisper-relay maintainer): the gateway fires its cancel
+    POST from its cancel-event handler, not from inside its SSE read loop
+    (checking a flag between lines would add latency) -- so the POST can
+    genuinely arrive slightly BEFORE the client stops reading. All three
+    orderings below must be safe."""
+
+    async def test_cancel_while_reader_still_attached_works_and_reader_gets_clean_eof(
+        self, store, monkeypatch,
+    ):
+        import api.services.agent_loop as agent_loop_mod
+
+        hang_forever = asyncio.Event()
+
+        async def fake_loop(**kwargs):
+            yield {"type": "text", "content": "partial "}
+            await hang_forever.wait()
+            yield {"type": "text", "content": "unreachable"}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)  # conversation_id, routing, "partial "
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+
+        # Cancel now, WITHOUT ever closing/disconnecting the reader -- it's
+        # still attached and the caller keeps reading from it below.
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        assert turn is not None
+        cancelled = chat_turns.get_turn_registry().cancel_conversation(conversation_id)
+        assert cancelled is True
+
+        # The still-attached reader must drain to a clean EOF (StopAsyncIteration
+        # via the sentinel) rather than hang or raise -- no more real frames
+        # were emitted after cancellation, so the loop should end immediately.
+        remaining = [item async for item in gen]
+        assert remaining == []
+
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task
+
+        messages = store.get_messages(conversation_id)
+        assert len(messages) == 2
+        assert "partial " in messages[1].content
+        assert "cut off" in messages[1].content
+
+    async def test_disconnect_after_already_cancelled_is_a_clean_noop(self, store, monkeypatch):
+        """The reverse ordering: cancel fires, the turn's own finally pops
+        the registry and (while the reader was still attached) queues the
+        sentinel -- and only THEN does the client actually disconnect. That
+        disconnect must not double-finalize or raise."""
+        import api.services.agent_loop as agent_loop_mod
+
+        hang_forever = asyncio.Event()
+
+        async def fake_loop(**kwargs):
+            yield {"type": "text", "content": "partial "}
+            await hang_forever.wait()
+            yield {"type": "text", "content": "unreachable"}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        chat_turns.get_turn_registry().cancel_conversation(conversation_id)
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task  # let the task's own finally (pop + close) fully run first
+
+        # NOW the client disconnects -- after the turn already finalized.
+        # Must not raise, and must not write a second time.
+        await gen.aclose()
+
+        messages = store.get_messages(conversation_id)
+        assert len(messages) == 2  # unchanged: one user + one assistant row, not two
+
+        # A cancel of this now-fully-finished conversation is also a clean
+        # no-op, not an error.
+        resp = chat_turns.get_turn_registry().cancel_conversation(conversation_id)
+        assert resp is False
+
+    async def test_cancel_of_a_normally_finished_turn_is_200_not_4xx(self, api_client, store, monkeypatch):
+        """Distinct from the already-cancelled case above: a turn that ran
+        to normal completion (never cancelled at all), then cancelled after
+        the fact -- e.g. the gateway's POST lands just after `done`. Must
+        read as success (cancelled: false), never an error status."""
+        import api.services.agent_loop as agent_loop_mod
+
+        async def fake_loop(**kwargs):
+            yield {"type": "text", "content": "the whole answer"}
+            yield {"type": "result", "result": SimpleNamespace(
+                total_input_tokens=1, total_output_tokens=1, total_cost_usd=0.0,
+                model="m", tool_calls_log=[], full_text="the whole answer",
+            )}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        events = []
+        async for raw in response.body_iterator:
+            text = raw.decode() if isinstance(raw, bytes) else raw
+            for line in text.split("\n"):
+                if line.startswith("data: "):
+                    events.append(json.loads(line[len("data: "):]))
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+
+        resp = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "cancelled": False}
+
+        messages = store.get_messages(conversation_id)
+        assert len(messages) == 2
+        assert messages[1].content == "the whole answer"
+        assert messages[1].routing != {"truncated": True, "truncation_reason": "cancelled"}

--- a/tests/test_chat_turn_survives_disconnect.py
+++ b/tests/test_chat_turn_survives_disconnect.py
@@ -24,16 +24,6 @@ from api.services.usage_store import UsageStore
 pytestmark = pytest.mark.unit
 
 
-@pytest.fixture(autouse=True)
-def _fresh_turn_registry():
-    """A real module-level singleton would otherwise leak in-flight turns
-    (and their background tasks) across tests — same isolation concern
-    conversation_store.reset_conversation_store() exists for."""
-    chat_turns.reset_turn_registry()
-    yield
-    chat_turns.reset_turn_registry()
-
-
 @pytest.fixture
 def store(tmp_path, monkeypatch):
     s = ConversationStore(db_path=str(tmp_path / "conversations.db"))

--- a/tests/test_chat_turn_survives_disconnect.py
+++ b/tests/test_chat_turn_survives_disconnect.py
@@ -1,0 +1,182 @@
+"""#611: a chat turn's lifetime is owned by the server, not the SSE
+connection that happened to be watching it when it started.
+
+Today (before #611), `generate()` in `api/routes/chat.py` has no `finally`
+block and the assistant row is written once at the very end — so closing
+the SSE reader mid-turn (a browser tab closing, an app backgrounding) kills
+generation within milliseconds via the `CancelledError`/`GeneratorExit`
+Starlette delivers at the suspended `yield`, and nothing is ever persisted,
+not even the partial text. `test_native_turn_completes_and_persists_after_client_disconnect`
+below drives that exact sequence and must fail until the turn registry
+(`api/services/chat_turns.py`) decouples the turn's task from its reader.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from api.routes import chat
+from api.services import chat_turns
+from api.services.conversation_store import ConversationStore
+from api.services.usage_store import UsageStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _fresh_turn_registry():
+    """A real module-level singleton would otherwise leak in-flight turns
+    (and their background tasks) across tests — same isolation concern
+    conversation_store.reset_conversation_store() exists for."""
+    chat_turns.reset_turn_registry()
+    yield
+    chat_turns.reset_turn_registry()
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    s = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+    monkeypatch.setattr(chat, "get_store", lambda: s)
+    return s
+
+
+@pytest.fixture
+def usage_store(tmp_path, monkeypatch):
+    s = UsageStore(db_path=str(tmp_path / "usage.db"))
+    monkeypatch.setattr(chat, "get_usage_store", lambda: s)
+    return s
+
+
+async def _drive_until(gen, min_events):
+    """Pull SSE `data:` events off a StreamingResponse body_iterator until at
+    least `min_events` have been parsed, then stop pulling (the caller
+    closes the generator from here to simulate a client disconnect)."""
+    events = []
+    async for raw in gen:
+        text = raw.decode() if isinstance(raw, bytes) else raw
+        for line in text.split("\n"):
+            if line.startswith("data: "):
+                events.append(json.loads(line[len("data: "):]))
+        if len(events) >= min_events:
+            break
+    return events
+
+
+async def test_native_turn_completes_and_persists_after_client_disconnect(
+    store, usage_store, monkeypatch,
+):
+    import api.services.agent_loop as agent_loop_mod
+
+    resume = asyncio.Event()
+
+    async def fake_loop(**kwargs):
+        yield {"type": "text", "content": "Hello "}
+        yield {"type": "text", "content": "world"}
+        # A long tool-using turn is still running when the browser goes
+        # away — resumed explicitly below, after the reader has been
+        # closed, so the test controls exactly when that happens.
+        await resume.wait()
+        yield {"type": "text", "content": ", the full answer"}
+        yield {"type": "result", "result": SimpleNamespace(
+            total_input_tokens=12,
+            total_output_tokens=34,
+            total_cost_usd=0.0012,
+            model="claude-haiku-4-5",
+            tool_calls_log=[],
+            full_text="Hello world, the full answer",
+        )}
+
+    async def fake_classify(*a, **k):
+        return None
+
+    monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+    monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+    request = chat.AskStreamRequest(question="tell me something")
+    response = await chat.ask_stream(request)
+    gen = response.body_iterator
+
+    events = await _drive_until(gen, 3)  # conversation_id, routing, first content chunk
+    conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+
+    # The client disconnects here: close the reader without ever pulling the
+    # rest of the stream — exactly what a closed tab does to a StreamingResponse.
+    await gen.aclose()
+
+    # Let the still-running turn past its artificial pause point.
+    resume.set()
+
+    turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+    assert turn is not None and turn.task is not None
+    await turn.task  # the turn must keep running to completion server-side
+
+    messages = store.get_messages(conversation_id)
+    assert [(m.role, m.content) for m in messages] == [
+        ("user", "tell me something"),
+        ("assistant", "Hello world, the full answer"),
+    ]
+    # A turn that ran to completion carries no truncation marker.
+    assert "cut off" not in messages[-1].content
+    assert not (messages[-1].routing or {}).get("truncated")
+
+    stats = usage_store.get_usage_stats()
+    assert stats["request_count"] == 1
+    assert stats["total_input_tokens"] == 12
+    assert stats["total_output_tokens"] == 34
+
+
+async def test_voice_modality_disconnect_cancels_rather_than_detaches(store, monkeypatch):
+    """LEAD'S DECISION (#611): whisper-relay's adapter deliberately abandons
+    the LifeOS stream as its cancel gesture on barge-in/hangup. A voice
+    turn must NOT survive its client disconnecting — it must be cancelled,
+    same as before #611 — or every interruption would silently run to
+    completion and bill for a reply the operator cut off on purpose."""
+    import api.services.agent_loop as agent_loop_mod
+
+    started = asyncio.Event()
+    never = asyncio.Event()  # never set -- the turn must not reach this
+
+    async def fake_loop(**kwargs):
+        yield {"type": "text", "content": "Hello "}
+        started.set()
+        await never.wait()  # would hang forever if NOT cancelled on disconnect
+        yield {"type": "result", "result": SimpleNamespace(
+            total_input_tokens=1, total_output_tokens=1, total_cost_usd=0.0,
+            model="m", tool_calls_log=[], full_text="Hello unreachable",
+        )}
+
+    async def fake_classify(*a, **k):
+        return None
+
+    monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+    monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+    request = chat.AskStreamRequest(question="hi", modality="voice")
+    response = await chat.ask_stream(request)
+    gen = response.body_iterator
+
+    events = await _drive_until(gen, 3)  # conversation_id, routing, "Hello "
+    conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+    await started.wait()
+
+    turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+    assert turn is not None and turn.modality == "voice"
+
+    # The client disconnects (a barge-in/hangup) -- a text-modality turn
+    # would detach and keep running; a voice turn must be cancelled instead.
+    await gen.aclose()
+
+    with pytest.raises(asyncio.CancelledError):
+        await turn.task
+    assert turn.task.cancelled()
+
+    # The partial reply is still persisted, marked as cut off -- cancelling
+    # doesn't mean losing what was already said.
+    messages = store.get_messages(conversation_id)
+    assert [(m.role, m.content) for m in messages[:1]] == [("user", "hi")]
+    assert len(messages) == 2
+    assert messages[1].role == "assistant"
+    assert "Hello " in messages[1].content
+    assert "cut off" in messages[1].content
+    assert (messages[1].routing or {}).get("truncated") is True

--- a/tests/test_chat_turns.py
+++ b/tests/test_chat_turns.py
@@ -1,0 +1,143 @@
+"""Unit tests for api/services/chat_turns.py (#611) — the turn registry
+primitives directly, below the HTTP layer already covered by
+tests/test_chat_turn_survives_disconnect.py and tests/test_chat_turn_cancel.py.
+
+Covers the detached-lifetime deadline and the shutdown drain: both act on a
+turn's own `task`, so these build a `ChatTurn` and give it a real asyncio
+task directly rather than going through `ask_stream()`.
+"""
+import asyncio
+
+import pytest
+
+from api.services import chat_turns
+from config.settings import settings
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    chat_turns.reset_turn_registry()
+    yield
+    chat_turns.reset_turn_registry()
+
+
+def _spawn_turn(registry, conversation_id="conv-1", modality="text", body=None):
+    """A ChatTurn with a real task running `body` (an awaitable), wired into
+    the registry the same way ask_stream() wires a real one."""
+    turn = registry.create(conversation_id=conversation_id, modality=modality)
+
+    async def _run():
+        try:
+            await (body or asyncio.Event().wait())
+        finally:
+            registry.pop(turn)
+            await turn.close()
+
+    turn.task = asyncio.create_task(_run())
+    return turn
+
+
+class TestArmDeadline:
+    async def test_detached_turn_is_cancelled_after_the_configured_timeout(self, monkeypatch):
+        monkeypatch.setattr(settings, "detached_turn_timeout_seconds", 0.05)
+        registry = chat_turns.get_turn_registry()
+        hang_forever = asyncio.Event()
+        turn = _spawn_turn(registry, body=hang_forever.wait())
+
+        registry.arm_deadline(turn)
+
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task
+        assert turn.cancel_reason == "deadline"
+        assert registry.get_by_conversation("conv-1") is None
+
+    async def test_a_turn_that_finishes_before_the_deadline_is_left_alone(self, monkeypatch):
+        monkeypatch.setattr(settings, "detached_turn_timeout_seconds", 60.0)
+        registry = chat_turns.get_turn_registry()
+        done = asyncio.Event()
+        turn = _spawn_turn(registry, body=done.wait())
+        registry.arm_deadline(turn)
+
+        done.set()
+        await turn.task  # completes normally, well inside the 60s deadline
+        assert turn.cancel_reason is None
+        assert registry.get_by_conversation("conv-1") is None
+        # The deadline watcher itself must not still be pending forever —
+        # pop() cancels it once the turn finalizes.
+        assert turn._deadline_task.cancelled() or turn._deadline_task.done()
+
+
+class TestShutdown:
+    async def test_cancels_every_in_flight_turn_and_awaits_it(self):
+        registry = chat_turns.get_turn_registry()
+        never = asyncio.Event()
+        turn_a = _spawn_turn(registry, conversation_id="conv-a", body=never.wait())
+        turn_b = _spawn_turn(registry, conversation_id="conv-b", body=never.wait())
+        # Let both tasks actually start (reach their `await`) before
+        # cancelling them -- a task cancelled before its first scheduled
+        # step ever runs never executes its `finally` at all, which would
+        # make this test pass for the wrong reason (or, with a real
+        # ask_stream() turn, never happens: there's always at least one
+        # `await turn.emit(...)` before anything could try to cancel it).
+        await asyncio.sleep(0)
+
+        await registry.shutdown()
+
+        assert turn_a.task.cancelled()
+        assert turn_b.task.cancelled()
+        assert turn_a.cancel_reason == "shutdown"
+        assert turn_b.cancel_reason == "shutdown"
+        assert registry.get_by_conversation("conv-a") is None
+        assert registry.get_by_conversation("conv-b") is None
+
+    async def test_shutdown_with_no_turns_in_flight_is_a_no_op(self):
+        registry = chat_turns.get_turn_registry()
+        await registry.shutdown()  # must not raise
+
+
+class TestBindAndPop:
+    def test_bind_points_a_new_conversation_id_at_the_turn(self):
+        registry = chat_turns.get_turn_registry()
+        turn = registry.create(conversation_id=None)
+        assert registry.get_by_conversation("brand-new") is None
+
+        registry.bind(turn, "brand-new")
+
+        assert turn.conversation_id == "brand-new"
+        assert registry.get_by_conversation("brand-new") is turn
+
+    def test_pop_does_not_clobber_a_superseding_turns_mapping(self):
+        registry = chat_turns.get_turn_registry()
+        old_turn = registry.create(conversation_id="conv-1")
+        new_turn = registry.create(conversation_id="conv-1")  # supersede
+
+        # The old turn finishing after being superseded must not remove the
+        # NEW turn's mapping for the same conversation id.
+        registry.pop(old_turn)
+
+        assert registry.get_by_conversation("conv-1") is new_turn
+
+
+class TestChatTurnEmit:
+    async def test_emit_drops_frames_once_detached_instead_of_blocking(self):
+        turn = chat_turns.ChatTurn("t1", "conv-1", "text")
+        turn.reader_attached = False
+        # A detached turn's queue (maxsize=1) already has room, but emit()
+        # must not even try to use it -- this must return immediately
+        # without ever touching the queue that nobody will drain again.
+        await asyncio.wait_for(turn.emit("frame-1"), timeout=1.0)
+        assert turn._queue.qsize() == 0
+
+    async def test_emit_backpressures_while_attached(self):
+        turn = chat_turns.ChatTurn("t1", "conv-1", "text")
+        await turn.emit("frame-1")  # fills the maxsize=1 queue
+        second_emit = asyncio.ensure_future(turn.emit("frame-2"))
+        await asyncio.sleep(0.01)
+        assert not second_emit.done()  # blocked -- nobody has consumed frame-1 yet
+
+        got = await turn._queue.get()
+        assert got == "frame-1"
+        await second_emit  # now unblocks
+        second_emit.result()

--- a/tests/test_chat_turns.py
+++ b/tests/test_chat_turns.py
@@ -16,13 +16,6 @@ from config.settings import settings
 pytestmark = pytest.mark.unit
 
 
-@pytest.fixture(autouse=True)
-def _fresh_registry():
-    chat_turns.reset_turn_registry()
-    yield
-    chat_turns.reset_turn_registry()
-
-
 def _spawn_turn(registry, conversation_id="conv-1", modality="text", body=None):
     """A ChatTurn with a real task running `body` (an awaitable), wired into
     the registry the same way ask_stream() wires a real one."""

--- a/tests/test_hermes_proxy.py
+++ b/tests/test_hermes_proxy.py
@@ -7,6 +7,7 @@ the proxy's httpx client through an in-process stub backend via ASGITransport
 (no sockets), so they're fast and deterministic.
 """
 
+import asyncio
 import base64
 import json
 import logging
@@ -632,11 +633,17 @@ async def test_truncated_stream_still_persists_partial_content(monkeypatch, herm
     assert resp.status_code == 200
     assert resp.content == b"".join(_TRUNCATED_SSE_CHUNKS)
 
+    # #611: no `done` event ever arrived (the stub's stream just ends), so
+    # this is now flagged as a genuine truncation -- the marker and
+    # `routing.truncated` mean the browser can never mistake this cut-off
+    # reply for a whole one, the same guarantee the native path gives a
+    # cancelled/errored turn.
     messages = hermes_store.get_messages("trunc-1")
     assert [(m.role, m.content) for m in messages] == [
         ("user", "will this finish?"),
-        ("assistant", "partial reply"),
+        ("assistant", "partial reply\n\n_[cut off — the turn ended before it finished]_"),
     ]
+    assert messages[-1].routing == {"truncated": True, "truncation_reason": "stream_error"}
 
 
 stub_hermes_crlf = FastAPI()
@@ -649,6 +656,11 @@ stub_hermes_crlf = FastAPI()
 _CRLF_SSE_CHUNKS = [
     b'data: {"type": "conversation_id", "conversation_id": "crlf-1"}\r\n\r\n',
     b'data: {"type": "content", "content": "crlf reply"}\r\n\r\n',
+    # A `done` event (#611: its absence is now the truncation signal — see
+    # test_truncated_stream_still_persists_partial_content below) so this
+    # CRLF-framing test isn't mistaken for a genuinely truncated turn; this
+    # fixture predates #611 and was never about completion signaling.
+    b'data: {"type": "done"}\r\n\r\n',
 ]
 
 
@@ -691,15 +703,23 @@ async def test_crlf_framed_stream_still_persists(monkeypatch, hermes_store):
 
 
 async def test_client_disconnect_still_persists_the_last_chunk(monkeypatch, hermes_store):
-    """MAJOR (#592 review): `_proxy.py`'s relay loop used to call
-    `observer.observe(chunk)` *after* `yield chunk`. Closing the response
-    generator while it's suspended at that yield — exactly what an early
-    client disconnect does — raises `GeneratorExit` right there, which
-    skips any code written after the yield in that same loop iteration. The
-    chunk the relay had already handed off was silently never observed, so
-    a disconnect mid-turn lost the very content the partial-turn guarantee
-    (see `test_truncated_stream_still_persists_partial_content` above)
-    exists to keep.
+    """MAJOR (#592 review), STRENGTHENED by #611: `_proxy.py`'s relay loop
+    used to call `observer.observe(chunk)` *after* `yield chunk`. Closing
+    the response generator while it's suspended at that yield — exactly
+    what an early client disconnect does — raised `GeneratorExit` right
+    there, which skipped any code written after the yield in that same
+    loop iteration, so the chunk already handed off was silently never
+    observed. Fixed for #592 by observing before yielding.
+
+    #611 goes further: the upstream drain is no longer the response
+    generator's own loop at all. It's a registry-owned background pump
+    that keeps draining upstream regardless of what the browser does, so a
+    disconnect doesn't just fail to lose the LAST delivered chunk — it no
+    longer stops the turn early at all. The invariant this test now pins is
+    stronger: a disconnect never loses ANY observed chunk, including ones
+    that hadn't reached the browser yet when it disconnected. That's why
+    the persisted content below is the FULL relayed text ("first
+    chunknever requested"), not just "first chunk".
 
     Drives the endpoint's returned `StreamingResponse.body_iterator` by
     hand — pulling exactly one chunk, then closing it without ever asking
@@ -718,6 +738,12 @@ async def test_client_disconnect_still_persists_the_last_chunk(monkeypatch, herm
         b'data: {"type": "conversation_id", "conversation_id": "disco-1"}\n\n'
         b'data: {"type": "content", "content": "first chunk"}\n\n',
         b'data: {"type": "content", "content": "never requested"}\n\n',
+        # A `done` event (#611: its absence is now the "this turn was cut
+        # off" signal used by test_truncated_stream_still_persists_partial_content
+        # below) — the detached pump drains this fully regardless of what
+        # the reader below ever pulls, so this is what makes the persisted
+        # reply come out unmarked, matching a turn that actually finished.
+        b'data: {"type": "done"}\n\n',
     ]
 
     class _FakeUpstream:
@@ -778,16 +804,178 @@ async def test_client_disconnect_still_persists_the_last_chunk(monkeypatch, herm
 
     # Simulate the client vanishing right here: close the generator without
     # ever pulling the second chunk. This is exactly the "suspended at the
-    # yield" moment the finding describes.
+    # yield" moment the finding describes. Unlike before #611, this detaches
+    # the pump rather than stopping it -- await its turn's task to let it
+    # actually finish draining upstream before asserting on what's persisted.
     await gen.aclose()
+
+    from api.services.chat_turns import get_turn_registry
+    turn = get_turn_registry().get_by_conversation("disco-1")
+    assert turn is not None and turn.task is not None
+    await turn.task
 
     conv = hermes_store.get_conversation("disco-1")
     assert conv is not None
     messages = hermes_store.get_messages("disco-1")
     assert [(m.role, m.content) for m in messages] == [
         ("user", "will this survive a disconnect?"),
-        ("assistant", "first chunk"),
+        ("assistant", "first chunknever requested"),
     ]
+
+
+def _fake_upstream_and_client(gen_factory):
+    """A minimal fake httpx client/response pair (mirrors the `_FakeClient`/
+    `_FakeUpstream` pattern above and in test_agent_proxy.py) giving exact
+    control over the SSE chunks and their timing, for tests that need to
+    pause the upstream mid-turn to simulate a disconnect landing before it
+    finishes."""
+    class _FakeUpstream:
+        status_code = 200
+        headers = httpx.Headers({"content-type": "text/event-stream"})
+
+        async def aiter_raw(self):
+            async for c in gen_factory():
+                yield c
+
+        async def aclose(self):
+            pass
+
+    class _FakeClient:
+        def build_request(self, *a, **k):
+            return object()
+
+        async def send(self, *a, **k):
+            return _FakeUpstream()
+
+        async def aclose(self):
+            pass
+
+    return _FakeClient
+
+
+def _manual_request(body: dict):
+    """A `Request` whose `receive()` delivers `body` once, then reports a
+    disconnect on every subsequent call -- the same manual ASGI-scope
+    construction `test_client_disconnect_still_persists_the_last_chunk`
+    above uses, factored out for the two tests below."""
+    raw_body = json.dumps(body).encode()
+    body_sent = False
+
+    async def receive():
+        nonlocal body_sent
+        if not body_sent:
+            body_sent = True
+            return {"type": "http.request", "body": raw_body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/hermes/ask/stream",
+        "raw_path": b"/api/hermes/ask/stream",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 123),
+        "server": ("testserver", 80),
+        "http_version": "1.1",
+    }
+    return Request(scope, receive=receive)
+
+
+async def test_disconnect_then_completion_persists_full_reply_and_a_usage_row(
+    monkeypatch, hermes_store, usage_store,
+):
+    """#611: a Hermes turn that survives a disconnect (as above) also gets
+    its `usage` event captured once the pump finishes draining -- the
+    money side of "the turn runs to completion" holds too, not just the
+    text."""
+    monkeypatch.setattr(hp.settings, "hermes_backend_url", "http://hermes")
+    monkeypatch.setattr(hp.settings, "hermes_backend_token", "")
+
+    hold = asyncio.Event()
+
+    async def gen():
+        yield b'data: {"type": "conversation_id", "conversation_id": "disco-usage-1"}\n\n'
+        yield b'data: {"type": "content", "content": "partial "}\n\n'
+        await hold.wait()
+        yield b'data: {"type": "content", "content": "rest"}\n\n'
+        yield b'data: {"type": "usage", "model": "m", "input_tokens": 5, "output_tokens": 7, "cost_usd": 0.002}\n\n'
+        yield b'data: {"type": "done"}\n\n'
+
+    monkeypatch.setattr(hp, "_client", lambda: _fake_upstream_and_client(gen)())
+
+    endpoint = next(r for r in hp.router.routes if r.path.endswith("/ask/stream")).endpoint
+    request = _manual_request({"question": "will usage survive a disconnect?"})
+
+    response = await endpoint(request)
+    gen_iter = response.body_iterator
+    await gen_iter.__anext__()  # conversation_id
+    await gen_iter.__anext__()  # "partial "
+
+    # Disconnect before "rest", the usage event, or done ever reach the browser.
+    await gen_iter.aclose()
+    hold.set()  # let the still-running pump past its pause
+
+    turn = hp.get_turn_registry().get_by_conversation("disco-usage-1")
+    assert turn is not None and turn.task is not None
+    await turn.task
+
+    messages = hermes_store.get_messages("disco-usage-1")
+    assert [(m.role, m.content) for m in messages] == [
+        ("user", "will usage survive a disconnect?"),
+        ("assistant", "partial rest"),
+    ]
+    stats = usage_store.get_usage_stats()
+    assert stats["request_count"] == 1
+    assert stats["total_input_tokens"] == 5
+    assert stats["total_output_tokens"] == 7
+    assert stats["total_cost"] == pytest.approx(0.002)
+
+
+async def test_voice_modality_disconnect_cancels_the_pump_rather_than_detaching(
+    monkeypatch, hermes_store,
+):
+    """LEAD'S DECISION (#611), extended to the Hermes pump: a voice-modality
+    turn relayed through Hermes must also be cancelled by a disconnect
+    rather than surviving it -- whisper-relay's barge-in/hangup cancel
+    gesture is abandoning whatever LifeOS-speaking stream it's talking to,
+    native or Hermes-relayed alike."""
+    monkeypatch.setattr(hp.settings, "hermes_backend_url", "http://hermes")
+    monkeypatch.setattr(hp.settings, "hermes_backend_token", "")
+
+    never = asyncio.Event()
+
+    async def gen():
+        yield b'data: {"type": "conversation_id", "conversation_id": "voice-disco-1"}\n\n'
+        yield b'data: {"type": "content", "content": "Hello "}\n\n'
+        await never.wait()  # would hang forever if the pump weren't cancelled
+        yield b'data: {"type": "content", "content": "unreachable"}\n\n'
+
+    monkeypatch.setattr(hp, "_client", lambda: _fake_upstream_and_client(gen)())
+
+    endpoint = next(r for r in hp.router.routes if r.path.endswith("/ask/stream")).endpoint
+    request = _manual_request({"question": "hi", "modality": "voice"})
+
+    response = await endpoint(request)
+    gen_iter = response.body_iterator
+    await gen_iter.__anext__()  # conversation_id
+    await gen_iter.__anext__()  # "Hello "
+    await gen_iter.aclose()  # the barge-in/hangup disconnect
+
+    turn = hp.get_turn_registry().get_by_conversation("voice-disco-1")
+    assert turn is not None and turn.modality == "voice"
+    with pytest.raises(asyncio.CancelledError):
+        await turn.task
+    assert turn.task.cancelled()
+
+    messages = hermes_store.get_messages("voice-disco-1")
+    assert [(m.role, m.content) for m in messages] == [
+        ("user", "hi"),
+        ("assistant", "Hello " + hp.TRUNCATION_MARKER),
+    ]
+    assert messages[-1].routing == {"truncated": True, "truncation_reason": "stream_error"}
 
 
 # ---------------------------------------------------------------------------
@@ -993,6 +1181,11 @@ class TestHermesTurnPersisterDirect:
         persister.observe(b'ersation_id": "split-1"}\n\n')
         persister.observe(b'data: {"type": "content", "content": "he')
         persister.observe(b'llo"}\n\n')
+        # A `done` event (#611: its absence is now the "this turn was cut
+        # off" signal — see test_truncated_stream_still_persists_partial_content
+        # below) so this frame-reassembly test isn't mistaken for a
+        # genuinely truncated turn; this fixture predates #611.
+        persister.observe(b'data: {"type": "done"}\n\n')
         persister.finalize()
 
         messages = hermes_store.get_messages("split-1")
@@ -1028,6 +1221,9 @@ class TestHermesTurnPersisterDirect:
         # Still mid-stream: nothing written to the store yet.
         assert calls == []
 
+        # A `done` event (#611) so this test isn't mistaken for a genuinely
+        # truncated turn — see test_truncated_stream_still_persists_partial_content.
+        persister.observe(b'data: {"type": "done"}\n\n')
         persister.finalize()
 
         assert calls == [
@@ -1050,6 +1246,9 @@ class TestHermesTurnPersisterDirect:
         persister = hp._HermesTurnPersister(question="second turn q", persona_id="primary")
         persister.observe(b'data: {"type": "conversation_id", "conversation_id": "existing-1"}\n\n')
         persister.observe(b'data: {"type": "content", "content": "second turn a"}\n\n')
+        # A `done` event (#611) so this test isn't mistaken for a genuinely
+        # truncated turn — see test_truncated_stream_still_persists_partial_content.
+        persister.observe(b'data: {"type": "done"}\n\n')
         persister.finalize()
 
         assert len(hermes_store.list_conversations()) == 1

--- a/web/chat/ask-stream.js
+++ b/web/chat/ask-stream.js
@@ -90,6 +90,23 @@ export async function askStream({ question, conversationId, attachments, persona
   }
 }
 
+// Stop the turn in flight for the current conversation (#611). A turn now
+// keeps running server-side after the browser gives up on the stream, so an
+// explicit cancel is the only way to actually stop it — closing the tab or
+// navigating away no longer does. Best-effort: on failure there's nothing
+// useful to show the user; the turn just keeps running, same as before #611.
+export async function stopTurn() {
+  const conversationId = state.currentConversationId;
+  if (!conversationId) return;
+  try {
+    await fetch(`${endpoints.conversations}/${encodeURIComponent(conversationId)}/cancel`, {
+      method: 'POST',
+    });
+  } catch (e) {
+    // network blip — nothing to surface here
+  }
+}
+
 export async function sendMessage() {
   const question = elements.inputField.value.trim();
   if (!question || state.isLoading) return;
@@ -104,6 +121,10 @@ export async function sendMessage() {
   state.isLoading = true;
   setStatus('loading', 'Thinking...');
   elements.sendBtn.disabled = true;
+  // Swap Send for Stop (#611) — hidden again once this turn settles, in the
+  // same place sendBtn is re-enabled below.
+  elements.sendBtn.style.display = 'none';
+  elements.stopBtn.classList.add('visible');
 
   // Capture attachments before clearing
   const messageAttachments = [...state.attachments];
@@ -330,6 +351,8 @@ export async function sendMessage() {
 
   state.isLoading = false;
   elements.sendBtn.disabled = false;
+  elements.sendBtn.style.display = '';
+  elements.stopBtn.classList.remove('visible');
   elements.inputField.focus();
 }
 

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -17,7 +17,7 @@ import {
   setupSwipeGestures, toggleSidebar, closeSidebar, newChat,
   filterConversations, loadConversation, deleteConversation,
 } from './conversations.js';
-import { sendMessage, askQuestion } from './ask-stream.js';
+import { sendMessage, askQuestion, stopTurn } from './ask-stream.js';
 import { loadPersonas, onPersonaChange, personaOrchestrates, personaSupportsHandoff } from './persona.js';
 import { initVoice, toggleVoiceMode, submitTurn } from './voice.js';
 import { initBackend } from './backend.js';
@@ -83,7 +83,7 @@ Object.assign(window, {
   // attachments.js
   openFilePicker, removeAttachment,
   // ask-stream.js
-  sendMessage, askQuestion,
+  sendMessage, askQuestion, stopTurn,
   // persona.js
   onPersonaChange,
   // model.js

--- a/web/index.html
+++ b/web/index.html
@@ -1256,6 +1256,33 @@
             transform: none;
         }
 
+        /* Stop button (#611): swapped in for send-btn while a turn is in
+           flight. Shares send-btn's box so the composer layout doesn't
+           shift; a distinct color signals it's a different action. */
+        .stop-btn {
+            width: 48px;
+            height: 48px;
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            color: var(--text-primary);
+            font-size: 1.1rem;
+            cursor: pointer;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s;
+            flex-shrink: 0;
+        }
+
+        .stop-btn.visible {
+            display: flex;
+        }
+
+        .stop-btn:hover {
+            background: var(--bg-secondary);
+        }
+
         /* Attach button — iMessage-style round "+" to the left of the box */
         .attach-btn {
             width: 40px;
@@ -2897,6 +2924,10 @@
                     ></textarea>
                 </div>
                 <button class="send-btn" id="sendBtn" onclick="sendMessage()" title="Send message">➤</button>
+                <!-- Stop (#611): shown in place of Send while a turn is in flight.
+                     Cancels the turn server-side rather than just walking away from
+                     the stream -- the turn otherwise keeps running to completion. -->
+                <button class="stop-btn" id="stopBtn" onclick="stopTurn()" title="Stop">⏹</button>
             </div>
             <!-- Voice dock (#361): tap-to-talk + dock toggles; shown in voice mode -->
             <div class="voice-dock" id="voiceDock">
@@ -3131,6 +3162,7 @@
                 elements: {
                     messagesEl, inputField, chatTitle,
                     sendBtn: document.getElementById('sendBtn'),
+                    stopBtn: document.getElementById('stopBtn'),
                     statusDot: document.getElementById('statusDot'),
                     statusText: document.getElementById('statusText'),
                     conversationsList: document.getElementById('conversationsList'),


### PR DESCRIPTION
## Problem

Reported from live use: a session mid-response should persist and finish when the app or webpage closes. It doesn't.

Measured on the running server rather than assumed, and the native path is **worse than reported**:

- **Native `/api/ask/stream`**: generation is killed within milliseconds of disconnect and **nothing is persisted** — not even partial text. `generate()` had zero `finally:` blocks; the assistant row is written at the end, and the `CancelledError`/`GeneratorExit` Starlette delivers at the suspended `yield` can't be caught by its `except Exception`. Result: conversation, title, and your question exist with **no assistant message**.
- **Hermes**: `finalize()` did fire on disconnect, so a truncated reply was stored — with **no marker** and **no usage row**, since the upstream `usage` event arrives after the reader leaves. A partially-billed turn recorded zero cost.
- **Agent proxy**: nothing persisted.
- Client-side rehydration was ruled out: the reply genuinely did not exist.

Upstream also aborts immediately on every path, so "keep it running" is a real change in spend — bounded by the existing `max_tool_rounds=5` × `max_tokens=4096`.

## Design

A turn owns its lifetime; the SSE response is a reader that may leave. New `api/services/chat_turns.py`: `ChatTurn` (bounded queue, `emit`/`reader`/`close`) and `TurnRegistry`. `ask_stream()` starts the turn as a background task and returns `StreamingResponse(turn.reader(), ...)`. Frames map 1:1 to `emit` exactly as they did to `yield`, so a connected turn's bytes and ordering are unchanged.

**Cancellation** — three gestures, because removing disconnect-as-stop requires replacing it:
- `POST /api/conversations/{id}/cancel` → `{ok, cancelled}`; 404 unknown, `cancelled: false` when nothing is in flight.
- `POST /api/chat/cancel` with `{client_turn_id}`. Separate endpoint deliberately: a conversation id names a persistent resource so an unknown one is a real 404, while a turn key is ephemeral and an unknown key is indistinguishable from a finished turn — there is no honest 404, so overloading one endpoint would make that incoherent.
- A **Stop** button in the composer, and **supersede** (a new turn on a conversation cancels the prior one, so asking again is itself a stop gesture).

`client_turn_id` is optional on `POST /api/ask/stream`, generated client-side **before the request is sent**. This exists because cancel-by-conversation-id cannot cancel a *first* turn — the real id only arrives in an SSE frame, and first-turn barge-in is the most common voice interruption. Found by the whisper-relay maintainer reviewing the shape against their adapter; they have since confirmed their existing per-turn UUID4 maps directly onto this field, so adopting it costs one body field and no new plumbing. Validated ≤200 chars, no control characters; a reused key supersedes its prior holder; the mapping clears only if it still points at the popping turn; keys are scoped so one client's key can't reach another's turn.

**Exactly-once**: all exits (normal / cancel / deadline / shutdown) funnel through one `_finalize` guarded by a `finalized` flag. Reconnecting is a read, not a POST, so no second turn can exist. `GET /api/conversations/{id}` gains an additive `active_turn`.

**Bounding**: `LIFEOS_DETACHED_TURN_TIMEOUT_SECONDS` (default 300), clock starting **at detach** so a watched turn is unchanged. Lifespan shutdown drains the registry so a mid-turn redeploy stores an honest partial. Interrupted writes carry a visible truncation marker plus `routing.truncated` / `truncation_reason`.

## Voice is gated out, deliberately

whisper-relay's adapter uses **abandoning the LifeOS stream as its cancel gesture** on barge-in and hangup. If voice turns detached, every interruption would silently run to completion and bill for a reply the user cut off on purpose — on the surface most used from mobile. Worse, the gateway would still emit a `cancelled` event to its client while the turn kept running server-side: invisible from that side.

So a `modality == "voice"` turn keeps today's cancel-on-disconnect semantics, on **both** the native path and the Hermes pump (Hermes supports voice turns per #593, so a native-only gate would leave the hole half-closed). Pinned by tests on both paths. The gate lifts once the gateway calls the explicit endpoint — tracked as **#616** here and whisper-relay#37 there — after which voice gets correct barge-in *and* survival across a hangup.

## Byte identity

`test_persists_turn_and_relay_stays_byte_identical` and all of `test_agent_proxy.py` pass **unmodified**. Detachment is gated on `make_observer` being set, so the Agent proxy is untouched — nothing is persisted there, and detaching would only spend money.

Six existing tests changed: the two authorized Hermes tests (strengthened, below) plus four classified **Equal** — one `done` SSE frame added to a fixture constant or `observe()` sequence, zero assertion changes (`test_crlf_framed_stream_still_persists`, `test_reassembles_frame_split_across_observe_calls`, `test_observe_never_calls_the_store`, `test_continues_an_existing_conversation_without_duplicating`). They relied on the incidental *absence* of `done`, which the new truncation signal would otherwise read as truncation. The two authorized Hermes tests are **strengthened**: the disconnect test now asserts the full relayed text rather than the first chunk, and the truncation test asserts the marker and routing.

## Known limitations, documented not hidden

- Hermes's truncation reason is **always** `"stream_error"` — never `cancelled`, `deadline`, or `shutdown`, even when a Hermes turn is cancelled by the deadline watcher or the shutdown drain. This is a wiring gap rather than an information gap: `turn.cancel_reason` *is* set correctly on the shared `ChatTurn` (Hermes turns go through the same `reader()`/registry as native ones), but `_HermesTurnPersister.finalize()` only reads its own `_done_seen` flag and never consults it. Closing it means passing a reason into `finalize()`. Asymmetry recorded in the ADR.
- An `asyncio.Task` cancelled before its first scheduled step never runs its `finally`. Harmless in practice (a real turn always awaits an `emit` first) but recorded, since `registry.shutdown()` is where it could surface.
- A cancelled native turn records partial text but no usage — `run_agent_loop` reports usage only in its final event. Filed as **#619**, deliberately not mixed in.
- The web Stop button cancels by `conversation_id`, which is set by the time a user could click it. `client_turn_id` targets the pre-first-frame voice case.

## Verification

The failing-today test asserts the **full** text (`[("user", ...), ("assistant", "Hello world, the full answer")]`), where the final chunk arrives only after a pause the test controls — so it fails today because nothing is persisted, and passes now only because the complete post-pause text landed, not because *a* row exists.

212 passed across `test_chat_turns.py`, `test_chat_turn_survives_disconnect.py`, `test_chat_turn_cancel.py`, `test_hermes_proxy.py`, `test_agent_proxy.py`, `test_chat_api.py`, `test_persona_api.py`, `test_conversations_api.py`, `test_attachments.py`.

Gate scope (`-m "unit and not slow"`): **3575 passed / 8 skipped** against a 3547 / 8 baseline on `main` — net +28, all from this branch's new and modified test files. Pre-push gate passed.

## Docs

New **ADR-019** ("a turn's lifetime is owned by the server, not the connection"), indexed, referencing ADR-018 — the tradeoff isn't "no spend without consent" but that an already-authorized turn is allowed to finish. Plus `client-surfaces.md`, `api-reference.md`, and `configuration.md`. `api-reference.md`'s now-false "HTTP stream close also finalizes" line was corrected.

## Merge note

Merge after #620. Merging 608 → 609 → 607 → 610 → 611 yields exactly one conflict: `tests/conftest.py`, where this branch's `_reset_turn_registry` and #610's `_isolate_usage_store_db` were inserted at the same spot. Purely additive — **keep both**.

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

