### PR TITLE
feat(agent-worker): configurable default route for single-executor installs (#707)

### DIFF
--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -39,6 +39,11 @@ ROUTE_CLAUDE_CODE = "claude_code"
 # preflight never emits it directly except via the `#codex` tag.
 ROUTE_CODEX = "codex"
 
+# All routing destinations `parse_preflight_response` accepts from the model,
+# and the same set `settings.agent_default_route` (#707) is validated
+# against — one source of truth so the two checks can't drift apart.
+KNOWN_ROUTES = (ROUTE_LOCAL, ROUTE_CLAUDE, ROUTE_CLAUDE_CODE, ROUTE_CODEX, ROUTE_ASK)
+
 # Allowed expected-output shapes. Used to phrase the final Telegram summary.
 OUTPUT_KINDS = ("text", "file", "external_action", "structured")
 
@@ -235,7 +240,7 @@ def parse_preflight_response(text: str) -> PreflightResult:
     )
 
     routing = raw.get("routing", ROUTE_ASK)
-    if routing not in (ROUTE_LOCAL, ROUTE_CLAUDE, ROUTE_CLAUDE_CODE, ROUTE_CODEX, ROUTE_ASK):
+    if routing not in KNOWN_ROUTES:
         routing = ROUTE_ASK
 
     expected_output = raw.get("expected_output", "text")
@@ -454,6 +459,69 @@ def _apply_tag_overrides(result: PreflightResult, tags: list[str], title: str = 
     return result
 
 
+def _apply_default_route(result: PreflightResult, original_routing: str) -> PreflightResult:
+    """Apply `settings.agent_default_route` when preflight landed on `ask`
+    purely for lack of routing cues (#707) — the "nothing to ask about" case
+    on a single-executor install. Empty setting (default) is a no-op, so an
+    unset install is byte-identical to pre-#707 behavior.
+
+    Gate: `result.routing == ROUTE_ASK and result.sane and result.ambiguity
+    is None`. Deliberately NOT a string match against `routing_reason` — the
+    LLM's reason text is free-form prose ("no tag and no title cue" today,
+    but not a stable contract), so matching on it would be brittle. This one
+    structural gate covers both "lack of cues" paths:
+      - the LLM's own rule-5 answer ("none of the routing rules matched")
+      - `parse_preflight_response`'s deterministic fallback when the model
+        omitted `routing` or returned a value outside `KNOWN_ROUTES`
+    and it correctly excludes the two "ask" outcomes the issue says must
+    stay ask: ambiguity (checked directly) and sanity failures — including
+    the empty-title short-circuit and the LLM-call-failure fallback in
+    `run_preflight`, both of which set `sane=False`.
+
+    One more `ask` source needs excluding that isn't in the issue's list:
+    `_apply_tag_overrides`'s #584 downgrade, which turns an *inferred*
+    (unconfirmed) cloud route into `ask` specifically so it can't
+    auto-dispatch. That result is also sane=True with ambiguity=None, so it
+    would slip through the gate above — this isn't "lack of cues", it's a
+    cue nobody confirmed, and silently routing it via the default would
+    undo the confirmation #584 exists for. Excluded via `original_routing`:
+    the routing value from BEFORE `_apply_tag_overrides` ran. Only when the
+    original LLM/parse outcome was *already* `ask` — not downgraded from
+    `claude` — do we know this is genuinely nothing-to-route-on.
+    """
+    if not settings.agent_default_route:
+        return result
+    if result.routing != ROUTE_ASK or not result.sane or result.ambiguity is not None:
+        return result
+    if original_routing != ROUTE_ASK:
+        return result
+
+    default_route = settings.agent_default_route
+    if default_route not in KNOWN_ROUTES:
+        # Surface loudly (AC): no precedent in this codebase for hard-failing
+        # process startup over a bad setting value (config/settings.py has no
+        # validators), so this logs an ERROR — one line per occurrence, not a
+        # crash — and falls back to `ask`, same as every other preflight
+        # error path. The worker loop must never die over a typo'd env var.
+        logger.error(
+            "invalid LIFEOS_AGENT_DEFAULT_ROUTE=%r — must be one of %s; "
+            "falling back to ask", default_route, KNOWN_ROUTES,
+        )
+        return result
+
+    result.routing = default_route
+    result.routing_reason = f"no cues; LIFEOS_AGENT_DEFAULT_ROUTE={default_route}"
+    if result.model not in ALLOWED_MODELS:
+        if default_route == ROUTE_CLAUDE:
+            result.model = MODEL_SONNET
+        elif default_route == ROUTE_LOCAL:
+            result.model = MODEL_LOCAL
+        # ROUTE_CLAUDE_CODE / ROUTE_CODEX / ROUTE_ASK: leave model as-is
+        # (CLI routes pick their own model; ROUTE_ASK is a pointless but
+        # harmless configuration — model stays unset for the operator).
+    return result
+
+
 def _apply_preset_class(result: PreflightResult, tags: list[str]) -> PreflightResult:
     """Set `result.preset_class` from an explicit `#<class>` tag if present.
 
@@ -536,6 +604,26 @@ def _apply_cost_gates(result: PreflightResult) -> PreflightResult:
     return result
 
 
+def _finish(result: PreflightResult, tags_list: list[str], title: str = "") -> PreflightResult:
+    """Shared post-processing pipeline for every `run_preflight` return path:
+    tag overrides > default route (#707) > preset class > cost gates —
+    matching the precedence tags > explicit LLM route > default route > ask.
+
+    Centralized (rather than each return path chaining the four calls
+    itself) so `original_routing` is captured exactly once, right after the
+    parse/short-circuit result is built and before `_apply_tag_overrides`
+    (the only thing that mutates `result.routing` ahead of the default-route
+    hook) gets a chance to change it. See `_apply_default_route` for why that
+    pre-tag-override value matters.
+    """
+    original_routing = result.routing
+    result = _apply_tag_overrides(result, tags_list, title)
+    result = _apply_default_route(result, original_routing)
+    result = _apply_preset_class(result, tags_list)
+    result = _apply_cost_gates(result)
+    return result
+
+
 def run_preflight(
     title: str,
     tags: list[str] | None = None,
@@ -548,22 +636,19 @@ def run_preflight(
     # Short-circuit: empty title is always unsafe, no need to spend a Haiku call.
     if not title.strip():
         defaults = _defaults()
-        return _apply_cost_gates(_apply_preset_class(
-            _apply_tag_overrides(
-                PreflightResult(
-                    budget=defaults,
-                    routing=ROUTE_ASK,
-                    routing_reason="empty title",
-                    expected_output="text",
-                    ambiguity=None,
-                    sane=False,
-                    sane_reason="task title is empty",
-                    raw={},
-                ),
-                tags_list,
+        return _finish(
+            PreflightResult(
+                budget=defaults,
+                routing=ROUTE_ASK,
+                routing_reason="empty title",
+                expected_output="text",
+                ambiguity=None,
+                sane=False,
+                sane_reason="task title is empty",
+                raw={},
             ),
             tags_list,
-        ))
+        )
 
     call = caller or _default_llm_caller
     prompt = build_preflight_prompt(title, tags_list)
@@ -572,24 +657,18 @@ def run_preflight(
     except Exception as exc:
         logger.warning("preflight LLM call failed: %s", exc)
         defaults = _defaults()
-        return _apply_cost_gates(_apply_preset_class(
-            _apply_tag_overrides(
-                PreflightResult(
-                    budget=defaults,
-                    routing=ROUTE_ASK,
-                    routing_reason="preflight LLM call failed",
-                    expected_output="text",
-                    ambiguity=None,
-                    sane=False,
-                    sane_reason=f"preflight error: {exc}",
-                    raw={},
-                ),
-                tags_list,
+        return _finish(
+            PreflightResult(
+                budget=defaults,
+                routing=ROUTE_ASK,
+                routing_reason="preflight LLM call failed",
+                expected_output="text",
+                ambiguity=None,
+                sane=False,
+                sane_reason=f"preflight error: {exc}",
+                raw={},
             ),
             tags_list,
-        ))
+        )
 
-    return _apply_cost_gates(_apply_preset_class(
-        _apply_tag_overrides(parse_preflight_response(reply), tags_list, title),
-        tags_list,
-    ))
+    return _finish(parse_preflight_response(reply), tags_list, title)

--- a/config/settings.py
+++ b/config/settings.py
@@ -549,6 +549,23 @@ class Settings(BaseSettings):
         alias="LIFEOS_AGENT_DEFAULT_MAX_TOKENS",
         description="Default per-task token budget (input + output combined)."
     )
+    agent_default_route: str = Field(
+        default="",
+        alias="LIFEOS_AGENT_DEFAULT_ROUTE",
+        description="Route preflight dispatches to instead of `ask` when a task "
+                    "has no routing cues at all (#707) — for a single-executor "
+                    "install (e.g. local-only, no Claude Code/Codex/Managed "
+                    "Agents) there's nothing useful to ask about. Empty (default) "
+                    "keeps today's behavior: no cues -> ask the operator. Only "
+                    "applies when preflight would otherwise land on `ask` purely "
+                    "for lack of cues; ambiguity, sanity failures, and preflight "
+                    "LLM errors always still ask. Tag overrides (#local, #cloud, "
+                    "etc.) always win over this. Value is validated in "
+                    "agent_worker/preflight.py against the known routing "
+                    "destinations (local/claude/claude_code/codex/ask); an "
+                    "invalid value logs an error and falls back to `ask` rather "
+                    "than silently misrouting."
+    )
     agent_daily_cap_dollars: float = Field(
         default=100.0,
         alias="LIFEOS_AGENT_DAILY_CAP_DOLLARS",

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -738,3 +738,137 @@ def test_default_llm_caller_raises_when_no_client_usable(monkeypatch):
     result = pf.run_preflight("do the thing", tags=["agent"], caller=None)
     assert result.sane is False
     assert result.routing == pf.ROUTE_ASK
+
+
+# ---------------------------------------------------------------------------
+# #707 — LIFEOS_AGENT_DEFAULT_ROUTE: route "ask for lack of cues" outcomes
+# instead of blocking, on installs with exactly one executor.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_default_route_unset_is_byte_identical_to_today():
+    """Empty setting (the default) must not touch the no-cues ask path."""
+    reply = _golden_reply(routing="ask", routing_reason="no tag and no title cue")
+    result = pf.run_preflight(title="research dolphins", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_ASK
+    assert result.routing_reason == "no tag and no title cue"
+
+
+@pytest.mark.unit
+def test_default_route_applies_when_no_cues(monkeypatch):
+    """Set + no-cues ask -> routes without blocking, and routing_reason
+    names the setting."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+    reply = _golden_reply(routing="ask", routing_reason="no tag and no title cue")
+    result = pf.run_preflight(title="research dolphins", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_LOCAL
+    assert "LIFEOS_AGENT_DEFAULT_ROUTE=local" in result.routing_reason
+    assert result.model == pf.MODEL_LOCAL
+
+
+@pytest.mark.unit
+def test_default_route_applies_to_llm_omitted_routing(monkeypatch):
+    """The deterministic no-cues path (invalid/missing `routing` from the
+    model) is also routed by the default — same "nothing to route on"
+    outcome as the LLM's own explicit `ask`."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+    reply = _golden_reply(routing="not-a-real-route")
+    result = pf.run_preflight(title="x", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_LOCAL
+
+
+@pytest.mark.unit
+def test_default_route_does_not_apply_on_ambiguity(monkeypatch):
+    """Set + ambiguity -> still ask."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+    reply = _golden_reply(
+        routing="ask", routing_reason="no tag and no title cue",
+        ambiguity={"question": "Which John — John Doe or John Smith?"},
+    )
+    result = pf.run_preflight(title="reply to John", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_ASK
+    assert result.ambiguity is not None
+
+
+@pytest.mark.unit
+def test_default_route_does_not_apply_on_sanity_failure(monkeypatch):
+    """Set + sane=False -> still ask."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+    reply = _golden_reply(routing="ask", sane=False, sane_reason="destructive: 'rm -rf /'")
+    result = pf.run_preflight(title="rm -rf /", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_ASK
+    assert result.sane is False
+
+
+@pytest.mark.unit
+def test_default_route_does_not_apply_on_empty_title(monkeypatch):
+    """Set + empty title (sanity short-circuit) -> still ask, no LLM call."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+
+    def fail(prompt):
+        raise AssertionError("LLM should not have been called for empty title")
+
+    result = pf.run_preflight(title="   ", tags=["agent"], caller=fail)
+    assert result.routing == pf.ROUTE_ASK
+    assert result.sane is False
+
+
+@pytest.mark.unit
+def test_default_route_does_not_apply_on_llm_error(monkeypatch):
+    """Set + preflight LLM call failed -> still ask."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+
+    def boom(prompt):
+        raise RuntimeError("no client available")
+
+    result = pf.run_preflight(title="do the thing", tags=["agent"], caller=boom)
+    assert result.routing == pf.ROUTE_ASK
+    assert result.sane is False
+
+
+@pytest.mark.unit
+def test_default_route_does_not_apply_to_unconfirmed_cloud_inference(monkeypatch):
+    """Set + a #584 cloud-inference downgrade (a cue nobody confirmed, not a
+    *lack* of cues) -> still ask. This is the case the plain
+    `routing == ask and sane and ambiguity is None` gate would wrongly
+    catch without the original-routing check."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+    result = pf.run_preflight("draft an email", tags=["agent"],
+                              caller=_stub_caller(routing="claude"))
+    assert result.routing == pf.ROUTE_ASK
+    assert "not explicitly requested" in result.routing_reason
+
+
+@pytest.mark.unit
+def test_default_route_invalid_value_logs_error_and_falls_back_to_ask(monkeypatch, caplog):
+    """AC: an invalid value surfaces a clear error rather than silently
+    asking (or crashing the worker loop) — falls back to `ask` with a
+    logged ERROR."""
+    import logging
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "bogus-route")
+    reply = _golden_reply(routing="ask", routing_reason="no tag and no title cue")
+    with caplog.at_level(logging.ERROR, logger="api.services.agent_worker.preflight"):
+        result = pf.run_preflight(title="research dolphins", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_ASK
+    assert any("LIFEOS_AGENT_DEFAULT_ROUTE" in rec.message for rec in caplog.records)
+    assert any(rec.levelno == logging.ERROR for rec in caplog.records)
+
+
+@pytest.mark.unit
+def test_default_route_tags_still_win(monkeypatch):
+    """Tag overrides beat the default route — precedence: tags > explicit
+    LLM route > default route > ask."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "claude")
+    reply = _golden_reply(routing="ask", routing_reason="no tag and no title cue")
+    result = pf.run_preflight(title="research dolphins", tags=["agent", "local"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_LOCAL
+    assert result.routing_reason == "#local tag present"


### PR DESCRIPTION
Closes #707.

On an install with exactly one executor, preflight's "no cues → ask" parks every untagged `#agent` task at `#agent-blocked` with a menu of engines the install doesn't have. New `LIFEOS_AGENT_DEFAULT_ROUTE` (default unset = byte-identical to today) applies only when preflight landed on `ask` purely for lack of cues.

- Structural gate (`routing==ask and sane and ambiguity is None`), not free-form reason-string matching — covers both the LLM's no-cues answer and the parser's missing/invalid-routing fallback.
- Ambiguity, sanity failures, and preflight-error results stay `ask`. So does #584's unconfirmed-cloud downgrade, excluded via the pre-tag-override routing value — a cue nobody confirmed is not "no cues" (dedicated test).
- Precedence: tags > explicit LLM route > default route > ask, centralized in a `_finish()` pipeline shared by all `run_preflight` return paths.
- Invalid values log an ERROR and fall back to ask (matching the codebase's no-startup-validators convention) — never crash the worker loop.
- `KNOWN_ROUTES` single source of truth for both the parser's and the setting's validation.
- 10 new tests covering the full matrix.

Gate: full-scope run green — 4,940 passed, 0 failed; rebased on main (post-#706) before push, hook suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)