### PR TITLE
feat(agent-worker): let the local route fall back to the #654 remote provider

### DIFF
--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -150,6 +150,13 @@ class ExecutorOutcome:
     # remote session. Worker uses this to append a footer to the completion
     # summary so the operator knows which connectors are broken.
     init_failed_mcps: list[str] = field(default_factory=list)
+    # #699 — non-empty only when this session actually ran on the flag-gated
+    # remote fallback provider (the model id it ran on). Empty for the
+    # ordinary local llama-server path, including every install with the
+    # flag off or the remote provider unconfigured. worker.py uses this to
+    # report what actually served the session (the #658 principle: report
+    # observed, not configured) instead of just the static "local" label.
+    served_by: str = ""
 
 
 # Static portion of the system prompt — never changes between sessions. Kept
@@ -312,6 +319,57 @@ def _user_message_for(task: dict) -> str:
     return "\n\n".join(parts)
 
 
+def _default_llm_client(model_name: str) -> tuple[object, str, bool]:
+    """Choose the LLM client + model attribution for a production
+    (no explicit `llm_client` injected) local executor. Returns
+    `(client, model_name, is_remote)`.
+
+    Default: bare `LocalLLMClient()` against the local llama-server,
+    `model_name` unchanged (the caller's default, "local"), `is_remote`
+    False — byte-identical to the executor's pre-#699 construction
+    whenever the flag is off or the remote provider (#654) isn't fully
+    configured. That's the operator's standing behavior-neutrality
+    requirement, so both conditions are checked before this function does
+    anything else network-shaped.
+
+    When `settings.agent_remote_executor` is on AND the remote OpenAI-
+    compatible provider is configured, this does exactly one cheap
+    reachability check against the local llama-server —
+    `LocalLLMClient.is_available()`, a single short-timeout GET /health —
+    at session-construction time. Deliberately not a background prober:
+    llama-server either answers right now or it doesn't, and checking
+    once, right when we're about to use it, is cheap and honest. This is
+    also the #688 lesson applied in reverse — that issue was "configured"
+    silently standing in for "reachable"; the mirror-image mistake here
+    would be treating "remote is configured" as license to skip actually
+    checking whether local is still up, so the check happens regardless
+    of how confident the config looks.
+
+    - Local reachable   → local wins. Explicit `#agent local` routing on a
+      host with a live llama-server is unaffected — remote is a fallback,
+      not a replacement.
+    - Local unreachable → build a `LocalLLMClient` pointed at the remote
+      provider instead (with `is_remote=True` and the remote model id for
+      attribution), so the session actually runs instead of dying with a
+      connection error on every call.
+    """
+    from api.services.llm_client import LocalLLMClient
+    from config.settings import settings as _settings
+
+    if _settings.agent_remote_executor and _settings.remote_llm_configured:
+        local_client = LocalLLMClient()
+        if not local_client.is_available():
+            remote_client = LocalLLMClient(
+                base_url=_settings.remote_llm_base_url,
+                model=_settings.remote_llm_model,
+                api_key=_settings.remote_llm_api_key,
+                timeout=_settings.remote_llm_timeout,
+            )
+            return remote_client, _settings.remote_llm_model, True
+        return local_client, model_name, False
+    return LocalLLMClient(), model_name, False
+
+
 class LocalExecutor:
     """Drives one turn or one yielded resumption per call to `execute`."""
 
@@ -322,6 +380,7 @@ class LocalExecutor:
         tool_registry: ToolRegistry | None = None,
         llm_client=None,
         model_name: str = "local",
+        is_remote: bool = False,
     ):
         self.session_store = session_store
         self.transcript_store = transcript_store
@@ -330,10 +389,16 @@ class LocalExecutor:
             tool_registry = ToolRegistry()
         self.tools = tool_registry
         if llm_client is None:
-            from api.services.llm_client import LocalLLMClient
-            llm_client = LocalLLMClient()
+            llm_client, model_name, is_remote = _default_llm_client(model_name)
         self.llm = llm_client
         self.model_name = model_name
+        # (#699) True iff this executor is running on the flag-gated remote
+        # fallback provider rather than the local llama-server. Drives both
+        # spend pricing (_record_spend) and the served_by attribution on
+        # ExecutorOutcome. Only ever True via `_default_llm_client`'s own
+        # selection, or a test that injects it explicitly alongside a fake
+        # `llm_client` — never a side effect of settings alone.
+        self.is_remote = is_remote
 
     # ------------------------------------------------------------------
     # Entry points
@@ -497,7 +562,7 @@ class LocalExecutor:
                 refreshed = self.session_store.get(session.task_id)
                 kind = "yielded_for_children" if refreshed.yield_waiting_for else "yielded_for_user"
                 self.transcript_store.append(sid, kind, {})
-                return ExecutorOutcome(status=STATUS_YIELDED)
+                return ExecutorOutcome(status=STATUS_YIELDED, served_by=self._served_by())
 
             if yielded_seconds is not None:
                 return self._finalize_sleeping(session, yielded_seconds)
@@ -590,13 +655,35 @@ class LocalExecutor:
         rate (that's the right call for a *budget* estimate, wrong here) --
         it's recorded as $0 and the session is flagged `unpriced` instead
         (#669).
+
+        (#699) The remote fallback provider's model id (e.g. a Fireworks
+        path) is never in pricing.PRICING -- that table is Anthropic-only
+        plus the free "local" sentinel. Its rate, when known, comes from
+        `settings.remote_llm_{input,output}_price_per_mtok` instead (set
+        by #654), mirroring the `force_remote` branch in
+        `agent_loop.py`'s `_track_usage` exactly. Unset rates still record
+        as real, unpriced spend -- never fallback-priced, same #669
+        convention as the unknown-model branch below.
         """
         usage = getattr(response, "usage", None)
         if not usage:
             return
         tokens_in = getattr(usage, "input_tokens", 0)
         tokens_out = getattr(usage, "output_tokens", 0)
-        if is_known_model(self.model_name):
+        if self.is_remote:
+            from config.settings import settings as _settings
+            input_price = _settings.remote_llm_input_price_per_mtok
+            output_price = _settings.remote_llm_output_price_per_mtok
+            if input_price is None or output_price is None:
+                dollars = 0.0
+                unpriced = True
+            else:
+                dollars = (
+                    (tokens_in / 1_000_000) * input_price
+                    + (tokens_out / 1_000_000) * output_price
+                )
+                unpriced = False
+        elif is_known_model(self.model_name):
             dollars = cost_for(self.model_name, tokens_in, tokens_out)
             unpriced = False
         else:
@@ -630,6 +717,15 @@ class LocalExecutor:
                 {"root": root_session_id, "reason": reason},
             )
 
+    def _served_by(self) -> str:
+        """(#699) Model id that actually ran this session, when that
+        differs from what the routing name ("local") implies -- i.e. this
+        executor is on the flag-gated remote fallback. Empty for the
+        ordinary local llama-server path, so a caller (worker.py) only
+        needs to add anything to its messaging when there's something
+        worth reporting (#658: report observed, not configured)."""
+        return self.model_name if self.is_remote else ""
+
     def _finalize_completed(self, session, final_text: str) -> ExecutorOutcome:
         self.session_store.update_status(session.task_id, STATUS_COMPLETED)
         # Persist the body, not just the length. The final text is also sent
@@ -639,19 +735,24 @@ class LocalExecutor:
             session.session_id, "completed",
             {"final_chars": len(final_text or ""), "final_text": final_text or ""},
         )
-        return ExecutorOutcome(status=STATUS_COMPLETED, final_text=final_text or "")
+        return ExecutorOutcome(
+            status=STATUS_COMPLETED, final_text=final_text or "", served_by=self._served_by(),
+        )
 
     def _finalize_failed(self, session, reason: str) -> ExecutorOutcome:
         self.session_store.update_status(session.task_id, STATUS_FAILED)
         self.transcript_store.append(session.session_id, "failed", {"reason": reason})
-        return ExecutorOutcome(status=STATUS_FAILED, reason=reason)
+        return ExecutorOutcome(status=STATUS_FAILED, reason=reason, served_by=self._served_by())
 
     def _finalize_budget_exceeded(self, session, kind: str) -> ExecutorOutcome:
         self.session_store.update_status(session.task_id, STATUS_BUDGET_EXCEEDED)
         self.transcript_store.append(
             session.session_id, "budget_exceeded", {"kind": kind}
         )
-        return ExecutorOutcome(status=STATUS_BUDGET_EXCEEDED, reason=f"budget exceeded ({kind})")
+        return ExecutorOutcome(
+            status=STATUS_BUDGET_EXCEEDED, reason=f"budget exceeded ({kind})",
+            served_by=self._served_by(),
+        )
 
     def _finalize_sleeping(self, session, seconds: int) -> ExecutorOutcome:
         wake_at = int(time.time()) + int(seconds)
@@ -660,4 +761,4 @@ class LocalExecutor:
         self.transcript_store.append(
             session.session_id, "sleep", {"seconds": int(seconds), "wake_at": wake_at}
         )
-        return ExecutorOutcome(status=STATUS_YIELDED, wake_at=wake_at)
+        return ExecutorOutcome(status=STATUS_YIELDED, wake_at=wake_at, served_by=self._served_by())

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -252,13 +252,23 @@ def _split_frontmatter(text: str) -> tuple[str, str]:
     return text[: m.end()], text[m.end():]
 
 
-def _worker_label(routing: str | None) -> str:
+def _worker_label(routing: str | None, served_by: str = "") -> str:
     """Telegram-message prefix that names the route — operator wants to
     know at a glance whether a result came from local Gemma or cloud
     Claude. Defaults to the generic "Agent worker" when the routing
-    isn't known yet (e.g., startup recovery messages)."""
+    isn't known yet (e.g., startup recovery messages).
+
+    (#699) `served_by` is the model id that actually ran the session when
+    it differs from what the routing name implies — currently only the
+    flag-gated remote fallback on the "local" route. Empty (the default,
+    and every session not on that fallback) leaves the label unchanged —
+    report observed, not configured (#658), only when there's something
+    to report."""
     if routing == ROUTE_LOCAL:
-        return "Local agent worker"
+        label = "Local agent worker"
+        if served_by:
+            label += f" (remote fallback: {served_by})"
+        return label
     if routing == ROUTE_CLAUDE:
         return "Cloud agent worker"
     return "Agent worker"
@@ -2330,7 +2340,8 @@ class Worker:
                 )
                 self._notify_terminal(
                     session,
-                    f"⚠️ {_worker_label(session.routing)}: task '{title}' returned "
+                    f"⚠️ {_worker_label(session.routing, served_by=getattr(outcome, 'served_by', ''))}: "
+                    f"task '{title}' returned "
                     f"empty result with no side-effect tool use — marking failed. "
                     f"What the agent did:\n\n{recovered}\n\n"
                     f"Transcript: `data/agent_transcripts/{sid}.jsonl`",
@@ -2429,7 +2440,7 @@ class Worker:
         active_s = int(refreshed.total_active_seconds or 0)
         expected = refreshed.expected_output or "text"
         title = task.get("description", session.task_id)
-        label = _worker_label(refreshed.routing or session.routing)
+        label = _worker_label(refreshed.routing or session.routing, served_by=getattr(outcome, "served_by", ""))
         # Four-bucket token breakdown so the operator can see what drove cost.
         # For local sessions cache buckets are always zero and collapse out of
         # the rendered string.

--- a/config/settings.py
+++ b/config/settings.py
@@ -475,6 +475,32 @@ class Settings(BaseSettings):
         unpriced (see remote_llm_input_price_per_mtok)."""
         return bool(self.remote_llm_base_url and self.remote_llm_model and self.remote_llm_api_key)
 
+    # #699 — lets the agent worker's `local` route fall back to the remote
+    # OpenAI-compatible provider above when the local llama-server isn't
+    # reachable. Exists for a real deployment with NO other #agent executor
+    # (no Claude Code, no Codex, no local llama-server, no Anthropic key) —
+    # without this, #agent tasks there have nowhere to run. Default False +
+    # empty remote config (default) is byte-identical to pre-#699 behavior
+    # everywhere, including the maintainer's own install, which has every
+    # other executor and no remote config. This is a fallback, not a new
+    # route: an explicit `#agent local` on a host with a live llama-server
+    # is unaffected — see agent_worker/local_executor.py's selection logic.
+    # It is also never a rung an escalation ladder can climb to on its own:
+    # NON_API_RUNGS in agent_loop.py only ever names "local" (the on-box
+    # llama-server route via `_select_client(force_local=True)`), which
+    # doesn't consult this flag at all — that selection logic lives solely
+    # in agent_worker/local_executor.py, a different code path from the
+    # chat orchestrator's escalation ladder.
+    agent_remote_executor: bool = Field(
+        default=False, alias="LIFEOS_AGENT_REMOTE_EXECUTOR",
+        description="Opt-in: when the remote provider above is configured "
+                    "(remote_llm_configured) and the local llama-server is "
+                    "unreachable at session start, the agent worker's local "
+                    "route runs the session on the remote provider instead "
+                    "of failing. Off by default; also a no-op unless the "
+                    "remote provider is fully configured."
+    )
+
     # MCP HTTP transport (used by remote agent platforms; local Claude Code keeps stdio)
     mcp_http_port: int = Field(
         default=8765,

--- a/tests/test_agent_escalation.py
+++ b/tests/test_agent_escalation.py
@@ -467,6 +467,36 @@ def test_remote_not_in_non_api_rungs():
     assert "remote" not in NON_API_RUNGS
 
 
+def test_local_escalation_rung_ignores_the_699_remote_executor_flag(monkeypatch):
+    """(#699) The agent worker's flag-gated remote fallback lives entirely
+    in agent_worker/local_executor.py — a different code path from the chat
+    orchestrator's escalation ladder in this module. Proves it structurally:
+    even with LIFEOS_AGENT_REMOTE_EXECUTOR on, the remote provider fully
+    configured, AND the local llama-server simulated unreachable, the
+    ladder's "local" rung (chat.py sets force_local=True for it) still
+    builds a plain local-llama-server client — automatic escalation has no
+    path to the remote executor, on top of NON_API_RUNGS already keeping
+    "remote" off the ladder entirely (test_remote_not_in_non_api_rungs)."""
+    from config.settings import settings
+    from api.services.llm_client import LocalLLMClient
+
+    monkeypatch.setattr(settings, "agent_remote_executor", True, raising=False)
+    monkeypatch.setattr(settings, "remote_llm_base_url", "https://remote.example/v1", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_model", "remote-model", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_api_key", "key", raising=False)
+    monkeypatch.setattr(settings, "llm_backend", "anthropic", raising=False)
+    # Even if the local server were down, _select_client's force_local branch
+    # never calls is_available() at all — but simulate it anyway so the test
+    # fails loudly if a future change makes that branch consult reachability.
+    monkeypatch.setattr(LocalLLMClient, "is_available", lambda self: False)
+
+    client = _select_client("local", force_local=True)
+
+    assert isinstance(client, LocalLLMClient)
+    assert client.base_url == LocalLLMClient().base_url
+    assert client.base_url != "https://remote.example/v1"
+
+
 # ---------------------------------------------------------------------------
 # engine handoff directives (#305 part b)
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -14,6 +14,7 @@ import pytest
 from api.services.agent_worker.local_executor import (
     _SYSTEM_PROMPT_STATIC,
     LocalExecutor,
+    _default_llm_client,
     _system_prompt,
 )
 from api.services.agent_worker.pricing import cost_for, is_known_model
@@ -417,6 +418,202 @@ def test_executor_records_unknown_model_as_unpriced_not_fallback_rate(tmp_path: 
     assert refreshed.total_output_tokens == 500
     assert refreshed.total_dollars == pytest.approx(0.0)
     assert refreshed.unpriced is True
+
+
+# ---------------------------------------------------------------------------
+# #699 — remote fallback executor construction, spend, and served_by
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_default_llm_client_flag_off_stays_local_without_probing(monkeypatch):
+    """Pins behavior-neutrality: flag off is byte-identical to pre-#699,
+    including making zero network calls to check anything — the remote
+    branch is never even entered."""
+    from config.settings import settings
+    from api.services.llm_client import LocalLLMClient
+
+    monkeypatch.setattr(settings, "agent_remote_executor", False, raising=False)
+    monkeypatch.setattr(settings, "remote_llm_base_url", "https://remote.example", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_model", "remote-model", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_api_key", "key", raising=False)
+
+    probed = []
+    monkeypatch.setattr(LocalLLMClient, "is_available", lambda self: probed.append(1) or True)
+
+    client, model_name, is_remote = _default_llm_client("local")
+
+    assert is_remote is False
+    assert model_name == "local"
+    assert isinstance(client, LocalLLMClient)
+    assert client.base_url == LocalLLMClient().base_url
+    assert probed == [], "flag off must not probe the local server at all"
+
+
+@pytest.mark.unit
+def test_default_llm_client_flag_on_but_remote_not_configured_stays_local(monkeypatch):
+    """Second half of behavior-neutrality: flag on with an incompletely
+    configured remote provider (missing api key here) is also a no-op —
+    same as flag off."""
+    from config.settings import settings
+    from api.services.llm_client import LocalLLMClient
+
+    monkeypatch.setattr(settings, "agent_remote_executor", True, raising=False)
+    monkeypatch.setattr(settings, "remote_llm_base_url", "https://remote.example", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_model", "remote-model", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_api_key", "", raising=False)  # unconfigured
+
+    probed = []
+    monkeypatch.setattr(LocalLLMClient, "is_available", lambda self: probed.append(1) or True)
+
+    client, model_name, is_remote = _default_llm_client("local")
+
+    assert is_remote is False
+    assert model_name == "local"
+    assert probed == []
+
+
+@pytest.mark.unit
+def test_default_llm_client_flag_on_remote_configured_local_alive_stays_local(monkeypatch):
+    """Fallback, not replacement: an explicit local route on a host with a
+    live llama-server keeps using it even with the flag on and a fully
+    configured remote provider."""
+    from config.settings import settings
+    from api.services.llm_client import LocalLLMClient
+
+    monkeypatch.setattr(settings, "agent_remote_executor", True, raising=False)
+    monkeypatch.setattr(settings, "remote_llm_base_url", "https://remote.example", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_model", "remote-model", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_api_key", "key", raising=False)
+
+    probed = []
+    monkeypatch.setattr(LocalLLMClient, "is_available", lambda self: probed.append(1) or True)
+
+    client, model_name, is_remote = _default_llm_client("local")
+
+    assert is_remote is False
+    assert model_name == "local"
+    assert client.base_url == LocalLLMClient().base_url
+    assert probed == [1], "must check reachability exactly once, not zero times"
+
+
+@pytest.mark.unit
+def test_default_llm_client_flag_on_remote_configured_local_down_selects_remote(monkeypatch):
+    """The end-to-end AC: flag on + remote configured + no reachable local
+    llama-server ⇒ construct a LocalLLMClient pointed at the remote
+    provider's base_url/model/api_key from settings."""
+    from config.settings import settings
+    from api.services.llm_client import LocalLLMClient
+
+    monkeypatch.setattr(settings, "agent_remote_executor", True, raising=False)
+    monkeypatch.setattr(settings, "remote_llm_base_url", "https://remote.example/v1", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_model", "accounts/fireworks/models/deepseek-v4-flash-0731", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_api_key", "fw_test_key", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_timeout", 42, raising=False)
+
+    monkeypatch.setattr(LocalLLMClient, "is_available", lambda self: False)
+
+    client, model_name, is_remote = _default_llm_client("local")
+
+    assert is_remote is True
+    assert model_name == "accounts/fireworks/models/deepseek-v4-flash-0731"
+    assert isinstance(client, LocalLLMClient)
+    assert client.base_url == "https://remote.example/v1"
+    assert client.model == "accounts/fireworks/models/deepseek-v4-flash-0731"
+    assert client.timeout == 42
+    assert client._auth_headers() == {"Authorization": "Bearer fw_test_key"}
+
+
+@pytest.mark.unit
+def test_executor_construction_flag_off_builds_bare_local_client(tmp_path: Path, monkeypatch):
+    """Same guarantee as the module-level test above, but through the
+    LocalExecutor constructor itself — pins the actual call site worker.py
+    uses (no llm_client injected)."""
+    from config.settings import settings
+    from api.services.llm_client import LocalLLMClient
+
+    monkeypatch.setattr(settings, "agent_remote_executor", False, raising=False)
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    executor = LocalExecutor(
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        tool_registry=ToolRegistry(lifeos_mcp_server=_FakeMCPServer()),
+    )
+    assert executor.is_remote is False
+    assert executor.model_name == "local"
+    assert isinstance(executor.llm, LocalLLMClient)
+    assert executor.llm.base_url == LocalLLMClient().base_url
+
+
+@pytest.mark.unit
+def test_executor_records_remote_spend_priced_with_configured_rates(tmp_path: Path, fake_session, monkeypatch):
+    """Mirrors agent_loop.py's force_remote _track_usage branch (#654):
+    when remote rates are configured, a remote-served session prices real
+    dollars from them, not from pricing.PRICING (the remote model id isn't
+    in that table at all)."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "remote_llm_input_price_per_mtok", 0.5, raising=False)
+    monkeypatch.setattr(settings, "remote_llm_output_price_per_mtok", 1.5, raising=False)
+
+    store, session = fake_session
+    llm = _ScriptedLLM([
+        _FakeResponse(text="done.", usage=_FakeUsage(1_000_000, 1_000_000)),
+    ])
+    executor = LocalExecutor(
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        tool_registry=ToolRegistry(lifeos_mcp_server=_FakeMCPServer()),
+        llm_client=llm,
+        model_name="accounts/fireworks/models/deepseek-v4-flash-0731",
+        is_remote=True,
+    )
+    outcome = executor.execute(session, {"id": "t1", "description": "x"})
+    refreshed = store.get("t1")
+    assert refreshed.total_dollars == pytest.approx(0.5 + 1.5)
+    assert refreshed.unpriced is False
+    assert outcome.served_by == "accounts/fireworks/models/deepseek-v4-flash-0731"
+
+
+@pytest.mark.unit
+def test_executor_records_remote_spend_unpriced_without_configured_rates(tmp_path: Path, fake_session, monkeypatch):
+    """No configured rate ⇒ real unpriced spend, never fallback-priced —
+    same #669 convention as the unknown-model case, applied to the remote
+    branch."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "remote_llm_input_price_per_mtok", None, raising=False)
+    monkeypatch.setattr(settings, "remote_llm_output_price_per_mtok", None, raising=False)
+
+    store, session = fake_session
+    llm = _ScriptedLLM([
+        _FakeResponse(text="done.", usage=_FakeUsage(1000, 500)),
+    ])
+    executor = LocalExecutor(
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        tool_registry=ToolRegistry(lifeos_mcp_server=_FakeMCPServer()),
+        llm_client=llm,
+        model_name="accounts/fireworks/models/deepseek-v4-flash-0731",
+        is_remote=True,
+    )
+    executor.execute(session, {"id": "t1", "description": "x"})
+    refreshed = store.get("t1")
+    assert refreshed.total_input_tokens == 1000
+    assert refreshed.total_output_tokens == 500
+    assert refreshed.total_dollars == pytest.approx(0.0)
+    assert refreshed.unpriced is True
+
+
+@pytest.mark.unit
+def test_executor_outcome_served_by_empty_for_ordinary_local_session(tmp_path: Path, fake_session):
+    """served_by must stay empty (no message-text change downstream) for
+    every session not on the remote fallback — including the default
+    is_remote=False path exercised by every existing test above."""
+    store, session = fake_session
+    llm = _ScriptedLLM([
+        _FakeResponse(text="done.", usage=_FakeUsage(10, 5)),
+    ])
+    executor = _make_executor(store, tmp_path / "transcripts", llm)
+    outcome = executor.execute(session, {"id": "t1", "description": "x"})
+    assert outcome.served_by == ""
 
 
 @pytest.mark.unit

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -1409,6 +1409,29 @@ def test_completion_label_says_local_for_local_routing(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_completion_label_reports_remote_fallback_model_when_served_by_set(tmp_path: Path):
+    """(#699) When the local route actually ran on the flag-gated remote
+    fallback, the completion message must name the model that actually
+    served the session, not just the static "local" route label — #658's
+    report-observed-not-configured principle applied to this new path."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "task", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(
+        status=STATUS_COMPLETED, final_text="done",
+        served_by="accounts/fireworks/models/deepseek-v4-flash-0731",
+    ))
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=executor)
+    w.tick()
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert sent
+    assert "Local agent worker" in sent[0]
+    assert "accounts/fireworks/models/deepseek-v4-flash-0731" in sent[0]
+
+
+@pytest.mark.unit
 def test_completion_inline_summary_kept_when_under_cap(tmp_path: Path):
     """A short final_text is delivered inline (not replaced by a preview), and
     every completion now also lands a note in the vault — so the message carries


### PR DESCRIPTION
Closes #699.

For installs with no other #agent executor (no Claude Code, no Codex, no local llama-server, no Anthropic key): when `LIFEOS_AGENT_REMOTE_EXECUTOR=true` AND the #654 remote OpenAI-compatible provider is fully configured AND the local llama-server fails a one-shot reachability check at session start, the agent worker's local route runs the session on the remote provider instead of failing.

- Default off + unset remote config = byte-identical to today everywhere (pinned by a test asserting zero reachability probes with the flag off).
- Never an escalation-ladder rung: the chat orchestrator's "local" rung goes through `_select_client(force_local=True)`, which doesn't consult the flag — proven by `test_local_escalation_rung_ignores_the_699_remote_executor_flag`.
- Spend priced from `remote_llm_{input,output}_price_per_mtok`, mirroring `agent_loop._track_usage`'s `force_remote` branch exactly; unset rates record real unpriced spend (#669 convention).
- `ExecutorOutcome.served_by` carries the actual model id so Telegram completion/failure messages report observed, not configured (#658).
- Probe is per-executor-construction (per drive call), so a fallback session returns to local automatically when llama-server recovers.

Gate: full-scope run green — 4,918 passed, 0 failed. Reviewed against the real signatures (`LocalLLMClient` kwargs, `is_available`, #654 settings fields) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)