### PR TITLE
fix(chat): a cancelled turn records the spend it already incurred

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -599,9 +599,20 @@ async def ask_stream(request: AskStreamRequest):
         await turn.emit(f"data: {json.dumps({'type': 'content', 'content': text})}\n\n")
 
     partial_text = ""
+    # #615: live reference to the agent loop's own AgentResult, stashed from
+    # the `turn_state` event so a cancel/deadline handler can read accrued
+    # usage without waiting for the terminal `result` event, which a
+    # cancelled turn never reaches. Stays None for a fake loop that doesn't
+    # emit `turn_state` (e.g. the ones in tests/test_persona_api.py) --
+    # `usage_recorded` guards against recording it twice if the turn does
+    # reach the normal end-of-turn usage write below. "Accrued" means as of
+    # the last round boundary, not as of the last streamed token -- see the
+    # comment in the CancelledError handler below for what that leaves out.
+    live_result = None
+    usage_recorded = False
 
     async def _run_turn():
-        nonlocal partial_text
+        nonlocal partial_text, live_result, usage_recorded
         # Pre-initialized outside the try (a plain assignment can't itself be
         # interrupted) so the except/finally clauses below always have a
         # defined `conversation_id`, even if a cancellation lands before the
@@ -970,7 +981,11 @@ async def ask_stream(request: AskStreamRequest):
                 personal_context=personal_context,
                 force_local=force_local,
             ):
-                if event["type"] == "text":
+                if event["type"] == "turn_state":
+                    # #615: live, mutable AgentResult -- see the comment by
+                    # `live_result`'s declaration above.
+                    live_result = event["result"]
+                elif event["type"] == "text":
                     await _content(event['content'])
                 elif event["type"] == "status":
                     await turn.emit(f"data: {json.dumps({'type': 'status', 'message': event['message']})}\n\n")
@@ -1002,6 +1017,7 @@ async def ask_stream(request: AskStreamRequest):
                     cost_usd=agent_result.total_cost_usd,
                     conversation_id=conversation_id,
                 )
+                usage_recorded = True  # #615: the cancel/deadline handler must not double-write this
                 await turn.emit(f"data: {json.dumps({'type': 'usage', 'input_tokens': agent_result.total_input_tokens, 'output_tokens': agent_result.total_output_tokens, 'cost_usd': agent_result.total_cost_usd, 'model': agent_result.model})}\n\n")
 
             # Build source list from tool calls
@@ -1068,6 +1084,51 @@ async def ask_stream(request: AskStreamRequest):
                     conversation_id, "assistant", partial_text + TRUNCATION_MARKER,
                     routing=truncation_routing(turn.cancel_reason or "cancelled"),
                 )
+            # #615: the tokens for a cancelled turn were already spent (and
+            # billed) even though the loop never reached its terminal
+            # `result` event -- read them from the live reference stashed
+            # from `turn_state` instead. `usage_recorded` guards against a
+            # cancellation landing after the normal end-of-turn write above
+            # (e.g. during `finish_trace`/`turn.emit` on the way out) from
+            # double-recording it.
+            #
+            # `total_input_tokens > 0` is NOT "nothing was spent" -- it's
+            # "the accumulator hasn't moved off its initial zero." Both
+            # LocalLLMClient.astream and AnthropicLLMClient.astream
+            # (api/services/llm_client.py) only yield usage in the "done"
+            # event that closes out a full round's stream (the local client
+            # reads it off the OpenAI-compatible finish chunk;
+            # AnthropicLLMClient waits on stream.get_final_message()), and
+            # agent_loop._track_usage() only runs once that event arrives.
+            # A cancellation landing mid-round -- after text has already
+            # streamed to the user and tokens were almost certainly
+            # generated and billed upstream, but before that round's "done"
+            # event fires -- still reports zero here, so this is a known,
+            # narrower surviving gap, not a claim that nothing was spent.
+            # The guard exists because writing a zero-token row would
+            # affirmatively assert "this cost nothing," which is worse than
+            # writing nothing at all; it does not close the mid-round
+            # window. Closing that would need the streaming clients to
+            # surface usage incrementally as it accrues (Anthropic's wire
+            # protocol carries a running count via `message_start`/
+            # `message_delta` events that astream() currently discards in
+            # favor of the final message; the local OpenAI-compatible
+            # protocol has no equivalent mid-stream signal at all) -- a
+            # change to the client layer's event contract, out of scope for
+            # this fix.
+            #
+            # This also covers a cancelled turn before any round completed
+            # (the accumulator never moved) and a fake test loop that never
+            # emits `turn_state` (`live_result` stays None).
+            if conversation_id and not usage_recorded and live_result is not None and live_result.total_input_tokens > 0:
+                get_usage_store().record_usage(
+                    model=live_result.model,
+                    input_tokens=live_result.total_input_tokens,
+                    output_tokens=live_result.total_output_tokens,
+                    cost_usd=live_result.total_cost_usd,
+                    conversation_id=conversation_id,
+                )
+                usage_recorded = True
             finish_trace()
             raise
         except Exception as e:

--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -8,6 +8,8 @@ caller (SSE endpoint) can stream them to the client in real time.
 Uses the local LLM (OpenAI-compatible llama-server) by default.
 
 Event types yielded:
+  {"type": "turn_state", "result": AgentResult} -- live, mutable accumulator
+                                                     (first event; #615)
   {"type": "text",   "content": "..."}       -- streamed text chunk
   {"type": "status", "message": "..."}       -- tool execution status
   {"type": "self_correction"}                -- model retrying (consumers should clear buffered text)
@@ -485,7 +487,10 @@ async def run_agent_loop(
             "Gemma (local)" option. Builds a per-turn LocalLLMClient.
 
     Yields:
-        Dicts with "type" key: "text", "status", or "result".
+        Dicts with "type" key: "turn_state" (first event, #615 -- a live
+        reference to the mutable AgentResult, for a caller that needs
+        accrued usage before the loop reaches its terminal event), "text",
+        "status", or "result".
     """
     client = _select_client(model, force_local=force_local)
     system_prompt = build_system_prompt(persona=persona, max_tool_rounds=max_tool_rounds,
@@ -543,6 +548,12 @@ async def run_agent_loop(
     messages.append({"role": "user", "content": user_content})
 
     result = AgentResult(full_text="", model="local")
+    # #615: hand the caller a live reference to `result` before the loop does
+    # any work. `_track_usage` below mutates it in place every round, so a
+    # caller that stashes this object can read accrued usage at any point --
+    # in particular from a cancel/deadline handler that never reaches the
+    # terminal `result` event because the loop was cancelled mid-round.
+    yield {"type": "turn_state", "result": result}
     phantom_write_nudged = False  # phantom-write self-correction fires at most once per turn
 
     def _track_usage(usage: LLMUsage):

--- a/tests/test_agent_loop_turn_state.py
+++ b/tests/test_agent_loop_turn_state.py
@@ -1,0 +1,58 @@
+"""#615: `run_agent_loop` yields a `turn_state` event -- carrying a live,
+mutable reference to its `AgentResult` -- as the very first event, before
+any round runs. `api/routes/chat.py` stashes this reference so a cancelled
+turn's cancel/deadline handler can read accrued usage without waiting for
+the terminal `result` event, which a cancelled turn never reaches.
+
+This is a unit test of the loop's own event contract; tests/test_chat_turn_
+cancel_usage.py covers the route-level cancel/usage-recording behavior that
+depends on it.
+"""
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeClient:
+    """One text+done round, mirroring tests/test_agent_loop_caching.py's
+    fake client."""
+
+    async def astream(self, messages, *, system=None, max_tokens=4096,
+                      tools=None, temperature=None, timeout=None):
+        from api.services.llm_client import LLMUsage
+        yield {"type": "text", "content": "The answer is 42."}
+        yield {
+            "type": "done",
+            "usage": LLMUsage(input_tokens=120, output_tokens=8),
+            "finish_reason": "end_turn",
+        }
+
+
+@pytest.mark.asyncio
+async def test_turn_state_is_the_first_event_and_starts_at_zero_usage():
+    from api.services import agent_loop
+
+    with patch.object(agent_loop, "_select_client", return_value=_FakeClient()):
+        gen = agent_loop.run_agent_loop("what is six times seven")
+        first = await gen.__anext__()
+
+        assert first["type"] == "turn_state"
+        live = first["result"]
+        # Yielded before any round has run -- nothing accrued yet.
+        assert live.total_input_tokens == 0
+        assert live.total_output_tokens == 0
+
+        # Drain the rest of the loop.
+        rest = [e async for e in gen]
+
+    result_event = next(e for e in rest if e["type"] == "result")
+    # The terminal `result` event's payload IS the same object handed out by
+    # `turn_state`, mutated in place across the round -- not a copy, and not
+    # a different instance built later. This identity is what makes it safe
+    # for a caller to stash the `turn_state` reference and read it at any
+    # later point instead of waiting for `result`.
+    assert result_event["result"] is live
+    assert live.total_input_tokens == 120
+    assert live.total_output_tokens == 8
+    assert live.full_text == "The answer is 42."

--- a/tests/test_chat_turn_cancel_usage.py
+++ b/tests/test_chat_turn_cancel_usage.py
@@ -1,0 +1,295 @@
+"""#615: a native turn that ends via `asyncio.CancelledError` (explicit
+cancel, supersede, or the detached-lifetime deadline) must still record its
+usage row -- the tokens were already spent and billed even though the loop
+never reached its terminal `result` event.
+
+`run_agent_loop` now yields a `turn_state` event carrying a live, mutable
+reference to its `AgentResult` before doing any work; `chat.py` stashes it
+and reads accrued usage from it in the `CancelledError` handler if the
+normal end-of-turn write never ran. These tests exercise that path directly
+against real `ChatTurn`/`TurnRegistry` and `UsageStore` instances, following
+the same fake-agent-loop pattern as tests/test_chat_turn_cancel.py.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from api.routes import chat, conversations
+from api.services import chat_turns
+from api.services.conversation_store import ConversationStore
+from api.services.usage_store import get_usage_store
+from config.settings import settings
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    s = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+    monkeypatch.setattr(chat, "get_store", lambda: s)
+    monkeypatch.setattr(conversations, "get_store", lambda: s)
+    return s
+
+
+@pytest.fixture
+def api_client():
+    app = FastAPI()
+    app.include_router(conversations.router)
+    app.include_router(chat.router)
+
+    async def _call(method, path, **kw):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+            return await c.request(method, path, **kw)
+
+    return _call
+
+
+async def _drive_until(gen, min_events):
+    events = []
+    async for raw in gen:
+        text = raw.decode() if isinstance(raw, bytes) else raw
+        for line in text.split("\n"):
+            if line.startswith("data: "):
+                events.append(json.loads(line[len("data: "):]))
+        if len(events) >= min_events:
+            break
+    return events
+
+
+def _fake_loop_with_live_usage(hold, first_chunk="Hello "):
+    """A fake agent loop that emits `turn_state` up front (as the real
+    `run_agent_loop` does), streams one round of text, accrues usage on
+    that same object -- mirroring `_track_usage` mutating `result` in
+    place -- then blocks on `hold` before it would ever reach a terminal
+    `result` event."""
+    async def fake_loop(**kwargs):
+        live = SimpleNamespace(
+            total_input_tokens=0, total_output_tokens=0, total_cost_usd=0.0,
+            model="fake-model", tool_calls_log=[], full_text="",
+        )
+        yield {"type": "turn_state", "result": live}
+        yield {"type": "text", "content": first_chunk}
+        # A round "completed": usage accrues on the live object, exactly
+        # like _track_usage() does inside run_agent_loop.
+        live.total_input_tokens = 42
+        live.total_output_tokens = 7
+        live.total_cost_usd = 0.0123
+        await hold.wait()
+        yield {"type": "text", "content": "unreachable"}
+        live.full_text = first_chunk + "unreachable"
+        yield {"type": "result", "result": live}
+    return fake_loop
+
+
+def _fake_loop_turn_state_before_any_round(hold):
+    """Emits `turn_state` (zero usage) then blocks before any round ever
+    completes -- no usage was ever accrued."""
+    async def fake_loop(**kwargs):
+        live = SimpleNamespace(
+            total_input_tokens=0, total_output_tokens=0, total_cost_usd=0.0,
+            model="fake-model", tool_calls_log=[], full_text="",
+        )
+        yield {"type": "turn_state", "result": live}
+        await hold.wait()
+        yield {"type": "text", "content": "unreachable"}
+        yield {"type": "result", "result": live}
+    return fake_loop
+
+
+class TestCancelledTurnRecordsUsage:
+    async def test_cancelled_after_one_round_records_nonzero_usage(
+        self, api_client, store, monkeypatch,
+    ):
+        import api.services.agent_loop as agent_loop_mod
+
+        hold = asyncio.Event()
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_loop_with_live_usage(hold))
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)  # conversation_id, routing, "Hello "
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+        await gen.aclose()  # detach -- turn keeps running, unwatched
+
+        resp = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        if turn is not None and turn.task is not None:
+            with pytest.raises(asyncio.CancelledError):
+                await turn.task
+
+        usage = get_usage_store().get_conversation_usage(conversation_id)
+        assert usage["turn_count"] == 1
+        assert usage["input_tokens"] == 42
+        assert usage["output_tokens"] == 7
+        assert usage["cost_usd"] == pytest.approx(0.0123)
+
+        # The partial-text persistence #611 already guarantees is unaffected.
+        messages = store.get_messages(conversation_id)
+        assert "Hello " in messages[1].content
+        assert "cut off" in messages[1].content
+
+    async def test_cancelled_before_any_round_writes_no_usage_row(
+        self, api_client, store, monkeypatch,
+    ):
+        import api.services.agent_loop as agent_loop_mod
+
+        hold = asyncio.Event()
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_loop_turn_state_before_any_round(hold))
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 2)  # conversation_id, routing -- no content ever arrives
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+        await gen.aclose()
+
+        resp = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        if turn is not None and turn.task is not None:
+            with pytest.raises(asyncio.CancelledError):
+                await turn.task
+
+        usage = get_usage_store().get_conversation_usage(conversation_id)
+        assert usage["turn_count"] == 0
+
+    async def test_deadline_cancellation_records_usage_too(
+        self, store, monkeypatch,
+    ):
+        """Not just the explicit /cancel endpoint -- the detached-lifetime
+        deadline watcher (chat_turns.ChatTurn.reader()'s finally -> arm_deadline)
+        also runs the turn's task through the same `except CancelledError`,
+        so it must record usage on the same terms."""
+        import api.services.agent_loop as agent_loop_mod
+
+        monkeypatch.setattr(settings, "detached_turn_timeout_seconds", 0.05)
+
+        hold = asyncio.Event()  # never set -- the deadline, not `hold`, ends this turn
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_loop_with_live_usage(hold))
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)  # conversation_id, routing, "Hello "
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+        await gen.aclose()  # detach -- arms the deadline watcher (text modality)
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        assert turn is not None
+        with pytest.raises(asyncio.CancelledError):
+            await turn.task
+        assert turn.cancel_reason == "deadline"
+
+        usage = get_usage_store().get_conversation_usage(conversation_id)
+        assert usage["turn_count"] == 1
+        assert usage["input_tokens"] == 42
+        assert usage["output_tokens"] == 7
+
+
+class TestCompletedTurnStillRecordsExactlyOneRow:
+    async def test_no_double_write_on_normal_completion(self, store, monkeypatch):
+        """Regression guard for #611's own acceptance criterion: a turn that
+        completes normally (never cancelled) must still write exactly one
+        usage row, via the pre-existing end-of-turn path -- the new
+        `turn_state` reference must not cause a second write."""
+        import api.services.agent_loop as agent_loop_mod
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+
+        async def fake_loop(**kwargs):
+            live = SimpleNamespace(
+                total_input_tokens=10, total_output_tokens=5, total_cost_usd=0.001,
+                model="fake-model", tool_calls_log=[], full_text="",
+            )
+            yield {"type": "turn_state", "result": live}
+            yield {"type": "text", "content": "the full answer"}
+            live.total_input_tokens = 10
+            live.total_output_tokens = 5
+            live.full_text = "the full answer"
+            yield {"type": "result", "result": live}
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        events = await _drive_until(response.body_iterator, 100)  # drain to "done"
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        if turn is not None and turn.task is not None:
+            await turn.task  # let the turn's own finally (pop/close) finish
+
+        usage = get_usage_store().get_conversation_usage(conversation_id)
+        assert usage["turn_count"] == 1
+        assert usage["input_tokens"] == 10
+        assert usage["output_tokens"] == 5
+
+
+class TestFakeLoopWithoutTurnStateEvent:
+    async def test_a_loop_that_never_emits_turn_state_still_cancels_cleanly(
+        self, api_client, store, monkeypatch,
+    ):
+        """A consumer (or, as here, a test double) that predates #615 and
+        never emits `turn_state` must be unaffected: `live_result` simply
+        stays None, no usage row is invented, and cancellation still
+        persists the partial text exactly as #611 designed it."""
+        import api.services.agent_loop as agent_loop_mod
+
+        hold = asyncio.Event()
+
+        async def fake_loop(**kwargs):
+            yield {"type": "text", "content": "Hello "}
+            await hold.wait()
+            yield {"type": "text", "content": "unreachable"}
+            yield {"type": "result", "result": SimpleNamespace(
+                total_input_tokens=1, total_output_tokens=1, total_cost_usd=0.0,
+                model="m", tool_calls_log=[], full_text="Hello unreachable",
+            )}
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", fake_loop)
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)  # conversation_id, routing, "Hello "
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+        await gen.aclose()
+
+        resp = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        if turn is not None and turn.task is not None:
+            with pytest.raises(asyncio.CancelledError):
+                await turn.task
+
+        messages = store.get_messages(conversation_id)
+        assert "Hello " in messages[1].content
+        assert "cut off" in messages[1].content
+
+        usage = get_usage_store().get_conversation_usage(conversation_id)
+        assert usage["turn_count"] == 0


### PR DESCRIPTION
## Problem

`run_agent_loop` surfaces token usage exactly once, in the terminal `result` event. #611 made a native turn cancellable mid-loop — the Stop button, supersede-on-new-question, or the detached-turn deadline — so a cancelled turn persisted its partial reply but **never wrote a usage row**.

The tokens were spent and billed; the row was absent. `GET /api/admin/usage` and the chat header both silently excluded it. That is the wrong direction under [ADR-018](docs/adr/018-api-spend-requires-consent.md), and cancellation is precisely when a user has most likely burned tool rounds before giving up.

Contrast with the Hermes path, which already got this right: its usage capture is a **tee on the byte stream**, so it fires in `finalize()` however the turn ended. The native path had no equivalent — usage lived inside `AgentResult` and was surfaced once, at the end.

## Fix

`run_agent_loop` yields `{"type": "turn_state", "result": result}` immediately after constructing its `AgentResult`, before any round runs. `_run_turn()` stashes it, and the `except asyncio.CancelledError` handler records usage from that live reference if the normal end-of-turn write never happened.

The stashed object is the *same* `AgentResult` later mutated into the terminal event — asserted by identity in a test, not assumed.

## Exactly-once, by three separate guards

`if conversation_id and not usage_recorded and live_result is not None and live_result.total_input_tokens > 0`

- `not usage_recorded` — set right after the pre-existing end-of-turn `record_usage()`, so a cancellation landing *after* that write (during `finish_trace` / `turn.emit` on the way out) can't double-record.
- `live_result is not None` — a fake loop that never emits `turn_state` still cancels cleanly. `test_persona_api.py`'s fakes are exactly this case and are included in the test run deliberately.
- `total_input_tokens > 0` — no invented row when the accumulator is genuinely still zero.

**Partial text is untouched** and still comes from the streamed `text` deltas, never `live_result.full_text` — the loop only appends to `full_text` at round end, so mid-round it is missing exactly what the user watched arrive. `turn_state` carries no text at all.

## Known limitation, documented rather than assumed

The accumulator only reflects usage as of the **last completed round boundary**, so a cancellation landing mid-round still records nothing for that round. Traced rather than guessed:

- `AnthropicLLMClient.astream` yields usage only in its terminal `done` event, after `await stream.get_final_message()`. Anthropic's wire protocol *does* carry running usage via `message_start` / `message_delta` — this client discards those events.
- `LocalLLMClient.astream` reads usage only from the terminal finish chunk; that protocol has no mid-stream usage signal at all.
- `agent_loop._track_usage()` runs once per round, after the round's stream loop returns.

The guard is kept deliberately: writing a zero-token row would assert "this turn cost nothing" — an affirmative false claim, worse than a missing one. The comments at both the declaration and the guard site now say this plainly instead of claiming nothing was spent.

Closing that window is a client-layer contract change (an incremental-usage event Anthropic could emit, with no local-backend parity possible, plus an audit of every `astream()` consumer). Filed as **#629**, sequenced after this.

## Verification

Failing before the change, confirmed by stashing the two source diffs and running against unmodified main:

- `test_turn_state_is_the_first_event_and_starts_at_zero_usage` → `assert 'text' == 'turn_state'`
- `test_cancelled_after_one_round_records_nonzero_usage` → `assert 0 == 1`
- `test_deadline_cancellation_records_usage_too` → `assert 0 == 1`

(3 failed pre-fix, 6/6 pass after.)

New coverage: cancelled-after-one-round records non-zero usage scoped to the conversation; cancelled-before-any-round writes zero rows; the deadline path records on the same terms; normal completion still writes exactly one row (#611's own criterion); a fake loop that never emits `turn_state` cancels cleanly with no invented row.

Targeted suite (`test_chat_turn_cancel_usage.py`, `test_agent_loop_turn_state.py`, `test_chat_turns.py`, `test_chat_turn_cancel.py`, `test_chat_turn_survives_disconnect.py`, the three `test_agent_loop_*`, `test_persona_api.py`): **96 passed.**

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)