### PR TITLE
feat(telegram): persona resolution for the Hermes Telegram path

### DIFF
--- a/api/routes/hermes_proxy.py
+++ b/api/routes/hermes_proxy.py
@@ -18,6 +18,18 @@ only place that happens among the text-backend proxies. The status/
 bearer-injection/streaming-response logic is otherwise shared with the Agent
 backend via `make_backend_router()` in `_proxy.py`.
 
+#644: `POST /api/hermes/resolve-persona`, at the bottom of this module, is a
+second, standalone entry point into the same persona resolution — for
+Hermes's own Telegram front door, which never passes through the proxy above
+(that would couple its Telegram availability to LifeOS being reachable).
+Hermes calls it directly with the raw message text; both entry points share
+`_resolve_lifeos_context()` so persona/voice/turn resolution has exactly one
+implementation. See that section for the request/response contract, the
+`@persona` selection grammar, and (a #644 follow-up) reply-thread persona
+inheritance via `HermesPersonaThreadStore`
+(`api/services/hermes_persona_thread_store.py`) and its companion
+`POST /api/hermes/register-persona-message`.
+
 #642 CROSS-REPO CONTRACT CHANGE: `lifeos_context.persona.orchestrates` can now
 be `true` (previously always `false` — see `_build_envelope`'s comment on that
 field). Its meaning has changed too: no longer "a LifeOS bug leaked an
@@ -32,13 +44,15 @@ and deploying first**; landing this side alone would 500 every doctor turn on
 Hermes rather than run one.
 """
 
+import hmac
 import json
 import logging
+import re
 from typing import Optional
 
 import httpx
-from fastapi import HTTPException
-from pydantic import ValidationError
+from fastapi import HTTPException, Request
+from pydantic import BaseModel, ValidationError
 
 # Imported (not just re-exported through _proxy.py) so tests can monkeypatch
 # `hermes_proxy.settings.hermes_backend_url` / `hermes_backend_token` directly —
@@ -51,6 +65,7 @@ from api.routes.chat import AskStreamRequest
 from api.services.agent_system_prompt import build_turn_context
 from api.services.chat_turns import TRUNCATION_MARKER, get_turn_registry, truncation_routing
 from api.services.conversation_store import get_store
+from api.services.hermes_persona_thread_store import get_persona_thread_store
 from api.services.usage_store import get_usage_store
 
 logger = logging.getLogger(__name__)
@@ -92,33 +107,31 @@ def _resolve_caller_session_id(conversation_id: Optional[str]) -> str:
     return resolve_hermes_caller_session_id(SessionStore(), conversation_id)
 
 
-def _build_envelope(raw_body: bytes) -> bytes:
-    """Attach `lifeos_context` to the forwarded body, resolving the persona.
+def _resolve_lifeos_context(
+    persona_id: str, *, modality: str, conversation_id: Optional[str], apply_voice_rules: bool,
+) -> dict:
+    """Resolve one persona id into the `lifeos_context` envelope's contents.
 
-    Runs before the request reaches httpx, so a malformed body or a bad
-    persona is a clean 400 — mirroring the ordering `ask_stream` in
-    `api/routes/chat.py` uses for the native path (resolve persona before the
-    stream opens). Every field the browser sent is preserved untouched; this
-    adds exactly one top-level key.
+    This is the ONE place persona/voice/turn-context resolution happens for
+    Hermes (#644's AC: "Persona resolution shall have exactly one source of
+    truth") — extracted out of `_build_envelope` (the `/api/hermes/ask/stream`
+    proxy, browser/voice-selected persona) so `resolve_persona_from_text`
+    below (the Hermes-Telegram `@tag` path) can share it verbatim instead of
+    re-implementing preamble/voice/label/turn lookups a second time. Purely
+    extracted — every line below is unchanged from `_build_envelope`'s
+    previous inline body, so the existing proxy path's behavior is untouched.
+
+    `apply_voice_rules` is passed in rather than derived from `modality` here
+    because the two callers gate it differently: `_build_envelope` mirrors
+    `ask_stream`'s `modality == "voice" and request.persona_id` gate (a voice
+    turn that omitted persona_id and fell back to "primary" gets no voice
+    rules, even if primary's file defines some); `resolve_persona_from_text`
+    only ever calls this with an explicitly-tagged persona_id, so for it
+    `apply_voice_rules` is simply `modality == "voice"`.
+
+    Raises `HTTPException(400)` for an unknown `persona_id` — the same
+    contract `_build_envelope` documented inline before this extraction.
     """
-    try:
-        data = json.loads(raw_body)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        raise HTTPException(status_code=400, detail=f"Invalid JSON body: {exc}")
-    if not isinstance(data, dict):
-        raise HTTPException(status_code=400, detail="Request body must be a JSON object")
-
-    # Reuse the native request model's validation (attachment size/type caps,
-    # persona length bound) rather than reimplementing it — see AskStreamRequest
-    # in api/routes/chat.py.
-    try:
-        parsed = AskStreamRequest.model_validate(data)
-    except ValidationError as exc:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {exc}")
-
-    # Same registry-backed resolution the native /api/ask/stream uses, and the
-    # same default-to-primary behavior when no persona_id is sent.
-    persona_id = parsed.persona_id or "primary"
     # surface="hermes" (#642): an orchestrating persona (e.g. doctor) has a
     # Hermes-specific preamble (config/personas/doctor.hermes.md, #641)
     # describing a Claude Code worker driven via lifeos_agent_spawn, not the
@@ -137,17 +150,7 @@ def _build_envelope(raw_body: bytes) -> bytes:
     # the surface-specific preamble resolved above is what actually tells it
     # to spawn and supervise a worker instead of answering inline.
 
-    # Spoken-style rules apply only on voice turns, matching the exact gate
-    # ask_stream() uses in api/routes/chat.py: `modality == "voice" and
-    # request.persona_id`. Gating on the *raw* parsed.persona_id (not the
-    # primary-defaulted `persona_id` above) matters: a voice turn that omits
-    # persona_id entirely gets no voice rules natively, even though primary's
-    # own persona file could define some — mirror that rather than inventing
-    # a rule for the omitted-persona case.
-    modality = "voice" if (parsed.modality or "").strip().lower() == "voice" else "text"
-    voice_rules = (
-        list(settings.persona_voice(persona_id)) if modality == "voice" and parsed.persona_id else []
-    )
+    voice_rules = list(settings.persona_voice(persona_id)) if apply_voice_rules else []
 
     # No fallback: list_http_personas() draws "primary" plus every entry in
     # the same settings.telegram_bots registry resolve_persona() just matched
@@ -155,7 +158,7 @@ def _build_envelope(raw_body: bytes) -> bytes:
     # that already passed validation.
     label = next(p.label for p in settings.list_http_personas() if p.id == persona_id)
 
-    turn = build_turn_context(persona_id, parsed.conversation_id)
+    turn = build_turn_context(persona_id, conversation_id)
     # `caller_session_id` (#640) is added here, on the envelope's copy of
     # `turn`, rather than folded into `build_turn_context()` itself —
     # that function is shared with the plain `GET /api/chat/turn-context`
@@ -168,9 +171,9 @@ def _build_envelope(raw_body: bytes) -> bytes:
     # request. Additive at schema_version 1 (no version bump): a consumer
     # that doesn't know this key ignores it exactly as it would any other
     # unrecognized field.
-    turn["caller_session_id"] = _resolve_caller_session_id(parsed.conversation_id)
+    turn["caller_session_id"] = _resolve_caller_session_id(conversation_id)
 
-    data["lifeos_context"] = {
+    return {
         "schema_version": 1,
         "modality": modality,
         "persona": {
@@ -205,6 +208,51 @@ def _build_envelope(raw_body: bytes) -> bytes:
         # default to "primary"), so that reverse lookup doesn't apply here.
         "turn": turn,
     }
+
+
+def _build_envelope(raw_body: bytes) -> bytes:
+    """Attach `lifeos_context` to the forwarded body, resolving the persona.
+
+    Runs before the request reaches httpx, so a malformed body or a bad
+    persona is a clean 400 — mirroring the ordering `ask_stream` in
+    `api/routes/chat.py` uses for the native path (resolve persona before the
+    stream opens). Every field the browser sent is preserved untouched; this
+    adds exactly one top-level key.
+    """
+    try:
+        data = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON body: {exc}")
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+
+    # Reuse the native request model's validation (attachment size/type caps,
+    # persona length bound) rather than reimplementing it — see AskStreamRequest
+    # in api/routes/chat.py.
+    try:
+        parsed = AskStreamRequest.model_validate(data)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid request: {exc}")
+
+    # Same registry-backed resolution the native /api/ask/stream uses, and the
+    # same default-to-primary behavior when no persona_id is sent.
+    persona_id = parsed.persona_id or "primary"
+    modality = "voice" if (parsed.modality or "").strip().lower() == "voice" else "text"
+    # Spoken-style rules apply only on voice turns, matching the exact gate
+    # ask_stream() uses in api/routes/chat.py: `modality == "voice" and
+    # request.persona_id`. Gating on the *raw* parsed.persona_id (not the
+    # primary-defaulted `persona_id` above) matters: a voice turn that omits
+    # persona_id entirely gets no voice rules natively, even though primary's
+    # own persona file could define some — mirror that rather than inventing
+    # a rule for the omitted-persona case.
+    apply_voice_rules = modality == "voice" and bool(parsed.persona_id)
+
+    data["lifeos_context"] = _resolve_lifeos_context(
+        persona_id,
+        modality=modality,
+        conversation_id=parsed.conversation_id,
+        apply_voice_rules=apply_voice_rules,
+    )
     return json.dumps(data).encode("utf-8")
 
 
@@ -492,3 +540,237 @@ router = make_backend_router(
     transform_body=_build_envelope,
     make_observer=_make_persister,
 )
+
+
+# ---------------------------------------------------------------------------
+# `POST /api/hermes/resolve-persona` (#644) — persona selection for Hermes's
+# own Telegram front door, which never passes through the proxy above (that
+# would couple its availability to LifeOS being up — see #658/#644's "two
+# decisions already made"). Hermes instead calls this endpoint directly with
+# the raw message text; the response tells it which persona (if any) was
+# selected, the text with the selector stripped, and the same
+# `lifeos_context` envelope `_build_envelope` above would attach for that
+# persona — computed by the SAME `_resolve_lifeos_context` helper, so this
+# and the proxy path can never resolve a persona differently.
+#
+# Resolution is an ORDERED rule, not a single check (#644 follow-up — reply-
+# thread persona inheritance):
+#   1. An explicit `@persona` prefix on this message wins, always — even
+#      inside an existing persona thread, so replying with a new tag switches
+#      personas mid-thread.
+#   2. Else, if this message is a reply (Telegram's native reply-to) to a
+#      message whose persona is known, inherit it.
+#   3. Else, no persona — byte-identical to today.
+# The mapping behind rule 2 (`HermesPersonaThreadStore`,
+# api/services/hermes_persona_thread_store.py) is the one place that state
+# lives, deliberately on the LifeOS side: putting it in Hermes would make
+# persona resolution two-sourced again. `POST /api/hermes/register-persona-
+# message`, below `resolve_persona_from_text`, is how Hermes anchors its OWN
+# reply's message id to the same persona — needed because that id isn't
+# known until after Hermes has already sent the reply to Telegram, which is
+# necessarily after this endpoint already returned.
+# ---------------------------------------------------------------------------
+
+# Selection mechanism (Nathan's decision, documented in
+# docs/specs/technical/client-surfaces.md): a per-message `@name` prefix, no
+# persisted state — every message is judged independently. A tag is
+# recognized only when it opens the message, the character right after `@`
+# is a letter, and it's immediately followed by whitespace or the end of the
+# message. Every configured persona id is `[a-z0-9_-]+` and, in practice,
+# always letter-led (`_BOT_NAME_RE` in config/settings.py permits more, but
+# no persona is actually named e.g. "123") — requiring a leading letter is a
+# deliberate heuristic, not a hard technical constraint, chosen so an
+# ordinary message that merely *starts* with `@` (a bare "@", "@3pm meeting",
+# "@ what's up") is never mistaken for a tag attempt. Punctuation glued
+# directly onto the tag (`@doctor,`) is likewise not recognized — the
+# grammar matches the one documented form (`@doctor <message>`) rather than
+# guessing at variants.
+_PERSONA_TAG_RE = re.compile(r"^@([A-Za-z][A-Za-z0-9_-]*)(?:\s+(.*))?$", re.DOTALL)
+
+
+def _parse_persona_tag(text: str) -> tuple[Optional[str], str]:
+    """Split a raw Hermes-Telegram message into an optional persona tag
+    (lowercased) and the remaining text — see the prefix-grammar comment
+    above `_PERSONA_TAG_RE`.
+
+    Returns `(None, text)` unchanged when no tag-shaped prefix is present.
+    A tag-shaped prefix that doesn't match any *configured* persona is still
+    returned here (lowercased, not discarded) — `resolve_persona_from_text`
+    below is responsible for treating that as a deliberate error rather than
+    silently falling back to "no persona selected", which would make a typo
+    indistinguishable from working.
+    """
+    match = _PERSONA_TAG_RE.match(text)
+    if not match:
+        return None, text
+    tag = match.group(1).lower()
+    remainder = (match.group(2) or "").strip()
+    return tag, remainder
+
+
+class HermesPersonaResolveRequest(BaseModel):
+    """Body for `POST /api/hermes/resolve-persona` — a raw, not-yet-split
+    Hermes-Telegram message. `text` stands in for `AskStreamRequest.question`:
+    no question is being answered here, only a persona (if any) resolved.
+
+    `chat_id`/`message_id`/`reply_to_message_id` are opaque string ids
+    (Hermes stringifies Telegram's integer ids the same way `conversation_id`
+    is already an opaque string elsewhere on this contract) used only for
+    reply-thread persona inheritance (#644 follow-up):
+    - `reply_to_message_id`, when this message is a Telegram reply, is looked
+      up in `HermesPersonaThreadStore` (scoped to `chat_id`) to inherit a
+      persona when this message carries no explicit `@tag` of its own.
+    - `chat_id` + `message_id` (THIS message's own id) are where the
+      resolved persona, if any, gets recorded — so a later reply to *this*
+      message can itself inherit. All three are optional: omitting them
+      degrades to the base (non-threaded) contract, tag or nothing.
+    """
+    text: str
+    modality: Optional[str] = None
+    conversation_id: Optional[str] = None
+    chat_id: Optional[str] = None
+    message_id: Optional[str] = None
+    reply_to_message_id: Optional[str] = None
+
+
+def _check_hermes_inbound_auth(request: Request) -> None:
+    """Bearer-token gate for the inbound Hermes-to-LifeOS direction, shared
+    by `/resolve-persona` and `/register-persona-message`.
+
+    Reuses `hermes_backend_token` — the same shared secret already
+    authenticating the outbound LifeOS-to-Hermes call `_build_envelope`'s
+    proxy makes — rather than inventing a second Hermes-specific token for
+    the reverse direction. Disabled (503) until a token is configured,
+    mirroring `api/routes/fitness.py`'s `_check_ingest_auth`: a fresh clone
+    has these endpoints closed until an operator deliberately sets one, since
+    unlike the outbound direction (where an empty token just means "send no
+    auth to a backend I trust"), an empty token here would mean "accept
+    unauthenticated input from the network."
+    """
+    expected = settings.hermes_backend_token
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="Hermes persona resolution disabled: set LIFEOS_HERMES_BACKEND_TOKEN to enable.",
+        )
+    header = request.headers.get("authorization", "")
+    scheme, _, token = header.partition(" ")
+    token = token.strip()
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    if not hmac.compare_digest(token, expected):
+        raise HTTPException(status_code=401, detail="invalid bearer token")
+
+
+@router.post("/resolve-persona")
+async def resolve_persona_from_text(request: Request):
+    """Resolve a Hermes-Telegram message's persona: explicit `@tag` first,
+    then reply-thread inheritance, then nothing — see the ordered-rule
+    comment above this section.
+
+    Response shape: `{"persona_id": str | None, "text": str, "lifeos_context":
+    dict | None}`. Neither a tag nor an inheritable reply -> `persona_id`/
+    `lifeos_context` are both `None` and `text` is returned byte-identical to
+    the input `text` field — Hermes's untagged path needs nothing from this
+    endpoint and should behave exactly as it did before this endpoint
+    existed. A resolved persona (tag or inherited) resolves `lifeos_context`
+    via `_resolve_lifeos_context` (the same helper `_build_envelope` uses for
+    `/api/hermes/ask/stream`); a tag also strips itself from `text`, while an
+    inherited persona leaves `text` untouched (there was no prefix to strip).
+    An `@`-prefixed token that isn't a known persona id is a 400, not a
+    silent fall-through to "no persona" — a typo must not look like it
+    worked. An unknown or expired `reply_to_message_id` is NOT an error —
+    silently falls through to "no persona", the same as a thread that
+    started before this feature existed.
+    """
+    _check_hermes_inbound_auth(request)
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+    try:
+        parsed = HermesPersonaResolveRequest.model_validate(body)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid request: {exc}")
+
+    tag, remainder = _parse_persona_tag(parsed.text)
+    if tag is not None:
+        # Rule 1: an explicit tag always wins, even over an inheritable
+        # reply — this is how a thread switches personas mid-stream.
+        persona_id = tag
+        resolved_text = remainder
+    elif parsed.reply_to_message_id and parsed.chat_id:
+        # Rule 2: inherit the replied-to message's persona, if LifeOS still
+        # has it on record. A miss (unknown id, expired, cross-chat, or a
+        # thread from before this feature shipped) is not an error — it's
+        # rule 3, indistinguishable from "no tag at all".
+        persona_id = get_persona_thread_store().lookup(parsed.chat_id, parsed.reply_to_message_id)
+        resolved_text = parsed.text
+    else:
+        persona_id = None
+        resolved_text = parsed.text
+
+    if persona_id is None:
+        # Rule 3.
+        return {"persona_id": None, "text": parsed.text, "lifeos_context": None}
+
+    modality = "voice" if (parsed.modality or "").strip().lower() == "voice" else "text"
+    # A resolved persona — tag or inherited — is always the "chose a
+    # persona" case for this endpoint, unlike `_build_envelope`'s
+    # default-to-primary path, so there's no "omitted persona_id" ambiguity
+    # to gate voice_rules on here.
+    context = _resolve_lifeos_context(
+        persona_id, modality=modality, conversation_id=parsed.conversation_id, apply_voice_rules=(modality == "voice"),
+    )
+
+    # Anchor THIS message under its resolved persona too, so a later reply to
+    # it — whether it arrived via an explicit tag or by inheriting one —
+    # itself becomes a valid inheritance target. This is what makes a
+    # reply-to-a-reply chain inherit transitively with no special case: every
+    # link records itself the same way.
+    if parsed.chat_id and parsed.message_id:
+        get_persona_thread_store().record(parsed.chat_id, parsed.message_id, persona_id)
+
+    return {"persona_id": persona_id, "text": resolved_text, "lifeos_context": context}
+
+
+class HermesRegisterPersonaMessageRequest(BaseModel):
+    """Body for `POST /api/hermes/register-persona-message` — anchors a
+    message Hermes itself authored (its reply to a resolved persona turn) to
+    that persona, so a later reply threaded off the BOT's message inherits
+    too, not just one threaded off the user's original tagged message.
+
+    Needed as a second call, after the fact: the bot reply's own message id
+    isn't known until Telegram has accepted it, which is necessarily after
+    `/resolve-persona` already returned.
+    """
+    chat_id: str
+    message_id: str
+    persona_id: str
+
+
+@router.post("/register-persona-message")
+async def register_persona_message(request: Request):
+    """Anchor a Hermes-authored message id to the persona it was sent under.
+
+    `persona_id` must be a currently-configured persona (the same check
+    `_resolve_lifeos_context` applies) — defense in depth against a stale or
+    malformed id polluting the thread table, even though in practice Hermes
+    only ever passes back an id this same service handed it moments earlier
+    from `/resolve-persona`.
+    """
+    _check_hermes_inbound_auth(request)
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+    try:
+        parsed = HermesRegisterPersonaMessageRequest.model_validate(body)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid request: {exc}")
+
+    if settings.resolve_persona(parsed.persona_id, surface="hermes") is None:
+        raise HTTPException(status_code=400, detail=f"Unknown persona_id: {parsed.persona_id!r}")
+
+    get_persona_thread_store().record(parsed.chat_id, parsed.message_id, parsed.persona_id)
+    return {"ok": True}

--- a/api/services/hermes_persona_thread_store.py
+++ b/api/services/hermes_persona_thread_store.py
@@ -1,0 +1,142 @@
+"""Reply-thread persona inheritance for Hermes-Telegram (#644 follow-up).
+
+Threading a reply (Telegram's native reply-to) inherits the persona of the
+message being replied to, without re-tagging. That needs a small amount of
+state — a `(chat_id, message_id) -> persona_id` mapping — and it has to live
+on the LifeOS side: putting it in Hermes would make persona resolution
+two-sourced again, which the #644 AC forbids.
+
+Design choices:
+- **No message content, ever.** Only the id -> persona mapping is stored —
+  these are personal Telegram messages and their text has no business in a
+  routing table.
+- **Scoped per chat.** Telegram message ids are unique only within a chat,
+  so the primary key is `(chat_id, message_id)`, never a bare message id.
+- **Bounded, not unbounded.** Rows expire after `_TTL_SECONDS` and the table
+  is capped at `_MAX_ROWS`, oldest first — both enforced opportunistically on
+  every `record()` rather than via a separate cron, since write volume here
+  (one row per Hermes-Telegram turn) is low. An expired or evicted row is
+  never an error for the reader: `lookup()` returns `None` exactly as it
+  would for an id it never saw, and the caller (hermes_proxy.py) treats that
+  as "no inheritance, fall through to no persona" — the same safe default a
+  thread that predates this feature gets.
+- **Persisted, not in-memory.** Unlike `SessionToolResultCache` (in-process,
+  cache-shaped), this needs to survive an API restart — this host redeploys
+  automatically within ~10 minutes of `main` advancing, and a Hermes-Telegram
+  thread can easily go longer than that between replies. An in-memory table
+  would silently reset the mapping on every deploy; sqlite (mirroring
+  `UsageStore`/`ConversationStore`) doesn't.
+- **Every resolved message is recorded, not just tagged ones.** Whether a
+  turn's persona came from an explicit `@tag` or from inheriting its own
+  reply-to, `hermes_proxy.py` records THIS message's id under that persona
+  too — that's what makes a reply-to-a-reply chain inherit transitively
+  without a special case: each link in the chain becomes a valid anchor for
+  the next.
+"""
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+from config.settings import settings
+
+# A Hermes-Telegram persona thread is a conversational thread, not a
+# long-lived relationship — a week comfortably covers "picked back up a
+# few days later" while still bounding the table for an install that's
+# been running for months.
+_TTL_SECONDS = 7 * 24 * 3600
+
+# Cheap upper bound on table size regardless of traffic; oldest rows are
+# evicted first once this is exceeded; generous by real Telegram-turn volume.
+_MAX_ROWS = 20_000
+
+
+class HermesPersonaThreadStore:
+    """SQLite-backed `(chat_id, message_id) -> persona_id` mapping."""
+
+    def __init__(self, db_path: str = None):
+        if db_path is None:
+            db_path = str(Path(settings.chroma_path).parent / "hermes_persona_threads.db")
+        self.db_path = db_path
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS persona_threads (
+                    chat_id TEXT NOT NULL,
+                    message_id TEXT NOT NULL,
+                    persona_id TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    PRIMARY KEY (chat_id, message_id)
+                )
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_persona_threads_created_at
+                ON persona_threads(created_at)
+            """)
+
+    def record(self, chat_id: str, message_id: str, persona_id: str) -> None:
+        """Anchor `message_id` (within `chat_id`) to `persona_id`, so a later
+        reply to it can inherit. Idempotent — re-recording the same id just
+        refreshes its timestamp (extends its TTL), which matters for a
+        message that gets threaded off more than once.
+
+        Prunes expired and (if still over `_MAX_ROWS`) oldest rows on every
+        call — see the module docstring for why this is opportunistic rather
+        than a separate sweep.
+        """
+        now = time.time()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO persona_threads (chat_id, message_id, persona_id, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (chat_id, message_id)
+                DO UPDATE SET persona_id = excluded.persona_id, created_at = excluded.created_at
+                """,
+                (chat_id, message_id, persona_id, now),
+            )
+            conn.execute(
+                "DELETE FROM persona_threads WHERE created_at < ?", (now - _TTL_SECONDS,),
+            )
+            (row_count,) = conn.execute("SELECT COUNT(*) FROM persona_threads").fetchone()
+            if row_count > _MAX_ROWS:
+                conn.execute(
+                    """
+                    DELETE FROM persona_threads WHERE rowid IN (
+                        SELECT rowid FROM persona_threads
+                        ORDER BY created_at ASC LIMIT ?
+                    )
+                    """,
+                    (row_count - _MAX_ROWS,),
+                )
+
+    def lookup(self, chat_id: str, message_id: str) -> Optional[str]:
+        """The persona anchored to `message_id` in `chat_id`, or `None` if
+        it was never recorded, has expired, or belongs to a different chat.
+        Never raises — an unknown id is exactly as valid a result as an
+        expired one, both meaning "no inheritance" to the caller."""
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT persona_id, created_at FROM persona_threads WHERE chat_id = ? AND message_id = ?",
+                (chat_id, message_id),
+            ).fetchone()
+        if row is None:
+            return None
+        persona_id, created_at = row
+        if created_at < time.time() - _TTL_SECONDS:
+            return None
+        return persona_id
+
+
+_persona_thread_store: Optional[HermesPersonaThreadStore] = None
+
+
+def get_persona_thread_store() -> HermesPersonaThreadStore:
+    global _persona_thread_store
+    if _persona_thread_store is None:
+        _persona_thread_store = HermesPersonaThreadStore()
+    return _persona_thread_store

--- a/config/settings.py
+++ b/config/settings.py
@@ -202,7 +202,10 @@ class Settings(BaseSettings):
     hermes_backend_token: str = Field(
         default="",
         alias="LIFEOS_HERMES_BACKEND_TOKEN",
-        description="Optional bearer token for the Hermes text backend"
+        description="Bearer token shared with Hermes. Sent by LifeOS on outbound calls to "
+                    "the Hermes text backend (optional there — Hermes may not require one), "
+                    "and required from Hermes on inbound calls to "
+                    "POST /api/hermes/resolve-persona (#644) — empty disables that endpoint."
     )
 
     # Bounded lifetime for a chat turn that has detached from its client (#611):

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -188,7 +188,69 @@ The native orchestrator (`POST /api/ask/stream`, documented above and in [api-re
 
 ### Hermes
 
-`hermes` is an agent harness reached as a gateway (#587), at `LIFEOS_HERMES_BACKEND_URL` (optional bearer token), proxied at `POST /api/hermes/ask/stream` with the same server-side bearer injection and a `GET /api/hermes/status` availability check. Both proxies are built by the same `make_backend_router()` factory in `api/routes/_proxy.py`; `agent_proxy.py` and `hermes_proxy.py` each just name their own settings fields and `_client()` test seam. Hermes has **no handoff** either — but unlike Agent, it keeps the persona picker visible, carries spoken-style rules on voice turns, receives the orchestrator's auto-injected turn context, and its history **is** LifeOS-owned. Its route (`api/routes/hermes_proxy.py`) buffers the request body (`transform_body`) to resolve the selected persona and attach it as the `lifeos_context` envelope below — the only text-backend proxy that does. **Orchestrating personas reach this route like any other, since #642** — resolved with `surface="hermes"` so a persona with a Hermes-specific variant (`config/personas/doctor.hermes.md`, #641) gets that body instead of the plain one; see "Orchestrating personas on Hermes vs. LifeOS" in the Persona contract above for what changed and why, and the envelope section below for the `orchestrates` field's revised contract.
+`hermes` is an agent harness reached as a gateway (#587), at `LIFEOS_HERMES_BACKEND_URL` (optional bearer token), proxied at `POST /api/hermes/ask/stream` with the same server-side bearer injection and a `GET /api/hermes/status` availability check. Both proxies are built by the same `make_backend_router()` factory in `api/routes/_proxy.py`; `agent_proxy.py` and `hermes_proxy.py` each just name their own settings fields and `_client()` test seam. Hermes has **no handoff** either — but unlike Agent, it keeps the persona picker visible, carries spoken-style rules on voice turns, receives the orchestrator's auto-injected turn context, and its history **is** LifeOS-owned. Its route (`api/routes/hermes_proxy.py`) buffers the request body (`transform_body`) to resolve the selected persona and attach it as the `lifeos_context` envelope below — the only text-backend proxy that does. **Orchestrating personas reach this route like any other, since #642** — resolved with `surface="hermes"` so a persona with a Hermes-specific variant (`config/personas/doctor.hermes.md`, #641) gets that body instead of the plain one; see "Orchestrating personas on Hermes vs. LifeOS" in the Persona contract above for what changed and why, and the envelope section below for the `orchestrates` field's revised contract. **This section describes `/chat`'s Hermes backend specifically — Hermes's own Telegram front door is a separate integration, covered in "Hermes-Telegram persona selection (#644)" below.**
+
+#### Hermes-Telegram persona selection (#644)
+
+The `/api/hermes/ask/stream` proxy above only ever sees a turn that `/chat` (browser or the voice gateway) already sent to LifeOS. Hermes's **own** Telegram bot is a separate front door — Hermes's own `state/config.yaml`, no LifeOS involvement — and until #644 it received no persona context at all, so asking it to "act as the doctor persona" was prompt-level roleplay with no real preamble, voice rules, or turn context behind it.
+
+**Direction (decided, not re-open-able): Hermes fetches persona context *from* LifeOS; it is not proxied.** The Hermes-Telegram path does **not** route through `/api/hermes/ask/stream` — that would couple its availability to LifeOS being reachable, which #658's accepted criteria require it to survive without. Instead, Hermes calls a dedicated resolution endpoint, `POST /api/hermes/resolve-persona`, before it ever talks to its own backend LLM, and folds the response into its own request the way it sees fit.
+
+**Selection mechanism (Nathan's decision): a per-message `@name` prefix, plus reply-thread inheritance.** Resolution is an ordered rule, not a single check:
+
+1. An explicit `@persona` prefix on this message wins, always — even inside an existing persona thread, so replying with a new tag switches personas mid-thread.
+2. Else, if this message is a Telegram native reply to a message whose persona is known, inherit it — no re-tagging needed to keep talking to the same persona.
+3. Else, no persona — byte-identical to today.
+
+There is still no `/persona` command and no per-chat setting: a message with neither a tag of its own nor an inheritable reply-to is evaluated exactly as if this feature didn't exist. The prefix grammar itself lives in LifeOS (`_parse_persona_tag()` in `api/routes/hermes_proxy.py`), not in Hermes — Hermes stays a transport, sending the **raw, unparsed** message text and letting LifeOS decide what's a tag: a tag is recognized only when it opens the message, the character right after `@` is a letter, and it's immediately followed by whitespace or the end of the message. This is deliberately narrower than "starts with `@`" — a bare `@`, `@3pm meeting`, or `@doctor,` (punctuation glued to the tag) are not tag attempts, since no persona id is digit-led and the one supported form is `@name <message>`.
+
+**Reply-thread inheritance needs a small amount of state, and it lives on the LifeOS side, not Hermes's.** Putting a message-id → persona mapping in Hermes would make persona resolution two-sourced again, which the AC forbids. `HermesPersonaThreadStore` (`api/services/hermes_persona_thread_store.py`) is a `(chat_id, message_id) -> persona_id` table — nothing else, no message content — scoped per chat (Telegram message ids are unique only within a chat) and bounded: rows expire after 7 days and the table is capped at 20,000 rows, oldest evicted first. Every message this endpoint resolves a persona for — whether from an explicit tag or an inherited one — is itself recorded under that persona, which is what makes a reply-to-a-reply chain inherit transitively with no special case: each link becomes a valid anchor for the next.
+
+**Endpoint contract — `POST /api/hermes/resolve-persona`:**
+
+```json
+// Request
+{
+  "text": "@doctor the sync timer looks wedged",
+  "modality": "text",
+  "conversation_id": "...",
+  "chat_id": "12345",
+  "message_id": "987",
+  "reply_to_message_id": "986"
+}
+
+// Response (tag recognized, or inherited from reply_to_message_id)
+{
+  "persona_id": "doctor",
+  "text": "the sync timer looks wedged",
+  "lifeos_context": { "schema_version": 1, "modality": "text", "persona": { "...": "..." }, "turn": { "...": "..." } }
+}
+
+// Response (no tag, and no inheritable reply) — for a request of { "text": "what's on my calendar today" }
+{ "persona_id": null, "text": "what's on my calendar today", "lifeos_context": null }
+```
+
+`modality`/`conversation_id` are optional, mirroring the same fields on `/api/hermes/ask/stream`. `chat_id`/`message_id`/`reply_to_message_id` are opaque strings (Hermes stringifies Telegram's integer ids, the same convention `conversation_id` already uses) and are also optional — omitting all three degrades to the base, non-threaded contract (tag or nothing). `lifeos_context` — when present — is byte-for-byte the same shape the envelope section below documents, built by the identical `_resolve_lifeos_context()` helper both entry points share (the AC's "persona resolution shall have exactly one source of truth"): the resolved preamble for a resolved persona (tagged or inherited) is guaranteed identical to what `/chat` would use for that same persona.
+
+- **No tag and no inheritable reply → unchanged from today, by construction.** `persona_id` and `lifeos_context` are both `null`, and `text` is returned exactly as sent. Hermes needs nothing from this response in that case and should proceed exactly as it did before this endpoint existed — no LifeOS-derived preamble, no envelope, no dependency on LifeOS being reachable.
+- **An unrecognized `@tag` is a 400, not a silent no-persona.** `@nonsense do a thing` matches the tag grammar (starts with a letter, ends at whitespace) but doesn't match any configured persona id — this is rejected with `400 Unknown persona_id: 'nonsense'` rather than falling back to `persona_id: null`. Deliberately: a typo that silently became "no persona selected" would look like it worked, when the user's actual intent (routing to a specific persona) was dropped on the floor.
+- **An unrecognized or expired `reply_to_message_id` is NOT an error.** A miss (never recorded, expired, cross-chat, or a thread that predates this feature) falls through to rule 3 exactly as if no `reply_to_message_id` had been sent at all — a pruned mapping degrading safely is the whole point of bounding it.
+- **Voice applies the same gate `/chat` uses.** `modality: "voice"` on a resolved persona populates `persona.voice_rules` exactly as a voice turn on `/api/hermes/ask/stream` would for the same persona_id — see the envelope section below.
+- **Auth reuses the existing Hermes bearer, in the reverse direction.** `hermes_backend_token` (`LIFEOS_HERMES_BACKEND_TOKEN`) already authenticates LifeOS's outbound calls *to* Hermes; this endpoint requires the same token on Hermes's inbound calls *to* LifeOS (`Authorization: Bearer <token>`, checked with a constant-time compare) rather than introducing a second shared secret. An unset token disables the endpoint (`503`), matching the closed-by-default posture `api/routes/fitness.py`'s health-ingest endpoint uses for the same reason: this accepts input from the network, so a fresh clone must not expose it unauthenticated.
+
+**Endpoint contract — `POST /api/hermes/register-persona-message`:** anchors a message Hermes itself authored — its reply, sent under a resolved persona — to that persona, so a later reply threaded off the **bot's** message inherits too, not just one threaded off the user's original tagged message. This has to be a second call, after the fact: the bot's reply doesn't have a message id until Telegram has accepted it, which is necessarily after `/resolve-persona` already returned.
+
+```json
+// Request
+{ "chat_id": "12345", "message_id": "988", "persona_id": "doctor" }
+
+// Response
+{ "ok": true }
+```
+
+Same auth as `/resolve-persona`. `persona_id` must be a currently-configured persona (`400` otherwise) — defense in depth, since in practice Hermes only ever passes back an id this same service handed it moments earlier.
+
+**The honest boundary of "independent of LifeOS":** a Telegram message that needs LifeOS to resolve its persona — whether via an explicit `@tag` or by inheriting one from its reply-to — genuinely needs LifeOS reachable, while a message with neither does not and behaves exactly as if #644 had never shipped. #658's "keeps working when LifeOS is down" guarantee therefore applies only to that untagged, non-inheriting path; a persona-tagged or persona-inheriting message during a LifeOS outage should fail (or fall back to no-persona) rather than silently pretend to apply a preamble it couldn't fetch — that failure mode is Hermes's call to make, not LifeOS's, since Hermes owns what happens when either endpoint above is unreachable.
 
 #### Hermes turn persistence (#592, survives disconnect since #611) and usage capture (#595)
 
@@ -354,4 +416,5 @@ Since #592, `restoreBackendConversation()` renders the stored conversation on a 
 - [Conversations route](../../api/routes/conversations.py) — List/detail handlers
 - [Proxy factory](../../api/routes/_proxy.py) — Shared status/ask-stream plumbing for the Agent and Hermes backends
 - [Agent proxy](../../api/routes/agent_proxy.py) — Agent text-backend routes
-- [Hermes proxy](../../api/routes/hermes_proxy.py) — Hermes text-backend routes, `lifeos_context` envelope, turn persistence
+- [Hermes proxy](../../api/routes/hermes_proxy.py) — Hermes text-backend routes, `lifeos_context` envelope, turn persistence, and `POST /api/hermes/resolve-persona` / `POST /api/hermes/register-persona-message` (#644, Hermes-Telegram persona selection + reply-thread inheritance)
+- [Hermes persona thread store](../../api/services/hermes_persona_thread_store.py) — the `(chat_id, message_id) -> persona_id` mapping behind reply-thread inheritance (#644 follow-up)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,6 +393,26 @@ def _isolate_usage_store_db(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_hermes_persona_thread_store_db(tmp_path, monkeypatch):
+    """Stop tests from opening (and writing to) the production Hermes-
+    Telegram reply-thread persona mapping (#644 follow-up).
+
+    ``HermesPersonaThreadStore`` is a process-wide singleton
+    (``get_persona_thread_store()``) keyed off ``settings.chroma_path`` —
+    the real ``data/hermes_persona_threads.db`` on whatever machine runs the
+    suite. Redirect the shared singleton itself to a per-test tmp instance,
+    mirroring ``_isolate_usage_store_db`` above.
+    """
+    import api.services.hermes_persona_thread_store as thread_store_mod
+
+    monkeypatch.setattr(
+        thread_store_mod,
+        "_persona_thread_store",
+        thread_store_mod.HermesPersonaThreadStore(str(tmp_path / "hermes_persona_threads.db")),
+    )
+
+
+@pytest.fixture(autouse=True)
 def _isolate_session_store_db(tmp_path, monkeypatch):
     """Stop tests from opening (and writing to) the production agent-session
     store (#652).

--- a/tests/test_hermes_persona_thread_store.py
+++ b/tests/test_hermes_persona_thread_store.py
@@ -1,0 +1,111 @@
+"""Tests for the Hermes-Telegram reply-thread persona mapping
+(api/services/hermes_persona_thread_store.py, #644 follow-up).
+
+Endpoint-level behavior (resolution order, the register-persona-message
+call) lives in tests/test_hermes_proxy.py; this file covers the store in
+isolation: per-chat scoping, TTL expiry, and the row cap.
+"""
+import sqlite3
+
+import pytest
+
+from api.services.hermes_persona_thread_store import HermesPersonaThreadStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def store(tmp_path):
+    return HermesPersonaThreadStore(db_path=str(tmp_path / "threads.db"))
+
+
+def test_record_then_lookup_round_trips(store):
+    store.record("chat-1", "msg-1", "doctor")
+    assert store.lookup("chat-1", "msg-1") == "doctor"
+
+
+def test_lookup_miss_returns_none_not_an_error(store):
+    assert store.lookup("chat-1", "does-not-exist") is None
+
+
+def test_scoped_per_chat_no_cross_chat_collision(store):
+    # Telegram message ids are unique only within a chat -- the same
+    # message_id in two different chats must resolve independently.
+    store.record("chat-1", "msg-1", "doctor")
+    store.record("chat-2", "msg-1", "fitness")
+    assert store.lookup("chat-1", "msg-1") == "doctor"
+    assert store.lookup("chat-2", "msg-1") == "fitness"
+    # A chat that never recorded this message_id gets nothing, even though
+    # the same id exists in another chat.
+    assert store.lookup("chat-3", "msg-1") is None
+
+
+def test_record_is_idempotent_and_updates_persona(store):
+    store.record("chat-1", "msg-1", "doctor")
+    store.record("chat-1", "msg-1", "fitness")
+    assert store.lookup("chat-1", "msg-1") == "fitness"
+
+
+def test_no_message_content_is_ever_stored(store, tmp_path):
+    # Only ids and a persona label belong in this table -- confirm the
+    # schema itself has no room for message text, not just that callers
+    # never pass it.
+    store.record("chat-1", "msg-1", "doctor")
+    with sqlite3.connect(store.db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(persona_threads)")}
+    assert columns == {"chat_id", "message_id", "persona_id", "created_at"}
+
+
+def test_expired_row_is_a_lookup_miss_not_an_error(store, monkeypatch):
+    import api.services.hermes_persona_thread_store as mod
+
+    fake_time = [1_000_000.0]
+    monkeypatch.setattr(mod.time, "time", lambda: fake_time[0])
+
+    store.record("chat-1", "msg-1", "doctor")
+    assert store.lookup("chat-1", "msg-1") == "doctor"
+
+    # Advance past the TTL -- the row is still physically present (no sweep
+    # has run) but must read back as a miss, the same as one that was never
+    # recorded, so the caller's fallback path can't tell them apart.
+    fake_time[0] += mod._TTL_SECONDS + 1
+    assert store.lookup("chat-1", "msg-1") is None
+
+
+def test_record_prunes_expired_rows(store, monkeypatch):
+    import api.services.hermes_persona_thread_store as mod
+
+    fake_time = [1_000_000.0]
+    monkeypatch.setattr(mod.time, "time", lambda: fake_time[0])
+
+    store.record("chat-1", "old-msg", "doctor")
+    fake_time[0] += mod._TTL_SECONDS + 1
+    # A later record() call sweeps out the now-expired row as a side effect.
+    store.record("chat-1", "new-msg", "fitness")
+
+    with sqlite3.connect(store.db_path) as conn:
+        (count,) = conn.execute(
+            "SELECT COUNT(*) FROM persona_threads WHERE message_id = 'old-msg'"
+        ).fetchone()
+    assert count == 0
+
+
+def test_record_caps_total_rows_evicting_oldest_first(store, monkeypatch):
+    import api.services.hermes_persona_thread_store as mod
+
+    monkeypatch.setattr(mod, "_MAX_ROWS", 3)
+    fake_time = [1_000_000.0]
+    monkeypatch.setattr(mod.time, "time", lambda: fake_time[0])
+
+    for i in range(3):
+        store.record("chat-1", f"msg-{i}", "doctor")
+        fake_time[0] += 1
+
+    # A 4th row pushes the table over the cap -- the oldest (msg-0) is
+    # evicted, not the newest.
+    store.record("chat-1", "msg-3", "doctor")
+
+    assert store.lookup("chat-1", "msg-0") is None
+    assert store.lookup("chat-1", "msg-1") == "doctor"
+    assert store.lookup("chat-1", "msg-2") == "doctor"
+    assert store.lookup("chat-1", "msg-3") == "doctor"

--- a/tests/test_hermes_proxy.py
+++ b/tests/test_hermes_proxy.py
@@ -1798,3 +1798,458 @@ class TestMakePersister:
     def test_returns_none_when_question_is_missing_or_wrong_type(self):
         assert hp._make_persister(json.dumps({}).encode()) is None
         assert hp._make_persister(json.dumps({"question": 5}).encode()) is None
+
+
+# ---------------------------------------------------------------------------
+# `POST /api/hermes/resolve-persona` (#644) — persona selection for Hermes's
+# own Telegram front door, which never passes through the proxy above. Grammar
+# tests exercise `_parse_persona_tag()` directly; endpoint tests exercise auth,
+# the untagged/tagged/unrecognized-tag response contract, voice gating, and
+# parity with `/api/hermes/ask/stream`'s envelope for the same persona.
+# ---------------------------------------------------------------------------
+
+class TestParsePersonaTag:
+    """Grammar for the per-message `@name` prefix (Nathan's decision, no
+    persisted state) — see the comment above `_PERSONA_TAG_RE` in
+    hermes_proxy.py for the full rationale."""
+
+    def test_recognizes_a_simple_tag(self):
+        assert hp._parse_persona_tag("@doctor the sync timer looks wedged") == (
+            "doctor", "the sync timer looks wedged",
+        )
+
+    def test_lowercases_the_tag(self):
+        assert hp._parse_persona_tag("@DOCTOR hi") == ("doctor", "hi")
+
+    def test_tag_with_no_trailing_text(self):
+        assert hp._parse_persona_tag("@doctor") == ("doctor", "")
+
+    def test_collapses_extra_whitespace_after_the_tag(self):
+        assert hp._parse_persona_tag("@doctor   hi there") == ("doctor", "hi there")
+
+    def test_plain_message_has_no_tag(self):
+        assert hp._parse_persona_tag("just a normal message") == (None, "just a normal message")
+
+    def test_leading_at_digit_is_not_a_tag(self):
+        # "a message that merely begins with an @ is not necessarily a
+        # persona tag" — no configured persona id starts with a digit.
+        assert hp._parse_persona_tag("@3pm meeting reminder") == (None, "@3pm meeting reminder")
+
+    def test_bare_at_with_space_is_not_a_tag(self):
+        assert hp._parse_persona_tag("@ what's up") == (None, "@ what's up")
+
+    def test_punctuation_glued_to_tag_is_not_a_tag(self):
+        # Only the documented `@name <message>` form is recognized —
+        # "@doctor," (no space before the comma) doesn't match it.
+        assert hp._parse_persona_tag("@doctor, please check") == (None, "@doctor, please check")
+
+    def test_unknown_tag_shaped_prefix_is_still_returned(self):
+        # Deliberately NOT (None, text) — the caller must see this as an
+        # attempted-but-unrecognized tag, not "no tag at all".
+        assert hp._parse_persona_tag("@nonsense do a thing") == ("nonsense", "do a thing")
+
+
+@pytest.fixture
+def resolve_client(monkeypatch):
+    """Same auth token as `proxy_client`, but only the resolve-persona route
+    is needed — no upstream Hermes stub."""
+    monkeypatch.setattr(hp.settings, "hermes_backend_token", "secret-token")
+    app = FastAPI()
+    app.include_router(hp.router)
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://proxy")
+
+
+async def test_resolve_persona_503_when_token_not_configured(monkeypatch):
+    monkeypatch.setattr(hp.settings, "hermes_backend_token", "")
+    app = FastAPI()
+    app.include_router(hp.router)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+        resp = await c.post(
+            "/api/hermes/resolve-persona", json={"text": "hi"},
+            headers={"Authorization": "Bearer whatever"},
+        )
+    assert resp.status_code == 503
+
+
+async def test_resolve_persona_401_when_missing_bearer(resolve_client):
+    resp = await resolve_client.post("/api/hermes/resolve-persona", json={"text": "hi"})
+    assert resp.status_code == 401
+
+
+async def test_resolve_persona_401_when_wrong_bearer(resolve_client):
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona", json={"text": "hi"},
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert resp.status_code == 401
+
+
+def _auth(token="secret-token"):
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_resolve_persona_untagged_is_unchanged(resolve_client):
+    # "Given no persona selected, then behavior shall be unchanged from
+    # today" (#644 AC) — text passes through byte-identical and there is no
+    # envelope for Hermes to apply.
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona", json={"text": "what's on my calendar today"},
+        headers=_auth(),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "persona_id": None,
+        "text": "what's on my calendar today",
+        "lifeos_context": None,
+    }
+
+
+async def test_resolve_persona_unrecognized_tag_is_a_400_not_silent(resolve_client):
+    # A typo'd/unknown tag must be a deliberate error, never silently treated
+    # as "no persona selected" (which would make the typo look like it worked).
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona", json={"text": "@nonsense do a thing"},
+        headers=_auth(),
+    )
+    assert resp.status_code == 400
+    assert "nonsense" in resp.json()["detail"]
+
+
+async def test_resolve_persona_tagged_resolves_and_strips_prefix(resolve_client, tmp_path, monkeypatch):
+    persona_file = tmp_path / "fitness.md"
+    persona_file.write_text("FITNESS PERSONA BODY")
+    reg = _registry(tmp_path, [
+        {"name": "fitness", "label": "Fitness Coach", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+    ])
+    monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+    monkeypatch.setenv("TG_FIT", "tok")
+
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona", json={"text": "@fitness what's my workout today"},
+        headers=_auth(),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["persona_id"] == "fitness"
+    assert body["text"] == "what's my workout today"
+    ctx = body["lifeos_context"]
+    # Same preamble /chat (via resolve_persona) would use for this persona —
+    # the #644 AC in a nutshell.
+    assert ctx["persona"]["id"] == "fitness"
+    assert ctx["persona"]["label"] == "Fitness Coach"
+    assert ctx["persona"]["preamble"] == "FITNESS PERSONA BODY"
+    assert ctx["persona"]["preamble"] == hp.settings.resolve_persona("fitness", surface="hermes")
+
+
+async def test_resolve_persona_matches_ask_stream_envelope_for_same_persona(
+    resolve_client, proxy_client, tmp_path, monkeypatch,
+):
+    """The two entry points into persona resolution (`/resolve-persona` for
+    Hermes-Telegram, `/ask/stream`'s envelope for the browser/voice-selected
+    persona) must produce an IDENTICAL envelope for the same persona and
+    conversation — proof they share `_resolve_lifeos_context()` rather than
+    two implementations that happen to agree today."""
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    from api.services import agent_system_prompt as asp
+
+    fixed_now = datetime(2026, 8, 19, 9, 14, 22, tzinfo=ZoneInfo("America/New_York"))
+
+    class _Frozen(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is not None else fixed_now.replace(tzinfo=None)
+
+    monkeypatch.setattr(asp, "datetime", _Frozen)
+
+    persona_file = tmp_path / "fitness.md"
+    persona_file.write_text("---\nid: fitness\nvoice:\n  - terse\n---\n\nFITNESS BODY")
+    reg = _registry(tmp_path, [
+        {"name": "fitness", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+    ])
+    monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+    monkeypatch.setenv("TG_FIT", "tok")
+
+    conv_id = "11111111-1111-1111-1111-111111111111"
+
+    resolve_resp = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={"text": "@fitness ready for today", "modality": "voice", "conversation_id": conv_id},
+        headers=_auth(),
+    )
+    assert resolve_resp.status_code == 200
+    resolved_ctx = resolve_resp.json()["lifeos_context"]
+
+    ask_resp = await proxy_client.post(
+        "/api/hermes/ask/stream",
+        json={"question": "ready for today", "persona_id": "fitness", "modality": "voice", "conversation_id": conv_id},
+    )
+    assert ask_resp.status_code == 200
+    ask_ctx = json.loads(_received["body"])["lifeos_context"]
+
+    assert resolved_ctx == ask_ctx
+
+
+async def test_resolve_persona_voice_modality_applies_voice_rules(resolve_client, tmp_path, monkeypatch):
+    persona_file = tmp_path / "fitness.md"
+    persona_file.write_text("---\nid: fitness\nvoice:\n  - terse\n  - no emoji\n---\n\nBODY")
+    reg = _registry(tmp_path, [
+        {"name": "fitness", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+    ])
+    monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+    monkeypatch.setenv("TG_FIT", "tok")
+
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={"text": "@fitness plan", "modality": "voice"},
+        headers=_auth(),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["lifeos_context"]["persona"]["voice_rules"] == ["terse", "no emoji"]
+
+
+async def test_resolve_persona_text_modality_gives_empty_voice_rules(resolve_client, tmp_path, monkeypatch):
+    persona_file = tmp_path / "fitness.md"
+    persona_file.write_text("---\nid: fitness\nvoice:\n  - terse\n---\n\nBODY")
+    reg = _registry(tmp_path, [
+        {"name": "fitness", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+    ])
+    monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+    monkeypatch.setenv("TG_FIT", "tok")
+
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona", json={"text": "@fitness plan"}, headers=_auth(),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["lifeos_context"]["persona"]["voice_rules"] == []
+
+
+async def test_resolve_persona_missing_text_field_is_400(resolve_client):
+    resp = await resolve_client.post("/api/hermes/resolve-persona", json={}, headers=_auth())
+    assert resp.status_code == 400
+
+
+async def test_resolve_persona_malformed_json_400(resolve_client):
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona", content=b"{not valid json",
+        headers={**_auth(), "content-type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Reply-thread persona inheritance (#644 follow-up) — the ordered rule:
+# explicit @tag > inherited from reply-to > nothing. `resolve_client`,
+# `_registry`, and `_auth` above are reused unchanged.
+# ---------------------------------------------------------------------------
+
+def _setup_fitness_persona(tmp_path, monkeypatch):
+    persona_file = tmp_path / "fitness.md"
+    persona_file.write_text("FITNESS PERSONA BODY")
+    reg = _registry(tmp_path, [
+        {"name": "fitness", "label": "Fitness Coach", "token_env": "TG_FIT", "persona_file": str(persona_file)},
+    ])
+    monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+    monkeypatch.setenv("TG_FIT", "tok")
+
+
+def _setup_doctor_persona(tmp_path, monkeypatch):
+    persona_file = tmp_path / "doctor.md"
+    persona_file.write_text("DOCTOR PERSONA BODY")
+    reg = _registry(tmp_path, [
+        {"name": "doctor", "token_env": "TG_DOC", "persona_file": str(persona_file), "orchestrates": True},
+    ])
+    monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+    monkeypatch.setenv("TG_DOC", "tok")
+
+
+async def test_reply_inherits_persona_from_tagged_message(resolve_client, tmp_path, monkeypatch):
+    _setup_fitness_persona(tmp_path, monkeypatch)
+
+    # First message tags fitness explicitly and is recorded under its own id.
+    first = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={"text": "@fitness plan for today", "chat_id": "chat-1", "message_id": "msg-1"},
+        headers=_auth(),
+    )
+    assert first.status_code == 200
+    assert first.json()["persona_id"] == "fitness"
+
+    # A reply to msg-1 with no tag inherits fitness -- text is untouched,
+    # there was no prefix to strip.
+    reply = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "what about tomorrow", "chat_id": "chat-1",
+            "message_id": "msg-2", "reply_to_message_id": "msg-1",
+        },
+        headers=_auth(),
+    )
+    assert reply.status_code == 200
+    body = reply.json()
+    assert body["persona_id"] == "fitness"
+    assert body["text"] == "what about tomorrow"
+    assert body["lifeos_context"]["persona"]["id"] == "fitness"
+
+
+async def test_explicit_tag_overrides_inherited_persona(resolve_client, tmp_path, monkeypatch):
+    _setup_fitness_persona(tmp_path, monkeypatch)
+    _setup_doctor_persona(tmp_path, monkeypatch)
+
+    await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={"text": "@fitness plan for today", "chat_id": "chat-1", "message_id": "msg-1"},
+        headers=_auth(),
+    )
+
+    # A reply that carries its OWN tag switches personas mid-thread rather
+    # than inheriting fitness from msg-1.
+    reply = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "@doctor unrelated question", "chat_id": "chat-1",
+            "message_id": "msg-2", "reply_to_message_id": "msg-1",
+        },
+        headers=_auth(),
+    )
+    assert reply.status_code == 200
+    body = reply.json()
+    assert body["persona_id"] == "doctor"
+    assert body["text"] == "unrelated question"
+
+
+async def test_unknown_reply_to_id_falls_back_to_no_persona(resolve_client):
+    # Never recorded (old thread, pruned mapping, predates this feature) --
+    # not an error, just today's behavior.
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "continuing our chat", "chat_id": "chat-1",
+            "message_id": "msg-2", "reply_to_message_id": "never-seen",
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"persona_id": None, "text": "continuing our chat", "lifeos_context": None}
+
+
+async def test_expired_reply_to_id_falls_back_to_no_persona(resolve_client, tmp_path, monkeypatch):
+    _setup_fitness_persona(tmp_path, monkeypatch)
+    import api.services.hermes_persona_thread_store as thread_store_mod
+
+    fake_time = [1_000_000.0]
+    monkeypatch.setattr(thread_store_mod.time, "time", lambda: fake_time[0])
+
+    await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={"text": "@fitness plan", "chat_id": "chat-1", "message_id": "msg-1"},
+        headers=_auth(),
+    )
+    fake_time[0] += thread_store_mod._TTL_SECONDS + 1
+
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "still there?", "chat_id": "chat-1",
+            "message_id": "msg-2", "reply_to_message_id": "msg-1",
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"persona_id": None, "text": "still there?", "lifeos_context": None}
+
+
+async def test_reply_to_id_from_a_different_chat_does_not_collide(resolve_client, tmp_path, monkeypatch):
+    _setup_fitness_persona(tmp_path, monkeypatch)
+
+    await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={"text": "@fitness plan", "chat_id": "chat-1", "message_id": "msg-1"},
+        headers=_auth(),
+    )
+    # Same message_id, different chat -- must not inherit fitness from chat-1's msg-1.
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "hi there", "chat_id": "chat-2",
+            "message_id": "msg-2", "reply_to_message_id": "msg-1",
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["persona_id"] is None
+
+
+async def test_reply_to_a_reply_inherits_transitively(resolve_client, tmp_path, monkeypatch):
+    # A reply to a reply in a doctor thread is still doctor -- no special
+    # case needed since every resolved message (tag or inherited) is
+    # recorded under its own id.
+    _setup_doctor_persona(tmp_path, monkeypatch)
+
+    await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={"text": "@doctor is the sync timer wedged", "chat_id": "chat-1", "message_id": "msg-1"},
+        headers=_auth(),
+    )
+    await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "any update", "chat_id": "chat-1",
+            "message_id": "msg-2", "reply_to_message_id": "msg-1",
+        },
+        headers=_auth(),
+    )
+    third = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "still nothing?", "chat_id": "chat-1",
+            "message_id": "msg-3", "reply_to_message_id": "msg-2",
+        },
+        headers=_auth(),
+    )
+    assert third.status_code == 200
+    assert third.json()["persona_id"] == "doctor"
+
+
+async def test_reply_to_a_bot_authored_message_inherits(resolve_client, tmp_path, monkeypatch):
+    # The thread anchor doesn't have to be a message this endpoint resolved
+    # -- a bot reply registered via /register-persona-message works too.
+    _setup_fitness_persona(tmp_path, monkeypatch)
+
+    reg_resp = await resolve_client.post(
+        "/api/hermes/register-persona-message",
+        json={"chat_id": "chat-1", "message_id": "bot-msg-1", "persona_id": "fitness"},
+        headers=_auth(),
+    )
+    assert reg_resp.status_code == 200
+    assert reg_resp.json() == {"ok": True}
+
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "one more thing", "chat_id": "chat-1",
+            "message_id": "msg-2", "reply_to_message_id": "bot-msg-1",
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["persona_id"] == "fitness"
+
+
+async def test_register_persona_message_rejects_unknown_persona(resolve_client):
+    resp = await resolve_client.post(
+        "/api/hermes/register-persona-message",
+        json={"chat_id": "chat-1", "message_id": "bot-msg-1", "persona_id": "ghost"},
+        headers=_auth(),
+    )
+    assert resp.status_code == 400
+
+
+async def test_register_persona_message_requires_auth(resolve_client):
+    resp = await resolve_client.post(
+        "/api/hermes/register-persona-message",
+        json={"chat_id": "chat-1", "message_id": "bot-msg-1", "persona_id": "primary"},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
Closes #644. Hermes half: nbramia/hermes#60.

Hermes's Telegram bot receives no persona context today. This exposes LifeOS's resolution so it can, without routing Telegram through LifeOS's proxy — #658's criteria require that path to survive LifeOS being down.

**Selection is a per-message prefix with reply-thread inheritance:**
1. an explicit `@persona` wins, always — switchable mid-thread;
2. else a native reply inherits the persona of the message it replies to;
3. else no persona, byte-identical to today.

Grammar lives in LifeOS, not Hermes, so the valid-name set has one home. `@name` is a tag only when it opens the message, is followed by whitespace or end, and starts with a letter — `@3pm meeting` and `@doctor,` are not tag attempts. An unrecognised tag is a **400, never a silent "no persona"**: a typo must not look like it worked.

**One implementation, two entry points.** `_resolve_lifeos_context()` was extracted from `_build_envelope` unchanged and parameterized; a parity test asserts both endpoints produce byte-identical envelopes for the same inputs.

Inheritance needs a `(chat_id, message_id) → persona` map, kept in LifeOS beside resolution rather than in Hermes. Per-chat scoped (Telegram ids collide across chats), 7-day TTL + 20k-row cap, and no message text in the schema — asserted by a test on the column set.

`POST /api/hermes/register-persona-message` is required beyond the base contract: the bot's own reply has no message id until Telegram accepts it, after `/resolve-persona` has returned, so there is no other way to anchor it. Chains inherit transitively as a consequence, not a special case.

Documented in `client-surfaces.md`, including the honest boundary: **tagged or inheriting messages need LifeOS reachable; untagged ones don't.**

99 tests in the file. Gate: 3797 passed, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)