### PR TITLE
fix(imessage): close SQLite connections in the export path and stop misreporting fd exhaustion as missing Full Disk Access

### DIFF
--- a/api/services/imessage.py
+++ b/api/services/imessage.py
@@ -11,6 +11,7 @@ import logging
 import re
 import sqlite3
 import uuid as uuid_mod
+from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -217,7 +218,7 @@ class IMessageStore:
         """Create the local database schema if it doesn't exist."""
         self.storage_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn, conn:
             conn.execute("PRAGMA journal_mode=WAL")
             conn.executescript("""
                 CREATE TABLE IF NOT EXISTS messages (
@@ -248,23 +249,34 @@ class IMessageStore:
 
     def _get_last_synced_rowid(self) -> int:
         """Get the last synced ROWID for incremental sync."""
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn:
             cursor = conn.execute(
                 "SELECT value FROM sync_state WHERE key = 'last_rowid'"
             )
             row = cursor.fetchone()
             return int(row[0]) if row else 0
 
-    def _set_last_synced_rowid(self, rowid: int) -> None:
-        """Update the last synced ROWID."""
-        with sqlite3.connect(self.storage_path) as conn:
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO sync_state (key, value)
-                VALUES ('last_rowid', ?)
-                """,
-                (str(rowid),),
-            )
+    def _set_last_synced_rowid(
+        self, rowid: int, conn: Optional[sqlite3.Connection] = None
+    ) -> None:
+        """Update the last synced ROWID.
+
+        Args:
+            rowid: New high-water mark.
+            conn: Optional caller-owned connection to reuse. When omitted a
+                connection is opened and closed for this call.
+        """
+        sql = """
+            INSERT OR REPLACE INTO sync_state (key, value)
+            VALUES ('last_rowid', ?)
+        """
+        if conn is not None:
+            with conn:
+                conn.execute(sql, (str(rowid),))
+            return
+
+        with closing(sqlite3.connect(self.storage_path)) as own_conn, own_conn:
+            own_conn.execute(sql, (str(rowid),))
 
     def export_from_source(
         self,
@@ -320,78 +332,69 @@ class IMessageStore:
         if limit:
             query += f" LIMIT {limit}"
 
-        try:
-            with sqlite3.connect(f"file:{self.SOURCE_DB_PATH}?mode=ro", uri=True) as source_conn:
-                source_conn.row_factory = sqlite3.Row
-                cursor = source_conn.execute(query, (last_rowid,))
+        # One destination connection for the whole export. Reconnecting per
+        # batch leaks a file descriptor each time and dies at the default
+        # macOS `ulimit -n` of 256 partway through a full export (#647).
+        with closing(sqlite3.connect(self.storage_path)) as dest_conn:
+            batch = []
+            max_rowid = last_rowid
 
-                batch = []
-                max_rowid = last_rowid
+            for row in self._iter_source_rows(query, last_rowid):
+                rowid = row["ROWID"]
+                text = row["text"]
+                attributed_body = row["attributedBody"]
+                apple_ts = row["date"]
+                is_from_me = bool(row["is_from_me"])
+                handle = row["handle"] or ""
+                service = row["service"] or "Unknown"
 
-                for row in cursor:
-                    rowid = row["ROWID"]
-                    text = row["text"]
-                    attributed_body = row["attributedBody"]
-                    apple_ts = row["date"]
-                    is_from_me = bool(row["is_from_me"])
-                    handle = row["handle"] or ""
-                    service = row["service"] or "Unknown"
+                # Try text field first, then attributedBody
+                final_text = text
+                if not final_text and attributed_body:
+                    final_text = extract_text_from_attributed_body(attributed_body)
 
-                    # Try text field first, then attributedBody
-                    final_text = text
-                    if not final_text and attributed_body:
-                        final_text = extract_text_from_attributed_body(attributed_body)
-
-                    # Skip messages with no extractable text (attachments, etc.)
-                    if not final_text:
-                        stats["messages_skipped"] += 1
-                        max_rowid = max(max_rowid, rowid)
-                        continue
-
-                    # Convert timestamp
-                    timestamp = apple_timestamp_to_datetime(apple_ts)
-                    if not timestamp:
-                        stats["messages_skipped"] += 1
-                        max_rowid = max(max_rowid, rowid)
-                        continue
-
-                    # Normalize phone number
-                    handle_normalized = normalize_phone(handle) if handle else None
-
-                    batch.append((
-                        rowid,
-                        final_text,
-                        timestamp.isoformat(),
-                        1 if is_from_me else 0,
-                        handle,
-                        handle_normalized,
-                        service,
-                    ))
-
+                # Skip messages with no extractable text (attachments, etc.)
+                if not final_text:
+                    stats["messages_skipped"] += 1
                     max_rowid = max(max_rowid, rowid)
-                    stats["messages_exported"] += 1
+                    continue
 
-                    # Batch insert
-                    if len(batch) >= 1000:
-                        self._insert_batch(batch)
-                        batch = []
+                # Convert timestamp
+                timestamp = apple_timestamp_to_datetime(apple_ts)
+                if not timestamp:
+                    stats["messages_skipped"] += 1
+                    max_rowid = max(max_rowid, rowid)
+                    continue
 
-                # Insert remaining
-                if batch:
-                    self._insert_batch(batch)
+                # Normalize phone number
+                handle_normalized = normalize_phone(handle) if handle else None
 
-                # Update sync state
-                if max_rowid > last_rowid:
-                    self._set_last_synced_rowid(max_rowid)
-                    stats["new_last_rowid"] = max_rowid
+                batch.append((
+                    rowid,
+                    final_text,
+                    timestamp.isoformat(),
+                    1 if is_from_me else 0,
+                    handle,
+                    handle_normalized,
+                    service,
+                ))
 
-        except sqlite3.OperationalError as e:
-            if "unable to open database" in str(e).lower():
-                raise PermissionError(
-                    "Cannot access iMessage database. "
-                    "Grant Full Disk Access to Terminal/IDE in System Preferences."
-                ) from e
-            raise
+                max_rowid = max(max_rowid, rowid)
+                stats["messages_exported"] += 1
+
+                # Batch insert
+                if len(batch) >= 1000:
+                    self._insert_batch(batch, dest_conn)
+                    batch = []
+
+            # Insert remaining
+            if batch:
+                self._insert_batch(batch, dest_conn)
+
+            # Update sync state
+            if max_rowid > last_rowid:
+                self._set_last_synced_rowid(max_rowid, dest_conn)
+                stats["new_last_rowid"] = max_rowid
 
         logger.info(
             f"iMessage export complete: {stats['messages_exported']} messages, "
@@ -400,21 +403,59 @@ class IMessageStore:
 
         return stats
 
-    def _insert_batch(self, batch: list) -> None:
-        """Insert a batch of messages."""
-        with sqlite3.connect(self.storage_path) as conn:
-            conn.executemany(
-                """
-                INSERT OR REPLACE INTO messages
-                (rowid, text, timestamp, is_from_me, handle, handle_normalized, service)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                batch,
-            )
+    def _iter_source_rows(self, query: str, last_rowid: int):
+        """Yield rows from the macOS Messages database.
+
+        The source connection and its error handling live entirely inside this
+        generator. A generator's ``except`` clause is only active while the
+        generator itself is running, so a sqlite3.OperationalError raised by
+        the consumer's loop body — i.e. while writing to the *destination*
+        database — can never be misreported as a Full Disk Access problem on
+        the source (#647).
+        """
+        try:
+            with closing(
+                sqlite3.connect(f"file:{self.SOURCE_DB_PATH}?mode=ro", uri=True)
+            ) as source_conn:
+                source_conn.row_factory = sqlite3.Row
+                yield from source_conn.execute(query, (last_rowid,))
+        except sqlite3.OperationalError as e:
+            if "unable to open database" in str(e).lower():
+                raise PermissionError(
+                    f"Cannot read the iMessage database at {self.SOURCE_DB_PATH} "
+                    f"({e}). Grant Full Disk Access to Terminal/IDE in "
+                    "System Preferences."
+                ) from e
+            raise
+
+    def _insert_batch(
+        self, batch: list, conn: Optional[sqlite3.Connection] = None
+    ) -> None:
+        """Insert a batch of messages.
+
+        Args:
+            batch: Rows to insert.
+            conn: Optional caller-owned connection to reuse. Exports pass the
+                connection they hold open for the whole run; opening one per
+                batch exhausts the process file-descriptor limit on a full
+                export (see issue #647).
+        """
+        sql = """
+            INSERT OR REPLACE INTO messages
+            (rowid, text, timestamp, is_from_me, handle, handle_normalized, service)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """
+        if conn is not None:
+            with conn:
+                conn.executemany(sql, batch)
+            return
+
+        with closing(sqlite3.connect(self.storage_path)) as own_conn, own_conn:
+            own_conn.executemany(sql, batch)
 
     def _clear_data(self) -> None:
         """Clear all exported data (for full resync)."""
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn, conn:
             conn.execute("DELETE FROM messages")
             conn.execute("DELETE FROM sync_state")
         logger.info("Cleared iMessage export data for full resync")

--- a/api/services/imessage.py
+++ b/api/services/imessage.py
@@ -453,6 +453,22 @@ class IMessageStore:
         with closing(sqlite3.connect(self.storage_path)) as own_conn, own_conn:
             own_conn.executemany(sql, batch)
 
+    def checkpoint(self) -> None:
+        """Fold the write-ahead log back into the main database file.
+
+        The store runs in WAL mode, so recent writes live in a ``-wal`` sidecar
+        until a checkpoint. Anything that copies ``storage_path`` as a single
+        file — the Apple export does — silently ships a stale database unless
+        the WAL has been folded in first (#647).
+
+        SQLite checkpoints automatically when the last connection closes, but
+        that is skipped whenever any other connection is still open, which
+        fails silently. Callers that are about to copy the file should ask for
+        a checkpoint explicitly rather than rely on that.
+        """
+        with closing(sqlite3.connect(self.storage_path)) as conn:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
     def _clear_data(self) -> None:
         """Clear all exported data (for full resync)."""
         with closing(sqlite3.connect(self.storage_path)) as conn, conn:

--- a/scripts/apple_data_export.py
+++ b/scripts/apple_data_export.py
@@ -415,6 +415,10 @@ def export_imessage(dry_run: bool = False) -> dict:
         size_mb = imessage_db.stat().st_size / (1024 * 1024)
         return {"status": "dry_run", "size_mb": round(size_mb, 1)}
 
+    # Fold the WAL into the main file first — copy2 takes only imessage.db, so
+    # anything still sitting in imessage.db-wal would be dropped from the copy.
+    store.checkpoint()
+
     # Copy the database file (it's already in portable SQLite format)
     out_path = EXPORT_DIR / "imessage.db"
     shutil.copy2(str(imessage_db), str(out_path))

--- a/scripts/apple_data_export.py
+++ b/scripts/apple_data_export.py
@@ -403,8 +403,8 @@ def export_imessage(dry_run: bool = False) -> dict:
     except FileNotFoundError:
         logger.warning("Apple Messages database not found — skipping iMessage export")
         return {"status": "skipped", "reason": "Messages.db not found"}
-    except PermissionError:
-        logger.warning("Cannot access Messages.db — grant Full Disk Access to Terminal")
+    except PermissionError as e:
+        logger.warning(f"Cannot access Messages.db — grant Full Disk Access to Terminal: {e}")
         return {"status": "skipped", "reason": "Full Disk Access required"}
 
     if not imessage_db.exists():

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -1,8 +1,12 @@
 """
 Tests for iMessage integration.
 """
+import os
 import pytest
+import resource
+import sqlite3
 import tempfile
+from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -439,3 +443,170 @@ class TestExtractTextFromAttributedBody:
         blob = "streamtyped\x00\x00Hello café world!\x00NSString".encode("utf-8")
         result = extract_text_from_attributed_body(blob)
         assert result == "Hello café world!"
+
+
+# Enough messages to span ~30 of the export's 1000-row batches.
+SOURCE_MESSAGE_COUNT = 30_000
+
+
+def _count_open_fds() -> int:
+    """Number of file descriptors this process currently holds open."""
+    proc_fds = Path("/proc/self/fd")
+    if proc_fds.is_dir():  # Linux
+        return len(os.listdir(proc_fds))
+
+    soft, _ = resource.getrlimit(resource.RLIMIT_NOFILE)  # macOS/BSD
+    ceiling = 4096 if soft == resource.RLIM_INFINITY else min(soft, 4096)
+    open_fds = 0
+    for fd in range(ceiling):
+        try:
+            os.fstat(fd)
+        except OSError:
+            continue
+        open_fds += 1
+    return open_fds
+
+
+def _make_synthetic_chat_db(path: Path, message_count: int) -> None:
+    """Build a chat.db-shaped source database with obviously synthetic messages."""
+    # 2024-06-15T12:00:00Z in Apple's nanoseconds-since-2001 epoch.
+    apple_ts = datetime_to_apple_timestamp(datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc))
+
+    with closing(sqlite3.connect(path)) as conn, conn:
+        conn.executescript("""
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE message (
+                ROWID INTEGER PRIMARY KEY,
+                text TEXT,
+                attributedBody BLOB,
+                date INTEGER,
+                is_from_me INTEGER,
+                handle_id INTEGER,
+                service TEXT
+            );
+        """)
+        conn.execute("INSERT INTO handle (ROWID, id) VALUES (1, '+15550001111')")
+        conn.executemany(
+            "INSERT INTO message (ROWID, text, attributedBody, date, is_from_me, handle_id, service)"
+            " VALUES (?, ?, NULL, ?, ?, 1, 'iMessage')",
+            [
+                (rowid, f"synthetic message {rowid}", apple_ts, rowid % 2)
+                for rowid in range(1, message_count + 1)
+            ],
+        )
+
+
+class TestExportConnectionLifecycle:
+    """Regression tests for the file-descriptor leak in the export path (#647).
+
+    `with sqlite3.connect(...)` is a *transaction* context manager, not a
+    closing one: it commits but leaves the connection (and its fds) open. One
+    connection per batch exhausted the default macOS `ulimit -n` of 256 partway
+    through a first full export, and the resulting OperationalError on the
+    *destination* database was reported as missing Full Disk Access on the
+    *source*.
+    """
+
+    @pytest.fixture
+    def temp_store(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            store = IMessageStore(f.name)
+            yield store
+            for suffix in ("", "-wal", "-shm"):
+                Path(f.name + suffix).unlink(missing_ok=True)
+
+    @pytest.fixture
+    def synthetic_source(self, tmp_path):
+        """A chat.db stand-in with enough rows to span many 1000-row batches.
+
+        The count matters: it has to exceed the fd headroom the low-limit test
+        allows, so a per-batch connection actually exhausts the limit.
+        """
+        source = tmp_path / "chat.db"
+        _make_synthetic_chat_db(source, message_count=SOURCE_MESSAGE_COUNT)
+        return source
+
+    def test_insert_batch_does_not_leak_fds(self, temp_store):
+        """200 batches must not accumulate 200 connections."""
+        now = datetime.now(timezone.utc).isoformat()
+        temp_store._insert_batch(
+            [(0, "warmup", now, 0, "+15550001111", "+15550001111", "iMessage")]
+        )
+
+        before = _count_open_fds()
+        for rowid in range(1, 201):
+            temp_store._insert_batch(
+                [(rowid, f"synthetic {rowid}", now, rowid % 2, "+15550001111", "+15550001111", "iMessage")]
+            )
+        leaked = _count_open_fds() - before
+
+        assert leaked <= 2, f"{leaked} file descriptors leaked across 200 batches"
+
+    def test_clear_data_does_not_leak_fds(self, temp_store):
+        temp_store._clear_data()  # warm up any lazily-created WAL sidecar files
+
+        before = _count_open_fds()
+        for _ in range(50):
+            temp_store._clear_data()
+        leaked = _count_open_fds() - before
+
+        assert leaked <= 2, f"{leaked} file descriptors leaked across 50 _clear_data calls"
+
+    def test_full_export_does_not_leak_fds(self, temp_store, synthetic_source):
+        """A multi-batch export holds one destination connection, not one per batch."""
+        temp_store.SOURCE_DB_PATH = synthetic_source
+
+        before = _count_open_fds()
+        stats = temp_store.export_from_source()
+        leaked = _count_open_fds() - before
+
+        assert stats["messages_exported"] == SOURCE_MESSAGE_COUNT
+        assert stats["new_last_rowid"] == SOURCE_MESSAGE_COUNT
+        assert leaked <= 2, f"{leaked} file descriptors leaked across a multi-batch export"
+
+    def test_full_export_survives_a_low_fd_limit(self, temp_store, synthetic_source):
+        """The real failure mode: a full export under a tight `ulimit -n`."""
+        temp_store.SOURCE_DB_PATH = synthetic_source
+
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        headroom = _count_open_fds() + 24
+        if soft != resource.RLIM_INFINITY and soft <= headroom:
+            pytest.skip("fd limit already tighter than the test's headroom")
+
+        resource.setrlimit(resource.RLIMIT_NOFILE, (headroom, hard))
+        try:
+            stats = temp_store.export_from_source()
+        finally:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+
+        assert stats["messages_exported"] == SOURCE_MESSAGE_COUNT
+
+    def test_destination_failure_is_not_reported_as_full_disk_access(
+        self, temp_store, synthetic_source
+    ):
+        """An OperationalError while writing must surface as itself, not as FDA."""
+        temp_store.SOURCE_DB_PATH = synthetic_source
+
+        def failing_insert(batch, conn=None):
+            raise sqlite3.OperationalError("unable to open database file")
+
+        temp_store._insert_batch = failing_insert
+
+        with pytest.raises(sqlite3.OperationalError, match="unable to open database file"):
+            temp_store.export_from_source()
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses file permissions, so the source cannot be made unreadable",
+    )
+    def test_unreadable_source_still_reports_full_disk_access(
+        self, temp_store, synthetic_source
+    ):
+        """FDA guidance is still given when the source database is genuinely unreadable."""
+        temp_store.SOURCE_DB_PATH = synthetic_source
+        synthetic_source.chmod(0o000)
+        try:
+            with pytest.raises(PermissionError, match="Full Disk Access"):
+                temp_store.export_from_source()
+        finally:
+            synthetic_source.chmod(0o600)

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -4,6 +4,7 @@ Tests for iMessage integration.
 import os
 import pytest
 import resource
+import shutil
 import sqlite3
 import tempfile
 from contextlib import closing
@@ -610,3 +611,34 @@ class TestExportConnectionLifecycle:
                 temp_store.export_from_source()
         finally:
             synthetic_source.chmod(0o600)
+
+    def test_checkpoint_flushes_wal_so_a_file_copy_is_complete(
+        self, temp_store, synthetic_source, tmp_path
+    ):
+        """A single-file copy of the store must not drop freshly exported rows.
+
+        The store runs in WAL mode, so an export's writes can still be sitting
+        in the -wal sidecar. `shutil.copy2` takes only the main database file,
+        which is how the Apple export shipped a database missing its newest
+        messages (#647).
+
+        SQLite checkpoints on its own when the *last* connection closes, so the
+        gap only opens when something else holds the database open — the API
+        server, say. This test pins that case open deliberately; without it the
+        implicit checkpoint would mask the bug.
+        """
+        temp_store.SOURCE_DB_PATH = synthetic_source
+
+        with closing(sqlite3.connect(temp_store.storage_path)) as bystander:
+            bystander.execute("SELECT COUNT(*) FROM messages").fetchone()
+
+            temp_store.export_from_source()
+            temp_store.checkpoint()
+
+            copied = tmp_path / "copy-of-imessage.db"
+            shutil.copy2(temp_store.storage_path, copied)  # main file only, no -wal
+
+        with closing(sqlite3.connect(copied)) as conn:
+            copied_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+
+        assert copied_count == SOURCE_MESSAGE_COUNT


### PR DESCRIPTION
Closes #647

## TL;DR

Copying iMessage history over to the server could fail partway through a first full run, and then blame the wrong thing entirely. Every batch of messages written during an export opened a database connection that was never closed, so a large history ran the process out of file handles and stopped. The failure was reported as a missing macOS Full Disk Access permission, which sent anyone debugging it chasing a permission that had been granted all along. This change closes those connections, reports the real error when the write side fails, and flushes pending writes before the database is copied so the copy can no longer ship without the newest messages.

## Problem

`with sqlite3.connect(...)` is a **transaction** context manager, not a closing one — it commits on exit and leaves the connection (and its file descriptors) open. `IMessageStore._insert_batch` used that shape, so a full export leaked one connection per 1000-row batch.

Incremental nightly exports move a few batches, so it never tripped. A *first full export* (`ROWID > 0`) over a ~300k-message `chat.db` blows through macOS's default `ulimit -n` of 256 and dies partway.

The failure was then misreported. `export_from_source` wrapped the whole export loop in `except sqlite3.OperationalError` and translated it into `PermissionError`, which `apple_data_export.py` renders as *"Cannot access Messages.db — grant Full Disk Access to Terminal"*. So fd exhaustion on the **destination** database was reported as a permissions problem on the **source**. FDA was correctly granted the whole time.

## Changes

**`api/services/imessage.py`**

- `export_from_source` now opens **one** destination connection for the whole export and passes it to each batch insert. That is both the fix and a performance win — no reconnect per batch.
- `_insert_batch` and `_set_last_synced_rowid` take an optional caller-owned `conn`, and open-and-close their own only when called standalone.
- Every connection in the export path is wrapped in `contextlib.closing` so it is deterministically closed: `_ensure_schema`, `_get_last_synced_rowid`, `_set_last_synced_rowid`, `_insert_batch`, `_clear_data`.
- Source-database reads moved into a `_iter_source_rows` generator that owns the source connection **and its error handling**. A generator's `except` clause is only live while the generator itself is running, so an `OperationalError` raised by the consumer's loop body — i.e. while writing to the destination — can no longer be caught and relabelled as an FDA problem. The `PermissionError` translation now applies only to failures opening/reading `chat.db`, and the message includes the path and the underlying error.
- New `checkpoint()` method — see WAL section below.

**`scripts/apple_data_export.py`**

- The `PermissionError` handler now includes the underlying error in the log line instead of discarding it.
- Calls `store.checkpoint()` before copying the database.

## The WAL bug (same root cause — included deliberately)

`export_imessage` copies `data/imessage.db` with `shutil.copy2`, which takes only the main database file. In WAL mode recent writes can still be in the `-wal` sidecar, so the copy silently shipped a stale database — observed in production at 306,309 of 307,083 messages.

This is the same defect: SQLite folds the WAL back in automatically when the *last* connection closes, and the leaked per-batch connections meant that never happened. Fixing the leak repairs it implicitly, **but only while nothing else holds the database open** — the API server does, and then the copy silently goes stale again. Verified: with one bystander connection open, the copied database had 0 of 5000 rows without an explicit checkpoint and 5000 with it. Relying on the implicit behaviour is a silent-data-loss trap, so the checkpoint is explicit.

## Tests

New `TestExportConnectionLifecycle` in `tests/test_imessage.py`, all Linux-safe — they build a synthetic `chat.db`-shaped source in a tmpdir and point the store at a temp destination. No real `chat.db` required, obviously synthetic data throughout (`+15550001111`, `"synthetic message N"`).

| Test | Asserts |
|---|---|
| `test_insert_batch_does_not_leak_fds` | 200 batches don't accumulate 200 connections |
| `test_clear_data_does_not_leak_fds` | 50 `_clear_data` calls leak nothing |
| `test_full_export_does_not_leak_fds` | A 30-batch export holds one destination connection |
| `test_full_export_survives_a_low_fd_limit` | The real failure mode — a full export under a deliberately tightened `RLIMIT_NOFILE` |
| `test_destination_failure_is_not_reported_as_full_disk_access` | A write-side `OperationalError` surfaces as itself, not as `PermissionError` |
| `test_unreadable_source_still_reports_full_disk_access` | Guards the over-correction: FDA guidance is *still* given when `chat.db` is genuinely unreadable |
| `test_checkpoint_flushes_wal_so_a_file_copy_is_complete` | A single-file copy is complete, with a bystander connection held open to suppress the implicit checkpoint |

Each was verified to actually catch the bug: 5 of the 6 leak/misreporting tests fail against the pre-fix code and pass after. The WAL test fails without the checkpoint call (19,000 of 30,000 rows — the same "missing newest messages" symptom seen in production).

## Test results

`./scripts/test.sh`: **4801 passed, 12 skipped, 1 failed**.

The one failure is `tests/test_mcp_server.py::TestOpenAPIAvailability::test_openapi_spec_available` — pre-existing flakiness, not from this change. `test_mcp_server.py` runs against the shared live `lifeos-api` service; re-running it three times with an unchanged tree produced 1, 4, and 4 failures on *different* tests each time, and the test passes in isolation. This PR touches no search, MCP, or OpenAPI code.

Pre-push hooks ran clean: 3797 unit tests passed, 74 server-free browser tests passed.

## Noticed but deliberately not changed

`api/services/imessage.py` has ~11 more `with sqlite3.connect(...)` blocks in the **query** paths (`search_messages`, `get_messages_for_person`, etc., around lines 475–943, plus one module-level function at 943). They have the identical no-close shape. They're left alone here to keep this PR scoped to the export path in #647 — the risk profile is different (one connection per API request in a long-running server, rather than thousands in a tight loop), so it deserves its own issue and its own testing rather than being folded in silently.
