### PR TITLE
fix(journal): capture fragments on the Hermes proxy path before relaying

### DIFF
--- a/api/routes/_proxy.py
+++ b/api/routes/_proxy.py
@@ -80,6 +80,7 @@ def make_backend_router(
     *, prefix, tag, backend_label, url_attr, token_attr, client_factory,
     transform_body: Optional[Callable[[bytes], bytes]] = None,
     make_observer: Optional[Callable[[bytes], Optional[object]]] = None,
+    pre_send: Optional[Callable[[bytes], list]] = None,
 ):
     """Build a `status` + `ask/stream` reverse-proxy router for a text backend.
 
@@ -143,6 +144,45 @@ def make_backend_router(
     it — and why an observer that returns `None` for a given request (a
     `make_observer` configured but declining to observe this one) falls
     through to the plain, still-client-tied `relay()` for that request.
+
+    `pre_send` (#685) runs a side-effecting precondition — the journal
+    persona's deterministic capture is the motivating case — before the
+    backend is contacted at all. Called once per request with the same raw,
+    pre-transform body the other two hooks receive, AFTER `transform_body`/
+    `make_observer` but BEFORE the upstream request is built: it may raise
+    `HTTPException` (e.g. a capture write failure) and that happens before a
+    single byte reaches the backend, exactly like `transform_body`'s own
+    HTTPException case above — no false success is possible, and whatever
+    "this delivery already happened" bookkeeping the caller does downstream
+    (e.g. an idempotency key) stays unclaimed. On success it returns a list
+    of frames (of whatever type `emit()`/`yield` already accept elsewhere in
+    this module — an SSE `data: ...` string, in practice) to hand the
+    browser BEFORE any backend byte. An empty list — the default for every
+    request this hook doesn't apply to — changes nothing; its absence (every
+    other backend) leaves this router exactly as it was before this
+    parameter existed.
+
+    A non-empty return ALSO changes how this request's backend call itself
+    is handled (#685 adversarial-review follow-up): a caller like
+    `chat_via_api()` (api/services/telegram.py) or the ring ingest
+    (api/routes/journal_ingest.py) treats a non-200 response as "nothing
+    happened" and never inspects its body, so if the backend call could
+    still turn into an HTTP-level 502 or a passed-through non-200 status,
+    proof that already reached disk (or wherever `pre_send`'s side effect
+    landed) would be silently discarded along with it. So once there ARE
+    prelude frames, `client_factory()`/the upstream call is made only AFTER
+    they're already queued for the browser, the response is unconditionally
+    a 200 SSE stream, and a connect failure or a non-200 upstream response
+    becomes an in-stream `{"type": "error", "message": ...}` event — the
+    same shape `api/routes/chat.py`'s native path already emits and
+    `chat_via_api()` already folds into its answer — rather than an
+    exception or a forwarded status code. This is why the plain path below
+    builds the upstream request unconditionally before deciding how to
+    relay it: that ordering is only wrong when there's a precondition's
+    proof to protect, i.e. only when `pre_send` is set AND actually returned
+    something for this request. Every other request (no `pre_send`, or one
+    that returns `[]` for this particular request — e.g. every non-journal
+    Hermes turn) takes the plain path, completely unchanged.
     """
     router = APIRouter(prefix=prefix, tags=[tag])
 
@@ -170,13 +210,96 @@ def make_backend_router(
         # otherwise stream straight through unbuffered (Agent), unchanged from
         # before #590. transform_body may raise HTTPException (e.g. a bad
         # persona) — that happens before client_factory(), so nothing is sent.
-        # make_observer (#592) shares this same raw body rather than a second
-        # request.body() read.
-        raw_body = await request.body() if (transform_body or make_observer) else None
+        # make_observer (#592) and pre_send (#685) share this same raw body
+        # rather than a second/third request.body() read.
+        raw_body = await request.body() if (transform_body or make_observer or pre_send) else None
         body = transform_body(raw_body) if transform_body else request.stream()
         observer = make_observer(raw_body) if make_observer else None
+        # pre_send may itself raise HTTPException (e.g. a journal capture
+        # write failure) — like transform_body's, that happens before
+        # client_factory() below, so the backend is never contacted.
+        prelude_frames = pre_send(raw_body) if pre_send else []
 
         client = client_factory()
+
+        if prelude_frames:
+            # #685 adversarial-review follow-up — see make_backend_router's
+            # docstring on `pre_send` for the full reasoning. Short version:
+            # a precondition's proof (journal capture) has already succeeded
+            # by the time there are frames here, and that proof must reach
+            # the caller no matter what the backend then does, so the
+            # backend call is made INSIDE the turn (after the frames are
+            # already queued) and its failure becomes an in-stream event
+            # rather than an HTTP-level 502/passed-through status.
+            #
+            # Reuses the same turn-registry/detached-pump machinery (#611)
+            # the observer branch below uses, so a journal turn survives a
+            # client disconnect and is cancellable the same way any other
+            # turn is.
+            client_turn_id = _sniff_client_turn_id(raw_body)
+            if client_turn_id:
+                get_turn_registry().cancel_by_client_turn_id(client_turn_id)
+            turn = get_turn_registry().create(
+                conversation_id=None,
+                modality=_sniff_modality(raw_body),
+                client_turn_id=client_turn_id,
+            )
+            if hasattr(observer, "bind_turn"):
+                observer.bind_turn(turn)
+
+            async def _pump_guaranteed():
+                try:
+                    for frame in prelude_frames:
+                        await turn.emit(frame)
+                    try:
+                        upstream_req = client.build_request(
+                            "POST", url, headers=headers, content=body,
+                        )
+                        upstream = await client.send(upstream_req, stream=True)
+                    except (httpx.RequestError, httpx.InvalidURL) as exc:
+                        logger.warning(
+                            "%s backend request failed after a precondition "
+                            "already succeeded: %s", backend_label, exc,
+                        )
+                        await turn.emit(
+                            "data: " + json.dumps({
+                                "type": "error",
+                                "message": f"{backend_label} backend unreachable: {exc}",
+                            }) + "\n\n"
+                        )
+                        return
+                    if upstream.status_code >= 400:
+                        logger.warning(
+                            "%s backend returned HTTP %s after a precondition "
+                            "already succeeded", backend_label, upstream.status_code,
+                        )
+                        await turn.emit(
+                            "data: " + json.dumps({
+                                "type": "error",
+                                "message": f"{backend_label} backend returned HTTP {upstream.status_code}",
+                            }) + "\n\n"
+                        )
+                        await upstream.aclose()
+                        return
+                    try:
+                        async for chunk in upstream.aiter_raw():
+                            if observer is not None:
+                                observer.observe(chunk)
+                            await turn.emit(chunk)
+                    finally:
+                        await upstream.aclose()
+                finally:
+                    if observer is not None:
+                        observer.finalize()
+                    await client.aclose()
+                    get_turn_registry().pop(turn)
+                    await turn.close()
+
+            turn.task = asyncio.create_task(_pump_guaranteed())
+            return StreamingResponse(
+                turn.reader(), status_code=200, media_type="text/event-stream",
+            )
+
         try:
             upstream_req = client.build_request(
                 "POST", url, headers=headers, content=body,

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -541,6 +541,74 @@ async def _handle_agent_slash(stripped: str, conversation_id, store):
     yield f"data: {json.dumps({'type': 'done'})}\n\n"
 
 
+def resolve_effective_persona_id(persona_id: Optional[str], persona: Optional[str]) -> Optional[str]:
+    """The exact persona-shape validation and effective-id derivation
+    `ask_stream()` performs for its `_effective_pid` — shared with the
+    Hermes proxy's journal-capture gate (`api/routes/hermes_proxy.py`,
+    #685 adversarial-review follow-up) so a raw-`persona` preamble turn
+    (`chat_via_api()`'s and the ring ingest's shape, not just a
+    `persona_id`-selected one) resolves identically on both surfaces —
+    approximating it as `persona_id or "primary"` alone, as the proxy's
+    envelope-building code does, silently misses a raw-preamble journal
+    turn entirely.
+
+    Raises `HTTPException(400)` for the same two malformed shapes
+    `ask_stream()`'s own persona resolution rejects: `persona_id` and
+    `persona` both given, or a `persona_id` that doesn't resolve to any
+    registered persona (including `""`, which resolves to nothing).
+    Returns `persona_id` once validated; otherwise, when only `persona` (a
+    raw preamble) was given, the registered bot name whose preamble matches
+    it verbatim — `None` if neither field is given or no bot matches.
+    """
+    if persona_id is not None:
+        if persona is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Provide either persona_id or persona, not both",
+            )
+        if settings.resolve_persona(persona_id) is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown persona_id: {persona_id!r}",
+            )
+        return persona_id
+    if persona:
+        return next((b.name for b in settings.telegram_bots if b.persona == persona), None)
+    return None
+
+
+def journal_capture_gate(persona_id: Optional[str], text: str) -> Optional[CaptureResult]:
+    """#674's deterministic journal capture, as a single gate shared by every
+    surface that can drive a journal-persona turn — the native path below and
+    the Hermes proxy relay (`api/routes/hermes_proxy.py`, #685) — so a third
+    surface can't recreate the gap this closes: the journal persona used to be
+    told to call `lifeos_vault_write` itself, a tool that doesn't exist in
+    either agentic loop, so every fragment was silently lost while the reply
+    still read like a successful capture.
+
+    No-op (returns `None`) for any persona other than `journal`. Must be
+    called BEFORE the caller's SSE stream opens / before the turn is handed
+    to a downstream backend — a capture failure is then a clean HTTP 500
+    instead of a mid-stream error: no caller can report success for a
+    fragment that was never written, and a delivery's idempotency key (the
+    ring ingest, `api/routes/journal_ingest.py`) stays unburned so a retry
+    can still land.
+
+    Raises `HTTPException(500)` on a write failure. Deliberately not
+    `str(e)` in the detail — it is surfaced to the user (Telegram renders it
+    verbatim) and must never quote the fragment.
+    """
+    if persona_id != JOURNAL_PERSONA_ID:
+        return None
+    try:
+        return capture_fragment(text)
+    except JournalCaptureError:
+        raise HTTPException(
+            status_code=500,
+            detail="journal capture failed: the fragment was not written",
+        )
+
+
 @router.post("/ask/stream")
 async def ask_stream(request: AskStreamRequest):
     """
@@ -588,35 +656,22 @@ async def ask_stream(request: AskStreamRequest):
     # Personal-context block: the therapist persona pre-resolves the user's people
     # from config so it can target sessions/messages without a lookup round. Works
     # on the persona_id path and the raw-`persona` (Telegram) path via a reverse
-    # lookup of the preamble back to a bot name.
-    _effective_pid = request.persona_id
-    if _effective_pid is None and request.persona:
-        _effective_pid = next((b.name for b in settings.telegram_bots if b.persona == request.persona), None)
+    # lookup of the preamble back to a bot name. By the time this runs, the block
+    # above has already validated persona_id/persona's shape, so
+    # resolve_effective_persona_id() below can't actually raise here — it's
+    # reused rather than re-inlined so the Hermes proxy's journal-capture gate
+    # (#685) shares the exact same derivation instead of approximating it.
+    _effective_pid = resolve_effective_persona_id(request.persona_id, request.persona)
     personal_context = settings.personal_context(_effective_pid or "")
 
-    # #674: the journal persona's capture is deterministic, done here in code,
-    # not left to the model. It used to be prompt-only — the persona was told to
-    # call `lifeos_vault_write`, a tool the native agentic loop does not have, so
-    # every fragment was lost while the reply read like a successful capture.
-    #
-    # Done BEFORE the SSE stream opens (like the persona resolution above) so a
-    # capture failure is a clean HTTP 500 rather than a mid-stream error: no
-    # caller can report success for a fragment that wasn't written, and the ring
-    # ingest's idempotency key stays unburned so a retry can still land. Covers
-    # every journal surface at once — the Telegram bot and the ingest endpoint
-    # both arrive here through `chat_via_api`'s raw-`persona` path, `/chat` and
-    # voice through `persona_id`.
-    journal_capture: Optional[CaptureResult] = None
-    if _effective_pid == JOURNAL_PERSONA_ID:
-        try:
-            journal_capture = capture_fragment(request.question)
-        except JournalCaptureError:
-            # Deliberately not `str(e)` — the detail is surfaced to the user
-            # (Telegram renders it verbatim) and must never quote the fragment.
-            raise HTTPException(
-                status_code=500,
-                detail="journal capture failed: the fragment was not written",
-            )
+    # #674 (shared with the Hermes proxy via `journal_capture_gate`, #685):
+    # deterministic journal capture, done here in code, not left to the
+    # model. Done BEFORE the SSE stream opens (like the persona resolution
+    # above) — see the helper's docstring for why. Covers every journal
+    # surface at once — the Telegram bot and the ingest endpoint both arrive
+    # here through `chat_via_api`'s raw-`persona` path, `/chat` and voice
+    # through `persona_id`.
+    journal_capture = journal_capture_gate(_effective_pid, request.question)
 
     # #611: the turn's lifetime is owned by the server from here on, not by
     # this SSE connection — every modality survives the client leaving

--- a/api/routes/hermes_proxy.py
+++ b/api/routes/hermes_proxy.py
@@ -61,11 +61,12 @@ from pydantic import BaseModel, ValidationError
 from config.settings import settings  # noqa: F401
 
 from api.routes._proxy import TIMEOUT, make_backend_router
-from api.routes.chat import AskStreamRequest
+from api.routes.chat import AskStreamRequest, journal_capture_gate, resolve_effective_persona_id
 from api.services.agent_system_prompt import build_turn_context
 from api.services.chat_turns import TRUNCATION_MARKER, get_turn_registry, truncation_routing
 from api.services.conversation_store import get_store
 from api.services.hermes_persona_thread_store import get_persona_thread_store
+from api.services.journal_capture import JOURNAL_PERSONA_ID
 from api.services.model_readout import record_hermes_chat_turn_model
 from api.services.usage_store import get_usage_store
 
@@ -255,6 +256,71 @@ def _build_envelope(raw_body: bytes) -> bytes:
         apply_voice_rules=apply_voice_rules,
     )
     return json.dumps(data).encode("utf-8")
+
+
+def _journal_capture_prelude(raw_body: bytes) -> list:
+    """`pre_send` hook (#685): mirrors `ask_stream`'s native journal-capture
+    gate (api/routes/chat.py) on this proxy's relay path, via the shared
+    `journal_capture_gate` + `resolve_effective_persona_id` helpers — the
+    same one-source-of-truth argument `_resolve_lifeos_context()` already
+    makes for persona resolution. Before #685, a journal-persona turn sent
+    through this proxy (which `/chat` reaches by default whenever Hermes is
+    available) was relayed to Hermes and never captured at all — #674's gap,
+    resurrected on a surface nobody had checked.
+
+    Deliberately does NOT reuse `_build_envelope`'s own `parsed.persona_id or
+    "primary"` shorthand (adversarial-review follow-up): that ignores a raw
+    `persona` preamble entirely, which is exactly the shape `chat_via_api()`
+    and the ring ingest send (issue #684 is what points those callers at
+    this proxy) — approximating persona resolution that way would silently
+    stop capturing a raw-preamble journal turn the moment #684 lands, the
+    same bug class a third time. `resolve_effective_persona_id()` reverse-
+    maps a raw `persona` the same way `ask_stream()` does, and rejects the
+    same malformed shapes (`persona_id` and `persona` both set; an
+    unrecognized/empty `persona_id`) with the same `HTTPException(400)` —
+    raised here, before the backend is contacted, exactly like
+    `journal_capture_gate`'s own `HTTPException(500)` below.
+
+    `make_backend_router`'s `pre_send` contract runs this before the backend
+    is contacted, so either exception means Hermes is never sent the turn —
+    no false success, and the ring ingest's idempotency key
+    (api/routes/journal_ingest.py) stays unburned exactly as it does on the
+    native path.
+
+    Reparses `raw_body` independently rather than sharing `_build_envelope`'s
+    parse — the same "each hook is self-contained" pattern `_make_persister`
+    already uses for this identical raw body. A body that fails to parse or
+    fails Pydantic validation here returns no frames rather than raising:
+    `_build_envelope` (this router's `transform_body`) is what turns THAT
+    kind of malformed body into a 400, and it runs on the same raw body
+    regardless of hook order — only the persona-shape checks above need to
+    live here too, since `_build_envelope` doesn't perform them.
+    """
+    try:
+        data = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    try:
+        parsed = AskStreamRequest.model_validate(data)
+    except ValidationError:
+        return []
+
+    effective_pid = resolve_effective_persona_id(parsed.persona_id, parsed.persona)
+    result = journal_capture_gate(effective_pid, parsed.question)
+    if result is None:
+        return []
+    # Same event shape the native path emits (api/routes/chat.py) — the ring
+    # ingest and chat_via_api() require this exact event as proof of
+    # capture, on either path alike.
+    return [
+        "data: " + json.dumps({
+            "type": "journal_capture",
+            "path": result.path,
+            "created": result.created,
+        }) + "\n\n"
+    ]
 
 
 class _HermesTurnPersister:
@@ -544,6 +610,7 @@ router = make_backend_router(
     client_factory=lambda: _client(),
     transform_body=_build_envelope,
     make_observer=_make_persister,
+    pre_send=_journal_capture_prelude,
 )
 
 
@@ -718,6 +785,29 @@ async def resolve_persona_from_text(request: Request):
     if persona_id is None:
         # Rule 3.
         return {"persona_id": None, "text": parsed.text, "lifeos_context": None}
+
+    if persona_id == JOURNAL_PERSONA_ID:
+        # #685 adversarial-review follow-up: this endpoint resolves a
+        # persona WITHOUT running a turn — Hermes's own Telegram front door
+        # calls it to build an envelope BEFORE deciding what, if anything,
+        # it does with the message — so there is no ask/stream turn here for
+        # the journal-capture gate to hook (that gate lives on the relay
+        # above, keyed off a persona id that's actually about to drive a
+        # turn). Silently resolving `journal` here would either double-
+        # capture once Hermes relays the real turn through that proxy, or
+        # capture text that never becomes a turn at all (a reply Hermes
+        # never sends, a tag with no follow-up). Until this surface has its
+        # own capture/proof protocol, refuse it visibly rather than let
+        # Hermes reply "Logged." with nothing on disk — the #674/#685
+        # signature a third time, this time silent since nothing here would
+        # even try to write. Applies identically whether `journal` came from
+        # an explicit `@journal` tag (rule 1) or thread inheritance (rule
+        # 2) — deliberately checked after both, once persona_id is settled,
+        # rather than duplicated in each branch above.
+        raise HTTPException(
+            status_code=400,
+            detail="journal capture isn't available via the Hermes Telegram bot; use the journal bot",
+        )
 
     modality = "voice" if (parsed.modality or "").strip().lower() == "voice" else "text"
     # A resolved persona — tag or inherited — is always the "chose a

--- a/tests/test_hermes_proxy.py
+++ b/tests/test_hermes_proxy.py
@@ -12,15 +12,18 @@ import base64
 import json
 import logging
 import sqlite3
+from datetime import date
 from pathlib import Path
 
 import httpx
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import Response, StreamingResponse
+from fastapi.testclient import TestClient
 
 from api.routes import hermes_proxy as hp
 from api.services.conversation_store import ConversationStore
+from api.services.journal_capture import log_path_for
 from api.services.usage_store import UsageStore
 
 pytestmark = pytest.mark.unit
@@ -2253,3 +2256,473 @@ async def test_register_persona_message_requires_auth(resolve_client):
         json={"chat_id": "chat-1", "message_id": "bot-msg-1", "persona_id": "primary"},
     )
     assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Journal capture gate on the proxy relay path (#685). Before this, a
+# journal-persona turn sent through `/api/hermes/ask/stream` — which `/chat`
+# reaches by default whenever Hermes is available — was relayed to Hermes and
+# never captured at all: #674's exact signature (a reply that reads like a
+# successful capture and no file) resurrected on a surface nobody had
+# checked. Mirrors tests/test_journal_capture.py's coverage of the native
+# path: assertions land on the actual file on disk, not on a mock having
+# been called — the gap that let #674 ship broken in the first place.
+# ---------------------------------------------------------------------------
+
+# Obviously synthetic fragment — nothing here resembles a real note.
+_JOURNAL_FRAGMENT = "the deploy gate should fail closed #eng"
+
+
+def _bullets(text: str) -> list[str]:
+    return [line for line in text.splitlines() if line.startswith("- ")]
+
+
+@pytest.fixture
+def journal_vault(tmp_path, monkeypatch) -> Path:
+    """A throwaway vault for the proxy's journal-capture gate. Same
+    redirect-and-assert pattern as tests/test_journal_capture.py's `vault`
+    fixture, extended to this module's own `hp.settings` reference (the gate
+    is reached through hermes_proxy.py, not just chat.py/journal_capture.py)
+    since `config.settings` can be reloaded elsewhere in the suite, leaving a
+    module that imported `settings` at import time holding a stale instance."""
+    import api.services.journal_capture as journal_capture_mod
+    import config.settings as settings_mod
+
+    root = tmp_path / "vault"
+    root.mkdir()
+    seen = {}
+    for obj in (settings_mod.settings, journal_capture_mod.settings, hp.settings):
+        seen[id(obj)] = obj
+    for obj in seen.values():
+        monkeypatch.setattr(obj, "vault_path", root)
+    assert journal_capture_mod.settings.vault_path == root
+    return root
+
+
+@pytest.fixture
+def journal_persona_registered(tmp_path, monkeypatch) -> str:
+    """Register a `journal` bot against the real persona file, the same way
+    tests/test_journal_capture.py's `journal_persona` fixture does, so
+    `persona_id="journal"` resolves on this proxy's envelope path too.
+    Returns the resolved raw preamble — the shape `chat_via_api()` and the
+    ring ingest actually send (`persona=...`, no `persona_id`), needed by
+    the raw-preamble capture test below (#685 finding 1)."""
+    reg = _registry(tmp_path, [
+        {"name": "journal", "token_env": "TG_JOURNAL_TEST", "persona_file": "config/personas/journal.md"},
+    ])
+    monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
+    monkeypatch.setenv("TG_JOURNAL_TEST", "tok")
+    preamble = hp.settings.resolve_persona("journal")
+    assert preamble, "journal persona did not resolve"
+    return preamble
+
+
+def _sse_events(resp) -> list[dict]:
+    return [
+        json.loads(chunk[len("data: "):])
+        for chunk in resp.text.split("\n\n")
+        if chunk.startswith("data: ")
+    ]
+
+
+async def test_journal_persona_writes_fragment_before_hermes_relay(
+    proxy_client, journal_vault, journal_persona_registered,
+):
+    resp = await proxy_client.post(
+        "/api/hermes/ask/stream",
+        json={"question": _JOURNAL_FRAGMENT, "persona_id": "journal"},
+    )
+    assert resp.status_code == 200
+
+    log = journal_vault / log_path_for(date.today())
+    assert log.exists(), "the fragment never reached disk"
+    written = log.read_text()
+    assert written.startswith(f"---\ntype: log\ndate: {date.today().isoformat()}\n---\n")
+    assert [b.split(" · ")[1] for b in _bullets(written)] == [_JOURNAL_FRAGMENT]
+
+    # The turn was still relayed to Hermes — a captured fragment doesn't
+    # short-circuit the proxy, it just has to land first (the failure-path
+    # test below proves that ordering structurally: on a capture failure,
+    # Hermes is never contacted at all).
+    assert json.loads(_received["body"])["question"] == _JOURNAL_FRAGMENT
+
+
+async def test_journal_capture_sse_event_matches_native_shape(
+    proxy_client, journal_vault, journal_persona_registered,
+):
+    resp = await proxy_client.post(
+        "/api/hermes/ask/stream",
+        json={"question": _JOURNAL_FRAGMENT, "persona_id": "journal"},
+    )
+    assert resp.status_code == 200
+    events = _sse_events(resp)
+
+    # Same event shape ask_stream() emits natively (api/routes/chat.py) —
+    # chat_via_api() and the ring ingest (api/routes/journal_ingest.py)
+    # require this exact event as proof of capture on either path alike.
+    capture_events = [e for e in events if e.get("type") == "journal_capture"]
+    assert capture_events == [{
+        "type": "journal_capture",
+        "path": log_path_for(date.today()),
+        "created": True,
+    }]
+    # It's the first frame the browser sees — ahead of anything Hermes
+    # itself streamed for this turn.
+    assert events[0]["type"] == "journal_capture"
+
+
+async def test_second_fragment_of_the_day_appends_and_created_is_false(
+    proxy_client, journal_vault, journal_persona_registered,
+):
+    first = await proxy_client.post(
+        "/api/hermes/ask/stream",
+        json={"question": _JOURNAL_FRAGMENT, "persona_id": "journal"},
+    )
+    assert [e for e in _sse_events(first) if e.get("type") == "journal_capture"][0]["created"] is True
+
+    second = await proxy_client.post(
+        "/api/hermes/ask/stream",
+        json={"question": "a second synthetic fragment", "persona_id": "journal"},
+    )
+    assert [e for e in _sse_events(second) if e.get("type") == "journal_capture"][0]["created"] is False
+
+    written = (journal_vault / log_path_for(date.today())).read_text()
+    assert written.count("type: log") == 1
+    assert [b.split(" · ")[1] for b in _bullets(written)] == [
+        _JOURNAL_FRAGMENT, "a second synthetic fragment",
+    ]
+
+
+async def test_capture_failure_fails_the_request_and_never_reaches_hermes(
+    proxy_client, journal_vault, journal_persona_registered,
+):
+    # Same "day dir exists as a file" trick tests/test_journal_capture.py's
+    # equivalent native-path test (test_capture_failure_is_a_clean_error_and_
+    # no_stream) uses to force a real write failure out of capture_fragment().
+    (journal_vault / "Personal").mkdir()
+    (journal_vault / "Personal" / "Log").write_text("not a directory")
+
+    resp = await proxy_client.post(
+        "/api/hermes/ask/stream",
+        json={"question": _JOURNAL_FRAGMENT, "persona_id": "journal"},
+    )
+    assert resp.status_code == 500
+    # No false success, and the reply a user sees must not quote what they
+    # said.
+    assert _JOURNAL_FRAGMENT not in resp.text
+    # Hermes was never contacted — no false success is even possible, and
+    # whatever idempotency key a caller (e.g. the ring ingest) tracks for
+    # this delivery stays unburned since the whole request failed before any
+    # relay began.
+    assert _received == {}
+
+
+async def test_non_journal_persona_proxy_behavior_unchanged(proxy_client, journal_vault):
+    resp = await proxy_client.post(
+        "/api/hermes/ask/stream", json={"question": "what did I do last week?"},
+    )
+    assert resp.status_code == 200
+    assert resp.content == b"".join(_UPSTREAM_SSE_CHUNKS)
+    assert not any(e.get("type") == "journal_capture" for e in _sse_events(resp))
+    assert not (journal_vault / "Personal").exists()
+    assert json.loads(_received["body"])["question"] == "what did I do last week?"
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review follow-up (#685, finding 1): the journal-capture gate's
+# effective-persona resolution must match ask_stream()'s native semantics —
+# reverse-mapping a raw `persona` preamble (the exact shape chat_via_api()
+# and the ring ingest send, api/routes/journal_ingest.py:172), and rejecting
+# the same malformed persona_id/persona shapes with the same 400 — not
+# approximate them as `persona_id or "primary"` alone.
+# ---------------------------------------------------------------------------
+
+async def test_raw_persona_preamble_journal_turn_still_captures(
+    proxy_client, journal_vault, journal_persona_registered,
+):
+    """The shape chat_via_api()/the ring ingest actually send: a raw
+    `persona` preamble, no `persona_id` at all. #684 is what's expected to
+    point those callers at this proxy — if the prelude only ever looked at
+    `persona_id`, this turn would silently stop being captured the moment
+    that happens, #674's bug a third time."""
+    journal_preamble = journal_persona_registered
+    resp = await proxy_client.post(
+        "/api/hermes/ask/stream",
+        json={"question": _JOURNAL_FRAGMENT, "persona": journal_preamble},
+    )
+    assert resp.status_code == 200
+
+    written = (journal_vault / log_path_for(date.today())).read_text()
+    assert [b.split(" · ")[1] for b in _bullets(written)] == [_JOURNAL_FRAGMENT]
+    assert [e for e in _sse_events(resp) if e.get("type") == "journal_capture"] == [{
+        "type": "journal_capture",
+        "path": log_path_for(date.today()),
+        "created": True,
+    }]
+
+
+async def test_empty_persona_id_gets_native_400_on_proxy(proxy_client, journal_vault):
+    resp = await proxy_client.post(
+        "/api/hermes/ask/stream", json={"question": "hi", "persona_id": ""},
+    )
+    assert resp.status_code == 400
+    assert _received == {}  # rejected before the upstream backend was ever called
+
+
+async def test_persona_and_persona_id_conflict_gets_native_400_on_proxy(proxy_client, journal_vault):
+    resp = await proxy_client.post(
+        "/api/hermes/ask/stream",
+        json={"question": "hi", "persona": "X", "persona_id": "primary"},
+    )
+    assert resp.status_code == 400
+    assert _received == {}
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review follow-up (#685, finding 2): once capture has already
+# succeeded, its proof must reach the caller regardless of what Hermes then
+# does — chat_via_api() (api/services/telegram.py) and the ring ingest
+# (api/routes/journal_ingest.py) both treat a non-200 response as "nothing
+# happened" and never look at its body for a `journal_capture` event.
+# ---------------------------------------------------------------------------
+
+async def test_journal_capture_proof_survives_hermes_connect_failure(
+    journal_vault, journal_persona_registered, monkeypatch,
+):
+    class _Refusing:
+        def build_request(self, *a, **k):
+            return object()
+
+        async def send(self, *a, **k):
+            raise httpx.ConnectError("refused")
+
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr(hp, "_client", _Refusing)
+    monkeypatch.setattr(hp.settings, "hermes_backend_url", "http://hermes")
+    app = FastAPI()
+    app.include_router(hp.router)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+        resp = await c.post(
+            "/api/hermes/ask/stream",
+            json={"question": _JOURNAL_FRAGMENT, "persona_id": "journal"},
+        )
+
+    # NOT a 502 — a caller that error-branches on status code alone (both
+    # real callers do) must still be able to see the capture proof.
+    assert resp.status_code == 200
+    events = _sse_events(resp)
+    assert events[0] == {
+        "type": "journal_capture",
+        "path": log_path_for(date.today()),
+        "created": True,
+    }
+    error_events = [e for e in events if e.get("type") == "error"]
+    assert len(error_events) == 1
+    # Same {"type": "error", "message": ...} shape api/routes/chat.py's
+    # native path already emits, which chat_via_api() already knows to fold
+    # into its answer rather than choke on.
+    assert "unreachable" in error_events[0]["message"]
+
+    written = (journal_vault / log_path_for(date.today())).read_text()
+    assert [b.split(" · ")[1] for b in _bullets(written)] == [_JOURNAL_FRAGMENT]
+
+
+async def test_journal_capture_proof_survives_hermes_non_200(
+    journal_vault, journal_persona_registered, monkeypatch,
+):
+    # Reuses the module's existing `_stub_500` app (already used by
+    # test_non_200_upstream_is_passed_through above) rather than a second
+    # near-identical stub.
+    monkeypatch.setattr(
+        hp, "_client",
+        lambda: httpx.AsyncClient(transport=httpx.ASGITransport(app=_stub_500), base_url="http://a"),
+    )
+    monkeypatch.setattr(hp.settings, "hermes_backend_url", "http://a")
+    monkeypatch.setattr(hp.settings, "hermes_backend_token", "")
+    app = FastAPI()
+    app.include_router(hp.router)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://p") as c:
+        resp = await c.post(
+            "/api/hermes/ask/stream",
+            json={"question": _JOURNAL_FRAGMENT, "persona_id": "journal"},
+        )
+
+    assert resp.status_code == 200
+    events = _sse_events(resp)
+    assert events[0]["type"] == "journal_capture"
+    error_events = [e for e in events if e.get("type") == "error"]
+    assert len(error_events) == 1
+    assert "500" in error_events[0]["message"]
+
+    written = (journal_vault / log_path_for(date.today())).read_text()
+    assert [b.split(" · ")[1] for b in _bullets(written)] == [_JOURNAL_FRAGMENT]
+
+
+@pytest.fixture
+def journal_ingest_via_proxy(tmp_path, monkeypatch, journal_vault, journal_persona_registered):
+    """`POST /api/journal/ingest` wired to a `chat_via_api`-shaped bridge that
+    posts through the Hermes PROXY instead of native `/api/ask/stream` — the
+    wiring #684 is expected to give `chat_via_api()` itself once it points
+    the journal bot at Hermes. Exercises the REAL, unmocked ring-ingest
+    dedupe logic (api/routes/journal_ingest.py) on top of the guaranteed-
+    prelude-delivery fix (#685 finding 2): a capture that succeeds while
+    Hermes then fails must still get the delivery's idempotency key burned,
+    or a genuine retry re-invokes `capture_fragment()` a second time for the
+    same delivery — the double-append the adversarial review flagged.
+
+    Hermes is unreachable for every call in this fixture — the point being
+    proven is that capture (and the ring ingest's success/dedupe
+    bookkeeping) never depended on Hermes working in the first place.
+    """
+    import api.routes.journal_ingest as journal_ingest
+    import api.services.journal_ingest_store as journal_ingest_store
+    from api.services.journal_ingest_store import JournalIngestStore
+
+    store = JournalIngestStore(db_path=str(tmp_path / "journal_ingest.db"))
+    monkeypatch.setattr(journal_ingest_store, "_store_instance", store)
+    journal_ingest._conversations.clear()
+    monkeypatch.setattr(journal_ingest.settings, "journal_ingest_token", "secret-token")
+
+    class _Refusing:
+        def build_request(self, *a, **k):
+            return object()
+
+        async def send(self, *a, **k):
+            raise httpx.ConnectError("refused")
+
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr(hp, "_client", _Refusing)
+    monkeypatch.setattr(hp.settings, "hermes_backend_url", "http://hermes")
+
+    proxy_app = FastAPI()
+    proxy_app.include_router(hp.router)
+    proxy_transport = httpx.ASGITransport(app=proxy_app)
+
+    async def chat_via_proxy(question, conversation_id=None, persona=None):
+        # Mirrors api.services.telegram.chat_via_api()'s SSE-parsing loop
+        # verbatim, posting through the Hermes proxy instead of native
+        # /api/ask/stream — see the fixture docstring.
+        body = {"question": question}
+        if conversation_id:
+            body["conversation_id"] = conversation_id
+        if persona:
+            body["persona"] = persona
+        full_text = ""
+        conv_id = conversation_id
+        journal_capture = None
+        async with httpx.AsyncClient(transport=proxy_transport, base_url="http://proxy") as c:
+            async with c.stream("POST", "/api/hermes/ask/stream", json=body) as resp:
+                if resp.status_code != 200:
+                    error_body = await resp.aread()
+                    raise RuntimeError(f"Chat pipeline returned HTTP {resp.status_code}: {error_body[:500]}")
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    try:
+                        event = json.loads(line[len("data: "):])
+                    except json.JSONDecodeError:
+                        continue
+                    etype = event.get("type")
+                    if etype == "content":
+                        full_text += event.get("content", "")
+                    elif etype == "conversation_id":
+                        conv_id = event.get("conversation_id", conv_id)
+                    elif etype == "journal_capture":
+                        journal_capture = {"path": event.get("path"), "created": bool(event.get("created"))}
+                    elif etype == "error":
+                        msg = event.get("message", "Unknown error")
+                        full_text += f"\n\nError: {msg}" if full_text else f"Error: {msg}"
+        return {"answer": full_text, "conversation_id": conv_id, "journal_capture": journal_capture}
+
+    monkeypatch.setattr("api.services.telegram.chat_via_api", chat_via_proxy)
+
+    ingest_app = FastAPI()
+    ingest_app.include_router(journal_ingest.router)
+    return TestClient(ingest_app), store
+
+
+def _journal_ingest_payload(**overrides):
+    payload = {
+        "text": _JOURNAL_FRAGMENT,
+        "device_id": "ring-test-1",
+        "timestamp": "2026-08-23T14:37:00Z",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _journal_ingest_auth():
+    return {"Authorization": "Bearer secret-token"}
+
+
+def test_capture_proof_survives_hermes_failure_and_retry_does_not_double_append(
+    journal_ingest_via_proxy, journal_vault,
+):
+    client, store = journal_ingest_via_proxy
+
+    first = client.post(
+        "/api/journal/ingest", json=_journal_ingest_payload(), headers=_journal_ingest_auth(),
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["status"] == "logged"
+
+    written = (journal_vault / log_path_for(date.today())).read_text()
+    assert [b.split(" · ")[1] for b in _bullets(written)] == [_JOURNAL_FRAGMENT]
+
+    # A genuine retry of the SAME delivery — Hermes is STILL unreachable,
+    # but the dedupe key was already burned on the first attempt (its
+    # capture proof reached the ring ingest despite Hermes failing), so this
+    # must short-circuit as a duplicate rather than append a second bullet.
+    second = client.post(
+        "/api/journal/ingest", json=_journal_ingest_payload(), headers=_journal_ingest_auth(),
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["status"] == "duplicate"
+
+    written = (journal_vault / log_path_for(date.today())).read_text()
+    assert [b.split(" · ")[1] for b in _bullets(written)] == [_JOURNAL_FRAGMENT]
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review follow-up (#685, finding 3): `/resolve-persona` resolves
+# a persona WITHOUT running a turn, so there is no ask/stream turn here for
+# the journal-capture gate to hook — `journal` must be refused visibly
+# instead of silently resolving into a phantom "Logged." reply with nothing
+# on disk, whether it arrived via an explicit tag (rule 1) or thread
+# inheritance (rule 2).
+# ---------------------------------------------------------------------------
+
+async def test_resolve_persona_rejects_tagged_journal(resolve_client, journal_persona_registered):
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={"text": "@journal had a thought"},
+        headers=_auth(),
+    )
+    assert resp.status_code == 400
+    assert "journal" in resp.json()["detail"].lower()
+
+
+async def test_resolve_persona_rejects_inherited_journal(
+    resolve_client, journal_persona_registered,
+):
+    first = await resolve_client.post(
+        "/api/hermes/register-persona-message",
+        json={"chat_id": "chat-1", "message_id": "bot-msg-1", "persona_id": "journal"},
+        headers=_auth(),
+    )
+    assert first.status_code == 200
+
+    resp = await resolve_client.post(
+        "/api/hermes/resolve-persona",
+        json={
+            "text": "one more thing", "chat_id": "chat-1",
+            "message_id": "msg-2", "reply_to_message_id": "bot-msg-1",
+        },
+        headers=_auth(),
+    )
+    assert resp.status_code == 400
+    assert "journal" in resp.json()["detail"].lower()


### PR DESCRIPTION
Closes #685. **Live bug**: /chat defaults to the Hermes backend when configured, so a journal-persona turn in the web UI routed through `/api/hermes/ask/stream` — which never captured. #674's failure signature resurrected on a surface nobody checked.

### The fix

A generic `pre_send` hook on `make_backend_router()`: when the resolved persona is journal, `capture_fragment()` runs **before Hermes is contacted**, the `journal_capture` proof event is emitted ahead of any relayed content, and a write failure aborts with the backend never called. `journal_capture_gate()` + `resolve_effective_persona_id()` are shared with native `ask_stream` — one source of truth, native behavior pinned byte-identical by untouched tests.

### Codex adversarial review: MERGE-AFTER-FIXES, all three addressed

- **Blocking — persona-shape divergence**: the prelude originally resolved `persona_id` only, but `chat_via_api()` and the ring ingest send raw `persona` — the exact callers #684 will point here. Now one shared resolver with native semantics (raw-preamble reverse-mapping, same 400s on malformed shapes).
- **Proof frame lost on Hermes failure**: once capture succeeds, the response is unconditionally a 200 SSE stream with the proof queued before the upstream attempt; a Hermes connect failure/non-200 becomes an in-stream error event. End-to-end test wires the REAL ring-ingest dedupe store: capture succeeds while Hermes is down → key burns on attempt 1 → a retry short-circuits as duplicate instead of double-appending.
- **`@journal` hole on `/resolve-persona`**: a Hermes-Telegram `@journal` tag (or thread inheritance) could resolve real journal context with no capture path — Hermes replies "Logged.", nothing written. Now rejected visibly with a message pointing at the journal bot, until that path has a capture protocol.

### Gate

Full `test.sh`-scope gate: **4,865 passed**; 20 failures all accounted for — 13 known env-dependent (#682) plus 7 proven **pre-existing on clean main** (`test_vault_write_route.py` reloads `config.settings` and splits the singleton; deterministic repro filed as #689 — this PR's added tests merely reshuffled the xdist distribution to expose it). Zero regressions attributable to this change. Real vault confirmed untouched throughout.

Prerequisite for #684. Related: #674, #660, #644, #689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)