### PR TITLE
feat(chat): intelligent conversation titling across all backends + persona subtitle

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -16,6 +16,7 @@ from api.services.vectorstore import VectorStore
 from api.services.hybrid_search import HybridSearch
 from api.services.synthesizer import get_synthesizer
 from api.services.conversation_store import get_store, generate_title
+from api.services.conversation_titler import schedule_retitle
 from api.services.calendar import CalendarService
 from api.services.drive import DriveService
 from api.services.gmail import GmailService
@@ -1314,6 +1315,14 @@ async def ask_stream(request: AskStreamRequest):
                 )
             await turn.emit(f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n")
         finally:
+            # Post-turn intelligent titling (one shared seam — see
+            # conversation_titler.py's module docstring). Idempotent and
+            # cheap-guarded, so calling it unconditionally here — regardless
+            # of which branch above produced the turn's assistant reply, or
+            # whether the turn errored/cancelled before persisting one — is
+            # safe: it only actually fires once, right after the user's 2nd
+            # message completes a turn.
+            schedule_retitle(conversation_id)
             get_turn_registry().pop(turn)
             await turn.close()
 

--- a/api/routes/hermes_proxy.py
+++ b/api/routes/hermes_proxy.py
@@ -65,6 +65,7 @@ from api.routes.chat import AskStreamRequest, journal_capture_gate, resolve_effe
 from api.services.agent_system_prompt import build_turn_context
 from api.services.chat_turns import TRUNCATION_MARKER, get_turn_registry, truncation_routing
 from api.services.conversation_store import get_store
+from api.services.conversation_titler import schedule_retitle
 from api.services.hermes_persona_thread_store import get_persona_thread_store
 from api.services.journal_capture import JOURNAL_PERSONA_ID
 from api.services.model_readout import record_hermes_chat_turn_model
@@ -574,6 +575,11 @@ class _HermesTurnPersister:
                     store.add_message(conv_id, "assistant", content, routing=routing)
                 except Exception:
                     logger.warning("hermes turn persistence: failed to save assistant reply", exc_info=True)
+                else:
+                    # Shared post-turn titling seam (conversation_titler.py) —
+                    # same call the native path and the voice tee make; no-ops
+                    # unless this is exactly the 2nd user message.
+                    schedule_retitle(conv_id)
 
         if self._usage_captured:
             try:

--- a/api/routes/voice.py
+++ b/api/routes/voice.py
@@ -33,6 +33,7 @@ from config.settings import settings
 
 from api.routes._proxy import TIMEOUT, filter_headers as _filter_headers
 from api.services.conversation_store import get_store
+from api.services.conversation_titler import schedule_retitle
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +179,11 @@ class _VoiceTurnPersister:
             store.add_message(conv_id, "assistant", response_text)
         except Exception:
             logger.warning("voice turn persistence: failed to save assistant reply", exc_info=True)
+        else:
+            # Shared post-turn titling seam (conversation_titler.py) — same
+            # call the native path and the Hermes proxy tee make; no-ops
+            # unless this is exactly the 2nd user message.
+            schedule_retitle(conv_id)
 
 
 async def _build_persister(request: Request) -> "_VoiceTurnPersister":

--- a/api/services/conversation_titler.py
+++ b/api/services/conversation_titler.py
@@ -1,0 +1,126 @@
+"""Post-turn conversation titling.
+
+Generates a conversation title from the actual content once the user's
+second message in a thread has been persisted, replacing whatever placeholder
+("New Conversation") or first-message-truncation title (`generate_title()` in
+conversation_store.py) currently sits there. This is the one shared seam for
+all three surfaces that persist chat turns — the native `/api/ask/stream`
+turn (api/routes/chat.py), the Hermes proxy tee (api/routes/hermes_proxy.py),
+and the #711 voice tee (api/routes/voice.py) — each calls `schedule_retitle()`
+once its turn is done, instead of three separate titling implementations.
+
+LLM selection mirrors `query_router.py` / `agent_viz_summary.py`: both use
+`llm_client.generate_text()`, which is pinned to the local llama-server
+(`_get_local_routing_client()`) regardless of `LIFEOS_LLM_BACKEND` — the
+established pattern in this codebase for cheap, auxiliary, non-user-facing
+LLM calls. That means titling works on a no-Anthropic-key install (local,
+remote, or Hermes-backend chat) and never touches the paid API path.
+Thinking is explicitly disabled (`enable_thinking=False`), matching
+query_router's routing call — titling is a short classification-like task
+that doesn't benefit from chain-of-thought and shouldn't pay for it.
+
+`schedule_retitle()` is fire-and-forget (`asyncio.create_task`) — the turn
+that calls it never awaits the title, so a slow or unavailable local LLM
+can't delay or break the chat response. Any failure is caught, logged once
+(no retry), and leaves the existing title in place.
+
+There's no rename feature in the UI or API today — a conversation's title is
+only ever system-set (the truncation default, or this module). So "never
+retitle a manual rename" reduces to "retitle exactly once": the guard below
+fires only when the conversation has *exactly* 2 user messages, checked fresh
+against the store on every call. Calling `schedule_retitle()` after every
+turn — even ones that persisted nothing new, even repeatedly — is therefore
+safe and idempotent; it silently no-ops once the count moves past 2.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+
+from api.services.conversation_store import format_conversation_history, get_store
+from api.services.llm_client import generate_text
+
+logger = logging.getLogger(__name__)
+
+MAX_TITLE_LENGTH = 50
+
+_TITLE_PROMPT = """Based on this conversation, write a short, specific title that \
+captures what it's actually about.
+
+{transcript}
+
+Rules:
+- Plain text only. No quotes, no markdown, no trailing punctuation.
+- {max_len} characters or fewer.
+- Describe the specific topic — never a generic label like "Conversation" or "Chat".
+
+Respond with the title text only, nothing else."""
+
+
+def schedule_retitle(conversation_id: str | None) -> None:
+    """Fire-and-forget entry point for the three persisting paths.
+
+    No-op for a missing id, and no-op outside a running event loop (all three
+    call sites are async route/tee handlers, so this only guards test/script
+    contexts that call in synchronously).
+    """
+    if not conversation_id:
+        return
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    asyncio.create_task(_maybe_retitle(conversation_id))
+
+
+async def _maybe_retitle(conversation_id: str) -> None:
+    try:
+        store = get_store()
+        messages = store.get_messages(conversation_id)
+        user_message_count = sum(1 for m in messages if m.role == "user")
+        # Short/trivial conversations (fewer than 2 user messages) keep
+        # whatever title they already have. Exactly 2 (not >=2) makes this
+        # the one-time intelligent pass rather than a re-title on every turn.
+        if user_message_count != 2:
+            return
+
+        transcript = format_conversation_history(messages, max_tokens=1000)
+        if not transcript:
+            return
+
+        prompt = _TITLE_PROMPT.format(transcript=transcript, max_len=MAX_TITLE_LENGTH)
+        text = await generate_text(
+            prompt, max_tokens=80, temperature=0.3, timeout=20.0,
+            enable_thinking=False,
+        )
+        title = sanitize_title(text)
+        if title:
+            store.update_title(conversation_id, title)
+    except Exception as exc:  # noqa: BLE001 -- never break/delay the turn over a title
+        logger.warning("conversation titling failed for %s: %s", conversation_id, exc)
+
+
+def sanitize_title(text: str) -> str:
+    """Clean a raw model response into a plain-text title.
+
+    Strips surrounding quotes/markdown emphasis a model might add despite the
+    prompt, collapses whitespace, drops trailing punctuation, and truncates
+    at a word boundary to `MAX_TITLE_LENGTH`. Returns "" for empty/junk input
+    so the caller can treat that as "keep the existing title".
+    """
+    title = (text or "").strip()
+    # A model occasionally answers "Title: ..." despite the prompt asking
+    # for bare text -- strip that one common leading-label failure mode
+    # before the general quote/markdown stripping below.
+    title = re.sub(r"(?i)^title\s*[:\-]\s*", "", title)
+    title = title.strip("\"'`*_“”‘’")
+    title = re.sub(r"\s+", " ", title).strip()
+    title = title.rstrip(".!?,;: ")
+    if len(title) > MAX_TITLE_LENGTH:
+        truncated = title[:MAX_TITLE_LENGTH]
+        last_space = truncated.rfind(" ")
+        if last_space > MAX_TITLE_LENGTH // 2:
+            truncated = truncated[:last_space]
+        title = truncated.strip()
+    return title

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -356,6 +356,38 @@ def _isolate_conversation_store_db(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _stub_conversation_titler(monkeypatch):
+    """Stop an ordinary turn-completion test from firing a real background
+    call to the local LLM.
+
+    ``conversation_titler.schedule_retitle()`` is wired into the `finally` of
+    every native chat turn (``api/routes/chat.py``) and the Hermes/voice
+    persistence tees (``api/routes/hermes_proxy.py``, ``api/routes/voice.py``)
+    — unlike ``query_router``/``agent_viz_summary`` (mocked per-test, called
+    from a handful of call sites), this fires from every turn-completing test
+    in the whole suite whenever a conversation happens to reach exactly 2
+    user messages. There's no Anthropic-style host guard for the local
+    routing LLM it calls (``generate_text`` → the local llama-server), so an
+    unmocked test would either hang/slow down waiting on a real model or
+    leave a dangling ``asyncio.create_task`` if none is running. Each of the
+    three call sites imported the function by name (``from
+    api.services.conversation_titler import schedule_retitle``), so it's
+    patched at each of those three module namespaces, not just the source
+    module. Tests that actually exercise titling behavior — see
+    tests/test_conversation_titler.py — call ``conversation_titler``'s
+    functions directly instead of relying on this default.
+    """
+    noop = lambda conversation_id: None  # noqa: E731
+    import api.routes.chat as chat_mod
+    import api.routes.hermes_proxy as hermes_mod
+    import api.routes.voice as voice_mod
+
+    monkeypatch.setattr(chat_mod, "schedule_retitle", noop)
+    monkeypatch.setattr(hermes_mod, "schedule_retitle", noop)
+    monkeypatch.setattr(voice_mod, "schedule_retitle", noop)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_gmail_draft_ledger(tmp_path, monkeypatch):
     """Stop tests from opening (and writing to) the production Gmail draft
     send-gate ledger (#588).

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -189,6 +189,40 @@ class TestBackendTaggingField:
         assert tagged_conv.backend == "hermes"
 
 
+class TestConversationTitlingSeam:
+    """Verifies `/api/ask/stream` invokes the shared post-turn titling seam
+    (api/services/conversation_titler.py) once the turn finishes — the
+    seam's own behavior (not-before-2nd-message, sanitization,
+    failure-safety) is unit-tested directly in test_conversation_titler.py;
+    this only pins that the native chat path calls it, with the turn's own
+    conversation id, alongside (not instead of) the pre-existing
+    first-message truncation title (`generate_title()`)."""
+
+    @pytest.fixture
+    def client(self):
+        return TestClient(app)
+
+    def test_schedule_retitle_called_with_the_turns_conversation_id(self, client):
+        with patch('api.routes.chat.VectorStore') as mock_vs, \
+                patch('api.routes.chat.get_synthesizer') as mock_synth, \
+                patch('api.routes.chat.schedule_retitle') as mock_retitle:
+            mock_vs.return_value.search.return_value = []
+
+            async def mock_stream(*args, **kwargs):
+                yield "Test response"
+            mock_synth.return_value.stream_response = mock_stream
+
+            response = client.post("/api/ask/stream", json={"question": "test question"})
+
+        assert response.status_code == 200
+        import re
+        m = re.search(r'"conversation_id": "([^"]+)"', response.text)
+        assert m, f"no conversation_id event in: {response.text!r}"
+        conv_id = m.group(1)
+
+        mock_retitle.assert_called_once_with(conv_id)
+
+
 class TestChatRequestValidation:
     """Test request validation for chat endpoints."""
 

--- a/tests/test_conversation_persona_subtitle_ui_browser.py
+++ b/tests/test_conversation_persona_subtitle_ui_browser.py
@@ -1,0 +1,150 @@
+"""Browser test for the conversation sidebar's persona subtitle suffix.
+
+Drives `web/chat/conversations.js`'s `renderConversations()` — a conversation
+row's date subtitle (e.g. "Aug 25") gains a " · (Persona Label)" suffix when
+the conversation's `persona_id` isn't the default ("primary"), resolved from
+`config.personas` (loaded from `/api/personas` at boot, the same source the
+persona picker itself renders from — see `web/chat/persona.js`), never a
+hardcoded id→label map.
+
+Self-contained like tests/test_mode_pill_ui_browser.py: serves `web/` itself
+on an ephemeral port and stubs every `/api/` call, so it carries no
+`requires_server` marker and runs at pre-push (`browser and not
+requires_server`) — the only gate that catches a `web/` JS regression before
+it reaches main.
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+
+class _ChatHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the chat SPA the way api/main.py does: `/chat` is index.html and
+    the module tree hangs off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/chat", "/"):
+            return str(WEB_DIR / "index.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def chat_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _ChatHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _conversations_payload():
+    return {
+        "conversations": [
+            {
+                "id": "conv-primary",
+                "title": "Weekend plans",
+                "created_at": "2026-08-25T10:00:00",
+                "updated_at": "2026-08-25T10:05:00",
+                "message_count": 4,
+                "persona_id": "primary",
+                "backend": "lifeos",
+            },
+            {
+                "id": "conv-therapist",
+                "title": "Check-in",
+                "created_at": "2026-08-25T09:00:00",
+                "updated_at": "2026-08-25T09:05:00",
+                "message_count": 4,
+                "persona_id": "therapist",
+                "backend": "lifeos",
+            },
+        ]
+    }
+
+
+def _open_chat(page: Page, base_url, *, personas_payload):
+    def handle_api(route):
+        req = route.request
+        path = req.url.split("?", 1)[0]
+        if path.endswith("/api/personas"):
+            return route.fulfill(
+                status=200, content_type="application/json",
+                body=json.dumps(personas_payload))
+        if path.endswith("/api/conversations"):
+            return route.fulfill(
+                status=200, content_type="application/json",
+                body=json.dumps(_conversations_payload()))
+        return route.fulfill(status=200, content_type="application/json", body=json.dumps({}))
+
+    page.route("**/api/**", handle_api)
+    page.goto(f"{base_url}/chat")
+    page.wait_for_selector("#conversationsList .conversation-item")
+
+
+def _date_text_for(page: Page, title_substring: str) -> str:
+    item = page.locator(".conversation-item", has_text=title_substring)
+    return item.locator(".conversation-date").inner_text()
+
+
+class TestConversationPersonaSubtitle:
+    PERSONAS = {
+        "personas": [
+            {"id": "primary", "label": "Primary", "capabilities": [], "orchestrates": False},
+            {"id": "therapist", "label": "Therapist", "capabilities": [], "orchestrates": False},
+        ]
+    }
+
+    def test_primary_persona_conversation_has_no_suffix(self, page: Page, chat_base_url):
+        _open_chat(page, chat_base_url, personas_payload=self.PERSONAS)
+        date_text = _date_text_for(page, "Weekend plans")
+        assert "·" not in date_text
+        assert "(" not in date_text
+
+    def test_non_primary_persona_conversation_shows_persona_suffix(self, page: Page, chat_base_url):
+        _open_chat(page, chat_base_url, personas_payload=self.PERSONAS)
+        date_text = _date_text_for(page, "Check-in")
+        assert date_text.endswith("· (Therapist)")
+        # The date portion itself is preserved (appended to, not replaced) --
+        # whatever formatDate() produced for this fixed-in-the-past
+        # timestamp, relative to the real "now" the test runs at.
+        date_part = date_text[: -len("· (Therapist)")].strip()
+        assert date_part  # non-empty: formatDate()'s own output is untouched
+
+    def test_persona_label_resolved_from_loaded_personas_not_hardcoded(self, page: Page, chat_base_url):
+        """The suffix text comes from whatever label `/api/personas` served,
+        not a hardcoded id→label map in the JS — renaming the persona's label
+        upstream changes the rendered suffix with no client-side changes."""
+        renamed = {
+            "personas": [
+                {"id": "primary", "label": "Primary", "capabilities": [], "orchestrates": False},
+                {"id": "therapist", "label": "Wellness Coach", "capabilities": [], "orchestrates": False},
+            ]
+        }
+        _open_chat(page, chat_base_url, personas_payload=renamed)
+        date_text = _date_text_for(page, "Check-in")
+        assert date_text.endswith("· (Wellness Coach)")
+
+    def test_unknown_persona_id_falls_back_to_raw_id(self, page: Page, chat_base_url):
+        """A persona_id absent from the loaded personas list (e.g. a persona
+        removed from config after the conversation was created) still renders
+        something useful instead of silently dropping the suffix."""
+        empty_personas = {"personas": [{"id": "primary", "label": "Primary", "capabilities": [], "orchestrates": False}]}
+        _open_chat(page, chat_base_url, personas_payload=empty_personas)
+        date_text = _date_text_for(page, "Check-in")
+        assert date_text.endswith("· (therapist)")

--- a/tests/test_conversation_titler.py
+++ b/tests/test_conversation_titler.py
@@ -1,0 +1,183 @@
+"""Unit tests for the shared post-turn conversation titling seam
+(api/services/conversation_titler.py) — the one titling implementation
+shared by the native chat turn (api/routes/chat.py), the Hermes proxy tee
+(api/routes/hermes_proxy.py), and the #711 voice tee (api/routes/voice.py).
+
+Wiring — that each of those three surfaces actually calls
+``schedule_retitle()`` at the right point — is covered by call-site tests in
+test_chat_api.py / test_hermes_proxy.py / test_voice_proxy.py. This file
+covers the shared logic itself: the not-before-2nd-message gate,
+failure-safety, and title sanitization — using a fake LLM client
+(monkeypatched ``generate_text``) rather than a real local model.
+"""
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.services import conversation_titler as titler
+from api.services.conversation_store import ConversationStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def store(tmp_path):
+    return ConversationStore(db_path=str(tmp_path / "conversations.db"))
+
+
+def _seed(store, conv_id, *, user_messages, persona_id="primary"):
+    """Create a conversation with the placeholder title and alternating
+    user/assistant messages, mirroring a real turn-by-turn thread."""
+    store.create_conversation(conv_id=conv_id, persona_id=persona_id)
+    for i, text in enumerate(user_messages):
+        store.add_message(conv_id, "user", text)
+        store.add_message(conv_id, "assistant", f"reply {i}")
+
+
+class TestNotBeforeSecondMessage:
+    """Short/trivial conversations keep their current title; the intelligent
+    pass fires exactly once, at the 2nd user message — never again."""
+
+    async def test_no_retitle_with_zero_or_one_user_messages(self, store, monkeypatch):
+        mock_generate = AsyncMock(return_value="Some Title")
+        monkeypatch.setattr(titler, "generate_text", mock_generate)
+        monkeypatch.setattr(titler, "get_store", lambda: store)
+
+        store.create_conversation(conv_id="empty")
+        await titler._maybe_retitle("empty")
+        mock_generate.assert_not_called()
+
+        _seed(store, "one-turn", user_messages=["hi there"])
+        await titler._maybe_retitle("one-turn")
+        mock_generate.assert_not_called()
+        assert store.get_conversation("one-turn").title == "New Conversation"
+
+    async def test_retitles_at_exactly_two_user_messages(self, store, monkeypatch):
+        mock_generate = AsyncMock(return_value="Weekend Trip Planning")
+        monkeypatch.setattr(titler, "generate_text", mock_generate)
+        monkeypatch.setattr(titler, "get_store", lambda: store)
+        _seed(store, "c1", user_messages=["where should we go", "how about the coast"])
+
+        await titler._maybe_retitle("c1")
+
+        mock_generate.assert_awaited_once()
+        assert store.get_conversation("c1").title == "Weekend Trip Planning"
+
+    async def test_no_retitle_past_two_user_messages(self, store, monkeypatch):
+        """The 3rd+ user message must not re-trigger — there's no rename
+        feature to defend the title from being clobbered otherwise (see the
+        module docstring), so "exactly once" is the whole guard."""
+        mock_generate = AsyncMock(return_value="Should Not Be Used")
+        monkeypatch.setattr(titler, "generate_text", mock_generate)
+        monkeypatch.setattr(titler, "get_store", lambda: store)
+        _seed(store, "c1", user_messages=["one", "two", "three"])
+
+        await titler._maybe_retitle("c1")
+
+        mock_generate.assert_not_called()
+        assert store.get_conversation("c1").title == "New Conversation"
+
+    async def test_prompt_includes_both_user_and_assistant_content(self, store, monkeypatch):
+        mock_generate = AsyncMock(return_value="A Title")
+        monkeypatch.setattr(titler, "generate_text", mock_generate)
+        monkeypatch.setattr(titler, "get_store", lambda: store)
+        _seed(store, "c1", user_messages=["plan a trip to the coast", "book the coastal inn"])
+
+        await titler._maybe_retitle("c1")
+
+        prompt = mock_generate.await_args.args[0]
+        assert "plan a trip to the coast" in prompt
+        assert "book the coastal inn" in prompt
+        assert "reply 0" in prompt
+
+
+class TestFailureSafety:
+    async def test_llm_failure_keeps_existing_title_and_logs_once(self, store, monkeypatch, caplog):
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("local LLM unavailable")
+
+        monkeypatch.setattr(titler, "generate_text", _boom)
+        monkeypatch.setattr(titler, "get_store", lambda: store)
+        _seed(store, "c1", user_messages=["a", "b"])
+
+        with caplog.at_level(logging.WARNING, logger=titler.logger.name):
+            await titler._maybe_retitle("c1")
+
+        assert store.get_conversation("c1").title == "New Conversation"
+        failures = [r for r in caplog.records if "conversation titling failed" in r.message]
+        assert len(failures) == 1  # logged once, no retry storm
+
+    async def test_timeout_is_caught_like_any_other_failure(self, store, monkeypatch):
+        async def _timeout(*args, **kwargs):
+            raise asyncio.TimeoutError()
+
+        monkeypatch.setattr(titler, "generate_text", _timeout)
+        monkeypatch.setattr(titler, "get_store", lambda: store)
+        _seed(store, "c1", user_messages=["a", "b"])
+
+        await titler._maybe_retitle("c1")  # must not raise
+
+        assert store.get_conversation("c1").title == "New Conversation"
+
+    async def test_empty_llm_response_keeps_existing_title(self, store, monkeypatch):
+        monkeypatch.setattr(titler, "generate_text", AsyncMock(return_value="   "))
+        monkeypatch.setattr(titler, "get_store", lambda: store)
+        _seed(store, "c1", user_messages=["a", "b"])
+
+        await titler._maybe_retitle("c1")
+
+        assert store.get_conversation("c1").title == "New Conversation"
+
+    async def test_missing_conversation_does_not_raise(self, store, monkeypatch):
+        monkeypatch.setattr(titler, "get_store", lambda: store)
+        await titler._maybe_retitle("does-not-exist")
+
+
+class TestSanitizeTitle:
+    @pytest.mark.parametrize("raw,expected", [
+        ('"Weekend Getaway Plans"', "Weekend Getaway Plans"),
+        ("**Budget Review**", "Budget Review"),
+        ("Fixing the login bug.", "Fixing the login bug"),
+        ("Trip   planning   for    June", "Trip planning for June"),
+        ("`docker compose setup`", "docker compose setup"),
+        ("Title: Weekend Trip Planning", "Weekend Trip Planning"),
+        ("title - Budget Review", "Budget Review"),
+        ("Refactor the parser?", "Refactor the parser"),
+    ])
+    def test_strips_quotes_markdown_and_trailing_punctuation(self, raw, expected):
+        assert titler.sanitize_title(raw) == expected
+
+    def test_truncates_to_max_length_at_word_boundary(self):
+        raw = "This is a very long title that definitely exceeds the fifty character budget we allow"
+        result = titler.sanitize_title(raw)
+        assert len(result) <= titler.MAX_TITLE_LENGTH
+        assert not result.endswith(" ")
+        assert raw.startswith(result)  # truncation, not rewriting
+
+    def test_empty_or_junk_input_returns_empty_string(self):
+        assert titler.sanitize_title("") == ""
+        assert titler.sanitize_title("   ") == ""
+        assert titler.sanitize_title('""') == ""
+        assert titler.sanitize_title(None) == ""
+
+
+class TestScheduleRetitle:
+    def test_noop_for_missing_conversation_id(self):
+        titler.schedule_retitle(None)
+        titler.schedule_retitle("")
+
+    def test_noop_outside_a_running_event_loop(self):
+        # Plain (non-async) test function -- no event loop exists here at
+        # all, exercising the RuntimeError guard directly.
+        titler.schedule_retitle("some-conv-id")  # must not raise
+
+    async def test_schedules_a_background_task_inside_a_running_loop(self, monkeypatch):
+        called = AsyncMock()
+        monkeypatch.setattr(titler, "_maybe_retitle", called)
+
+        titler.schedule_retitle("conv-1")
+        await asyncio.sleep(0)  # let the scheduled task actually run
+
+        called.assert_awaited_once_with("conv-1")

--- a/tests/test_hermes_proxy.py
+++ b/tests/test_hermes_proxy.py
@@ -975,6 +975,27 @@ async def test_persists_turn_and_relay_stays_byte_identical(persist_proxy_client
     ]
 
 
+async def test_persisted_turn_schedules_retitle(persist_proxy_client, hermes_store, monkeypatch):
+    """The shared post-turn titling seam (api/services/conversation_titler.py,
+    tested directly in test_conversation_titler.py) is wired into this
+    surface too -- `finalize()` calls it right after the assistant reply is
+    persisted. conftest's `_stub_conversation_titler` autouse fixture
+    defaults this to a no-op for the whole suite; override it here with a
+    spy to prove the call site actually fires, with the right conversation
+    id, rather than asserting on its (separately-tested) internal behavior.
+    """
+    from unittest.mock import Mock
+    mock_retitle = Mock()
+    monkeypatch.setattr(hp, "schedule_retitle", mock_retitle)
+
+    resp = await persist_proxy_client.post(
+        "/api/hermes/ask/stream", json={"question": "hi there", "persona_id": "primary"},
+    )
+    assert resp.status_code == 200
+
+    mock_retitle.assert_called_once_with("hermes-conv-1")
+
+
 async def test_persists_with_the_selected_persona(persist_proxy_client, hermes_store, tmp_path, monkeypatch):
     persona_file = tmp_path / "fitness.md"
     persona_file.write_text("FITNESS BODY")

--- a/tests/test_voice_proxy.py
+++ b/tests/test_voice_proxy.py
@@ -303,6 +303,31 @@ async def test_hermes_backend_turn_persists_transcript_and_response(persist_prox
     ]
 
 
+async def test_persisted_turn_schedules_retitle(persist_proxy_client, voice_store, monkeypatch):
+    """The shared post-turn titling seam (api/services/conversation_titler.py,
+    tested directly in test_conversation_titler.py) is wired into this tee
+    too -- `finalize()` calls it right after the assistant reply is
+    persisted. conftest's `_stub_conversation_titler` autouse fixture
+    defaults this to a no-op for the whole suite; override it here with a
+    spy to prove the call site actually fires, with the right conversation
+    id, rather than asserting on its (separately-tested) internal behavior.
+    """
+    from unittest.mock import Mock
+    mock_retitle = Mock()
+    monkeypatch.setattr(voice_module, "schedule_retitle", mock_retitle)
+
+    data = {
+        "backend": "hermes", "persona_id": "fitness", "conversation_id": "voice-conv-1",
+        "transcript_out": "what's my next workout", "response_out": "leg day, per your plan",
+    }
+    resp = await persist_proxy_client.post(
+        "/api/voice/turn/stream", files=_voice_turn_files(), data=data
+    )
+    assert resp.status_code == 200
+
+    mock_retitle.assert_called_once_with("voice-conv-1")
+
+
 async def test_hermes_backend_multi_turn_groups_into_one_conversation(persist_proxy_client, voice_store):
     """Two turns of the same voice session (same `done.conversation_id`)
     group into ONE conversation, matching the Hermes text route's grouping

--- a/web/chat/conversations.js
+++ b/web/chat/conversations.js
@@ -146,6 +146,22 @@ async function filterConversationsAsync(searchTerm) {
   renderConversations(allMatches);
 }
 
+// Persona suffix for the sidebar's date subtitle, e.g. "Aug 25 · (Therapist)"
+// — appended only for a conversation whose persona isn't the default
+// ("primary"). Resolves the display name from `config.personas` (loaded at
+// boot by persona.js's loadPersonas(), same source the persona picker
+// itself renders from) rather than a hardcoded name map, so a renamed or
+// newly-added persona picks up automatically. Falls back to the raw
+// persona_id if the id isn't (or isn't yet) in that list — e.g. a persona
+// removed from config after the conversation was created.
+function personaSubtitleSuffix(conv) {
+  const personaId = conv.persona_id;
+  if (!personaId || personaId === 'primary') return '';
+  const persona = (config.personas || []).find(p => p.id === personaId);
+  const label = persona ? persona.label : personaId;
+  return ` · (${label})`;
+}
+
 function renderConversations(conversations, isPartial = false) {
   const { conversationsList } = elements;
   if (conversations.length === 0 && !isPartial) {
@@ -162,7 +178,7 @@ function renderConversations(conversations, isPartial = false) {
                     <div class="conversation-icon">💬</div>
                     <div class="conversation-info">
                         <div class="conversation-title" title="${escapeHtml(conv.title || 'New conversation')}">${escapeHtml(conv.title || 'New conversation')}</div>
-                        <div class="conversation-date">${formatDate(conv.updated_at)}</div>
+                        <div class="conversation-date">${escapeHtml(formatDate(conv.updated_at) + personaSubtitleSuffix(conv))}</div>
                     </div>
                     <button class="conversation-delete" onclick="event.stopPropagation(); deleteConversation('${conv.id}')" title="Delete">✕</button>
                 </div>


### PR DESCRIPTION
Two operator-requested /chat improvements.

**Intelligent titling** — after the user's 2nd message, one shared seam (`api/services/conversation_titler.py`) generates a content-based title, replacing the "New Conversation" placeholder. Wired into all three persisting paths (native `chat.py`, Hermes proxy, #711 voice tee) — previously only the native path titled, so Hermes conversations stayed "New Conversation" (the reported bug). Fire-and-forget (never blocks the turn), fires exactly once (2-user-message guard), failure-safe (keeps existing title, logs once). LLM selection mirrors `query_router`/`agent_viz_summary` (local routing client). Known limitation on keyless installs with no local llama-server tracked as #716.

**Persona subtitle** — sidebar date line gains ` · (Persona)` for non-primary personas, resolved from `/api/personas` (no hardcoded names). No schema/backend change — `persona_id` already flowed through all three paths.

Tests: 21 titler unit + 3 wiring (one per surface) + 4 persona-subtitle browser tests. conftest autouse guard stubs the seam suite-wide so turn-completion tests don't fire real background LLM calls; wiring tests override with a spy.

Gate: full-scope run green — 4,983 passed, 0 failed (the 2 `test_pair_strength_migration` failures seen in one broad run are a pre-existing ordering flake — did not reproduce in my clean gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)