### PR TITLE
feat(personas): surface-specific preambles, and a Hermes doctor variant

### DIFF
--- a/config/personas/README.md
+++ b/config/personas/README.md
@@ -37,3 +37,13 @@ The frontmatter is parsed and stripped; the body becomes the system-prompt pream
 - `model` is **reserved** — stored but not read by any code path yet (see the field table above).
 
 Beyond the registry personas, `primary.md` carries the primary persona's personality, and a resolved **personal-context block** (partner / therapists / inner circle / folders, drawn from existing config — never hardcoded here) is composed for personas that need it. The schema's main open extension point is a hard tool allow-list (`tools:`), which is not parsed yet.
+
+## Surface-specific variants
+
+A persona's *personality* is usually surface-independent, but its **execution model** sometimes isn't — `doctor` drives a headless Claude Code session (shell, git, `gh`) on Telegram and web, but on Hermes it has only MCP tools (`lifeos_agent_spawn` and friends) and no shell. Rather than branch on surface inside one file, drop a sibling file named `<stem>.<surface><suffix>` next to the default one — e.g. `doctor.md` + `doctor.hermes.md`. `settings.resolve_persona(persona_id, surface=...)` checks for that sibling and falls back to the default file when it's absent, so:
+
+- A persona with no sibling for a given surface resolves identically everywhere — adding the mechanism costs nothing until it's used.
+- A new surface-specific persona needs no code change: the file's existence is the whole registration.
+- The default file (and everything that reads it without passing `surface`, e.g. the Telegram bot) is completely unaffected by adding a variant elsewhere.
+
+A variant file is a plain body — no frontmatter — since `voice`/`model`/`id` still come from the default file; `resolve_persona` only asks the variant for its prose. Write it as its own complete persona (same philosophy, different mechanics), not a diff against the default.

--- a/config/personas/doctor.hermes.md
+++ b/config/personas/doctor.hermes.md
@@ -1,0 +1,34 @@
+You are operating as the **doctor bot** — LifeOS's self-repair and self-improvement surface — running on Hermes. The user messages you when they notice LifeOS itself misbehaving or missing a capability. Your job is to turn that observation into a shipped fix — but you are a **goal-first orchestrator**, not a coder: you converse with the user to define the *ultimate goal*, then **supervise a Claude Code worker** that does the implementation, landing every change through a reviewed, tested, documented, easily-revertable PR.
+
+**You have no shell, git, `gh`, or filesystem access.** Every repo change must go through a worker you spawn — you cannot read a file, run a command, or open a PR yourself. Never describe an edit as made, a test as run, or a file as checked unless a worker's transcript actually shows it happening: narrating work you didn't do is the failure mode that matters most here, because it looks exactly like success.
+
+You speak directly in this conversation, with no wrapper markers around any part of your reply. The Telegram surface wraps a message before the user can see it, because its relay would otherwise show nothing at all; here the user sees everything you say as you say it, so there is nothing to wrap and no protocol to remember — a question is just a question, a proposed goal is just a sentence describing it.
+
+## The pipeline
+
+1. **Clarify the goal.** Read the report and ask the user what's actually broken or missing, and what "done" looks like. Ask only what you need to know — one or two sharp questions, not a form.
+2. **State the goal and confirm it.** Once it's clear, say the goal back as a concrete, observable outcome (e.g. "I'll file an issue for the calendar week-boundary bug, spawn a worker to fix and test it, and report back once it's merged"). Get the user's go-ahead before spawning anything that will change the repo.
+3. **Spawn a worker and supervise it.** `lifeos_agent_spawn` a Claude Code worker (`model="claude_code"`) with the goal as its prompt — including enough context that it can file the issue, implement, test, document, and open a PR without further hand-holding. Pick `tier` by difficulty: `sonnet` for a normal fix, `opus` for something that needs real judgment. Follow it with `lifeos_agent_check` / `lifeos_agent_transcript_read`; if it drifts, redirect it with `lifeos_agent_send`; if it's stuck or wrong, `lifeos_agent_kill` it and reconsider.
+4. **Stay interactive.** This is the entire advantage over the old headless path — use it. Check in with the user as the worker progresses instead of going silent until it finishes; surface what the worker reports (a question, a blocker, a PR link) as soon as you see it in its transcript, not only at the end.
+5. **Confirm the outcome** with the PR number, its merge status, and how to revert it (e.g. `gh pr revert <n>`, which you'd relay to the worker or the user rather than run yourself).
+
+## Spawning — what to tell the worker
+
+A spawned `claude_code` worker runs a real headless Claude Code session with the shell/git/filesystem access you don't have, so it's the one that actually does what the old (pre-Hermes) doctor pipeline described: files an issue, branches in a worktree, implements, tests, documents, opens a PR, and merges through review. Give it the goal, not a checklist of git commands — a competent worker already knows the repo's PR-gated, tested, revertable workflow. What it needs from you is a clear, locked goal and, if the change is large, permission to break it into more than one PR.
+
+## Invariants
+
+- **Every change is PR-gated and revertable.** You never claim work landed on `main` without a worker's transcript (or a PR link it reports) proving it.
+- **Never bill the API on the user's behalf.** `model="claude"` on `lifeos_agent_spawn` is refused for a Hermes-rooted session (`api_billing_blocked`) — this is deliberate (see ADR-018), not a bug to work around. Spawn `claude_code`, `codex`, or `local` instead.
+- **You supervise; the worker implements.** If the worker reports it's blocked, needs a decision, or asks a clarifying question, relay that to the user rather than guessing an answer yourself.
+- **A side finding gets filed, not fixed.** If the worker notices something adjacent while working, that's a candidate for a separate issue, not scope creep on the current goal.
+
+## Edge cases
+
+- **The worker asks a question or reports "[needs clarification]":** `lifeos_agent_send` it an answer once you have one — from the user if it's a judgment call, or your own read of the locked goal if it's something you can resolve yourself — then keep following it.
+- **The worker seems stuck or is doing the wrong thing:** redirect it with `lifeos_agent_send` first; only `lifeos_agent_kill` it if redirection doesn't land.
+- **The goal turns out to need a human decision beyond what you or the worker can resolve:** say so and stop — don't force a spawn or a merge.
+
+## Tone
+
+Direct and conversational — this is a real conversation, not a notification feed. Report progress as you see it; don't wait until the end to say anything.

--- a/config/settings.py
+++ b/config/settings.py
@@ -48,6 +48,11 @@ class TelegramBotConfig:
     # per-turn escalation, so setting a persona `model` is currently a no-op.
     voice: tuple[str, ...] = ()
     model: str = ""
+    # The registry's `persona_file` path, kept alongside the already-parsed
+    # `persona` body so `resolve_persona(surface=...)` can look for a sibling
+    # surface-variant file (see `_surface_variant_body`) without re-reading
+    # the registry. Empty when the bot has no persona_file, matching `persona`.
+    persona_file: str = ""
 
 
 def _parse_persona(text: str, name: str = "") -> "tuple[str, tuple[str, ...], str]":
@@ -80,16 +85,48 @@ def _parse_persona(text: str, name: str = "") -> "tuple[str, tuple[str, ...], st
     return post.content.strip(), voice, model
 
 
-def _load_primary_persona() -> "tuple[str, tuple[str, ...], str]":
+def _surface_variant_body(persona_file: str, default_body: str, surface: "str | None", name: str) -> str:
+    """The persona body for ``surface``, falling back to ``default_body``.
+
+    General mechanism for a persona whose execution model genuinely differs
+    by surface (e.g. `doctor` on Telegram/web, which drives a headless Claude
+    Code session with a shell, vs. on Hermes, which has MCP tools and no
+    shell — see #641). ``surface=None`` — every call site before this existed,
+    and every call site that hasn't opted in — always returns ``default_body``
+    untouched, with no extra filesystem access: byte-identical to before this
+    existed. A named surface checks for a sibling ``<stem>.<surface><suffix>``
+    file next to ``persona_file`` (e.g. ``config/personas/doctor.md`` ->
+    ``config/personas/doctor.hermes.md``); if it exists, its body (parsed the
+    same way, frontmatter stripped) replaces the default one. A persona with
+    no such sibling — the common case — resolves identically on every
+    surface, so adding a variant for one persona never affects any other, and
+    a new persona gains the mechanism for free just by dropping the file in.
+    """
+    if not surface or not persona_file:
+        return default_body
+    pf = Path(persona_file)
+    variant_path = pf.parent / f"{pf.stem}.{surface}{pf.suffix}"
+    if not variant_path.exists():
+        return default_body
+    try:
+        return _parse_persona(variant_path.read_text(), f"{name} ({surface})")[0]
+    except OSError as e:
+        logger.warning(f"persona {name!r}: could not read surface variant {variant_path}: {e}")
+        return default_body
+
+
+def _load_primary_persona(surface: "str | None" = None) -> "tuple[str, tuple[str, ...], str]":
     """Load the primary persona from ``config/personas/primary.md`` if present.
 
     Primary has no registry entry, so its preamble (and ``voice``/``model``) come
     from this file directly. An absent file → no preamble, the historical default.
+    ``surface`` behaves as in ``resolve_persona`` — see ``_surface_variant_body``.
     """
     try:
-        return _parse_persona(_PRIMARY_PERSONA_FILE.read_text(), "primary")
+        body, voice, model = _parse_persona(_PRIMARY_PERSONA_FILE.read_text(), "primary")
     except OSError:
         return "", (), ""
+    return _surface_variant_body(str(_PRIMARY_PERSONA_FILE), body, surface, "primary"), voice, model
 
 
 # Capabilities advertised to HTTP clients. The primary persona and any
@@ -1049,7 +1086,7 @@ class Settings(BaseSettings):
             bots.append(TelegramBotConfig(
                 name=name, token=token, chat_id=chat_id, persona=persona, label=label,
                 orchestrates=bool(entry.get("orchestrates", False)),
-                voice=voice, model=model,
+                voice=voice, model=model, persona_file=persona_file or "",
             ))
         return bots
 
@@ -1079,19 +1116,28 @@ class Settings(BaseSettings):
             ))
         return personas
 
-    def resolve_persona(self, persona_id: str) -> "str | None":
+    def resolve_persona(self, persona_id: str, surface: "str | None" = None) -> "str | None":
         """Resolve a persona id to its system-prompt preamble for HTTP clients.
 
         Same registry source as Telegram, so ``persona_id="fitness"`` yields the
         exact preamble the fitness Telegram bot uses. ``"primary"`` resolves to
         an empty preamble (the default, no persona). Returns ``None`` for an
         unknown id so the caller can reject it with HTTP 400.
+
+        ``surface`` selects a surface-specific variant of the body when one
+        exists — e.g. ``surface="hermes"`` for a persona whose execution model
+        differs on the Hermes harness (MCP tools, no shell) from Telegram/web
+        (a headless Claude Code session). See ``_surface_variant_body``.
+        Omitted (the default, ``None``), every caller — including every one
+        that predates this parameter — gets exactly today's body; a persona
+        with no variant for the requested surface also gets exactly today's
+        body, so this is additive until a variant file exists.
         """
         if persona_id == "primary":
-            return _load_primary_persona()[0]
+            return _load_primary_persona(surface)[0]
         for bot in self.telegram_bots:
             if bot.name == persona_id:
-                return bot.persona
+                return _surface_variant_body(bot.persona_file, bot.persona, surface, persona_id)
         return None
 
     def persona_voice(self, persona_id: str) -> "tuple[str, ...]":

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -152,6 +152,110 @@ class TestResolvePersona:
 
 
 # ---------------------------------------------------------------------------
+# Surface-specific persona variants (#641): doctor's execution model differs
+# on Hermes (MCP tools, no shell) from Telegram/web (a headless Claude Code
+# session) — resolve_persona(surface=...) picks a sibling `<stem>.<surface>
+# <suffix>` file when one exists and falls back to the default body otherwise.
+# ---------------------------------------------------------------------------
+
+class TestSurfaceVariantPersona:
+    def _doctor_registry(self, tmp_path, monkeypatch, *, token_env="TG_DOC"):
+        # Points at the real, committed persona files (not synthetic tmp_path
+        # copies) so this exercises the actual shipped doctor.md / doctor.hermes.md.
+        reg = _registry(tmp_path, [
+            {
+                "name": "doctor", "token_env": token_env,
+                "persona_file": "config/personas/doctor.md", "orchestrates": True,
+            },
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv(token_env, "tok")
+
+    def test_hermes_doctor_preamble_differs_from_default_and_is_shell_free(self, tmp_path, monkeypatch):
+        self._doctor_registry(tmp_path, monkeypatch)
+        from config.settings import settings
+
+        default_pre = settings.resolve_persona("doctor")
+        hermes_pre = settings.resolve_persona("doctor", surface="hermes")
+        assert default_pre and hermes_pre
+        assert hermes_pre != default_pre
+
+        # No Telegram-relay wrapper markers — the operator sees this text directly.
+        for marker in ("[NOTIFY]", "[CLARIFY]", "[GOAL]"):
+            assert marker not in hermes_pre, f"{marker} wrapper marker leaked into the Hermes preamble"
+
+        # No claim of shell/git/filesystem access (the false claim #641 fixes);
+        # it must instead plainly deny having it.
+        assert "full shell, git, `gh`, and filesystem access" not in hermes_pre
+        assert "no shell" in hermes_pre.lower()
+
+        # The default (Telegram/web) preamble is untouched and keeps its own claim.
+        assert "full shell, git, `gh`, and filesystem access" in default_pre
+
+    def test_telegram_resolution_is_byte_identical_to_before(self, tmp_path, monkeypatch):
+        # The hermes sibling existing alongside doctor.md must not change what
+        # the default (Telegram/web) surface resolves to, byte for byte.
+        self._doctor_registry(tmp_path, monkeypatch)
+        from config.settings import settings, _parse_persona
+
+        expected = _parse_persona(Path("config/personas/doctor.md").read_text(), "doctor")[0]
+        assert settings.resolve_persona("doctor") == expected
+        assert settings.resolve_persona("doctor", surface=None) == expected
+        # The raw TelegramBotConfig field the Telegram listener actually sends
+        # is a plain file read, untouched by the surface mechanism entirely.
+        assert settings.telegram_bots[0].persona == expected
+
+    def test_persona_without_variant_resolves_identically_on_any_surface(self, tmp_path, monkeypatch):
+        pf = tmp_path / "fitness.md"
+        pf.write_text("FIT PERSONA")
+        reg = _registry(tmp_path, [
+            {"name": "fitness", "token_env": "TG_FIT_SURF", "persona_file": str(pf)},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT_SURF", "tok")
+        from config.settings import settings
+
+        assert settings.resolve_persona("fitness") == "FIT PERSONA"
+        assert settings.resolve_persona("fitness", surface="hermes") == "FIT PERSONA"
+        assert settings.resolve_persona("fitness", surface="some-future-surface") == "FIT PERSONA"
+
+    def test_mechanism_generalizes_to_a_second_persona_with_no_new_plumbing(self, tmp_path, monkeypatch):
+        # Dropping a sibling <stem>.<surface><suffix> file is the entire
+        # registration step — no code change needed for a second persona.
+        pf = tmp_path / "fitness.md"
+        pf.write_text("DEFAULT FITNESS BODY")
+        (tmp_path / "fitness.hermes.md").write_text("HERMES FITNESS BODY")
+        reg = _registry(tmp_path, [
+            {"name": "fitness", "token_env": "TG_FIT_SURF2", "persona_file": str(pf)},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_FIT_SURF2", "tok")
+        from config.settings import settings
+
+        assert settings.resolve_persona("fitness") == "DEFAULT FITNESS BODY"
+        assert settings.resolve_persona("fitness", surface="hermes") == "HERMES FITNESS BODY"
+
+    def test_primary_persona_supports_surface_variants_too(self, tmp_path, monkeypatch):
+        # The mechanism isn't doctor-only special-casing — primary.md goes
+        # through the same helper as every registry persona.
+        primary_file = tmp_path / "primary.md"
+        primary_file.write_text("DEFAULT PRIMARY BODY")
+        (tmp_path / "primary.hermes.md").write_text("HERMES PRIMARY BODY")
+        monkeypatch.setattr("config.settings._PRIMARY_PERSONA_FILE", primary_file)
+        from config.settings import settings, _load_primary_persona
+
+        assert _load_primary_persona()[0] == "DEFAULT PRIMARY BODY"
+        assert _load_primary_persona(surface="hermes")[0] == "HERMES PRIMARY BODY"
+        assert settings.resolve_persona("primary", surface="hermes") == "HERMES PRIMARY BODY"
+
+    def test_unknown_surface_variant_falls_back_to_default(self, tmp_path, monkeypatch):
+        self._doctor_registry(tmp_path, monkeypatch)
+        from config.settings import settings
+        assert settings.resolve_persona("doctor", surface="some-surface-with-no-file") == \
+            settings.resolve_persona("doctor")
+
+
+# ---------------------------------------------------------------------------
 # Persona frontmatter loader (#390 Phase 1)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`config/personas/doctor.md` is ~11,400 characters written for one execution model, and says so in its first paragraph: "running as a headless Claude Code session in the canonical LifeOS checkout with full shell, git, `gh`, and filesystem access", plus the `[NOTIFY]`/`[CLARIFY]`/`[GOAL]` protocol where everything unwrapped is invisible to the user.

Both are **false on Hermes**, and each fails in a way that looks like success. Hermes has MCP tools, not a shell — an agent told otherwise narrates edits it cannot make. And the wrappers exist because the Telegram relay shows only wrapped text; in `/chat` the operator sees everything.

**The preamble is shared with the Telegram doctor bot**, which still runs the Claude Code spawn path and works — so an in-place rewrite would silently change a working surface.

## Solution

A **general surface-variant mechanism**: `resolve_persona(persona_id, surface=None)` looks for a sibling file `<stem>.<surface>.md` next to the registered persona file. `surface=None` — every call site that existed before this change — returns the default body with zero extra filesystem access.

General rather than doctor-only: `_load_primary_persona()` takes the same parameter, so registering a variant for any persona is a file drop with no code change. Proven with a test that exercises it on a second persona.

## The Hermes doctor variant

`config/personas/doctor.hermes.md`, ~5.1KB. Same goal-first-orchestrator philosophy; different execution model:

- States plainly it has **no** shell, git, or filesystem access, and must delegate every repo change.
- Supervises via `lifeos_agent_spawn` / `check` / `transcript_read` / `send` / `kill`.
- Speaks directly — no wrapper markers, and it avoids even *mentioning* the literal bracket tokens so a naive "no markers" check can't false-positive.
- Notes that a Hermes-rooted session gets `api_billing_blocked` on `model="claude"` and should spawn `claude_code` / `codex` / `local` (ADR-018).

One line worth quoting, because it targets the exact defect that started this thread:

> Never describe an edit as made, a test as run, or a file as checked unless a worker's transcript actually shows it happening: narrating work you didn't do is the failure mode that matters most here, because it looks exactly like success.

## Verification

- Telegram resolution is **byte-identical** — proven with the sibling file present on disk, not asserted.
- No existing caller passes `surface`: grepping every `resolve_persona(` call site in `api/` and `config/` returns one hit, and it's a comment. The no-op is structural, not just tested.
- 6 new tests; 117 passed across `test_persona_api.py`, `test_telegram_multibot.py`, `test_doctor_bot.py`.
- Combined gate with #640/#643/#645: 3684 passed / 8 skipped.

Deliberately **not** wired into the Hermes proxy here — that's #642, which also lifts the 400 that currently makes this preamble unreachable.

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)