### PR TITLE
fix(entities): create people for contacts with iMessage evidence but no person yet

### DIFF
--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -187,6 +187,13 @@ SYNC_SOURCES = {
         "phase": 2,
         "depends_on": ["imessage"],
     },
+    "create_contact_persons": {
+        "description": "Create people for contacts with iMessage interaction evidence (#700)",
+        "script": "scripts/create_contact_persons.py",
+        "frequency": "daily",
+        "phase": 2,
+        "depends_on": ["imessage", "apple_import", "contacts"],
+    },
     "link_source_entities": {
         "description": "Retroactively link unlinked source entities to people",
         "script": "scripts/link_source_entities.py",

--- a/config/settings.py
+++ b/config/settings.py
@@ -868,6 +868,17 @@ class Settings(BaseSettings):
                     "elapsed time), so they are bounded by count with "
                     "oldest-first eviction instead of by age."
     )
+    contact_person_min_messages: int = Field(
+        default=5,
+        alias="LIFEOS_CONTACT_PERSON_MIN_MESSAGES",
+        description="Minimum iMessage count on a contact's phone or email "
+                    "handle before scripts/create_contact_persons.py will "
+                    "create a PersonEntity for an otherwise person-less "
+                    "Apple Contacts record (#700). The contact-record "
+                    "requirement already filters the address book down to "
+                    "real people; this just avoids one-off wrong-number "
+                    "artifacts."
+    )
 
     # ==========================================================================
     # WORK INTEGRATION TOGGLES

--- a/scripts/create_contact_persons.py
+++ b/scripts/create_contact_persons.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Create PersonEntity records for Apple Contacts that have iMessage evidence
+but no person yet (#700).
+
+The chicken-and-egg this closes: a contacts SourceEntity never creates a
+PersonEntity on its own (correctly -- most of the address book shouldn't
+become CRM people), and `link_imessage_entities.py` only links handles to
+*existing* people. So a contact who only ever texts (no WhatsApp, no email
+correspondence) can never get a person entity, even with a deep iMessage
+history.
+
+This script closes the gap without inventing a new creation pattern: for
+every unlinked `contacts` SourceEntity, it checks whether the contact's
+normalized phone or (lowercased) email appears as an iMessage handle at
+least `settings.contact_person_min_messages` times in data/imessage.db. If
+so, it creates a person the same way scripts/apple_data_import.py's WhatsApp
+import does -- `EntityResolver.resolve(..., create_if_missing=True)` -- then
+links both the contacts SourceEntity and the matching message rows to it.
+Categorization (family/work rules) is deliberately left to the normal
+`compute_person_category` pass that already runs on every person during the
+nightly "strengths" step; this script's only job is to make sure the person
+exists and is linked.
+
+Idempotent: a contacts SourceEntity that already has a canonical_person_id
+(created by this script or anything else) is never revisited.
+
+Usage:
+    # Dry run (default) - see what would be created
+    python scripts/create_contact_persons.py
+
+    # Actually apply changes
+    python scripts/create_contact_persons.py --execute
+"""
+import sqlite3
+import logging
+import sys
+from contextlib import closing
+from pathlib import Path
+from typing import Optional
+
+# Running `python scripts/foo.py` puts scripts/ on sys.path, not the project
+# root, so `import api` fails without this. Mirrors the sibling sync scripts.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from api.services.entity_resolver import EntityResolver
+from api.services.person_entity import PersonEntityStore, get_person_entity_store
+from api.services.phone_utils import normalize_phone
+from api.services.source_entity import (
+    SourceEntityStore,
+    get_source_entity_store,
+    LINK_STATUS_AUTO,
+)
+from config.settings import settings
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+IMESSAGE_DB = Path(__file__).parent.parent / "data" / "imessage.db"
+
+# A contacts SE without at least this many messages on a handle is treated
+# as address-book noise, not evidence of a real relationship worth a person.
+DEFAULT_LIMIT = 10000
+
+
+def _count_messages_for_phone(conn: sqlite3.Connection, phone: str) -> int:
+    """Count iMessages whose normalized handle matches an E.164 phone."""
+    row = conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE handle_normalized = ?",
+        (phone,),
+    ).fetchone()
+    return row[0] if row else 0
+
+
+def _count_messages_for_email(conn: sqlite3.Connection, email: str) -> int:
+    """Count iMessages whose (email) handle matches, case-insensitively.
+
+    Email handles never get a handle_normalized (phone_utils.normalize_phone
+    returns None for them), so that column being NULL is what distinguishes
+    an email handle row from a phone one -- mirrors
+    api.services.imessage.join_imessages_to_entities.
+    """
+    row = conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE handle_normalized IS NULL AND LOWER(handle) = ?",
+        (email.lower(),),
+    ).fetchone()
+    return row[0] if row else 0
+
+
+def _link_messages_to_person(
+    conn: sqlite3.Connection,
+    person_id: str,
+    phone: Optional[str],
+    email: Optional[str],
+) -> int:
+    """Point this contact's phone- and/or email-handle messages at the new
+    person, so interactions/timeline show up immediately instead of waiting
+    on the next retroactive link_imessage/link_source_entities pass.
+
+    Only touches rows that aren't already linked, so re-running is a no-op.
+    """
+    updated = 0
+    if phone:
+        cursor = conn.execute(
+            """
+            UPDATE messages SET person_entity_id = ?
+            WHERE handle_normalized = ?
+            AND (person_entity_id IS NULL OR person_entity_id = '')
+            """,
+            (person_id, phone),
+        )
+        updated += cursor.rowcount
+    if email:
+        cursor = conn.execute(
+            """
+            UPDATE messages SET person_entity_id = ?
+            WHERE handle_normalized IS NULL AND LOWER(handle) = ?
+            AND (person_entity_id IS NULL OR person_entity_id = '')
+            """,
+            (person_id, email.lower()),
+        )
+        updated += cursor.rowcount
+    return updated
+
+
+def create_contact_persons(
+    dry_run: bool = True,
+    min_messages: Optional[int] = None,
+    limit: int = DEFAULT_LIMIT,
+    source_store: Optional[SourceEntityStore] = None,
+    person_store: Optional[PersonEntityStore] = None,
+    resolver: Optional[EntityResolver] = None,
+    imessage_db_path: Optional[str] = None,
+) -> dict:
+    """
+    Create PersonEntity records for contacts with iMessage interaction evidence.
+
+    Args:
+        dry_run: If True, don't actually create/link anything
+        min_messages: Evidence threshold (default: settings.contact_person_min_messages)
+        limit: Max unlinked contacts SourceEntities to consider in one run
+        source_store: Override SourceEntityStore (for tests)
+        person_store: Override PersonEntityStore (for tests)
+        resolver: Override EntityResolver (for tests)
+        imessage_db_path: Override path to imessage.db (for tests)
+
+    Returns:
+        Stats dict
+    """
+    threshold = min_messages if min_messages is not None else settings.contact_person_min_messages
+    source_store = source_store or get_source_entity_store()
+    person_store = person_store or get_person_entity_store()
+    resolver = resolver or EntityResolver(entity_store=person_store)
+    db_path = imessage_db_path or str(IMESSAGE_DB)
+
+    stats = {
+        "contacts_checked": 0,
+        "no_evidence": 0,
+        "persons_created": 0,
+        "persons_matched_existing": 0,
+        "messages_linked": 0,
+        "skipped_no_name": 0,
+        "errors": 0,
+    }
+
+    contacts = source_store.get_unlinked(source_type="contacts", limit=limit)
+    logger.info(f"Found {len(contacts)} unlinked contacts to check for iMessage evidence")
+
+    if not contacts:
+        logger.info("No unlinked contacts to process!")
+        from api.services.sync_health import emit_sync_stats
+        emit_sync_stats({"processed": 0, "people_updated": 0, "updated": 0})
+        return stats
+
+    with closing(sqlite3.connect(db_path)) as conn:
+        for contact in contacts:
+            stats["contacts_checked"] += 1
+            try:
+                phone = normalize_phone(contact.observed_phone) if contact.observed_phone else None
+                email = contact.observed_email.lower() if contact.observed_email else None
+
+                phone_count = _count_messages_for_phone(conn, phone) if phone else 0
+                email_count = _count_messages_for_email(conn, email) if email else 0
+
+                if phone_count < threshold and email_count < threshold:
+                    stats["no_evidence"] += 1
+                    continue
+
+                if not contact.observed_name:
+                    # resolver.resolve() never creates from phone alone (#226)
+                    # and this script shouldn't invent a name-less person.
+                    stats["skipped_no_name"] += 1
+                    continue
+
+                if dry_run:
+                    # EntityResolver.resolve(create_if_missing=True) always
+                    # persists -- it has no dry-run mode of its own -- so a
+                    # true dry run must never call it. Report the evidence
+                    # found without creating or linking anything.
+                    stats["persons_created"] += 1
+                    stats["messages_linked"] += phone_count + email_count
+                    continue
+
+                result = resolver.resolve(
+                    name=contact.observed_name,
+                    email=contact.observed_email,
+                    phone=phone,
+                    create_if_missing=True,
+                )
+                if not result or not result.entity:
+                    stats["no_evidence"] += 1
+                    continue
+
+                person = result.entity
+                if result.is_new:
+                    stats["persons_created"] += 1
+                    logger.info(
+                        f"Created person for contact evidence: {contact.observed_name} "
+                        f"(phone_msgs={phone_count}, email_msgs={email_count})"
+                    )
+                else:
+                    stats["persons_matched_existing"] += 1
+
+                source_store.link_to_person(
+                    contact.id,
+                    person.id,
+                    confidence=0.9,
+                    status=LINK_STATUS_AUTO,
+                    method="contact_imessage_evidence",
+                )
+                stats["messages_linked"] += _link_messages_to_person(
+                    conn, person.id, phone, email
+                )
+
+            except Exception as e:
+                stats["errors"] += 1
+                logger.warning(f"Error processing contact {contact.id}: {e}")
+
+        if not dry_run:
+            conn.commit()
+
+    logger.info("\n=== Contact Person Creation Summary ===")
+    logger.info(f"Contacts checked:         {stats['contacts_checked']}")
+    logger.info(f"No evidence (skipped):    {stats['no_evidence']}")
+    logger.info(f"Persons created:          {stats['persons_created']}")
+    logger.info(f"Persons matched existing: {stats['persons_matched_existing']}")
+    logger.info(f"Messages linked:          {stats['messages_linked']}")
+    logger.info(f"Skipped (no name):        {stats['skipped_no_name']}")
+    logger.info(f"Errors:                   {stats['errors']}")
+
+    from api.services.sync_health import emit_sync_stats
+    emit_sync_stats({
+        "processed": stats["contacts_checked"],
+        "people_updated": stats["persons_created"] + stats["persons_matched_existing"],
+        "updated": stats["messages_linked"],
+        "errors": stats["errors"],
+    })
+
+    if dry_run:
+        logger.info("\nDRY RUN - no changes made. Use --execute to apply.")
+
+    return stats
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Create PersonEntity records for contacts with iMessage evidence (#700)'
+    )
+    parser.add_argument('--execute', action='store_true', help='Actually apply changes')
+    parser.add_argument(
+        '--min-messages', type=int, default=None,
+        help='Evidence threshold (default: settings.contact_person_min_messages)',
+    )
+    args = parser.parse_args()
+
+    create_contact_persons(dry_run=not args.execute, min_messages=args.min_messages)

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -690,6 +690,7 @@ SYNC_ORDER = [
     "link_slack",               # Link Slack users to people by email
     "imessage",                 # Create interactions from iMessage data (links its own unlinked messages internally)
     "link_imessage",            # Retroactive: backfill phone-based links against latest CRM data (runs after imessage — see depends_on)
+    "create_contact_persons",   # Create people for contacts with iMessage evidence but no person yet (#700)
     "link_source_entities",     # Retroactive linking for all unlinked entities
     "photos",                   # Sync Photos face data to people
 
@@ -745,6 +746,7 @@ SYNC_SCRIPTS = {
     # Phase 2: Entity Processing
     "link_slack": ("scripts/link_slack_entities.py", ["--execute"]),
     "link_imessage": ("scripts/link_imessage_entities.py", ["--execute"]),
+    "create_contact_persons": ("scripts/create_contact_persons.py", ["--execute"]),
     "link_source_entities": ("scripts/link_source_entities.py", ["--execute"]),
     "photos": ("scripts/sync_photos.py", ["--execute"]),
 

--- a/tests/test_create_contact_persons.py
+++ b/tests/test_create_contact_persons.py
@@ -1,0 +1,286 @@
+"""
+Tests for scripts/create_contact_persons.py (#700).
+
+A contacts SourceEntity never creates a PersonEntity on its own, and
+link_imessage_entities.py only links handles to *existing* people. So a
+contact who only ever texts (no WhatsApp, no email correspondence) could
+never get a person entity, no matter how deep the iMessage history. This
+script closes that gap: a contacts SE with enough iMessage evidence (phone
+or email handle) gets a person created and both the contact SE and the
+matching message rows linked to it.
+
+All fixtures use synthetic names/numbers and tmp_path-backed databases —
+never the real data/ directory. The EntityResolver's link-override lookup
+(api.services.entity_resolver.get_link_override_store) is monkeypatched to a
+tmp_path db too, since its default constructor points at the real
+data/crm.db.
+"""
+import sqlite3
+from contextlib import closing
+
+import pytest
+
+from api.services.entity_resolver import EntityResolver
+from api.services.imessage import IMessageStore
+from api.services.link_override import LinkOverrideStore
+from api.services.person_entity import PersonEntityStore, compute_person_category
+from api.services.source_entity import (
+    SourceEntityStore,
+    create_contacts_source_entity,
+)
+
+from scripts.create_contact_persons import create_contact_persons
+
+pytestmark = pytest.mark.unit
+
+THRESHOLD = 5
+
+
+@pytest.fixture(autouse=True)
+def _isolate_link_override_store(tmp_path, monkeypatch):
+    """EntityResolver.resolve_by_name() calls get_link_override_store()
+    unconditionally when no exact match is found. Its default db_path is the
+    real data/crm.db -- redirect it to a tmp_path db for every test in this
+    file so nothing here can touch real data.
+    """
+    store = LinkOverrideStore(db_path=tmp_path / "link_overrides.db")
+    monkeypatch.setattr(
+        "api.services.entity_resolver.get_link_override_store", lambda: store
+    )
+
+
+@pytest.fixture
+def person_store(tmp_path, monkeypatch):
+    store = PersonEntityStore(str(tmp_path / "crm.db"))
+    # source_store.link_to_person() and .add() resolve merge chains via the
+    # global get_person_entity_store() singleton internally -- point it at
+    # this same tmp_path store so linking lands in the store the test reads.
+    monkeypatch.setattr(
+        "api.services.person_entity.get_person_entity_store", lambda *a, **kw: store
+    )
+    return store
+
+
+@pytest.fixture
+def source_store(tmp_path):
+    return SourceEntityStore(str(tmp_path / "crm.db"))
+
+
+@pytest.fixture
+def resolver(person_store):
+    return EntityResolver(entity_store=person_store)
+
+
+@pytest.fixture
+def imessage_db_path(tmp_path):
+    path = str(tmp_path / "imessage.db")
+    IMessageStore(path)  # creates schema
+    return path
+
+
+def _insert_messages(db_path, handle, handle_normalized, count, start_rowid=1):
+    with closing(sqlite3.connect(db_path)) as conn, conn:
+        for i in range(count):
+            conn.execute(
+                """
+                INSERT INTO messages
+                    (rowid, text, timestamp, is_from_me, handle, handle_normalized, service)
+                VALUES (?, ?, ?, 0, ?, ?, 'iMessage')
+                """,
+                (start_rowid + i, f"msg {i}", f"2026-01-{i+1:02d}T00:00:00+00:00", handle, handle_normalized),
+            )
+
+
+def _add_contact(source_store, name=None, phone=None, email=None, contact_id="c1"):
+    se = create_contacts_source_entity(contact_id, name=name, email=email, phone=phone)
+    return source_store.add(se)
+
+
+def _run(source_store, person_store, resolver, imessage_db_path, dry_run=False, min_messages=THRESHOLD):
+    return create_contact_persons(
+        dry_run=dry_run,
+        min_messages=min_messages,
+        source_store=source_store,
+        person_store=person_store,
+        resolver=resolver,
+        imessage_db_path=imessage_db_path,
+    )
+
+
+class TestPhoneEvidenceCreation:
+    def test_phone_with_enough_messages_creates_and_links_person(
+        self, source_store, person_store, resolver, imessage_db_path
+    ):
+        phone = "+15550001111"
+        contact = _add_contact(source_store, name="Jordan Rivera", phone=phone)
+        _insert_messages(imessage_db_path, phone, phone, THRESHOLD)
+
+        stats = _run(source_store, person_store, resolver, imessage_db_path)
+
+        assert stats["persons_created"] == 1
+        assert stats["messages_linked"] == THRESHOLD
+
+        updated = source_store.get_by_source("contacts", contact.source_id)
+        assert updated.canonical_person_id is not None
+
+        person = person_store.get_by_id(updated.canonical_person_id)
+        assert person is not None
+        assert person.canonical_name == "Jordan Rivera"
+
+        with closing(sqlite3.connect(imessage_db_path)) as conn:
+            rows = conn.execute(
+                "SELECT person_entity_id FROM messages WHERE handle_normalized = ?", (phone,)
+            ).fetchall()
+        assert all(r[0] == person.id for r in rows)
+
+
+class TestEmailEvidenceCreation:
+    def test_email_only_contact_with_enough_messages_creates_person(
+        self, source_store, person_store, resolver, imessage_db_path
+    ):
+        """Motivating case: a phone-less, email-only contact (#700)."""
+        email = "avery.chen@example.com"
+        contact = _add_contact(source_store, name="Avery Chen", email=email)
+        # Handle case differs from the stored (lowercased) email to mirror
+        # real chat.db data and confirm matching is case-insensitive.
+        _insert_messages(imessage_db_path, "Avery.Chen@Example.com", None, THRESHOLD)
+
+        stats = _run(source_store, person_store, resolver, imessage_db_path)
+
+        assert stats["persons_created"] == 1
+        updated = source_store.get_by_source("contacts", contact.source_id)
+        assert updated.canonical_person_id is not None
+
+        person = person_store.get_by_id(updated.canonical_person_id)
+        assert person.canonical_name == "Avery Chen"
+
+        with closing(sqlite3.connect(imessage_db_path)) as conn:
+            rows = conn.execute(
+                "SELECT person_entity_id FROM messages WHERE LOWER(handle) = ?", (email,)
+            ).fetchall()
+        assert all(r[0] == person.id for r in rows)
+
+
+class TestBelowThreshold:
+    def test_below_threshold_creates_nothing(
+        self, source_store, person_store, resolver, imessage_db_path
+    ):
+        phone = "+15550002222"
+        contact = _add_contact(source_store, name="Sam Okafor", phone=phone)
+        _insert_messages(imessage_db_path, phone, phone, THRESHOLD - 1)
+
+        stats = _run(source_store, person_store, resolver, imessage_db_path)
+
+        assert stats["persons_created"] == 0
+        assert stats["no_evidence"] == 1
+        updated = source_store.get_by_source("contacts", contact.source_id)
+        assert updated.canonical_person_id is None
+        assert person_store.get_all() == []
+
+
+class TestNoContactRecord:
+    def test_messages_alone_never_create_a_person(
+        self, source_store, person_store, resolver, imessage_db_path
+    ):
+        """Address book ≠ CRM: interaction evidence with no contacts SE at
+        all must never create a person -- this script only ever iterates
+        unlinked contacts SEs.
+        """
+        phone = "+15550003333"
+        _insert_messages(imessage_db_path, phone, phone, THRESHOLD * 5)
+
+        stats = _run(source_store, person_store, resolver, imessage_db_path)
+
+        assert stats["contacts_checked"] == 0
+        assert stats["persons_created"] == 0
+        assert person_store.get_all() == []
+
+
+class TestIdempotency:
+    def test_rerun_does_not_duplicate(
+        self, source_store, person_store, resolver, imessage_db_path
+    ):
+        phone = "+15550004444"
+        contact = _add_contact(source_store, name="Riley Fontaine", phone=phone)
+        _insert_messages(imessage_db_path, phone, phone, THRESHOLD)
+
+        first = _run(source_store, person_store, resolver, imessage_db_path)
+        assert first["persons_created"] == 1
+
+        second = _run(source_store, person_store, resolver, imessage_db_path)
+        assert second["persons_created"] == 0
+        assert second["contacts_checked"] == 0  # already linked, no longer "unlinked"
+
+        assert len(person_store.get_all()) == 1
+        updated = source_store.get_by_source("contacts", contact.source_id)
+        assert updated.canonical_person_id is not None
+
+
+class TestExistingLinkedUntouched:
+    def test_already_linked_contact_is_byte_identical(
+        self, source_store, person_store, resolver, imessage_db_path
+    ):
+        phone = "+15550005555"
+        # Person + link already exist before this script ever runs (e.g.
+        # created via WhatsApp import, as in the issue's control case).
+        existing_result = resolver.resolve(name="Morgan Ito", phone=phone, create_if_missing=True)
+        person = existing_result.entity
+        contact = _add_contact(source_store, name="Morgan Ito", phone=phone)
+        source_store.link_to_person(contact.id, person.id, confidence=0.95)
+
+        before = source_store.get_by_source("contacts", contact.source_id)
+        # Plenty of evidence present, but should never be re-processed.
+        _insert_messages(imessage_db_path, phone, phone, THRESHOLD * 10)
+
+        stats = _run(source_store, person_store, resolver, imessage_db_path)
+
+        assert stats["contacts_checked"] == 0
+        after = source_store.get_by_source("contacts", contact.source_id)
+        assert after.canonical_person_id == before.canonical_person_id
+        assert after.link_confidence == before.link_confidence
+        assert after.linked_at == before.linked_at
+        assert len(person_store.get_all()) == 1
+
+
+class TestCategorizationReachable:
+    def test_created_person_gets_family_category_on_standard_recompute(
+        self, source_store, person_store, resolver, imessage_db_path, monkeypatch
+    ):
+        """This script must not duplicate family/work categorization logic --
+        it only has to make sure the person exists and is linked so the
+        normal compute_person_category() pass (run on every person during
+        the nightly "strengths" step) can categorize it like anyone else.
+        """
+        phone = "+15550006666"
+        _add_contact(source_store, name="Casey Whitfield", phone=phone)
+        _insert_messages(imessage_db_path, phone, phone, THRESHOLD)
+
+        stats = _run(source_store, person_store, resolver, imessage_db_path)
+        assert stats["persons_created"] == 1
+
+        person = person_store.get_all()[0]
+        assert person.category == "unknown"  # not categorized at creation time
+
+        import api.services.person_entity as person_entity_mod
+        monkeypatch.setattr(person_entity_mod, "FAMILY_LAST_NAMES", {"whitfield"})
+        monkeypatch.setattr(person_entity_mod, "FAMILY_EXACT_NAMES", set())
+        monkeypatch.setattr(person_entity_mod, "FAMILY_PERSON_IDS", set())
+
+        category = compute_person_category(person, source_entities=[])
+        assert category == "family"
+
+
+class TestDryRun:
+    def test_dry_run_creates_nothing(
+        self, source_store, person_store, resolver, imessage_db_path
+    ):
+        phone = "+15550007777"
+        contact = _add_contact(source_store, name="Devon Marsh", phone=phone)
+        _insert_messages(imessage_db_path, phone, phone, THRESHOLD)
+
+        stats = _run(source_store, person_store, resolver, imessage_db_path, dry_run=True)
+
+        assert stats["persons_created"] == 1  # reported, but not persisted
+        assert person_store.get_all() == []
+        updated = source_store.get_by_source("contacts", contact.source_id)
+        assert updated.canonical_person_id is None


### PR DESCRIPTION
Closes #700.

Contacts with substantial iMessage history but no WhatsApp/email correspondence could never become CRM people: person creation lived only in the WhatsApp/Gmail imports, and `link_imessage_entities.py` links handles to *existing* people. Measured on a real install: 152 contacts with ≥10 iMessages each were invisible, including immediate family.

- New Phase-2 pipeline step `scripts/create_contact_persons.py`: an unlinked `contacts` SourceEntity whose normalized phone **or email** appears as an iMessage handle ≥ `LIFEOS_CONTACT_PERSON_MIN_MESSAGES` times (default 5) gets a person via the same `EntityResolver.resolve(create_if_missing=True)` pattern the WhatsApp import uses, then both the contact SE and the matching message rows link to it.
- Selection is `canonical_person_id IS NULL` — deliberately ignoring `link_status`, since the orphaned rows in the field carry a misleading `'auto'` status.
- Categorization untouched: created persons start `unknown` and the existing `compute_person_category` pass classifies them on the next nightly (family rules, work domains).
- Idempotent by construction — linked contacts are never revisited. Dry-run is genuinely non-mutating (`EntityResolver.resolve` has no dry-run of its own, so the script never calls it in preview mode).
- Wired into `SYNC_ORDER`/`SYNC_SCRIPTS` after `link_imessage`, registered in `SYNC_SOURCES`, emits `SYNC_STATS` on every path including no-op.
- 8 new tests (phone evidence, email-handle evidence incl. case-insensitivity, below-threshold, idempotency, already-linked untouched, categorization reachability, dry-run safety) on synthetic fixtures.

Note for this install: person counts will legitimately rise on the next nightly — contacts-with-iMessage-only relationships surfacing is the fix working, not drift.

Gate: full-scope run green — 4,916 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)