### PR TITLE
fix(stores): anchor seven cwd-relative data paths to the repo root

### DIFF
--- a/api/services/cc_wezterm_store.py
+++ b/api/services/cc_wezterm_store.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Optional
 
 
-DEFAULT_DB_PATH = Path("data/cc_wezterm.db")
+DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "cc_wezterm.db"
 
 
 _SCHEMA = """

--- a/api/services/person_stats.py
+++ b/api/services/person_stats.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from api.services.person_entity import PersonEntityStore
+
 logger = logging.getLogger(__name__)
 
 
@@ -181,7 +183,9 @@ def _update_timestamps(entity, person_ids, int_conn) -> bool:
     # Get timestamp range from source_entities across the same variants
     # (source_entities.canonical_person_id may also still carry legacy IDs
     # if a merge happened without backfilling that column).
-    crm_db = Path("data/crm.db")
+    # Same physical database as PersonEntityStore's default — reuse its anchored
+    # constant rather than a second cwd-relative literal for the same file.
+    crm_db = Path(PersonEntityStore.CRM_DB_PATH)
     source_first = None
     source_last = None
     if crm_db.exists():

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -49,7 +49,7 @@ from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_INDEX_PATH = Path("data/scheduler_index.json")
+DEFAULT_INDEX_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "scheduler_index.json"
 
 SCHEDULER_FOLDER = "LifeOS/Scheduler"
 INBOX_FILE = "Inbox.md"

--- a/api/services/slack_indexer.py
+++ b/api/services/slack_indexer.py
@@ -12,7 +12,7 @@ Features:
 """
 import logging
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -22,8 +22,6 @@ from api.services.slack_integration import (
     SlackChannel,
     SlackUser,
     get_slack_client,
-    get_workspace_id,
-    is_slack_enabled,
     SLACK_TEAM_ID,
 )
 from api.services.vectorstore import VectorStore
@@ -61,7 +59,7 @@ class SlackIndexer:
         self._client = client
         self._user_cache: dict[str, SlackUser] = {}
         self._channel_cache: dict[str, SlackChannel] = {}
-        self._ts_db_path = Path("data/slack_sync_timestamps.db")
+        self._ts_db_path = Path(__file__).resolve().parent.parent.parent / "data" / "slack_sync_timestamps.db"
         self._init_timestamp_db()
 
     def _init_timestamp_db(self):

--- a/api/services/slack_integration.py
+++ b/api/services/slack_integration.py
@@ -49,8 +49,10 @@ SLACK_SCOPES = [
     "search:read",          # search.messages (day-pull endpoint — issue #441)
 ]
 
-# Token storage path
-SLACK_TOKEN_PATH = Path("data/slack_tokens.json")
+# Token storage path (anchored to the repo root — see AGENTS.md's data-path idiom
+# — so a process whose cwd isn't the repo doesn't silently look for credentials
+# in the wrong place).
+SLACK_TOKEN_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "slack_tokens.json"
 
 # Channel system-message subtypes skipped during bulk history fetch (sync path).
 # These are membership/metadata noise ("X has joined the channel") that would

--- a/api/services/task_manager.py
+++ b/api/services/task_manager.py
@@ -24,7 +24,7 @@ from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_INDEX_PATH = Path("data/task_index.json")
+DEFAULT_INDEX_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "task_index.json"
 
 # Status ↔ checkbox symbol mapping
 STATUS_TO_SYMBOL = {

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -490,7 +490,7 @@ class TelegramBotListener:
     Forwards messages through the LifeOS chat pipeline and sends responses back.
     """
 
-    _STATE_FILE = Path("data/telegram_state.json")
+    _STATE_FILE = Path(__file__).resolve().parent.parent.parent / "data" / "telegram_state.json"
     _DEDUP_WINDOW = 1000  # Track last N message IDs for deduplication
 
     def __init__(self, bot: Optional[TelegramBotConfig] = None):

--- a/tests/test_data_path_anchoring.py
+++ b/tests/test_data_path_anchoring.py
@@ -1,0 +1,181 @@
+"""Regression tests for #645: seven data-store defaults resolved against the
+*process's* working directory instead of the repo root — the same class of
+bug ``mcp_server.py`` already had to defend against for the agent-session
+stores (see ``test_inter_agent_stores_anchored_to_repo_not_cwd``).
+
+Every existing test in this suite runs from the repo root, so none of them
+can see a cwd-relative default resolving incorrectly — the module is always
+imported (and its constants computed) with cwd == repo root. To actually
+exercise the bug, these tests spawn a fresh subprocess with its *working
+directory* set to somewhere outside the repo before the module is ever
+imported, mirroring how a non-repo-root caller (e.g. a stdio MCP child) sees
+these modules. That also sidesteps this suite's autouse isolation fixtures
+(e.g. ``_isolate_telegram_state_file``), which would otherwise mask the
+in-process class attribute under a fixture-chosen tmp path.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _resolve_in_foreign_cwd(foreign_cwd: Path, import_stmt: str, expr: str) -> str:
+    """Run `expr` in a fresh subprocess whose cwd is `foreign_cwd` and whose
+    sys.path is seeded with the repo root, and return its printed result."""
+    code = f"import sys; sys.path.insert(0, {str(REPO_ROOT)!r}); {import_stmt}; print({expr})"
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(foreign_cwd),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "import_stmt, expr, relative_data_file",
+    [
+        (
+            "from api.services.slack_integration import SLACK_TOKEN_PATH",
+            "SLACK_TOKEN_PATH",
+            "data/slack_tokens.json",
+        ),
+        (
+            "from api.services.scheduler_store import DEFAULT_INDEX_PATH",
+            "DEFAULT_INDEX_PATH",
+            "data/scheduler_index.json",
+        ),
+        (
+            "from api.services.task_manager import DEFAULT_INDEX_PATH",
+            "DEFAULT_INDEX_PATH",
+            "data/task_index.json",
+        ),
+        (
+            "from api.services.telegram import TelegramBotListener",
+            "TelegramBotListener._STATE_FILE",
+            "data/telegram_state.json",
+        ),
+        (
+            "from api.services.person_stats import PersonEntityStore",
+            "PersonEntityStore.CRM_DB_PATH",
+            "data/crm.db",
+        ),
+        (
+            "from api.services.cc_wezterm_store import DEFAULT_DB_PATH",
+            "DEFAULT_DB_PATH",
+            "data/cc_wezterm.db",
+        ),
+    ],
+    ids=[
+        "slack_integration.SLACK_TOKEN_PATH",
+        "scheduler_store.DEFAULT_INDEX_PATH",
+        "task_manager.DEFAULT_INDEX_PATH",
+        "telegram.TelegramBotListener._STATE_FILE",
+        "person_stats' PersonEntityStore.CRM_DB_PATH",
+        "cc_wezterm_store.DEFAULT_DB_PATH",
+    ],
+)
+def test_default_resolves_to_repo_root_from_foreign_cwd(
+    tmp_path, import_stmt, expr, relative_data_file
+):
+    foreign_cwd = tmp_path / "not-the-repo"
+    foreign_cwd.mkdir()
+
+    resolved = _resolve_in_foreign_cwd(foreign_cwd, import_stmt, expr)
+
+    assert resolved == str(REPO_ROOT / relative_data_file)
+    # No phantom `data/` directory should appear under the foreign cwd.
+    assert not (foreign_cwd / "data").exists()
+
+
+@pytest.mark.unit
+def test_slack_indexer_ts_db_path_resolves_to_repo_root_from_foreign_cwd(tmp_path):
+    """`SlackIndexer._ts_db_path` is computed in `__init__`, not a module
+    constant, and `__init__` also creates the sqlite file as a side effect —
+    so avoid instantiating against the real default in-process (that would
+    touch this repo's actual data/slack_sync_timestamps.db). Instead, patch
+    `_init_timestamp_db` to a no-op inside the subprocess before constructing,
+    so only the path computation is observed."""
+    foreign_cwd = tmp_path / "not-the-repo"
+    foreign_cwd.mkdir()
+
+    code = (
+        f"import sys; sys.path.insert(0, {str(REPO_ROOT)!r})\n"
+        "from unittest.mock import patch\n"
+        "from api.services.slack_indexer import SlackIndexer\n"
+        "with patch.object(SlackIndexer, '_init_timestamp_db', lambda self: None):\n"
+        "    idx = SlackIndexer()\n"
+        "print(idx._ts_db_path)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(foreign_cwd),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(REPO_ROOT / "data" / "slack_sync_timestamps.db")
+    assert not (foreign_cwd / "data").exists()
+
+
+@pytest.mark.unit
+def test_slack_token_store_explicit_relative_path_still_resolves_against_cwd(
+    tmp_path, monkeypatch
+):
+    """Anchoring the *default* must not change resolution for a caller that
+    deliberately passes a relative path — it should still resolve against
+    cwd exactly as before. Credentials path, so covered explicitly per #645."""
+    from api.services.slack_integration import SlackTokenStore
+
+    monkeypatch.chdir(tmp_path)
+    store = SlackTokenStore(path=Path("data/explicit_tokens.json"))
+    assert store.path == Path("data/explicit_tokens.json")
+    assert not store.path.is_absolute()
+
+
+@pytest.mark.unit
+def test_cc_wezterm_store_explicit_relative_path_still_resolves_against_cwd(
+    tmp_path, monkeypatch
+):
+    from api.services.cc_wezterm_store import CCWezTermStore
+
+    monkeypatch.chdir(tmp_path)
+    store = CCWezTermStore(db_path=Path("data/explicit_wezterm.db"))
+    assert store.db_path == Path("data/explicit_wezterm.db")
+    # The relative path resolved against the (foreign) cwd, not the repo root.
+    assert (tmp_path / "data" / "explicit_wezterm.db").exists()
+
+
+@pytest.mark.unit
+def test_task_manager_explicit_relative_index_path_still_resolves_against_cwd(
+    tmp_path, monkeypatch
+):
+    from api.services.task_manager import TaskManager
+
+    monkeypatch.chdir(tmp_path)
+    manager = TaskManager(
+        vault_path=tmp_path / "vault", index_path=Path("data/explicit_tasks.json")
+    )
+    assert manager.index_path == Path("data/explicit_tasks.json")
+    assert (tmp_path / "data" / "explicit_tasks.json").parent.exists()
+
+
+@pytest.mark.unit
+def test_scheduler_store_explicit_relative_index_path_still_resolves_against_cwd(
+    tmp_path, monkeypatch
+):
+    from api.services.scheduler_store import SchedulerStore
+
+    monkeypatch.chdir(tmp_path)
+    store = SchedulerStore(
+        vault_path=tmp_path / "vault", index_path=Path("data/explicit_sched.json")
+    )
+    assert store.index_path == Path("data/explicit_sched.json")
+    assert (tmp_path / "data" / "explicit_sched.json").parent.exists()


### PR DESCRIPTION
## Problem

Seven data paths in `api/services/` resolved against the **process's working directory** rather than the repo:

```
slack_integration.py:53   Path("data/slack_tokens.json")     ← credentials
scheduler_store.py:52     Path("data/scheduler_index.json")
task_manager.py:27        Path("data/task_index.json")
telegram.py:493           Path("data/telegram_state.json")
person_stats.py:184       Path("data/crm.db")
slack_indexer.py:64       Path("data/slack_sync_timestamps.db")
cc_wezterm_store.py:22    Path("data/cc_wezterm.db")
```

The repo already had the correct idiom in `person_entity.py`, `job_queue.py`, and `sync_health.py`. This is drift between two coexisting patterns.

## Scope correction from the original issue

#645 as filed claimed this was **live**, citing Hermes's stdio MCP subprocess creating a phantom database. **That was wrong**, and the correction is on the issue: `mcp_server.py` already anchors `AGENT_SESSIONS_DB` / `AGENT_TRANSCRIPTS_DIR` and passes them explicitly, with a test already pinning it.

So this is **latent drift, not a fault** — which argued for being *more* conservative, since any behavior change here is pure regression risk with no offsetting fix.

## Solution

All seven anchored with `Path(__file__).resolve().parent.parent.parent / "data" / ...` (three parents is correct — all live directly in `api/services/`). Explicitly-passed paths, including deliberately relative ones, resolve exactly as before.

**`person_stats.py` now shares `PersonEntityStore.CRM_DB_PATH`** rather than carrying a second literal for the same physical database — two paths to one file is how they drift apart. The `Path(...)` wrapper at the call site is retained deliberately: two tests patch `person_stats.Path`, and that patch only intercepts calls made inside the module.

## Testing had to be done by subprocess, and that's the interesting part

These couldn't be tested in-process. An autouse `_isolate_telegram_state_file` fixture masks the telegram class attribute, and two tests monkeypatch `person_stats.Path` directly — so an in-process assertion would have measured **the fixtures, not the anchoring**. Each check spawns a subprocess with `cwd` outside the repo, which is also the only way to exercise the bug at all.

That is precisely why no existing test could see this class of defect: they all run from the repo root.

`slack_indexer`'s `_ts_db_path` is an instance attribute whose `__init__` creates the sqlite file immediately, so its test patches `_init_timestamp_db` to a no-op — path computation only, no disk I/O.

## Verification

- `tests/test_data_path_anchoring.py`: 11 tests (6 parametrized foreign-cwd cases + slack_indexer's instance case + 4 pinning that explicit relative paths still resolve against cwd)
- **Proven as a real guard** by reverting `task_manager.py`'s anchor — that parametrized case fails while the explicit-override test keeps passing
- 455 passed across the 19 affected suites; 45 more across `test_person_entity.py` / `test_slack_sync.py`
- Combined gate with #640/#641/#643: 3684 passed / 8 skipped

Incidental: removing one line in `slack_indexer.py` tripped the pre-commit ruff gate on three pre-existing unused imports. Removed rather than bypassed — noted separately in the commit body.

**Out of scope, recorded:** `ConversationStore` and `UsageStore` derive their defaults from `settings.chroma_path`, itself `Path("./data/chromadb")`. Fixing that means changing `config/settings.py` path defaults, with blast radius across ChromaDB, vault indexing, and every `chroma_path`/`vault_path` consumer.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)