### PR TITLE
fix(whatsapp): treat a wacli sync failure as an error, and tell a 405 client-version rejection apart from auth

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -441,7 +441,9 @@ on the Mac Mini that rsyncs `data/apple-imports/` to the Linux server.
 
 On the Mac Mini:
 
-1. Install: `brew install steipete/tap/wacli`
+1. Install: `brew install openclaw/tap/wacli` (formerly `steipete/tap/wacli` —
+   the tap was renamed; a stale local tap silently disables `brew outdated`,
+   see issue #677)
 2. Authenticate: `wacli auth` (scan the QR code with WhatsApp → Linked Devices)
 3. Verify: `wacli chats list --limit 5`
 4. Confirm the exporter picks up WhatsApp:

--- a/docs/specs/technical/data-and-sync.md
+++ b/docs/specs/technical/data-and-sync.md
@@ -253,7 +253,7 @@ file; the next run re-fetches and re-evaluates the whole window.
 | `apple_data_import.py` | Import Apple data exports into LifeOS | Linux server |
 | `apple_data_agent.sh` | Orchestrate export + rsync + import | Mac Mini (cron) |
 
-WhatsApp data flows through the same Mac Mini → Linux pipeline. The Mac runs `wacli` (steipete/tap/wacli) which reads the WhatsApp Desktop app's local SQLite database; `apple_data_export.export_whatsapp` dumps contacts, messages, group memberships and the LID-to-phone map to `whatsapp.json`; `apple_data_import.import_whatsapp` calls into `api/services/whatsapp.py` to create SourceEntity and Interaction records.
+WhatsApp data flows through the same Mac Mini → Linux pipeline. The Mac runs `wacli` (openclaw/tap/wacli) which reads the WhatsApp Desktop app's local SQLite database; `apple_data_export.export_whatsapp` dumps contacts, messages, group memberships and the LID-to-phone map to `whatsapp.json`; `apple_data_import.import_whatsapp` calls into `api/services/whatsapp.py` to create SourceEntity and Interaction records. A non-zero `wacli sync` exit (including a "Client outdated (405)" protocol rejection, distinct from an auth failure) marks the export `status: "error"` rather than silently exporting stale data as `ok` — see issue #677.
 
 ### Phase 2: Entity Processing
 

--- a/scripts/apple_data_export.py
+++ b/scripts/apple_data_export.py
@@ -688,18 +688,154 @@ def export_photos_faces(dry_run: bool = False) -> dict:
     }
 
 
+
+# Markers used by _diagnose_wacli_failure to classify a failed `wacli sync`.
+_WACLI_CLIENT_OUTDATED_MARKERS = ("outdated", "405")
+_WACLI_AUTH_FAILURE_MARKERS = (
+    "unauthorized",
+    "401",
+    "not authenticated",
+    "not logged in",
+    "please pair",
+    "please scan",
+    "session expired",
+    "logged out",
+)
+
+
+def _diagnose_wacli_failure(output: str) -> dict:
+    """Classify a failed `wacli sync` from its combined stdout/stderr.
+
+    Issue #677: WhatsApp sync was dead for 3+ months because a silent
+    Homebrew tap rename (steipete/tap -> openclaw/tap) froze wacli at 0.5.0
+    while WhatsApp's protocol moved on, producing "Client outdated (405)".
+    `wacli doctor` kept reporting AUTHENTICATED true throughout — the
+    session genuinely was valid — so every investigation re-paired the
+    client, which just produces a fresh, equally-rejected session. This
+    tells the two failure modes apart so the diagnosis it feeds into this
+    source's manifest entry (via the "reason"/"diagnosis" fields) names the
+    real cause and the real remedy instead of sending the operator to
+    re-pair.
+
+    The path this actually escapes by: a status of "error" here marks this
+    source as errored in manifest.json; on the Linux side
+    `_manifest_source_errored` reads that and makes `import_whatsapp`
+    return `status: "error"` too; apple_data_import.py's main() collects
+    that into `errored_sources` and calls `sys.exit(1)`; run_all_syncs.py
+    (around line 1109) sees the subprocess's non-zero return code and
+    records the failure (health_message/markdown_message/classify_message,
+    the nightly summary status, any alert) from that exit code. The
+    CRITICAL log check_manifest() also emits IS captured into the sync log
+    file, so a human reading it does see the diagnosis (#646) — it just
+    doesn't drive record_failure or anything downstream of it. Only the
+    exit code does.
+    """
+    lowered = (output or "").lower()
+    if all(marker in lowered for marker in _WACLI_CLIENT_OUTDATED_MARKERS):
+        return {
+            "diagnosis": "client_version",
+            "reason": (
+                "wacli client rejected by WhatsApp: Client outdated (405). "
+                "This is a client-version problem, NOT authentication — "
+                "`wacli doctor` will keep reporting AUTHENTICATED true "
+                "because the session is still valid, and re-pairing will "
+                "not fix it. Run `brew upgrade wacli`; if `brew outdated` "
+                "reports nothing, check for a tap rename first with "
+                "`brew info wacli`."
+            ),
+        }
+    if any(marker in lowered for marker in _WACLI_AUTH_FAILURE_MARKERS):
+        return {
+            "diagnosis": "auth",
+            "reason": "wacli reports an authentication failure — re-pair with `wacli auth`.",
+        }
+    return {
+        "diagnosis": "unknown",
+        "reason": f"wacli sync failed: {(output or '').strip()[:200]}",
+    }
+
+
+def _get_wacli_version() -> str | None:
+    """Best-effort `wacli --version` lookup for the export manifest.
+
+    Recorded on every export (issue #677) so a frozen client is visible
+    from the Linux side without shelling into the Mac — a version that
+    hasn't moved in months is the frozen-client signal even before a sync
+    actually fails outright. Mirrors _get_agent_sha's best-effort shape:
+    any failure here just means the field is null in the manifest, never a
+    broken export.
+    """
+    try:
+        result = subprocess.run(
+            ["wacli", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    version = (result.stdout or result.stderr or "").strip()
+    return version or None
+
+
+def _newest_message_timestamp(messages: list[dict]) -> str | None:
+    """Return the ISO timestamp of the newest message, or None if empty.
+
+    wacli stores `ts` as either an ISO string or unix epoch seconds — the
+    same ambiguity api.services.whatsapp.parse_message_timestamp handles on
+    the import side. Reimplemented locally (rather than importing that
+    module) to keep this macOS-only export script free of the CRM/DB
+    dependencies api.services.whatsapp pulls in at import time.
+    """
+    newest: datetime | None = None
+    for msg in messages:
+        ts = msg.get("ts")
+        if ts is None:
+            continue
+        try:
+            if isinstance(ts, str):
+                parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            else:
+                parsed = datetime.fromtimestamp(ts, tz=timezone.utc)
+        except (ValueError, TypeError, OSError):
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        if newest is None or parsed > newest:
+            newest = parsed
+    return newest.isoformat() if newest else None
+
+
 def export_whatsapp(dry_run: bool = False) -> dict:
     """Export WhatsApp data via wacli for import on Linux.
 
-    Routes through the wacli CLI (steipete/tap/wacli) which is macOS-only
-    and reads the WhatsApp Desktop app's local SQLite database. The Mac Mini
-    is the canonical source — Linux can't run wacli, so this export bridges
-    them via a JSON file the Linux importer can consume.
+    Routes through the wacli CLI (openclaw/tap, formerly steipete/tap) which
+    is macOS-only and reads the WhatsApp Desktop app's local SQLite
+    database. The Mac Mini is the canonical source — Linux can't run wacli,
+    so this export bridges them via a JSON file the Linux importer can
+    consume.
+
+    Periodic "is wacli current?" check (issue #677 AC): deliberately NOT
+    implemented as a separate network call to GitHub/Homebrew. `brew
+    outdated` already claims to do this and is exactly what silently broke
+    (a tap rename made it go quiet); a second freshness poll would rot the
+    same way. Instead this relies on two things that are always-on: (1)
+    _get_wacli_version() records the installed version on every export, so
+    a version frozen for months is visible as a passive signal even before
+    anything fails outright, and (2) _diagnose_wacli_failure() below turns
+    the first real protocol rejection into an immediate, correctly-labeled
+    error rather than a silent "ok" — so staleness surfaces on the next
+    nightly sync after it actually starts mattering, not months later.
     """
-    import subprocess
+    wacli_version = _get_wacli_version()
 
     # Step 1: Have wacli refresh its local database from WhatsApp Desktop.
-    # Best effort — if this fails we still export whatever's already on disk.
+    # A non-zero exit (or a timeout) must not be treated as "continue with
+    # whatever's on disk and call it ok" — that is exactly how a 405 Client
+    # outdated failure exported as status "ok" for 3+ months (issue #677).
+    sync_diagnosis: dict | None = None
     try:
         result = subprocess.run(
             ["wacli", "sync", "--once"],
@@ -710,19 +846,26 @@ def export_whatsapp(dry_run: bool = False) -> dict:
         if result.returncode == 0:
             logger.info("wacli sync completed")
         else:
-            logger.warning(f"wacli sync returned non-zero: {result.stderr.strip()[:200]}")
+            sync_diagnosis = _diagnose_wacli_failure(f"{result.stdout}\n{result.stderr}")
+            logger.error(
+                f"wacli sync failed ({sync_diagnosis['diagnosis']}): {sync_diagnosis['reason']}"
+            )
     except FileNotFoundError:
-        logger.error("wacli not found. Install with: brew install steipete/tap/wacli")
-        return {"status": "error", "reason": "wacli not installed"}
+        logger.error("wacli not found. Install with: brew install openclaw/tap/wacli")
+        return {"status": "error", "reason": "wacli not installed", "wacli_version": wacli_version}
     except subprocess.TimeoutExpired:
-        logger.warning("wacli sync timed out after 3 minutes — continuing with existing data")
+        sync_diagnosis = {
+            "diagnosis": "timeout",
+            "reason": "wacli sync timed out after 3 minutes — exported data may be stale",
+        }
+        logger.warning(sync_diagnosis["reason"])
 
     # Step 2: Verify wacli databases exist
     wacli_db = Path.home() / ".wacli" / "wacli.db"
     session_db = Path.home() / ".wacli" / "session.db"
     if not wacli_db.exists():
         logger.error(f"wacli database not found at {wacli_db}")
-        return {"status": "error", "reason": "wacli.db not found"}
+        return {"status": "error", "reason": "wacli.db not found", "wacli_version": wacli_version}
 
     # Step 3: Pull the contact list via the wacli command (richer than raw rows)
     try:
@@ -734,7 +877,7 @@ def export_whatsapp(dry_run: bool = False) -> dict:
         )
     except subprocess.TimeoutExpired:
         logger.error("wacli contacts search timed out")
-        return {"status": "error", "reason": "wacli contacts timeout"}
+        return {"status": "error", "reason": "wacli contacts timeout", "wacli_version": wacli_version}
 
     contacts: list[dict] = []
     if result.returncode == 0 and result.stdout.strip():
@@ -750,11 +893,16 @@ def export_whatsapp(dry_run: bool = False) -> dict:
         logger.warning(f"wacli contacts search failed: {result.stderr.strip()[:200]}")
 
     if dry_run:
-        return {
-            "status": "dry_run",
+        dry_result = {
+            "status": "error" if sync_diagnosis else "dry_run",
             "contacts": len(contacts),
             "wacli_db_mb": round(wacli_db.stat().st_size / (1024 * 1024), 1),
+            "wacli_version": wacli_version,
         }
+        if sync_diagnosis:
+            dry_result["reason"] = sync_diagnosis["reason"]
+            dry_result["diagnosis"] = sync_diagnosis["diagnosis"]
+        return dry_result
 
     # Step 4: Dump messages, group_participants, lid contacts from wacli.db
     conn = sqlite3.connect(f"file:{wacli_db}?mode=ro", uri=True)
@@ -813,14 +961,20 @@ def export_whatsapp(dry_run: bool = False) -> dict:
         f"Exported WhatsApp: {len(contacts)} contacts, {len(messages)} messages, "
         f"{len(group_participants)} group memberships, {len(lid_phones)} LID phones to {out_path}"
     )
-    return {
-        "status": "ok",
+    result_dict = {
+        "status": "error" if sync_diagnosis else "ok",
         "contacts": len(contacts),
         "messages": len(messages),
         "group_participants": len(group_participants),
         "lid_phones": len(lid_phones),
         "path": str(out_path),
+        "wacli_version": wacli_version,
+        "newest_message_at": _newest_message_timestamp(messages),
     }
+    if sync_diagnosis:
+        result_dict["reason"] = sync_diagnosis["reason"]
+        result_dict["diagnosis"] = sync_diagnosis["diagnosis"]
+    return result_dict
 
 
 def _finalize_result(result: dict) -> dict:

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -1065,6 +1065,256 @@ class TestAgentShaImport:
 
 
 # ---------------------------------------------------------------------------
+# WhatsApp export (issue #677) — a failed `wacli sync` must not export as
+# status "ok", a 405 "Client outdated" must be diagnosed as client-version
+# (not auth), and a genuine auth failure must still be diagnosed as auth.
+# ---------------------------------------------------------------------------
+
+class TestWacliFailureDiagnosis:
+    """_diagnose_wacli_failure classifies a failed `wacli sync` from its
+    combined stdout/stderr. Real sample output from issue #677 (synthetic
+    protocol/version numbers only, no personal data)."""
+
+    # Captured 2026-08-24 on a wacli client frozen at 0.5.0 by a silent
+    # Homebrew tap rename (steipete/tap -> openclaw/tap) — see issue #677.
+    SYNC_405_OUTPUT = (
+        "[Client/Socket ERROR] Error reading from websocket: failed to get "
+        "reader: failed to read frame header: EOF\n"
+        "[Client ERROR] Client outdated (405) connect failure "
+        "(client version: 2.3000.1037076227)\n\n"
+        "Idle for 30s, exiting.\n"
+        "Messages stored: 0"
+    )
+
+    # Synthetic — wacli doesn't publish a canonical auth-failure message;
+    # this exercises the auth-marker branch without inventing 405 text.
+    SYNC_AUTH_OUTPUT = (
+        "[Client ERROR] Unauthorized (401): session not authenticated. "
+        "Run `wacli auth` to pair a device.\n"
+        "Idle for 5s, exiting.\n"
+        "Messages stored: 0"
+    )
+
+    def _diagnose(self):
+        from scripts.apple_data_export import _diagnose_wacli_failure
+        return _diagnose_wacli_failure
+
+    def test_405_client_outdated_is_client_version_not_auth(self):
+        diagnose = self._diagnose()
+        result = diagnose(self.SYNC_405_OUTPUT)
+
+        assert result["diagnosis"] == "client_version"
+        assert "auth" not in result["diagnosis"]
+        assert "brew upgrade wacli" in result["reason"]
+        assert "NOT authentication" in result["reason"]
+
+    def test_genuine_auth_failure_is_still_auth(self):
+        """The 405 fix must not overcorrect into misdiagnosing a real auth
+        failure as a client-version problem."""
+        diagnose = self._diagnose()
+        result = diagnose(self.SYNC_AUTH_OUTPUT)
+
+        assert result["diagnosis"] == "auth"
+        assert "wacli auth" in result["reason"]
+
+    def test_unrecognized_failure_is_unknown_not_silently_ok(self):
+        diagnose = self._diagnose()
+        result = diagnose("[Client ERROR] connection refused")
+
+        assert result["diagnosis"] == "unknown"
+        assert "connection refused" in result["reason"]
+
+    def test_empty_output_handled(self):
+        diagnose = self._diagnose()
+        result = diagnose("")
+        assert result["diagnosis"] == "unknown"
+
+
+class TestWacliVersionLookup:
+    """_get_wacli_version is best-effort, like _get_agent_sha: any failure
+    just means the manifest field is null, never a broken export."""
+
+    def _get_version(self):
+        from scripts.apple_data_export import _get_wacli_version
+        return _get_wacli_version
+
+    def test_returns_stripped_version(self):
+        get_version = self._get_version()
+        fake_result = MagicMock(returncode=0, stdout="0.17.1\n", stderr="")
+        with patch("scripts.apple_data_export.subprocess.run", return_value=fake_result):
+            assert get_version() == "0.17.1"
+
+    def test_none_on_nonzero_exit(self):
+        get_version = self._get_version()
+        fake_result = MagicMock(returncode=1, stdout="", stderr="unknown flag")
+        with patch("scripts.apple_data_export.subprocess.run", return_value=fake_result):
+            assert get_version() is None
+
+    def test_none_when_wacli_missing(self):
+        get_version = self._get_version()
+        with patch("scripts.apple_data_export.subprocess.run", side_effect=FileNotFoundError()):
+            assert get_version() is None
+
+
+class TestNewestMessageTimestamp:
+    """_newest_message_timestamp handles wacli's mixed ISO-string/epoch-
+    second `ts` formats, same ambiguity as the import-side parser."""
+
+    def _newest(self):
+        from scripts.apple_data_export import _newest_message_timestamp
+        return _newest_message_timestamp
+
+    def test_picks_latest_iso_timestamp(self):
+        newest = self._newest()
+        result = newest([
+            {"ts": "2026-08-20T10:00:00+00:00"},
+            {"ts": "2026-08-24T09:30:00+00:00"},
+            {"ts": "2026-08-22T00:00:00+00:00"},
+        ])
+        assert result == "2026-08-24T09:30:00+00:00"
+
+    def test_picks_latest_epoch_timestamp(self):
+        newest = self._newest()
+        earlier = int(datetime(2026, 8, 20, tzinfo=timezone.utc).timestamp())
+        later = int(datetime(2026, 8, 24, tzinfo=timezone.utc).timestamp())
+        result = newest([{"ts": earlier}, {"ts": later}])
+        assert result == datetime(2026, 8, 24, tzinfo=timezone.utc).isoformat()
+
+    def test_empty_list_returns_none(self):
+        newest = self._newest()
+        assert newest([]) is None
+
+    def test_unparseable_timestamps_skipped(self):
+        newest = self._newest()
+        result = newest([{"ts": "not-a-date"}, {"ts": "2026-08-24T00:00:00+00:00"}])
+        assert result == "2026-08-24T00:00:00+00:00"
+
+
+class TestExportWhatsapp:
+    """export_whatsapp's end-to-end status/diagnosis behavior."""
+
+    def _build_wacli_db(self, path: Path, messages: list[tuple]):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(path))
+        conn.executescript("""
+            CREATE TABLE messages (
+                msg_id TEXT, chat_jid TEXT, chat_name TEXT, sender_jid TEXT,
+                sender_name TEXT, ts TEXT, from_me INTEGER, text TEXT,
+                display_text TEXT, media_type TEXT
+            );
+            CREATE TABLE group_participants (group_jid TEXT, user_jid TEXT);
+            CREATE TABLE contacts (jid TEXT, push_name TEXT);
+        """)
+        for m in messages:
+            conn.execute(
+                "INSERT INTO messages (msg_id, chat_jid, chat_name, sender_jid, "
+                "sender_name, ts, from_me, text, display_text, media_type) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                m,
+            )
+        conn.commit()
+        conn.close()
+
+    def _msg(self, msg_id: str, ts: str):
+        return (msg_id, "15555550100@s.whatsapp.net", "Test Chat",
+                "15555550100@s.whatsapp.net", "Tester", ts, 0, "hi", "hi", None)
+
+    def _run_export(
+        self,
+        tmp_path: Path,
+        sync_returncode: int,
+        sync_output: str = "",
+        messages: list[tuple] | None = None,
+        dry_run: bool = False,
+        wacli_version: str = "0.17.1",
+    ):
+        from scripts.apple_data_export import export_whatsapp
+
+        export_dir = tmp_path / "exports"
+        export_dir.mkdir()
+        wacli_db = tmp_path / ".wacli" / "wacli.db"
+        self._build_wacli_db(wacli_db, messages or [])
+
+        sync_result = MagicMock(returncode=sync_returncode, stdout=sync_output, stderr="")
+        version_result = MagicMock(returncode=0, stdout=wacli_version, stderr="")
+        contacts_result = MagicMock(returncode=0, stdout='{"data": []}', stderr="")
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["wacli", "sync"]:
+                return sync_result
+            if cmd[:2] == ["wacli", "--version"]:
+                return version_result
+            if "--json" in cmd:
+                return contacts_result
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        with patch("scripts.apple_data_export.Path.home", return_value=tmp_path), \
+             patch("scripts.apple_data_export.EXPORT_DIR", export_dir), \
+             patch("scripts.apple_data_export.subprocess.run", side_effect=fake_run):
+            return export_whatsapp(dry_run=dry_run)
+
+    def test_successful_sync_is_ok(self, tmp_path):
+        result = self._run_export(tmp_path, sync_returncode=0)
+        assert result["status"] == "ok"
+        assert "reason" not in result
+
+    def test_nonzero_sync_exit_marks_error_not_ok(self, tmp_path):
+        """Issue #677's core bug: a failing `wacli sync` used to export as
+        status "ok" and package whatever stale data was already on disk."""
+        result = self._run_export(
+            tmp_path, sync_returncode=1, sync_output="[Client ERROR] connection refused",
+        )
+        assert result["status"] == "error"
+        assert result["diagnosis"] == "unknown"
+        # The export still runs to completion — stale data is better than
+        # none, but the run must not look like a clean success.
+        assert result["path"]
+
+    def test_405_client_outdated_is_error_with_client_version_diagnosis(self, tmp_path):
+        result = self._run_export(
+            tmp_path,
+            sync_returncode=1,
+            sync_output=TestWacliFailureDiagnosis.SYNC_405_OUTPUT,
+        )
+        assert result["status"] == "error"
+        assert result["diagnosis"] == "client_version"
+        assert "brew upgrade wacli" in result["reason"]
+
+    def test_auth_failure_is_error_with_auth_diagnosis(self, tmp_path):
+        result = self._run_export(
+            tmp_path,
+            sync_returncode=1,
+            sync_output=TestWacliFailureDiagnosis.SYNC_AUTH_OUTPUT,
+        )
+        assert result["status"] == "error"
+        assert result["diagnosis"] == "auth"
+
+    def test_manifest_records_wacli_version_and_newest_message_timestamp(self, tmp_path):
+        result = self._run_export(
+            tmp_path,
+            sync_returncode=0,
+            wacli_version="0.17.1",
+            messages=[
+                self._msg("m1", "2026-08-20T10:00:00+00:00"),
+                self._msg("m2", "2026-08-24T09:30:00+00:00"),
+            ],
+        )
+        assert result["wacli_version"] == "0.17.1"
+        assert result["newest_message_at"] == "2026-08-24T09:30:00+00:00"
+
+    def test_dry_run_still_surfaces_sync_error(self, tmp_path):
+        result = self._run_export(
+            tmp_path,
+            sync_returncode=1,
+            sync_output=TestWacliFailureDiagnosis.SYNC_405_OUTPUT,
+            dry_run=True,
+        )
+        assert result["status"] == "error"
+        assert result["diagnosis"] == "client_version"
+        assert result["wacli_version"] == "0.17.1"
+
+
+# ---------------------------------------------------------------------------
 # Phone import — phone number extraction and person resolution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #677.

WhatsApp sync was dead for **3+ months**. Repeated re-authentication never fixed it because **auth was never the problem** — a silent Homebrew tap rename (`steipete/tap` → `openclaw/tap`) froze wacli at 0.5.0 while WhatsApp's protocol moved on, producing `Client outdated (405)`. `wacli doctor` reported `AUTHENTICATED true` throughout (the session genuinely was valid), so every investigation re-paired the client and got a fresh, equally-rejected session.

The host is already fixed (wacli 0.5.0 → 0.17.1). This is the code that should have made it diagnosable.

### Changes

- **A non-zero `wacli sync` exit is now an error, not `ok`.** Previously it produced zero messages and still reported success, so the Linux side saw health.
- **`_diagnose_wacli_failure()` distinguishes the two failure modes.** A 405 yields `diagnosis: "client_version"` whose reason explicitly says this is *not* authentication, warns that `wacli doctor` will keep reporting `AUTHENTICATED true`, notes that re-pairing will not help, and points at `brew upgrade wacli`. Auth markers still yield `diagnosis: "auth"` pointing at `wacli auth`; anything else is `unknown`. Misdiagnosis was the expensive part here, so the fix is as much about naming the right remedy as detecting the failure.
- **Manifest records `wacli_version` and `newest_message_at`**, so a frozen client is visible from the Linux side without shelling into the Mac.
- Corrects the now-dead `steipete/tap/wacli` install hint in the error path and in `setup.md` / `data-and-sync.md`.

### Periodic version check — considered, deliberately not added

`brew outdated` already claims to do this, and a silent tap rename is exactly what made it go quiet; a second freshness check carries the same rot risk. Instead, `wacli_version` in every manifest gives a passive "hasn't moved in months" signal, and the 405 diagnosis turns the first real protocol rejection into an immediate correctly-labelled error rather than a silent `ok`. Reasoning is recorded in the code.

### How the signal escapes

export `status: "error"` → `_manifest_source_errored` → `import_whatsapp` returns error → `errored_sources` → `sys.exit(1)` → `run_all_syncs.py` records the failure from the non-zero return code.

`check_manifest()`'s CRITICAL log for the same error **is** captured in the sync log and visible to a human reading it — it just doesn't drive `record_failure`, the run status, or the nightly summary. Only the exit code does. (An earlier draft of this PR claimed the log was discarded; that was wrong and is corrected — see #646.)

### Tests

Four new tests, all asserting `status == "error"` on the export's own return — the field the real escape mechanism keys off — rather than asserting a log was emitted. A log-asserting test would have passed happily throughout the entire three-month outage.

Covers: non-zero exit → error not ok; 405 → client-version diagnosis naming the upgrade remedy; a genuine auth failure still diagnosed as auth (no overcorrection in the other direction); dry-run surfaces it too; manifest carries version + newest-message timestamp.

Gate: **3836 passed, 9 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)