### PR TITLE
fix(deploy): a local merge on main deployed nothing — close all four gaps

### DIFF
--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 # LifeOS Auto-Deploy
 # ==================
-# Polls origin/main and, when it advances, fast-forward pulls the new code and
-# restarts the services whose code the deploy touched. Pull-based by design: it
-# needs no inbound network, so it works on this WiFi-only host and simply catches
-# up on the next tick after any outage.
+# Polls origin/main and, when it advances, fast-forward pulls the new code.
+# Pull-based by design: it needs no inbound network, so it works on this
+# WiFi-only host and simply catches up on the next tick after any outage.
+#
+# Whether to restart a service is decided by a separate, unconditional drift
+# check (every tick, pull or no pull) that compares what's actually running
+# against what's on disk — see "Verify what's actually running" below. Earlier
+# this inferred "services are current" from "nothing to pull", which is false
+# for a merge performed in THIS checkout: local == remote the instant it's
+# pushed, so that merge was never deployed (#631).
 #
 # Triggered by lifeos-autodeploy.timer (installed by setup-systemd.sh), default
 # every 10 min. Opt-in: does nothing unless LIFEOS_AUTODEPLOY_ENABLED=true in .env.
@@ -60,6 +66,69 @@ NOTIFY=$(_read_env "LIFEOS_AUTODEPLOY_NOTIFY" "failure")
 notify_failure() { [ "$NOTIFY" != "never" ] && send_telegram "$1"; }
 notify_success() { [ "$NOTIFY" = "always" ] && send_telegram "$1"; }
 
+# --- Drift check helpers (#631) --------------------------------------------------
+#
+# Newest on-disk mtime among tracked files under the paths lifeos-api,
+# lifeos-mcp-http, and lifeos-agent-worker all import (api/, config/,
+# mcp_server.py — the same set the post-commit hook watches). `git ls-files`
+# (not `find`) so __pycache__/*.pyc and other untracked/generated files never
+# count: a .pyc's mtime tracks its last import, not its last real edit, which
+# would make every service look permanently "current" the moment it runs.
+#
+# mtime, not `git log`'s commit date: scripts/post-commit normalizes every
+# commit's author/committer date to 12:00 UTC (privacy: hides work schedule),
+# so commit dates don't reliably order same-day commits, and a rebased or
+# cherry-picked commit can carry an old author date that predates when it
+# actually landed on main. A file's mtime is set by the checkout itself
+# (pull/merge rewrite the file at real wall-clock time) and neither
+# normalization touches it, so it's the sturdier signal for "did the code on
+# disk actually change, and when."
+newest_code_mtime() {
+    git ls-files -- api config mcp_server.py 2>/dev/null \
+        | xargs -r stat -c '%Y' 2>/dev/null \
+        | sort -rn | head -1
+}
+
+# Real wall-clock time $1's current process started, on this host's own
+# clock — the same clock `newest_code_mtime` read the mtimes from, so there's
+# no cross-host skew to worry about. Empty output (return 1) means "unknown"
+# (unit inactive, or systemd/date failed to parse); callers must skip rather
+# than guess.
+service_active_since_epoch() {
+    local raw
+    raw=$(systemctl show "$1" -p ActiveEnterTimestamp --value 2>/dev/null)
+    [ -n "$raw" ] && [ "$raw" != "n/a" ] || return 1
+    date -d "$raw" +%s 2>/dev/null
+}
+
+# Authoritative "is the worker mid-session" check (#631 gap 3). Queries the
+# same SQLite session store the worker itself consults on restart —
+# SessionStore.list_non_terminal(), the "sessions the worker may still need to
+# act on" set (claimed/running/yielded) — rather than guessing from process
+# CPU or log recency. Any failure to ask it (missing venv, locked DB, import
+# error) is treated as busy: killing an in-flight #agent session is worse than
+# leaving the worker one more 10-minute tick stale.
+worker_busy() {
+    "$VENV_DIR/bin/python" -c "
+import sys
+try:
+    from api.services.agent_worker.session_store import SessionStore
+    sys.exit(0 if SessionStore().list_non_terminal() else 2)
+except Exception as e:
+    print(f'worker_busy check failed: {e}', file=sys.stderr)
+    sys.exit(3)
+" 2>>"$LOG_FILE"
+    [ $? -eq 2 ] && return 1   # confirmed idle
+    return 0                   # busy, or unknown/error -> treat as busy
+}
+
+# Everything below is the operational run — wrapped in a function, guarded so
+# it only fires when the file is executed directly, so tests can `source` this
+# script to call the decision helpers above (newest_code_mtime,
+# service_active_since_epoch, worker_busy) against a synthetic repo/stubbed
+# systemctl without tripping the opt-in gate, guards, or a real git fetch/pull.
+main() {
+
 # --- Opt-in gate ---------------------------------------------------------------
 case "$(_read_env "LIFEOS_AUTODEPLOY_ENABLED" "false" | tr '[:upper:]' '[:lower:]')" in
     true|1|yes) ;;
@@ -104,61 +173,78 @@ fi
 
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
-[ "$LOCAL" = "$REMOTE" ] && exit 0   # up to date — the common case, stay silent
+if [ "$LOCAL" != "$REMOTE" ]; then
+    log "main advanced: ${LOCAL:0:7} -> ${REMOTE:0:7}"
+    CHANGED=$(git diff --name-only "$LOCAL" "$REMOTE")   # capture before the pull moves HEAD
 
-log "main advanced: ${LOCAL:0:7} -> ${REMOTE:0:7}"
-CHANGED=$(git diff --name-only "$LOCAL" "$REMOTE")   # capture before the pull moves HEAD
-
-# --- Fast-forward pull ----------------------------------------------------------
-if ! git pull --ff-only --quiet origin main 2>>"$LOG_FILE"; then
-    log "ERROR: --ff-only pull failed (local main diverged from origin)"
-    notify_failure "🚨 *LifeOS Auto-Deploy*
-Fast-forward pull failed — local \`main\` has diverged from origin. Manual fix needed."
-    exit 1
-fi
-
-# --- Install dependencies if they changed ---------------------------------------
-if echo "$CHANGED" | grep -q '^requirements\.txt$'; then
-    log "requirements.txt changed — installing into $VENV_DIR"
-    if ! "$VENV_DIR/bin/pip" install -q -r requirements.txt >>"$LOG_FILE" 2>&1; then
-        log "ERROR: pip install failed — NOT restarting services"
+    # --- Fast-forward pull -------------------------------------------------------
+    if ! git pull --ff-only --quiet origin main 2>>"$LOG_FILE"; then
+        log "ERROR: --ff-only pull failed (local main diverged from origin)"
         notify_failure "🚨 *LifeOS Auto-Deploy*
-\`pip install\` failed after pulling new requirements. Services were NOT restarted."
+Fast-forward pull failed — local \`main\` has diverged from origin. Manual fix needed."
         exit 1
     fi
-fi
 
-# --- Decide whether a restart is needed -----------------------------------------
-# Docs / tests / static frontend / CI config ship without a service restart.
-CODE_CHANGED=$(echo "$CHANGED" | grep -vE '^(docs/|tests/|web/|\.github/|plans/)|\.md$' || true)
-if [ -z "$CODE_CHANGED" ]; then
-    log "deployed ${REMOTE:0:7} (docs/tests only — no restart)"
-    notify_success "✅ *LifeOS Auto-Deploy*
-Pulled \`${REMOTE:0:7}\` (docs/tests only — no restart)."
-    exit 0
-fi
-
-# Restart every *currently active* code service. Restarting only running units
-# keeps opt-in services (agent-worker, mcp-http) off if the operator left them
-# off, and restarting the API on any code change is correct because it imports
-# the worker/mcp modules too. llm + chromadb hold no repo Python that changes.
-RESTARTED=()
-FAILED=()
-for unit in lifeos-api lifeos-agent-worker lifeos-mcp-http; do
-    systemctl is-active --quiet "$unit" || continue
-    if sudo -n systemctl restart "$unit" 2>>"$LOG_FILE"; then
-        RESTARTED+=("$unit")
-    else
-        FAILED+=("$unit")
-        log "ERROR: restart failed for $unit"
+    # --- Install dependencies if they changed ------------------------------------
+    if echo "$CHANGED" | grep -q '^requirements\.txt$'; then
+        log "requirements.txt changed — installing into $VENV_DIR"
+        if ! "$VENV_DIR/bin/pip" install -q -r requirements.txt >>"$LOG_FILE" 2>&1; then
+            log "ERROR: pip install failed — NOT restarting services"
+            notify_failure "🚨 *LifeOS Auto-Deploy*
+\`pip install\` failed after pulling new requirements. Services were NOT restarted."
+            exit 1
+        fi
     fi
-done
+fi
+
+# --- Verify what's actually running, don't infer from the pull (#631) -----------
+# Runs every tick, whether or not the block above found anything to pull — a
+# merge committed and pushed from this checkout already has LOCAL == REMOTE by
+# the time this fires. Restarting only actually-running units keeps opt-in
+# services (agent-worker, mcp-http) off if the operator left them off.
+RESTARTED=()
+DEFERRED=()
+FAILED=()
+CODE_MTIME=$(newest_code_mtime)
+if [ -n "$CODE_MTIME" ]; then
+    for unit in lifeos-api lifeos-agent-worker lifeos-mcp-http; do
+        systemctl is-active --quiet "$unit" || continue
+        active_since=$(service_active_since_epoch "$unit") || {
+            log "drift-check: could not read $unit's start time — skipping"
+            continue
+        }
+        [ "$active_since" -ge "$CODE_MTIME" ] && continue   # current, nothing to do
+
+        drift_msg="$unit active since $(date -d "@$active_since" '+%F %T'), code on disk changed $(date -d "@$CODE_MTIME" '+%F %T')"
+
+        # Worker policy: restart when idle, defer when busy (mirrors the
+        # sync_in_progress guard above) — never silently stay stale, never
+        # kill an in-flight #agent session either.
+        if [ "$unit" = "lifeos-agent-worker" ] && worker_busy; then
+            DEFERRED+=("$unit")
+            log "defer: $drift_msg — session in flight, retrying next tick"
+            continue
+        fi
+
+        log "drift: $drift_msg — restarting"
+        if sudo -n systemctl restart "$unit" 2>>"$LOG_FILE"; then
+            RESTARTED+=("$unit")
+        else
+            FAILED+=("$unit")
+            log "ERROR: restart failed for $unit"
+        fi
+    done
+fi
 
 if [ "${#FAILED[@]}" -gt 0 ]; then
-    log "deployed ${REMOTE:0:7} but restart FAILED: ${FAILED[*]}"
+    log "restart FAILED for stale service(s): ${FAILED[*]}"
     notify_failure "🚨 *LifeOS Auto-Deploy*
-Pulled \`${REMOTE:0:7}\` but restart failed: ${FAILED[*]}. Manual intervention needed."
+Drift detected but restart failed: ${FAILED[*]}. Manual intervention needed."
     exit 1
+fi
+
+if [ "${#RESTARTED[@]}" -eq 0 ]; then
+    exit 0   # nothing was stale (or the only stale unit deferred, already logged)
 fi
 
 # --- Post-deploy health check (API takes ~30-60s to reload its ML model) --------
@@ -172,13 +258,18 @@ for _ in $(seq 1 18); do
 done
 
 if [ "$HEALTHY" -ne 1 ]; then
-    log "deployed ${REMOTE:0:7}, restarted ${RESTARTED[*]}, but /health did not recover"
+    log "restarted ${RESTARTED[*]} for drift, but /health did not recover"
     notify_failure "🚨 *LifeOS Auto-Deploy*
-Deployed \`${REMOTE:0:7}\` and restarted ${RESTARTED[*]}, but \`/health\` never came back. Check the host."
+Restarted ${RESTARTED[*]} (was running stale code), but \`/health\` never came back. Check the host."
     exit 1
 fi
 
-log "deployed ${REMOTE:0:7}, restarted ${RESTARTED[*]}, health OK"
+log "restarted ${RESTARTED[*]} for drift, health OK"
 notify_success "✅ *LifeOS Auto-Deploy*
-Deployed \`${REMOTE:0:7}\`, restarted ${RESTARTED[*]}. Health OK."
+Restarted ${RESTARTED[*]} — was running stale code. Health OK."
 exit 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -51,7 +51,14 @@ fi
 # Restart the API server if api/ or config/ files changed. server.sh
 # restarts lifeos-api only — the agent worker deliberately does NOT follow
 # (see lifeos-agent-worker.service), so in-flight agent sessions survive.
-CHANGED_API=$(git diff-tree --no-commit-id --name-only -r HEAD -- api/ config/)
+#
+# `-m --first-parent`: without it, `diff-tree -r` on a MERGE commit produces
+# no output at all (it only diffs single-parent commits), so a local merge
+# silently detected zero changed files and restarted nothing (#631). Adding
+# the flags diffs a merge against its first parent same as `diff HEAD^1..HEAD`
+# would, while leaving ordinary (non-merge) and root commits byte-identical
+# to the prior output — verified empirically, not just by flag docs.
+CHANGED_API=$(git diff-tree -m --first-parent --no-commit-id --name-only -r HEAD -- api/ config/)
 
 if [ -n "$IN_WORKTREE" ]; then
     echo "Worktree commit — skipping service restarts (deploy happens on main)"
@@ -67,7 +74,7 @@ fi
 # with lifeos-api, so it does NOT cascade from the api restart. Cloud
 # agents connect to this service exclusively. The sudoers allowlist
 # installed by setup-systemd.sh permits passwordless restart.
-CHANGED_MCP=$(git diff-tree --no-commit-id --name-only -r HEAD -- mcp_server.py)
+CHANGED_MCP=$(git diff-tree -m --first-parent --no-commit-id --name-only -r HEAD -- mcp_server.py)
 
 if [ -z "$IN_WORKTREE" ] && [ -n "$CHANGED_MCP" ]; then
     if systemctl list-unit-files lifeos-mcp-http.service &>/dev/null; then

--- a/tests/test_deploy_drift.py
+++ b/tests/test_deploy_drift.py
@@ -1,0 +1,595 @@
+"""Deploy-drift coverage (#631).
+
+Three services (lifeos-api, lifeos-mcp-http, lifeos-agent-worker) were found
+running three-day-old code while autodeploy fired cleanly every 10 minutes the
+whole time. Three independent mechanisms each declined to act for individually
+defensible reasons:
+
+1. `scripts/post-commit`'s change detection used `git diff-tree -r HEAD`,
+   which is blind to merge commits (no output without `-m`/`--first-parent`),
+   so a local merge restarted nothing.
+2. `scripts/auto-deploy.sh` inferred "services are current" from "nothing to
+   pull" (`LOCAL == REMOTE`) — false the instant a merge is pushed from the
+   canonical checkout itself.
+3. The agent worker had no restart path at all in that workflow, and no
+   explicit busy/idle policy.
+
+This file covers (1) via subprocess (bash isn't pytest-covered except by
+driving the real script, per the established pattern in
+test_agent_worker_self_restart.py), and the decision helpers behind (2)/(3) —
+`newest_code_mtime`, `service_active_since_epoch`, `worker_busy` — by
+`source`-ing scripts/auto-deploy.sh (its operational body is wrapped in
+`main()` and guarded so sourcing only defines functions, never fetches,
+pulls, or restarts anything for real).
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.session_store import STATUS_CLAIMED, SessionStore
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POST_COMMIT = REPO_ROOT / "scripts" / "post-commit"
+AUTO_DEPLOY = REPO_ROOT / "scripts" / "auto-deploy.sh"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _stub_bin(dir_: Path, name: str, body: str) -> None:
+    p = dir_ / name
+    p.write_text("#!/bin/bash\n" + body, encoding="utf-8")
+    p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — post-commit's merge blindness
+# ---------------------------------------------------------------------------
+def _make_repo_with_post_commit(tmp_path: Path) -> Path:
+    """A synthetic repo with the real post-commit script + a stubbed
+    server.sh, systemctl, and sudo so nothing real is ever restarted."""
+    repo = tmp_path / "repo"
+    (repo / "api").mkdir(parents=True)
+    (repo / "config").mkdir(parents=True)
+    (repo / "docs").mkdir(parents=True)
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    (scripts / "post-commit").write_text(POST_COMMIT.read_text(), encoding="utf-8")
+    (scripts / "post-commit").chmod(0o755)
+    # No-op server.sh — the hook only checks `-x` and backgrounds a call to it.
+    _stub_bin(scripts, "server.sh", "exit 0\n")
+
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("base\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    return repo
+
+
+def _run_post_commit(repo: Path) -> subprocess.CompletedProcess:
+    bindir = repo / "stubbin"
+    bindir.mkdir(exist_ok=True)
+    _stub_bin(bindir, "systemctl", "exit 1\n")  # lifeos-mcp-http.service "not found"
+    _stub_bin(bindir, "sudo", 'exec "$@"\n')
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    return subprocess.run(
+        ["bash", "scripts/post-commit"], cwd=repo, env=env,
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+@pytest.mark.unit
+def test_post_commit_detects_merge_touching_api(tmp_path: Path):
+    """A merge commit touching api/ must still trigger the API restart —
+    this is the exact scenario that silently restarted nothing (#631)."""
+    if not POST_COMMIT.exists():
+        pytest.skip("scripts/post-commit not present")
+    repo = _make_repo_with_post_commit(tmp_path)
+
+    _git(repo, "checkout", "-qb", "feature")
+    (repo / "api" / "handler.py").write_text("# feature change\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "feature: touch api/")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "README.md").write_text("main moved on\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "unrelated main commit")
+
+    _git(repo, "merge", "--no-ff", "-q", "-m", "merge feature", "feature")
+    # Sanity: this is genuinely a merge commit non-git-diff-tree-visible case.
+    parents = subprocess.run(
+        ["git", "rev-list", "--parents", "-n", "1", "HEAD"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    assert len(parents) == 3, "expected a real 2-parent merge commit"
+
+    result = _run_post_commit(repo)
+    assert result.returncode == 0, result.stderr
+    assert "Server restart triggered" in result.stdout, result.stdout
+    assert "No server restart needed" not in result.stdout
+
+
+@pytest.mark.unit
+def test_post_commit_merge_touching_docs_only_restarts_nothing(tmp_path: Path):
+    """A merge whose only changes are under docs/ must still restart nothing
+    (today's non-merge behavior, preserved for merges too)."""
+    if not POST_COMMIT.exists():
+        pytest.skip("scripts/post-commit not present")
+    repo = _make_repo_with_post_commit(tmp_path)
+
+    _git(repo, "checkout", "-qb", "feature")
+    (repo / "docs" / "notes.md").write_text("feature docs\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "feature: docs only")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "README.md").write_text("main moved on\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "unrelated main commit")
+
+    _git(repo, "merge", "--no-ff", "-q", "-m", "merge feature", "feature")
+
+    result = _run_post_commit(repo)
+    assert result.returncode == 0, result.stderr
+    assert "No server restart needed" in result.stdout, result.stdout
+    assert "Server restart triggered" not in result.stdout
+    assert "MCP HTTP service restart triggered" not in result.stdout
+
+
+@pytest.mark.unit
+def test_post_commit_merge_touching_mcp_server_triggers_mcp_restart(tmp_path: Path):
+    """A merge touching mcp_server.py must restart lifeos-mcp-http."""
+    if not POST_COMMIT.exists():
+        pytest.skip("scripts/post-commit not present")
+    repo = _make_repo_with_post_commit(tmp_path)
+    (repo / "mcp_server.py").write_text("# base\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add mcp_server.py")
+
+    _git(repo, "checkout", "-qb", "feature")
+    (repo / "mcp_server.py").write_text("# feature change\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "feature: touch mcp_server.py")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "README.md").write_text("main moved on\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "unrelated main commit")
+
+    _git(repo, "merge", "--no-ff", "-q", "-m", "merge feature", "feature")
+
+    bindir = repo / "stubbin"
+    bindir.mkdir(exist_ok=True)
+    # This time report the mcp-http unit as installed so the hook takes the branch.
+    _stub_bin(bindir, "systemctl", 'exit 0\n')
+    _stub_bin(bindir, "sudo", 'exec "$@"\n')
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    result = subprocess.run(
+        ["bash", "scripts/post-commit"], cwd=repo, env=env,
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "MCP HTTP service restart triggered" in result.stdout, result.stdout
+
+
+@pytest.mark.unit
+def test_post_commit_normal_commit_docs_only_restarts_nothing(tmp_path: Path):
+    """Regression guard: an ordinary (non-merge) docs-only commit must keep
+    restarting nothing, unaffected by the `-m --first-parent` change."""
+    if not POST_COMMIT.exists():
+        pytest.skip("scripts/post-commit not present")
+    repo = _make_repo_with_post_commit(tmp_path)
+    (repo / "docs" / "notes.md").write_text("more docs\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "docs only")
+
+    result = _run_post_commit(repo)
+    assert result.returncode == 0, result.stderr
+    assert "No server restart needed" in result.stdout, result.stdout
+
+
+@pytest.mark.unit
+def test_post_commit_normal_commit_api_change_still_restarts(tmp_path: Path):
+    """Regression guard: an ordinary (non-merge) api/ commit must still
+    restart, unaffected by the `-m --first-parent` change."""
+    if not POST_COMMIT.exists():
+        pytest.skip("scripts/post-commit not present")
+    repo = _make_repo_with_post_commit(tmp_path)
+    (repo / "api" / "handler.py").write_text("# change\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "touch api/")
+
+    result = _run_post_commit(repo)
+    assert result.returncode == 0, result.stderr
+    assert "Server restart triggered" in result.stdout, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Gap 2/3 — auto-deploy.sh's drift-check helpers (sourced, not executed)
+# ---------------------------------------------------------------------------
+def _run_sourced(repo: Path, call: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    """Source auto-deploy.sh (defines functions only — see module docstring)
+    then run `call`. cwd=repo so PROJECT_DIR-relative git/file operations
+    inside the helpers see the synthetic repo, not the real one."""
+    script = repo / "scripts" / "auto-deploy.sh"
+    env = dict(os.environ)
+    env.update(env_extra or {})
+    return subprocess.run(
+        ["bash", "-c", f'source "{script}" && {call}'],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+
+
+def _make_repo_for_drift(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "api").mkdir(parents=True)
+    (repo / "config").mkdir(parents=True)
+    (repo / "docs").mkdir(parents=True)
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "scripts" / "auto-deploy.sh").write_text(AUTO_DEPLOY.read_text(), encoding="utf-8")
+    (repo / "scripts" / "auto-deploy.sh").chmod(0o755)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "t")
+    return repo
+
+
+@pytest.mark.unit
+def test_sourcing_auto_deploy_does_not_run_main(tmp_path: Path):
+    """Sourcing must only define functions — no fetch/pull/restart/exit."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo = _make_repo_for_drift(tmp_path)
+    result = _run_sourced(repo, "echo did-not-exit")
+    assert result.returncode == 0, result.stderr
+    assert "did-not-exit" in result.stdout
+
+
+@pytest.mark.unit
+def test_newest_code_mtime_ignores_docs_and_untracked_files(tmp_path: Path):
+    """Only tracked files under api/, config/, mcp_server.py count — an
+    untracked file (e.g. a .pyc-like build artifact) and docs/ changes must
+    not move the watermark forward or backward."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo = _make_repo_for_drift(tmp_path)
+    (repo / "api" / "a.py").write_text("base\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+
+    before = _run_sourced(repo, "newest_code_mtime").stdout.strip()
+    assert before, "expected a real mtime for a tracked api/ file"
+
+    # Untracked file under a watched dir (simulates a __pycache__/*.pyc) —
+    # must be invisible to the watermark.
+    (repo / "api" / "__pycache__").mkdir()
+    (repo / "api" / "__pycache__" / "a.cpython-312.pyc").write_bytes(b"junk")
+    os.utime(repo / "api" / "__pycache__" / "a.cpython-312.pyc", (9_999_999_999, 9_999_999_999))
+    after_untracked = _run_sourced(repo, "newest_code_mtime").stdout.strip()
+    assert after_untracked == before
+
+    # docs/ change — not a watched path at all. Add the docs file explicitly
+    # (not `-A`) so the untracked pycache junk above doesn't get swept in and
+    # invalidate the "untracked files don't count" half of this test.
+    (repo / "docs" / "notes.md").write_text("docs\n")
+    _git(repo, "add", "docs/notes.md")
+    _git(repo, "commit", "-qm", "docs")
+    after_docs = _run_sourced(repo, "newest_code_mtime").stdout.strip()
+    assert after_docs == before
+
+
+@pytest.mark.unit
+def test_newest_code_mtime_reflects_real_api_edit(tmp_path: Path):
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo = _make_repo_for_drift(tmp_path)
+    (repo / "api" / "a.py").write_text("base\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    before = int(_run_sourced(repo, "newest_code_mtime").stdout.strip())
+
+    (repo / "config" / "c.py").write_text("changed\n")
+    os.utime(repo / "config" / "c.py", (before + 1000, before + 1000))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "config change")
+    after = int(_run_sourced(repo, "newest_code_mtime").stdout.strip())
+    assert after >= before + 1000
+
+
+@pytest.mark.unit
+def test_service_active_since_epoch_unknown_for_inactive_unit(tmp_path: Path):
+    """systemctl reporting no ActiveEnterTimestamp (inactive/nonexistent
+    unit) must be treated as unknown (empty output, nonzero exit) — never a
+    guessed value."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo = _make_repo_for_drift(tmp_path)
+    bindir = repo / "stubbin"
+    bindir.mkdir()
+    _stub_bin(bindir, "systemctl", "echo -n ''\nexit 0\n")
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    result = subprocess.run(
+        ["bash", "-c", 'source scripts/auto-deploy.sh && service_active_since_epoch some.service; echo "rc=$?"'],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert "rc=1" in result.stdout, result.stdout
+
+
+@pytest.mark.unit
+def test_service_active_since_epoch_parses_systemd_timestamp(tmp_path: Path):
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo = _make_repo_for_drift(tmp_path)
+    bindir = repo / "stubbin"
+    bindir.mkdir()
+    _stub_bin(bindir, "systemctl", "echo 'Thu 2026-08-20 12:00:00 UTC'\nexit 0\n")
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    result = _run_sourced(repo, "service_active_since_epoch some.service", env)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "1787227200"  # 2026-08-20T12:00:00Z
+
+
+def _venv_with_python(tmp_path: Path) -> Path:
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(sys.executable)
+    return venv
+
+
+@pytest.mark.unit
+def test_worker_busy_true_when_non_terminal_session_exists(tmp_path: Path):
+    """Authoritative source of truth: SessionStore.list_non_terminal() — a
+    claimed/running/yielded row means busy."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    workdir = tmp_path / "work"
+    (workdir / "data").mkdir(parents=True)
+    (workdir / "scripts").mkdir()
+    (workdir / "scripts" / "auto-deploy.sh").write_text(AUTO_DEPLOY.read_text(), encoding="utf-8")
+
+    store = SessionStore(db_path=workdir / "data" / "agent_sessions.db")
+    store.create(task_id="t-1", session_id="s-1", status=STATUS_CLAIMED)
+
+    venv = _venv_with_python(tmp_path)
+    env = dict(os.environ)
+    env["LIFEOS_VENV"] = str(venv)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    result = subprocess.run(
+        ["bash", "-c", 'source scripts/auto-deploy.sh && worker_busy; echo "rc=$?"'],
+        cwd=workdir, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert "rc=0" in result.stdout, (result.stdout, result.stderr)
+
+
+@pytest.mark.unit
+def test_worker_busy_false_when_no_sessions(tmp_path: Path):
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    workdir = tmp_path / "work"
+    (workdir / "data").mkdir(parents=True)
+    (workdir / "scripts").mkdir()
+    (workdir / "scripts" / "auto-deploy.sh").write_text(AUTO_DEPLOY.read_text(), encoding="utf-8")
+    # Create the store (and its schema) with zero sessions.
+    SessionStore(db_path=workdir / "data" / "agent_sessions.db")
+
+    venv = _venv_with_python(tmp_path)
+    env = dict(os.environ)
+    env["LIFEOS_VENV"] = str(venv)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    result = subprocess.run(
+        ["bash", "-c", 'source scripts/auto-deploy.sh && worker_busy; echo "rc=$?"'],
+        cwd=workdir, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert "rc=1" in result.stdout, (result.stdout, result.stderr)
+
+
+@pytest.mark.unit
+def test_worker_busy_defaults_to_busy_on_query_failure(tmp_path: Path):
+    """No DB, broken venv, whatever — an inability to determine busy-ness
+    must default to busy (defer), not idle (restart and risk killing an
+    in-flight #agent session)."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "scripts").mkdir()
+    (workdir / "scripts" / "auto-deploy.sh").write_text(AUTO_DEPLOY.read_text(), encoding="utf-8")
+    # No data/ dir, no venv at all — LIFEOS_VENV points nowhere.
+    env = dict(os.environ)
+    env["LIFEOS_VENV"] = str(workdir / "no-such-venv")
+    result = subprocess.run(
+        ["bash", "-c", 'source scripts/auto-deploy.sh && worker_busy; echo "rc=$?"'],
+        cwd=workdir, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert "rc=0" in result.stdout, (result.stdout, result.stderr)
+
+
+@pytest.mark.unit
+def test_auto_deploy_syntax_and_sourced_functions_defined(tmp_path: Path):
+    """bash -n passes, and sourcing exposes exactly the decision helpers a
+    drift check needs."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    syntax = subprocess.run(["bash", "-n", str(AUTO_DEPLOY)], capture_output=True, text=True)
+    assert syntax.returncode == 0, syntax.stderr
+
+    repo = _make_repo_for_drift(tmp_path)
+    result = _run_sourced(repo, "type -t newest_code_mtime service_active_since_epoch worker_busy main")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count("function") == 4, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Gap 2/3 integration — the actual per-service loop inside main(), not just
+# the helpers in isolation: restart-when-idle/defer-when-busy in one tick,
+# and no-thrash across two consecutive ticks with no new commits.
+# ---------------------------------------------------------------------------
+def _make_policy_repo(tmp_path: Path) -> tuple[Path, Path, int]:
+    """A real git repo (with a real 'origin' remote so `main()`'s fetch/pull
+    guards are genuinely exercised) laid out like the canonical checkout, plus
+    a stub bin/ for systemctl and sudo whose fake service state lives in
+    files under `state/` (so a stubbed restart can move a unit's recorded
+    start time forward, the way a real restart would). Returns
+    (repo, state_dir, code_epoch) where code_epoch is the fixed mtime given
+    to the one tracked api/ file, an hour in the past.
+    """
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(origin)], check=True)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "checkout", "-qb", "main")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "remote", "add", "origin", str(origin))
+    (repo / "api").mkdir()
+    (repo / "config").mkdir()
+    (repo / "scripts").mkdir()
+    (repo / "data").mkdir()
+    (repo / "scripts" / "auto-deploy.sh").write_text(AUTO_DEPLOY.read_text(), encoding="utf-8")
+    (repo / "scripts" / "auto-deploy.sh").chmod(0o755)
+    (repo / "api" / "a.py").write_text("code\n")
+    (repo / ".env").write_text(
+        "LIFEOS_AUTODEPLOY_ENABLED=true\nLIFEOS_AUTODEPLOY_NOTIFY=never\n"
+    )
+    # Matches the real repo's .gitignore: logs/ and data/ are runtime output,
+    # not source — without this, main()'s own `mkdir -p logs` and the
+    # SessionStore db it creates would show up as untracked files and trip
+    # the "working tree dirty" guard before the drift check ever runs.
+    (repo / ".gitignore").write_text("logs/\ndata/\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    _git(repo, "push", "-q", "origin", "main")
+
+    import time as _time
+    code_epoch = int(_time.time()) - 3600  # "code changed an hour ago"
+    os.utime(repo / "api" / "a.py", (code_epoch, code_epoch))
+
+    state = tmp_path / "state"
+    state.mkdir()
+    return repo, state, code_epoch
+
+
+_SYSTEMCTL_STUB = r"""
+STATE="$LIFEOS_TEST_STATE"
+case "$1" in
+    show)
+        # sync_in_progress's lifeos-sync.service query is a `show` too —
+        # distinguish by unit name ($2), not by the -p property (which
+        # shifts position depending on whether --value comes before/after).
+        if [ "$2" = "lifeos-sync.service" ]; then
+            echo "inactive"; exit 0
+        fi
+        unit="$2"
+        f="$STATE/since_$unit"
+        [ -f "$f" ] && echo "@$(cat "$f")"
+        exit 0
+        ;;
+    is-active)
+        unit="${*: -1}"
+        [ -f "$STATE/active_$unit" ] && exit 0 || exit 3
+        ;;
+    restart)
+        unit="$2"
+        date +%s > "$STATE/since_$unit"
+        echo "restart $unit" >> "$STATE/restart.log"
+        exit 0
+        ;;
+esac
+exit 1
+"""
+
+_SUDO_STUB = 'while [[ "$1" == -* ]]; do shift; done\nexec "$@"\n'
+
+
+def _write_policy_stubs(state: Path) -> Path:
+    bindir = state / "bin"
+    bindir.mkdir(exist_ok=True)
+    _stub_bin(bindir, "systemctl", _SYSTEMCTL_STUB)
+    _stub_bin(bindir, "sudo", _SUDO_STUB)
+    _stub_bin(bindir, "curl", "exit 0\n")  # only reached if something restarted
+    return bindir
+
+
+def _run_main(repo: Path, state: Path, venv: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PATH"] = f"{_write_policy_stubs(state)}:{env['PATH']}"
+    env["LIFEOS_TEST_STATE"] = str(state)
+    env["LIFEOS_VENV"] = str(venv)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        ["bash", "-c", "source scripts/auto-deploy.sh && main"],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+
+
+@pytest.mark.unit
+def test_main_restarts_stale_services_and_defers_busy_worker(tmp_path: Path):
+    """One tick, three active-but-stale services: api and mcp-http restart;
+    the worker — mid-session — defers instead (#631 acceptance: never
+    silently stay stale, never kill an in-flight #agent session)."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo, state, code_epoch = _make_policy_repo(tmp_path)
+    stale = code_epoch - 3600  # started 2h ago, an hour before the code changed
+    for unit in ("lifeos-api", "lifeos-mcp-http", "lifeos-agent-worker"):
+        (state / f"active_{unit}").touch()
+        (state / f"since_{unit}").write_text(str(stale))
+
+    store = SessionStore(db_path=repo / "data" / "agent_sessions.db")
+    store.create(task_id="t-1", session_id="s-1", status=STATUS_CLAIMED)
+
+    result = _run_main(repo, state, _venv_with_python(tmp_path))
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+    restart_log = (state / "restart.log").read_text() if (state / "restart.log").exists() else ""
+    assert "restart lifeos-api" in restart_log
+    assert "restart lifeos-mcp-http" in restart_log
+    assert "restart lifeos-agent-worker" not in restart_log
+
+    deploy_log = (repo / "logs" / "auto-deploy.log").read_text()
+    assert "defer" in deploy_log and "lifeos-agent-worker" in deploy_log
+
+
+@pytest.mark.unit
+def test_main_no_thrash_on_repeat_run_with_no_new_commits(tmp_path: Path):
+    """A stale, active-only-as-api service gets restarted on tick 1. Tick 2,
+    with no new commits, must not restart it again — the point of comparing
+    against the service's own (now-current) start time instead of re-deriving
+    from 'did a pull just happen'."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo, state, code_epoch = _make_policy_repo(tmp_path)
+    stale = code_epoch - 3600
+    (state / "active_lifeos-api").touch()
+    (state / "since_lifeos-api").write_text(str(stale))
+    # mcp-http and the worker are simply not active — the loop skips them.
+
+    venv = _venv_with_python(tmp_path)
+
+    first = _run_main(repo, state, venv)
+    assert first.returncode == 0, (first.stdout, first.stderr)
+    restart_log = (state / "restart.log").read_text()
+    assert restart_log.count("restart lifeos-api") == 1
+
+    second = _run_main(repo, state, venv)
+    assert second.returncode == 0, (second.stdout, second.stderr)
+    restart_log_after = (state / "restart.log").read_text()
+    assert restart_log_after.count("restart lifeos-api") == 1, (
+        "second tick with no new commits restarted an already-current service"
+    )


### PR DESCRIPTION
## Problem

`lifeos-mcp-http` and `lifeos-agent-worker` were found running **August 18** code — three days and ~11 merged issues stale — while `lifeos-api` was current. Autodeploy was enabled and firing every 10 minutes the whole time, exiting cleanly each tick. Nothing alerted.

Three mechanisms each declined to act, all behaving as documented. Individually defensible; composed, they meant a local merge deployed nothing and warned nobody.

## Gap 1 — the post-commit hook was blind to merge commits

`scripts/post-commit` used `git diff-tree --no-commit-id --name-only -r HEAD`, which produces **no output** on a merge commit. Measured on a real one here:

```
old flags: 0 files      new flags (-m --first-parent): 10 files
```

Both `CHANGED_API` and `CHANGED_MCP` came out empty, so the hook printed "No server restart needed" while merging five branches of `api/` changes — observed verbatim.

Fixed by adding `-m --first-parent` to both invocations. Verified equivalent on ordinary and root commits (byte-identical output) before changing anything.

## Gap 2 — autodeploy inferred instead of verifying

`[ "$LOCAL" = "$REMOTE" ] && exit 0` is correct for "nothing to pull" and wrong as a proxy for "services are current." Merging in the canonical checkout makes local == remote the instant the push finishes, so **autodeploy only ever deployed changes that arrived from elsewhere.**

Now it runs an unconditional per-tick drift check regardless of whether a pull happened, comparing each service's `ActiveEnterTimestamp` against the newest mtime of `git ls-files -- api config mcp_server.py`.

**Why mtime rather than commit date**, which was the original suggestion: `post-commit` deliberately normalizes commit dates to noon UTC for privacy, and a rebase or cherry-pick can carry an author date predating when the code actually landed on main. Either makes a commit date lie about arrival time, silently and without self-healing. mtime is immune to both — a pull or merge rewrites changed files at real wall-clock checkout time — and `git ls-files` (not `find`) means only tracked source counts, so `__pycache__/*.pyc` mtimes, which track last *import* rather than last edit, can't fake freshness. Both sides of the comparison come from the same host clock, so no skew.

Self-stabilizing: after a restart, `ActiveEnterTimestamp` becomes "now," which always exceeds any past mtime, so it cannot re-trigger without a genuinely newer change. Pinned by a no-thrash test across two consecutive ticks.

## Gap 3 — the worker had no restart path at all

The hook deliberately excludes `lifeos-agent-worker` so in-flight `#agent` sessions survive a commit — sound, but it made autodeploy the only thing that ever restarted it, and per Gap 1 that never fired on a local merge.

Policy decided by the repo owner: **restart when idle, defer when busy.** Alert-only would have left the same hole open with a nicer log line.

Busy is determined from `SessionStore.list_non_terminal()` (claimed/running/yielded — the same set the worker itself checks on its own restart-recovery path), queried against the real store rather than inferred from process CPU or log recency. Any failure to query — missing venv, locked DB, import error — **counts as busy**: killing a live session is worse than one more idle tick of staleness. Deferrals are logged and retried on the next tick, so an indefinitely-busy worker is visible as repeated deferral rather than as silence.

This mirrors the deferral autodeploy already does for the nightly sync rather than introducing a new mechanism.

## Gap 4 — drift is now surfaced

Reused the existing `log` / `notify_failure` / `notify_success` helpers; no new channel. Failure and health-check messages now say "drift detected" / "was running stale code" instead of the old pull-centric wording.

## A fifth gap, confirmed and not fixed here

**Nothing installs `scripts/post-commit` into `.git/hooks/post-commit`.** The only reference anywhere is a manual `cp` in the file's own docstring. So the tracked fix takes effect on no clone until someone copies it by hand — including this one. Deploying that copy is a separate step, done out-of-band with this merge.

## Testability

`auto-deploy.sh`'s operational body is now wrapped in `main()` behind `[[ "${BASH_SOURCE[0]}" == "${0}" ]]`, so a test can `source` it to get `newest_code_mtime` / `service_active_since_epoch` / `worker_busy` / `main` without fetching, pulling, or restarting anything. The cron entry path is unchanged.

New `tests/test_deploy_drift.py`, 16 tests: per-helper units; 5 subprocess-driven post-commit tests (merge+api, merge+docs-only, merge+mcp, plus two non-merge regression guards, following `test_agent_worker_self_restart.py`'s existing pattern); and 2 full-loop integration tests against a real git repo with a bare origin and stubbed `systemctl`/`sudo` — one covering "stale api/mcp restart while a busy worker defers" in a single tick, one covering no-thrash across two ticks.

## Behavior change worth flagging

The old script sent a success ping under `LIFEOS_AUTODEPLOY_NOTIFY=always` for "pulled, docs/tests only, no restart." That branch no longer exists — "nothing to restart" now falls out of the drift check finding nothing stale. The pull is still logged. Failure notifications are unchanged in kind.

## Verification

- `tests/test_deploy_drift.py`: 16 passed
- `tests/test_agent_worker_self_restart.py`: 10 passed (regression check on untouched machinery)
- `tests/test_agent_worker_stores.py` + `tests/test_doctor_bot.py`: 54 passed
- Pre-push gate: passed, 73 browser

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)