### PR TITLE
feat(chat): unify toolbar dropdowns with pill styling; Text/Voice pill replaces mic/keyboard icons

### DIFF
--- a/docs/guides/voice-setup.md
+++ b/docs/guides/voice-setup.md
@@ -70,7 +70,7 @@ Restart the API after editing `.env`:
 In voice mode the text composer is replaced by the dock:
 
 - **Tap-to-talk** — the shutter button starts/stops recording; a cancel (`✕`) aborts an in-flight turn.
-- **Keyboard button** (`⌨️`) — swaps back to the text composer (Voice ↔ Text). The mode persists per browser.
+- **Text/Voice pill** — a two-way pill selector at the top of `/chat` (next to the backend selector) swaps between the text composer and the voice dock. The mode persists per browser.
 - Three dock toggles (state saved per browser):
   - **Mute** — suppress spoken playback (the reply still returns as text).
   - **2×** — play spoken replies at double speed.
@@ -110,7 +110,7 @@ On the **Hermes** backend an orchestrating persona's spoken turn never spawns an
 | "Mic blocked — this page is not on HTTPS" | Not on HTTPS. If `TAILNET_HTTPS_URL` is set, the message carries an **Open over HTTPS** link to this same page on that origin — tap it. Otherwise reopen `/chat` on your tailnet HTTPS URL, not `http://` or a LAN IP, and confirm `lifeos-tailscale.service` is active. |
 | "Mic unavailable — …" (no microphone API / no MediaRecorder / no supported audio format) | Not an HTTPS problem: the browser itself lacks a recording capability. Use a current Chrome, Safari, or Firefox; in-app webviews and stripped-down browsers often omit these. |
 | Dock present but turns error immediately | whisper-relay isn't running on `LIFEOS_VOICE_GATEWAY_URL` (default `:9788`). Start the gateway; check `curl http://127.0.0.1:9788` locally. |
-| Voice dock never appears | Voice is opt-in per browser. Toggle to Voice with the mic control, or set `LIFEOS_CHAT_DEFAULT_VOICE=true` and restart the API. |
+| Voice dock never appears | Voice is opt-in per browser. Tap **Voice** on the Text/Voice pill, or set `LIFEOS_CHAT_DEFAULT_VOICE=true` and restart the API. |
 | `Agent` toggle missing | Expected unless `LIFEOS_AGENT_BACKEND_URL` is set. |
 | `Hermes` toggle missing | Expected unless `LIFEOS_HERMES_BACKEND_URL` is set. |
 

--- a/tests/test_mode_pill_ui_browser.py
+++ b/tests/test_mode_pill_ui_browser.py
@@ -1,0 +1,143 @@
+"""Browser tests for the Text|Voice input-mode pill (#684).
+
+Drives `web/chat/voice.js`'s `setVoiceMode()` through the real toolbar pill
+that replaced the old mic (🎙️)/keyboard (⌨️) icon toggle: explicit-choice
+clicks, the CSS the `voice-mode` body class actually flips (dock vs.
+composer), the no-op guard on a redundant click, and persistence across a
+reload — same `lifeos:chat:voice_mode` sessionStorage key and resolution
+order voice.js has always used.
+
+Unlike most of the browser suite this serves `web/` itself from an ephemeral
+port rather than pointing at a running API, because the assertions are about
+the JS in *this* checkout and every API call the page makes is intercepted
+anyway. That is why it carries no `requires_server` marker, and so runs at
+pre-push (`browser and not requires_server`) — see
+tests/test_voice_mic_block_ui_browser.py for the same pattern.
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+
+class _ChatHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the chat SPA the way api/main.py does: `/chat` is index.html and
+    the module tree hangs off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/chat", "/"):
+            return str(WEB_DIR / "index.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def chat_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _ChatHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _open_chat(page: Page, base_url, *, path="/chat"):
+    """Every `/api/` call the page makes on load is stubbed empty so nothing
+    depends on a running server — including `/api/chat/config`, which leaves
+    `default_voice` unset (text mode, matching a fresh clone's default)."""
+    page.route("**/api/**", lambda route: route.fulfill(
+        status=200, content_type="application/json", body=json.dumps({})))
+    page.goto(f"{base_url}{path}")
+    page.wait_for_selector("#modeTextBtn")
+
+
+def _is_voice_mode(page: Page):
+    return page.evaluate("document.body.classList.contains('voice-mode')")
+
+
+class TestModePillClicks:
+    """The Text|Voice pill (#684) is the sole control now wired to
+    setVoiceMode() — no mic/keyboard icons remain."""
+
+    def test_default_is_text_mode(self, page: Page, chat_base_url):
+        _open_chat(page, chat_base_url)
+        expect(page.locator("#modeTextBtn")).to_have_class("mode-toggle-option active")
+        expect(page.locator("#modeVoiceBtn")).to_have_class("mode-toggle-option")
+        assert _is_voice_mode(page) is False
+
+    def test_click_voice_switches_mode_and_ui(self, page: Page, chat_base_url):
+        _open_chat(page, chat_base_url)
+
+        page.locator("#modeVoiceBtn").click()
+
+        assert _is_voice_mode(page) is True
+        expect(page.locator("#modeVoiceBtn")).to_have_class("mode-toggle-option active")
+        expect(page.locator("#modeTextBtn")).to_have_class("mode-toggle-option")
+        # body.voice-mode is what actually swaps the dock in for the composer
+        # (index.html's `body.voice-mode .voice-dock` / `.input-container`
+        # display rules) — assert the real observable, not just the class.
+        expect(page.locator("#voiceDock")).to_be_visible()
+        expect(page.locator(".input-container")).to_be_hidden()
+        assert page.evaluate("window.lifeChat.config.voiceMode") is True
+
+    def test_click_text_reverses_mode_and_ui(self, page: Page, chat_base_url):
+        # ?mode=voice starts the page in voice mode without going through a
+        # click first, isolating the reversal from the switch-to-voice case.
+        _open_chat(page, chat_base_url, path="/chat?mode=voice")
+        assert _is_voice_mode(page) is True
+
+        page.locator("#modeTextBtn").click()
+
+        assert _is_voice_mode(page) is False
+        expect(page.locator("#modeTextBtn")).to_have_class("mode-toggle-option active")
+        expect(page.locator("#modeVoiceBtn")).to_have_class("mode-toggle-option")
+        expect(page.locator("#voiceDock")).to_be_hidden()
+        expect(page.locator(".input-container")).to_be_visible()
+        assert page.evaluate("window.lifeChat.config.voiceMode") is False
+
+    def test_clicking_the_active_pill_is_a_noop(self, page: Page, chat_base_url):
+        """setVoiceMode() early-returns when the target mode is already in
+        effect — pin that a redundant click doesn't re-fire the transition."""
+        _open_chat(page, chat_base_url)
+        expect(page.locator("#modeTextBtn")).to_have_class("mode-toggle-option active")
+
+        page.locator("#modeTextBtn").click()  # already active — no-op
+
+        expect(page.locator("#modeTextBtn")).to_have_class("mode-toggle-option active")
+        expect(page.locator("#modeVoiceBtn")).to_have_class("mode-toggle-option")
+        assert _is_voice_mode(page) is False
+        assert page.evaluate("window.lifeChat.config.voiceMode") is False
+
+
+class TestModePillPersistence:
+    """The stored preference (`lifeos:chat:voice_mode`, sessionStorage)
+    survives a reload — same resolution order voice.js has always used."""
+
+    def test_voice_choice_persists_across_reload(self, page: Page, chat_base_url):
+        _open_chat(page, chat_base_url)
+
+        page.locator("#modeVoiceBtn").click()
+        assert _is_voice_mode(page) is True
+        assert page.evaluate(
+            "window.sessionStorage.getItem('lifeos:chat:voice_mode')") == "1"
+
+        page.reload()
+        page.wait_for_selector("#modeTextBtn")
+
+        assert _is_voice_mode(page) is True
+        expect(page.locator("#modeVoiceBtn")).to_have_class("mode-toggle-option active")
+        expect(page.locator("#modeTextBtn")).to_have_class("mode-toggle-option")
+        assert page.evaluate("window.lifeChat.config.voiceMode") is True

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -19,7 +19,7 @@ import {
 } from './conversations.js';
 import { sendMessage, askQuestion, stopTurn } from './ask-stream.js';
 import { loadPersonas, onPersonaChange, personaOrchestrates, personaSupportsHandoff } from './persona.js';
-import { initVoice, toggleVoiceMode, submitTurn } from './voice.js';
+import { initVoice, submitTurn } from './voice.js';
 import { initBackend } from './backend.js';
 import { initModel, onModelChange } from './model.js';
 
@@ -94,8 +94,6 @@ Object.assign(window, {
   onPersonaChange,
   // model.js
   onModelChange,
-  // voice.js
-  toggleVoiceMode,
 });
 
 // Voice helpers for the headless test harness (mic/audio can't run headless).

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -319,16 +319,25 @@ export function initVoice() {
       else stopAllAudio();
     });
   }
+
+  // Text|Voice mode pill (#684) — replaces the old mic/keyboard icon toggle;
+  // mirrors backend.js's explicit-set pattern (each button picks its own
+  // mode) rather than a single toggle button.
+  if (elements.modeTextBtn) elements.modeTextBtn.addEventListener('click', () => setVoiceMode(false));
+  if (elements.modeVoiceBtn) elements.modeVoiceBtn.addEventListener('click', () => setVoiceMode(true));
 }
 
-export function toggleVoiceMode() {
-  config.voiceMode = !isVoiceMode();
-  storeVoiceMode(config.voiceMode);
+export function setVoiceMode(on) {
+  if (on === isVoiceMode()) return;
+  config.voiceMode = on;
+  storeVoiceMode(on);
   applyVoiceMode();
 }
 
 function applyVoiceMode() {
   document.body.classList.toggle('voice-mode', isVoiceMode());
+  if (elements.modeTextBtn) elements.modeTextBtn.classList.toggle('active', !isVoiceMode());
+  if (elements.modeVoiceBtn) elements.modeVoiceBtn.classList.toggle('active', isVoiceMode());
 }
 
 function setTalkActive(on) {

--- a/web/index.html
+++ b/web/index.html
@@ -660,16 +660,30 @@
             color: white;
         }
 
-        /* Persona picker (#359) */
-        .persona-picker {
-            padding: 0.375rem 0.5rem;
+        /* Persona picker (#359). Restyled to match the backend/mode pill
+           selectors below (#684) — same height, font, background, and colors
+           — via grouped selectors that share the pill rules rather than
+           duplicating their values, even though the picker itself is a
+           single <select> with no separate container element. */
+        .persona-picker,
+        .backend-toggle,
+        .mode-toggle-group {
             background: var(--bg-tertiary);
             border: 1px solid var(--border);
             border-radius: 6px;
-            color: var(--text-primary);
-            font-size: 0.75rem;
+        }
+
+        .persona-picker,
+        .backend-option,
+        .mode-toggle-option {
+            font-size: 0.72rem;
+            padding: 0.3rem 0.55rem;
+            color: var(--text-secondary);
             cursor: pointer;
-            transition: all 0.2s;
+            transition: all 0.15s;
+        }
+
+        .persona-picker {
             max-width: 160px;
         }
 
@@ -684,14 +698,24 @@
            server-side (body.agent-available / body.hermes-available). Each
            non-lifeos option additionally hides itself unless ITS backend is
            configured, so a machine with only one configured still gets a
-           clean two-way toggle rather than a dead third button. */
+           clean two-way toggle rather than a dead third button.
+
+           .mode-toggle-group shares this same pill shape for the Text|Voice
+           input-mode selector (#684) — unlike the backend toggle it has no
+           availability gating, so it sets its own `display` instead of
+           joining the conditional rule below. */
+        .backend-toggle,
+        .mode-toggle-group {
+            align-items: center;
+            overflow: hidden;
+        }
+
         .backend-toggle {
             display: none;
-            align-items: center;
-            background: var(--bg-tertiary);
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            overflow: hidden;
+        }
+
+        .mode-toggle-group {
+            display: inline-flex;
         }
 
         body.agent-available .backend-toggle,
@@ -699,17 +723,14 @@
             display: inline-flex;
         }
 
-        .backend-option {
+        .backend-option,
+        .mode-toggle-option {
             background: none;
             border: none;
-            color: var(--text-secondary);
-            font-size: 0.72rem;
-            padding: 0.3rem 0.55rem;
-            cursor: pointer;
-            transition: all 0.15s;
         }
 
-        .backend-option.active {
+        .backend-option.active,
+        .mode-toggle-option.active {
             background: var(--accent);
             color: white;
         }
@@ -1038,23 +1059,6 @@
             flex-shrink: 0;
         }
 
-        /* The mode toggle sits to the left of the box (same spot in both modes,
-           so tapping the same place flips Voice <-> Text). */
-        .mode-toggle {
-            width: 40px;
-            height: 40px;
-            background: none;
-            border: none;
-            cursor: pointer;
-            font-size: 1.3rem;
-            opacity: 0.75;
-            padding: 0;
-            flex-shrink: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
         /* The model picker rides along on voice turns too — voice.js sends the
            pick as `model_override` on /api/voice/turn/stream, which whisper-relay
            relays to /api/ask/stream (whisper-relay#24) — so it stays visible in
@@ -1062,10 +1066,6 @@
            `body.agent-mode .persona-picker` (that backend ignores model picks)
            and on Hermes via `body.hermes-mode #modelPicker` (#587) — Hermes
            keeps the persona picker visible but owns its own model selection. */
-
-        .mode-toggle:hover {
-            opacity: 1;
-        }
 
         .voice-dock {
             display: none;
@@ -1075,13 +1075,6 @@
             gap: 0.5rem;
             max-width: 800px;
             margin: 0 auto;
-        }
-
-        /* The text toggle sits in the dock's bottom-left corner in voice mode. */
-        .voice-dock .dock-keyboard {
-            position: absolute;
-            left: 0;
-            bottom: 0;
         }
 
         .voice-dock-row {
@@ -2873,7 +2866,7 @@
             </div>
         </header>
 
-        <!-- Top-of-chat selector toolbar (#361 UI): persona + routing + backend -->
+        <!-- Top-of-chat selector toolbar (#361 UI): persona + routing + backend + mode -->
         <div class="chat-toolbar">
             <select class="persona-picker" id="personaPicker" onchange="onPersonaChange()" title="Choose persona" aria-label="Persona"></select>
             <span class="orchestrates-badge" id="orchestratesBadge" hidden title="This persona runs on LifeOS as a background Claude Code session">⚙️ Runs on LifeOS</span>
@@ -2889,6 +2882,12 @@
                 <button class="backend-option active" id="backendLifeos" type="button" title="LifeOS backend">LifeOS</button>
                 <button class="backend-option" id="backendAgent" type="button" title="Agent backend">Agent</button>
                 <button class="backend-option" id="backendHermes" type="button" title="Hermes backend">Hermes</button>
+            </div>
+            <!-- Text|Voice input-mode selector (#684): replaces the old mic/keyboard
+                 icon toggle with a pill matching .backend-toggle above. -->
+            <div class="mode-toggle-group" role="group" aria-label="Input mode">
+                <button class="mode-toggle-option active" id="modeTextBtn" type="button" title="Text input">Text</button>
+                <button class="mode-toggle-option" id="modeVoiceBtn" type="button" title="Voice input">Voice</button>
             </div>
         </div>
 
@@ -2915,7 +2914,6 @@
             <div class="input-container">
                 <input type="file" id="fileInput" class="file-input" multiple
                        accept="image/png,image/jpeg,image/jpg,image/gif,image/webp,application/pdf,text/plain,text/markdown,text/csv,application/json">
-                <button class="mode-toggle" id="voiceModeBtn" onclick="toggleVoiceMode()" title="Voice input" aria-label="Switch to voice">🎙️</button>
                 <button class="attach-btn" id="attachBtn" onclick="openFilePicker()" title="Attach files" aria-label="Attach files">+</button>
                 <div class="input-wrapper">
                     <textarea
@@ -2934,7 +2932,6 @@
             </div>
             <!-- Voice dock (#361): tap-to-talk + dock toggles; shown in voice mode -->
             <div class="voice-dock" id="voiceDock">
-                <button class="mode-toggle dock-keyboard" onclick="toggleVoiceMode()" title="Text input" aria-label="Switch to text">⌨️</button>
                 <div class="voice-dock-row">
                     <button class="voice-talk-btn shutter" id="voiceTalkBtn" title="Tap to talk" aria-label="Tap to talk"><span class="shutter-core"></span></button>
                     <button class="voice-cancel-btn" id="voiceCancelBtn" title="Cancel turn">✕</button>
@@ -3183,6 +3180,8 @@
                     voiceMute: document.getElementById('voiceMute'),
                     voiceFast: document.getElementById('voiceFast'),
                     voiceAuto: document.getElementById('voiceAuto'),
+                    modeTextBtn: document.getElementById('modeTextBtn'),
+                    modeVoiceBtn: document.getElementById('modeVoiceBtn'),
                     backendLifeos: document.getElementById('backendLifeos'),
                     backendAgent: document.getElementById('backendAgent'),
                     backendHermes: document.getElementById('backendHermes'),


### PR DESCRIPTION
Operator-requested UI standardization in the /chat SPA:

- `.persona-picker` (persona + model `<select>`s) now shares the pill selector's height, font, background, border, and radius via grouped CSS selectors with `.backend-toggle`/`.backend-option` — no duplicated rules.
- The mic (🎙️) / keyboard (⌨️) icon toggles are gone; a Text|Voice pill (`.mode-toggle-group`, mirroring the backend-toggle markup) sits in the top toolbar. `toggleVoiceMode()` → explicit `setVoiceMode(on)` (backend.js pattern); all state/persistence unchanged (`lifeos:chat:voice_mode` sessionStorage, `?mode=` param, server-default resolution, `voice-mode` body-class transitions).
- Dead `.mode-toggle`/`.dock-keyboard` CSS removed; voice-setup guide wording updated.
- New self-contained browser suite `tests/test_mode_pill_ui_browser.py` (5 tests: default state, both transitions with real observables — dock/input visibility, persistence across reload, active-pill no-op) — runs in the pre-push gate alongside the existing suites (47 passed together).
- Visually verified against a static render: dropdowns and pills are pixel-consistent; a preview-only console exception was confirmed present on main too (API-less artifact, unrelated).

No HTTP contract, SSE, or route changes (client-surfaces.md untouched).

Gate: full-scope run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)