### PR TITLE
fix(deploy): a yielded session must not pin the worker on stale code

### DIFF
--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -101,19 +101,33 @@ service_active_since_epoch() {
     date -d "$raw" +%s 2>/dev/null
 }
 
-# Authoritative "is the worker mid-session" check (#631 gap 3). Queries the
-# same SQLite session store the worker itself consults on restart —
-# SessionStore.list_non_terminal(), the "sessions the worker may still need to
-# act on" set (claimed/running/yielded) — rather than guessing from process
-# CPU or log recency. Any failure to ask it (missing venv, locked DB, import
-# error) is treated as busy: killing an in-flight #agent session is worse than
-# leaving the worker one more 10-minute tick stale.
+# Authoritative "is the worker mid-session" check (#631 gap 3, narrowed by
+# #636). Queries the SQLite session store rather than guessing from process
+# CPU or log recency.
+#
+# Busy means genuinely-active work only: claimed or running. `yielded` is
+# deliberately excluded (#636) — the worker's own recovery path skips yielded
+# sessions with "Sleeping sessions are healthy — main loop will wake them",
+# so a restart does not harm them. `list_non_terminal()` (which includes
+# yielded) answers "which sessions must I look at?", not "which would a
+# restart harm?" — a wider set, and using it meant one abandoned yielded
+# session pinned the worker on stale code on every tick forever. One such
+# session, 82 days old, was doing exactly that when this was found.
+#
+# Any failure to ask (missing venv, locked DB, import error) is still treated
+# as busy: killing live work is worse than one more 10-minute stale tick.
 worker_busy() {
     "$VENV_DIR/bin/python" -c "
 import sys
 try:
-    from api.services.agent_worker.session_store import SessionStore
-    sys.exit(0 if SessionStore().list_non_terminal() else 2)
+    from api.services.agent_worker.session_store import (
+        STATUS_CLAIMED,
+        STATUS_RUNNING,
+        SessionStore,
+    )
+    active = {STATUS_CLAIMED, STATUS_RUNNING}
+    busy = [s for s in SessionStore().list_non_terminal() if s.status in active]
+    sys.exit(0 if busy else 2)
 except Exception as e:
     print(f'worker_busy check failed: {e}', file=sys.stderr)
     sys.exit(3)

--- a/tests/test_deploy_drift.py
+++ b/tests/test_deploy_drift.py
@@ -32,7 +32,12 @@ from pathlib import Path
 
 import pytest
 
-from api.services.agent_worker.session_store import STATUS_CLAIMED, SessionStore
+from api.services.agent_worker.session_store import (
+    STATUS_CLAIMED,
+    STATUS_RUNNING,
+    STATUS_YIELDED,
+    SessionStore,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 POST_COMMIT = REPO_ROOT / "scripts" / "post-commit"
@@ -352,8 +357,8 @@ def _venv_with_python(tmp_path: Path) -> Path:
 
 @pytest.mark.unit
 def test_worker_busy_true_when_non_terminal_session_exists(tmp_path: Path):
-    """Authoritative source of truth: SessionStore.list_non_terminal() — a
-    claimed/running/yielded row means busy."""
+    """Authoritative source of truth: the session store. A claimed or
+    running row means busy (yielded does not — see #636)."""
     if not AUTO_DEPLOY.exists():
         pytest.skip("scripts/auto-deploy.sh not present")
     workdir = tmp_path / "work"
@@ -658,3 +663,58 @@ def test_main_still_skips_when_a_tracked_file_is_modified(tmp_path: Path):
     assert "not auto-deploying over local edits" in deploy_log, deploy_log
     restart_log = (state / "restart.log").read_text() if (state / "restart.log").exists() else ""
     assert "restart lifeos-api" not in restart_log, restart_log
+
+
+def _worker_busy_rc(tmp_path: Path, statuses: list[str]) -> str:
+    """Run auto-deploy.sh's `worker_busy` against a store seeded with exactly
+    `statuses`. Returns the shell rc line ("rc=0" busy, "rc=1" idle)."""
+    workdir = tmp_path / f"work_{'_'.join(statuses) or 'empty'}"
+    (workdir / "data").mkdir(parents=True)
+    (workdir / "scripts").mkdir()
+    (workdir / "scripts" / "auto-deploy.sh").write_text(AUTO_DEPLOY.read_text(), encoding="utf-8")
+    store = SessionStore(db_path=workdir / "data" / "agent_sessions.db")
+    for i, st in enumerate(statuses):
+        store.create(task_id=f"t-{i}", session_id=f"s-{i}", status=st)
+    env = dict(os.environ)
+    env["LIFEOS_VENV"] = str(_venv_with_python(tmp_path))
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    result = subprocess.run(
+        ["bash", "-c", 'source scripts/auto-deploy.sh && worker_busy; echo "rc=$?"'],
+        cwd=workdir, env=env, capture_output=True, text=True, timeout=30,
+    )
+    return result.stdout
+
+
+@pytest.mark.unit
+def test_worker_busy_excludes_yielded_sessions(tmp_path: Path):
+    """#636: a yielded session must NOT block a restart.
+
+    The worker's own recovery path skips yielded sessions ("Sleeping sessions
+    are healthy — main loop will wake them"), so a restart does not harm them.
+    Counting them meant one abandoned yielded session — 82 days old, on the
+    real host — deferred the worker on every tick forever, logging a deferral
+    each time and never updating. `list_non_terminal()` answers "which
+    sessions must I look at?", which is a wider set than "which would a
+    restart harm?".
+    """
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    assert "rc=1" in _worker_busy_rc(tmp_path, [STATUS_YIELDED])
+
+
+@pytest.mark.unit
+def test_worker_busy_still_true_for_a_running_session(tmp_path: Path):
+    """The narrowing must not become "never busy": genuinely-active work
+    still defers."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    assert "rc=0" in _worker_busy_rc(tmp_path, [STATUS_RUNNING])
+
+
+@pytest.mark.unit
+def test_worker_busy_true_when_active_work_sits_alongside_a_yielded_session(tmp_path: Path):
+    """The mixed case is the one a naive filter gets wrong: excluding yielded
+    must not cause a claimed session in the same store to be overlooked."""
+    if not AUTO_DEPLOY.exists():
+        pytest.skip("scripts/auto-deploy.sh not present")
+    assert "rc=0" in _worker_busy_rc(tmp_path, [STATUS_YIELDED, STATUS_CLAIMED])


### PR DESCRIPTION
## Problem

#631's worker policy determined "busy" from `SessionStore.list_non_terminal()`, which returns claimed + running + **yielded**. Counting yielded turned a temporary deferral into a permanent one.

**The worker itself treats yielded sessions as safe across a restart**, in its own recovery loop:

```python
# Sleeping sessions are healthy — main loop will wake them.
if session.status == STATUS_YIELDED:
    continue
```

Recovery exists to handle sessions a restart *interrupted*; it skips yielded ones precisely because they need no handling. So restarting with one present loses nothing.

## Observed live

On the first tick where the drift check actually ran — after #634 unblocked it — `lifeos-api` and `lifeos-mcp-http` restarted correctly and the worker did not:

```
13:44:39 - defer: lifeos-agent-worker active since 11:51:43,
           code on disk changed 12:29:22 — session in flight, retrying next tick
```

The blocking session:

```
session_id: sess_c51d6bf718d24990
status:     yielded
started:    2026-05-31   (82 days earlier)
```

One abandoned parked session would have deferred the worker on **every tick indefinitely**, logging a deferral each time and never updating.

That is strictly better than #631's original failure — the deferral is visible, which #631 explicitly required — but it reaches the same end state: the worker runs stale code forever.

## Why the wrong set was chosen

For a plausible reason: `list_non_terminal()` is "the same set the worker checks on its own restart-recovery path." True, and it inverts the semantics. That set answers **"which sessions must I look at?"**. The question here is **"which would a restart harm?"** — a strictly narrower set.

## Fix

Busy is now `claimed` + `running` only. Everything else about the policy is unchanged:

- A query failure still counts as busy — killing live work remains worse than one more stale tick.
- Deferrals are still logged.
- The next tick still retries.

## Verification

`tests/test_deploy_drift.py`, **21 passed**:

- A yielded-only store **restarts** rather than defers. **Fails against the previous check**, confirmed by reverting it.
- A running store still defers.
- The mixed case — a claimed session alongside a yielded one — still defers. This is the case a naive filter gets wrong, and it **passes on both sides**, so the narrowing cannot have silently become "never busy."

## Note

Seventh distinct failure found in this deploy chain, and the fourth that passed its own test suite while not working in practice. Found the same way #634 was: by verifying on the host instead of trusting green tests.

Not addressed here: whether an 82-day-old yielded session with no reachable wake condition should be reaped. It is almost certainly an artifact, but reaping it would fix one instance while this fixes the class — and it is currently the only real-world case available to verify the fix against.

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)