### PR TITLE
fix(usage): guard against a negative cost_usd at record_usage()

### DIFF
--- a/api/services/usage_store.py
+++ b/api/services/usage_store.py
@@ -97,7 +97,8 @@ class UsageStore:
             model: Model name used
             input_tokens: Number of input tokens
             output_tokens: Number of output tokens
-            cost_usd: Cost in USD
+            cost_usd: Cost in USD. A negative value is clamped to 0.0 and
+                logged loudly (#657) -- see below.
             conversation_id: Optional conversation ID
             unpriced: True when the caller has no real cost for this turn
                 (an external backend that sent no `cost_usd`) — `cost_usd`
@@ -108,6 +109,26 @@ class UsageStore:
         Returns:
             ID of the created record
         """
+        # A negative cost is never legitimate -- money spent can't be less
+        # than zero -- and it silently shrinks every SUM(cost_usd) it feeds
+        # (GET /api/admin/usage, session-cost totals). #657 traced one
+        # historical cause (a cache-token accounting bug in a long-gone
+        # version of agent_loop.py that subtracted cache tokens from an
+        # already-non-cached input_tokens count), but this guard is a
+        # backstop against *any* upstream miscalculation, not just that one.
+        # Clamp rather than reject so the call still succeeds and the
+        # (accurate) token counts are still recorded -- but log loudly so a
+        # recurrence is visible instead of silently absorbed.
+        if cost_usd < 0:
+            logger.error(
+                "record_usage: negative cost_usd=%r for model=%s "
+                "(input_tokens=%d, output_tokens=%d, conversation_id=%s) -- "
+                "clamping to 0.0. Cost cannot be negative; this indicates a "
+                "bug in whatever computed it.",
+                cost_usd, model, input_tokens, output_tokens, conversation_id,
+            )
+            cost_usd = 0.0
+
         now = datetime.now().isoformat()
 
         with sqlite3.connect(self.db_path) as conn:

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -6,6 +6,10 @@ name and cost it's given and never recomputes or filters by model. This is
 what lets a Hermes-proxied (external-backend) turn land in the same table
 as a native turn and count toward the same totals with no store or admin
 route change -- these tests are the proof.
+
+The one exception is a negative `cost_usd`: money spent can't be less than
+zero, so `record_usage()` clamps a negative value to 0.0 rather than storing
+it verbatim (#657) -- see `test_record_usage_clamps_negative_cost_and_logs`.
 """
 import sqlite3
 
@@ -36,6 +40,28 @@ def test_record_usage_stores_cost_verbatim(store):
             "SELECT model, input_tokens, output_tokens, cost_usd, conversation_id FROM usage"
         ).fetchone()
     assert row == ("deepseek-v3-fireworks", 120, 340, 0.00087, "conv-1")
+
+
+def test_record_usage_clamps_negative_cost_and_logs(store, caplog):
+    """A negative `cost_usd` (#657 -- e.g. a cache-token accounting bug that
+    subtracts more than it should) must never reach the table: a floor that
+    can be dragged below zero silently shrinks every SUM(cost_usd) it feeds
+    (GET /api/admin/usage, session-cost totals). The guard clamps to 0.0 but
+    must log loudly rather than silently absorbing it, so a recurrence is
+    visible."""
+    with caplog.at_level("ERROR"):
+        store.record_usage(
+            model="claude-sonnet-4-5-20250929", input_tokens=1087, output_tokens=245,
+            cost_usd=-0.008319, conversation_id="conv-negative",
+        )
+
+    with sqlite3.connect(store.db_path) as conn:
+        row = conn.execute(
+            "SELECT input_tokens, output_tokens, cost_usd FROM usage WHERE conversation_id = 'conv-negative'"
+        ).fetchone()
+    # Token counts are untouched -- only the invalid cost is clamped.
+    assert row == (1087, 245, 0.0)
+    assert any("negative cost_usd" in r.message for r in caplog.records)
 
 
 def test_summary_totals_include_a_non_anthropic_model(store):


### PR DESCRIPTION
Closes #657. Two rows in the live store had negative costs. Guards at the write boundary so the store cannot accept one again.

Gate: 3709 passed, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)