### PR TITLE
fix(llm): normalize a trailing /v1 on OpenAI-compatible base URLs (#706)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,10 @@
 # explicit operator intent) — it only runs when picked for that turn.
 # Unset (default): hidden from the picker, no behavior change at all.
 #
-# Base URL, model id, and API key together turn the option on:
+# Base URL, model id, and API key together turn the option on. Either URL
+# convention is accepted — with or without the trailing /v1 the provider's
+# docs show (one trailing /v1 segment is stripped automatically, so both
+# resolve to the same .../v1/chat/completions):
 # LIFEOS_REMOTE_LLM_URL=https://api.fireworks.ai/inference/v1
 # LIFEOS_REMOTE_LLM_MODEL=accounts/fireworks/models/deepseek-v4-flash-0731
 # LIFEOS_REMOTE_LLM_API_KEY=fw_...

--- a/api/services/llm_client.py
+++ b/api/services/llm_client.py
@@ -300,6 +300,16 @@ class LocalLLMClient:
         api_key: str | None = None,
     ):
         self.base_url = (base_url or getattr(settings, "local_llm_url", None) or "http://localhost:8080").rstrip("/")
+        # Every OpenAI-compatible provider documents its base URL *with* the
+        # /v1 suffix (Fireworks, DeepSeek, ...), while llama-server's own
+        # default has none — and every call site below already appends
+        # "/v1/chat/completions" itself. Strip exactly one trailing /v1
+        # segment so both conventions land on the same wire path instead of
+        # doubling up into ".../v1/v1/chat/completions" (#706). Segment-exact
+        # match only — "/av1" or "/v10" must NOT be stripped.
+        if self.base_url.endswith("/v1"):
+            self.base_url = self.base_url[: -len("/v1")]
+
         self.timeout = timeout or getattr(settings, "local_llm_timeout", 90)
         self._model = model
         self._api_key = api_key
@@ -727,7 +737,15 @@ class LocalLLMClient:
         )
 
     def is_available(self) -> bool:
-        """Check if the local LLM server is reachable."""
+        """Check if the local LLM server is reachable.
+
+        GET /health is a llama-server-ism, not part of the OpenAI-compatible
+        surface this class otherwise speaks — a remote provider (#654,
+        e.g. Fireworks) would 404 here regardless of the /v1 base-url
+        normalization above. That's fine: every caller (`local_executor`,
+        `preflight`) only ever calls this on the default, local-pointed
+        client to decide whether to fall back to the remote one; the
+        remote client itself is used unprobed, by design (#706)."""
         try:
             resp = self.sync_client.get("/health", timeout=3.0)
             return resp.status_code == 200
@@ -735,7 +753,8 @@ class LocalLLMClient:
             return False
 
     async def ais_available(self) -> bool:
-        """Async check if the local LLM server is reachable."""
+        """Async check if the local LLM server is reachable. See
+        `is_available` — same llama-server-only /health caveat."""
         try:
             resp = await self.async_client.get("/health", timeout=3.0)
             return resp.status_code == 200

--- a/tests/test_agent_escalation.py
+++ b/tests/test_agent_escalation.py
@@ -644,7 +644,9 @@ def test_force_remote_builds_client_from_settings(monkeypatch):
 
     from api.services.llm_client import LocalLLMClient
     assert isinstance(client, LocalLLMClient)
-    assert client.base_url == "https://api.fireworks.ai/inference/v1"
+    # #706: LocalLLMClient strips one trailing /v1 segment so the wire
+    # path is always {base}/v1/chat/completions, never .../v1/v1/....
+    assert client.base_url == "https://api.fireworks.ai/inference"
     assert client.model == "accounts/fireworks/models/deepseek-v4-flash-0731"
     assert client._api_key == "fw_test_key"
     assert client.timeout == 42

--- a/tests/test_agent_worker_local_executor.py
+++ b/tests/test_agent_worker_local_executor.py
@@ -517,7 +517,9 @@ def test_default_llm_client_flag_on_remote_configured_local_down_selects_remote(
     assert is_remote is True
     assert model_name == "accounts/fireworks/models/deepseek-v4-flash-0731"
     assert isinstance(client, LocalLLMClient)
-    assert client.base_url == "https://remote.example/v1"
+    # #706: LocalLLMClient strips one trailing /v1 segment so the wire
+    # path is always {base}/v1/chat/completions, never .../v1/v1/....
+    assert client.base_url == "https://remote.example"
     assert client.model == "accounts/fireworks/models/deepseek-v4-flash-0731"
     assert client.timeout == 42
     assert client._auth_headers() == {"Authorization": "Bearer fw_test_key"}

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -706,7 +706,9 @@ def test_default_llm_caller_falls_back_to_remote_when_local_unreachable(monkeypa
     result = pf._default_llm_caller("some prompt")
 
     assert result == "remote reply"
-    assert captured["base_url"] == "https://remote.example/v1"
+    # #706: LocalLLMClient strips one trailing /v1 segment so the wire
+    # path is always {base}/v1/chat/completions, never .../v1/v1/....
+    assert captured["base_url"] == "https://remote.example"
     assert captured["model"] == "accounts/fireworks/models/deepseek-v4-flash-0731"
     assert captured["timeout"] == 42
     assert captured["auth"] == {"Authorization": "Bearer fw_test_key"}

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -666,6 +666,73 @@ class TestRemoteProviderConfig:
         assert captured["kwargs"]["json"]["model"] == "accounts/fireworks/models/x"
 
 
+class TestBaseUrlV1Normalization:
+    """LocalLLMClient.__init__ strips one trailing /v1 segment so both
+    OpenAI-compatible URL conventions land on the same
+    /v1/chat/completions wire path (#706)."""
+
+    def test_strips_trailing_v1(self):
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient(base_url="https://api.fireworks.ai/inference/v1")
+        assert client.base_url == "https://api.fireworks.ai/inference"
+
+    def test_strips_trailing_v1_with_trailing_slash(self):
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient(base_url="https://api.fireworks.ai/inference/v1/")
+        assert client.base_url == "https://api.fireworks.ai/inference"
+
+    def test_bare_v1_root_strips_to_empty_host_path(self):
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient(base_url="https://host/v1")
+        assert client.base_url == "https://host"
+
+    def test_no_v1_suffix_unchanged(self):
+        """Base URL without the /v1 suffix must be byte-identical to
+        today — no normalization applied."""
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient(base_url="https://api.deepseek.com")
+        assert client.base_url == "https://api.deepseek.com"
+
+    def test_llama_server_default_unchanged(self):
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient()
+        assert client.base_url == "http://localhost:8080"
+
+    def test_near_miss_av1_not_stripped(self):
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient(base_url="https://host/path/av1")
+        assert client.base_url == "https://host/path/av1"
+
+    def test_near_miss_v10_not_stripped(self):
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient(base_url="https://host/path/v10")
+        assert client.base_url == "https://host/path/v10"
+
+    def test_both_conventions_resolve_to_same_chat_completions_wire_path(self):
+        """The /v1 form and the no-/v1 form must both end up POSTing to
+        the same relative path once combined with base_url — this is
+        what actually fixes the doubled .../v1/v1/chat/completions 404."""
+        from api.services.llm_client import LocalLLMClient
+        with_v1 = LocalLLMClient(base_url="https://api.fireworks.ai/inference/v1")
+        without_v1 = LocalLLMClient(base_url="https://api.fireworks.ai/inference")
+        assert with_v1.base_url == without_v1.base_url
+        assert with_v1.base_url + "/v1/chat/completions" == "https://api.fireworks.ai/inference/v1/chat/completions"
+
+    def test_health_probe_path_unaffected_for_llama_server_default(self):
+        """is_available() GETs {base}/health — must remain the exact
+        llama-server default path with no /v1 involved."""
+        from unittest.mock import MagicMock
+        from api.services.llm_client import LocalLLMClient
+        client = LocalLLMClient()
+        fake_resp = MagicMock(status_code=200)
+        fake_sync_client = MagicMock(is_closed=False)
+        fake_sync_client.get.return_value = fake_resp
+        client._sync_client = fake_sync_client
+
+        assert client.is_available() is True
+        fake_sync_client.get.assert_called_once_with("/health", timeout=3.0)
+
+
 class TestAStreamReasoningControl:
     """astream() forwards reasoning control the same way create()/acreate() do."""
 


### PR DESCRIPTION
Closes #706.

`LocalLLMClient` appends `/v1/chat/completions` to its base URL, but every OpenAI-compatible provider (and `.env.example`'s own example) documents base URLs *with* the `/v1` suffix — producing `.../v1/v1/chat/completions` → 404 on every remote call. Found live: the first real Fireworks call through #704's preflight fallback 404'd, showing #654's remote path had never been exercised against a real provider (the same bug sits in `agent_loop`'s `force_remote` branch).

- `__init__` strips exactly one trailing `/v1` segment after the existing `rstrip("/")` — `endswith("/v1")` is segment-exact, so `/av1`/`/v10` are untouched and llama-server's suffix-less default is byte-identical.
- Documented that `is_available`'s GET `/health` is a llama-server-ism only ever probed on the default local client (verified across `local_executor` and `preflight`); no remote health mechanism added.
- `.env.example` notes both URL forms are accepted.
- 8 new tests; 3 existing tests updated because they asserted the buggy pass-through itself (including the `force_remote` escalation-path test).

Gate: full-scope run green — 4,939 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)