### PR TITLE
fix(tests): derive the env-isolation expectation from the checkout, not assume it

### DIFF
--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -150,22 +150,68 @@ def test_main_py_does_not_use_bare_load_dotenv():
         "parent checkout's real .env). Pass an explicit repo-root path."
     )
 
-
 def test_settings_user_name_is_deterministic_regardless_of_import_order():
     """The downstream effect of the fix: `settings.user_name` (read into a
     module-level constant at import time by several modules -- see this
-    file's module docstring) is the safe field default, whether or not
-    `api.main` has already been imported by something else in this worker
-    process. Before the fix, whichever test triggered that import first
-    decided the answer for the rest of the process; there was no way for a
-    single test to assert this, because the outcome depended on collection
-    order under xdist. After the fix there's nothing left to depend on.
+    file's module docstring) comes from *this checkout's own* config, whether
+    or not `api.main` has already been imported by something else in this
+    worker process. Before the fix, whichever test triggered that import
+    first decided the answer for the rest of the process; there was no way
+    for a single test to assert this, because the outcome depended on
+    collection order under xdist.
+
+    The expected value is derived from whether this checkout has its own
+    `.env`, rather than assumed absent (#623). Asserting the bare field
+    default only holds in a worktree; in the canonical checkout a real `.env`
+    sits at the repo root and *is* the correct thing to have loaded. Pinning
+    the default there made a correct environment look broken and blocked
+    `git push` outright, since the pre-push hook runs the suite in the
+    pushing repository.
+
+    Be clear about how much this test guards, because it is less than it
+    looks. It is a demonstration of the downstream effect, not the primary
+    regression catcher:
+
+    - In the canonical checkout a bare `load_dotenv()` finds this same
+      repo-root file anyway, so the regression is invisible *by value* here.
+    - Even in a worktree it only catches the regression when `config.settings`
+      is imported *after* `api.main` in the same process. `settings` is a
+      module-level singleton built at its own import time, so when something
+      (conftest, another test) has already imported it, a later leak into
+      `os.environ` no longer changes `settings.user_name`. Verified by
+      reverting `api/main.py` to a bare `load_dotenv()`: this test still
+      passed, and only the static guard below failed.
+
+    So the real coverage lives elsewhere in this file, and both of those are
+    location-independent: `test_bare_load_dotenv_leaks_from_a_worktree_parent`
+    / `test_pinned_load_dotenv_does_not_leak` prove the mechanism in a
+    subprocess against a synthetic nested checkout, and
+    `test_main_py_does_not_use_bare_load_dotenv` guards the call form
+    statically. Keep this test for the downstream illustration it provides --
+    just don't rely on it as the guard.
     """
+    from dotenv import dotenv_values
+
     import api.main  # noqa: F401 -- exercise the (now-pinned) load_dotenv path
     from config.settings import settings
 
-    assert settings.user_name == "User", (
-        "settings.user_name is not the field default. Either a real .env is "
-        "reachable from this checkout (see test_fixtures_no_personal_data.py) "
-        "or api/main.py's load_dotenv regressed to searching upward."
-    )
+    field = type(settings).model_fields["user_name"]
+    own_dotenv = Path(__file__).resolve().parent.parent / ".env"
+
+    # dotenv_values parses without touching os.environ, so reading a real
+    # machine-specific file here can't itself leak config into this process
+    # (same approach as tests/test_fixtures_no_personal_data.py).
+    expected = field.default
+    if own_dotenv.is_file():
+        expected = dotenv_values(own_dotenv).get(field.alias) or field.default
+
+    if settings.user_name != expected:
+        # Deliberately not echoing either value: on a real machine both may
+        # be personal, and this message can reach CI logs.
+        pytest.fail(
+            "settings.user_name did not come from this checkout's own config. "
+            "Either api/main.py's load_dotenv regressed to an upward search "
+            "(escaping a worktree into an ancestor checkout's .env, reopening "
+            "#598), or some other .env is being loaded. Values withheld -- "
+            "they may be personal."
+        )


### PR DESCRIPTION
## Problem

`tests/test_env_isolation.py::test_settings_user_name_is_deterministic_regardless_of_import_order` asserted `settings.user_name == "User"` — the bare field default. That holds in a worktree (no `.env` of its own) and **never** holds in the canonical checkout, where a real `.env` sits at the repo root and *is* the correct thing to have loaded.

Because the pre-push hook runs the unit suite in the pushing repository, **`git push` from the canonical checkout was unconditionally blocked** — the gate died on this one test regardless of what was being pushed. Worse, it made a *correct* environment look broken: its own message named "a real `.env` is reachable" first, without saying that's expected there.

Confirmed pre-existing and environment-dependent: reproduced at `80148af` in a detached worktree with the real `.env` symlinked in (1 failed, 3 passed); a clean worktree at the same commit passes 4/4.

## Fix

Derive the expected value instead of assuming it: parse this checkout's own repo-root `.env` when one exists, fall back to the field default when it doesn't.

Both the env key and the default come from the model field itself (`alias` / `default`) rather than being retyped, so renaming either can't silently decouple the test. Parsing uses `dotenv_values`, which never touches `os.environ` — the same approach `tests/test_fixtures_no_personal_data.py` already takes for reading a real config safely. On mismatch the failure **withholds both values**, since on a real machine either may be personal and the message can reach CI logs.

## What verifying this revealed

I reverted `api/main.py` to a bare `load_dotenv()` to confirm the test still catches the #598 regression. **It didn't** — only the static guard failed.

The reason: `settings` is a module-level singleton built at its own import time. Once anything has imported `config.settings` (conftest, another test), a later leak into `os.environ` no longer changes `settings.user_name`. So this test only ever caught the regression when `config.settings` happened to be imported *after* `api.main`, and it only "worked" at all because asserting the bare default happened to hold in a worktree.

The docstring now says this plainly, because it was not written down and is easy to over-trust. This test is a **demonstration of the downstream effect, not the regression catcher.**

## Where the real coverage lives — unchanged and untouched

Both are location-independent and both actually fail on a regression:

- `test_bare_load_dotenv_leaks_from_a_worktree_parent` / `test_pinned_load_dotenv_does_not_leak` — prove the mechanism in a **subprocess** against a synthetic nested checkout, so no in-process import ordering can mask it.
- `test_main_py_does_not_use_bare_load_dotenv` — static guard on the call form; this is what caught my deliberate regression.

The #598 invariant is fully preserved. Only the weakest of the four tests changed, and only in how it computes its expectation.

## Verification

- Worktree with no `.env`: **4 passed**
- Real repo-root `.env` present: **4 passed**
- Deliberate regression to bare `load_dotenv()`: caught by the static guard (and documented as the reason the value test alone is insufficient)

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)