### PR TITLE
feat(observability): live per-surface model readout

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -629,6 +629,14 @@ async def full_health_check():
         "GET", "/api/imessage/statistics",
     )
 
+    # 12. Model readout (#658) — which model is actually serving each chat
+    # surface right now. Informational, not a pass/fail check: kept out of
+    # `results["checks"]` (and its "ok"/"error" degraded/unhealthy counting
+    # below) because an "unknown" Hermes readout doesn't mean LifeOS itself
+    # is unhealthy. See api/services/model_readout.py.
+    from api.services.model_readout import get_model_readout
+    results["models"] = await get_model_readout()
+
     # Set overall status
     failed = [k for k, v in results["checks"].items() if v["status"] == "error"]
     if failed:

--- a/api/routes/hermes_proxy.py
+++ b/api/routes/hermes_proxy.py
@@ -51,6 +51,7 @@ from api.routes.chat import AskStreamRequest
 from api.services.agent_system_prompt import build_turn_context
 from api.services.chat_turns import TRUNCATION_MARKER, get_turn_registry, truncation_routing
 from api.services.conversation_store import get_store
+from api.services.model_readout import record_hermes_chat_turn_model
 from api.services.usage_store import get_usage_store
 
 logger = logging.getLogger(__name__)
@@ -408,6 +409,10 @@ class _HermesTurnPersister:
         self._usage_output_tokens = output_tokens
         self._usage_cost_usd = cost_usd
         self._usage_unpriced = not priced
+        # #658: the model that actually answered this turn, per Hermes's own
+        # report — see model_readout.py's module docstring for why this is
+        # the only trustworthy live signal for the "hermes_chat" surface.
+        record_hermes_chat_turn_model(model)
 
     def finalize(self) -> None:
         """Write this turn to the stores, once each. Runs after the pump has

--- a/api/services/model_readout.py
+++ b/api/services/model_readout.py
@@ -1,0 +1,192 @@
+"""Model readout (#658) — which model is actually serving each chat surface,
+right now.
+
+Two upstream failures motivated this: hermes#49 mistook a stale tracked
+config snapshot for the live value, and hermes#50 had two surfaces answering
+with materially different competence and nobody told. Both were
+**invisibility**, not disagreement — this module answers "what's live" by
+asking the actual running process, or observing what actually happened,
+never by re-reading a config file:
+
+- LifeOS native picker, Anthropic backend: `settings.anthropic_model` IS the
+  live value here — it's read straight out of this process's own in-memory
+  settings (the same object every request already uses), not re-parsed off
+  disk. There's no separate Anthropic process on this box that could be
+  running a different model out from under that setting.
+- LifeOS native picker, local backend: `settings.local_llm_model` is only a
+  declared intent — llama-server serves one model per process and can be
+  restarted against a different one without this setting changing (exactly
+  the tracked-snapshot-vs-live mismatch hermes#49 hit), so it's confirmed
+  with a live probe instead of trusted.
+- Hermes chat: `LIFEOS_HERMES_BACKEND_URL` (confirmed live on the real host,
+  #658 review) points at LifeOS's own hermes-lifeos-adapter, not the Hermes
+  gateway itself — the adapter has no `/v1/models` (or any capability
+  endpoint) to probe, and even if it did, a capability probe answers "what
+  COULD serve a turn", not "what DID": the adapter's `hermes_model` config
+  (or a per-turn `model_hint`) can pick a different model per request, so a
+  single "current capability" value would misrepresent turns that overrode
+  it. The only trustworthy signal is the model Hermes itself *reported*
+  serving a turn with, in that turn's own `usage` event — observed, not
+  declared. `api/routes/hermes_proxy.py`'s `_HermesTurnPersister` already
+  parses that event for every real Hermes chat turn; `record_hermes_chat_turn_model`
+  below is its write side, called the moment a turn's usage event validates.
+  "unknown" until this process has relayed at least one such turn.
+- Hermes Telegram: Hermes's Telegram bot talks to the Hermes gateway
+  directly, bypassing LifeOS entirely — by design, so Hermes's Telegram
+  path stays independent of LifeOS uptime (see client-surfaces.md). That
+  means LifeOS never sees a single byte of that traffic: not a config, not
+  a probe, not an observed turn. Reported as "not_observable" — a status
+  distinct from "unknown" ("tried to find out, couldn't") because there is
+  no attempt to fail here, only an acknowledged structural blind spot. A
+  borrowed value from hermes_chat would be dishonest: the adapter's
+  `hermes_model`/`model_hint` machinery means the two CAN genuinely differ
+  per turn (this is exactly the hermes#50 shape — two surfaces, potentially
+  different competence — so asserting they match would recreate the same
+  invisibility this readout exists to end, just with more confidence).
+
+Every surface reports `{"status": "ok" | "unknown" | "not_configured" |
+"not_observable", "model": str | None, ...}`. "unknown" is the deliberate
+answer when a surface can't be confirmed — never falling back to whatever's
+configured, which would repeat hermes#49's mistake in a different place.
+
+Never returns a credential. `_probe_live_model` sends the bearer token it's
+given (used only for the local-backend probe path today, which has no
+credential) but never echoes it, logs it, or includes it in a returned
+value.
+"""
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# Short and symmetric (connect/read/write/pool) like the other inline health
+# probes in api/main.py's full_health_check (e.g. the ChromaDB heartbeat) —
+# this runs inside a health check, not a user-facing turn, so it should fail
+# fast rather than hang the readout on a wedged backend.
+_PROBE_TIMEOUT = httpx.Timeout(5.0)
+
+
+def _client() -> httpx.AsyncClient:
+    """httpx client for live model probes — a seam for tests."""
+    return httpx.AsyncClient(timeout=_PROBE_TIMEOUT)
+
+
+async def _probe_live_model(base_url: str, token: str = "") -> Optional[str]:
+    """GET {base_url}/v1/models and return the first advertised model id, or
+    None if unreachable, unauthorized, or the response is unparseable.
+
+    Used today only for the LifeOS native picker's local backend
+    (llama-server) — see module docstring for why Hermes is read via
+    observation instead.
+    """
+    headers = {"authorization": f"Bearer {token}"} if token else {}
+    try:
+        async with _client() as client:
+            resp = await client.get(f"{base_url.rstrip('/')}/v1/models", headers=headers)
+        if resp.status_code != 200:
+            return None
+        data = resp.json().get("data")
+        if not isinstance(data, list) or not data or not isinstance(data[0], dict):
+            return None
+        model_id = data[0].get("id")
+        return model_id if isinstance(model_id, str) and model_id else None
+    except (httpx.HTTPError, ValueError):
+        # ValueError covers resp.json() on a non-JSON body. Deliberately not
+        # logging the exception text or returning it to the caller: never
+        # surface anything derived from a response to a request that carried
+        # this call's own Authorization header.
+        return None
+
+
+async def get_lifeos_native_model() -> dict:
+    """The model the native LifeOS chat picker's default ("auto") turn
+    actually runs on right now. See module docstring for the per-backend
+    rationale."""
+    backend = (settings.llm_backend or "anthropic").lower()
+    if backend != "local":
+        return {"status": "ok", "backend": "anthropic", "model": settings.anthropic_model}
+
+    model = await _probe_live_model(settings.local_llm_url)
+    if model is None:
+        return {"status": "unknown", "backend": "local", "model": None}
+    return {"status": "ok", "backend": "local", "model": model}
+
+
+# --- Hermes chat: observed from the last real turn, not probed -----------
+#
+# In-memory only, deliberately: it resets to "nothing observed" on every
+# restart rather than persisting a last-known value across one, which is
+# the correct behavior — a value from before a restart is exactly the kind
+# of stale-but-plausible reading hermes#49 got burned by. A single process
+# is this repo's deployment model today (server.sh runs one), matching
+# every other in-memory singleton here (e.g. ServiceHealthRegistry in
+# service_health.py); the lock guards against a future multi-worker
+# deployment, not against any concurrency that exists today.
+_hermes_chat_lock = threading.Lock()
+_hermes_chat_last_model: Optional[str] = None
+_hermes_chat_last_observed_at: Optional[str] = None
+
+
+def record_hermes_chat_turn_model(model: str) -> None:
+    """Called by `api/routes/hermes_proxy.py`'s `_HermesTurnPersister` the
+    moment a real Hermes chat turn's `usage` event validates and reports a
+    model (#658). See module docstring: this is the only trustworthy
+    "what's live" signal for Hermes chat, because Hermes can serve a
+    different model per turn. Ignores a falsy model rather than clobbering
+    a real prior observation with nothing.
+    """
+    if not model:
+        return
+    global _hermes_chat_last_model, _hermes_chat_last_observed_at
+    with _hermes_chat_lock:
+        _hermes_chat_last_model = model
+        _hermes_chat_last_observed_at = datetime.now(timezone.utc).isoformat()
+
+
+def _last_observed_hermes_chat_model() -> tuple[Optional[str], Optional[str]]:
+    with _hermes_chat_lock:
+        return _hermes_chat_last_model, _hermes_chat_last_observed_at
+
+
+async def get_hermes_models() -> dict:
+    """Hermes chat and Hermes Telegram. See module docstring for why the
+    two are read completely differently and never assumed to match."""
+    if not settings.hermes_backend_url:
+        return {
+            "hermes_chat": {"status": "not_configured", "model": None},
+            "hermes_telegram": {"status": "not_configured", "model": None},
+        }
+
+    model, observed_at = _last_observed_hermes_chat_model()
+    if model is None:
+        hermes_chat = {"status": "unknown", "model": None}
+    else:
+        hermes_chat = {"status": "ok", "model": model, "observed_at": observed_at}
+
+    return {
+        "hermes_chat": hermes_chat,
+        "hermes_telegram": {
+            "status": "not_observable",
+            "model": None,
+            "note": (
+                "Hermes's Telegram bot talks to the Hermes gateway directly, "
+                "bypassing LifeOS by design (client-surfaces.md) — LifeOS has "
+                "no channel to observe or probe it, and hermes_chat's model "
+                "can genuinely differ per turn, so it is never assumed to match."
+            ),
+        },
+    }
+
+
+async def get_model_readout() -> dict:
+    """Per-surface live model readout (#658): LifeOS native picker, Hermes
+    chat, Hermes Telegram. See module docstring."""
+    native = await get_lifeos_native_model()
+    hermes = await get_hermes_models()
+    return {"lifeos_native": native, **hermes}

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Operations
-> **Last Updated:** 2026-08-09
+> **Last Updated:** 2026-08-23
 > **Audience:** Operators
 
 Operational procedures that don't belong in the day-to-day coding reference: the Apple Data Agent, Monarch Money auth, and quick observability commands. Moved here from `AGENTS.md` to keep the agent-facing file lean.
@@ -119,6 +119,75 @@ systemctl list-timers lifeos-autodeploy.timer
 **Watch it:** `tail -f logs/auto-deploy.log`. Failures (fetch, diverged pull, pip, restart, or `/health` not recovering post-deploy) send a Telegram alert.
 
 **Caveat:** it deploys whatever lands on `main` *without* re-running the test suite — safe only because merged `main` is expected to be green. It does not gate on tests by design (running the suite would take the API down and thrash the shared server).
+
+---
+
+## Shared Credentials Across Tools (#658)
+
+LifeOS sometimes shares a paid provider account with another tool running on the
+same box (e.g. `LIFEOS_REMOTE_LLM_API_KEY` in `config/settings.py` — a vendor-neutral
+credential for whichever OpenAI-compatible remote provider is configured, #654).
+When another local tool authenticates to that *same* provider account, the two
+tools end up with two independent copies of one secret: two rotation targets,
+and two places that silently drift when only one gets updated.
+
+**The fix is never a config-sharing mechanism between the two codebases** —
+LifeOS reading the other tool's config file (or vice versa) creates exactly the
+kind of cross-repo coupling and stale-snapshot risk this section exists to avoid
+(see the model readout below for what that failure mode looks like in practice).
+Instead: store the literal secret in exactly **one** file, outside either tool's
+own config tree (e.g. `~/.credentials/<provider>.env`, mode 600), and have each
+tool's own config *reference* that file rather than embed the value:
+
+- If a tool's env-loading already supports `${VAR}` expansion against the
+  process environment (LifeOS's own `.env` does, via `python-dotenv`/
+  `pydantic-settings` — confirmed: `dotenv_values()` resolves `${OTHER_VAR}`
+  against anything already in `os.environ` when it parses a file), export the
+  one shared variable into the environment ahead of that tool's own env-file
+  load (e.g. a systemd `EnvironmentFile=` pointed at the shared file), then
+  have each tool's own `.env` set its own variable name to `${THE_SHARED_VAR}`.
+- If a tool's env-loading is a plain line-by-line reader with no expansion
+  support, this trick doesn't work for it — check before relying on it. The
+  fallback for such a tool is whatever file-reference mechanism its own config
+  format supports (an `api_key_file`-style setting, systemd's own
+  `EnvironmentFile=`, etc.); embedding the literal value is what this section
+  is trying to eliminate.
+
+Either way, each tool keeps its own variable name — there's no requirement (or
+benefit) to renaming across tools, only to stop duplicating the value.
+
+## Model Readout (#658)
+
+`GET /health/full` includes a `models` key reporting, per chat surface, which
+model is **actually serving it right now** — `api/services/model_readout.py`.
+This exists because a configured value and a live value can silently diverge
+(a local LLM server restarted against a different model than its own config
+still names; an external tool's config snapshot going stale relative to its
+running process). The readout never re-reads a config file to answer "what's
+live" — each surface uses whichever live signal actually exists for it:
+
+- **LifeOS native picker:** in-memory settings for the Anthropic backend
+  (that setting IS the live value — nothing else can run a different
+  Anthropic model out from under it), or a live `/v1/models` probe against
+  the local backend's llama-server.
+- **Hermes chat:** observed from the last real turn's own `usage` event,
+  not probed. `LIFEOS_HERMES_BACKEND_URL` points at LifeOS's own adapter in
+  front of the Hermes gateway, which has no capability endpoint to probe —
+  and even a live probe against the gateway itself would answer "what
+  could serve a turn," not "what did," since the adapter can pick a
+  different model per turn. Reports `"unknown"` until this process has
+  relayed at least one Hermes chat turn.
+- **Hermes Telegram:** Hermes's Telegram bot talks to the gateway directly,
+  bypassing LifeOS by design (its independence from LifeOS uptime is a
+  property worth keeping — see client-surfaces.md), so LifeOS has no
+  channel to observe or probe it at all. Reports `"not_observable"` — a
+  status distinct from `"unknown"` (an attempt that failed) — and is never
+  assumed to match Hermes chat's observed value, since the two can
+  genuinely be answered by different models per turn.
+
+A surface that can't be confirmed reports `"status": "unknown"` (or
+`"not_observable"` where there's no attempt to make) — never the configured
+value dressed up as confirmed-live.
 
 ---
 

--- a/tests/test_model_readout.py
+++ b/tests/test_model_readout.py
@@ -1,0 +1,279 @@
+"""Tests for the per-surface live model readout (api/services/model_readout.py, #658).
+
+The local-LLM probe hits an OpenAI-compatible `/v1/models` shape, stubbed via
+ASGITransport (no sockets) — mirroring the pattern tests/test_hermes_proxy.py
+and tests/test_agent_proxy.py already use for stubbing httpx calls to an
+external backend. Hermes chat is read from an in-memory "last observed turn"
+cache instead (#658 review: the configured Hermes URL is LifeOS's own
+adapter, not the Hermes gateway, so there is no `/v1/models` to probe there —
+and even if there were, a capability probe can't reflect a per-turn model
+override the way an actually-observed turn can) — those tests call
+`record_hermes_chat_turn_model()` directly, the same entry point
+`api/routes/hermes_proxy.py` calls from a real turn's `usage` event.
+"""
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from api.services import model_readout as mr
+
+pytestmark = pytest.mark.unit
+
+stub_models = FastAPI()
+_state = {"model_id": "some-model-v1"}
+
+
+@stub_models.get("/v1/models")
+async def _stub_models(request: Request):
+    return JSONResponse({"object": "list", "data": [{"id": _state["model_id"]}]})
+
+
+@pytest.fixture
+def stub_client(monkeypatch):
+    """Route mr._client() through the in-process stub instead of a real socket."""
+    _state["model_id"] = "some-model-v1"
+
+    def _client():
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=stub_models), base_url="http://stub"
+        )
+
+    monkeypatch.setattr(mr, "_client", _client)
+    return _state
+
+
+class _FailingClient:
+    """httpx.AsyncClient stand-in whose every request raises — simulates an
+    unreachable backend (connection refused / DNS failure / timeout)."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def get(self, *args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+
+@pytest.fixture(autouse=True)
+def _reset_hermes_observation():
+    """The observed-model cache is a module-level singleton (by design —
+    see model_readout.py) so it must be reset between tests to keep them
+    independent."""
+    mr._hermes_chat_last_model = None
+    mr._hermes_chat_last_observed_at = None
+    yield
+    mr._hermes_chat_last_model = None
+    mr._hermes_chat_last_observed_at = None
+
+
+# --- LifeOS native picker -----------------------------------------------
+
+async def test_native_anthropic_backend_reads_live_settings(monkeypatch):
+    """Anthropic backend: the configured model IS the live value — no probe."""
+    monkeypatch.setattr(mr.settings, "llm_backend", "anthropic")
+    monkeypatch.setattr(mr.settings, "anthropic_model", "claude-haiku-4-5")
+    result = await mr.get_lifeos_native_model()
+    assert result == {"status": "ok", "backend": "anthropic", "model": "claude-haiku-4-5"}
+
+
+async def test_native_local_backend_probes_live_server(monkeypatch, stub_client):
+    monkeypatch.setattr(mr.settings, "llm_backend", "local")
+    monkeypatch.setattr(mr.settings, "local_llm_url", "http://stub")
+    stub_client["model_id"] = "gemma-4-26b-a4b"
+
+    result = await mr.get_lifeos_native_model()
+
+    assert result == {"status": "ok", "backend": "local", "model": "gemma-4-26b-a4b"}
+
+
+async def test_native_local_backend_reflects_a_changed_model(monkeypatch, stub_client):
+    """A model swap on the live local server is reflected without any code
+    or config change on the LifeOS side."""
+    monkeypatch.setattr(mr.settings, "llm_backend", "local")
+    monkeypatch.setattr(mr.settings, "local_llm_url", "http://stub")
+
+    stub_client["model_id"] = "gemma-4-26b-a4b"
+    first = await mr.get_lifeos_native_model()
+    assert first["model"] == "gemma-4-26b-a4b"
+
+    stub_client["model_id"] = "gemma-4-26b-a4b-q8"
+    second = await mr.get_lifeos_native_model()
+    assert second["model"] == "gemma-4-26b-a4b-q8"
+
+
+async def test_native_local_backend_unreachable_reports_unknown_not_configured_value(monkeypatch):
+    """The configured LIFEOS_LLM_MODEL must never stand in for a value that
+    couldn't actually be confirmed live — that's the exact hermes#49 mistake."""
+    monkeypatch.setattr(mr.settings, "llm_backend", "local")
+    monkeypatch.setattr(mr.settings, "local_llm_url", "http://stub-down")
+    monkeypatch.setattr(mr.settings, "local_llm_model", "configured-model-should-not-appear")
+    monkeypatch.setattr(mr, "_client", lambda: _FailingClient())
+
+    result = await mr.get_lifeos_native_model()
+
+    assert result["status"] == "unknown"
+    assert result["model"] is None
+    assert "configured-model-should-not-appear" not in str(result)
+
+
+# --- Hermes chat / Hermes Telegram ---------------------------------------
+
+async def test_hermes_not_configured(monkeypatch):
+    monkeypatch.setattr(mr.settings, "hermes_backend_url", "")
+    result = await mr.get_hermes_models()
+    assert result["hermes_chat"] == {"status": "not_configured", "model": None}
+    assert result["hermes_telegram"]["status"] == "not_configured"
+    assert result["hermes_telegram"]["model"] is None
+
+
+async def test_hermes_chat_unknown_before_any_observed_turn(monkeypatch):
+    """Configured but no turn has been relayed yet in this process — must
+    not be confused with, or fall back to, anything configured."""
+    monkeypatch.setattr(mr.settings, "hermes_backend_url", "http://adapter")
+    result = await mr.get_hermes_models()
+    assert result["hermes_chat"] == {"status": "unknown", "model": None}
+
+
+async def test_hermes_chat_reports_the_last_observed_turn_model(monkeypatch):
+    monkeypatch.setattr(mr.settings, "hermes_backend_url", "http://adapter")
+    mr.record_hermes_chat_turn_model("accounts/fireworks/models/deepseek-v4-flash-0731")
+
+    result = await mr.get_hermes_models()
+
+    assert result["hermes_chat"]["status"] == "ok"
+    assert result["hermes_chat"]["model"] == "accounts/fireworks/models/deepseek-v4-flash-0731"
+    assert result["hermes_chat"]["observed_at"]  # a timestamp is present
+
+
+async def test_hermes_chat_reflects_a_changed_model(monkeypatch):
+    """A later turn served by a different model overwrites the observation
+    — this is exactly the per-turn override the adapter's model_hint makes
+    possible, and the readout must track it, not the first thing it saw."""
+    monkeypatch.setattr(mr.settings, "hermes_backend_url", "http://adapter")
+
+    mr.record_hermes_chat_turn_model("model-a")
+    first = await mr.get_hermes_models()
+    assert first["hermes_chat"]["model"] == "model-a"
+
+    mr.record_hermes_chat_turn_model("model-b")
+    second = await mr.get_hermes_models()
+    assert second["hermes_chat"]["model"] == "model-b"
+
+
+async def test_hermes_telegram_is_never_reported_as_matching_hermes_chat(monkeypatch):
+    """The two surfaces can genuinely differ (adapter model_hint vs the
+    gateway's own Telegram-served model) — telegram must never borrow
+    chat's observed value."""
+    monkeypatch.setattr(mr.settings, "hermes_backend_url", "http://adapter")
+    mr.record_hermes_chat_turn_model("accounts/fireworks/models/deepseek-v4-flash-0731")
+
+    result = await mr.get_hermes_models()
+
+    assert result["hermes_chat"]["model"] == "accounts/fireworks/models/deepseek-v4-flash-0731"
+    assert result["hermes_telegram"]["status"] == "not_observable"
+    assert result["hermes_telegram"]["model"] is None
+
+
+async def test_record_hermes_chat_turn_model_ignores_falsy(monkeypatch):
+    monkeypatch.setattr(mr.settings, "hermes_backend_url", "http://adapter")
+    mr.record_hermes_chat_turn_model("real-model")
+    mr.record_hermes_chat_turn_model("")  # must not clobber the real observation
+    mr.record_hermes_chat_turn_model(None)
+
+    result = await mr.get_hermes_models()
+
+    assert result["hermes_chat"]["model"] == "real-model"
+
+
+# --- Full readout + credential safety --------------------------------------
+
+async def test_get_model_readout_aggregates_all_three_surfaces(monkeypatch):
+    monkeypatch.setattr(mr.settings, "llm_backend", "anthropic")
+    monkeypatch.setattr(mr.settings, "anthropic_model", "claude-haiku-4-5")
+    monkeypatch.setattr(mr.settings, "hermes_backend_url", "http://adapter")
+    mr.record_hermes_chat_turn_model("accounts/fireworks/models/deepseek-v4-flash-0731")
+
+    result = await mr.get_model_readout()
+
+    assert set(result.keys()) == {"lifeos_native", "hermes_chat", "hermes_telegram"}
+    assert result["lifeos_native"]["model"] == "claude-haiku-4-5"
+    assert result["hermes_chat"]["model"] == "accounts/fireworks/models/deepseek-v4-flash-0731"
+    assert result["hermes_telegram"]["status"] == "not_observable"
+
+
+async def test_health_full_includes_the_model_readout(monkeypatch):
+    """Wiring check: GET /health/full (api/main.py) surfaces the readout
+    under a `models` key, separate from the pass/fail `checks` — an
+    "unknown" Hermes readout shouldn't flip LifeOS's own health status."""
+    import api.main as main
+
+    monkeypatch.setattr(main.settings, "llm_backend", "anthropic")
+    monkeypatch.setattr(main.settings, "anthropic_model", "claude-haiku-4-5")
+    monkeypatch.setattr(main.settings, "hermes_backend_url", "")
+
+    result = await main.full_health_check()
+
+    assert result["models"]["lifeos_native"] == {
+        "status": "ok", "backend": "anthropic", "model": "claude-haiku-4-5",
+    }
+    assert result["models"]["hermes_chat"]["status"] == "not_configured"
+    # The pass/fail counting below `checks` is untouched by this section.
+    assert "models" not in result["checks"]
+
+
+async def test_no_credential_leaks_when_local_probe_fails(monkeypatch):
+    """Belt-and-suspenders: even in the failure path, no configured secret
+    ever appears in the aggregated readout. hermes_backend_token is set here
+    even though the current Hermes path never sends it anywhere (#658
+    review removed the live Hermes probe) — guards against a future
+    regression that reintroduces a network call without this check."""
+    monkeypatch.setattr(mr.settings, "llm_backend", "local")
+    monkeypatch.setattr(mr.settings, "local_llm_url", "http://stub-down")
+    monkeypatch.setattr(mr.settings, "hermes_backend_url", "http://adapter")
+    monkeypatch.setattr(mr.settings, "hermes_backend_token", "super-secret-token-value")
+    monkeypatch.setattr(mr, "_client", lambda: _FailingClient())
+
+    result = await mr.get_model_readout()
+
+    assert "super-secret-token-value" not in str(result)
+    assert result["lifeos_native"]["status"] == "unknown"
+    assert result["hermes_chat"]["status"] == "unknown"
+    assert result["hermes_telegram"]["status"] == "not_observable"
+
+
+# --- hermes_proxy.py wiring: a real turn's usage event feeds the readout --
+
+async def test_hermes_proxy_usage_event_records_the_observed_model(monkeypatch):
+    """The exact call site: _HermesTurnPersister._handle_usage() must call
+    record_hermes_chat_turn_model() when a turn's usage event validates."""
+    from api.routes.hermes_proxy import _HermesTurnPersister
+
+    persister = _HermesTurnPersister(question="hi", persona_id="primary")
+    persister._handle_usage({
+        "type": "usage",
+        "model": "accounts/fireworks/models/deepseek-v4-flash-0731",
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "cost_usd": 0.001,
+    })
+
+    model, observed_at = mr._last_observed_hermes_chat_model()
+    assert model == "accounts/fireworks/models/deepseek-v4-flash-0731"
+    assert observed_at is not None
+
+
+async def test_hermes_proxy_malformed_usage_event_does_not_record(monkeypatch):
+    from api.routes.hermes_proxy import _HermesTurnPersister
+
+    persister = _HermesTurnPersister(question="hi", persona_id="primary")
+    persister._handle_usage({"type": "usage", "model": None, "input_tokens": 10, "output_tokens": 20})
+
+    model, _ = mr._last_observed_hermes_chat_model()
+    assert model is None


### PR DESCRIPTION
Closes #658.

Reports which model is actually serving each surface, via `/health/full` (extending it rather than adding a public route). Kept out of the pass/fail `checks` block so an unreachable Hermes doesn't flip LifeOS's own health.

**The value reported is observed, never re-read from config** — a readout that re-parses config would have happily reported the stale snapshot in hermes#49.

- `lifeos_native` — the live backend model.
- `hermes_chat` — recorded from the `usage` event of a real relayed turn, with `observed_at`. `unknown` before any turn since process start; deliberately not persisted, since a stale pre-restart value is exactly the hermes#49 failure.
- `hermes_telegram` — `not_observable`, a status distinct from `unknown`. Telegram bypasses LifeOS by design, so LifeOS genuinely cannot see it.

A first cut probed `/v1/models` at `LIFEOS_HERMES_BACKEND_URL` and reported both Hermes surfaces from one query. Both were wrong: that URL is the *adapter*, which 404s there, and the two surfaces can genuinely differ — the adapter injects its own `hermes_model` per request (`bridge.py:201`) while Telegram gets the gateway's profile default. Asserting they match is the hermes#50 failure restated.

Credential consolidation needed no code change — `LIFEOS_REMOTE_LLM_API_KEY` (#654) is already vendor-neutral. The shared-credential pattern is documented in `operations.md`; applying it is a host step.

Gate: 3797 passed, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)