### PR TITLE
docs: tell a macOS-hosted cloner what they're getting before they hit it

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,7 +1,7 @@
 # Installation Guide
 
 > **Status:** Complete
-> **Last Updated:** 2026-07-09
+> **Last Updated:** 2026-08-25
 > **Audience:** New users
 
 > **Quick start**: If you have Claude Code, run it in the project root and point it at
@@ -49,6 +49,45 @@ The minimal path is Steps 1–8 below. The full-setup integrations are covered i
 - **Linux** (primary) or **macOS** (required only for Apple Data Agent: iMessage, Contacts, Photos)
 - **Python 3.11+**
 - **Anthropic API key** — required for the default LLM backend (`LIFEOS_LLM_BACKEND=anthropic`), which handles orchestration and synthesis. Only optional if you run the fully-local path instead (`LIFEOS_LLM_BACKEND=local` + llama-server + a high-VRAM GPU — see [Local LLM (optional)](#local-llm-optional)).
+
+---
+
+## Running LifeOS on macOS as the Host
+
+The minimal setup (Steps 1–7 below) works identically on macOS and Linux —
+Anthropic API key, vault, ChromaDB, working `/chat`. Past that point, most of
+the packaged "keep itself healthy unattended" automation is Linux-only:
+**17 systemd units** ship for Linux (sync, three crash-restart watchdogs,
+autodeploy, agent worker, MCP-HTTP, local LLM) versus **3 launchd templates**
+for macOS (`com.lifeos.api`, `com.lifeos.crm-sync`, and an unused
+`com.lifeos.chromadb` — ChromaDB uses a cron watchdog instead, see Step 3).
+See [launchd-setup.md](launchd-setup.md) for why macOS-as-primary-server was
+superseded by the Linux migration and what's preserved from it.
+
+**Nightly sync does have a packaged macOS path.** `./scripts/setup-launchd.sh`
+(Phase 8 of [setup.md](setup.md)) installs `com.lifeos.crm-sync`, a launchd
+agent that runs `scripts/run_sync_wrapper.sh --execute --trigger=scheduled`
+at 3 AM — a wrapper that adds preflight checks, `LIFEOS_HEADLESS=true`, and a
+6-hour runtime watchdog around the bare sync script. It does not restart
+itself on failure (`KeepAlive: false` — a crashed run just waits for the
+next scheduled tick). If you'd rather skip launchd entirely, a plain cron
+entry calling `run_all_syncs.py` directly is simpler but **not equivalent**
+— it skips the wrapper's preflight checks, headless-mode env var, and
+watchdog, so a hang just runs until cron's own environment kills it (if
+ever):
+
+```bash
+# Add to crontab (crontab -e) -- runs the full nightly sync at 3:00 AM
+# Replace /path/to/LifeOS with wherever you cloned the repo.
+0 3 * * * cd /path/to/LifeOS && ~/.venvs/lifeos/bin/python scripts/run_all_syncs.py --execute --trigger scheduled >> logs/sync.log 2>&1
+```
+
+**What you're living without, either way:** if a sync run hangs or crashes,
+nothing restarts it until the next scheduled tick (no `lifeos-watchdog`
+equivalent); pushing to `main` doesn't auto-redeploy the running server (no
+`lifeos-autodeploy`); and the agent worker and MCP-HTTP bridge aren't
+packaged for launchd at all. None of that blocks chat, search, or manual
+sync runs — it's the unattended-operations layer, and it's Linux-only today.
 
 ---
 
@@ -203,6 +242,16 @@ llama-server; a few are pre-configured:
 | `Qwen/Qwen3-32B-GGUF` | ~20 GB (Q4_K_M) | Strong general-purpose option |
 | `ggml-org/gpt-oss-120b-GGUF` | ~59 GB (MXFP4) | Highest quality, but starves embeddings (sync stops the LLM automatically) |
 
+**On a 16 GB machine (e.g. a base Mac mini), the default local model has zero
+headroom** — 16 GB of VRAM/unified memory for a ~16 GB model leaves nothing
+for the OS, the embedding model, or the server process itself. Don't try to
+force the local path on a small machine. Anthropic-API-only
+(`LIFEOS_LLM_BACKEND=anthropic`, the default — see [Step 4](#step-4-configure-environment))
+is the intended mode for small machines and is fully functional: it's what
+the entire Minimal Setup tier above already runs on. Treat "Local LLM" as
+something you opt into on hardware that has the VRAM for it, not a
+requirement.
+
 ### Switching models
 
 ```bash
@@ -251,8 +300,62 @@ sudo systemd-run --scope -p MemoryMax=16G --user bash
 
 See [Troubleshooting](troubleshooting.md) for detailed solutions.
 
+## Setting up for a second user (config-only)
+
+A common deployment: someone other than the maintainer clones LifeOS onto
+their own machine (e.g. a family member's Mac mini), talks to it through an
+external Hermes front door instead of `/chat` directly, and never touches
+the repo's own source files. This checklist is that path.
+
+1. **Minimal tier, as above.** Vault path + Anthropic key + ChromaDB gets you
+   a working `/chat` (Steps 1–7). Every person-specific value lives in files
+   git doesn't track: `.env` (copied from `.env.example`) and, if you use
+   them, `config/*.json` / `config/*.yaml` files copied from their
+   `.example`/`.example.yaml` templates (e.g.
+   `config/people_dictionary.example.json`,
+   `config/family_members.example.json` — full list in
+   [Configuration § Configuration Files](configuration.md#configuration-files)). You should never need
+   to edit a tracked file in the repo itself to configure an instance.
+2. **Connect an external Hermes.** Add `LIFEOS_HERMES_BACKEND_URL` (and
+   `LIFEOS_HERMES_BACKEND_TOKEN` if Hermes requires one) directly to your
+   `.env` — both are deliberately absent from `.env.example` since they're
+   opt-in. Once set, `/chat` shows a **LifeOS | Agent | Hermes** backend
+   selector and defaults new sessions to Hermes automatically. **The
+   fallback to plain LifeOS only fires when the URL is unset** — `GET
+   /api/hermes/status` reports "available" purely from whether
+   `LIFEOS_HERMES_BACKEND_URL` is configured, not from actually reaching
+   Hermes, so a configured-but-down Hermes still gets selected and every
+   turn on it fails until you fix Hermes or unset the URL (which reverts
+   `/chat` to plain LifeOS). See
+   [client-surfaces.md](../specs/technical/client-surfaces.md) for the exact
+   contract and [voice-setup.md § Optional Agent and Hermes text
+   backends](voice-setup.md#optional-agent-and-hermes-text-backends) for the
+   full variable reference. **Standing up the Hermes adapter service itself
+   is Hermes-repo setup — out of scope here.** LifeOS only proxies to a URL
+   you already have running.
+3. **Skip the local LLM.** API-only mode (`LIFEOS_LLM_BACKEND=anthropic`,
+   the default) is the intended small-machine path — see the 16 GB caveat in
+   [Local LLM (optional)](#local-llm-optional) above. Leave
+   `LIFEOS_LLM_MODEL*` unset entirely.
+4. **Leave everything else unconfigured.** Google OAuth (beyond whatever
+   account you actually want indexed), Slack, Monarch Money, a dedicated
+   Telegram bot, the Apple Data Agent — any of these you don't set up simply
+   stay unset. The nightly sync already treats several sources this way
+   (Apple-only sources report `skipped` rather than failing on a Linux/no-Mac
+   host — see [data-and-sync.md](../specs/technical/data-and-sync.md)), and
+   Monarch Money and the personal Google account join that clean-skip
+   pattern once #687 lands: an unconfigured source reports
+   "skipped (not configured)," not a failure, and the rest of the sync
+   still succeeds.
+5. **macOS as the host.** If this second machine is a Mac, see
+   [Running LifeOS on macOS as the Host](#running-lifeos-on-macos-as-the-host)
+   above for what's packaged (nightly sync) versus what you'll want to
+   hand-roll (crash-restart watchdogs, autodeploy).
+
 ## Related Documents
 
 - [Configuration](configuration.md) -- Environment variables and config files
 - [First Run](first-run.md) -- Post-installation first use guide
+- [Launchd Setup](launchd-setup.md) -- macOS service automation: what's packaged (`com.lifeos.api`, `com.lifeos.crm-sync`), what's superseded, and why
+- [Client Surfaces](../specs/technical/client-surfaces.md) -- The Agent/Hermes backend contract and fallback behavior referenced above
 - [ADR-005: External Venv](../adr/005-external-venv-macos-tcc.md) -- Why the venv is outside the project

--- a/docs/guides/launchd-setup.md
+++ b/docs/guides/launchd-setup.md
@@ -1,7 +1,7 @@
 # Launchd Setup — Superseded
 
 **Status:** Superseded
-**Last Updated:** 2026-05-27
+**Last Updated:** 2026-08-25
 **Audience:** Operators
 
 > **This guide is superseded by [ADR-007: Linux Migration](../adr/007-linux-migration.md).**
@@ -9,6 +9,13 @@
 > LifeOS no longer ships a macOS-as-primary-server deployment. The Linux migration (ADR-007) moved the API server, ChromaDB, embedding pipeline, sync, agent worker, and LLM orchestration to a Linux workstation under **systemd** (`./scripts/setup-systemd.sh`).
 >
 > The original content of this guide (`com.lifeos.api`, `com.lifeos.crm-sync`, `com.lifeos.chromadb` launchd plists and the ChromaDB cron watchdog) is preserved in git history if you need it for a legacy Mac Mini deployment.
+
+**If you're setting up LifeOS to run *on* a Mac** (not just for Apple Data
+Agent export), see [Installation § Running LifeOS on macOS as the
+Host](installation.md#running-lifeos-on-macos-as-the-host) for what's
+packaged today (`com.lifeos.api`, `com.lifeos.crm-sync`) versus what's
+Linux-only (crash-restart watchdogs, autodeploy, agent worker, MCP-HTTP) and
+a cron/launchd snippet for nightly sync.
 
 ## If you have a Mac in the system today
 

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Operations
-> **Last Updated:** 2026-08-23
+> **Last Updated:** 2026-08-25
 > **Audience:** Operators
 
 Operational procedures that don't belong in the day-to-day coding reference: the Apple Data Agent, Monarch Money auth, and quick observability commands. Moved here from `AGENTS.md` to keep the agent-facing file lean.
@@ -21,9 +21,9 @@ If adding new cron jobs or scripts on macOS that need to access protected direct
 
 ### Self-update (issue #509)
 
-The Mac Mini runs `apple_data_agent.sh` from its own separate checkout, which nothing else ever pulls — a fix to the export pipeline on `main` would otherwise silently never reach it. Step 0 of the agent script self-updates that checkout before exporting, using the same guards as `auto-deploy.sh`: only on the `main` branch, only with a clean working tree, and only via `git pull --ff-only` (never force, never reset). If any guard trips or the pull fails, the agent logs a warning (and, on an actual pull failure, sends a Telegram alert) and **continues with the existing checkout** — a slightly stale export is better than a skipped one, as long as the staleness is visible.
+The Apple Data Agent Mac runs `apple_data_agent.sh` from its own separate checkout, which nothing else ever pulls — a fix to the export pipeline on `main` would otherwise silently never reach it. Step 0 of the agent script self-updates that checkout before exporting, using the same guards as `auto-deploy.sh`: only on the `main` branch, only with a clean working tree, and only via `git pull --ff-only` (never force, never reset). If any guard trips or the pull fails, the agent logs a warning (and, on an actual pull failure, sends a Telegram alert) and **continues with the existing checkout** — a slightly stale export is better than a skipped one, as long as the staleness is visible.
 
-The before/after SHA is logged in the agent's own log, and the export's `manifest.json` records the SHA it ran from as `agent_sha`. On the Linux side, `apple_data_import.py`'s `check_manifest()` compares `agent_sha` against the host's own `main` SHA and logs a warning on mismatch — so a stuck self-update is diagnosable from the import log without SSHing to the Mac Mini. Manifests written before this change simply lack `agent_sha`, which is treated as "nothing to compare" rather than a warning.
+The before/after SHA is logged in the agent's own log, and the export's `manifest.json` records the SHA it ran from as `agent_sha`. On the Linux side, `apple_data_import.py`'s `check_manifest()` compares `agent_sha` against the host's own `main` SHA and logs a warning on mismatch — so a stuck self-update is diagnosable from the import log without SSHing to the Apple Data Agent Mac. Manifests written before this change simply lack `agent_sha`, which is treated as "nothing to compare" rather than a warning.
 
 ## Monarch Money (Financial Data)
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -1,7 +1,7 @@
 # LifeOS New Instance Setup
 
 > **Status:** Complete
-> **Last Updated:** 2026-08-09
+> **Last Updated:** 2026-08-25
 > **Audience:** New users
 
 Read this top-to-bottom. Execute each step, verify the check, then proceed.
@@ -135,7 +135,7 @@ cp .env.example .env
 - **Monarch Money** — Financial data (account balances, transactions, budgets)
 - **Telegram bot** — Chat interface and push notifications
 - **Slack** — Workspace message sync
-- **WhatsApp** — Chat history sync via `wacli` on a paired Mac Mini (the LifeOS
+- **WhatsApp** — Chat history sync via `wacli` on a paired Apple Data Agent Mac (the LifeOS
   host runs on Linux; wacli is macOS-only). Data is exported into
   `data/apple-imports/whatsapp.json` and rsynced alongside contacts/iMessage.
 - **MCP for Claude Code** — Use LifeOS as a tool from Claude Code/Desktop
@@ -331,7 +331,7 @@ systemctl status lifeos-api lifeos-chromadb
 > **Note:** launchd is macOS-only and superseded by systemd on Linux — see
 > [ADR-007: Linux Migration](../adr/007-linux-migration.md). Use this only on a macOS host.
 
-`setup-launchd.sh` is interactive and takes no arguments — it prompts for the vault path:
+`setup-launchd.sh` accepts an optional `[vault_path] [--yes]` and is interactive when you omit them — it prompts for the vault path:
 
 ```bash
 ./scripts/setup-launchd.sh
@@ -435,11 +435,12 @@ For a **second work account**, repeat with `--account work2`:
 
 ### WhatsApp
 
-WhatsApp sync runs on the Mac Mini side of the Apple Data Agent pipeline —
-the Linux LifeOS host does not touch wacli directly. These steps must be run
-on the Mac Mini that rsyncs `data/apple-imports/` to the Linux server.
+WhatsApp sync runs on the Apple Data Agent side of the pipeline — the Linux
+LifeOS host does not touch wacli directly. These steps must be run on
+whichever Mac plays the Apple Data Agent role (any spare Mac with FDA
+granted works), which rsyncs `data/apple-imports/` to the Linux server.
 
-On the Mac Mini:
+On the Apple Data Agent Mac:
 
 1. Install: `brew install openclaw/tap/wacli` (formerly `steipete/tap/wacli` —
    the tap was renamed; a stale local tap silently disables `brew outdated`,

--- a/docs/guides/voice-setup.md
+++ b/docs/guides/voice-setup.md
@@ -1,7 +1,7 @@
 # Voice Setup
 
 **Status:** Complete
-**Last Updated:** 2026-08-19
+**Last Updated:** 2026-08-25
 **Audience:** Operators
 
 This guide sets up **voice mode** in LifeOS. Voice is a tap-to-talk input mode *inside* the web `/chat` client — not a separate app or page. It reaches the same orchestrator, the same personas, and the same conversations as text chat. The speech pipeline (STT and TTS) is provided by a **separate** service, **whisper-relay**; LifeOS only reverse-proxies it and adds the browser UI.
@@ -127,6 +127,7 @@ On the **Hermes** backend an orchestrating persona's spoken turn never spawns an
 ### Operational
 - [Configuration](configuration.md) — Environment variable reference
 - [Personas](personas.md) — The persona layer shared by web chat and voice, including per-persona `voice` formatting rules
+- [Installation](installation.md) — Config-only second-user setup checklist that references the Agent/Hermes backend variables documented here
 
 ### Project Context
 - [README](../../README.md) — Architecture overview, including the whisper-relay voice gateway in the service topology

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-08-21
+> **Last Updated:** 2026-08-25
 
 LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that submit text and consume SSE without importing LifeOS Python modules. Endpoint and event **shapes** are defined in [api-reference.md](../product/api-reference.md); this doc covers **who consumes them**, **whisper-relay integration**, and **breaking-change policy**.
 
@@ -412,6 +412,7 @@ Since #592, `restoreBackendConversation()` renders the stored conversation on a 
 
 ### Operational
 - [Voice Setup](../../guides/voice-setup.md) — Operator-facing voice mode setup, including the Hermes/Agent backend contract this doc specifies
+- [Installation](../../guides/installation.md) — Config-only second-user setup checklist that references this doc's Hermes default/fallback contract
 
 ### Code References
 - [Chat route](../../api/routes/chat.py) — SSE emission and handoff handler

--- a/docs/specs/technical/data-and-sync.md
+++ b/docs/specs/technical/data-and-sync.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Data Pipeline
-> **Last Updated:** 2026-08-13
+> **Last Updated:** 2026-08-25
 
 How LifeOS ingests and stores data from multiple sources.
 
@@ -28,11 +28,11 @@ How LifeOS ingests and stores data from multiple sources.
 |--------|-------------|----------------|
 | Gmail | Google API | From/To/CC, subjects, timestamps, threads |
 | Calendar | Google API | Attendees, organizer, titles, times |
-| Apple Contacts | Apple Data Agent (Mac Mini export via rsync) | Names, emails, phone numbers, companies |
-| Apple Photos | Apple Data Agent (Mac Mini export via rsync) | Face recognition, co-appearances, timestamps |
-| Phone Calls | Apple Data Agent (Mac Mini export via rsync) | Numbers, names, duration, direction |
+| Apple Contacts | Apple Data Agent (export via rsync) | Names, emails, phone numbers, companies |
+| Apple Photos | Apple Data Agent (export via rsync) | Face recognition, co-appearances, timestamps |
+| Phone Calls | Apple Data Agent (export via rsync) | Numbers, names, duration, direction |
 | WhatsApp | wacli CLI | JIDs, names, phone numbers |
-| iMessage | Apple Data Agent (Mac Mini export via rsync) | Phone/email, message content, timestamps |
+| iMessage | Apple Data Agent (export via rsync) | Phone/email, message content, timestamps |
 | Slack | Slack API (OAuth) | User profiles, DMs, channels |
 | Vault Notes | Obsidian markdown | Name mentions, context paths |
 | LinkedIn | CSV Import | Connections, companies, titles |
@@ -62,9 +62,9 @@ How LifeOS ingests and stores data from multiple sources.
 All data syncing is consolidated into a single daily sync with proper phase ordering (`SYNC_ORDER` in `scripts/run_all_syncs.py`). This ensures downstream processes always have access to fresh upstream data.
 
 ```
-02:50          Apple Data Agent export (Mac Mini → Linux server via rsync)
+02:50          Apple Data Agent export (any spare Mac -> Linux server via rsync)
                └─ Exports contacts, phone calls, iMessage, photos, WhatsApp
-               └─ scripts/apple_data_agent.sh → scripts/apple_data_export.py (Mac Mini)
+               └─ scripts/apple_data_agent.sh → scripts/apple_data_export.py (Apple Data Agent Mac)
                └─ scripts/apple_data_import.py (Linux server)
 02:30          Pre-sync health check (API server)
 03:00          Unified sync starts (via run_all_syncs.py)
@@ -76,7 +76,7 @@ All data syncing is consolidated into a single daily sync with proper phase orde
                └─ LinkedIn (connections CSV export)
                └─ Contacts (Apple Contacts; macOS-only — reports `skipped` on Linux)
                └─ Apple import (contacts, phone, iMessage, photos, WhatsApp from
-                 the Mac Mini export; Linux only)
+                 the Apple Data Agent export; Linux only)
                └─ Slack (users + DM and member-channel messages)
 
                === PHASE 2: Entity Processing ===
@@ -150,7 +150,7 @@ The 7-phase structure ensures correct data flow:
 6. **Post-Sync Cleanup** auto-hides obvious non-human entities after all other syncs
 7. **Consistency Verification** checks cross-store consistency after everything else has run
 
-**Note:** Apple data (contacts, phone calls, iMessage, photos, WhatsApp) is exported from the Mac Mini via the Apple Data Agent (`scripts/apple_data_agent.sh`) at 2:50 AM, before the main pipeline, and imported on Linux by the `apple_import` source. The export runs on the Mac Mini (which has FDA access) and syncs to the Linux server via rsync. Three sources are macOS-only and report `skipped` (not a failure) when the nightly sync runs on the Linux host: `contacts`, `photos`, `push_birthdays`.
+**Note:** Apple data (contacts, phone calls, iMessage, photos, WhatsApp) is exported from an Apple Data Agent (any spare Mac with FDA granted) via `scripts/apple_data_agent.sh` at 2:50 AM, before the main pipeline, and imported on Linux by the `apple_import` source. The export runs on that Mac (which has FDA access) and syncs to the Linux server via rsync. Three sources are macOS-only and report `skipped` (not a failure) when the nightly sync runs on the Linux host: `contacts`, `photos`, `push_birthdays`.
 
 ### Process Summary
 
@@ -223,7 +223,7 @@ All sync scripts in `scripts/` follow the pattern:
 | `sync_gmail_calendar_interactions.py` | Sync emails (sent+received+CC) and calendar | Gmail/Calendar API |
 | `sync_linkedin.py` | Sync LinkedIn connections | CSV export |
 | `sync_apple_contacts.py` | Sync Apple Contacts (macOS-only — `skipped` on Linux) | Apple Data Agent export |
-| `apple_data_import.py` | Import Apple ecosystem data (contacts, phone, iMessage, photos, WhatsApp) from the Mac Mini export | Apple Data Agent export (Linux only) |
+| `apple_data_import.py` | Import Apple ecosystem data (contacts, phone, iMessage, photos, WhatsApp) from the Apple Data Agent export | Apple Data Agent export (Linux only) |
 | `sync_phone_calls.py` | Sync phone calls (not in nightly `SYNC_ORDER` — runs via the separate FDA cron on macOS) | Apple Data Agent export |
 | `sync_slack.py` | Sync Slack users, DMs, and member channels | Slack API |
 
@@ -249,11 +249,11 @@ file; the next run re-fetches and re-evaluates the whole window.
 
 | Script | Purpose | Runs On |
 |--------|---------|---------|
-| `apple_data_export.py` | Export Apple data (contacts, phone, iMessage, photos, WhatsApp) | Mac Mini |
+| `apple_data_export.py` | Export Apple data (contacts, phone, iMessage, photos, WhatsApp) | Apple Data Agent Mac |
 | `apple_data_import.py` | Import Apple data exports into LifeOS | Linux server |
-| `apple_data_agent.sh` | Orchestrate export + rsync + import | Mac Mini (cron) |
+| `apple_data_agent.sh` | Orchestrate export + rsync + import | Apple Data Agent Mac (cron) |
 
-WhatsApp data flows through the same Mac Mini → Linux pipeline. The Mac runs `wacli` (openclaw/tap/wacli) which reads the WhatsApp Desktop app's local SQLite database; `apple_data_export.export_whatsapp` dumps contacts, messages, group memberships and the LID-to-phone map to `whatsapp.json`; `apple_data_import.import_whatsapp` calls into `api/services/whatsapp.py` to create SourceEntity and Interaction records. A non-zero `wacli sync` exit (including a "Client outdated (405)" protocol rejection, distinct from an auth failure) marks the export `status: "error"` rather than silently exporting stale data as `ok` — see issue #677.
+WhatsApp data flows through the same Apple Data Agent → Linux pipeline. The Mac runs `wacli` (openclaw/tap/wacli) which reads the WhatsApp Desktop app's local SQLite database; `apple_data_export.export_whatsapp` dumps contacts, messages, group memberships and the LID-to-phone map to `whatsapp.json`; `apple_data_import.import_whatsapp` calls into `api/services/whatsapp.py` to create SourceEntity and Interaction records. A non-zero `wacli sync` exit (including a "Client outdated (405)" protocol rejection, distinct from an auth failure) marks the export `status: "error"` rather than silently exporting stale data as `ok` — see issue #677.
 
 ### Phase 2: Entity Processing
 
@@ -349,13 +349,13 @@ All scheduled times use **America/New_York** (Eastern Time).
 
 ### WhatsApp Sync
 
-**Data Source:** `~/.wacli/wacli.db` on the Mac Mini (wacli CLI tool database).
+**Data Source:** `~/.wacli/wacli.db` on the Apple Data Agent Mac (wacli CLI tool database).
 LifeOS runs on Linux; wacli is macOS-only, so WhatsApp data rides through the
 Apple Data Agent pipeline alongside contacts, iMessage, phone calls, and
 photos.
 
 **Sync Process:**
-1. Mac Mini cron runs `scripts/apple_data_export.py --execute`, which invokes
+1. Apple Data Agent Mac cron runs `scripts/apple_data_export.py --execute`, which invokes
    `wacli sync --once` to refresh the local database, then dumps messages,
    group participants, LID contacts, and the whatsmeow LID→phone map to
    `data/apple-imports/whatsapp.json`. If `wacli` is missing or fails the
@@ -453,10 +453,10 @@ The unified sync runner (`run_all_syncs.py`) executes `SYNC_ORDER` in this order
 2. `calendar_personal` / `calendar_work` / `calendar_work2` - Calendar sync
 3. `linkedin` - LinkedIn connections
 4. `contacts` - Apple Contacts (macOS-only — `skipped` on Linux)
-5. `apple_import` - Import Apple ecosystem data + WhatsApp from the Mac Mini export (Linux only)
+5. `apple_import` - Import Apple ecosystem data + WhatsApp from the Apple Data Agent export (Linux only)
 6. `slack` - Slack users, DMs, and member channels
 
-**Note:** `phone` is defined as a source but is not in nightly `SYNC_ORDER` — it runs via the separate FDA cron on macOS (`scripts/run_sync_with_fda.sh`). Apple data (contacts, phone, iMessage, photos, WhatsApp) is exported from the Mac Mini via the Apple Data Agent at 2:50 AM (before the main pipeline) and imported on the Linux server by `apple_import`.
+**Note:** `phone` is defined as a source but is not in nightly `SYNC_ORDER` — it runs via the separate FDA cron on macOS (`scripts/run_sync_with_fda.sh`). Apple data (contacts, phone, iMessage, photos, WhatsApp) is exported from an Apple Data Agent (any spare Mac) at 2:50 AM (before the main pipeline) and imported on the Linux server by `apple_import`.
 
 **Phase 2: Entity Processing**
 7. `link_slack` - Link Slack entities by email
@@ -621,6 +621,7 @@ The scraping system uses Claude in Chrome MCP for browser automation. It require
 - [Data Model](../product/data-model.md) -- Two-tier data model (SourceEntity / PersonEntity)
 - [Entity Resolution](../product/entity-resolution.md) -- How source entities are linked to canonical records
 - [Search & Indexing](search-indexing.md) -- Hybrid search pipeline
+- [Installation](../../guides/installation.md) -- Config-only second-user setup checklist, which points here for the unconfigured-source clean-skip pattern
 - [ADR-002: ChromaDB](../../adr/002-chromadb-vector-store.md) -- Why ChromaDB was chosen
 - [ADR-003: Two-Tier Data Model](../../adr/003-two-tier-data-model.md) -- Why SourceEntity and PersonEntity are separate
 - [ADR-012: Embedding Pipeline](../../adr/012-embedding-pipeline.md) -- Embedding model, GPU/CPU fallback, pre-flight RAM gate around phase 4

--- a/docs/specs/technical/security-privacy.md
+++ b/docs/specs/technical/security-privacy.md
@@ -2,7 +2,7 @@
 
 > **Status:** Draft
 > **Owner:** Core
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-08-25
 
 ## Overview
 
@@ -10,7 +10,7 @@ LifeOS is single-user, self-hosted on Linux (or macOS). The threat model is fund
 
 ## Guiding Principles
 
-- **All data stays local.** No cloud storage, no telemetry, no analytics. Data leaves the machine only when using `LIFEOS_LLM_BACKEND=anthropic`; the local backend (default) keeps all data on-machine.
+- **All data stays local by choice, not by default.** `LIFEOS_LLM_BACKEND` defaults to `anthropic`, which sends query text and tool results to the Claude API (see "What Leaves the Machine" below). Setting it to `local` keeps everything on-machine, but that's an opt-in, not the out-of-the-box behavior.
 - **The LLM receives only query payloads.** The LLM call sends the user's question and relevant search results, never bulk data exports or full database dumps.
 - **External service credentials are stored locally.** OAuth tokens, API keys, and session cookies never leave the machine.
 - **Logs never contain personal data content.** Log entity IDs and counts, not message bodies, email content, or contact details.
@@ -90,7 +90,7 @@ logger.info(f"Search result: {result.content[:200]}")
 ## OS Security Integration
 
 - **Linux**: systemd service isolation. The API server and sync jobs run as user-level systemd services. No special permission wrappers needed.
-- **macOS (Apple Data Agent only)**: FDA/TCC permissions are managed on the Mac Mini for Apple data export. See [ADR-005](../../adr/005-external-venv-macos-tcc.md) for TCC background.
+- **macOS (Apple Data Agent only)**: FDA/TCC permissions are managed on the Apple Data Agent Mac for Apple data export. See [ADR-005](../../adr/005-external-venv-macos-tcc.md) for TCC background.
 - **Full-disk encryption**: LUKS (Linux) or FileVault (macOS) assumed to be enabled. LifeOS does not implement its own encryption at rest.
 
 ## Related Documents


### PR DESCRIPTION
Closes #686. Docs-only, per operator decision — no code, no behavior change for any configured system.

From the fresh-clone accessibility audit, for the realistic newcomer: someone hosting LifeOS on a Mac mini, API-only, possibly with an external Hermes as their primary interface.

- **macOS-host callout** in `installation.md` (cross-linked from `launchd-setup.md`): what you get (API + chat, plus the packaged `com.lifeos.crm-sync` nightly agent — which the audit itself had missed), what you don't (watchdogs, autodeploy), and an honest account of what the hand-rolled cron alternative omits vs the wrapper (preflight, `LIFEOS_HEADLESS`, 6-hour watchdog). Cron snippet flags verified against `run_all_syncs.py`'s argparse; `/path/to/LifeOS` placeholder.
- **16 GB caveat**: the default local model (~16 GB) leaves zero headroom on a base Mac mini; Anthropic-API-only is the intended small-machine mode and fully functional.
- **"Setting up for a second user (config-only)" checklist**: the untracked-`.env`/`config/*.example` pattern (the repo itself is never edited), connecting an external Hermes via `LIFEOS_HERMES_BACKEND_URL`/`TOKEN`, and — per adversarial review — the honest fallback statement: availability means *configured*, not *reachable*; a configured-but-down Hermes fails per-turn until fixed or unset (#688 filed for the behavior).
- **"the Mac Mini" sweep**: 12 role-description references softened to "an Apple Data Agent (any spare Mac)" across 4 guides/specs plus the review's 10 additional hits; the 8 ADR references deliberately left (immutable historical record).

### Adversarial review (Codex): MERGE-AFTER-FIXES, all 8 addressed

Two blocking accuracy bugs caught and fixed: the Hermes-fallback claim above, and `security-privacy.md` claiming the *local* backend is the default (it's `anthropic` — the doc now says "local by choice, not by default"). Every remaining claim (launchd agent, env vars, flags, model size, unit counts) verified against actual code.

All touched docs within `docs/AGENTS.md` line-count limits, bidirectional Related Documents links added, Last Updated stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)