### PR TITLE
feat(voice): lift the modality-keyed detachment gate

### DIFF
--- a/api/routes/_proxy.py
+++ b/api/routes/_proxy.py
@@ -43,8 +43,10 @@ def _sniff_modality(raw_body: bytes) -> str:
     """Best-effort read of the request's `modality` field (#611), straight
     off the same raw pre-transform body `transform_body`/`make_observer`
     already receive — generic across whatever backend uses this router, not
-    Hermes-specific. Used only to gate a relayed turn out of detachment the
-    same way the native path does (see ChatTurn.reader()'s voice gate);
+    Hermes-specific. Recorded on the `ChatTurn` for parity with the native
+    path's own turn (and, until #616, used to gate a relayed voice turn out
+    of detachment the same way ChatTurn.reader() gated the native path — that
+    gate is now lifted, so this no longer affects cancellation on its own);
     anything unparseable defaults to "text" rather than raising, since a
     malformed body is `transform_body`'s problem to reject, not this one's."""
     try:

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -566,10 +566,11 @@ async def ask_stream(request: AskStreamRequest):
     personal_context = settings.personal_context(_effective_pid or "")
 
     # #611: the turn's lifetime is owned by the server from here on, not by
-    # this SSE connection. `modality` decides how a disconnect behaves once
-    # the turn task is running (see ChatTurn.reader() in chat_turns.py for
-    # the voice gate); text/unset turns survive the client leaving, voice
-    # turns keep today's disconnect-cancels semantics.
+    # this SSE connection — every modality survives the client leaving
+    # (#616 lifted the voice-only exception; see ChatTurn.reader() in
+    # chat_turns.py). `modality` is still recorded on the turn for parity
+    # with the request and for other voice-specific behavior elsewhere
+    # (e.g. spoken-style system-prompt rules, below).
     _modality = (request.modality or "").strip().lower() or "text"
     # Supersede (#611): a new turn on a conversation OR client_turn_id that
     # already has one in flight cancels the old one first — asking again is
@@ -1058,11 +1059,10 @@ async def ask_stream(request: AskStreamRequest):
         except asyncio.CancelledError:
             # #611: the client disconnected (survivable turn, now cancelled
             # by an explicit /cancel, a supersede, the detached-lifetime
-            # deadline, or a shutdown drain), or this is a voice turn whose
-            # disconnect immediately cancels it (see ChatTurn.reader()'s
-            # voice gate). Persist whatever the user had already seen rather
-            # than losing it outright — marked so it's never mistaken for a
-            # finished reply.
+            # deadline, or a shutdown drain) — every modality alike since
+            # #616 lifted the voice-only immediate-cancel gate. Persist
+            # whatever the user had already seen rather than losing it
+            # outright — marked so it's never mistaken for a finished reply.
             if conversation_id and partial_text:
                 store.add_message(
                     conversation_id, "assistant", partial_text + TRUNCATION_MARKER,

--- a/api/services/chat_turns.py
+++ b/api/services/chat_turns.py
@@ -73,6 +73,12 @@ class ChatTurn:
         # matters most for voice barge-in, where the interruption is
         # frequently within the first second of a reply.
         self.client_turn_id = client_turn_id
+        # Recorded for parity with the request (voice turns get spoken-style
+        # system-prompt rules elsewhere, e.g. `api/routes/chat.py`'s
+        # `build_system_prompt()` call) and for observability. #616 lifted
+        # the modality-keyed detachment gate `reader()` used to check here —
+        # a voice turn's disconnect now detaches exactly like a text turn's,
+        # so this field no longer changes cancellation behavior on its own.
         self.modality = modality
         self.started_at = time.time()
         self.detached_at: Optional[float] = None
@@ -81,10 +87,7 @@ class ChatTurn:
         # Set by whoever initiates a cancellation (the /cancel endpoint, a
         # supersede, the deadline watcher, or registry.shutdown()) BEFORE
         # calling task.cancel(), so the task's `except asyncio.CancelledError`
-        # handler can record why. Falls back to "cancelled" if unset (the
-        # voice-modality immediate-cancel-on-disconnect path below never sets
-        # it, since a disconnect there is exactly the same gesture as an
-        # explicit cancel).
+        # handler can record why. Falls back to "cancelled" if unset.
         self.cancel_reason: Optional[str] = None
         self.task: Optional[asyncio.Task] = None
         self._deadline_task: Optional[asyncio.Task] = None
@@ -133,23 +136,17 @@ class ChatTurn:
             self.reader_attached = False
             if not self.finalized:
                 self.detached_at = time.time()
-                if self.modality == "voice":
-                    # LEAD'S DECISION (#611): whisper-relay's adapter
-                    # (voice_gateway/adapters/lifeos.py in the whisper-relay
-                    # repo) deliberately abandons this stream as its cancel
-                    # gesture on barge-in/hangup (raises `LifeOSCancelled`).
-                    # If a voice turn detached instead of being cancelled,
-                    # every interruption would silently run to completion and
-                    # bill for a full reply the operator cut off on purpose —
-                    # a behavior regression AND a spend regression on the
-                    # surface used most from mobile. So a voice-modality
-                    # turn keeps today's disconnect-cancels semantics until
-                    # whisper-relay calls the explicit cancel endpoint
-                    # instead of just walking away.
-                    if self.task is not None and not self.task.done():
-                        self.task.cancel()
-                else:
-                    get_turn_registry().arm_deadline(self)
+                # #616 lifted the modality-keyed gate that used to live here:
+                # a voice-modality turn's disconnect immediately cancelled
+                # the task instead of arming the deadline below, because
+                # whisper-relay's adapter (src/voice_gateway/adapters/lifeos.py
+                # in the whisper-relay repo) used to only abandon this stream
+                # on barge-in/hangup, with no explicit way to say "stop". Now
+                # that it calls `POST /api/chat/cancel` with its
+                # `client_turn_id` instead, every modality detaches and
+                # survives its client identically — see ADR-019 (as amended
+                # by ADR-020) for the full history.
+                get_turn_registry().arm_deadline(self)
 
     def request_cancel(self, reason: str) -> bool:
         """Cancel this turn's task, recording why. Returns False (no-op) if

--- a/docs/adr/019-turn-owned-by-server.md
+++ b/docs/adr/019-turn-owned-by-server.md
@@ -3,6 +3,7 @@
 **Status:** Complete
 **Last Updated:** 2026-08-21
 **Decision:** Accepted
+**Amended by:** [ADR-020](020-voice-cancel-gate-lifted.md)
 
 ## Context
 

--- a/docs/adr/020-voice-cancel-gate-lifted.md
+++ b/docs/adr/020-voice-cancel-gate-lifted.md
@@ -1,0 +1,145 @@
+# ADR-020: The Voice Detachment Gate Is Lifted
+
+**Status:** Complete
+**Last Updated:** 2026-08-21
+**Decision:** Accepted
+
+## Context
+
+[ADR-019](019-turn-owned-by-server.md) decoupled a chat turn's lifetime from
+its SSE connection, with one deliberate exception: a turn with `modality:
+"voice"` was gated out of detachment in `ChatTurn.reader()`. whisper-relay's
+adapter (`src/voice_gateway/adapters/lifeos.py` in the whisper-relay repo)
+had no way to say "stop" other than abandoning the LifeOS/Hermes stream on
+barge-in and hangup, and that abandonment was also the only signal a
+disconnect could carry. If voice turns detached like every other turn, that
+single gesture would have become ambiguous — every barge-in would silently
+run the interrupted turn to completion and, on an API-billed backend, spend
+money the operator explicitly declined by interrupting. ADR-019 recorded
+this as a narrower fix than the ideal end state, pending a cross-repo
+follow-up: whisper-relay calling an explicit cancel endpoint instead of
+relying on disconnect-as-cancel.
+
+That follow-up is `whisper-relay#37`, tracked alongside this repo's #616.
+It changes the gateway's cancel gesture to call `POST /api/chat/cancel`
+with its own `client_turn_id` — the key #611's review already added to
+`TurnRegistry` specifically to close the "barge-in before the first SSE
+frame" gap, since a brand-new conversation has no `conversation_id` yet for
+the gateway to cancel by otherwise. Once the gateway states its cancel
+intent explicitly, the reason for treating voice differently from every
+other modality no longer holds: a disconnect with no accompanying cancel is
+just a hangup or a network switch, not a stop gesture, on any modality.
+
+## Decision
+
+**The modality-keyed detachment gate in `ChatTurn.reader()` is removed.** A
+voice-modality turn's disconnect now detaches and survives exactly like a
+text turn's — the turn keeps running server-side and persists its full
+reply, readable once the conversation is reopened. The gateway's barge-in
+and hangup gestures are no longer inferred from a dropped connection; they
+are the same explicit `POST /api/chat/cancel` (keyed by `client_turn_id` or
+`conversation_id`) every other client already uses, including for a
+barge-in landing before the turn's first SSE frame.
+
+`api/routes/_proxy.py`'s Hermes pump shares the same `ChatTurn` class as the
+native path, so this single change lifts the gate for both backends at
+once — there was never a second, independent gate to remove; the pump's
+`_sniff_modality()` only ever fed the one gate this ADR removes, and now
+just records the turn's modality for parity with the native path's request.
+
+Nothing else about #611 changes: the explicit cancel endpoints, the
+detached-turn deadline, the shutdown drain, and the truncation marker on an
+interrupted turn all behave identically regardless of modality now — voice
+was the only modality that ever behaved differently, and it no longer does.
+
+## Rationale
+
+- **The premise for the exception was cross-repo, not architectural.**
+  ADR-019's gate existed only because whisper-relay had no explicit cancel
+  path yet. Once it has one, keeping voice as a special case in
+  `ChatTurn.reader()` would be carrying old behavior forward for no reason
+  tied to voice itself — the gate was always meant to be temporary (ADR-019
+  says so explicitly).
+- **Correct barge-in and surviving a hangup are no longer in tension.**
+  Before this change, voice had to choose one or the other: detaching would
+  break barge-in (nothing would stop a turn the operator interrupted);
+  keeping the gate meant a hangup mid-answer still lost the reply outright,
+  exactly the problem #611 fixed everywhere else. An explicit cancel signal
+  makes both true at once — a real stop request halts generation, and mere
+  abandonment (a locked phone, a dropped network) no longer discards work
+  in flight.
+- **One registry, one gate, one place to remove it.** Because the native
+  and Hermes paths share `ChatTurn`/`TurnRegistry`, this is a single,
+  surgical change rather than two backends' worth of special-casing to
+  unwind.
+
+## Alternatives Considered
+
+### Keep the gate and add a separate "soft cancel" signal for voice
+
+Have the gateway send some lighter-weight "I'm about to disconnect, that
+means cancel" signal instead of reusing the general-purpose cancel
+endpoints.
+
+**Rejected because:** `POST /api/chat/cancel` and `client_turn_id` already
+exist, already close the pre-first-frame gap that motivated them, and
+already have the exact semantics wanted here (200 + `cancelled: true|false`,
+never a 4xx for an unknown/expired key). Adding a second, voice-specific
+cancel mechanism would duplicate that surface for no behavioral gain.
+
+### Lift the gate only on the native path, leave Hermes-relayed voice turns gated
+
+Since the issue that surfaced this asked specifically about `ChatTurn.reader()`.
+
+**Rejected because:** the native and Hermes paths share the exact same
+`ChatTurn` instance and gate — there is no separate Hermes-specific gate to
+selectively keep. A native-only lift is not actually achievable without
+re-introducing a modality check somewhere Hermes turns pass through, which
+would just recreate the removed asymmetry in a different place.
+
+## Consequences
+
+### Positive
+
+- Voice now gets the full benefit of #611 (surviving a hangup or network
+  switch mid-answer) without giving up correct barge-in — the tradeoff
+  ADR-019 flagged as temporary is resolved, not just relocated.
+- No client-visible contract change for a gateway already sending
+  `client_turn_id` and calling the explicit cancel endpoint on its cancel
+  gesture — the SSE byte stream is unaffected either way, exactly as
+  ADR-019 already guaranteed for a connected client.
+
+### Negative
+
+- **A whisper-relay release that has not yet adopted the explicit cancel
+  call regresses barge-in silently.** Until such a release calls `POST
+  /api/chat/cancel` on its cancel gesture, abandoning the stream is no
+  longer a stop signal on the LifeOS side — the turn detaches and keeps
+  running (and, on an API-billed backend, keeps costing) to completion or
+  the detached-turn deadline. This is exactly the risk ADR-019's gate
+  existed to avoid, which is why lifting the gate here and shipping the
+  corresponding whisper-relay release are sequenced together rather than
+  independently.
+- **The Hermes truncation reason stays coarse.** ADR-019 already notes
+  that a Hermes-relayed turn can only report `truncation_reason:
+  "stream_error"`, never the native path's finer distinction. This is
+  unchanged by lifting the gate — an explicitly cancelled voice turn
+  relayed through Hermes is marked truncated the same way any other
+  cancelled Hermes turn is.
+
+## Related Documents
+
+### Design Context
+
+- [ADR-019: A Turn's Lifetime Is Owned by the Server, Not the Connection](019-turn-owned-by-server.md) — the original decision, including the voice gate this ADR removes
+- [ADR-018: API Spend Requires Consent](018-api-spend-requires-consent.md) — the consent posture the original gate protected, now upheld by an explicit cancel signal instead of an inferred one
+
+### Specifications
+
+- [Client surfaces](../specs/technical/client-surfaces.md) — "Turn lifetime and cancellation" documents the lifted state and the explicit cancel endpoints
+
+### Code References
+
+- `api/services/chat_turns.py` — `ChatTurn.reader()`, where the gate lived
+- `api/routes/_proxy.py` — `_sniff_modality()`, which fed the gate for the Hermes pump and now only records modality for parity
+- `api/routes/chat.py` — `ask_stream()`'s turn creation, unaffected in shape, changed only in effect

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -20,7 +20,8 @@ This directory contains Architecture Decision Records (ADRs) — immutable recor
 - `016-voice-gateway-reverse-proxy.md` — Voice gateway reverse-proxied through LifeOS
 - `017-retire-ollama-llama-server-routing.md` — Ollama retired; query routing moved onto the shared llama-server runtime (supersedes 006)
 - `018-api-spend-requires-consent.md` — LifeOS never picks an API-billed engine on its own (amends 008)
-- `019-turn-owned-by-server.md` — a chat turn's lifetime is owned by the server, not the SSE connection watching it
+- `019-turn-owned-by-server.md` — a chat turn's lifetime is owned by the server, not the SSE connection watching it **(Amended by 020)**
+- `020-voice-cancel-gate-lifted.md` — the voice-only detachment exception in 019 is removed now that whisper-relay cancels explicitly (amends 019)
 
 ## Key Principles
 

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-08-19
+> **Last Updated:** 2026-08-21
 
 LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that submit text and consume SSE without importing LifeOS Python modules. Endpoint and event **shapes** are defined in [api-reference.md](../product/api-reference.md); this doc covers **who consumes them**, **whisper-relay integration**, and **breaking-change policy**.
 
@@ -26,7 +26,7 @@ Voice transport in the same GitHub org: [github.com/nbramia/whisper-relay](https
 
 The gateway connects to LifeOS at `LIFEOS_BASE_URL` for orchestration (ask/stream, handoff). Persona listing and conversation CRUD are **LifeOS-owned** — consumed by `/chat` directly, not through whisper-relay.
 
-**LifeOS endpoints the gateway calls** (shapes: [api-reference.md](../product/api-reference.md)): `POST /api/ask/stream`, `POST /api/chat/handoff`. At startup it may call `GET /api/personas` server-side for handoff capability caching (not exposed to browsers). `POST /api/chat/cancel` (`client_turn_id`, #611) exists for the gateway to adopt as its explicit stop path — tracked as `whisper-relay#37`, not yet started — but is not called today: voice still relies on cancel-on-disconnect (see "Turn lifetime and cancellation" below) until that lands.
+**LifeOS endpoints the gateway calls** (shapes: [api-reference.md](../product/api-reference.md)): `POST /api/ask/stream`, `POST /api/chat/handoff`. At startup it may call `GET /api/personas` server-side for handoff capability caching (not exposed to browsers). `POST /api/chat/cancel` (`client_turn_id`, #611) is the gateway's explicit stop path (`whisper-relay#37`) on barge-in and hangup — voice's old cancel-on-disconnect fallback is retired (#616; see "Turn lifetime and cancellation" below): a gateway not yet calling this endpoint on cancel loses correct barge-in outright, since a disconnect alone now just detaches the turn like any other modality, rather than stopping it.
 
 **Persona contract** (shared by web and voice; lets a thin client expose LifeOS's multi-bot personas without reading LifeOS config):
 
@@ -88,12 +88,17 @@ proxy; the Agent backend is unaffected (below).
   /api/conversations/{id}` once it's reopened. A connected client's frame
   sequence and bytes are unaffected — this is purely about what happens
   *after* a disconnect.
-- **Exception: voice.** whisper-relay's adapter deliberately abandons the
-  LifeOS/Hermes stream as its cancel gesture on barge-in and hangup. A turn
-  with `modality: "voice"` therefore keeps the *old* disconnect-cancels
-  behavior — a voice-modality disconnect cancels the turn immediately,
-  exactly as before #611 — until whisper-relay is updated to call the
-  cancel endpoint below explicitly instead of just walking away.
+- **Voice is no longer an exception (#616).** whisper-relay's adapter used
+  to abandon the LifeOS/Hermes stream as its only cancel gesture on
+  barge-in and hangup, so a turn with `modality: "voice"` kept the *old*
+  disconnect-cancels behavior — a voice-modality disconnect cancelled the
+  turn immediately rather than surviving it, unlike every other turn. That
+  gate is lifted now that whisper-relay's cancel gesture is calling `POST
+  /api/chat/cancel` with its `client_turn_id` (below) explicitly instead of
+  just walking away (whisper-relay#37). A voice turn's disconnect now
+  detaches and survives exactly like a text turn's; only an explicit cancel
+  — the gateway's real barge-in gesture — stops it. See
+  [ADR-020](../../adr/020-voice-cancel-gate-lifted.md) for the history.
 - **`POST /api/conversations/{id}/cancel`** stops whatever turn is in
   flight for that conversation, native or Hermes-relayed alike. `{ok:
   true, cancelled: true|false}` — `false` when nothing was running (already
@@ -267,7 +272,7 @@ A Hermes session had no way to answer "what has this cost?" even though the brow
 | Orchestrating personas | Runs natively (spawns a background session) | N/A — never selectable | Diverted client-side to LifeOS (#596); never actually forwarded to Hermes |
 | Per-turn model selection | Yes (`model_override`: Auto/Sonnet/Opus/Gemma/Claude Code) | No — picker hidden | No — picker hidden; model choice is the harness's call, not LifeOS's |
 | Conversation history LifeOS-owned | Yes (always has been) | No | Yes, since #592 (tee-persisted) |
-| Survives a client disconnect (#611) | Yes (voice modality excepted — see above) | No — untouched, no observer to persist a detached turn's output | Yes (voice modality excepted — same gate) |
+| Survives a client disconnect (#611) | Yes, every modality (#616 lifted the voice exception — see above) | No — untouched, no observer to persist a detached turn's output | Yes, every modality (same as LifeOS) |
 | Explicit cancel (`POST .../cancel`, #611) | Yes | Yes (the endpoint doesn't distinguish backends — but nothing detaches here to cancel) | Yes |
 
 ### Default backend selection
@@ -302,7 +307,8 @@ Since #592, `restoreBackendConversation()` renders the stored conversation on a 
 ## Related Documents
 
 ### Design Context
-- [ADR-019: A Turn's Lifetime Is Owned by the Server, Not the Connection](../../adr/019-turn-owned-by-server.md) — why a disconnect no longer stops a turn, the voice exception, and the tradeoffs
+- [ADR-019: A Turn's Lifetime Is Owned by the Server, Not the Connection](../../adr/019-turn-owned-by-server.md) — why a disconnect no longer stops a turn, the original voice exception, and the tradeoffs
+- [ADR-020: The Voice Detachment Gate Is Lifted](../../adr/020-voice-cancel-gate-lifted.md) — why ADR-019's voice exception was temporary, and what made it safe to remove
 
 ### Specifications
 - [API Reference](../product/api-reference.md) — Canonical endpoint and SSE shapes

--- a/tests/test_chat_turn_cancel.py
+++ b/tests/test_chat_turn_cancel.py
@@ -547,3 +547,202 @@ class TestCancelOrderingsAroundAnAttachedReader:
         assert len(messages) == 2
         assert messages[1].content == "the whole answer"
         assert messages[1].routing != {"truncated": True, "truncation_reason": "cancelled"}
+
+
+class TestVoiceModalityCancelAfterGateLift:
+    """#616: with the modality-keyed detachment gate lifted, a voice turn
+    now goes through the exact same explicit-cancel machinery as a text
+    turn -- these are the acceptance-criteria cases the issue calls out by
+    name: an explicit cancel stops a voice turn on the same bound as web
+    chat's Stop button, the partial reply is marked truncated on the same
+    terms as any other interrupted turn, and a barge-in that lands before
+    the turn's first SSE frame (no conversation_id yet) still halts
+    generation via `client_turn_id` -- exactly the whisper-relay first-turn
+    barge-in gap #611 review closed for text and #616 now extends to voice."""
+
+    async def test_explicit_cancel_stops_a_voice_turn_same_as_web_chats_stop(
+        self, api_client, store, monkeypatch,
+    ):
+        import api.services.agent_loop as agent_loop_mod
+
+        hold = asyncio.Event()
+        monkeypatch.setattr(
+            agent_loop_mod, "run_agent_loop", _fake_agent_loop_holding_at(hold),
+        )
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(question="hi there", modality="voice")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)  # conversation_id, routing, "Hello "
+        conversation_id = next(
+            e["conversation_id"] for e in events if e.get("type") == "conversation_id"
+        )
+        await gen.aclose()  # detach -- must NOT itself cancel (that's #616's point)
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        assert turn is not None and turn.modality == "voice"
+
+        # The explicit cancel -- the same endpoint, same bound, same
+        # response shape web chat's Stop button gets for a text turn.
+        resp = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task
+
+        # Marked truncated on the same terms as any other interrupted turn
+        # -- not a voice-specific truncation reason.
+        messages = store.get_messages(conversation_id)
+        assert len(messages) == 2
+        assert "Hello " in messages[1].content
+        assert "cut off" in messages[1].content
+        assert messages[1].routing == {"truncated": True, "truncation_reason": "cancelled"}
+
+    async def test_client_turn_id_cancel_halts_a_voice_barge_in_before_first_sse_frame(
+        self, store, monkeypatch,
+    ):
+        """The corrected acceptance criterion #616 adds: a barge-in landing
+        BEFORE the turn's first SSE frame -- so before any conversation_id
+        exists to cancel by -- must still halt generation. This is exactly
+        `client_turn_id`'s reason for existing (#611 review), now proven for
+        a voice-modality turn specifically rather than just a text one."""
+        import api.services.agent_loop as agent_loop_mod
+
+        hang_forever = asyncio.Event()
+
+        async def fake_loop(**kwargs):
+            await hang_forever.wait()  # would hang forever if not cancelled
+            yield {"type": "text", "content": "unreachable"}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(
+            question="hi", modality="voice", client_turn_id="voice-barge-in-1",
+        )
+        await chat.ask_stream(request)
+        # Deliberately never touch response.body_iterator -- no SSE frame,
+        # not even conversation_id, has been read. The gateway's only
+        # handle is the client_turn_id it minted before sending.
+
+        turn = chat_turns.get_turn_registry().get_by_client_turn_id("voice-barge-in-1")
+        assert turn is not None and turn.modality == "voice"
+        assert turn.conversation_id is None  # not yet bound -- the whole point
+
+        cancelled = chat_turns.get_turn_registry().cancel_by_client_turn_id("voice-barge-in-1")
+        assert cancelled is True
+
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task
+
+    async def test_voice_cancel_via_client_turn_id_while_reader_attached_then_disconnect_is_clean(
+        self, api_client, store, monkeypatch,
+    ):
+        """Mirrors the real whisper-relay#37 sequence: its `cancel_turn()`
+        fires `POST /api/chat/cancel` with `client_turn_id` from its
+        cancel-event handler (not its SSE read loop), and only afterward
+        abandons the stream -- so the POST can genuinely land while our
+        reader is still attached, with the disconnect following. #611
+        review already proved this ordering safe for a text turn
+        (`TestCancelOrderingsAroundAnAttachedReader` above); this is the
+        same proof for a voice turn specifically, since with the gate
+        removed this exact sequence is what a real barge-in now produces on
+        a detachable voice turn -- the ordering must not depend on modality,
+        and it doesn't: `reader()`'s `finally` no-ops once `finalized` is
+        already True, regardless of which modality got it there."""
+        import api.services.agent_loop as agent_loop_mod
+
+        hang_forever = asyncio.Event()
+
+        async def fake_loop(**kwargs):
+            yield {"type": "text", "content": "partial "}
+            await hang_forever.wait()
+            yield {"type": "text", "content": "unreachable"}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(
+            question="hi", modality="voice", client_turn_id="voice-ordering-1",
+        )
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)  # conversation_id, routing, "partial "
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+
+        turn = chat_turns.get_turn_registry().get_by_client_turn_id("voice-ordering-1")
+        assert turn is not None and turn.modality == "voice"
+
+        # The gateway's cancel-event handler fires the POST now -- the
+        # reader is STILL attached, the stream hasn't been abandoned yet.
+        resp = await api_client("POST", "/api/chat/cancel", json={"client_turn_id": "voice-ordering-1"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        # The still-attached reader must drain to a clean EOF -- no more
+        # real frames were emitted after cancellation.
+        remaining = [item async for item in gen]
+        assert remaining == []
+
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task  # let the task's own finally (pop + close) fully run
+
+        # NOW the gateway abandons the stream -- after the turn already
+        # finalized. Must not raise or double-finalize.
+        await gen.aclose()
+
+        messages = store.get_messages(conversation_id)
+        assert len(messages) == 2  # one user + one assistant row, not two
+        assert "partial " in messages[1].content
+        assert "cut off" in messages[1].content
+        assert messages[1].routing == {"truncated": True, "truncation_reason": "cancelled"}
+
+    async def test_cancel_of_an_already_finished_voice_turn_is_200_not_4xx(
+        self, api_client, store, monkeypatch,
+    ):
+        """whisper-relay's `cancel_turn()` treats a `cancelled: false`
+        response as success, never as an error -- e.g. if its cancel POST
+        (keyed by `client_turn_id`) lands just after the turn already ran
+        to completion and was popped from the registry. Must read 200, not
+        404/4xx, exactly like the existing text-turn proof of this
+        (`TestCancelOrderingsAroundAnAttachedReader.test_cancel_of_a_normally_finished_turn_is_200_not_4xx`
+        above) -- re-confirmed here via `client_turn_id` specifically,
+        since that's the key whisper-relay actually sends."""
+        import api.services.agent_loop as agent_loop_mod
+
+        async def fake_loop(**kwargs):
+            yield {"type": "text", "content": "the whole answer"}
+            yield {"type": "result", "result": SimpleNamespace(
+                total_input_tokens=1, total_output_tokens=1, total_cost_usd=0.0,
+                model="m", tool_calls_log=[], full_text="the whole answer",
+            )}
+
+        async def fake_classify(*a, **k):
+            return None
+
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        request = chat.AskStreamRequest(
+            question="hi", modality="voice", client_turn_id="voice-finished-1",
+        )
+        response = await chat.ask_stream(request)
+        async for _ in response.body_iterator:
+            pass  # drain fully -- the fake loop finishes immediately
+
+        # The turn already finished and was popped -- client_turn_id no
+        # longer resolves to anything, same as an unknown/expired key.
+        resp = await api_client("POST", "/api/chat/cancel", json={"client_turn_id": "voice-finished-1"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "cancelled": False}

--- a/tests/test_chat_turn_survives_disconnect.py
+++ b/tests/test_chat_turn_survives_disconnect.py
@@ -116,24 +116,30 @@ async def test_native_turn_completes_and_persists_after_client_disconnect(
     assert stats["total_output_tokens"] == 34
 
 
-async def test_voice_modality_disconnect_cancels_rather_than_detaches(store, monkeypatch):
-    """LEAD'S DECISION (#611): whisper-relay's adapter deliberately abandons
-    the LifeOS stream as its cancel gesture on barge-in/hangup. A voice
-    turn must NOT survive its client disconnecting — it must be cancelled,
-    same as before #611 — or every interruption would silently run to
-    completion and bill for a reply the operator cut off on purpose."""
+async def test_voice_modality_disconnect_detaches_and_survives_like_text(store, monkeypatch):
+    """#616: this test used to be named
+    `test_voice_modality_disconnect_cancels_rather_than_detaches` and
+    asserted the OPPOSITE of what it asserts now — that a voice-modality
+    turn's disconnect cancelled the task immediately rather than detaching
+    it, because whisper-relay had no way to say "stop" other than
+    abandoning the stream. Now that whisper-relay calls `POST
+    /api/chat/cancel` with its `client_turn_id` on a real cancel gesture
+    (whisper-relay#37), a disconnect alone — a hangup or network drop with
+    no explicit cancel — no longer means "stop": a voice turn detaches and
+    keeps running to completion server-side, exactly like the text turn in
+    `test_native_turn_completes_and_persists_after_client_disconnect`
+    above. This inversion is deliberate, not a weakening — see #616."""
     import api.services.agent_loop as agent_loop_mod
 
-    started = asyncio.Event()
-    never = asyncio.Event()  # never set -- the turn must not reach this
+    resume = asyncio.Event()
 
     async def fake_loop(**kwargs):
         yield {"type": "text", "content": "Hello "}
-        started.set()
-        await never.wait()  # would hang forever if NOT cancelled on disconnect
+        await resume.wait()
+        yield {"type": "text", "content": "world"}
         yield {"type": "result", "result": SimpleNamespace(
             total_input_tokens=1, total_output_tokens=1, total_cost_usd=0.0,
-            model="m", tool_calls_log=[], full_text="Hello unreachable",
+            model="m", tool_calls_log=[], full_text="Hello world",
         )}
 
     async def fake_classify(*a, **k):
@@ -148,25 +154,22 @@ async def test_voice_modality_disconnect_cancels_rather_than_detaches(store, mon
 
     events = await _drive_until(gen, 3)  # conversation_id, routing, "Hello "
     conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
-    await started.wait()
 
     turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
     assert turn is not None and turn.modality == "voice"
 
-    # The client disconnects (a barge-in/hangup) -- a text-modality turn
-    # would detach and keep running; a voice turn must be cancelled instead.
+    # The client disconnects (a hangup or network drop, NOT an explicit
+    # cancel) — the turn must detach and keep running, same as a
+    # text-modality turn.
     await gen.aclose()
+    resume.set()
+    await turn.task  # must run to completion, never cancelled
 
-    with pytest.raises(asyncio.CancelledError):
-        await turn.task
-    assert turn.task.cancelled()
-
-    # The partial reply is still persisted, marked as cut off -- cancelling
-    # doesn't mean losing what was already said.
     messages = store.get_messages(conversation_id)
-    assert [(m.role, m.content) for m in messages[:1]] == [("user", "hi")]
-    assert len(messages) == 2
-    assert messages[1].role == "assistant"
-    assert "Hello " in messages[1].content
-    assert "cut off" in messages[1].content
-    assert (messages[1].routing or {}).get("truncated") is True
+    assert [(m.role, m.content) for m in messages] == [
+        ("user", "hi"),
+        ("assistant", "Hello world"),
+    ]
+    # A turn that ran to completion carries no truncation marker.
+    assert "cut off" not in messages[-1].content
+    assert not (messages[-1].routing or {}).get("truncated")

--- a/tests/test_hermes_proxy.py
+++ b/tests/test_hermes_proxy.py
@@ -1031,24 +1031,32 @@ async def test_disconnect_then_completion_persists_full_reply_and_a_usage_row(
     assert stats["total_cost"] == pytest.approx(0.002)
 
 
-async def test_voice_modality_disconnect_cancels_the_pump_rather_than_detaching(
+async def test_voice_modality_disconnect_detaches_the_pump_like_a_text_turn(
     monkeypatch, hermes_store,
 ):
-    """LEAD'S DECISION (#611), extended to the Hermes pump: a voice-modality
-    turn relayed through Hermes must also be cancelled by a disconnect
-    rather than surviving it -- whisper-relay's barge-in/hangup cancel
-    gesture is abandoning whatever LifeOS-speaking stream it's talking to,
-    native or Hermes-relayed alike."""
+    """#616: this test used to be named
+    `test_voice_modality_disconnect_cancels_the_pump_rather_than_detaching`
+    and asserted the OPPOSITE of what it asserts now -- that a
+    voice-modality Hermes turn was cancelled by a disconnect rather than
+    surviving it, because whisper-relay had no way to say "stop" other than
+    abandoning the stream. Now that whisper-relay calls `POST
+    /api/chat/cancel` with its `client_turn_id` on a real cancel gesture
+    (whisper-relay#37), a disconnect alone no longer means "stop": a
+    voice-modality turn relayed through Hermes detaches and keeps draining
+    upstream to completion, exactly like the text turn in
+    `test_client_disconnect_still_persists_the_last_chunk` above. This
+    inversion is deliberate, not a weakening -- see #616."""
     monkeypatch.setattr(hp.settings, "hermes_backend_url", "http://hermes")
     monkeypatch.setattr(hp.settings, "hermes_backend_token", "")
 
-    never = asyncio.Event()
+    hold = asyncio.Event()
 
     async def gen():
         yield b'data: {"type": "conversation_id", "conversation_id": "voice-disco-1"}\n\n'
         yield b'data: {"type": "content", "content": "Hello "}\n\n'
-        await never.wait()  # would hang forever if the pump weren't cancelled
-        yield b'data: {"type": "content", "content": "unreachable"}\n\n'
+        await hold.wait()
+        yield b'data: {"type": "content", "content": "world"}\n\n'
+        yield b'data: {"type": "done"}\n\n'
 
     monkeypatch.setattr(hp, "_client", lambda: _fake_upstream_and_client(gen)())
 
@@ -1059,20 +1067,64 @@ async def test_voice_modality_disconnect_cancels_the_pump_rather_than_detaching(
     gen_iter = response.body_iterator
     await gen_iter.__anext__()  # conversation_id
     await gen_iter.__anext__()  # "Hello "
-    await gen_iter.aclose()  # the barge-in/hangup disconnect
+
+    # The client disconnects (a hangup or network drop, NOT an explicit
+    # cancel) -- the pump must detach and keep draining, same as a
+    # text-modality turn.
+    await gen_iter.aclose()
+    hold.set()
 
     turn = hp.get_turn_registry().get_by_conversation("voice-disco-1")
     assert turn is not None and turn.modality == "voice"
-    with pytest.raises(asyncio.CancelledError):
-        await turn.task
-    assert turn.task.cancelled()
+    await turn.task  # must run to completion, never cancelled
 
     messages = hermes_store.get_messages("voice-disco-1")
     assert [(m.role, m.content) for m in messages] == [
         ("user", "hi"),
-        ("assistant", "Hello " + hp.TRUNCATION_MARKER),
+        ("assistant", "Hello world"),
     ]
-    assert messages[-1].routing == {"truncated": True, "truncation_reason": "stream_error"}
+    # A turn that ran to completion carries no truncation marker.
+    assert not (messages[-1].routing or {}).get("truncated")
+
+
+async def test_client_turn_id_cancel_halts_a_voice_barge_in_before_the_pumps_first_frame(
+    monkeypatch, hermes_store,
+):
+    """#616 acceptance criterion, extended to the Hermes pump: a barge-in
+    landing before the turn's first SSE frame -- before any conversation_id
+    exists to cancel by -- must still halt generation via `client_turn_id`,
+    the same first-turn barge-in gap #611 review closed for the native
+    path (tests/test_chat_turn_cancel.py's `TestClientTurnIdCancel`)."""
+    monkeypatch.setattr(hp.settings, "hermes_backend_url", "http://hermes")
+    monkeypatch.setattr(hp.settings, "hermes_backend_token", "")
+
+    hang_forever = asyncio.Event()
+
+    async def gen():
+        await hang_forever.wait()  # would hang forever if not cancelled
+        yield b'data: {"type": "content", "content": "unreachable"}\n\n'
+
+    monkeypatch.setattr(hp, "_client", lambda: _fake_upstream_and_client(gen)())
+
+    endpoint = next(r for r in hp.router.routes if r.path.endswith("/ask/stream")).endpoint
+    request = _manual_request({
+        "question": "hi", "modality": "voice", "client_turn_id": "hermes-voice-barge-in-1",
+    })
+
+    await endpoint(request)
+    # Deliberately never touch the response's body_iterator -- no SSE
+    # frame, not even conversation_id, has been read. The gateway's only
+    # handle is the client_turn_id it minted before sending.
+
+    turn = hp.get_turn_registry().get_by_client_turn_id("hermes-voice-barge-in-1")
+    assert turn is not None and turn.modality == "voice"
+    assert turn.conversation_id is None  # not yet bound -- the whole point
+
+    cancelled = hp.get_turn_registry().cancel_by_client_turn_id("hermes-voice-barge-in-1")
+    assert cancelled is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await turn.task
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this does

#611 made a chat turn survive its client, but deliberately excluded `modality == "voice"`. This removes that exclusion, so a voice turn now behaves like every other turn: it survives a hangup or a network drop instead of being lost.

## Why it's safe now

The gate existed because whisper-relay treated **abandoning the LifeOS stream as its cancel gesture** on barge-in and hangup. Lifting it before the gateway had an explicit way to say "stop" would have made every barge-in silently run to completion and bill for a reply the user interrupted on purpose — on the surface most used from a phone.

That's resolved. **whisper-relay#37 is merged and deployed:** commit `87eb686` landed and the `whisper-relay` service restarted ten seconds later onto it, so the running gateway calls `POST /api/chat/cancel` with a `client_turn_id` it generates before the request goes out. Verified in its source, not just its issue state.

Voice now gets both properties rather than trading one for the other: correct barge-in (an explicit stop that halts generation and spend) *and* survival across a hangup. They only ever looked like a trade while hanging up was the sole way to say stop.

## There was only one gate, not two

#611's brief described gates in two places — `ChatTurn.reader()` and the Hermes pump via `_sniff_modality()`. Only the first was real: `_sniff_modality()` merely feeds `modality` into the same `ChatTurn` both paths share, so removing the single branch in `reader()`'s `finally` lifts it everywhere. `arm_deadline()` is now called unconditionally.

`_sniff_modality()`'s docstring claimed it gated detachment; that stale comment is exactly how a reader concludes there are two gates, so it's corrected. The two remaining `modality == "voice"` checks in `hermes_proxy.py` are the **voice_rules** (spoken-style prompt) path and are unrelated.

## Tests inverted, deliberately and visibly

Two #611 tests pinned the gate and now assert the opposite. Both were **renamed** so the name matches the assertion, with before/after stated in each docstring — a test whose name contradicts what it checks is worse than no test:

- `test_voice_modality_disconnect_cancels_rather_than_detaches` → `test_voice_modality_disconnect_detaches_and_survives_like_text`
- the Hermes equivalent, likewise

The text-turn tests they mirror, and #611's "the gate is keyed on modality alone so it can't affect text" tests, are untouched — they now literally demonstrate the parity the inverted tests assert.

## New coverage

- Explicit cancel stops a voice turn on the same terms as web chat's Stop, with truncation marked `{"truncated": true, "truncation_reason": "cancelled"}`.
- **A barge-in before the first SSE frame** halts generation — cancelled by `client_turn_id` alone, with no `conversation_id` in existence yet. This is the case the pre-correction version of #616 couldn't even express, and it's the common voice interruption.
- The same pre-first-frame proof for the Hermes pump.
- Cancelling an already-finished voice turn returns 200 with `cancelled: false`, never 4xx — which is what the deployed `cancel_turn()` expects.
- The whisper-relay ordering: cancel lands **while the reader is still attached**, reader drains to clean EOF, stream abandoned afterward — no raise, no double-persist.

That ordering is also safe by construction, not only by test: the property lives in `turn.finalized`, not `modality`. `_run_turn()`'s `finally` sets `finalized` before cancellation unwinds, and `reader()`'s `finally` — where the gate lived — is entirely inside `if not self.finalized:`. The gate was never reachable on that path.

`test_agent_proxy.py` is untouched and passing: the Agent proxy never sets `make_observer`, so it never touches the registry at all.

## Docs

- **ADR-020** (new) records the lift. ADR-019 receives exactly one line — an `Amended by:` pointer — because ADRs are immutable as decisions and a new ADR amending the old one is the only honest way to add history. Both indexed, with 019 flagged as amended so a reader landing there first doesn't act on a superseded decision.
- `client-surfaces.md`: the "Exception: voice" bullet becomes "Voice is no longer an exception", the whisper-relay endpoint description updated from "not called today", and the capability table row corrected.

## Verification

- `-m unit`: **3614 passed / 8 skipped** (baseline 3611/8 — net +3, matching the 3 added tests; the 2 inversions are 1-for-1 replacements)
- `-m "browser and not requires_server"`: **71 passed** (baseline 71)
- Targeted turn/proxy set: 91 passed

Closes #616
Relates to whisper-relay#37

🤖 Generated with [Claude Code](https://claude.com/claude-code)