### PR TITLE
fix(deploy): stop an untracked .worktrees/ from silently disabling autodeploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,8 @@ scripts/clear-caches.sh
 # Code tooling may write at the repo root — the tracked root-level AGENTS.md
 # overrides this since gitignore doesn't apply to files already in the index.
 /AGENTS.md
+
+# Local git worktrees (agent/dev scratch). Never committed — and an untracked
+# .worktrees/ made `git status --porcelain` report dirty, which silently
+# disabled auto-deploy.sh for 62 consecutive ticks (#634).
+.worktrees/

--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -158,8 +158,16 @@ if [ "$BRANCH" != "main" ]; then
     log "skip: on branch '$BRANCH', not main"
     exit 0
 fi
-if [ -n "$(git status --porcelain)" ]; then
-    log "skip: working tree dirty — not auto-deploying over local edits"
+# `--untracked-files=no` is deliberate (#634). The guard's purpose is to avoid
+# deploying over uncommitted *edits to tracked code*; an untracked file is not
+# that. Counting untracked paths made a single `.worktrees/` directory — the
+# conventional location for worktree-based development here, which the
+# post-commit hook already expects to exist — skip every tick silently and
+# indefinitely: 62 consecutive skips before this was found, during which the
+# drift check below never ran at all. `.worktrees/` is now gitignored too;
+# this is the class fix, so the next stray scratch file doesn't repeat it.
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    log "skip: tracked files modified — not auto-deploying over local edits"
     exit 0
 fi
 

--- a/tests/test_deploy_drift.py
+++ b/tests/test_deploy_drift.py
@@ -593,3 +593,68 @@ def test_main_no_thrash_on_repeat_run_with_no_new_commits(tmp_path: Path):
     assert restart_log_after.count("restart lifeos-api") == 1, (
         "second tick with no new commits restarted an already-current service"
     )
+
+
+@pytest.mark.unit
+def test_main_proceeds_when_only_untracked_files_are_present(tmp_path: Path):
+    """#634: an untracked path must not block the deploy.
+
+    `.worktrees/` is the conventional location for worktree-based development
+    here — `.git/hooks/post-commit` already expects worktrees to exist — and it
+    is untracked. While the guard counted untracked paths, its mere presence
+    made `git status --porcelain` non-empty, so auto-deploy skipped every tick
+    silently: 62 consecutive skips on the real host, during which #631's drift
+    check never executed at all. The service stayed stale and the only evidence
+    was a log line nobody reads.
+    """
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo, state, code_epoch = _make_policy_repo(tmp_path)
+    stale = code_epoch - 3600
+    (state / "active_lifeos-api").touch()
+    (state / "since_lifeos-api").write_text(str(stale))
+
+    # Exactly the real-world shape: an untracked directory at the repo root.
+    (repo / ".worktrees" / "issue-999").mkdir(parents=True)
+    (repo / ".worktrees" / "issue-999" / "scratch.py").write_text("x = 1\n", encoding="utf-8")
+    assert subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, capture_output=True, text=True
+    ).stdout.strip(), "fixture must actually leave the tree untracked-dirty"
+
+    result = _run_main(repo, state, _venv_with_python(tmp_path))
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+    deploy_log = (repo / "logs" / "auto-deploy.log").read_text()
+    assert "not auto-deploying over local edits" not in deploy_log, deploy_log
+    restart_log = (state / "restart.log").read_text() if (state / "restart.log").exists() else ""
+    assert "restart lifeos-api" in restart_log, (deploy_log, restart_log)
+
+
+@pytest.mark.unit
+def test_main_still_skips_when_a_tracked_file_is_modified(tmp_path: Path):
+    """The guard's actual purpose survives #634's narrowing: uncommitted edits
+    to tracked code still stop the deploy. Loosening to
+    `--untracked-files=no` must not become "never skip"."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    repo, state, code_epoch = _make_policy_repo(tmp_path)
+    stale = code_epoch - 3600
+    (state / "active_lifeos-api").touch()
+    (state / "since_lifeos-api").write_text(str(stale))
+
+    tracked = next(
+        p for p in (repo / "api").rglob("*.py")
+        if subprocess.run(
+            ["git", "ls-files", "--error-unmatch", str(p.relative_to(repo))],
+            cwd=repo, capture_output=True,
+        ).returncode == 0
+    )
+    tracked.write_text(tracked.read_text(encoding="utf-8") + "\n# local edit\n", encoding="utf-8")
+
+    result = _run_main(repo, state, _venv_with_python(tmp_path))
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+    deploy_log = (repo / "logs" / "auto-deploy.log").read_text()
+    assert "not auto-deploying over local edits" in deploy_log, deploy_log
+    restart_log = (state / "restart.log").read_text() if (state / "restart.log").exists() else ""
+    assert "restart lifeos-api" not in restart_log, restart_log


### PR DESCRIPTION
## Problem

`auto-deploy.sh` guarded on `git status --porcelain`, which reports **untracked** paths. `.worktrees/` was not gitignored, so the moment any worktree existed the tree read as dirty and the script skipped every tick — before reaching any other logic.

Measured on the host: **62 consecutive skips** beginning `2026-08-21 00:03:20`, with the tree dirty for exactly one reason:

```
$ git status --porcelain
?? .worktrees/
```

## This is the root cause behind #631

#631 diagnosed three real gaps in the deploy chain and fixed them — but placed its drift check **after** this guard, so on this host the fix never executed. Verifying #631 end-to-end is what surfaced this: after merging it, the services did not restart, and the log showed the dirty-tree skip at every tick including the one immediately following the merge.

#631's own tests all passed. Only the on-host check caught it.

## Why it stayed invisible

The failure is self-concealing:

- Worktree-based development is the normal workflow here — `.git/hooks/post-commit` already detects `*/.git/worktrees/*` in order to skip restarts for worktree commits, so the tooling *assumes* worktrees exist.
- Each worktree makes the canonical checkout permanently "dirty".
- Autodeploy then does nothing, indefinitely, reporting it only to a log file.
- Removing the worktrees restores it — so anyone investigating afterwards finds a working autodeploy and no evidence of the outage.

## Fix — two changes, instance and class

**`.gitignore` gains `.worktrees/`.** Worktrees are local scratch and are never committed. This alone restores autodeploy today.

**The guard uses `--untracked-files=no`.** Its stated purpose is to avoid deploying over uncommitted edits to *tracked* code; an untracked file is not that. Without this, the next stray scratch file, editor swapfile, or log reproduces the identical silent failure.

The protection itself is unchanged: a modified tracked file still stops the deploy. The skip message now reads "tracked files modified" so the log states what it actually checked.

## Verification

Two tests added to `tests/test_deploy_drift.py`, reusing #631's harness:

- Untracked paths — shaped as a real `.worktrees/issue-999/scratch.py` — proceed past the guard and the stale service restarts. **This fails against the previous guard**, confirmed by reverting it.
- A modified tracked file still skips and restarts nothing. **This passes on both sides**, which is the point: narrowing the guard must not become "never skip."

`tests/test_deploy_drift.py`: **18 passed** (16 from #631 + 2).

## Note

That makes six distinct mechanisms in this deploy chain, each found to fail for a different reason: pull-based inference (#631 gap 1), merge-blind diffing (gap 2), a deliberately excluded unit (gap 3), an uninstalled hook (gap 5), and now an untracked directory ahead of all of them. The generalizable lesson is that each one passed its own tests.

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)