### PR TITLE
Telegram send-only mode + decouple personas from bot tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ scripts/clear-caches.sh
 # .worktrees/ made `git status --porcelain` report dirty, which silently
 # disabled auto-deploy.sh for 62 consecutive ticks (#634).
 .worktrees/
+
+# Per-install persona selection; the tracked telegram_bots.json is the template.
+config/telegram_bots.local.json

--- a/api/services/telegram.py
+++ b/api/services/telegram.py
@@ -1541,8 +1541,14 @@ def get_telegram_listeners() -> list[TelegramBotListener]:
     global _telegram_listeners
     if _telegram_listeners is None:
         listeners: list[TelegramBotListener] = []
-        if settings.telegram_enabled:
+        if settings.telegram_enabled and settings.telegram_primary_listener_enabled:
             listeners.append(TelegramBotListener(settings.telegram_primary_bot))
+        elif settings.telegram_enabled:
+            logger.info(
+                "Primary Telegram listener disabled "
+                "(TELEGRAM_PRIMARY_LISTENER_ENABLED=false); send-only mode. "
+                "The scheduler still delivers; another process owns getUpdates."
+            )
         for bot in settings.telegram_bots:
             listeners.append(TelegramBotListener(bot))
         _telegram_listeners = listeners

--- a/config/settings.py
+++ b/config/settings.py
@@ -1152,6 +1152,23 @@ class Settings(BaseSettings):
         return bool(self.telegram_bot_token and self.telegram_chat_id)
 
     @property
+    def telegram_primary_listener_enabled(self) -> bool:
+        """Whether to POLL the primary bot, as opposed to only sending as it.
+
+        Sending (sendMessage) and receiving (getUpdates) are separable, but
+        Telegram allows only ONE getUpdates consumer per bot token. When the
+        primary token belongs to a bot another process already polls — e.g. a
+        Hermes gateway that owns the Telegram surface — LifeOS must send as that
+        bot without polling it, or the two clients 409 each other.
+
+        Set TELEGRAM_PRIMARY_LISTENER_ENABLED=false in that case. The scheduler
+        still starts and still delivers; only the inbound listener is skipped.
+        """
+        import os
+        raw = os.getenv("TELEGRAM_PRIMARY_LISTENER_ENABLED", "true").strip().lower()
+        return raw not in ("false", "0", "no", "off")
+
+    @property
     def telegram_primary_bot(self) -> "TelegramBotConfig":
         """The default Telegram bot, driven by TELEGRAM_BOT_TOKEN/CHAT_ID.
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -1190,7 +1190,24 @@ class Settings(BaseSettings):
 
     @property
     def telegram_bots(self) -> list["TelegramBotConfig"]:
-        """Specialized Telegram bots beyond the primary, from the registry file.
+        """Specialized Telegram bots that can actually run — token env set.
+
+        Thin wrapper over :meth:`_load_registry_bots`; see it for the registry
+        format. Callers that start Telegram listeners want this one, since a
+        listener without a token is meaningless.
+        """
+        return self._load_registry_bots(require_token=True)
+
+    def _load_registry_bots(self, require_token: bool = True) -> list["TelegramBotConfig"]:
+        """Specialized bots from the registry file.
+
+        ``require_token=True`` (the default, used by Telegram listeners) drops
+        entries whose token env var is unset. ``require_token=False`` keeps
+        them, for surfaces that do not use Telegram at all — the web /chat UI
+        and voice list personas via :meth:`list_http_personas`, and requiring a
+        Telegram bot token to see a persona there was a coupling bug: it forced
+        creating a bot you never intend to message just to use a persona in the
+        browser.
 
         Each registry entry names an env var holding the bot's token; entries
         whose token is unset are skipped (logged) so a fresh clone with no extra
@@ -1230,7 +1247,7 @@ class Settings(BaseSettings):
                 logger.warning(f"Skipping duplicate/reserved Telegram bot name: {name!r}")
                 continue
             token = (env.get(entry.get("token_env", "")) or "").strip()
-            if not token:
+            if not token and require_token:
                 logger.info(
                     f"Telegram bot '{name}' skipped: env var "
                     f"{entry.get('token_env')!r} is unset"
@@ -1264,9 +1281,10 @@ class Settings(BaseSettings):
     def list_http_personas(self) -> list["PersonaInfo"]:
         """Chat personas visible to HTTP clients (web, voice/whisper-relay).
 
-        Returns the primary persona plus every configured specialized bot from
-        the registry whose token env is set (``telegram_bots`` already drops the
-        unset ones). No secrets are exposed. The primary persona and any
+        Returns the primary persona plus every specialized persona in the
+        registry, whether or not it has a Telegram bot token. These surfaces do
+        not use Telegram, so a token is irrelevant to them; gating on one meant
+        a persona was invisible in the browser until you created a bot for it. No secrets are exposed. The primary persona and any
         orchestrating bot (``orchestrates: true``, e.g. the doctor self-repair
         bot) advertise ``handoff``/``agent`` capabilities; pure-chat specialized
         bots advertise none. Adding a registry entry + its token env var surfaces
@@ -1283,7 +1301,7 @@ class Settings(BaseSettings):
             capabilities=list(ORCHESTRATOR_PERSONA_CAPABILITIES),
             orchestrates=self.persona_orchestrates("primary"),
         )]
-        for bot in self.telegram_bots:
+        for bot in self._load_registry_bots(require_token=False):
             personas.append(PersonaInfo(
                 id=bot.name,
                 label=bot.label or bot.name.capitalize(),

--- a/config/settings.py
+++ b/config/settings.py
@@ -17,7 +17,23 @@ logger = logging.getLogger(__name__)
 
 # Registry of specialized Telegram bots (beyond the primary). Committed, no
 # secrets — each entry references the env var holding its token.
+# The tracked file is a TEMPLATE listing every persona this repo ships.
+# Each install selects its own subset in an untracked local override, so one
+# person enabling "finance" doesn't commit that choice for everyone, and a
+# `git pull` never clobbers a local selection. Local wins entirely when present
+# (it replaces the template rather than merging, so removing an entry there
+# actually removes it).
 _TELEGRAM_BOTS_FILE = Path("config/telegram_bots.json")
+_TELEGRAM_BOTS_LOCAL_FILE = Path("config/telegram_bots.local.json")
+
+
+def _telegram_bots_source() -> "Path | None":
+    """Which registry file to read: the local override, else the template."""
+    if _TELEGRAM_BOTS_LOCAL_FILE.exists():
+        return _TELEGRAM_BOTS_LOCAL_FILE
+    if _TELEGRAM_BOTS_FILE.exists():
+        return _TELEGRAM_BOTS_FILE
+    return None
 _PRIMARY_PERSONA_FILE = Path("config/personas/primary.md")
 _BOT_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
 
@@ -1219,15 +1235,16 @@ class Settings(BaseSettings):
         bot out of Hermes permanently. An unrecognized value falls back to
         ``"hermes"`` with a warning, same pattern as an invalid bot name.
         """
-        if not _TELEGRAM_BOTS_FILE.exists():
+        source = _telegram_bots_source()
+        if source is None:
             return []
         try:
-            entries = json.loads(_TELEGRAM_BOTS_FILE.read_text())
+            entries = json.loads(source.read_text())
         except (json.JSONDecodeError, OSError) as e:
-            logger.warning(f"Could not read {_TELEGRAM_BOTS_FILE}: {e}")
+            logger.warning(f"Could not read {source}: {e}")
             return []
         if not isinstance(entries, list):
-            logger.warning(f"{_TELEGRAM_BOTS_FILE} must contain a JSON list, ignoring")
+            logger.warning(f"{source} must contain a JSON list, ignoring")
             return []
 
         # pydantic-settings loads .env into the model but does NOT export to

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -697,3 +697,17 @@ def reset_ml_singletons_at_session_end():
         reset_ml_singletons()
     except ImportError:
         pass
+
+
+@pytest.fixture(autouse=True)
+def _no_local_telegram_bots_override(tmp_path_factory, monkeypatch):
+    """Keep a real config/telegram_bots.local.json out of the test run.
+
+    The registry loader prefers the untracked local override over the tracked
+    template. Tests monkeypatch ``_TELEGRAM_BOTS_FILE`` (the template), so on a
+    machine that actually has a local override the loader would read that
+    instead of the fixture and the tests would depend on developer state.
+    Point the local path at somewhere that cannot exist.
+    """
+    missing = tmp_path_factory.mktemp("no-local-bots") / "telegram_bots.local.json"
+    monkeypatch.setattr("config.settings._TELEGRAM_BOTS_LOCAL_FILE", missing, raising=False)

--- a/tests/test_journal_persona.py
+++ b/tests/test_journal_persona.py
@@ -53,7 +53,12 @@ class TestRegistry:
         # Pure chat, like fitness/therapist/finance — not an orchestrator.
         assert not journal.get("orchestrates", False)
 
-    def test_omitted_without_token_present_with_token(self, tmp_path, monkeypatch):
+    def test_listed_for_http_with_or_without_token(self, tmp_path, monkeypatch):
+        """Journal is reachable in /chat whether or not a Telegram bot exists.
+
+        Only the Telegram listener needs a token; requiring one to see the
+        persona in a browser meant creating a bot you never intend to message.
+        """
         reg = tmp_path / "bots.json"
         reg.write_text(json.dumps([
             {"name": "journal", "token_env": "TG_JOURNAL", "persona_file": str(_PERSONA_PATH)},
@@ -61,10 +66,12 @@ class TestRegistry:
         monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
         monkeypatch.delenv("TG_JOURNAL", raising=False)
         from config.settings import settings
-        assert "journal" not in [p.id for p in settings.list_http_personas()]
+        assert "journal" in [p.id for p in settings.list_http_personas()]
+        assert [b.name for b in settings.telegram_bots] == []  # no token -> no listener
 
         monkeypatch.setenv("TG_JOURNAL", "tok")
         assert "journal" in [p.id for p in settings.list_http_personas()]
+        assert [b.name for b in settings.telegram_bots] == ["journal"]
 
     def test_pure_chat_advertises_no_capabilities(self, tmp_path, monkeypatch):
         reg = tmp_path / "bots.json"

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -60,7 +60,13 @@ class TestListHttpPersonas:
         assert fitness.capabilities == []  # specialized bots are pure chat
         assert fitness.orchestrates is False
 
-    def test_unset_token_bot_omitted(self, tmp_path, monkeypatch):
+    def test_unset_token_bot_still_listed_for_http(self, tmp_path, monkeypatch):
+        """A persona with no Telegram token is still usable in /chat and voice.
+
+        Those surfaces never speak Telegram, so a bot token is irrelevant to
+        them. Telegram listeners still require one — asserted below — because a
+        listener without a token cannot poll.
+        """
         reg = _registry(tmp_path, [
             {"name": "fitness", "token_env": "TG_FIT"},
             {"name": "therapist", "token_env": "TG_THER"},
@@ -68,6 +74,42 @@ class TestListHttpPersonas:
         monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", reg)
         monkeypatch.setenv("TG_FIT", "tok")
         monkeypatch.delenv("TG_THER", raising=False)
+        from config.settings import settings
+
+        # HTTP surfaces: both personas available.
+        assert [p.id for p in settings.list_http_personas()] == [
+            "primary", "fitness", "therapist",
+        ]
+        # Telegram listeners: only the one that can actually run.
+        assert [b.name for b in settings.telegram_bots] == ["fitness"]
+
+    def test_local_override_replaces_template(self, tmp_path, monkeypatch):
+        """An untracked local registry wins over the tracked template.
+
+        The template is repo-wide; the local file is this install's selection.
+        It REPLACES rather than merges, so dropping an entry there actually
+        drops it — otherwise you could never disable a persona the template
+        ships.
+        """
+        template = _registry(tmp_path, [
+            {"name": "fitness", "token_env": "TG_FIT"},
+            {"name": "therapist", "token_env": "TG_THER"},
+        ])
+        local = tmp_path / "telegram_bots.local.json"
+        local.write_text(json.dumps([{"name": "journal", "token_env": "TG_JOURNAL"}]))
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", template)
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_LOCAL_FILE", local)
+        from config.settings import settings
+
+        ids = [p.id for p in settings.list_http_personas()]
+        assert ids == ["primary", "journal"]
+        assert "fitness" not in ids and "therapist" not in ids
+
+    def test_template_used_when_no_local_override(self, tmp_path, monkeypatch):
+        template = _registry(tmp_path, [{"name": "fitness", "token_env": "TG_FIT"}])
+        missing = tmp_path / "does-not-exist.local.json"
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_FILE", template)
+        monkeypatch.setattr("config.settings._TELEGRAM_BOTS_LOCAL_FILE", missing)
         from config.settings import settings
 
         assert [p.id for p in settings.list_http_personas()] == ["primary", "fitness"]


### PR DESCRIPTION
Three related fixes, each independently useful. Motivated by standing up a second LifeOS instance alongside a Hermes gateway that owns the Telegram surface.

## 1. Send-only mode for the primary bot (`1ca6879`)

Telegram permits exactly one `getUpdates` consumer per bot token, but sending and receiving are otherwise independent. LifeOS coupled them: configuring `TELEGRAM_BOT_TOKEN`/`CHAT_ID` both enabled the scheduler and started a poller.

That makes one setup impossible — pointing LifeOS at a bot another process already owns. The scheduler refuses to start without a delivery channel (`"Telegram not configured, scheduler not started"`), and a bot can only send into chats it belongs to, so a *second* bot cannot deliver into the first bot's conversation. Using the same token put two pollers on one bot, which 409 each other.

`TELEGRAM_PRIMARY_LISTENER_ENABLED=false` skips only the primary listener. The scheduler still starts and still delivers. **Defaults to true**, so existing deployments are unchanged.

## 2. Web/voice personas no longer require a Telegram token (`b4c076c`)

`list_http_personas()` serves `/chat` and voice, neither of which touches Telegram — but it iterated `telegram_bots`, which drops entries whose token env is unset. A persona stayed invisible in the browser until you created a Telegram bot for it and never messaged it.

```
telegram_bots      -> _load_registry_bots(require_token=True)   # listeners need a token
list_http_personas -> _load_registry_bots(require_token=False)  # these surfaces don't
```

## 3. Per-install persona selection (`606556e`)

`config/telegram_bots.json` is tracked, so the enabled persona set was a repo-wide commit. Any install wanting a different subset had to either commit a personal choice for everyone or carry a permanent local diff that `git pull` fights.

The tracked file becomes a **template**. An install selects its subset in `config/telegram_bots.local.json` (gitignored), which **replaces** the template rather than merging — otherwise you could never disable a persona the template ships.

## Tests (`2203ed7`)

Two existing tests asserted the coupling removed in #2. Rewritten to assert the split explicitly — HTTP lists the persona, `telegram_bots` does not, in the same test — rather than weakened.

Also adds an autouse `conftest` guard pointing `_TELEGRAM_BOTS_LOCAL_FILE` at a path that cannot exist. Tests monkeypatch only the template, so on a machine with a real local override the loader would read developer state instead of the fixture. **CI has no local override, so this would have failed only on contributors' machines.**

## Verification

- Full suite: **4960 passed**, plus 79 browser tests.
- Behavior unchanged on an instance with all five bots configured: identical `telegram_bots` and HTTP persona list before/after.
- On an instance with no persona tokens, personas now appear in `/chat` instead of only `primary`.
- Send-only verified live: `0` listeners started, scheduler healthy, and a co-resident Hermes gateway kept polling without a 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFiGRh5fRJwxoTt4bSKjbu