### PR TITLE
fix(sync): clean-skip Monarch, personal Google, and gsheet-journal when unconfigured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -373,6 +373,7 @@ LIFEOS_RELATIONSHIP_FOLDER=Relationship
 # Monarch Money for account balances, transactions, budgets
 # MONARCH_EMAIL=
 # MONARCH_PASSWORD=
+# LIFEOS_MONARCH_VAULT_DIR=Personal/Finance/Monarch
 
 # =============================================================================
 # BACKUP (optional)

--- a/api/services/gsheet_sync.py
+++ b/api/services/gsheet_sync.py
@@ -7,7 +7,6 @@ Supports both a rolling document with all entries and appending to daily notes.
 import hashlib
 import json
 import logging
-import re
 import sqlite3
 import yaml
 from dataclasses import dataclass
@@ -86,6 +85,11 @@ class GSheetSyncService:
         self.vault_path = vault_path or settings.vault_path
         self.db_path = db_path or get_gsheet_sync_db_path()
         self.configs: list[SheetConfig] = []
+        # Distinguishes "no config" (skip -- issue #687) from "config present
+        # but failed to parse/load" (a real error -- a hand-edited YAML with
+        # broken indentation must not be reported as "not configured" while
+        # the file sits right there. Adversarial review of #687.)
+        self.config_load_error: Optional[str] = None
         self._load_config()
         self._init_db()
 
@@ -117,6 +121,7 @@ class GSheetSyncService:
 
         except Exception as e:
             logger.error(f"Failed to load GSheet sync config: {e}")
+            self.config_load_error = str(e)
 
     def _init_db(self):
         """Initialize SQLite database for tracking synced rows."""
@@ -608,7 +613,30 @@ class GSheetSyncService:
         }
 
         if not self.configs:
+            if self.config_load_error:
+                # The config file EXISTS but failed to parse/load (e.g. a
+                # hand-edited gsheet_sync.yaml with broken indentation) --
+                # this is a real error, not "not configured", and must not
+                # be reported as a quiet skip while the broken file sits
+                # right there. Same principle #687 applies to Monarch:
+                # absence of config and presence of errors must not be
+                # conflated. Adversarial review of #687.
+                logger.error(
+                    f"GSheet sync config exists but failed to load: {self.config_load_error}"
+                )
+                stats["status"] = "error"
+                stats["reason"] = f"gsheet_config_parse_error: {self.config_load_error}"
+                return stats
+
+            # No config file (or an empty/disabled one) — covers the
+            # gsheet-journal case: without a Google Form -> Sheet ->
+            # gsheet_sync.yaml pipeline set up, there's nothing to sync.
+            # Flagging this distinctly lets the caller emit SYNC_SKIPPED
+            # instead of a zero-count "success" that's indistinguishable
+            # from a real (if quiet) run — issue #687.
             logger.info("No sheets configured for GSheet sync")
+            stats["status"] = "skipped"
+            stats["reason"] = "gsheet_sync_not_configured"
             return stats
 
         for config in self.configs:

--- a/api/services/monarch.py
+++ b/api/services/monarch.py
@@ -30,6 +30,20 @@ SESSION_EXPIRY_DAYS = 30
 SESSION_WARNING_DAYS = 25  # Surface in health endpoints before things break.
 
 
+def is_monarch_configured() -> bool:
+    """Return True if Monarch Money has any way to authenticate.
+
+    "Configured" mirrors exactly what ``MonarchClient._get_client()`` tries,
+    in order: a cached session (``SESSION_PATH``) or, failing that, both
+    ``MONARCH_EMAIL``/``MONARCH_PASSWORD`` set. A fresh install with neither
+    is not configured — the nightly sync should skip quietly rather than
+    fail. Anything else (a stale/invalid session, a wrong password, a
+    network outage) still reaches ``_get_client()`` and raises for real,
+    which must keep surfacing as a failure — issue #687.
+    """
+    return SESSION_PATH.exists() or bool(settings.monarch_email and settings.monarch_password)
+
+
 def get_session_age_days() -> Optional[float]:
     """Return the cached Monarch session's age in days, or None if not present.
 
@@ -477,7 +491,7 @@ class MonarchClient:
         content = await self.generate_monthly_report(year, month)
         period = f"{year}-{month:02d}"
 
-        vault_path = settings.vault_path / "Personal" / "Finance" / "Monarch"
+        vault_path = settings.vault_path / settings.monarch_vault_dir
         file_path = vault_path / f"{period}.md"
 
         if dry_run:

--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -77,6 +77,20 @@ def _is_source_disabled(source: str) -> bool:
     if source in ("slack", "link_slack") and not getattr(settings, "sync_slack", False):
         return True
 
+    # Personal Google has no on/off toggle (it's the default account), so
+    # "disabled" means its OAuth credentials file is absent — same signal
+    # run_all_syncs.get_disabled_work_sources() uses to skip the source
+    # before ever invoking the script. Without this, an unconfigured
+    # install would show gmail_personal/calendar_personal as permanently
+    # "never run" in the health summary instead of quietly excluded, since
+    # no sync_runs row is ever written for a source that's pre-skipped —
+    # issue #687.
+    if source in ("gmail_personal", "calendar_personal"):
+        from pathlib import Path
+        credentials_path = Path(__file__).parent.parent.parent / "config" / "credentials-personal.json"
+        if not credentials_path.exists():
+            return True
+
     return False
 
 # =============================================================================

--- a/config/settings.py
+++ b/config/settings.py
@@ -1037,6 +1037,13 @@ class Settings(BaseSettings):
         alias="MONARCH_PASSWORD",
         description="Monarch Money account password"
     )
+    monarch_vault_dir: str = Field(
+        default="Personal/Finance/Monarch",
+        alias="LIFEOS_MONARCH_VAULT_DIR",
+        description="Vault-relative directory where the Monarch Money monthly "
+                    "summary (YYYY-MM.md) lands. Path is joined under "
+                    "LIFEOS_VAULT_PATH, same convention as LIFEOS_AGENT_OUTPUT_DIR."
+    )
 
     # Backup directory
     backup_path: str = Field(

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -339,8 +339,11 @@ Natural-language messages run through the chat pipeline (search, synthesis, tool
 |---|---|---|---|
 | `MONARCH_EMAIL` | str | — | Monarch Money login email. |
 | `MONARCH_PASSWORD` | str | — | Monarch Money password. |
+| `LIFEOS_MONARCH_VAULT_DIR` | path | `Personal/Finance/Monarch` | Vault-relative folder where the monthly Monarch summary (`YYYY-MM.md`) lands. |
 
 Auth tokens are cached at `data/monarch_session.pickle` after first login. Re-authenticate when the token expires (401/525) per the steps in the root [AGENTS.md § Monarch Money](../../AGENTS.md#monarch-money-financial-data).
+
+Both `MONARCH_EMAIL`/`MONARCH_PASSWORD` unset AND no cached session at `data/monarch_session.pickle` means Monarch isn't configured — the nightly sync records it as skipped rather than failed. Any other failure (bad session, wrong password, network) still fails the run.
 
 ## Configuration Files
 

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -787,12 +787,30 @@ SYNC_TIMEOUTS = {
 }
 
 
+# Personal Google account sources — unlike work/work2 (explicit opt-in
+# booleans below) there's no separate on/off toggle for personal, since it's
+# the default account most installs set up first. "Configured" for personal
+# means its OAuth credentials file exists — same signal
+# get_configured_accounts() uses for work/work2 in api/services/google_auth.py.
+# Kept as a plain path check here (not imported from google_auth) to avoid
+# pulling google-auth-oauthlib into this module for a one-line check.
+PERSONAL_GOOGLE_SOURCES = {"gmail_personal", "calendar_personal"}
+
+
+def _personal_google_credentials_exist() -> bool:
+    return (Path(__file__).parent.parent / "config" / "credentials-personal.json").exists()
+
+
 def get_disabled_work_sources() -> set[str]:
     """
-    Return set of sources that should be skipped because work integrations are disabled.
+    Return set of sources that should be skipped because they aren't configured.
 
     Work integrations are disabled by default for safety - work data will only be
-    synced if explicitly enabled via environment variables.
+    synced if explicitly enabled via environment variables. Personal Google has
+    no such toggle, but is gated the same way once its credentials are absent —
+    absence used to reach sync_gmail_calendar_interactions.py unguarded and
+    raise FileNotFoundError, recorded as SyncStatus.FAILED every night on any
+    install that never set up personal Gmail/Calendar — issue #687.
     """
     disabled = set()
 
@@ -816,6 +834,9 @@ def get_disabled_work_sources() -> set[str]:
     if not settings.sync_slack:
         disabled.add("slack")
         disabled.add("link_slack")
+
+    if not _personal_google_credentials_exist():
+        disabled.update(PERSONAL_GOOGLE_SOURCES)
 
     return disabled
 
@@ -1795,10 +1816,11 @@ def run_all_syncs(
     skipped_sources = []  # Exited early because they aren't configured
     start_time = datetime.now()
 
-    # Check for disabled work integrations
+    # Check for disabled/unconfigured sources (work integrations + personal
+    # Google without credentials)
     disabled_sources = get_disabled_work_sources()
     if disabled_sources:
-        logger.info(f"Work integration sources disabled: {', '.join(sorted(disabled_sources))}")
+        logger.info(f"Disabled/unconfigured sources: {', '.join(sorted(disabled_sources))}")
         logger.info("Enable via LIFEOS_SYNC_SLACK=true, etc. in .env")
 
     logger.info(f"Sync triggered: {trigger}")
@@ -1875,10 +1897,15 @@ def run_all_syncs(
                 logger.warning(f"Unknown source: {source}, skipping")
                 continue
 
-            # Skip sources disabled by work integration settings
+            # Skip sources disabled by work integration settings (or, for
+            # personal Google, missing OAuth credentials — issue #687)
             if source in disabled_sources:
-                logger.info(f"Skipping {source}: work integration disabled")
-                results[source] = {"skipped": True, "reason": "work_integration_disabled"}
+                if source in PERSONAL_GOOGLE_SOURCES:
+                    logger.info(f"Skipping {source}: personal Google account not configured")
+                    results[source] = {"skipped": True, "reason": "google_account_not_configured"}
+                else:
+                    logger.info(f"Skipping {source}: work integration disabled")
+                    results[source] = {"skipped": True, "reason": "work_integration_disabled"}
                 continue
 
             # Skip monthly sources unless it's the 1st of the month (or forced)

--- a/scripts/sync_google_sheets.py
+++ b/scripts/sync_google_sheets.py
@@ -38,7 +38,23 @@ def sync_google_sheets(dry_run: bool = True) -> dict:
 
     try:
         results = sync_gsheets()
-        logger.info(f"\n=== Google Sheets Sync Results ===")
+
+        if results.get("status") == "skipped":
+            # No config/gsheet_sync.yaml (or an empty/disabled one) — e.g.
+            # the gsheet-journal Form -> Sheet pipeline was never set up.
+            # Declare the skip so the parent records SKIPPED instead of a
+            # zero-count "success" — same pattern as Photos/Apple Contacts/
+            # Monarch — issue #687.
+            logger.info(f"GSheet sync skipped: {results.get('reason', 'not configured')}")
+            print(
+                "SYNC_SKIPPED: No Google Sheets configured — copy "
+                "config/gsheet_sync.example.yaml to config/gsheet_sync.yaml "
+                "to enable",
+                flush=True,
+            )
+            return results
+
+        logger.info("\n=== Google Sheets Sync Results ===")
         logger.info(f"  Sheets synced: {results.get('synced', 0)}")
         logger.info(f"  Rows processed: {results.get('rows', 0)}")
         return results

--- a/scripts/sync_monarch_money.py
+++ b/scripts/sync_monarch_money.py
@@ -2,7 +2,8 @@
 """
 Sync Monarch Money financial data to the Obsidian vault.
 
-Generates a monthly Markdown summary at Personal/Finance/Monarch/YYYY-MM.md.
+Generates a monthly Markdown summary at LIFEOS_MONARCH_VAULT_DIR/YYYY-MM.md
+(defaults to Personal/Finance/Monarch/YYYY-MM.md).
 Designed to run on the 1st of each month for the previous month's data.
 
 Usage:
@@ -36,7 +37,8 @@ async def sync_monarch(dry_run: bool = True, month: str | None = None) -> dict:
     Returns:
         Stats dict
     """
-    from api.services.monarch import get_monarch_client
+    from api.services.monarch import get_monarch_client, is_monarch_configured
+    from config.settings import settings
 
     # Determine target month
     if month:
@@ -53,15 +55,36 @@ async def sync_monarch(dry_run: bool = True, month: str | None = None) -> dict:
 
     if dry_run:
         logger.info(f"DRY RUN — would sync Monarch Money data for {period}")
-        logger.info(f"  Output: Personal/Finance/Monarch/{period}.md")
+        logger.info(f"  Output: {settings.monarch_vault_dir}/{period}.md")
         return {"status": "dry_run", "period": period}
+
+    if not is_monarch_configured():
+        # Declare the skip so the parent records SKIPPED instead of a
+        # FAILED that repeats every night on any install that never set up
+        # Monarch — same pattern as Photos/Apple Contacts (#495/#497).
+        # A configured-but-broken session (bad password, network, expired
+        # session with no fallback credentials) does NOT hit this branch —
+        # is_monarch_configured() only reports "no way to authenticate at
+        # all", so a real outage still reaches get_monarch_client() below
+        # and fails loud, exactly as before — issue #687.
+        logger.warning(
+            "Monarch Money not configured (no cached session and "
+            "MONARCH_EMAIL/MONARCH_PASSWORD unset) — skipping"
+        )
+        print(
+            "SYNC_SKIPPED: Monarch Money not configured — set MONARCH_EMAIL "
+            "and MONARCH_PASSWORD in .env or run the interactive login "
+            "(see AGENTS.md / docs/guides/operations.md)",
+            flush=True,
+        )
+        return {"status": "skipped", "reason": "monarch_not_configured", "period": period}
 
     logger.info(f"Starting Monarch Money sync for {period}...")
 
     client = get_monarch_client()
     result = await client.write_monthly_report(year, mon, dry_run=False)
 
-    logger.info(f"\n=== Monarch Money Sync Results ===")
+    logger.info("\n=== Monarch Money Sync Results ===")
     logger.info(f"  Period: {period}")
     logger.info(f"  File: {result.get('file', 'N/A')}")
     logger.info(f"  Size: {result.get('size', 0)} chars")
@@ -90,9 +113,14 @@ def main():
         if run_id is not None:
             try:
                 from api.services.sync_health import record_sync_complete, SyncStatus
+                status = (
+                    SyncStatus.SKIPPED
+                    if result.get("status") == "skipped"
+                    else SyncStatus.SUCCESS
+                )
                 record_sync_complete(
                     run_id,
-                    status=SyncStatus.SUCCESS,
+                    status=status,
                     records_processed=1,
                     records_created=1 if result.get("status") == "success" else 0,
                 )

--- a/tests/test_gsheet_sync.py
+++ b/tests/test_gsheet_sync.py
@@ -3,9 +3,8 @@ Tests for Google Sheets sync service.
 """
 import pytest
 import tempfile
-import sqlite3
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from datetime import datetime
 
 # Mark all tests as unit tests
@@ -388,6 +387,91 @@ sheets:
                     service = GSheetSyncService(vault_path=vault_path)
 
             assert len(service.configs) == 0
+
+    def test_sync_all_reports_skipped_when_missing_config(self):
+        """sync_all() must flow "no config" through the structured
+        status/reason contract, not just a zero-count dict indistinguishable
+        from a real (if quiet) success -- issue #687. This is the
+        gsheet-journal case: no config/gsheet_sync.yaml means the Google
+        Form -> Sheet -> vault pipeline was never set up.
+        """
+        from api.services.gsheet_sync import GSheetSyncService
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vault_path = Path(tmpdir) / "vault"
+            vault_path.mkdir()
+
+            with patch("api.services.gsheet_sync.CONFIG_PATH", Path(tmpdir) / "nonexistent.yaml"):
+                with patch("api.services.gsheet_sync.get_gsheet_sync_db_path", return_value=str(Path(tmpdir) / "test.db")):
+                    service = GSheetSyncService(vault_path=vault_path)
+                    stats = service.sync_all()
+
+            assert stats["status"] == "skipped"
+            assert stats["reason"] == "gsheet_sync_not_configured"
+            # The zero-count keys stay intact -- callers that only look at
+            # "synced"/"failed" (never "status") still see today's shape.
+            assert stats["synced"] == 0
+            assert stats["failed"] == 0
+
+    def test_sync_all_reports_error_when_config_malformed(self):
+        """A config file that EXISTS but fails to parse (e.g. hand-edited
+        YAML with broken indentation) must be reported as a real error, not
+        a quiet "not configured" skip -- adversarial review of #687 caught
+        that the pre-existing `except Exception` swallow in _load_config()
+        left self.configs empty either way, which the naive "not self.configs
+        -> skipped" branch couldn't tell apart from a genuinely absent file.
+        Absence of config and presence of errors must not be conflated --
+        the same principle #687 applies to Monarch.
+        """
+        from api.services.gsheet_sync import GSheetSyncService
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.yaml"
+            vault_path = Path(tmpdir) / "vault"
+            vault_path.mkdir()
+
+            # Invalid YAML (unbalanced flow mapping) -- yaml.safe_load raises.
+            config_path.write_text("sheets: [ { sheet_id: 'test123' \n")
+
+            with patch("api.services.gsheet_sync.CONFIG_PATH", config_path):
+                with patch("api.services.gsheet_sync.get_gsheet_sync_db_path", return_value=str(Path(tmpdir) / "test.db")):
+                    service = GSheetSyncService(vault_path=vault_path)
+                    assert service.config_load_error is not None
+                    stats = service.sync_all()
+
+            assert stats["status"] == "error"
+            assert stats["reason"].startswith("gsheet_config_parse_error:")
+            assert stats["status"] != "skipped"
+
+    def test_sync_all_no_status_key_when_configured(self):
+        """A configured install (sheets present) must see no change: no
+        "status"/"reason" key appears on the normal path, so existing
+        callers that don't check for it are unaffected."""
+        from api.services.gsheet_sync import GSheetSyncService
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.yaml"
+            vault_path = Path(tmpdir) / "vault"
+            vault_path.mkdir()
+
+            config_content = """
+sheets:
+  - sheet_id: "test123"
+    name: "Test Sheet"
+"""
+            config_path.write_text(config_content)
+
+            with patch("api.services.gsheet_sync.CONFIG_PATH", config_path):
+                with patch("api.services.gsheet_sync.get_gsheet_sync_db_path", return_value=str(Path(tmpdir) / "test.db")):
+                    service = GSheetSyncService(vault_path=vault_path)
+                    # _sync_sheet would hit the real Google Sheets API, so
+                    # stub it out -- only sync_all()'s empty-configs branch
+                    # (or lack thereof) is under test here.
+                    service._sync_sheet = lambda config: {"new_rows": 0, "skipped_rows": 0}
+                    stats = service.sync_all()
+
+            assert "status" not in stats
+            assert "reason" not in stats
 
 
 class TestDailyNoteAppend:

--- a/tests/test_monarch_session_status.py
+++ b/tests/test_monarch_session_status.py
@@ -67,3 +67,83 @@ class TestGetSessionStatus:
         backdate = time.time() - (SESSION_EXPIRY_DAYS + 5) * 86400
         os.utime(temp_session, (backdate, backdate))
         assert get_session_status()["status"] == "expired"
+
+
+class TestIsMonarchConfigured:
+    """Pins the exact "not configured" condition for issue #687: the
+    nightly sync must skip cleanly ONLY when there is truly no way to
+    authenticate (no cached session AND no credentials). Anything else
+    (a session that exists but might be stale, or credentials present but
+    wrong) has to keep reaching the real client so a genuine outage still
+    fails loud -- conflating the two would hide a real Monarch outage on
+    the maintainer's own box, the exact regression #646 fixed elsewhere.
+    """
+
+    def test_no_session_no_credentials_is_not_configured(self, temp_session, monkeypatch):
+        from api.services.monarch import is_monarch_configured, settings
+        monkeypatch.setattr(settings, "monarch_email", "")
+        monkeypatch.setattr(settings, "monarch_password", "")
+        assert is_monarch_configured() is False
+
+    def test_cached_session_alone_is_configured(self, temp_session, monkeypatch):
+        """A cached session is sufficient even with no credentials in .env --
+        the documented flow lets credentials be scrubbed after first login."""
+        from api.services.monarch import is_monarch_configured, settings
+        monkeypatch.setattr(settings, "monarch_email", "")
+        monkeypatch.setattr(settings, "monarch_password", "")
+        temp_session.write_bytes(b"")
+        assert is_monarch_configured() is True
+
+    def test_credentials_alone_is_configured(self, temp_session, monkeypatch):
+        """No cached session yet, but MONARCH_EMAIL/PASSWORD are set (e.g.
+        first run before the initial login) still counts as configured."""
+        from api.services.monarch import is_monarch_configured, settings
+        monkeypatch.setattr(settings, "monarch_email", "user@example.com")
+        monkeypatch.setattr(settings, "monarch_password", "hunter2")
+        assert is_monarch_configured() is True
+
+    def test_partial_credentials_is_not_configured(self, temp_session, monkeypatch):
+        """Only one of email/password set (e.g. mid-edit .env) must not
+        count as configured -- matches _get_client()'s `and` check."""
+        from api.services.monarch import is_monarch_configured, settings
+        monkeypatch.setattr(settings, "monarch_email", "user@example.com")
+        monkeypatch.setattr(settings, "monarch_password", "")
+        assert is_monarch_configured() is False
+
+
+class TestWriteMonthlyReportVaultDir:
+    """Pins that write_monthly_report() honors LIFEOS_MONARCH_VAULT_DIR
+    (issue #687 #4) -- both the unset-default (must match the previously
+    hardcoded path exactly) and an explicit override."""
+
+    @pytest.mark.asyncio
+    async def test_default_vault_dir_matches_hardcoded_path(self, tmp_path, monkeypatch):
+        from api.services.monarch import MonarchClient, settings
+
+        monkeypatch.setattr(settings, "vault_path", tmp_path)
+        monkeypatch.setattr(settings, "monarch_vault_dir", "Personal/Finance/Monarch")
+
+        client = MonarchClient()
+        async def _fake_generate(year, month):
+            return "content"
+
+        monkeypatch.setattr(client, "generate_monthly_report", _fake_generate)
+
+        result = await client.write_monthly_report(2026, 1, dry_run=True)
+        assert result["file"] == str(tmp_path / "Personal" / "Finance" / "Monarch" / "2026-01.md")
+
+    @pytest.mark.asyncio
+    async def test_env_override_changes_vault_dir(self, tmp_path, monkeypatch):
+        from api.services.monarch import MonarchClient, settings
+
+        monkeypatch.setattr(settings, "vault_path", tmp_path)
+        monkeypatch.setattr(settings, "monarch_vault_dir", "Personal/Money/Monarch")
+
+        client = MonarchClient()
+        async def _fake_generate(year, month):
+            return "content"
+
+        monkeypatch.setattr(client, "generate_monthly_report", _fake_generate)
+
+        result = await client.write_monthly_report(2026, 1, dry_run=True)
+        assert result["file"] == str(tmp_path / "Personal" / "Money" / "Monarch" / "2026-01.md")

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -1182,3 +1182,74 @@ class TestBackupRetentionGating:
 
         backup_mock.assert_called_once()
         prune_mock.assert_not_called()
+
+
+class TestPersonalGoogleGating:
+    """Direct tests of get_disabled_work_sources()'s personal-Google gating
+    (issue #687). Personal has no explicit on/off toggle like work/work2 --
+    "configured" means its OAuth credentials file exists. These call the
+    real function (unlike the higher-level run_all_syncs() tests above,
+    which patch it away entirely) so the settings-driven logic itself is
+    pinned.
+    """
+
+    def test_personal_disabled_when_no_credentials_file(self, monkeypatch):
+        from scripts.run_all_syncs import get_disabled_work_sources
+
+        monkeypatch.setattr(
+            "scripts.run_all_syncs._personal_google_credentials_exist", lambda: False
+        )
+        disabled = get_disabled_work_sources()
+        assert "gmail_personal" in disabled
+        assert "calendar_personal" in disabled
+
+    def test_personal_not_disabled_when_credentials_file_present(self, monkeypatch):
+        """Behavior-neutrality: a configured install (credentials file
+        present, exactly today's status quo) must see no change."""
+        from scripts.run_all_syncs import get_disabled_work_sources
+
+        monkeypatch.setattr(
+            "scripts.run_all_syncs._personal_google_credentials_exist", lambda: True
+        )
+        disabled = get_disabled_work_sources()
+        assert "gmail_personal" not in disabled
+        assert "calendar_personal" not in disabled
+
+    def test_personal_gating_independent_of_work_toggles(self, monkeypatch):
+        """Configured personal + unconfigured work must not cross-contaminate."""
+        from config.settings import settings
+        from scripts.run_all_syncs import get_disabled_work_sources
+
+        monkeypatch.setattr(
+            "scripts.run_all_syncs._personal_google_credentials_exist", lambda: True
+        )
+        monkeypatch.setattr(settings, "sync_work_gmail", False)
+        monkeypatch.setattr(settings, "work_email_domain", "")
+        disabled = get_disabled_work_sources()
+        assert "gmail_personal" not in disabled
+        assert "gmail_work" in disabled
+
+    def test_disabled_personal_source_has_distinct_reason(self):
+        """End-to-end through run_all_syncs(): a disabled personal source
+        must report reason='google_account_not_configured', not
+        'work_integration_disabled' -- it isn't a work integration, and
+        conflating the two would misreport why the source is quiet."""
+        from scripts.run_all_syncs import run_all_syncs
+
+        sync_sources = {
+            "gmail_personal": {"description": "Personal Gmail", "phase": 1, "frequency": "daily"},
+        }
+        with (
+            patch("scripts.run_all_syncs.SYNC_SOURCES", sync_sources),
+            patch("scripts.run_all_syncs.SYNC_ORDER", ["gmail_personal"]),
+            patch("scripts.run_all_syncs.run_sync", MagicMock()),
+            patch("scripts.run_all_syncs.check_sync_health", return_value=(True, "healthy")),
+            patch(
+                "scripts.run_all_syncs.get_disabled_work_sources",
+                return_value={"gmail_personal"},
+            ),
+            patch("scripts.run_all_syncs.log_sync_summary_to_markdown"),
+        ):
+            result = run_all_syncs(dry_run=True)
+
+        assert result["results"]["gmail_personal"]["reason"] == "google_account_not_configured"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -130,3 +130,27 @@ def test_orchestrator_model_default_is_alias_not_snapshot():
 
     default = Settings.model_fields["anthropic_model"].default
     assert not re.search(r"-20\d{6}$", default)
+
+
+def test_monarch_vault_dir_default_matches_hardcoded_path():
+    """LIFEOS_MONARCH_VAULT_DIR must default to exactly the path that was
+    previously hardcoded (Personal/Finance/Monarch) -- issue #687's
+    behavior-neutrality constraint requires an install that never sets this
+    var to write to the same place it always has.
+
+    Asserts the FIELD default, not a live instance, so a host-level override
+    can't turn this into a false failure.
+    """
+    from config.settings import Settings
+
+    assert Settings.model_fields["monarch_vault_dir"].default == "Personal/Finance/Monarch"
+
+
+def test_monarch_vault_dir_from_env(monkeypatch):
+    """LIFEOS_MONARCH_VAULT_DIR should be configurable via env var, same
+    convention as LIFEOS_AGENT_OUTPUT_DIR (issue #687)."""
+    monkeypatch.setenv("LIFEOS_MONARCH_VAULT_DIR", "Personal/Money/Monarch")
+    from config.settings import Settings
+
+    s = Settings()
+    assert s.monarch_vault_dir == "Personal/Money/Monarch"

--- a/tests/test_sync_google_sheets.py
+++ b/tests/test_sync_google_sheets.py
@@ -1,0 +1,55 @@
+"""Tests for scripts/sync_google_sheets.py's clean-skip path (issue #687).
+
+Before this fix, a missing config/gsheet_sync.yaml (e.g. the gsheet-journal
+Google Form -> Sheet pipeline never set up) produced a zero-count "success"
+dict with no SYNC_SKIPPED marker and no emitted SYNC_STATS -- indistinguishable
+from a real, quiet run. These tests pin that the script now surfaces the skip
+through the structured contract run_all_syncs._parse_sync_output reads.
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestSyncGoogleSheetsSkip:
+    def test_missing_config_prints_marker_and_returns_skip(self, monkeypatch, capsys):
+        from scripts.sync_google_sheets import sync_google_sheets
+
+        monkeypatch.setattr(
+            "api.services.gsheet_sync.sync_gsheets",
+            lambda: {"synced": 0, "failed": 0, "skipped": 0, "sheets": [],
+                      "status": "skipped", "reason": "gsheet_sync_not_configured"},
+        )
+
+        result = sync_google_sheets(dry_run=False)
+
+        assert result["status"] == "skipped"
+        captured = capsys.readouterr()
+        assert "SYNC_SKIPPED:" in captured.out
+
+    def test_configured_run_does_not_print_marker(self, monkeypatch, capsys):
+        from scripts.sync_google_sheets import sync_google_sheets
+
+        monkeypatch.setattr(
+            "api.services.gsheet_sync.sync_gsheets",
+            lambda: {"synced": 3, "failed": 0, "skipped": 0, "sheets": []},
+        )
+
+        result = sync_google_sheets(dry_run=False)
+
+        assert result.get("status") != "skipped"
+        captured = capsys.readouterr()
+        assert "SYNC_SKIPPED:" not in captured.out
+
+    def test_dry_run_never_touches_gsheets(self, monkeypatch):
+        """A plain dry run must behave exactly as before -- it never calls
+        sync_gsheets() at all, configured or not."""
+        from scripts.sync_google_sheets import sync_google_sheets
+
+        def _boom():
+            raise AssertionError("sync_gsheets must not be called on a dry run")
+
+        monkeypatch.setattr("api.services.gsheet_sync.sync_gsheets", _boom)
+
+        result = sync_google_sheets(dry_run=True)
+        assert result["status"] == "dry_run"

--- a/tests/test_sync_health.py
+++ b/tests/test_sync_health.py
@@ -242,8 +242,12 @@ class TestSyncHealthSummary:
     def test_get_sync_summary_with_issues(self, temp_db):
         """Test summary when some sources have issues."""
         with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
-            # One fresh success
-            run_id = record_sync_start("gmail_personal")
+            # One fresh success — use vault_reindex (never conditionally
+            # disabled, unlike gmail_personal since #687: a dev checkout
+            # with no config/credentials-personal.json now correctly
+            # reports that source as disabled, so it can no longer stand
+            # in for "a source that's always healthy" here).
+            run_id = record_sync_start("vault_reindex")
             record_sync_complete(run_id, SyncStatus.SUCCESS)
 
             # One failure — use imessage (never platform-disabled in the disabled list)
@@ -348,6 +352,55 @@ class TestSyncSourceConfiguration:
                 f"Script not found for {source}: {config['script']}"
 
 
+class TestPersonalGoogleDisabledCheck:
+    """Direct tests of _is_source_disabled()'s personal-Google handling
+    (issue #687). Without this, an unconfigured install would show
+    gmail_personal/calendar_personal as permanently "never run" in the
+    health summary instead of quietly excluded, since run_all_syncs
+    pre-skips the source and never writes a sync_runs row for it.
+
+    sync_health.py locates the repo root via __file__ (three parents up
+    from api/services/sync_health.py), not cwd, so these point __file__ at
+    a fake tree rather than chdir-ing.
+    """
+
+    def _fake_module_file(self, fake_root):
+        return str(fake_root / "api" / "services" / "sync_health.py")
+
+    def test_disabled_when_credentials_file_absent(self, tmp_path, monkeypatch):
+        import api.services.sync_health as mod
+
+        (tmp_path / "config").mkdir()
+        monkeypatch.setattr(mod, "__file__", self._fake_module_file(tmp_path))
+
+        assert mod._is_source_disabled("gmail_personal") is True
+        assert mod._is_source_disabled("calendar_personal") is True
+
+    def test_not_disabled_when_credentials_file_present(self, tmp_path, monkeypatch):
+        """Behavior-neutrality: a configured install (credentials file
+        present, today's status quo) must see no change."""
+        import api.services.sync_health as mod
+
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / "credentials-personal.json").write_text("{}")
+        monkeypatch.setattr(mod, "__file__", self._fake_module_file(tmp_path))
+
+        assert mod._is_source_disabled("gmail_personal") is False
+        assert mod._is_source_disabled("calendar_personal") is False
+
+    def test_unrelated_source_unaffected(self, tmp_path, monkeypatch):
+        """The new check must only ever apply to the two personal-Google
+        sources, never leak into an unrelated source's disabled-ness."""
+        import api.services.sync_health as mod
+
+        (tmp_path / "config").mkdir()  # credentials-personal.json absent
+        monkeypatch.setattr(mod, "__file__", self._fake_module_file(tmp_path))
+
+        # imessage has no Google-account dependency at all, so it must stay
+        # unaffected by the personal-credentials check either way.
+        assert mod._is_source_disabled("imessage") is False
+
+
 class TestSyncHealthIntegration:
     """Integration tests for sync health system."""
 
@@ -408,11 +461,15 @@ class TestOrphanReaper:
         """Rows in status=running older than max_age_hours are marked failed."""
         with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
             conn = get_sync_health_db()
-            # 10h ago — should be reaped at default 8h cutoff
+            # 10h ago — should be reaped at default 8h cutoff. vault_reindex
+            # (not gmail_personal) since #687: a dev checkout with no
+            # config/credentials-personal.json now correctly reports that
+            # source as disabled, and get_sync_health() deliberately doesn't
+            # surface last_status for a disabled source.
             old = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
             conn.execute(
                 "INSERT INTO sync_runs (source, status, started_at) VALUES (?, ?, ?)",
-                ("gmail_personal", "running", old),
+                ("vault_reindex", "running", old),
             )
             conn.commit()
             conn.close()
@@ -420,7 +477,7 @@ class TestOrphanReaper:
             reaped = reap_orphan_sync_runs()
             assert reaped == 1
 
-            health = get_sync_health("gmail_personal")
+            health = get_sync_health("vault_reindex")
             assert health.last_status == SyncStatus.FAILED
 
     def test_leaves_fresh_running_rows_alone(self, temp_db):

--- a/tests/test_sync_monarch_money.py
+++ b/tests/test_sync_monarch_money.py
@@ -1,0 +1,121 @@
+"""Tests for scripts/sync_monarch_money.py's clean-skip path (issue #687).
+
+Before this fix, an unconfigured Monarch install (no cached session, no
+MONARCH_EMAIL/MONARCH_PASSWORD) raised inside MonarchClient._get_client(),
+propagated through sync_monarch() to main()'s broad `except Exception`, and
+recorded SyncStatus.FAILED every night forever on any install without
+Monarch. These tests pin both directions: an unconfigured install skips
+cleanly (SYNC_SKIPPED marker + SyncStatus.SKIPPED, run succeeds), and a
+configured-but-genuinely-broken install still fails loud, so absence of
+config and presence of real errors are never conflated.
+"""
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestSyncMonarchFunctionSkip:
+    """Exercises sync_monarch() directly -- the structured status/reason it
+    returns, and the SYNC_SKIPPED marker run_all_syncs._parse_sync_output
+    reads from stdout."""
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_returns_skip_and_prints_marker(self, monkeypatch, capsys):
+        from scripts.sync_monarch_money import sync_monarch
+
+        monkeypatch.setattr("api.services.monarch.is_monarch_configured", lambda: False)
+
+        result = await sync_monarch(dry_run=False, month="2026-01")
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "monarch_not_configured"
+        captured = capsys.readouterr()
+        assert "SYNC_SKIPPED:" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_configured_does_not_skip(self, monkeypatch):
+        from scripts.sync_monarch_money import sync_monarch
+
+        monkeypatch.setattr("api.services.monarch.is_monarch_configured", lambda: True)
+
+        class FakeClient:
+            async def write_monthly_report(self, year, month, dry_run=False):
+                return {"status": "success", "file": "x.md", "size": 3}
+
+        monkeypatch.setattr("api.services.monarch.get_monarch_client", lambda: FakeClient())
+
+        result = await sync_monarch(dry_run=False, month="2026-01")
+        assert result["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_never_touches_configuration_check(self, monkeypatch):
+        """A plain (non-executing) dry run must behave exactly as before --
+        it never calls the Monarch client at all, configured or not."""
+        from scripts.sync_monarch_money import sync_monarch
+
+        def _boom():
+            raise AssertionError("is_monarch_configured must not be called on a dry run")
+
+        monkeypatch.setattr("api.services.monarch.is_monarch_configured", _boom)
+
+        result = await sync_monarch(dry_run=True, month="2026-01")
+        assert result["status"] == "dry_run"
+
+
+class TestMainRecordsSkipStatus:
+    """Exercises main() end-to-end -- the sync_health status it records is
+    the structured contract the orchestrator (and /health) actually reads,
+    not the log text (#646's lesson)."""
+
+    def _patch_sync_health(self, monkeypatch, recorded):
+        monkeypatch.setattr(
+            "api.services.sync_health.record_sync_start", lambda source: 1
+        )
+
+        def fake_complete(run_id, status=None, **kwargs):
+            recorded["status"] = status
+            recorded["kwargs"] = kwargs
+
+        monkeypatch.setattr(
+            "api.services.sync_health.record_sync_complete", fake_complete
+        )
+
+    def test_unconfigured_execute_records_skipped_and_succeeds(self, monkeypatch):
+        from api.services.sync_health import SyncStatus
+        from scripts.sync_monarch_money import main
+
+        monkeypatch.setattr("api.services.monarch.is_monarch_configured", lambda: False)
+        recorded = {}
+        self._patch_sync_health(monkeypatch, recorded)
+        monkeypatch.setattr(sys, "argv", ["sync_monarch_money.py", "--execute"])
+
+        main()  # must NOT sys.exit — a skip is not a failure
+
+        assert recorded["status"] == SyncStatus.SKIPPED
+
+    def test_configured_but_broken_still_records_failed(self, monkeypatch):
+        """A real outage (bad session, network, wrong password) on a
+        configured install must still exit nonzero and record FAILED --
+        the exact case a naive "no exception = skip" gate would have hidden."""
+        from api.services.sync_health import SyncStatus
+        from scripts.sync_monarch_money import main
+
+        monkeypatch.setattr("api.services.monarch.is_monarch_configured", lambda: True)
+
+        class BrokenClient:
+            async def write_monthly_report(self, year, month, dry_run=False):
+                raise RuntimeError("session invalid, re-auth required")
+
+        monkeypatch.setattr("api.services.monarch.get_monarch_client", lambda: BrokenClient())
+
+        recorded = {}
+        self._patch_sync_health(monkeypatch, recorded)
+        monkeypatch.setattr(sys, "argv", ["sync_monarch_money.py", "--execute"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        assert recorded["status"] == SyncStatus.FAILED


### PR DESCRIPTION
Closes #687. From the fresh-clone accessibility audit: three sources failed loud every night on installs that never configured them, while the repo's own clean-skip pattern (Apple/Photos, #495/#646) sat unapplied.

### Per-source "not configured" conditions

- **Monarch**: `is_monarch_configured()` mirrors `_get_client()`'s exact auth order — cached session OR both `MONARCH_EMAIL`/`MONARCH_PASSWORD`. Absent → `SYNC_SKIPPED` naming both requirements and the remedy. A stale session, wrong password, or network outage still reaches the real client and **fails loud** — absence and breakage are never conflated.
- **Personal Google**: gated on `config/credentials-personal.json` presence, mirroring work/work2's existing file-presence gating exactly; gated in both `run_all_syncs` pre-skip and `sync_health` (staleness flagging only — FAILED history stays visible).
- **gsheet-journal**: was *worse* than suspected — missing config silently produced an all-zero "success" dict. Now `status: skipped` via the structured path.
- **`LIFEOS_MONARCH_VAULT_DIR`**: env-overridable output dir, defaulting to exactly today's path.

### Behavior-neutrality (operator requirement)

Every gate is dead code on a configured system — verified per change: the maintainer's install has the session pickle, the personal credentials file, and the gsheet config, so no new branch executes there. The env override defaults to the identical path.

### Adversarial review (Codex hung mid-run; completed by coordinator with direct empirical probes)

Monarch truth-table probed empirically — every configured-but-broken state stays loud. One real finding, fixed: **malformed gsheet YAML** was swallowed by a pre-existing `except` and classified as not-configured. Now returns `status: "error", reason: "gsheet_config_parse_error: …"` — file-absent/empty keep the skip. Test added asserting error-not-skipped.

Two pre-existing tests had their arbitrary stand-in source (`gmail_personal`) swapped to `vault_reindex` since personal-Gmail is now correctly conditional — assertions unchanged.

### Gate

Full `test.sh`-scope: **4,880 passed**. 18 failures, all accounted: 13 known env/config-dependent (#682), the #689 order-dependent flake, and 4 newly-surfaced #689 victims (`test_directory_resolver`, `test_photos_sync_api`) — **reproduced on clean main**, recorded on #689. Zero regressions from this change. 243 targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)