### PR TITLE
fix(sync): make Apple import staleness and masked export errors fail the run

### DIFF
--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -733,6 +733,43 @@ def get_consecutive_zero_yield_runs(source: str, limit: int = 50) -> int:
     return streak
 
 
+def get_repeated_yield_streak(source: str, value: float, limit: int = 50) -> int:
+    """How many of the most recent successful runs, in a row, produced
+    exactly ``value`` records.
+
+    Complements :func:`get_consecutive_zero_yield_runs`, which only catches
+    a source going silent (yield drops to zero). A source re-importing the
+    same byte-identical stale upstream file every night can instead report
+    the *same non-zero* count forever — e.g. issue #646, where a dead Mac
+    Mini export agent left ten nights reporting an identical "1294 created"
+    while nothing had actually changed. A long streak of an identical
+    non-zero count is the signature of that: real nightly variation almost
+    never lands on the exact same number twice in a row.
+    """
+    conn = get_sync_health_db()
+    try:
+        rows = conn.execute(
+            """
+            SELECT records_created, records_updated, interactions_created,
+                   records_processed
+            FROM sync_runs
+            WHERE source = ? AND status = ?
+            ORDER BY started_at DESC
+            LIMIT ?
+            """,
+            (source, SyncStatus.SUCCESS.value, limit),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    streak = 0
+    for row in rows:
+        if _row_yield(row) != value:
+            break
+        streak += 1
+    return streak
+
+
 def get_yield_history(source: str) -> dict:
     """Lifetime yield stats for ``source``: run count and best run ever.
 

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -75,11 +75,27 @@ def check_manifest() -> dict | None:
 
     Logs warnings/errors based on data age:
     - >48h: WARNING (picked up by nightly health batch)
-    - >7d:  CRITICAL-level log (triggers immediate alert if server is running)
+    - >7d:  CRITICAL-level log, AND sets manifest["_staleness_critical_message"]
 
     Also walks manifest["results"] and logs CRITICAL for any source the Mac
     Mini export marked with status == "error". The caller (main) uses the
     returned manifest to decide exit status.
+
+    Issue #646: a CRITICAL log line alone never drives alerting. It does
+    land in the sync log file — a human reading it directly sees it fine —
+    but this script runs as a subprocess under run_all_syncs.py, and only
+    that subprocess's exit code (plus the ``SYNC_STATS:{json}`` line for
+    stats) feeds ``record_failure``/the run status/the nightly summary.
+    Logging alone never touches any of those. A 10-day dead export agent
+    produced exactly this CRITICAL every night — visible in the log, had
+    anyone gone looking — while the run was still recorded as a clean
+    success. So in addition to logging, staleness and agent-SHA drift are
+    recorded as keys directly on the returned manifest dict —
+    ``_staleness_critical_message`` (checked by main() below to force a
+    nonzero exit) and ``_agent_sha_drift_message`` (checked by run_all_syncs
+    directly, since drift is a warning, not a run failure). The leading
+    underscore marks these as synthetic, not part of the Mac-side export
+    schema.
     """
     manifest_path = IMPORT_DIR / "manifest.json"
     if not manifest_path.exists():
@@ -101,10 +117,12 @@ def check_manifest() -> dict | None:
             age_hours = age.total_seconds() / 3600
 
             if age_hours > STALENESS_CRITICAL_HOURS:
-                logger.critical(
+                message = (
                     f"Apple import data is {age.days} days old (exported {exported_at_str}). "
                     f"Check Mac Mini cron and rsync pipeline."
                 )
+                logger.critical(message)
+                manifest["_staleness_critical_message"] = message
             elif age_hours > STALENESS_WARNING_HOURS:
                 logger.warning(
                     f"Apple import data is {age_hours:.0f}h old (exported {exported_at_str}). "
@@ -115,9 +133,18 @@ def check_manifest() -> dict | None:
         except (ValueError, TypeError) as e:
             logger.warning(f"Cannot parse manifest exported_at: {e}")
 
-    # Walk per-source results and log CRITICAL for any export-side errors.
-    # The CRITICAL log level is the existing alerting path — it routes through
-    # email/Telegram when the server is running.
+    # Walk per-source results and log CRITICAL for any export-side errors,
+    # for visibility when this script is run directly (or when someone
+    # reads the sync log file). That log line alone does NOT drive
+    # record_failure, the run status, or the nightly summary — only the
+    # subprocess exit code does, and logging by itself never touches it.
+    # main() below is what actually makes this count, by folding any
+    # manifest-reported error into this run's results dict so the existing
+    # status=="error" -> sys.exit(1) path picks it up. (Issue #646:
+    # believing the CRITICAL log level *was* "the existing alerting path"
+    # — this comment used to say exactly that — is what let a stale export
+    # look healthy for ten days, even though the CRITICAL was right there
+    # in the log the whole time.)
     results = manifest.get("results") or {}
     if isinstance(results, dict):
         for source_name, source_result in results.items():
@@ -137,11 +164,13 @@ def check_manifest() -> dict | None:
     if agent_sha:
         local_sha = _get_local_main_sha()
         if local_sha and agent_sha != local_sha:
-            logger.warning(
+            message = (
                 f"Apple Data Agent exported from {agent_sha[:7]}, which differs from "
                 f"this host's main ({local_sha[:7]}) — its self-update may have failed. "
                 f"Check the agent log on the Mac Mini."
             )
+            logger.warning(message)
+            manifest["_agent_sha_drift_message"] = message
 
     return manifest
 
@@ -863,24 +892,58 @@ def main():
             logger.error(f"Failed to import {name}: {e}")
             results[name] = {"status": "error", "error": str(e)}
 
-    # Also surface per-source errors recorded in the manifest for sources we
-    # didn't attempt this run (e.g. --source contacts will skip whatsapp, but
-    # if the manifest says whatsapp errored on the Mac side we still want to
-    # propagate that). Only sources the caller selected are merged so that
-    # --source contacts doesn't spuriously fail on an unrelated phone error.
+    # Also surface per-source errors recorded in the manifest. Only sources
+    # the caller selected are considered so that --source contacts doesn't
+    # spuriously fail on an unrelated phone error.
+    #
+    # Two cases:
+    #   - Not attempted this run (e.g. --source contacts skips whatsapp, but
+    #     the manifest says whatsapp errored on the Mac side) — add it.
+    #   - Attempted and returned non-error. import_contacts/import_whatsapp
+    #     are manifest-aware internally (see _manifest_source_errored) and
+    #     already report "error" themselves when the manifest says so, so
+    #     this is a no-op for them. imessage/phone/photos/health are NOT
+    #     manifest-aware: if last export's file is still on disk, the local
+    #     import happily reprocesses it and reports "ok", silently masking
+    #     a Mac-side export failure (issue #646 — the same "logged but not
+    #     structured" gap as staleness, just for this specific walk in
+    #     check_manifest() above instead of the staleness guard). Override
+    #     status back to "error" here rather than teaching every import_*
+    #     function to check the manifest individually.
     if manifest:
         manifest_results = manifest.get("results") or {}
         for name in sources:
-            if name in results:
-                continue
             manifest_entry = manifest_results.get(name) if isinstance(manifest_results, dict) else None
-            if isinstance(manifest_entry, dict) and manifest_entry.get("status") == "error":
-                results[name] = {
-                    "status": "error",
-                    "reason": manifest_entry.get("reason")
-                    or manifest_entry.get("error")
-                    or "Mac export reported error",
-                }
+            if not isinstance(manifest_entry, dict) or manifest_entry.get("status") != "error":
+                continue
+            existing = results.get(name)
+            if isinstance(existing, dict) and existing.get("status") == "error":
+                continue  # already flagged (e.g. import_contacts's own manifest check)
+            reason = (
+                manifest_entry.get("reason")
+                or manifest_entry.get("error")
+                or "Mac export reported error"
+            )
+            if isinstance(existing, dict):
+                existing["status"] = "error"
+                existing["reason"] = reason
+            else:
+                results[name] = {"status": "error", "reason": reason}
+
+    # Issue #646: staleness past STALENESS_CRITICAL_HOURS must fail the run,
+    # not just log a CRITICAL that doesn't drive record_failure/alerting —
+    # only the exit code does. A synthetic "manifest_staleness" entry reuses
+    # the exact per-source error path below (results[...]["status"] ==
+    # "error" -> nonzero exit -> run_all_syncs.py marks apple_import FAILED
+    # -> reaches the Telegram/markdown summary) — the one mechanism already
+    # proven to reach alerting, instead of adding another log line that
+    # would land in the file the same way the staleness CRITICAL already
+    # does, without changing whether anyone is actually told.
+    if manifest and manifest.get("_staleness_critical_message"):
+        results["manifest_staleness"] = {
+            "status": "error",
+            "reason": manifest["_staleness_critical_message"],
+        }
 
     print(json.dumps({"results": results}, indent=2))
 

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -57,6 +57,7 @@ from api.services.sync_health import (
     get_typical_yield,
     get_yield_history,
     get_consecutive_zero_yield_runs,
+    get_repeated_yield_streak,
     get_recent_errors,
     check_sync_health,
     reap_orphan_sync_runs,
@@ -423,6 +424,32 @@ def log_sync_summary_to_markdown(result: dict, trigger: str = "unknown"):
             src_details = ", ".join(f"{s}: {c}" for s, c in interactions_by_src.items() if c > 0)
             lines.append(f"- Interactions: {interactions_created}" + (f" ({src_details})" if src_details else ""))
 
+    # Repeated-identical-yield sources (#646) — excluded from "New Records"
+    # above because a constant non-zero count across consecutive runs is
+    # evidence of re-importing unchanged upstream data, not real new
+    # records. Called out here so the run isn't just silently under-counted.
+    repeated_yield_sources = result.get("repeated_yield_sources", [])
+    if repeated_yield_sources:
+        lines.append("")
+        lines.append(f"**Possible stale re-import ({len(repeated_yield_sources)}, not counted as new):**")
+        for src in repeated_yield_sources:
+            info = result.get("results", {}).get(src, {}).get("repeated_yield", {})
+            value = info.get("repeated_value")
+            runs = info.get("consecutive_runs")
+            if value is not None and runs is not None:
+                lines.append(f"- {src}: {value:.0f} records, {runs} runs in a row")
+            else:
+                lines.append(f"- {src}")
+
+    # Apple Data Agent SHA drift (#646) — a silently-broken self-update on
+    # the Mac Mini export agent, surfaced here instead of a log line no
+    # batched report reads.
+    apple_agent_sha_drift = result.get("apple_agent_sha_drift")
+    if apple_agent_sha_drift:
+        lines.append("")
+        lines.append("**Apple Data Agent SHA drift:**")
+        lines.append(f"- {apple_agent_sha_drift}")
+
     lines.append("")
     lines.append("---")
 
@@ -448,7 +475,15 @@ def send_sync_summary_telegram(result: dict, trigger: str = "unknown"):
 
     # Build message
     collapsed_sources = result.get("duration_collapsed_sources", [])
-    status_emoji = "✅" if result["failed"] == 0 and not collapsed_sources and not result.get("investments_stale") else "⚠️"
+    status_emoji = (
+        "✅"
+        if result["failed"] == 0
+        and not collapsed_sources
+        and not result.get("investments_stale")
+        and not result.get("repeated_yield_sources")
+        and not result.get("apple_agent_sha_drift")
+        else "⚠️"
+    )
     lines = [
         f"{status_emoji} *LifeOS Sync Complete*",
         f"Trigger: {trigger}",
@@ -525,6 +560,32 @@ def send_sync_summary_telegram(result: dict, trigger: str = "unknown"):
         lines.append("")
         lines.append("⚠️ *Investments snapshot stale:*")
         lines.append(f"  {investments_stale}")
+
+    # Apple Data Agent SHA drift (#646) — surface here so a silently-broken
+    # Mac Mini self-update reaches the operator (the bare log line does not
+    # feed any batched report).
+    apple_agent_sha_drift = result.get("apple_agent_sha_drift")
+    if apple_agent_sha_drift:
+        lines.append("")
+        lines.append("⚠️ *Apple Data Agent SHA drift:*")
+        lines.append(f"  {apple_agent_sha_drift}")
+
+    # Repeated-identical-yield sources (#646) — a constant non-zero count
+    # across consecutive runs is evidence of re-importing unchanged upstream
+    # data, not real new records. Called out explicitly since these counts
+    # are excluded from "New People"/"New Interactions" above.
+    repeated_yield_sources = result.get("repeated_yield_sources", [])
+    if repeated_yield_sources:
+        lines.append("")
+        lines.append(f"*Possible stale re-import ({len(repeated_yield_sources)}, not counted as new):*")
+        for src in repeated_yield_sources:
+            info = result.get("results", {}).get(src, {}).get("repeated_yield", {})
+            value = info.get("repeated_value")
+            runs = info.get("consecutive_runs")
+            if value is not None and runs is not None:
+                lines.append(f"  • {src}: {value:.0f} records, {runs} runs in a row")
+            else:
+                lines.append(f"  • {src}")
 
     try:
         success = send_message("\n".join(lines))
@@ -867,6 +928,40 @@ def _detect_never_yielded(source: str, stats: dict) -> dict | None:
         "runs": history["runs"],
         "avg_duration_seconds": history["avg_duration_seconds"],
     }
+
+
+# Repeated-yield detection (issue #646): a dead export agent that leaves the
+# same stale upstream file in place every night is invisible to yield
+# collapse (yield collapse only fires on *zero* output) — the re-import
+# re-processes byte-identical data and reports an identical non-zero count,
+# night after night. Nathan's post-incident analysis found exactly this: a
+# 10-night streak of "1294 created" / "3302 created" while five Apple
+# sources were frozen, read by the nightly summary as thousands of healthy
+# new records.
+REPEATED_YIELD_MIN_CONSECUTIVE = 3
+
+
+def _detect_repeated_yield(source: str, stats: dict) -> dict | None:
+    """Return info if this run produced the exact same non-zero yield as
+    each of the last few runs — evidence of re-importing an unchanged
+    upstream file and reporting it as new, rather than genuine repetition.
+
+    Never raises — a sync_health DB hiccup must not fail the sync itself.
+    """
+    this_yield = _run_yield(stats)
+    if this_yield <= 0:
+        return None
+    try:
+        # +1 for the run in flight: it isn't recorded yet, so the stored
+        # history is one short of the true streak (mirrors _detect_yield_collapse).
+        streak = get_repeated_yield_streak(source, this_yield) + 1
+    except Exception as e:
+        logger.warning(f"Repeated-yield check failed for {source}: {e}")
+        return None
+
+    if streak < REPEATED_YIELD_MIN_CONSECUTIVE:
+        return None
+    return {"repeated_value": this_yield, "consecutive_runs": streak}
 
 
 # A chronic never-yielded source (link_slack, repoint_stale_ids, google_sheets,
@@ -1310,6 +1405,18 @@ def run_sync(source: str, dry_run: bool = False) -> tuple[bool, dict]:
                             record_sync_error(source, msg, error_type="never_yielded")
                             stats["never_yielded_warned"] = True
 
+                    repeated_yield = _detect_repeated_yield(source, stats)
+                    if repeated_yield:
+                        stats["repeated_yield"] = repeated_yield
+                        msg = (
+                            f"{source} produced the same "
+                            f"{repeated_yield['repeated_value']:.0f} records for "
+                            f"{repeated_yield['consecutive_runs']} runs in a row — "
+                            f"possible re-import of unchanged upstream data reported as new"
+                        )
+                        logger.error(msg)
+                        record_sync_error(source, msg, error_type="repeated_yield")
+
                 if skipped_reason:
                     stats["skipped"] = True
                     stats["skipped_reason"] = skipped_reason
@@ -1684,6 +1791,7 @@ def run_all_syncs(
     duration_collapsed = []  # Sources that "succeeded" suspiciously fast
     yield_collapsed = []  # Normally produce records, produced none this run
     never_yielded_sources = []  # Never produced anything across many runs
+    repeated_yield_sources = []  # Same non-zero count for several runs in a row
     skipped_sources = []  # Exited early because they aren't configured
     start_time = datetime.now()
 
@@ -1856,6 +1964,8 @@ def run_all_syncs(
                     yield_collapsed.append(source)
                 if stats.get("never_yielded_warned"):
                     never_yielded_sources.append(source)
+                if stats.get("repeated_yield"):
+                    repeated_yield_sources.append(source)
 
             # Restart LLM after last embedding phase completes (if we stopped it)
             if source in EMBEDDING_SOURCES and _llm_stopped_for_sync:
@@ -1891,6 +2001,11 @@ def run_all_syncs(
         logger.error(f"Yield collapse (produced nothing, normally do): {', '.join(yield_collapsed)}")
     if never_yielded_sources:
         logger.warning(f"Never produced records: {', '.join(never_yielded_sources)}")
+    if repeated_yield_sources:
+        logger.error(
+            f"Repeated identical yield (possible stale re-import reported as new): "
+            f"{', '.join(repeated_yield_sources)}"
+        )
     logger.info("=" * 60)
 
     # Apply backup retention only now, and only if nothing failed. Tonight's
@@ -1936,6 +2051,23 @@ def run_all_syncs(
     except Exception as e:
         logger.warning(f"Investments freshness check failed: {e}")
 
+    # Apple Data Agent SHA-drift warning (issue #646): the Mac Mini export
+    # agent's self-update (#509) can silently stop working, leaving it
+    # running stale code indefinitely with no per-run signal — apple_import's
+    # own CRITICAL log line never reaches this summary (it's a subprocess;
+    # only its SYNC_STATS line is parsed). Checked directly against
+    # manifest.json here, independent of the subprocess, the same way
+    # investments freshness is checked above. Non-fatal — a warning, not a
+    # run failure — and silent when not set up (missing manifest/agent_sha).
+    apple_agent_sha_drift = None
+    try:
+        from scripts.apple_data_import import check_manifest as _check_apple_manifest
+        _apple_manifest = _check_apple_manifest()
+        if _apple_manifest:
+            apple_agent_sha_drift = _apple_manifest.get("_agent_sha_drift_message")
+    except Exception as e:
+        logger.warning(f"Apple agent SHA-drift check failed: {e}")
+
     # Calculate duration
     end_time = datetime.now()
     duration_seconds = (end_time - start_time).total_seconds()
@@ -1950,6 +2082,14 @@ def run_all_syncs(
 
     for source, stats in results.items():
         if stats.get("skipped") or stats.get("dry_run"):
+            continue
+        # Issue #646: a source flagged repeated_yield reported the exact same
+        # non-zero count it reported on the last several runs — the
+        # signature of re-importing an unchanged upstream file, not real new
+        # records. Excluded here so the "New Records" summary doesn't repeat
+        # the same phantom total night after night; repeated_yield_sources
+        # (added to `result` below) is where this run's numbers actually go.
+        if stats.get("repeated_yield"):
             continue
         pc = stats.get("people_created", 0)
         pu = stats.get("people_updated", 0)
@@ -1985,7 +2125,9 @@ def run_all_syncs(
         "interactions_by_source": interactions_by_source,
         "dep_skipped_sources": sorted(dep_skipped),
         "duration_collapsed_sources": duration_collapsed,
+        "repeated_yield_sources": repeated_yield_sources,
         "investments_stale": investments_stale,
+        "apple_agent_sha_drift": apple_agent_sha_drift,
     }
 
     # Exit maintenance mode now that sync is complete

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 
 # ---------------------------------------------------------------------------
 # Contacts plist parsing
@@ -838,6 +840,57 @@ class TestStalenessAlerting:
         assert any(r.levelno >= logging.CRITICAL for r in caplog.records)
         assert any("10 days old" in r.message for r in caplog.records)
 
+    def test_stale_7d_critical_sets_structured_message(self, tmp_path, caplog):
+        """Issue #646 regression guard: the staleness signal must be readable
+        from check_manifest()'s return value, not just the log stream. A
+        CRITICAL log line lands in the sync log file fine, but it doesn't
+        drive record_failure/the run status/the nightly summary — only the
+        subprocess exit code does, and a prose-only CRITICAL (the pre-fix
+        behavior) never touches that. This test fails against that pre-fix
+        behavior: caplog would still show the CRITICAL, but
+        manifest["_staleness_critical_message"] wouldn't exist."""
+        from scripts.apple_data_import import check_manifest
+
+        import_dir = tmp_path / "apple-imports"
+        very_stale = datetime.now(timezone.utc) - timedelta(days=10)
+        self._write_manifest(import_dir, very_stale.isoformat())
+
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir):
+            with caplog.at_level(logging.DEBUG):
+                result = check_manifest()
+
+        assert result is not None
+        assert "10 days old" in result.get("_staleness_critical_message", "")
+
+    def test_fresh_data_no_structured_staleness_message(self, tmp_path, caplog):
+        from scripts.apple_data_import import check_manifest
+
+        import_dir = tmp_path / "apple-imports"
+        fresh = datetime.now(timezone.utc) - timedelta(hours=1)
+        self._write_manifest(import_dir, fresh.isoformat())
+
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir):
+            with caplog.at_level(logging.INFO):
+                result = check_manifest()
+
+        assert result is not None
+        assert "_staleness_critical_message" not in result
+
+    def test_stale_48h_no_structured_critical_message(self, tmp_path, caplog):
+        """The 48h WARNING tier must not set the critical-only flag."""
+        from scripts.apple_data_import import check_manifest
+
+        import_dir = tmp_path / "apple-imports"
+        stale = datetime.now(timezone.utc) - timedelta(hours=50)
+        self._write_manifest(import_dir, stale.isoformat())
+
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir):
+            with caplog.at_level(logging.WARNING):
+                result = check_manifest()
+
+        assert result is not None
+        assert "_staleness_critical_message" not in result
+
     def test_missing_manifest(self, tmp_path, caplog):
         from scripts.apple_data_import import check_manifest
 
@@ -1030,6 +1083,38 @@ class TestAgentShaImport:
             r.levelno == logging.WARNING and "differs from" in r.message
             for r in caplog.records
         )
+
+    def test_mismatched_sha_sets_structured_message(self, tmp_path, caplog):
+        """Issue #646: run_all_syncs.py reads this drift signal directly off
+        the manifest dict (not the subprocess log stream) so it can surface
+        in the nightly Telegram/markdown summary — this must be readable
+        from the return value, not just caplog."""
+        from scripts.apple_data_import import check_manifest
+
+        import_dir = tmp_path / "apple-imports"
+        self._write_manifest(import_dir, agent_sha="abc1234")
+
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir), \
+                patch("scripts.apple_data_import._get_local_main_sha", return_value="def5678"):
+            with caplog.at_level(logging.WARNING):
+                result = check_manifest()
+
+        assert result is not None
+        assert "differs from" in result.get("_agent_sha_drift_message", "")
+
+    def test_matching_sha_no_structured_message(self, tmp_path, caplog):
+        from scripts.apple_data_import import check_manifest
+
+        import_dir = tmp_path / "apple-imports"
+        self._write_manifest(import_dir, agent_sha="abc1234")
+
+        with patch("scripts.apple_data_import.IMPORT_DIR", import_dir), \
+                patch("scripts.apple_data_import._get_local_main_sha", return_value="abc1234"):
+            with caplog.at_level(logging.WARNING):
+                result = check_manifest()
+
+        assert result is not None
+        assert "_agent_sha_drift_message" not in result
 
     def test_missing_agent_sha_handled_silently(self, tmp_path, caplog):
         """Manifests written before this change have no agent_sha — must not
@@ -1305,3 +1390,266 @@ class TestPhoneImport:
         assert result["imported"] == 0
         assert result["unresolved"] == 1
         mock_resolver.resolve_by_phone.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# main() — critical staleness must fail the run (issue #646)
+# ---------------------------------------------------------------------------
+
+class TestManifestStalenessFailsRun:
+    """Regression for issue #646's headline defect: a manifest whose every
+    source reports ok, but whose exported_at is older than
+    STALENESS_CRITICAL_HOURS, must fail the run — not just log a CRITICAL
+    that lands in the sync log file but never drives record_failure, the
+    run status, or the nightly summary (only the subprocess exit code
+    does). This is the exact "27/27 succeeded" scenario from the linked
+    outage: a dead Mac Mini export agent left a stale-but-formally-healthy
+    manifest in place for 10 nights."""
+
+    def _stub_source(self, dry_run=False, **kwargs):
+        return {"status": "ok", "created": 0}
+
+    def test_stale_manifest_with_all_sources_ok_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        import scripts.apple_data_import as import_mod
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir(parents=True)
+        very_stale = datetime.now(timezone.utc) - timedelta(days=10)
+        manifest = {
+            "exported_at": very_stale.isoformat(),
+            "hostname": "test-host",
+            "results": {
+                "contacts": {"status": "ok"},
+                "imessage": {"status": "ok"},
+                "phone": {"status": "ok"},
+                "photos": {"status": "ok"},
+                "whatsapp": {"status": "ok"},
+            },
+        }
+        with open(import_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", import_dir)
+        for name in (
+            "import_contacts", "import_imessage", "import_phone_calls",
+            "import_photos_faces", "import_whatsapp", "import_health",
+        ):
+            monkeypatch.setattr(import_mod, name, self._stub_source)
+        monkeypatch.setattr(import_mod.sys, "argv", ["apple_data_import.py", "--execute"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            import_mod.main()
+
+        assert exc_info.value.code == 1
+        # The failure must be visible in the printed results, not just logs —
+        # this is what run_all_syncs.py's caller sees on top of the exit code.
+        printed = capsys.readouterr().out
+        assert "manifest_staleness" in printed
+
+    def test_fresh_manifest_with_all_sources_ok_does_not_exit(self, tmp_path, monkeypatch):
+        """Sanity check: the new staleness gate must not false-positive on a
+        healthy, fresh export."""
+        import scripts.apple_data_import as import_mod
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir(parents=True)
+        fresh = datetime.now(timezone.utc) - timedelta(hours=1)
+        manifest = {
+            "exported_at": fresh.isoformat(),
+            "hostname": "test-host",
+            "results": {
+                "contacts": {"status": "ok"},
+                "imessage": {"status": "ok"},
+                "phone": {"status": "ok"},
+                "photos": {"status": "ok"},
+                "whatsapp": {"status": "ok"},
+            },
+        }
+        with open(import_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", import_dir)
+        for name in (
+            "import_contacts", "import_imessage", "import_phone_calls",
+            "import_photos_faces", "import_whatsapp", "import_health",
+        ):
+            monkeypatch.setattr(import_mod, name, self._stub_source)
+        monkeypatch.setattr(import_mod.sys, "argv", ["apple_data_import.py", "--execute"])
+
+        # main() calls sys.exit(1) only on error; a clean run falls off the
+        # end of the function without exiting, so no SystemExit is raised.
+        import_mod.main()
+
+    def test_per_source_error_still_fails_run_alongside_fresh_staleness(self, tmp_path, monkeypatch):
+        """Keep the existing per-source status=='error' behaviour working
+        unchanged (issue #646 acceptance criteria: don't regress it while
+        fixing staleness)."""
+        import scripts.apple_data_import as import_mod
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir(parents=True)
+        fresh = datetime.now(timezone.utc) - timedelta(hours=1)
+        manifest = {
+            "exported_at": fresh.isoformat(),
+            "hostname": "test-host",
+            "results": {
+                "whatsapp": {"status": "error", "reason": "wacli not installed"},
+            },
+        }
+        with open(import_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", import_dir)
+
+        def _erroring_whatsapp(dry_run=False, **kwargs):
+            return {"status": "error", "reason": "wacli not installed"}
+
+        monkeypatch.setattr(import_mod, "import_contacts", self._stub_source)
+        monkeypatch.setattr(import_mod, "import_imessage", self._stub_source)
+        monkeypatch.setattr(import_mod, "import_phone_calls", self._stub_source)
+        monkeypatch.setattr(import_mod, "import_photos_faces", self._stub_source)
+        monkeypatch.setattr(import_mod, "import_whatsapp", _erroring_whatsapp)
+        monkeypatch.setattr(import_mod, "import_health", self._stub_source)
+        monkeypatch.setattr(import_mod.sys, "argv", ["apple_data_import.py", "--execute"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            import_mod.main()
+
+        assert exc_info.value.code == 1
+
+
+class TestManifestErrorOverridesLocalSuccess:
+    """Issue #646 follow-up: import_contacts/import_whatsapp check the
+    manifest internally (_manifest_source_errored) and already report
+    "error" themselves when the Mac-side export failed. imessage, phone,
+    photos, and health do NOT — they only look at whether their input file
+    exists. If a stale file from a prior successful export is still on
+    disk, the local import happily reprocesses it and reports "ok",
+    silently masking a Mac-side export failure that check_manifest()'s
+    per-source walk only logs (never structurally surfaced before this
+    fix). main() must override that back to "error" and still fail the
+    run — the exact same "logged but not structured" trap as staleness,
+    just for a different signal."""
+
+    def _run_with_manifest_error(self, tmp_path, monkeypatch, source_name, stub_result):
+        import scripts.apple_data_import as import_mod
+
+        # Subdirectory keyed by source_name so a test iterating over
+        # multiple sources (each calling this helper against the same
+        # tmp_path) doesn't collide on an already-existing import_dir.
+        import_dir = tmp_path / source_name / "apple-imports"
+        import_dir.mkdir(parents=True)
+        fresh = datetime.now(timezone.utc) - timedelta(hours=1)
+        manifest = {
+            "exported_at": fresh.isoformat(),
+            "hostname": "test-host",
+            "results": {
+                source_name: {"status": "error", "reason": "export tool crashed"},
+            },
+        }
+        with open(import_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", import_dir)
+
+        func_names = {
+            "contacts": "import_contacts",
+            "imessage": "import_imessage",
+            "phone": "import_phone_calls",
+            "photos": "import_photos_faces",
+            "whatsapp": "import_whatsapp",
+            "health": "import_health",
+        }
+        for name, func_name in func_names.items():
+            if name == source_name:
+                monkeypatch.setattr(
+                    import_mod, func_name,
+                    lambda dry_run=False, **kw: dict(stub_result),
+                )
+            else:
+                monkeypatch.setattr(
+                    import_mod, func_name,
+                    lambda dry_run=False, **kw: {"status": "ok"},
+                )
+        monkeypatch.setattr(import_mod.sys, "argv", ["apple_data_import.py", "--execute"])
+        return import_mod
+
+    def test_stale_imessage_db_reported_ok_still_fails_run(self, tmp_path, monkeypatch):
+        """imessage isn't manifest-aware — a stale imessage.db copy would
+        otherwise report 'ok' and mask the Mac-side failure entirely."""
+        import_mod = self._run_with_manifest_error(
+            tmp_path, monkeypatch, "imessage", {"status": "ok", "size_mb": 12.0},
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            import_mod.main()
+
+        assert exc_info.value.code == 1
+
+    def test_photos_and_health_also_covered(self, tmp_path, monkeypatch):
+        for source_name in ("photos", "health"):
+            import_mod = self._run_with_manifest_error(
+                tmp_path, monkeypatch, source_name, {"status": "ok"},
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                import_mod.main()
+            assert exc_info.value.code == 1
+
+    def test_override_preserves_stat_keys_unit_level(self):
+        """Unit-level check of the override behavior itself: status flips
+        to error, reason is set, and any stat keys the local import
+        produced (e.g. "imported") survive rather than being discarded —
+        mirrors import_contacts/import_whatsapp's own established pattern
+        of overriding status while keeping the stats."""
+        results = {"phone": {"status": "ok", "imported": 5, "source_entities_created": 2}}
+        manifest_results = {"phone": {"status": "error", "reason": "export tool crashed"}}
+
+        # Reproduce main()'s override loop in isolation.
+        for name in results:
+            manifest_entry = manifest_results.get(name)
+            if not isinstance(manifest_entry, dict) or manifest_entry.get("status") != "error":
+                continue
+            existing = results.get(name)
+            if isinstance(existing, dict) and existing.get("status") == "error":
+                continue
+            reason = manifest_entry.get("reason") or "Mac export reported error"
+            if isinstance(existing, dict):
+                existing["status"] = "error"
+                existing["reason"] = reason
+            else:
+                results[name] = {"status": "error", "reason": reason}
+
+        assert results["phone"]["status"] == "error"
+        assert results["phone"]["reason"] == "export tool crashed"
+        assert results["phone"]["imported"] == 5
+        assert results["phone"]["source_entities_created"] == 2
+
+    def test_no_override_when_source_not_attempted_this_run(self, tmp_path, monkeypatch):
+        """--source contacts must not spuriously fail on an unrelated
+        manifest-reported phone error (existing behavior, unchanged)."""
+        import scripts.apple_data_import as import_mod
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir(parents=True)
+        fresh = datetime.now(timezone.utc) - timedelta(hours=1)
+        manifest = {
+            "exported_at": fresh.isoformat(),
+            "hostname": "test-host",
+            "results": {
+                "phone": {"status": "error", "reason": "export tool crashed"},
+                "contacts": {"status": "ok"},
+            },
+        }
+        with open(import_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", import_dir)
+        monkeypatch.setattr(
+            import_mod, "import_contacts",
+            lambda dry_run=False, **kw: {"status": "ok", "created": 1},
+        )
+        monkeypatch.setattr(import_mod.sys, "argv", ["apple_data_import.py", "--execute", "--source", "contacts"])
+
+        # Must not raise — only "contacts" was selected, "phone"'s manifest
+        # error is out of scope for this invocation.
+        import_mod.main()

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -149,6 +149,88 @@ class TestDependencySkip:
             assert stats.get("reason") != "dependency_failed"
 
 
+class TestRepeatedYieldExcludedFromNewRecords:
+    """Issue #646 acceptance criterion: the nightly summary must distinguish
+    'N new records' from 'N records re-written from an unchanged upstream
+    file' — a stale-input run must not report new interactions."""
+
+    def test_repeated_yield_source_excluded_from_aggregate_counts(self):
+        from scripts.run_all_syncs import run_all_syncs
+
+        def side_effect(source, dry_run=False):
+            if source == "source_a":
+                return True, {
+                    "interactions_created": 1294,
+                    "repeated_yield": {"repeated_value": 1294, "consecutive_runs": 10},
+                }
+            return True, {"interactions_created": 5}
+
+        with (
+            patch("scripts.run_all_syncs.SYNC_SOURCES", TEST_SYNC_SOURCES),
+            patch("scripts.run_all_syncs.SYNC_ORDER", TEST_SYNC_ORDER),
+            patch("scripts.run_all_syncs.run_sync", MagicMock(side_effect=side_effect)),
+            patch("scripts.run_all_syncs.check_sync_health", return_value=(True, "healthy")),
+            patch("scripts.run_all_syncs.get_disabled_work_sources", return_value=set()),
+            patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
+        ):
+            result = run_all_syncs(dry_run=True)
+
+        assert result["repeated_yield_sources"] == ["source_a"]
+        # The flagged source's count must not appear in the "new" breakdown...
+        assert "source_a" not in result["interactions_by_source"]
+        # ...nor be folded into the aggregate total the Telegram/markdown
+        # "New Interactions" line reports — only the 7 other sources' real
+        # counts (5 each) should be there.
+        assert result["interactions_created"] == 35
+
+
+def test_run_all_syncs_surfaces_apple_agent_sha_drift():
+    """run_all_syncs() reads the SHA-drift signal directly from the Apple
+    import manifest (independent of the apple_import subprocess) and puts
+    it on the result dict so the Telegram/markdown summary can show it."""
+    from scripts.run_all_syncs import run_all_syncs
+
+    drifted_manifest = {
+        "exported_at": "2026-08-20T00:00:00+00:00",
+        "_agent_sha_drift_message": (
+            "Apple Data Agent exported from b347e1f, which differs from this "
+            "host's main (c13ba77) — its self-update may have failed."
+        ),
+    }
+
+    with (
+        patch("scripts.run_all_syncs.SYNC_SOURCES", TEST_SYNC_SOURCES),
+        patch("scripts.run_all_syncs.SYNC_ORDER", TEST_SYNC_ORDER),
+        patch("scripts.run_all_syncs.run_sync", MagicMock(side_effect=_make_run_sync_side_effect(set()))),
+        patch("scripts.run_all_syncs.check_sync_health", return_value=(True, "healthy")),
+        patch("scripts.run_all_syncs.get_disabled_work_sources", return_value=set()),
+        patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
+        patch("scripts.apple_data_import.check_manifest", return_value=drifted_manifest),
+    ):
+        result = run_all_syncs(dry_run=True)
+
+    assert result["apple_agent_sha_drift"] == drifted_manifest["_agent_sha_drift_message"]
+
+
+def test_run_all_syncs_sha_drift_absent_when_no_manifest():
+    """No Apple import configured (fresh clone, no manifest.json) must not
+    surface a drift warning or raise."""
+    from scripts.run_all_syncs import run_all_syncs
+
+    with (
+        patch("scripts.run_all_syncs.SYNC_SOURCES", TEST_SYNC_SOURCES),
+        patch("scripts.run_all_syncs.SYNC_ORDER", TEST_SYNC_ORDER),
+        patch("scripts.run_all_syncs.run_sync", MagicMock(side_effect=_make_run_sync_side_effect(set()))),
+        patch("scripts.run_all_syncs.check_sync_health", return_value=(True, "healthy")),
+        patch("scripts.run_all_syncs.get_disabled_work_sources", return_value=set()),
+        patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
+        patch("scripts.apple_data_import.check_manifest", return_value=None),
+    ):
+        result = run_all_syncs(dry_run=True)
+
+    assert result["apple_agent_sha_drift"] is None
+
+
 # =============================================================================
 # LLM Memory Gating Tests
 # =============================================================================
@@ -673,6 +755,120 @@ def test_sync_summary_omits_investments_when_fresh():
     assert message.startswith("✅")
 
 
+def test_sync_summary_surfaces_apple_agent_sha_drift():
+    """A silently-broken Mac Mini self-update must reach the nightly
+    Telegram summary — a bare logger.warning feeds no batched report (#646,
+    same lesson as #448's investments_stale)."""
+    from scripts.run_all_syncs import send_sync_summary_telegram
+    result = {
+        "succeeded": 3, "sources_run": 3, "failed": 0, "failed_sources": [],
+        "results": {}, "duration_seconds": 12,
+        "apple_agent_sha_drift": (
+            "Apple Data Agent exported from b347e1f, which differs from this "
+            "host's main (c13ba77) — its self-update may have failed."
+        ),
+    }
+    with patch("api.services.telegram.send_message", return_value=True) as send_mock:
+        send_sync_summary_telegram(result, trigger="test")
+    message = send_mock.call_args[0][0]
+    assert "SHA drift" in message
+    assert "self-update" in message
+    assert message.startswith("⚠️")
+
+
+def test_sync_summary_omits_sha_drift_when_absent():
+    from scripts.run_all_syncs import send_sync_summary_telegram
+    result = {
+        "succeeded": 3, "sources_run": 3, "failed": 0, "failed_sources": [],
+        "results": {}, "duration_seconds": 12, "apple_agent_sha_drift": None,
+    }
+    with patch("api.services.telegram.send_message", return_value=True) as send_mock:
+        send_sync_summary_telegram(result, trigger="test")
+    message = send_mock.call_args[0][0]
+    assert "SHA drift" not in message
+    assert message.startswith("✅")
+
+
+def test_sync_summary_surfaces_repeated_yield_sources():
+    """A source stuck reporting the same non-zero count must be called out
+    in the nightly summary and flip the status away from a clean ✅ (#646)."""
+    from scripts.run_all_syncs import send_sync_summary_telegram
+    result = {
+        "succeeded": 3, "sources_run": 3, "failed": 0, "failed_sources": [],
+        "duration_seconds": 12,
+        "repeated_yield_sources": ["apple_import"],
+        "results": {
+            "apple_import": {
+                "success": True,
+                "repeated_yield": {"repeated_value": 1294, "consecutive_runs": 10},
+            }
+        },
+    }
+    with patch("api.services.telegram.send_message", return_value=True) as send_mock:
+        send_sync_summary_telegram(result, trigger="test")
+    message = send_mock.call_args[0][0]
+    assert "apple_import" in message
+    assert "1294" in message
+    assert "not counted as new" in message
+    assert message.startswith("⚠️")
+
+
+def test_sync_summary_omits_repeated_yield_section_when_clean():
+    from scripts.run_all_syncs import send_sync_summary_telegram
+    result = {
+        "succeeded": 3, "sources_run": 3, "failed": 0, "failed_sources": [],
+        "duration_seconds": 12, "repeated_yield_sources": [], "results": {},
+    }
+    with patch("api.services.telegram.send_message", return_value=True) as send_mock:
+        send_sync_summary_telegram(result, trigger="test")
+    message = send_mock.call_args[0][0]
+    assert "not counted as new" not in message
+    assert message.startswith("✅")
+
+
+def test_markdown_summary_surfaces_repeated_yield_and_sha_drift():
+    """Same distinction (#646) must land in the markdown log, not just
+    Telegram — sync_errors.md is the other half of "the nightly summary"."""
+    from scripts.run_all_syncs import log_sync_summary_to_markdown
+    result = {
+        "succeeded": 3, "sources_run": 3, "failed": 0, "failed_sources": [],
+        "duration_seconds": 12,
+        "repeated_yield_sources": ["apple_import"],
+        "apple_agent_sha_drift": "Apple Data Agent exported from b347e1f, self-update may have failed.",
+        "results": {
+            "apple_import": {
+                "success": True,
+                "repeated_yield": {"repeated_value": 1294, "consecutive_runs": 10},
+            }
+        },
+    }
+    with patch("scripts.run_all_syncs._write_to_markdown_log") as write_mock:
+        log_sync_summary_to_markdown(result, trigger="test")
+
+    entry = write_mock.call_args[0][0]
+    assert "apple_import" in entry
+    assert "1294" in entry
+    assert "not counted as new" in entry
+    assert "SHA drift" in entry
+    assert "self-update may have failed" in entry
+
+
+def test_markdown_summary_omits_sections_when_clean():
+    from scripts.run_all_syncs import log_sync_summary_to_markdown
+    result = {
+        "succeeded": 3, "sources_run": 3, "failed": 0, "failed_sources": [],
+        "duration_seconds": 12,
+        "repeated_yield_sources": [], "apple_agent_sha_drift": None,
+        "results": {},
+    }
+    with patch("scripts.run_all_syncs._write_to_markdown_log") as write_mock:
+        log_sync_summary_to_markdown(result, trigger="test")
+
+    entry = write_mock.call_args[0][0]
+    assert "not counted as new" not in entry
+    assert "SHA drift" not in entry
+
+
 class TestYieldCollapse:
     """Yield-based no-op detection (#494).
 
@@ -722,6 +918,47 @@ class TestYieldCollapse:
 
         with patch("scripts.run_all_syncs.get_typical_yield", side_effect=RuntimeError("db gone")):
             assert _detect_yield_collapse("slack", {"created": 0}) is None
+
+
+class TestRepeatedYield:
+    """Repeated-identical-yield detection (#646).
+
+    Distinct from yield collapse (which only fires on zero output): a source
+    re-importing the same unchanged upstream file reports the same non-zero
+    count every run. Zero output is invisible to it; identical non-zero
+    output for several runs in a row is the signature.
+    """
+
+    def test_detects_repeated_identical_yield(self):
+        from scripts.run_all_syncs import _detect_repeated_yield
+
+        with patch("scripts.run_all_syncs.get_repeated_yield_streak", return_value=9):
+            info = _detect_repeated_yield("apple_import", {"created": 1294})
+
+        assert info is not None
+        assert info["repeated_value"] == 1294
+        assert info["consecutive_runs"] == 10  # +1 for the run in flight
+
+    def test_zero_yield_never_flagged(self):
+        """Zero output is yield_collapse's job, not this detector's."""
+        from scripts.run_all_syncs import _detect_repeated_yield
+
+        with patch("scripts.run_all_syncs.get_repeated_yield_streak", return_value=50):
+            assert _detect_repeated_yield("entity_cleanup", {"created": 0}) is None
+
+    def test_below_minimum_streak_not_flagged(self):
+        """A single repeat (this run matching just the last one) is normal —
+        only a real streak is suspicious."""
+        from scripts.run_all_syncs import _detect_repeated_yield
+
+        with patch("scripts.run_all_syncs.get_repeated_yield_streak", return_value=1):
+            assert _detect_repeated_yield("gmail_work", {"created": 42}) is None
+
+    def test_db_error_never_raises(self):
+        from scripts.run_all_syncs import _detect_repeated_yield
+
+        with patch("scripts.run_all_syncs.get_repeated_yield_streak", side_effect=RuntimeError("db gone")):
+            assert _detect_repeated_yield("slack", {"created": 42}) is None
 
 
 class TestNeverYielded:
@@ -832,6 +1069,7 @@ class TestNeverYieldedDamping:
             patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_never_yielded", return_value=never_yielded_info),
+            patch("scripts.run_all_syncs._detect_repeated_yield", return_value=None),
             patch("scripts.run_all_syncs._recently_warned_never_yielded", return_value=True),
         ):
             success, stats = run_sync(source, dry_run=False)
@@ -860,6 +1098,7 @@ class TestNeverYieldedDamping:
             patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_never_yielded", return_value=never_yielded_info),
+            patch("scripts.run_all_syncs._detect_repeated_yield", return_value=None),
             patch("scripts.run_all_syncs._recently_warned_never_yielded", return_value=False),
         ):
             success, stats = run_sync(source, dry_run=False)

--- a/tests/test_sync_health.py
+++ b/tests/test_sync_health.py
@@ -679,3 +679,81 @@ class TestTypicalDuration:
                 self._insert_run("gmail", "success", 5000.0, base - timedelta(days=i))
 
             assert get_typical_duration_seconds("gmail", n=5) == 100.0
+
+
+class TestRepeatedYieldStreak:
+    """Tests for get_repeated_yield_streak (issue #646).
+
+    A dead export agent that leaves a stale upstream file in place makes a
+    re-import report the same non-zero count night after night — invisible
+    to yield-collapse (which only fires on zero) and to never-yielded
+    (which only fires when nothing was EVER produced). This is the detector
+    for "reports the same thing every time," the signature defect #2 in the
+    linked issue: ten consecutive nights of an identical "1294 created."
+    """
+
+    def _insert_run(self, source, status, created, started_at):
+        conn = get_sync_health_db()
+        conn.execute(
+            """
+            INSERT INTO sync_runs (source, status, started_at, completed_at, records_created)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (source, status, started_at.isoformat(), started_at.isoformat(), created),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_streak_of_identical_value(self, temp_db):
+        from api.services.sync_health import get_repeated_yield_streak
+
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            base = datetime.now(timezone.utc)
+            for i in range(5):
+                self._insert_run("apple_import", "success", 1294, base - timedelta(days=i))
+
+            assert get_repeated_yield_streak("apple_import", 1294) == 5
+
+    def test_streak_stops_at_first_different_value(self, temp_db):
+        """A genuinely varying night (real new data) breaks the streak."""
+        from api.services.sync_health import get_repeated_yield_streak
+
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            base = datetime.now(timezone.utc)
+            # 3 most-recent identical runs, then a different value further back
+            for i in range(3):
+                self._insert_run("apple_import", "success", 1294, base - timedelta(days=i))
+            self._insert_run("apple_import", "success", 800, base - timedelta(days=3))
+            self._insert_run("apple_import", "success", 1294, base - timedelta(days=4))
+
+            assert get_repeated_yield_streak("apple_import", 1294) == 3
+
+    def test_no_matching_value_returns_zero(self, temp_db):
+        from api.services.sync_health import get_repeated_yield_streak
+
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            base = datetime.now(timezone.utc)
+            self._insert_run("apple_import", "success", 500, base)
+
+            assert get_repeated_yield_streak("apple_import", 1294) == 0
+
+    def test_no_history_returns_zero(self, temp_db):
+        from api.services.sync_health import get_repeated_yield_streak
+
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            assert get_repeated_yield_streak("apple_import", 1294) == 0
+
+    def test_failed_runs_excluded(self, temp_db):
+        """Only successful runs count toward the streak."""
+        from api.services.sync_health import get_repeated_yield_streak
+
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            base = datetime.now(timezone.utc)
+            self._insert_run("apple_import", "success", 1294, base - timedelta(days=0))
+            self._insert_run("apple_import", "failed", 1294, base - timedelta(days=1))
+            self._insert_run("apple_import", "success", 1294, base - timedelta(days=2))
+
+            # The failed row breaks the streak (it's excluded from the query
+            # entirely, so it doesn't even count as a "different value" —
+            # the two surrounding successes are adjacent in the result set).
+            assert get_repeated_yield_streak("apple_import", 1294) == 2

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -59,6 +59,7 @@ def _run_sync_with_patches(subprocess_side_effect):
         patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
         patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
         patch("scripts.run_all_syncs._detect_never_yielded", return_value=None),
+        patch("scripts.run_all_syncs._detect_repeated_yield", return_value=None),
     ):
         success, stats = run_sync(_SOURCE, dry_run=False)
 
@@ -307,6 +308,7 @@ class TestRetryLoop:
             patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_never_yielded", return_value=None),
+            patch("scripts.run_all_syncs._detect_repeated_yield", return_value=None),
         ):
             success, stats = run_sync(_SOURCE, dry_run=False)
 
@@ -362,6 +364,7 @@ class TestOrchestrationExceptionSafety:
             patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_yield_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_never_yielded", return_value=None),
+            patch("scripts.run_all_syncs._detect_repeated_yield", return_value=None),
         ):
             # Must not raise — a locked DB is not the subprocess's fault.
             success, stats = run_sync(_SOURCE, dry_run=False)
@@ -481,6 +484,7 @@ class TestCampaignStatsNotLostOnRetry:
             patch("scripts.run_all_syncs._detect_duration_collapse", return_value=None),
             patch("scripts.run_all_syncs._detect_yield_collapse") as yield_collapse_mock,
             patch("scripts.run_all_syncs._detect_never_yielded", return_value=None),
+            patch("scripts.run_all_syncs._detect_repeated_yield", return_value=None),
         ):
             yield_collapse_mock.return_value = None
             success, stats = run_sync(_SOURCE, dry_run=False)


### PR DESCRIPTION
Closes #646.

The Mac Mini export agent died 2026-08-12 and every Apple source — contacts, iMessage, calls, photos, WhatsApp — was frozen for **10 days**. Nothing alerted; the nightly summary reported `27/27 succeeded` every night.

### The real mechanism (per Nathan's correction on the issue)

The CRITICAL log lines are **not** discarded — they land in the sync log and a human reading it sees them fine. They simply don't drive anything. `record_failure` is driven by the subprocess's **exit code**, and `apple_data_import.py` decides that exit purely from per-source `status == "error"`. **Staleness never touches the exit code.**

A dead export agent leaves the last good manifest on disk: every source still reads `ok`, only `exported_at` goes stale. The import reprocesses those files, exits 0, and the night records as a clean success.

### Changes

- **Staleness past `STALENESS_CRITICAL_HOURS` now fails the run.** `check_manifest()` sets a structured field, and `main()` folds it into `results` as a synthetic `manifest_staleness` error — reusing the existing `status == "error"` → `sys.exit(1)` path that `run_all_syncs.py` already keys off, rather than adding a parallel mechanism.
- **Agent-SHA drift alerts** as a non-fatal warning in both summaries. (The Mini was **128 commits behind** — its guarded `--ff-only` self-update had silently stopped working.)
- **Repeated-yield detection.** A constant non-zero created-count across consecutive runs is strong evidence of stale re-import; those sources are excluded from the "New Records"/"New Interactions" aggregate and called out separately. Implemented generically off `sync_runs` history, so it also catches the `imessage` phantom counts from the issue's table without chasing that source's own undercounting.

### A second gap found while tracing this

Not in the issue, and worth reading: **only `contacts` and `whatsapp` consult the manifest.** `imessage`, `phone`, `photos`, and `health` don't take one — they only check whether their input file exists. So with a stale file still on disk, those four would reprocess it, return `ok`, and **mask a manifest-recorded Mac-side export failure entirely** — never reaching `results`, `errored_sources`, or the exit code.

Two of six sources were protected; now all six are. Handled centrally in `main()`'s merge loop rather than teaching six `import_*` functions to be manifest-aware, scoped to the caller's `--source` selection so `--source contacts` can't fail on an unrelated `phone` error, and preserving stats by overriding status in place.

### Tests

32 new tests. The regression guard is the literal `27/27` case: a manifest with every source `ok` and `exported_at` past the threshold must fail the run. Asserted on **exit status, not on a log being emitted** — a log-asserting test would have passed happily throughout the entire ten days.

Also covers: no false positive on a fresh manifest; per-source error handling unchanged; `imessage`/`photos`/`health` each fail the run off a stale-but-locally-ok result; stats survive the override; repeated-yield detection at DB and summary level.

Gate: **4875 passed** at `scripts/test.sh` scope. 12 failures in that run are pre-existing and unrelated — data-dependent CRM tests that require a populated production database and cannot pass in a clean worktree; no failing file references `apple_data_import`, `sync_health`, or `run_all_syncs`. See #682, which this surfaced: ~1,065 tests including these guards are outside the pre-push gate because their files carry no marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)