### PR TITLE
refactor(imessage): close the 9 remaining query-path sqlite connections

### DIFF
--- a/api/services/imessage.py
+++ b/api/services/imessage.py
@@ -488,7 +488,7 @@ class IMessageStore:
         """
         total_updated = 0
 
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn, conn:
             for phone, entity_id in phone_to_entity.items():
                 cursor = conn.execute(
                     """
@@ -516,7 +516,7 @@ class IMessageStore:
         """
         total_updated = 0
 
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn, conn:
             for handle, entity_id in handle_to_entity.items():
                 # Match case-insensitively on handle
                 cursor = conn.execute(
@@ -565,7 +565,7 @@ class IMessageStore:
         query += " ORDER BY timestamp DESC LIMIT ?"
         params.append(limit)
 
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.execute(query, params)
 
@@ -615,7 +615,7 @@ class IMessageStore:
         query += " ORDER BY timestamp DESC LIMIT ?"
         params.append(limit)
 
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.execute(query, params)
 
@@ -671,7 +671,7 @@ class IMessageStore:
         sql += " ORDER BY timestamp DESC LIMIT ?"
         params.append(limit)
 
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.execute(sql, params)
 
@@ -755,7 +755,7 @@ class IMessageStore:
         sql += " ORDER BY timestamp DESC LIMIT ?"
         params.append(limit)
 
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.execute(sql, params)
 
@@ -822,7 +822,7 @@ class IMessageStore:
 
     def get_statistics(self) -> dict:
         """Get statistics about the exported messages."""
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn:
             stats = {}
 
             # Total messages
@@ -884,7 +884,7 @@ class IMessageStore:
         Returns:
             List of dicts with contact info and message counts
         """
-        with sqlite3.connect(self.storage_path) as conn:
+        with closing(sqlite3.connect(self.storage_path)) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.execute(
                 """
@@ -956,7 +956,7 @@ def join_imessages_to_entities() -> dict:
     entity_store = get_person_entity_store()
 
     # Get unique phone numbers from messages
-    with sqlite3.connect(store.storage_path) as conn:
+    with closing(sqlite3.connect(store.storage_path)) as conn:
         cursor = conn.execute(
             """
             SELECT DISTINCT handle_normalized

--- a/docs/specs/standards/python-conventions.md
+++ b/docs/specs/standards/python-conventions.md
@@ -1,7 +1,7 @@
 # Python Conventions
 
 > **Status:** Complete
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-08-25
 > **Audience:** All developers and AI agents
 
 Coding conventions extracted from the LifeOS codebase. Match these patterns when writing new code.
@@ -130,6 +130,37 @@ def get_by_id(self, entity_id: str) -> Optional[PersonEntity]:
     finally:
         conn.close()
 ```
+
+## SQLite Connection Closing
+
+`with sqlite3.connect(...)` is a *transaction* context manager — it commits
+or rolls back on exit, but does not close the connection. Left alone,
+CPython's refcounting closes it once `conn` goes out of scope, which is why
+this has been safe in practice (see issue #678's fd measurements), but that
+is an implementation detail, not a guarantee: the same bare pattern leaked a
+file descriptor per batch in a tight loop and exhausted `ulimit -n` (#647).
+
+Prefer `contextlib.closing`, matching `api/services/imessage.py`:
+
+```python
+from contextlib import closing
+
+# Read-only: closing() alone ends the connection deterministically.
+with closing(sqlite3.connect(self.storage_path)) as conn:
+    conn.row_factory = sqlite3.Row
+    ...
+
+# Writes: pair it with the connection's own commit/rollback context too --
+# closing() alone silently drops the commit.
+with closing(sqlite3.connect(self.storage_path)) as conn, conn:
+    conn.execute("UPDATE ...")
+```
+
+This is the house style for new and touched code. `api/services/`'s other
+SQLite-backed stores (`agent_viz_summary.py`, `agent_viz_label_override.py`,
+`job_queue.py`, `hermes_persona_thread_store.py`, `perf_trace.py`,
+`gsheet_sync.py`, `usage_store.py`) still use the bare form; sweeping them is
+a separate follow-up, not a blocker for adopting this pattern elsewhere.
 
 ## Error Handling
 

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -18,6 +18,7 @@ from api.services.imessage import (
     apple_timestamp_to_datetime,
     datetime_to_apple_timestamp,
     extract_text_from_attributed_body,
+    join_imessages_to_entities,
     resolve_entity_id,
     resolve_entity_id_confidence,
 )
@@ -642,3 +643,137 @@ class TestExportConnectionLifecycle:
             copied_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
 
         assert copied_count == SOURCE_MESSAGE_COUNT
+
+
+class TestQueryPathConnectionsClose:
+    """Regression tests for #678: the 9 query-path connections now use
+    `contextlib.closing`, matching the export-path fix in #647.
+
+    Counting live fds (as TestExportConnectionLifecycle does) can't tell a
+    real fix from a no-op here: CPython's refcounting already closes a
+    connection the instant its local variable goes out of scope, so a bare
+    `with sqlite3.connect(...) as conn:` and a `closing(...)` one look
+    identical by fd count. Instead these tests spy on `sqlite3.connect` to
+    capture the actual connection object each method opens, then assert
+    operating on it raises "closed database" — which only `closing()`
+    guarantees deterministically at the end of the `with` block.
+    """
+
+    @pytest.fixture
+    def temp_store(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            store = IMessageStore(f.name)
+            yield store
+            for suffix in ("", "-wal", "-shm"):
+                Path(f.name + suffix).unlink(missing_ok=True)
+
+    @pytest.fixture
+    def captured_connections(self, monkeypatch):
+        """Spy on sqlite3.connect as used by imessage.py; return the connections it opens."""
+        captured = []
+        real_connect = sqlite3.connect
+
+        def spy_connect(*args, **kwargs):
+            conn = real_connect(*args, **kwargs)
+            captured.append(conn)
+            return conn
+
+        monkeypatch.setattr("api.services.imessage.sqlite3.connect", spy_connect)
+        return captured
+
+    def _assert_closed(self, conn: sqlite3.Connection) -> None:
+        with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+            conn.execute("SELECT 1")
+
+    def test_update_entity_mappings_closes_and_commits(self, temp_store, captured_connections):
+        with closing(sqlite3.connect(temp_store.storage_path)) as conn, conn:
+            conn.execute(
+                "INSERT INTO messages (rowid, text, timestamp, is_from_me, handle,"
+                " handle_normalized, service) VALUES"
+                " (1, 'hi', '2024-01-01T00:00:00', 0, '+15550001111', '+15550001111', 'iMessage')"
+            )
+        captured_connections.clear()  # drop the setup connection above
+
+        updated = temp_store.update_entity_mappings({"+15550001111": "entity-1"})
+
+        assert updated == 1
+        assert len(captured_connections) == 1
+        self._assert_closed(captured_connections[0])
+
+        # A closing() swap drops the commit unless paired with `, conn`; confirm
+        # the write actually landed, not just that the connection closed.
+        with closing(sqlite3.connect(temp_store.storage_path)) as conn:
+            row = conn.execute("SELECT person_entity_id FROM messages WHERE rowid = 1").fetchone()
+        assert row[0] == "entity-1"
+
+    def test_update_entity_mappings_by_handle_closes_and_commits(self, temp_store, captured_connections):
+        with closing(sqlite3.connect(temp_store.storage_path)) as conn, conn:
+            conn.execute(
+                "INSERT INTO messages (rowid, text, timestamp, is_from_me, handle,"
+                " handle_normalized, service) VALUES"
+                " (1, 'hi', '2024-01-01T00:00:00', 0, 'friend@example.com', NULL, 'iMessage')"
+            )
+        captured_connections.clear()  # drop the setup connection above
+
+        updated = temp_store.update_entity_mappings_by_handle({"friend@example.com": "entity-2"})
+
+        assert updated == 1
+        assert len(captured_connections) == 1
+        self._assert_closed(captured_connections[0])
+
+        with closing(sqlite3.connect(temp_store.storage_path)) as conn:
+            row = conn.execute("SELECT person_entity_id FROM messages WHERE rowid = 1").fetchone()
+        assert row[0] == "entity-2"
+
+    def test_get_messages_for_phone_closes(self, temp_store, captured_connections):
+        temp_store.get_messages_for_phone("+15550001111")
+
+        assert len(captured_connections) == 1
+        self._assert_closed(captured_connections[0])
+
+    def test_get_messages_for_entity_closes(self, temp_store, captured_connections):
+        temp_store.get_messages_for_entity("entity-1")
+
+        assert len(captured_connections) == 1
+        self._assert_closed(captured_connections[0])
+
+    def test_search_messages_closes(self, temp_store, captured_connections):
+        temp_store.search_messages("hello")
+
+        assert len(captured_connections) == 1
+        self._assert_closed(captured_connections[0])
+
+    def test_query_messages_closes(self, temp_store, captured_connections):
+        temp_store.query_messages()
+
+        assert len(captured_connections) == 1
+        self._assert_closed(captured_connections[0])
+
+    def test_get_statistics_closes(self, temp_store, captured_connections):
+        temp_store.get_statistics()
+
+        # get_statistics() also calls _get_last_synced_rowid(), which opens
+        # its own connection (line 252) — expect both, both closed.
+        assert len(captured_connections) == 2
+        for conn in captured_connections:
+            self._assert_closed(conn)
+
+    def test_get_recent_conversations_closes(self, temp_store, captured_connections):
+        temp_store.get_recent_conversations()
+
+        assert len(captured_connections) == 1
+        self._assert_closed(captured_connections[0])
+
+    def test_join_imessages_to_entities_closes(self, temp_store, captured_connections, monkeypatch):
+        monkeypatch.setattr("api.services.imessage.get_imessage_store", lambda *a, **kw: temp_store)
+        monkeypatch.setattr(
+            "api.services.person_entity.get_person_entity_store",
+            lambda *a, **kw: SimpleNamespace(get_by_phone=lambda p: None, get_by_email=lambda e: None),
+        )
+
+        stats = join_imessages_to_entities()
+
+        assert stats["unique_phones"] == 0
+        assert stats["unique_emails"] == 0
+        assert len(captured_connections) == 1
+        self._assert_closed(captured_connections[0])


### PR DESCRIPTION
Closes #678.

#647 / PR #675 fixed the no-close `sqlite3.connect` pattern in the **export** path, where it was fatal. This converts the 9 remaining sites in the query paths of the same file, so `api/services/imessage.py` is uniform — all 16 connections now use `contextlib.closing`.

**Not an active defect.** The issue established by measurement that fd count is flat across 80 requests; CPython's refcounting reclaims each connection at function return. This is hygiene and latent-risk reduction — the file was internally inconsistent (7 converted, 9 not), so the next person adding a batch loop would copy whichever they landed on.

### The commit hazard

`with sqlite3.connect(...)` commits on exit but does **not** close; `closing()` closes but does **not** commit. A naive swap silently drops writes.

Two of the nine write (`update_entity_mappings`, `update_entity_mappings_by_handle`); both use the combined `with closing(...) as conn, conn:` form so closing provides the close and the bare `conn` still provides the commit. Verified by reopening a **fresh** connection after each write and confirming the row persisted — reading back through the same connection would have looked correct either way.

The other seven are read-only and use `closing()` alone.

### Tests

**No existing test was modified** — the diff is purely additive. That was the issue's own tripwire for whether the change was as mechanical as it looked, and it held.

Adds 9 tests, one per site, asserting the connection is actually closed afterward. Deliberately not fd-counting: since CPython reclaims an out-of-scope connection immediately, an fd check cannot distinguish a real fix from a no-op, and "tests still pass" alone would equally describe doing nothing. (`get_statistics()` legitimately opens two — it also calls `_get_last_synced_rowid()` — and the test asserts both close.)

### Standards

Records `closing()` as house style in `docs/specs/standards/python-conventions.md`, with the read and write forms shown. All 7 other services named in the issue still use the bare form, confirming this file was the outlier; sweeping them is deferred to a follow-up per the issue.

Gate: **3811 passed, 9 skipped, 0 failed.** `tests/test_imessage.py`: 50 passed, 0 skipped. `usage.db` unchanged at 1057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)