### PR TITLE
feat(journal): authenticated ingestion endpoint for ring transcriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMe
 | How does the doctor self-repair bot work? | [guides/doctor-bot.md](docs/guides/doctor-bot.md) |
 | How do schedules (triggers + actions) work? | [guides/scheduler.md](docs/guides/scheduler.md) |
 | How do I import Apple Health/Fitness data? | [guides/apple-health.md](docs/guides/apple-health.md) |
+| How do I configure a capture device (e.g. the Pebble Index ring) to feed the journal persona? | [guides/journal-ring-ingest.md](docs/guides/journal-ring-ingest.md) |
 | How do I run the Apple Data Agent / re-auth Monarch / check alerting? | [guides/operations.md](docs/guides/operations.md) |
 | What does `/agents` show? | [specs/product/agent-viz.md](docs/specs/product/agent-viz.md) |
 | How does the `/agents` page work internally? | [specs/technical/agent-viz.md](docs/specs/technical/agent-viz.md) |

--- a/api/main.py
+++ b/api/main.py
@@ -49,7 +49,7 @@ from fastapi.exceptions import RequestValidationError
 
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, investments, jobs, perf, agents, vault, fitness, voice, agent_proxy, hermes_proxy, journal, journal_trends
+from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, investments, jobs, perf, agents, vault, fitness, voice, agent_proxy, hermes_proxy, journal, journal_trends, journal_ingest
 from api.services.log_redaction import configure_telegram_log_redaction
 from config.settings import settings
 
@@ -322,6 +322,7 @@ app.include_router(agent_proxy.router)
 app.include_router(hermes_proxy.router)
 app.include_router(journal.router)
 app.include_router(journal_trends.router)
+app.include_router(journal_ingest.router)
 
 # Serve static files
 web_dir = Path(__file__).parent.parent / "web"

--- a/api/routes/journal_ingest.py
+++ b/api/routes/journal_ingest.py
@@ -1,0 +1,179 @@
+"""
+Journal ring ingestion endpoint (#660).
+
+Lets a capture device outside the tailnet — the Pebble Index ring is the
+motivating case, transcribing speech on-phone and posting the text — feed
+fragments into the `journal` persona built in #659. It intentionally does
+NOT reimplement capture: `_ingest_fragment` below calls the exact same chat
+pipeline entry point (`api.services.telegram.chat_via_api`, with the journal
+persona's preamble) that the journal Telegram bot uses for a typed fragment,
+so a spoken fragment gets identical treatment — same log file, same task/
+schedule thresholds, same ask-when-unsure behavior.
+
+Our own contract (see docs/guides/journal-ring-ingest.md) — the exact shape a
+real Pebble Index webhook sends is unknown until the device ships in March
+2026 (issue #660 is explicit: build against a contract we control, adapt when
+the device is in hand). `_adapt_payload` is the ONLY function that knows the
+request body's shape; if a real device's webhook doesn't match, only that
+function should need to change.
+
+Auth mirrors the existing bearer-token ingest pattern (`api/routes/fitness.py`
+`_check_ingest_auth`, itself modeled on the MCP HTTP transport's
+`LIFEOS_MCP_BEARER_TOKEN`): a dedicated token, 503 while unset, 401 on a
+missing/wrong bearer, checked BEFORE the body is parsed so an unauthenticated
+caller can't probe validation behavior or cause any write.
+"""
+import hashlib
+import hmac
+import logging
+from datetime import datetime
+from typing import NamedTuple, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+
+from api.services.journal_ingest_store import get_journal_ingest_store
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/journal", tags=["journal"])
+
+# The journal persona bot's registry name (config/telegram_bots.json) — the
+# preamble this resolves to is exactly what a typed Telegram fragment gets.
+_JOURNAL_PERSONA_ID = "journal"
+
+# Per-device conversation continuity, mirroring TelegramBotListener's
+# per-chat_id `_conversations` map (api/services/telegram.py): in-memory,
+# process-lifetime only, one entry per device so consecutive fragments from
+# the same ring share conversation context the way consecutive messages in
+# the same Telegram chat would.
+_conversations: dict[str, str] = {}
+
+
+class _IngestFields(NamedTuple):
+    text: str
+    device_id: str
+    timestamp: str
+    external_id: Optional[str]
+
+
+def _adapt_payload(body: dict) -> _IngestFields:
+    """Extract (text, device_id, timestamp, external_id) from a device
+    payload. THE payload adapter — see module docstring. Deliberately does
+    not read any "action" field: the device's on-device LLM may include one
+    (its guess at create-note/add-reminder/etc), but honoring it would mean a
+    spoken fragment and a typed one get interpreted by two different brains.
+    The ring is transport; the journal persona (#659) is the interpreter.
+    """
+    text = str(body.get("text") or "").strip()
+    device_id = str(body.get("device_id") or "").strip()
+    timestamp = str(body.get("timestamp") or "").strip()
+    external_id_raw = body.get("id")
+    external_id = str(external_id_raw).strip() if external_id_raw else None
+    return _IngestFields(text=text, device_id=device_id, timestamp=timestamp, external_id=external_id)
+
+
+def _dedupe_key(fields: _IngestFields) -> str:
+    """A retried delivery must log once (#660 AC). Prefer a device-supplied
+    id when present; otherwise derive the key from the payload itself
+    (device_id + timestamp + text) rather than trusting the device to send a
+    unique id at all — a flaky-connection retry resends the same three
+    values, so the derived key still collapses it to one. Only the derived
+    hash (or the external id) is persisted, never the fragment text."""
+    if fields.external_id:
+        return f"id:{fields.external_id}"
+    raw = f"{fields.device_id}|{fields.timestamp}|{fields.text}"
+    return "hash:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _check_ingest_auth(request: Request) -> None:
+    """Bearer-token gate. Disabled (503) until LIFEOS_JOURNAL_INGEST_TOKEN is
+    set — a dedicated token, separate from the MCP transport's and the health
+    ingest's."""
+    expected = settings.journal_ingest_token
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="Journal ring ingest disabled: set LIFEOS_JOURNAL_INGEST_TOKEN to enable.",
+        )
+    header = request.headers.get("authorization", "")
+    scheme, _, token = header.partition(" ")
+    token = token.strip()
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    if not hmac.compare_digest(token, expected):
+        raise HTTPException(status_code=401, detail="invalid bearer token")
+
+
+def _parse_timestamp(value: str) -> None:
+    """Validate the timestamp parses as ISO 8601. Only used to reject a
+    malformed payload cleanly (422) — the log bullet's own HH:MM comes from
+    the journal persona's normal "now, local time" convention (same as a
+    typed fragment, which carries no separate authored-at time either), not
+    from this field. Accepts a trailing 'Z' (fromisoformat pre-3.11 doesn't)."""
+    datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+@router.post("/ingest")
+async def journal_ring_ingest(request: Request):
+    """Ingest a transcribed fragment from a capture device (e.g. a Pebble
+    Index ring) into the journal persona's capture log — the same path a
+    typed fragment to the journal Telegram bot takes.
+
+    Authenticates and validates BEFORE any write: an unauthenticated or
+    malformed request writes nothing, not even a log line containing the
+    payload. A previously-seen delivery (same dedupe key) is acknowledged
+    without being reprocessed, so a retry logs once.
+    """
+    _check_ingest_auth(request)
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="payload must be a JSON object")
+
+    fields = _adapt_payload(body)
+    if not fields.text:
+        raise HTTPException(status_code=422, detail="text is required")
+    if not fields.device_id:
+        raise HTTPException(status_code=422, detail="device_id is required")
+    if not fields.timestamp:
+        raise HTTPException(status_code=422, detail="timestamp is required")
+    try:
+        _parse_timestamp(fields.timestamp)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="timestamp is not valid ISO 8601")
+
+    store = get_journal_ingest_store()
+    dedupe_key = _dedupe_key(fields)
+    if store.was_processed(dedupe_key):
+        logger.info(f"Journal ring ingest: duplicate delivery from device {fields.device_id}, not reprocessed")
+        return {"status": "duplicate"}
+
+    persona_preamble = settings.resolve_persona(_JOURNAL_PERSONA_ID)
+    if persona_preamble is None:
+        # The journal bot's token isn't configured (settings.list_http_personas()
+        # would omit it) — nothing to route into. Fail closed rather than
+        # silently falling back to an unprimed chat turn.
+        raise HTTPException(
+            status_code=503,
+            detail="journal persona is not configured (TELEGRAM_JOURNAL_BOT_TOKEN unset)",
+        )
+
+    from api.services.telegram import chat_via_api
+
+    try:
+        conversation_id = _conversations.get(fields.device_id)
+        result = await chat_via_api(fields.text, conversation_id=conversation_id, persona=persona_preamble)
+    except Exception:
+        # Never let a fragment (or the underlying error, which may quote it)
+        # reach the logs.
+        logger.error(f"Journal ring ingest: pipeline error for device {fields.device_id}")
+        raise HTTPException(status_code=502, detail="capture pipeline error")
+
+    _conversations[fields.device_id] = result["conversation_id"]
+    store.mark_processed(dedupe_key)
+    logger.info(f"Journal ring ingest: captured fragment from device {fields.device_id}")
+    return {"status": "logged", "reply": result.get("answer", "")}

--- a/api/services/journal_ingest_store.py
+++ b/api/services/journal_ingest_store.py
@@ -1,0 +1,83 @@
+"""
+Idempotency store for the journal ring ingestion endpoint (#660).
+
+A capture device (e.g. the Pebble Index ring) may retry a delivery on a flaky
+connection; this store lets `POST /api/journal/ingest` recognize a retried
+delivery and log it exactly once. It persists only a *derived* dedupe key
+(a sha256 hash of device/timestamp/text, or a device-supplied id) — never the
+fragment text itself — so this store can't become another place personal
+content leaks.
+
+Mirrors `api/services/fitness_store.py`'s db-path and singleton pattern.
+"""
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from config.settings import settings
+
+
+def get_journal_ingest_db_path() -> str:
+    """Path to the journal-ingest dedupe database (alongside the other LifeOS
+    SQLite stores)."""
+    db_dir = Path(settings.chroma_path).parent
+    db_dir.mkdir(parents=True, exist_ok=True)
+    return str(db_dir / "journal_ingest.db")
+
+
+class JournalIngestStore:
+    """SQLite-backed record of dedupe keys already processed."""
+
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path = db_path or get_journal_ingest_db_path()
+        self._init_db()
+
+    def _init_db(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS processed_ingests ("
+                "dedupe_key TEXT PRIMARY KEY, "
+                "processed_at TEXT NOT NULL)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def was_processed(self, dedupe_key: str) -> bool:
+        """True if this dedupe key has already been recorded as processed."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM processed_ingests WHERE dedupe_key = ?",
+                (dedupe_key,),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+
+    def mark_processed(self, dedupe_key: str) -> None:
+        """Record a dedupe key as processed. Call only after the capture
+        pipeline has succeeded, so a delivery that failed mid-flight can still
+        be retried rather than being silently swallowed as a "duplicate"."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                "INSERT OR IGNORE INTO processed_ingests (dedupe_key, processed_at) "
+                "VALUES (?, ?)",
+                (dedupe_key, datetime.now(timezone.utc).isoformat()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+_store_instance: Optional[JournalIngestStore] = None
+
+
+def get_journal_ingest_store() -> JournalIngestStore:
+    global _store_instance
+    if _store_instance is None:
+        _store_instance = JournalIngestStore()
+    return _store_instance

--- a/config/settings.py
+++ b/config/settings.py
@@ -1012,6 +1012,17 @@ class Settings(BaseSettings):
                     "Generate with `openssl rand -hex 32`."
     )
 
+    # Journal ring ingest (#660) — a wearable (e.g. the Pebble Index ring) posts
+    # transcribed fragments here from outside the tailnet.
+    journal_ingest_token: str = Field(
+        default="",
+        alias="LIFEOS_JOURNAL_INGEST_TOKEN",
+        description="Bearer token for POST /api/journal/ingest (transcription webhook "
+                    "for a capture device, e.g. the Pebble Index ring). Empty disables "
+                    "the endpoint (503). Generate with `openssl rand -hex 32`. Dedicated "
+                    "token, separate from LIFEOS_MCP_BEARER_TOKEN/LIFEOS_HEALTH_INGEST_TOKEN."
+    )
+
     # Monarch Money
     monarch_email: str = Field(
         default="",

--- a/docs/guides/apple-health.md
+++ b/docs/guides/apple-health.md
@@ -156,3 +156,4 @@ metrics and Apple workouts live in `data/fitness.db` alongside your manual log.
 - [apple/HealthBridge/README.md](../../apple/HealthBridge/README.md) — Build/sign/run the app
 - [ADR-010 — Apple Data Agent](../adr/010-apple-data-agent.md)
 - [guides/scheduler.md](scheduler.md) — proactive check-ins (e.g. morning weight)
+- [guides/journal-ring-ingest.md](journal-ring-ingest.md) — another external capture device following this same dedicated-bearer-token ingest pattern

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -272,6 +272,14 @@ Apple Health/Fitness ingestion. See [apple-health.md](apple-health.md) for the e
 | `LIFEOS_HEALTH_INGEST_TOKEN` | str | — | Bearer token for `POST /api/fitness/health/ingest` (the HealthBridge app's POST delivery mode). Empty disables the endpoint (503). Generate with `openssl rand -hex 32`. |
 | `LIFEOS_FITNESS_SHEET_ID` | str | — | Google Sheet ID to mirror the workout log into (optional; mirror is off if unset). Requires the read-write Sheets OAuth scope — re-run the Google auth flow after enabling. |
 
+## Journal Ring Ingest
+
+A capture device (e.g. the Pebble Index ring) posts transcriptions here. See [journal-ring-ingest.md](journal-ring-ingest.md) for the endpoint contract.
+
+| Variable | Type | Default | Sets |
+|---|---|---|---|
+| `LIFEOS_JOURNAL_INGEST_TOKEN` | str | — | Bearer token for `POST /api/journal/ingest` (a capture device's transcription webhook). Empty disables the endpoint (503). Generate with `openssl rand -hex 32`. |
+
 ## Notifications
 
 | Variable | Type | Default | Sets |
@@ -398,6 +406,7 @@ LIFEOS_ALERT_EMAIL=you@example.com
 - [Voice Setup](voice-setup.md) — The `/chat` Agent/Hermes text-backend toggle and voice dock that the vars above configure.
 - [Agent Worker Setup](agent-worker-setup.md) — Operator setup for the `#agent` worker; references many of the `LIFEOS_AGENT_*` vars above in operator-flow context.
 - [Claude Code Orchestration](claude-code-orchestration.md) — `/claude` setup; references the `LIFEOS_CLAUDE_*` vars in operator-flow context.
+- [Journal Ring Ingest](journal-ring-ingest.md) — `LIFEOS_JOURNAL_INGEST_TOKEN` in operator-flow context.
 - [Doctor Bot](doctor-bot.md) — The self-repair orchestration bot; setup of its `TELEGRAM_DOCTOR_*` vars and the repair flow.
 - [ADR-009: LIFEOS_LLM_BACKEND toggle](../adr/009-llm-backend-toggle.md) — Why the synthesis backend is operator-configurable.
 - [ADR-019: A Turn's Lifetime Is Owned by the Server](../adr/019-turn-owned-by-server.md) — Why `LIFEOS_DETACHED_TURN_TIMEOUT_SECONDS` exists.

--- a/docs/guides/journal-ring-ingest.md
+++ b/docs/guides/journal-ring-ingest.md
@@ -1,0 +1,141 @@
+# Journal Ring Ingest — `POST /api/journal/ingest`
+
+> **Audience:** Operator configuring a capture device
+> **Status:** Complete
+> **Last Updated:** 2026-08-23
+
+Lets a capture device — the motivating case is the [Pebble Index](https://repebble.com/index)
+ring, which transcribes speech on-phone and can "route… transcribed text
+directly to your own app via webhook" — feed fragments into the `journal`
+persona ([#659](../../config/personas/journal.md)) from outside the tailnet.
+
+**This is our own contract, not the ring's.** The Pebble Index ships March
+2026; its real webhook payload shape is unknown until then. This endpoint
+defines the shape we control and documents it so a device (or a `curl` test)
+can be configured against it now. If a real device's webhook doesn't match,
+only `_adapt_payload()` in [`api/routes/journal_ingest.py`](../../api/routes/journal_ingest.py)
+needs to change — everything else (auth, idempotency, the capture call) is
+independent of the payload's exact field names.
+
+## Why a webhook, not direct MCP
+
+`lifeos-mcp-http` (`:8765`) already exposes LifeOS's tools behind a bearer
+token and could be called directly by the ring's app. That path is
+deliberately **not** used here: it would hand interpretation of a spoken
+fragment to the ring's own small on-device model choosing among 60+ tools,
+so a spoken thought and a typed one could end up governed by two different
+judgments about what deserves a task. This endpoint keeps the ring as
+transport and the `journal` persona as the sole interpreter — see #660.
+
+## Behavior
+
+A valid request is handed to **the exact same chat pipeline call** the
+`journal` Telegram bot makes for a typed message (`api.services.telegram.
+chat_via_api`, primed with the journal persona's preamble). It is not a
+separate implementation of capture — same log file
+(`Personal/Log/YYYY-MM-DD.md`), same task/schedule extraction thresholds,
+same ask-when-unsure behavior described in
+[`config/personas/journal.md`](../../config/personas/journal.md).
+
+One documented difference from a Telegram message: the bullet's `HH:MM`
+timestamp is whatever the persona resolves as "now, local time" at
+processing time — same as a typed message, which also carries no separate
+"composed at" time. The payload's `timestamp` field is used for validation
+and idempotency, not injected into the fragment text, so it does not
+override the bullet's clock. This only matters if a device buffers a
+fragment offline and delivers it late; nothing in the product description
+suggests that today.
+
+**The device's on-device LLM may include its own guessed `action`.** It is
+read by nobody — the field may be present in a real payload and is
+deliberately ignored, for the reason above.
+
+## Enabling it
+
+Set a dedicated bearer token in `.env` (separate from `LIFEOS_MCP_BEARER_TOKEN`
+and `LIFEOS_HEALTH_INGEST_TOKEN` — a compromised ring token shouldn't need
+rotating the others):
+
+```bash
+LIFEOS_JOURNAL_INGEST_TOKEN=$(openssl rand -hex 32)
+```
+
+Empty (the default) disables the endpoint — it returns `503`. The `journal`
+persona itself must also be configured (`TELEGRAM_JOURNAL_BOT_TOKEN` set,
+per [#659](../../config/personas/journal.md)); if it isn't, the endpoint
+returns `503` rather than routing to an unprimed chat turn.
+
+Point the device (or its phone-side app) at:
+```
+https://<your-machine>.<tailnet>.ts.net/api/journal/ingest
+```
+
+## Contract
+
+```
+POST /api/journal/ingest
+Authorization: Bearer <LIFEOS_JOURNAL_INGEST_TOKEN>
+Content-Type: application/json
+
+{
+  "text": "call a friend this week",       // required, non-empty transcription
+  "device_id": "pebble-index-fa12",         // required, identifies the source device
+  "timestamp": "2026-08-23T14:37:00Z",      // required, ISO 8601
+  "id": "device-local-message-id",          // optional — see Idempotency below
+  "action": "reminder"                      // optional, deliberately ignored (see Behavior)
+}
+```
+
+Response (`200`):
+```json
+{"status": "logged", "reply": "Logged."}
+```
+or, for a delivery already seen:
+```json
+{"status": "duplicate"}
+```
+
+| Status | Meaning |
+|---|---|
+| `200` | Captured (`status: "logged"`) or recognized as a repeat delivery (`status: "duplicate"`) — nothing reprocessed either way. |
+| `401` | Missing or wrong bearer token. Nothing written. |
+| `422` | Missing/empty `text`, `device_id`, or `timestamp`, or a `timestamp` that isn't valid ISO 8601. Nothing written. |
+| `400` | Body isn't valid JSON. Nothing written. |
+| `502` | The chat pipeline itself failed (e.g. the LLM backend is down). Nothing written; not recorded as processed, so an identical retry is *not* treated as a duplicate. |
+| `503` | The endpoint is disabled (`LIFEOS_JOURNAL_INGEST_TOKEN` unset) or the `journal` persona isn't configured. |
+
+Auth is checked **before** the body is parsed, so an unauthenticated request
+can't probe validation behavior, and a rejected request never reaches the
+capture pipeline — no partial entry, no log line containing the payload.
+
+## Idempotency
+
+A retried delivery (flaky connection) must log once. If the payload carries
+an `id`, it is used as the dedupe key directly — a device-native identifier
+is the most reliable signal when the device provides one. Otherwise the key
+is derived from the payload itself: a hash of `device_id + timestamp + text`,
+since a retry resends those three values unchanged. Either way, only the
+derived key (a hash, or the device's own id) is persisted — never the
+fragment text — in `data/journal_ingest.db`.
+
+A delivery is marked processed only **after** the capture pipeline succeeds,
+so a failed attempt (`502`) can be retried rather than being silently
+swallowed as a duplicate forever.
+
+## Verify with `curl`
+
+```bash
+curl -X POST http://localhost:8000/api/journal/ingest \
+  -H "Authorization: Bearer $LIFEOS_JOURNAL_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "idea about the deploy gate", "device_id": "test-device", "timestamp": "2026-08-23T14:37:00Z"}'
+```
+
+Check `Personal/Log/<today>.md` in the vault for the new bullet.
+
+## Related Documents
+
+- [`config/personas/journal.md`](../../config/personas/journal.md) — The capture behavior this endpoint routes into (#659); authoritative on log shape and task/schedule extraction.
+- [Configuration](configuration.md#journal-ring-ingest) — `LIFEOS_JOURNAL_INGEST_TOKEN` reference.
+- [`api/routes/journal_ingest.py`](../../api/routes/journal_ingest.py) — Implementation; `_adapt_payload()` is the one function to change once a real device's webhook is observed.
+- [Apple Health Import](apple-health.md) — The precedent this mirrors: a dedicated bearer-token ingest endpoint for an external capture device.

--- a/tests/test_journal_ring_ingest.py
+++ b/tests/test_journal_ring_ingest.py
@@ -1,0 +1,278 @@
+"""
+Tests for the journal ring ingestion endpoint (#660).
+
+POST /api/journal/ingest lets a capture device (e.g. the Pebble Index ring)
+feed transcribed fragments into the `journal` persona built in #659. The
+underlying chat pipeline (`api.services.telegram.chat_via_api`) is mocked
+throughout — these tests cover the endpoint's own contract (auth, payload
+adapter, idempotency, clean failure) and that it calls into the pipeline the
+same way the journal Telegram bot does, not the persona's LLM behavior
+itself (which #659's own tests already note isn't unit-testable without a
+model). Never touches the real vault or a real chat pipeline.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.journal_ingest as journal_ingest
+import api.services.journal_ingest_store as journal_ingest_store
+from api.services.journal_ingest_store import JournalIngestStore
+
+pytestmark = pytest.mark.unit
+
+
+def _payload(**overrides):
+    payload = {
+        "text": "call a friend this week",
+        "device_id": "ring-test-1",
+        "timestamp": "2026-08-23T14:37:00Z",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    store = JournalIngestStore(db_path=str(tmp_path / "journal_ingest.db"))
+    monkeypatch.setattr(journal_ingest_store, "_store_instance", store)
+    journal_ingest._conversations.clear()
+
+    monkeypatch.setattr(journal_ingest.settings, "journal_ingest_token", "secret-token")
+    # `settings` is a pydantic model — instance attributes must be declared
+    # fields, so a method override goes on the class, not the instance.
+    monkeypatch.setattr(
+        type(journal_ingest.settings), "resolve_persona",
+        lambda self, persona_id, surface=None: "JOURNAL PERSONA PREAMBLE" if persona_id == "journal" else None,
+    )
+
+    calls = []
+
+    async def fake_chat_via_api(question, conversation_id=None, persona=None):
+        calls.append({"question": question, "conversation_id": conversation_id, "persona": persona})
+        return {"answer": "Logged.", "conversation_id": "conv-1", "claude_intent": False, "task": None}
+
+    monkeypatch.setattr("api.services.telegram.chat_via_api", fake_chat_via_api)
+
+    app = FastAPI()
+    app.include_router(journal_ingest.router)
+    client = TestClient(app)
+    return client, store, calls, monkeypatch
+
+
+def _auth():
+    return {"Authorization": "Bearer secret-token"}
+
+
+class TestAuth:
+    def test_disabled_without_token(self, env):
+        client, _, calls, monkeypatch = env
+        monkeypatch.setattr(journal_ingest.settings, "journal_ingest_token", "")
+        resp = client.post("/api/journal/ingest", json=_payload())
+        assert resp.status_code == 503
+        assert calls == []
+
+    def test_missing_bearer_rejected(self, env):
+        client, _, calls, _ = env
+        resp = client.post("/api/journal/ingest", json=_payload())
+        assert resp.status_code == 401
+        assert calls == []
+
+    def test_wrong_token_rejected(self, env):
+        client, _, calls, _ = env
+        resp = client.post(
+            "/api/journal/ingest", json=_payload(),
+            headers={"Authorization": "Bearer wrong"},
+        )
+        assert resp.status_code == 401
+        assert calls == []
+
+    def test_unauthenticated_post_writes_nothing(self, env):
+        client, store, calls, _ = env
+        resp = client.post("/api/journal/ingest", json=_payload())
+        assert resp.status_code == 401
+        assert calls == []
+        assert not store.was_processed("hash:anything")
+
+    def test_auth_runs_before_body_validation(self, env):
+        # Malformed body + no auth must hit the auth gate, never 422 leaking
+        # field-level validation to an unauthenticated caller.
+        client, _, calls, monkeypatch = env
+        monkeypatch.setattr(journal_ingest.settings, "journal_ingest_token", "")
+        resp = client.post("/api/journal/ingest", json={"text": 123})
+        assert resp.status_code == 503
+
+        monkeypatch.setattr(journal_ingest.settings, "journal_ingest_token", "secret-token")
+        resp = client.post("/api/journal/ingest", json={"text": 123})
+        assert resp.status_code == 401
+        assert calls == []
+
+
+class TestCapture:
+    def test_valid_post_captures_exactly_as_typed_fragment(self, env):
+        """Same call the journal Telegram bot makes for a typed message:
+        chat_via_api(text, conversation_id=..., persona=<journal preamble>)."""
+        client, store, calls, _ = env
+        resp = client.post("/api/journal/ingest", json=_payload(text="idea about the deploy gate"), headers=_auth())
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "logged"
+
+        assert len(calls) == 1
+        assert calls[0]["question"] == "idea about the deploy gate"
+        assert calls[0]["persona"] == "JOURNAL PERSONA PREAMBLE"
+
+    def test_action_field_ignored(self, env):
+        """The device's on-device LLM may pick an 'action' — never honored;
+        the fragment sent to the pipeline carries only the text."""
+        client, _, calls, _ = env
+        resp = client.post(
+            "/api/journal/ingest",
+            json=_payload(text="add reminder to call mum", action="create_reminder"),
+            headers=_auth(),
+        )
+        assert resp.status_code == 200
+        assert calls[0]["question"] == "add reminder to call mum"
+
+    def test_conversation_continuity_per_device(self, env):
+        client, _, calls, _ = env
+        client.post("/api/journal/ingest", json=_payload(device_id="ring-A", timestamp="2026-08-23T09:00:00Z", text="first"), headers=_auth())
+        client.post("/api/journal/ingest", json=_payload(device_id="ring-A", timestamp="2026-08-23T09:05:00Z", text="second"), headers=_auth())
+        assert calls[0]["conversation_id"] is None
+        assert calls[1]["conversation_id"] == "conv-1"  # from fake_chat_via_api's fixed return
+
+
+class TestIdempotency:
+    def test_duplicate_payload_logged_once(self, env):
+        client, _, calls, _ = env
+        payload = _payload(text="same fragment twice")
+        r1 = client.post("/api/journal/ingest", json=payload, headers=_auth())
+        r2 = client.post("/api/journal/ingest", json=payload, headers=_auth())
+        assert r1.status_code == 200 and r1.json()["status"] == "logged"
+        assert r2.status_code == 200 and r2.json()["status"] == "duplicate"
+        assert len(calls) == 1
+
+    def test_duplicate_by_derived_key_ignores_incidental_field_order(self, env):
+        # Same device/timestamp/text -> same derived key, even without an id.
+        client, _, calls, _ = env
+        client.post("/api/journal/ingest", json=_payload(text="derived key dedupe"), headers=_auth())
+        r2 = client.post("/api/journal/ingest", json=_payload(text="derived key dedupe"), headers=_auth())
+        assert r2.json()["status"] == "duplicate"
+        assert len(calls) == 1
+
+    def test_explicit_id_preferred_over_derived_key(self, env):
+        # Device-supplied id wins even if timestamp differs slightly (e.g. a
+        # retry that re-stamps "now" on resend) — same id must still collapse.
+        client, _, calls, _ = env
+        client.post(
+            "/api/journal/ingest",
+            json=_payload(id="ring-msg-42", timestamp="2026-08-23T14:37:00Z"),
+            headers=_auth(),
+        )
+        r2 = client.post(
+            "/api/journal/ingest",
+            json=_payload(id="ring-msg-42", timestamp="2026-08-23T14:37:05Z"),
+            headers=_auth(),
+        )
+        assert r2.json()["status"] == "duplicate"
+        assert len(calls) == 1
+
+    def test_different_fragments_both_processed(self, env):
+        client, _, calls, _ = env
+        client.post("/api/journal/ingest", json=_payload(text="fragment one"), headers=_auth())
+        client.post("/api/journal/ingest", json=_payload(text="fragment two", timestamp="2026-08-23T14:38:00Z"), headers=_auth())
+        assert len(calls) == 2
+
+    def test_only_derived_hash_persisted_never_raw_text(self, env):
+        client, store, _, _ = env
+        client.post("/api/journal/ingest", json=_payload(text="a very personal thought"), headers=_auth())
+        conn = __import__("sqlite3").connect(store.db_path)
+        rows = conn.execute("SELECT dedupe_key FROM processed_ingests").fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert "a very personal thought" not in rows[0][0]
+
+    def test_pipeline_failure_not_marked_processed_can_retry(self, env):
+        client, store, calls, monkeypatch = env
+
+        async def failing_chat_via_api(question, conversation_id=None, persona=None):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("api.services.telegram.chat_via_api", failing_chat_via_api)
+        payload = _payload(text="will fail then succeed")
+        resp = client.post("/api/journal/ingest", json=payload, headers=_auth())
+        assert resp.status_code == 502
+
+        async def fake_chat_via_api(question, conversation_id=None, persona=None):
+            calls.append(question)
+            return {"answer": "Logged.", "conversation_id": "conv-2"}
+
+        monkeypatch.setattr("api.services.telegram.chat_via_api", fake_chat_via_api)
+        resp = client.post("/api/journal/ingest", json=payload, headers=_auth())
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "logged"
+        assert calls == ["will fail then succeed"]
+
+
+class TestMalformedPayload:
+    def test_invalid_json_body(self, env):
+        client, _, calls, _ = env
+        resp = client.post(
+            "/api/journal/ingest", content=b"not json",
+            headers={**_auth(), "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert calls == []
+
+    def test_missing_text_rejected(self, env):
+        client, _, calls, _ = env
+        resp = client.post("/api/journal/ingest", json={"device_id": "d1", "timestamp": "2026-08-23T00:00:00Z"}, headers=_auth())
+        assert resp.status_code == 422
+        assert calls == []
+
+    def test_empty_text_rejected(self, env):
+        client, _, calls, _ = env
+        resp = client.post("/api/journal/ingest", json=_payload(text="   "), headers=_auth())
+        assert resp.status_code == 422
+        assert calls == []
+
+    def test_missing_device_id_rejected(self, env):
+        client, _, calls, _ = env
+        resp = client.post("/api/journal/ingest", json={"text": "x", "timestamp": "2026-08-23T00:00:00Z"}, headers=_auth())
+        assert resp.status_code == 422
+        assert calls == []
+
+    def test_missing_timestamp_rejected(self, env):
+        client, _, calls, _ = env
+        resp = client.post("/api/journal/ingest", json={"text": "x", "device_id": "d1"}, headers=_auth())
+        assert resp.status_code == 422
+        assert calls == []
+
+    def test_malformed_timestamp_rejected(self, env):
+        client, _, calls, _ = env
+        resp = client.post("/api/journal/ingest", json=_payload(timestamp="not-a-timestamp"), headers=_auth())
+        assert resp.status_code == 422
+        assert calls == []
+
+    def test_non_object_body_rejected(self, env):
+        client, _, calls, _ = env
+        resp = client.post("/api/journal/ingest", json=["not", "an", "object"], headers=_auth())
+        assert resp.status_code == 422
+        assert calls == []
+
+    def test_malformed_payload_writes_nothing(self, env):
+        client, store, calls, _ = env
+        client.post("/api/journal/ingest", json={"device_id": "d1"}, headers=_auth())
+        assert calls == []
+        import sqlite3
+        conn = sqlite3.connect(store.db_path)
+        count = conn.execute("SELECT COUNT(*) FROM processed_ingests").fetchone()[0]
+        conn.close()
+        assert count == 0
+
+
+class TestPersonaUnconfigured:
+    def test_journal_persona_not_configured_returns_503(self, env):
+        client, _, calls, monkeypatch = env
+        monkeypatch.setattr(type(journal_ingest.settings), "resolve_persona", lambda self, persona_id, surface=None: None)
+        resp = client.post("/api/journal/ingest", json=_payload(), headers=_auth())
+        assert resp.status_code == 503
+        assert calls == []


### PR DESCRIPTION
Closes #660. Builds on #659.

`POST /api/journal/ingest` accepts transcribed text and routes it through the *same* capture path a typed journal fragment takes — no reimplementation, so capture, task/schedule thresholds, and ask-when-unsure behaviour are identical by construction.

- **Auth:** dedicated `LIFEOS_JOURNAL_INGEST_TOKEN`, checked before any body parsing; 503 while unset, 401 on missing/wrong bearer via `hmac.compare_digest`. A separate secret so rotating the ring's token doesn't touch MCP or health ingest. Fails closed if the journal persona isn't configured.
- **Idempotency:** device-supplied `id` when present, else sha256 of `device_id|timestamp|text`. Marked processed only *after* the pipeline succeeds, so a failed call can still be retried; a repeat of a succeeded delivery returns `duplicate` without re-running.
- **Privacy:** fragment text is never logged, and the dedupe store holds only a hash — never content.

The device's on-device-LLM `action` field is accepted and deliberately ignored: the ring is transport, LifeOS is the interpreter, so spoken and typed fragments aren't interpreted by different brains.

The hardware ships March 2026, so the contract is ours; the payload adapter (`_adapt_payload`) is the single function that knows field names and is meant to be replaced once a real webhook is observed.

23 tests. Gate: 3797 passed, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)