### PR TITLE
fix(api): /api/personas returns orchestrates instead of the client inferring it

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -221,6 +221,7 @@ class PersonaInfoResponse(BaseModel):
     id: str
     label: str
     capabilities: list[str] = []
+    orchestrates: bool = False
 
 
 class PersonasResponse(BaseModel):
@@ -234,11 +235,18 @@ async def list_personas():
 
     Returns the primary persona plus each configured specialized bot. Adding a
     registry entry + its token env var surfaces a new persona after restart with
-    no code change. Only the primary advertises handoff/agent capabilities.
+    no code change. Only the primary and orchestrating bots advertise
+    handoff/agent capabilities. ``orchestrates`` (#643) is the server's own
+    `settings.persona_orchestrates()` verdict, so clients no longer have to
+    infer it from `capabilities` alone (which look identical for `primary` and
+    an orchestrating bot like `doctor`).
     """
     return PersonasResponse(
         personas=[
-            PersonaInfoResponse(id=p.id, label=p.label, capabilities=p.capabilities)
+            PersonaInfoResponse(
+                id=p.id, label=p.label, capabilities=p.capabilities,
+                orchestrates=p.orchestrates,
+            )
             for p in settings.list_http_personas()
         ]
     )

--- a/config/settings.py
+++ b/config/settings.py
@@ -104,6 +104,7 @@ class PersonaInfo:
     id: str
     label: str
     capabilities: list = field(default_factory=list)
+    orchestrates: bool = False
 
 
 class Settings(BaseSettings):
@@ -1063,11 +1064,17 @@ class Settings(BaseSettings):
         bot) advertise ``handoff``/``agent`` capabilities; pure-chat specialized
         bots advertise none. Adding a registry entry + its token env var surfaces
         a new persona on the next restart with no code change.
+
+        ``orchestrates`` is sourced from ``persona_orchestrates()`` — the same
+        check real routing (chat.py, hermes_proxy.py) uses — rather than
+        derived from ``capabilities``, which happen to be identical for
+        ``primary`` and an orchestrating bot like ``doctor`` (#643).
         """
         personas = [PersonaInfo(
             id="primary",
             label="Primary",
             capabilities=list(ORCHESTRATOR_PERSONA_CAPABILITIES),
+            orchestrates=self.persona_orchestrates("primary"),
         )]
         for bot in self.telegram_bots:
             personas.append(PersonaInfo(
@@ -1076,6 +1083,7 @@ class Settings(BaseSettings):
                 capabilities=(
                     list(ORCHESTRATOR_PERSONA_CAPABILITIES) if bot.orchestrates else []
                 ),
+                orchestrates=self.persona_orchestrates(bot.name),
             ))
         return personas
 

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -126,16 +126,18 @@ List chat personas available to HTTP clients (web chat, voice/whisper-relay). Re
 ```json
 {
   "personas": [
-    { "id": "primary", "label": "LifeOS", "capabilities": ["handoff", "agent"] },
-    { "id": "fitness", "label": "Fitness", "capabilities": [] },
-    { "id": "therapist", "label": "Therapist", "capabilities": [] }
+    { "id": "primary", "label": "LifeOS", "capabilities": ["handoff", "agent"], "orchestrates": false },
+    { "id": "doctor", "label": "Doctor", "capabilities": ["handoff", "agent"], "orchestrates": true },
+    { "id": "fitness", "label": "Fitness", "capabilities": [], "orchestrates": false },
+    { "id": "therapist", "label": "Therapist", "capabilities": [], "orchestrates": false }
   ]
 }
 ```
 
 - `id` — pass as `persona_id` on [`POST /api/ask/stream`](#post-apiaskstream) and as the `persona_id` query param on [`GET /api/conversations`](#get-apiconversations).
 - `label` — display name; defaults to the capitalized id when the registry entry omits an explicit `label`.
-- `capabilities` — `["handoff", "agent"]` (CLI engine handoff and `/agent` spawns) for the `primary` persona and any orchestrating bot (`orchestrates: true` in the registry, e.g. the doctor self-repair bot). Pure-chat specialized personas advertise `[]`.
+- `capabilities` — `["handoff", "agent"]` (CLI engine handoff and `/agent` spawns) for the `primary` persona and any orchestrating bot (`orchestrates: true` in the registry, e.g. the doctor self-repair bot). Pure-chat specialized personas advertise `[]`. Note that `capabilities` alone doesn't distinguish `primary` from an orchestrating bot — both carry `["handoff", "agent"]` — use `orchestrates` for that (#643).
+- `orchestrates` (#643) — whether this persona spawns a background Claude Code session on send (e.g. `doctor`) rather than answering inline, mirroring `settings.persona_orchestrates()` — the same check real routing (`api/routes/chat.py`, `api/routes/hermes_proxy.py`) applies. Always `false` for `primary`, which carries handoff/agent capabilities but answers inline itself.
 
 ### GET /api/chat/turn-context
 

--- a/tests/test_backend_selector_ui_browser.py
+++ b/tests/test_backend_selector_ui_browser.py
@@ -255,9 +255,9 @@ class TestPersonaPickerAcrossBackends:
     hiding it from the picker."""
 
     _PERSONAS = [
-        {"id": "primary", "label": "Primary", "capabilities": ["handoff", "agent"]},
-        {"id": "fitness", "label": "Fitness", "capabilities": []},
-        {"id": "doctor", "label": "Doctor", "capabilities": ["handoff", "agent"]},
+        {"id": "primary", "label": "Primary", "capabilities": ["handoff", "agent"], "orchestrates": False},
+        {"id": "fitness", "label": "Fitness", "capabilities": [], "orchestrates": False},
+        {"id": "doctor", "label": "Doctor", "capabilities": ["handoff", "agent"], "orchestrates": True},
     ]
 
     @staticmethod
@@ -288,9 +288,9 @@ class TestOrchestratingPersonaOnHermes:
     (no persona pass-through at all) is unaffected too."""
 
     _PERSONAS = [
-        {"id": "primary", "label": "Primary", "capabilities": ["handoff", "agent"]},
-        {"id": "fitness", "label": "Fitness", "capabilities": []},
-        {"id": "doctor", "label": "Doctor", "capabilities": ["handoff", "agent"]},
+        {"id": "primary", "label": "Primary", "capabilities": ["handoff", "agent"], "orchestrates": False},
+        {"id": "fitness", "label": "Fitness", "capabilities": [], "orchestrates": False},
+        {"id": "doctor", "label": "Doctor", "capabilities": ["handoff", "agent"], "orchestrates": True},
     ]
 
     def test_orchestrating_persona_on_hermes_diverts_to_lifeos_endpoint(self, page: Page, chat_base_url):
@@ -332,6 +332,27 @@ class TestOrchestratingPersonaOnHermes:
         with page.expect_request("**/api/hermes/ask/stream") as req_info:
             page.locator("#sendBtn").click()
         body = json.loads(req_info.value.post_data)
+        assert "backend" not in body
+
+    def test_handoff_but_not_orchestrating_persona_on_hermes_still_posts_to_proxy(self, page: Page, chat_base_url):
+        # #643 regression guard: the case a capabilities-based inference gets
+        # wrong. A persona carrying `handoff` (like primary/doctor) but with
+        # `orchestrates: false` must NOT be diverted — only the server's own
+        # `orchestrates` flag decides that, not the `handoff` capability.
+        personas = self._PERSONAS + [
+            {"id": "scout", "label": "Scout", "capabilities": ["handoff", "agent"], "orchestrates": False},
+        ]
+        _open_chat(page, chat_base_url, hermes_available=True, personas=personas)
+        expect(page.locator("#backendHermes")).to_have_class("backend-option active")
+        page.locator("#personaPicker").select_option("scout")
+
+        page.locator("#inputField").fill("hello")
+        with page.expect_request("**/api/hermes/ask/stream") as req_info:
+            page.locator("#sendBtn").click()
+        body = json.loads(req_info.value.post_data)
+        assert body["persona_id"] == "scout"
+        # Never tagged — this turn was never diverted, so there's no LifeOS-
+        # native conversation to tag.
         assert "backend" not in body
 
     def test_orchestrating_persona_on_agent_is_not_diverted(self, page: Page, chat_base_url):

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -53,10 +53,12 @@ class TestListHttpPersonas:
         primary = personas[0]
         assert primary.label == "Primary"
         assert primary.capabilities == ["handoff", "agent"]
+        assert primary.orchestrates is False  # answers inline despite handoff/agent capabilities
 
         fitness = personas[1]
         assert fitness.label == "Fitness"  # capitalized default
         assert fitness.capabilities == []  # specialized bots are pure chat
+        assert fitness.orchestrates is False
 
     def test_unset_token_bot_omitted(self, tmp_path, monkeypatch):
         reg = _registry(tmp_path, [
@@ -107,6 +109,32 @@ class TestListHttpPersonas:
         by_id = {p.id: p for p in settings.list_http_personas()}
         assert by_id["doctor"].capabilities == ["handoff", "agent"]
         assert by_id["fitness"].capabilities == []
+        # #643: orchestrates is real, not inferred from capabilities — doctor
+        # and primary share identical capabilities but only doctor orchestrates.
+        assert by_id["doctor"].orchestrates is True
+        assert by_id["fitness"].orchestrates is False
+
+    def test_orchestrates_matches_persona_orchestrates_for_every_persona(self, tmp_path, monkeypatch):
+        """Drift guard for #643: list_http_personas()'s `orchestrates` must
+        never diverge from `settings.persona_orchestrates()`, which is what
+        real routing (api/routes/chat.py, api/routes/hermes_proxy.py) actually
+        checks. This is the test that couldn't exist before the field did —
+        there was nothing to compare the client's inference against."""
+        reg = _registry(tmp_path, [
+            {"name": "doctor", "token_env": "TG_DOC", "orchestrates": True},
+            {"name": "fitness", "token_env": "TG_FIT"},
+            {"name": "therapist", "token_env": "TG_THER"},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_DOC", "tok")
+        monkeypatch.setenv("TG_FIT", "tok")
+        monkeypatch.setenv("TG_THER", "tok")
+        from config.settings import settings
+
+        personas = settings.list_http_personas()
+        assert [p.id for p in personas] == ["primary", "doctor", "fitness", "therapist"]
+        for p in personas:
+            assert p.orchestrates == settings.persona_orchestrates(p.id)
 
 
 # ---------------------------------------------------------------------------
@@ -507,6 +535,29 @@ class TestPersonasEndpoint:
         assert [p["id"] for p in data["personas"]] == ["primary", "fitness"]
         assert data["personas"][0]["capabilities"] == ["handoff", "agent"]
         assert data["personas"][1]["capabilities"] == []
+        assert data["personas"][0]["orchestrates"] is False
+        assert data["personas"][1]["orchestrates"] is False
+
+    def test_orchestrates_field_matches_settings_for_every_persona(self, client, tmp_path, monkeypatch):
+        """Endpoint-level drift guard for #643: `GET /api/personas`'s
+        `orchestrates` must match `settings.persona_orchestrates()` for every
+        persona it returns — this is the actual public contract clients read,
+        not just the settings helper underneath it."""
+        reg = _registry(tmp_path, [
+            {"name": "doctor", "token_env": "TG_DOC", "orchestrates": True},
+            {"name": "fitness", "token_env": "TG_FIT"},
+        ])
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+        monkeypatch.setenv("TG_DOC", "tok")
+        monkeypatch.setenv("TG_FIT", "tok")
+        from config.settings import settings
+
+        resp = client.get("/api/personas")
+        assert resp.status_code == 200
+        personas = resp.json()["personas"]
+        assert [p["id"] for p in personas] == ["primary", "doctor", "fitness"]
+        for p in personas:
+            assert p["orchestrates"] == settings.persona_orchestrates(p["id"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_voice_backend_parity_ui_browser.py
+++ b/tests/test_voice_backend_parity_ui_browser.py
@@ -180,8 +180,9 @@ def _polled_conversation(page: Page, conv_id):
 
 
 # An orchestrating persona (e.g. doctor), matching personaOrchestrates()'s own
-# gate: non-primary + a persona carrying the `handoff` capability.
-_ORCHESTRATING_PERSONA = {"id": "doctor", "label": "Doctor", "capabilities": ["handoff"]}
+# gate: non-primary + a persona with `orchestrates: true` (#643 — the server's
+# own verdict, not inferred from `capabilities`).
+_ORCHESTRATING_PERSONA = {"id": "doctor", "label": "Doctor", "capabilities": ["handoff"], "orchestrates": True}
 
 
 class TestSpokenTurnFieldsAcrossBackends:

--- a/web/chat/persona.js
+++ b/web/chat/persona.js
@@ -167,14 +167,22 @@ export function personaSupportsHandoff() {
 
 // True iff the selected persona is an *orchestrating* bot — one that spawns a
 // background Claude Code session on send (e.g. doctor) rather than answering
-// inline. Mirrors the server's `persona_orchestrates`: the `primary` persona is
-// the inline orchestrator (it carries handoff capability but never spawns), so
-// it is excluded; orchestrating bots are the non-primary personas that advertise
-// handoff. Used to decide whether a turn should poll for a `[CLARIFY]`/`[GOAL]`
-// on surfaces (voice) whose stream doesn't expose the `claude_code` routing the
-// text path keys off (#412), and (askStream, #596) whether a Hermes-selected
-// turn must be diverted to the LifeOS endpoint instead of the Hermes proxy —
-// the spawn path this gates is LifeOS-only, so Hermes no longer excludes it.
+// inline. Reads the server's own `orchestrates` flag (#643 — sourced from
+// `settings.persona_orchestrates()`) rather than inferring it from
+// `capabilities`, which look identical for `primary` and an orchestrating bot
+// like `doctor`. Used to decide whether a turn should poll for a
+// `[CLARIFY]`/`[GOAL]` on surfaces (voice) whose stream doesn't expose the
+// `claude_code` routing the text path keys off (#412), and (askStream, #596)
+// whether a Hermes-selected turn must be diverted to the LifeOS endpoint
+// instead of the Hermes proxy — the spawn path this gates is LifeOS-only, so
+// Hermes no longer excludes it.
+//
+// Before `/api/personas` resolves (or if discovery failed), `personas` is
+// empty and the lookup below finds nothing — this fails closed for every
+// persona, including a restored non-primary selection, which is the intended
+// load-window behavior. `primary` never orchestrates regardless (it answers
+// inline), so there's no separate "fail open" case needed here the way
+// `personaSupportsHandoff()` has one.
 export function personaOrchestrates() {
   const { personas, personaId } = config;
   // The agent backend has no persona pass-through at all (no persona_id is
@@ -185,5 +193,5 @@ export function personaOrchestrates() {
   if (config.backend === 'agent') return false;
   if (!personaId || personaId === DEFAULT_PERSONA_ID) return false;  // primary answers inline
   const p = personas && personas.find(x => x.id === personaId);
-  return !!(p && p.capabilities && p.capabilities.includes('handoff'));
+  return !!(p && p.orchestrates);
 }


### PR DESCRIPTION
## Problem

The server knows which personas orchestrate (`settings.persona_orchestrates()`); `/api/personas` didn't return it. `primary` and `doctor` came back **byte-identical** apart from id/label — both `capabilities: ["handoff","agent"]` — yet only `doctor` orchestrates.

So the client reverse-engineered it: not the agent backend, AND not the default persona, AND has `handoff`. Correct for all five personas today — but correct **by coincidence**, since the only thing separating `doctor` from `primary` is a hardcoded "primary answers inline" check.

That inference decided real routing: it gated the diversion away from the Hermes proxy, and the proxy answered a wrong guess with a hard 400. A future persona with `handoff` that doesn't orchestrate would be misrouted, and **no test could catch it**, because the client had no access to the truth to compare against.

## Solution

`/api/personas` returns an `orchestrates` boolean sourced from `settings.persona_orchestrates()`. Additive. `personaOrchestrates()` reads it once the list has loaded.

The load-window fallback is unchanged — and worth noting I briefed this wrong: I asked for a "fail open for the default persona" behavior that actually belongs to `personaSupportsHandoff()`, a different function. `personaOrchestrates()` never had one; during the load window `personas` is empty, `find()` returns undefined, and the result is `false` before and after. Bit-for-bit identical, with a comment now explaining why no such branch is needed.

## The test that couldn't exist before

`test_orchestrates_matches_persona_orchestrates_for_every_persona` (settings level) and `test_orchestrates_field_matches_settings_for_every_persona` (HTTP contract) assert the endpoint agrees with the server for **every** registered persona. **Verified as real guards** by sabotaging `orchestrates=self.persona_orchestrates(...)` at both call sites — both fail.

Plus a browser test for the future case: a stubbed persona with `capabilities: ["handoff","agent"]` and `orchestrates: false` still posts to the Hermes proxy rather than being diverted.

## Verification

- `test_persona_api.py`: 52 passed; browser: 74 (baseline 73 + 1)
- Combined gate with #640/#641/#645: 3684 passed / 8 skipped
- Existing shape-asserting fixtures were **extended**, not loosened — required once the client stopped reading capabilities.

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)