### PR TITLE
feat(llm): surface incremental usage so a mid-round cancellation records its spend

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -1094,43 +1094,52 @@ async def ask_stream(request: AskStreamRequest):
             # (e.g. during `finish_trace`/`turn.emit` on the way out) from
             # double-recording it.
             #
-            # `total_input_tokens > 0` is NOT "nothing was spent" -- it's
-            # "the accumulator hasn't moved off its initial zero." Both
-            # LocalLLMClient.astream and AnthropicLLMClient.astream
-            # (api/services/llm_client.py) only yield usage in the "done"
-            # event that closes out a full round's stream (the local client
-            # reads it off the OpenAI-compatible finish chunk;
-            # AnthropicLLMClient waits on stream.get_final_message()), and
-            # agent_loop._track_usage() only runs once that event arrives.
-            # A cancellation landing mid-round -- after text has already
-            # streamed to the user and tokens were almost certainly
-            # generated and billed upstream, but before that round's "done"
-            # event fires -- still reports zero here, so this is a known,
-            # narrower surviving gap, not a claim that nothing was spent.
-            # The guard exists because writing a zero-token row would
+            # #629 narrowed, but did not close, the gap #615 left open: both
+            # LocalLLMClient.astream and AnthropicLLMClient.astream only
+            # yield *confirmed* usage in the "done" event that closes out a
+            # full round's stream, and agent_loop._track_usage() folds that
+            # into total_input_tokens/total_output_tokens only once "done"
+            # arrives. A cancellation landing mid-round used to report zero
+            # for that round no matter what. Now, on the Anthropic backend,
+            # agent_loop also tracks provisional_input_tokens /
+            # provisional_output_tokens -- the in-flight round's cumulative
+            # usage-so-far, from the "usage_update" events Anthropic's wire
+            # protocol carries via `message_start`/`message_delta` (see
+            # AnthropicLLMClient.astream's docstring) -- so a mid-round
+            # cancellation there credits the tokens already billed instead
+            # of reporting nothing. The local backend's OpenAI-compatible
+            # protocol has no equivalent mid-stream signal, so
+            # provisional_input_tokens/provisional_output_tokens stay 0
+            # there always, and a mid-round cancellation on that backend is
+            # unchanged from before #629: still a known, narrower surviving
+            # gap, not a claim that nothing was spent.
+            #
+            # `total_input_tokens + provisional_input_tokens > 0` is NOT
+            # "nothing was spent" -- it's "neither the confirmed nor the
+            # provisional accumulator has moved off its initial zero." The
+            # guard exists because writing a zero-token row would
             # affirmatively assert "this cost nothing," which is worse than
-            # writing nothing at all; it does not close the mid-round
-            # window. Closing that would need the streaming clients to
-            # surface usage incrementally as it accrues (Anthropic's wire
-            # protocol carries a running count via `message_start`/
-            # `message_delta` events that astream() currently discards in
-            # favor of the final message; the local OpenAI-compatible
-            # protocol has no equivalent mid-stream signal at all) -- a
-            # change to the client layer's event contract, out of scope for
-            # this fix.
+            # writing nothing at all. `getattr(..., 0)` tolerates a
+            # `live_result` that predates #629 (e.g. a test double) and
+            # therefore has no provisional_* fields at all.
             #
             # This also covers a cancelled turn before any round completed
-            # (the accumulator never moved) and a fake test loop that never
-            # emits `turn_state` (`live_result` stays None).
-            if conversation_id and not usage_recorded and live_result is not None and live_result.total_input_tokens > 0:
-                get_usage_store().record_usage(
-                    model=live_result.model,
-                    input_tokens=live_result.total_input_tokens,
-                    output_tokens=live_result.total_output_tokens,
-                    cost_usd=live_result.total_cost_usd,
-                    conversation_id=conversation_id,
-                )
-                usage_recorded = True
+            # (neither accumulator ever moved) and a fake test loop that
+            # never emits `turn_state` (`live_result` stays None).
+            if conversation_id and not usage_recorded and live_result is not None:
+                cancelled_input_tokens = live_result.total_input_tokens + getattr(
+                    live_result, "provisional_input_tokens", 0)
+                cancelled_output_tokens = live_result.total_output_tokens + getattr(
+                    live_result, "provisional_output_tokens", 0)
+                if cancelled_input_tokens > 0:
+                    get_usage_store().record_usage(
+                        model=live_result.model,
+                        input_tokens=cancelled_input_tokens,
+                        output_tokens=cancelled_output_tokens,
+                        cost_usd=live_result.total_cost_usd,
+                        conversation_id=conversation_id,
+                    )
+                    usage_recorded = True
             finish_trace()
             raise
         except Exception as e:

--- a/api/services/agent_loop.py
+++ b/api/services/agent_loop.py
@@ -449,6 +449,17 @@ class AgentResult:
     total_cache_creation_tokens: int = 0
     total_cost_usd: float = 0.0
     model: str = ""
+    # (#629) the current in-flight round's cumulative usage-so-far, from
+    # AnthropicLLMClient.astream's "usage_update" event. Only that backend
+    # emits it -- LocalLLMClient.astream never does (its protocol has no
+    # mid-stream usage signal), so these stay 0 for a local-backed turn,
+    # same as before this field existed. Folded into total_input_tokens /
+    # total_output_tokens (and reset to 0) as soon as the round's "done"
+    # event arrives -- see _track_usage -- so a caller reading "usage
+    # accrued so far" must add these to the total_* fields rather than
+    # read either in isolation, or it will double- or under-count.
+    provisional_input_tokens: int = 0
+    provisional_output_tokens: int = 0
 
 
 async def run_agent_loop(
@@ -489,7 +500,9 @@ async def run_agent_loop(
     Yields:
         Dicts with "type" key: "turn_state" (first event, #615 -- a live
         reference to the mutable AgentResult, for a caller that needs
-        accrued usage before the loop reaches its terminal event), "text",
+        accrued usage before the loop reaches its terminal event; #629
+        extends what "accrued so far" means -- see AgentResult's
+        provisional_input_tokens/provisional_output_tokens), "text",
         "status", or "result".
     """
     client = _select_client(model, force_local=force_local)
@@ -563,6 +576,12 @@ async def run_agent_loop(
         result.total_cache_creation_tokens += usage.cache_creation_input_tokens
         # Local model has no cost
         result.total_cost_usd = 0.0
+        # (#629) this round's usage is now folded into the totals above --
+        # clear the provisional (in-flight) figures so a caller that adds
+        # provisional_* to total_* (chat.py's cancel handler) doesn't
+        # double-count them once the round has actually closed out.
+        result.provisional_input_tokens = 0
+        result.provisional_output_tokens = 0
 
     # Pass tool definitions through with their cache_control marker intact so
     # Anthropic caches the large, stable tool schema across turns and rounds.
@@ -594,6 +613,13 @@ async def run_agent_loop(
                             yield {"type": "text", "content": event["content"]}
                         elif event["type"] == "tool_calls":
                             tool_use_blocks = openai_tool_calls_to_anthropic(event["calls"])
+                        elif event["type"] == "usage_update":
+                            # (#629) Anthropic-only -- see AgentResult's
+                            # provisional_* fields. Folded into total_* (and
+                            # cleared) by _track_usage once "done" arrives
+                            # below, so this is never added twice.
+                            result.provisional_input_tokens = event["usage"].input_tokens
+                            result.provisional_output_tokens = event["usage"].output_tokens
                         elif event["type"] == "done":
                             usage_this_round = event["usage"]
                             finish_reason = event.get("finish_reason", "")
@@ -742,6 +768,10 @@ async def run_agent_loop(
                     # LLM tried to call tools despite no tools in request —
                     # log and ignore (the text, if any, was already captured)
                     print(f"[agent] Synthesis round produced tool_calls (ignored): {[c.get('function', {}).get('name', '?') for c in event.get('calls', [])]}")
+                elif event["type"] == "usage_update":
+                    # (#629) same provisional tracking as the tool-round loop above.
+                    result.provisional_input_tokens = event["usage"].input_tokens
+                    result.provisional_output_tokens = event["usage"].output_tokens
                 elif event["type"] == "done":
                     _track_usage(event["usage"])
                     print(f"[agent] Synthesis round done: finish_reason={event.get('finish_reason', '?')}, events={synthesis_events}")

--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -499,6 +499,15 @@ class LocalLLMClient:
             {"type": "tool_calls", "calls": [...]}  — tool calls (complete)
             {"type": "done", "usage": LLMUsage, "finish_reason": "..."}
 
+        No ``{"type": "usage_update", ...}`` event (#629): unlike
+        AnthropicLLMClient.astream, this backend's OpenAI-compatible
+        streaming protocol carries no mid-stream usage signal at all, so
+        there's nothing to surface incrementally — usage is only ever known
+        at the terminal "done" chunk above. A caller that tracks a running
+        total from "usage_update" events (to credit a mid-round
+        cancellation for tokens already generated) gets no such credit on
+        this backend; that's a real, documented gap, not a bug to fix here.
+
         ``enable_thinking``/``reasoning_effort`` control reasoning for this
         request only — see ``_reasoning_control_payload``. Both default to
         ``None`` (unset), which adds no new keys to the request body.
@@ -780,9 +789,24 @@ class AnthropicLLMClient:
     ) -> AsyncGenerator[dict, None]:
         """Async streaming via Anthropic API.
 
-        Yields the same event format as LocalLLMClient.astream(). ``timeout``
-        (seconds) sets a per-request timeout — the agent loop's synthesis round
-        passes one, and LocalLLMClient.astream accepts the same kwarg.
+        Yields the same event format as LocalLLMClient.astream(), plus one
+        this backend alone can produce (#629):
+
+            {"type": "usage_update", "usage": LLMUsage}  — cumulative
+            usage-so-far for the in-flight response, not a per-event delta.
+
+        Anthropic's wire protocol carries a running usage count via the
+        ``message_start`` and ``message_delta`` SSE events — the former as
+        soon as the request is accepted (before any output token exists),
+        the latter as generation proceeds. Surfacing them lets a caller
+        that's cancelled mid-round credit the tokens that were already
+        billed instead of reporting nothing for the whole round.
+        LocalLLMClient.astream never yields this event — see its docstring
+        for why that backend can't.
+
+        ``timeout`` (seconds) sets a per-request timeout — the agent loop's
+        synthesis round passes one, and LocalLLMClient.astream accepts the
+        same kwarg.
         """
         kwargs: dict[str, Any] = {
             "model": self._model,
@@ -802,11 +826,54 @@ class AnthropicLLMClient:
             kwargs["timeout"] = timeout
 
         async with self._async_client.messages.stream(**kwargs) as stream:
+            # (#629) message_start's usage always carries all four fields
+            # (Anthropic's `Usage` type), but message_delta's usage has
+            # input_tokens/cache_* typed Optional and frequently absent —
+            # only output_tokens is guaranteed there. Carry the last-known
+            # value forward per field so an event that omits one doesn't
+            # look like it dropped to zero in the yielded snapshot.
+            last_input_tokens = 0
+            last_cache_creation = 0
+            last_cache_read = 0
             async for event in stream:
-                if hasattr(event, "type"):
-                    if event.type == "content_block_delta":
-                        if hasattr(event.delta, "text"):
-                            yield {"type": "text", "content": event.delta.text}
+                if not hasattr(event, "type"):
+                    continue
+                if event.type == "content_block_delta":
+                    if hasattr(event.delta, "text"):
+                        yield {"type": "text", "content": event.delta.text}
+                elif event.type == "message_start":
+                    u = event.message.usage
+                    last_input_tokens = u.input_tokens
+                    last_cache_creation = u.cache_creation_input_tokens or 0
+                    last_cache_read = u.cache_read_input_tokens or 0
+                    yield {
+                        "type": "usage_update",
+                        "usage": LLMUsage(
+                            input_tokens=last_input_tokens,
+                            output_tokens=u.output_tokens,
+                            total_tokens=last_input_tokens + u.output_tokens,
+                            cache_creation_input_tokens=last_cache_creation,
+                            cache_read_input_tokens=last_cache_read,
+                        ),
+                    }
+                elif event.type == "message_delta":
+                    u = event.usage
+                    if u.input_tokens is not None:
+                        last_input_tokens = u.input_tokens
+                    if u.cache_creation_input_tokens is not None:
+                        last_cache_creation = u.cache_creation_input_tokens
+                    if u.cache_read_input_tokens is not None:
+                        last_cache_read = u.cache_read_input_tokens
+                    yield {
+                        "type": "usage_update",
+                        "usage": LLMUsage(
+                            input_tokens=last_input_tokens,
+                            output_tokens=u.output_tokens,
+                            total_tokens=last_input_tokens + u.output_tokens,
+                            cache_creation_input_tokens=last_cache_creation,
+                            cache_read_input_tokens=last_cache_read,
+                        ),
+                    }
 
             # Get the final message for tool calls and usage
             msg = await stream.get_final_message()

--- a/tests/test_agent_loop_incremental_usage.py
+++ b/tests/test_agent_loop_incremental_usage.py
@@ -1,0 +1,194 @@
+"""#629: a cancellation landing mid-round (after the client has surfaced a
+"usage_update" event but before that round's "done" event) must not report
+zero usage for the whole round, and a round that completes normally must
+still fold its usage into AgentResult exactly once -- the "usage_update"
+snapshot from AnthropicLLMClient.astream must never be double-counted
+against the round-end total from _track_usage.
+
+These are unit tests of run_agent_loop's own wiring (a fake client stands in
+for AnthropicLLMClient); tests/test_chat_turn_cancel_usage.py covers the
+route-level cancel/usage-recording behavior built on top of it.
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from api.services.llm_client import LLMUsage
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeAnthropicLikeClient:
+    """One round: text, then a "usage_update" snapshot (as
+    AnthropicLLMClient.astream yields from message_start/message_delta),
+    then blocks on ``hold`` before the round's "done" event -- standing in
+    for a cancellation landing mid-round, after tokens were already billed
+    but before the round closed out."""
+
+    def __init__(self, hold, final_usage=None):
+        self._hold = hold
+        self._final_usage = final_usage or LLMUsage(input_tokens=100, output_tokens=20, total_tokens=120)
+
+    async def astream(self, messages, *, system=None, max_tokens=4096,
+                      tools=None, temperature=None, timeout=None):
+        yield {"type": "text", "content": "Hello "}
+        yield {
+            "type": "usage_update",
+            "usage": LLMUsage(input_tokens=100, output_tokens=15, total_tokens=115),
+        }
+        await self._hold.wait()
+        yield {"type": "done", "usage": self._final_usage, "finish_reason": "end_turn"}
+
+
+@pytest.mark.asyncio
+async def test_mid_round_cancellation_credits_provisional_tokens_without_folding_into_total():
+    """A cancellation that lands after "usage_update" but before "done"
+    must leave the tokens visible on the live AgentResult via
+    provisional_input_tokens/provisional_output_tokens -- exactly what a
+    cancel/deadline handler reads (#615, #629) -- without having advanced
+    total_input_tokens/total_output_tokens, since the round never closed
+    out."""
+    from api.services import agent_loop
+
+    hold = asyncio.Event()
+
+    with patch.object(agent_loop, "_select_client", return_value=_FakeAnthropicLikeClient(hold)):
+        gen = agent_loop.run_agent_loop("hi")
+        first = await gen.__anext__()
+        live = first["result"]
+        assert live.provisional_input_tokens == 0
+
+        second = await gen.__anext__()
+        assert second == {"type": "text", "content": "Hello "}
+
+        # Resuming the generator processes "usage_update" (mutating `live`)
+        # before it reaches the genuine suspension point (`hold.wait()`),
+        # all without another `yield` in between -- so by the time this
+        # task is actually running, `live.provisional_*` already reflects
+        # the "usage_update" event.
+        task = asyncio.ensure_future(gen.__anext__())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert live.provisional_input_tokens == 100
+        assert live.provisional_output_tokens == 15
+        # The round hasn't closed out -- _track_usage never ran.
+        assert live.total_input_tokens == 0
+        assert live.total_output_tokens == 0
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Cancellation landed mid-round: the provisional credit survives
+        # (this is what a cancel handler reads instead of a confident
+        # zero), and the confirmed totals are still untouched.
+        assert live.provisional_input_tokens == 100
+        assert live.provisional_output_tokens == 15
+        assert live.total_input_tokens == 0
+        assert live.total_output_tokens == 0
+
+        await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_usage_update_does_not_double_count_when_round_completes_normally():
+    """Regression guard for the double-count risk #629 explicitly warns
+    about: once the round's "done" event arrives, total_input_tokens/
+    total_output_tokens must reflect exactly that event's usage -- not the
+    "usage_update" snapshot plus the "done" usage added on top -- and the
+    provisional fields must be cleared so a later reader doesn't add them
+    again."""
+    from api.services import agent_loop
+
+    hold = asyncio.Event()
+    hold.set()  # never actually blocks -- straight through to "done"
+
+    with patch.object(agent_loop, "_select_client", return_value=_FakeAnthropicLikeClient(hold)):
+        events = [e async for e in agent_loop.run_agent_loop("hi")]
+
+    result = next(e["result"] for e in events if e["type"] == "result")
+    # The "done" event's usage (100/20) -- NOT 100+100 / 15+20 -- proves the
+    # "usage_update" snapshot (100/15) was never added on top.
+    assert result.total_input_tokens == 100
+    assert result.total_output_tokens == 20
+    assert result.provisional_input_tokens == 0
+    assert result.provisional_output_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_synthesis_round_tolerates_usage_update_without_double_counting():
+    """The second astream() call site in run_agent_loop -- the synthesis
+    round that runs once tool rounds are exhausted -- must handle
+    "usage_update" the same way as the main tool-round loop: tolerate it
+    without erroring, and fold "done" usage into the total exactly once.
+    Drives the REAL AnthropicLLMClient.astream (only the SDK's
+    messages.stream is mocked), mirroring
+    test_agent_loop_caching.py::test_synthesis_round_drives_real_client_with_timeout.
+    """
+    from unittest.mock import AsyncMock
+    from api.services import agent_loop
+    from api.services.llm_client import AnthropicLLMClient
+
+    def _usage(input_tokens=10, output_tokens=5):
+        return SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens,
+                               cache_creation_input_tokens=0, cache_read_input_tokens=0)
+
+    class _MockAnthropicStream:
+        def __init__(self, final, deltas=None):
+            self._final = final
+            self._deltas = deltas or []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def __aiter__(self):
+            return self._iter()
+
+        async def _iter(self):
+            for d in self._deltas:
+                yield d
+
+        async def get_final_message(self):
+            return self._final
+
+    def fake_stream(**kwargs):
+        if kwargs.get("tools"):
+            # tool round: a tool_use block so the loop spends its one round
+            # and falls through to the synthesis round.
+            final = SimpleNamespace(
+                content=[SimpleNamespace(type="tool_use", id="c1", name="search_vault", input={})],
+                usage=_usage(), stop_reason="tool_use")
+            return _MockAnthropicStream(final)
+        # synthesis round: message_start + message_delta ahead of the text
+        # answer -- the "usage_update" events the tool-round loop already
+        # handles, now exercised on this second call site.
+        final = SimpleNamespace(content=[], usage=_usage(input_tokens=30, output_tokens=12), stop_reason="end_turn")
+        message_start = SimpleNamespace(
+            type="message_start",
+            message=SimpleNamespace(usage=SimpleNamespace(
+                input_tokens=30, output_tokens=1,
+                cache_creation_input_tokens=0, cache_read_input_tokens=0)))
+        text_delta = SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(text="Synthesized answer."))
+        return _MockAnthropicStream(final, deltas=[message_start, text_delta])
+
+    client = AnthropicLLMClient(api_key="sk-ant-test")
+    client._async_client = SimpleNamespace(messages=SimpleNamespace(stream=fake_stream))
+
+    with patch.object(agent_loop, "_select_client", return_value=client), \
+         patch.object(agent_loop, "execute_tool_parallel", AsyncMock(return_value="vault result")):
+        events = [e async for e in agent_loop.run_agent_loop("find X", max_tool_rounds=1)]
+
+    result = next(e["result"] for e in events if e["type"] == "result")
+    assert result.full_text == "Synthesized answer."
+    # Tool round (10/5) + synthesis round's "done" usage (30/12) -- not the
+    # synthesis round's "usage_update" snapshot (30/1) added on top too.
+    assert result.total_input_tokens == 10 + 30
+    assert result.total_output_tokens == 5 + 12
+    assert result.provisional_input_tokens == 0
+    assert result.provisional_output_tokens == 0

--- a/tests/test_chat_turn_cancel_usage.py
+++ b/tests/test_chat_turn_cancel_usage.py
@@ -100,6 +100,127 @@ def _fake_loop_turn_state_before_any_round(hold):
     return fake_loop
 
 
+def _fake_loop_anthropic_backend_mid_round(hold, first_chunk="Hello "):
+    """#629: mimics an AnthropicLLMClient-backed turn cancelled mid-round.
+    Text streams, then a "usage_update" event (from message_start/
+    message_delta) sets provisional_input_tokens/provisional_output_tokens
+    -- exactly as agent_loop.run_agent_loop does now -- before the round's
+    "done" event (which would fold them into total_* and reset them to 0,
+    per _track_usage) ever arrives."""
+    async def fake_loop(**kwargs):
+        live = SimpleNamespace(
+            total_input_tokens=0, total_output_tokens=0, total_cost_usd=0.0,
+            model="fake-anthropic-model", tool_calls_log=[], full_text="",
+            provisional_input_tokens=0, provisional_output_tokens=0,
+        )
+        yield {"type": "turn_state", "result": live}
+        yield {"type": "text", "content": first_chunk}
+        live.provisional_input_tokens = 100
+        live.provisional_output_tokens = 15
+        await hold.wait()
+        yield {"type": "text", "content": "unreachable"}
+        yield {"type": "result", "result": live}
+    return fake_loop
+
+
+def _fake_loop_local_backend_mid_round(hold, first_chunk="Hello "):
+    """#629: mimics a LocalLLMClient-backed turn cancelled mid-round. Text
+    streams, but -- unlike the Anthropic-backed case above -- the local
+    backend's OpenAI-compatible protocol has no mid-stream usage signal at
+    all, so there is no "usage_update" event to set provisional_* from.
+    Usage stays at its initial zero right up to cancellation, exactly as it
+    did before #629 -- this backend gets no incremental-usage improvement,
+    by design (see LocalLLMClient.astream's docstring)."""
+    async def fake_loop(**kwargs):
+        live = SimpleNamespace(
+            total_input_tokens=0, total_output_tokens=0, total_cost_usd=0.0,
+            model="fake-local-model", tool_calls_log=[], full_text="",
+            provisional_input_tokens=0, provisional_output_tokens=0,
+        )
+        yield {"type": "turn_state", "result": live}
+        yield {"type": "text", "content": first_chunk}
+        await hold.wait()
+        yield {"type": "text", "content": "unreachable"}
+        yield {"type": "result", "result": live}
+    return fake_loop
+
+
+class TestIncrementalUsageOnCancellation:
+    """#629: a mid-round cancellation on the Anthropic backend now credits
+    the tokens already billed instead of reporting zero for the whole
+    round; the local backend's documented, unclosed gap is unchanged."""
+
+    async def test_anthropic_backed_mid_round_cancel_records_provisional_usage(
+        self, api_client, store, monkeypatch,
+    ):
+        import api.services.agent_loop as agent_loop_mod
+
+        hold = asyncio.Event()
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_loop_anthropic_backend_mid_round(hold))
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)  # conversation_id, routing, "Hello "
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+        await gen.aclose()  # detach -- turn keeps running, unwatched
+
+        resp = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        if turn is not None and turn.task is not None:
+            with pytest.raises(asyncio.CancelledError):
+                await turn.task
+
+        # Provisional usage (100/15) was credited even though
+        # total_input_tokens/total_output_tokens never moved off 0 -- the
+        # round never closed out, so _track_usage never ran.
+        usage = get_usage_store().get_conversation_usage(conversation_id)
+        assert usage["turn_count"] == 1
+        assert usage["input_tokens"] == 100
+        assert usage["output_tokens"] == 15
+
+    async def test_local_backed_mid_round_cancel_still_writes_no_usage_row(
+        self, api_client, store, monkeypatch,
+    ):
+        """The local backend's documented, unclosed gap: its streaming
+        protocol carries no mid-stream usage signal, so
+        provisional_input_tokens/provisional_output_tokens never move off
+        0, and a mid-round cancellation writes no usage row -- unchanged
+        from #615's behavior, not a regression introduced by #629."""
+        import api.services.agent_loop as agent_loop_mod
+
+        hold = asyncio.Event()
+
+        async def fake_classify(*a, **k):
+            return None
+        monkeypatch.setattr(chat, "classify_action_intent", fake_classify)
+        monkeypatch.setattr(agent_loop_mod, "run_agent_loop", _fake_loop_local_backend_mid_round(hold))
+
+        request = chat.AskStreamRequest(question="tell me something")
+        response = await chat.ask_stream(request)
+        gen = response.body_iterator
+        events = await _drive_until(gen, 3)  # conversation_id, routing, "Hello "
+        conversation_id = next(e["conversation_id"] for e in events if e.get("type") == "conversation_id")
+        await gen.aclose()
+
+        resp = await api_client("POST", f"/api/conversations/{conversation_id}/cancel")
+        assert resp.json() == {"ok": True, "cancelled": True}
+
+        turn = chat_turns.get_turn_registry().get_by_conversation(conversation_id)
+        if turn is not None and turn.task is not None:
+            with pytest.raises(asyncio.CancelledError):
+                await turn.task
+
+        usage = get_usage_store().get_conversation_usage(conversation_id)
+        assert usage["turn_count"] == 0
+
+
 class TestCancelledTurnRecordsUsage:
     async def test_cancelled_after_one_round_records_nonzero_usage(
         self, api_client, store, monkeypatch,

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1192,6 +1192,39 @@ class TestAStreamReasoning:
 # ---- Anthropic prompt caching (#383 Phase 1) ----
 
 
+def _fake_message_start(*, input_tokens=100, output_tokens=1, cache_creation=0, cache_read=0):
+    """A `message_start` SSE event as the Anthropic SDK models it: `.message.usage`
+    is a fully-populated `Usage` (input_tokens/output_tokens are required, never None)."""
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        type="message_start",
+        message=SimpleNamespace(
+            usage=SimpleNamespace(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_creation_input_tokens=cache_creation,
+                cache_read_input_tokens=cache_read,
+            )
+        ),
+    )
+
+
+def _fake_message_delta(*, output_tokens, input_tokens=None, cache_creation=None, cache_read=None):
+    """A `message_delta` SSE event: `.usage` is `MessageDeltaUsage` -- only
+    output_tokens is guaranteed there; input_tokens/cache_* are frequently
+    omitted (None) even though the SDK's type allows them."""
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        type="message_delta",
+        usage=SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=cache_creation,
+            cache_read_input_tokens=cache_read,
+        ),
+    )
+
+
 def _fake_anthropic_usage(*, input_tokens=100, output_tokens=10,
                           cache_creation=0, cache_read=0):
     from types import SimpleNamespace
@@ -1338,6 +1371,53 @@ class TestAnthropicCaching:
         assert text == "hello"
         done = next(e for e in events if e["type"] == "done")
         assert done["usage"].cache_read_input_tokens == 2600
+
+    @pytest.mark.asyncio
+    async def test_astream_yields_usage_update_from_message_start_and_message_delta(self):
+        """#629: message_start (usage always fully populated) and
+        message_delta (only output_tokens guaranteed -- input_tokens/cache_*
+        are frequently None) both surface as a "usage_update" event, so a
+        caller cancelled mid-round can credit tokens already billed instead
+        of reporting zero for the whole round. A message_delta that omits
+        input_tokens must NOT look like it dropped to zero -- the
+        last-known value has to carry forward."""
+        from types import SimpleNamespace
+        client = _anthropic_client()
+
+        final = SimpleNamespace(
+            content=[],
+            usage=_fake_anthropic_usage(input_tokens=100, output_tokens=15),
+            stop_reason="end_turn",
+        )
+        text_delta = SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(text="hi"))
+        deltas = [
+            _fake_message_start(input_tokens=100, output_tokens=1, cache_read=2600),
+            text_delta,
+            _fake_message_delta(output_tokens=15),  # input_tokens/cache_* omitted
+        ]
+
+        def fake_stream(**kwargs):
+            return _FakeAnthropicStream(final, deltas=deltas)
+
+        client._async_client = SimpleNamespace(messages=SimpleNamespace(stream=fake_stream))
+
+        events = [e async for e in client.astream([{"role": "user", "content": "hi"}])]
+
+        usage_updates = [e for e in events if e["type"] == "usage_update"]
+        assert len(usage_updates) == 2
+        first, second = usage_updates
+        assert (first["usage"].input_tokens, first["usage"].output_tokens) == (100, 1)
+        assert first["usage"].cache_read_input_tokens == 2600
+        # message_delta omitted input_tokens and cache_read_input_tokens --
+        # both must carry forward from message_start, not reset to 0.
+        assert (second["usage"].input_tokens, second["usage"].output_tokens) == (100, 15)
+        assert second["usage"].cache_read_input_tokens == 2600
+
+        # "usage_update" events don't disturb the existing "text"/"done" contract.
+        text = "".join(e["content"] for e in events if e["type"] == "text")
+        assert text == "hi"
+        done = next(e for e in events if e["type"] == "done")
+        assert (done["usage"].input_tokens, done["usage"].output_tokens) == (100, 15)
 
     @pytest.mark.asyncio
     async def test_astream_forwards_timeout_to_sdk(self):

--- a/tests/test_synthesizer_usage_update_tolerance.py
+++ b/tests/test_synthesizer_usage_update_tolerance.py
@@ -1,0 +1,56 @@
+"""#629 audit: Synthesizer.stream_response is one of astream()'s consumers
+(the other two call sites are in api/services/agent_loop.py, covered by
+tests/test_agent_loop_incremental_usage.py). Adding the "usage_update" event
+type to the astream() contract must not break a consumer that doesn't know
+about it -- stream_response's if/elif chain has no `else`, so an
+unrecognized event type is silently skipped by construction, but that's
+worth pinning down with a real test rather than leaving it implicit.
+"""
+import pytest
+
+from api.services.llm_client import LLMUsage
+from api.services.synthesizer import Synthesizer
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeClientWithUsageUpdate:
+    """Mirrors AnthropicLLMClient.astream: text, then a "usage_update"
+    snapshot the caller doesn't ask for, then the terminal "done"."""
+
+    async def astream(self, messages, *, system=None, max_tokens=4096,
+                      tools=None, temperature=None, timeout=None):
+        yield {"type": "text", "content": "The answer is 42."}
+        yield {
+            "type": "usage_update",
+            "usage": LLMUsage(input_tokens=50, output_tokens=8, total_tokens=58),
+        }
+        yield {
+            "type": "done",
+            "usage": LLMUsage(input_tokens=50, output_tokens=10, total_tokens=60),
+            "finish_reason": "end_turn",
+        }
+
+
+@pytest.mark.asyncio
+async def test_stream_response_tolerates_usage_update_event():
+    synth = Synthesizer()
+    synth._client = _FakeClientWithUsageUpdate()
+
+    chunks = [c async for c in synth.stream_response("what is six times seven")]
+
+    text = "".join(c for c in chunks if isinstance(c, str))
+    assert text == "The answer is 42."
+
+    usage_events = [c for c in chunks if isinstance(c, dict)]
+    # Only the "done" event's usage reaches the caller -- the "usage_update"
+    # snapshot in between was silently ignored, not surfaced as a second
+    # (and different-shaped) usage dict.
+    assert len(usage_events) == 1
+    assert usage_events[0] == {
+        "type": "usage",
+        "input_tokens": 50,
+        "output_tokens": 10,
+        "cost_usd": 0.0,
+        "model": "local",
+    }


### PR DESCRIPTION
## Problem

#615 made a cancelled turn record its spend, but usage only accumulated at **round boundaries** — so a cancellation landing mid-round still recorded nothing for that round, even though text had already streamed and the tokens were billed. Aborting a request is not the same as not being charged for what already ran.

## Fix

`AnthropicLLMClient.astream` now yields `{"type": "usage_update", "usage": LLMUsage}` from the SDK's `message_start` and `message_delta` events — which it previously **discarded**. A cumulative snapshot of usage-so-far, not a per-event delta.

A protocol detail that matters: `message_start`'s usage is fully populated, but `message_delta`'s `MessageDeltaUsage` only guarantees `output_tokens` — `input_tokens` and the cache fields are frequently `None`. The generator tracks last-known-per-field so an event omitting a field can never read as a drop to zero.

## Double-counting prevention

`AgentResult` gains `provisional_input_tokens` / `provisional_output_tokens`, set from `usage_update` at both `astream()` call sites. When a round's `done` arrives, `_track_usage()` folds the round into `total_*` **and zeroes the provisional fields in the same step**.

So "usage so far" is `total_* + provisional_*`, and the two are never simultaneously non-zero for the same tokens: provisional means "not yet folded in," total means "already folded in." Each round is its own Anthropic message, which is what makes a cumulative-per-message snapshot equal that round's usage.

`chat.py`'s cancel handler sums both (with `getattr(..., 0)` for pre-#629 test doubles) and still refuses to write unless the sum is > 0 — #615's "never write a confident zero" guard is intact, now checking both accumulators. A zero row would assert "this turn cost nothing," which is an affirmative false claim rather than a missing one.

## Per-backend reality, stated not implied

**Anthropic-backed turns** get real mid-round credit. **Local-backed turns are byte-for-byte unchanged from #615** — still zero on a mid-round cancel — because the OpenAI-compatible protocol carries no mid-stream usage signal at all. That gap is permanent and cannot be engineered around, so it is documented in three places: `LocalLLMClient.astream`'s docstring, `AgentResult`'s field comments, and the rewritten `chat.py` cancel-handler comment (which previously claimed this needed a "future client-layer change" — now replaced with the current backend-split reality).

## Consumer audit

Two corrections to the issue as filed:

- **`query_router.py` was never an `astream` consumer** — it calls `generate_text()`, non-streaming. The issue listed it based on an inherited note; verified false.
- **`synthesizer.py` tolerates the new event by construction** — its `if/elif` chain has no `else`, so unknown event types are ignored. No change needed, and there is now a test pinning that property rather than leaving it an observation.

Actual consumers updated: `agent_loop.py` (both call sites — tool-round loop and synthesis round). `chat.py` consumes `agent_loop`'s own event types, which are unchanged.

## Verification

Failing before the change, confirmed by reverting `api/services/llm_client.py` alone:

```
test_astream_yields_usage_update_from_message_start_and_message_delta
>       assert len(usage_updates) == 2
E       assert 0 == 2
```

New tests: producer-level carry-forward including the omitted-`input_tokens` case; mid-round cancellation credits provisional without touching `total_*`; normal completion does **not** double-count (100/20 from `done`, not 200/35); the synthesis-round call site tolerates `usage_update` while driving the real client with only the SDK mocked; synthesizer consumer tolerance; and an Anthropic-shaped mid-round cancel recording a non-zero row alongside a local-shaped one asserting `turn_count == 0` as the documented unclosed gap.

- Targeted (15 files): **298 passed**
- Pre-push gate: **3629 passed / 8 skipped**, 73 browser

Note on that 8: they are data-dependent skips (`people_dictionary` / `crm_mappings` not configured) that occur because the gate ran in a worktree rather than the canonical checkout. `main` shows 3630/0 for the same code. Collected counts confirm no test was lost: main 3638, this branch 3645 under `-m unit`.

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)