### PR TITLE
feat(voice): smart turn endpointing for auto mode (#718)

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -275,12 +275,21 @@ async def chat_config():
     never auto-escalated to. Unconfigured (no base URL/model/key) means
     `remote_model_available` is False and `remote_model_label` is "" — the
     picker hides the option and every existing path is unaffected.
+
+    `voice_endpoint_silence_ms`/`voice_endpoint_hard_cap_ms` (#718) drive
+    smart turn endpointing's VAD timing in auto-mode voice recording — see
+    `web/chat/voice.js`. `voice_endpoint_semantic` is reserved for a future
+    optional completeness classifier and is currently unwired on the client
+    (see `config/settings.py`'s `voice_endpoint_semantic` docstring).
     """
     return {
         "default_voice": bool(settings.chat_default_voice),
         "secure_url": (settings.tailnet_https_url or "").rstrip("/"),
         "remote_model_available": settings.remote_llm_configured,
         "remote_model_label": settings.remote_llm_label if settings.remote_llm_configured else "",
+        "voice_endpoint_silence_ms": settings.voice_endpoint_silence_ms,
+        "voice_endpoint_hard_cap_ms": settings.voice_endpoint_hard_cap_ms,
+        "voice_endpoint_semantic": bool(settings.voice_endpoint_semantic),
     }
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -202,6 +202,40 @@ class Settings(BaseSettings):
         description="whisper-relay voice gateway base URL"
     )
 
+    # Smart turn endpointing (#718): while auto-continue is on, the web client
+    # runs an energy VAD on the live recording stream and, after this much
+    # trailing silence following speech, POSTs the audio-so-far to the bare-STT
+    # route (POST /api/voice/transcribe) to check whether the user sounds done.
+    # Read by GET /api/chat/config -> web/chat/voice.js; both are pure client-
+    # side timing knobs, not used anywhere server-side.
+    voice_endpoint_silence_ms: int = Field(
+        default=1600,
+        alias="LIFEOS_VOICE_ENDPOINT_SILENCE_MS",
+        description="Trailing silence (ms) after speech in auto-mode voice recording "
+                    "before a candidate turn-endpoint check runs"
+    )
+    voice_endpoint_hard_cap_ms: int = Field(
+        default=3000,
+        alias="LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS",
+        description="Continuous silence (ms) in auto-mode voice recording that finalizes "
+                    "the turn regardless of the completeness check, so it can never hang"
+    )
+    # Reserved for an optional LLM completeness classifier for ambiguous
+    # candidate transcripts (no terminal punctuation, no trailing filler word
+    # either) — see isTranscriptComplete()'s doc comment in web/chat/voice.js.
+    # Not implemented yet: it would need a new server endpoint (a classify
+    # call analogous to conversation_titler.py's generate_text() use), which
+    # is out of scope for this change. Left False and unwired on the client —
+    # flipping it currently has no effect; the heuristic alone governs every
+    # completeness decision.
+    voice_endpoint_semantic: bool = Field(
+        default=False,
+        alias="LIFEOS_VOICE_ENDPOINT_SEMANTIC",
+        description="Reserved for an optional LLM completeness classifier for ambiguous "
+                    "auto-mode turn endpoints. Not implemented — has no effect yet; the "
+                    "heuristic alone governs completeness regardless of this setting."
+    )
+
     # Agent text backend (OpenClaw voice-adapter). LifeOS proxies the "Agent"
     # text backend to /api/ask/stream here, adding the bearer token server-side
     # so it's never exposed to the browser (#361). Empty url = Agent disabled.

--- a/docs/guides/voice-setup.md
+++ b/docs/guides/voice-setup.md
@@ -58,6 +58,11 @@ These variables are read by `config/settings.py` (aliases shown). They are **not
 |----------|---------|--------|
 | `LIFEOS_VOICE_GATEWAY_URL` | `http://127.0.0.1:9788` | whisper-relay base URL that LifeOS reverse-proxies `/api/voice/*` to. Override only if the gateway runs on a different local port. |
 | `LIFEOS_CHAT_DEFAULT_VOICE` | `false` | Makes voice the **default** `/chat` input mode. Left off so a fresh clone with no gateway isn't dropped onto a non-functional dock. A `?mode=` URL param or a stored per-browser preference still overrides it. |
+| `LIFEOS_VOICE_ENDPOINT_SILENCE_MS` | `1600` | Smart turn endpointing (below): trailing silence, in ms, after speech before a candidate endpoint check runs. |
+| `LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS` | `3000` | Smart turn endpointing: continuous silence, in ms, that finalizes the turn regardless of any completeness verdict. |
+| `LIFEOS_VOICE_ENDPOINT_SEMANTIC` | `false` | Reserved for an optional LLM completeness classifier — **not implemented**; flipping it currently has no effect. The heuristic alone governs completeness. |
+
+These three, along with `default_voice`/`secure_url`/the remote-model fields, are read by the web client from `GET /api/chat/config` — the endpointing pair are pure client-side VAD timing knobs with no server-side use; they exist as settings only so that timing is operator-tunable without editing `web/chat/voice.js`.
 
 Restart the API after editing `.env`:
 
@@ -74,7 +79,7 @@ In voice mode the text composer is replaced by the dock:
 - Four dock toggles (state saved per browser):
   - **Mute** — suppress spoken playback (the reply still returns as text).
   - **2×** — play spoken replies at double speed.
-  - **Auto** — auto-continue: after a reply finishes, start listening for the next turn without another tap.
+  - **Auto** — auto-continue: after a reply finishes, start listening for the next turn without another tap. While Auto is on, a recording also **ends itself** once you sound done — see "Smart turn endpointing" below — instead of always waiting for another tap.
   - **Listening** — wake-word mode, default off (#710). While on, the page holds its own mic stream and runs a local energy-based VAD (no third-party wake-word engine, no Web Speech API — that ships audio to Google). When it hears a speech burst end, it POSTs the short clip to `${voice gateway}/api/voice/transcribe` and fuzzy-matches the transcript against "Hermes" (tolerating whisper-isms like "Hermès" or "her mes" — see `matchesWakeWord()` in `web/chat/voice.js`); a match plays a short confirmation chime, then starts recording exactly as a talk-button tap would. Detection is suspended while recording, while a turn is in flight, and while a spoken reply or the chime is playing (so the assistant — or the chime itself — can never wake it), and resumes after. Leaving voice mode or unchecking Listening releases its mic entirely. **Requires a `/api/voice/transcribe` route on the voice gateway that does not exist yet as of this writing** — see the note below.
 
 ### The wake-confirmation chime
@@ -85,9 +90,24 @@ Both the sound files and the manifest are optional. If `web/chat/wake-sounds/` o
 
 **Attribution**: the bundled sound set is drawn from the PeonPing community packs — `jarvis-mk2`, `eve-walle`, `d2_deckard_cain`, and `diablo-drops` — licensed **CC-BY-NC-4.0** (non-commercial use, attribution required). This is the sole attribution notice for those files; see the license text for full terms if redistributing.
 
-### Listening's dependency: a bare-STT gateway route (not yet shipped)
+### Smart turn endpointing
 
-whisper-relay's `POST /api/voice/turn` and `/turn/stream` always run the full STT→LLM→TTS pipeline. Listening needs a **transcribe-only** route with no LLM call, no TTS, no conversation/turn persistence — it must be safe to call every second or two without creating any artifacts. LifeOS's `/api/voice/*` proxy already forwards any path generically (`api/routes/voice.py`), so once the gateway adds `POST /api/voice/transcribe` (multipart `audio` file in, `{"transcript": "..."}` out — the same audio normalization + `STTAdapter.transcribe()` step `turns.py` already uses internally, minus everything after it), Listening picks it up with no LifeOS-side change. Until then, every wake check 404s and Listening's toggle/mic-hold/VAD still work but never actually trigger.
+While **Auto** is on, a voice recording no longer only stops when you tap the talk button again — it also infers, mid-recording, when you've likely finished speaking, and ends and sends the turn itself. This runs entirely inside `web/chat/voice.js`, on the **same** recording stream the talk button already acquired (never a second microphone request), so it composes with Listening's own mic hold and wake detection above without conflict.
+
+The pipeline (`checkEndpointCandidate()`/`isTranscriptComplete()`/`handleEndpointFrame()` in `web/chat/voice.js`):
+
+1. **Pause detection.** The same local energy-VAD Listening uses for wake-burst detection runs on the recording. After `LIFEOS_VOICE_ENDPOINT_SILENCE_MS` (default 1600ms) of trailing silence *following speech*, the recording-so-far is a **candidate** endpoint — not a final decision yet.
+2. **Transcribe-so-far.** The candidate's audio is POSTed to the same bare-STT route Listening's wake check uses, `POST /api/voice/transcribe` (see the dependency note below) — no conversation/turn artifacts either way.
+3. **Completeness heuristic.** `isTranscriptComplete()` treats trailing terminal punctuation (`.`/`?`/`!`) as a finished thought. A trailing conjunction/filler word — "and", "but", "so", "because", "or", "if", "then", "um", "uh", "like", "i mean" — or no terminal punctuation at all reads as still-talking. Whisper often omits punctuation on short clips, so "no punctuation" alone is a soft signal; a false "keep listening" only costs one more candidate check (or the hard cap below), never a hang, so the heuristic is deliberately conservative about calling a turn complete.
+4. **Act.** Complete → the turn ends and sends through the exact same path a manual stop-tap uses. Incomplete → recording continues; if you keep talking, the silence timer re-arms for the next pause. Either way, `LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS` (default 3000ms) of *continuous* silence ends the turn regardless of any completeness verdict, so an ambiguous or unreachable check can never leave the mic open forever.
+
+`LIFEOS_VOICE_ENDPOINT_SEMANTIC` is a reserved setting for an optional LLM completeness classifier on ambiguous candidates (no terminal punctuation, no recognized filler word either). It is **not implemented** — there is no server endpoint backing it, and flipping it currently has no effect. The heuristic above is the only completeness signal today.
+
+Endpointing only ever runs while Auto is on, voice mode is active, and a recording is actually in progress; with Auto off, recording behaves exactly as it always has — only a tap ends it.
+
+### The bare-STT gateway route (not yet shipped)
+
+Both Listening (above) and smart turn endpointing depend on the same **transcribe-only** gateway route, `POST /api/voice/transcribe` — no LLM call, no TTS, no conversation/turn persistence, safe to call every second or two without creating any artifacts. whisper-relay's `POST /api/voice/turn` and `/turn/stream` always run the full STT→LLM→TTS pipeline instead. LifeOS's `/api/voice/*` proxy already forwards any path generically (`api/routes/voice.py`), so once the gateway adds `POST /api/voice/transcribe` (multipart `audio` file in, `{"transcript": "..."}` out — the same audio normalization + `STTAdapter.transcribe()` step `turns.py` already uses internally, minus everything after it), both features pick it up with no LifeOS-side change. Until then, every wake check and endpointing candidate check 404s (`transcribeClip()` in `web/chat/voice.js` treats that as "no transcript" and moves on, not an error), so Listening never actually triggers and an endpointing candidate never gets a "complete" verdict from step 3 above. The hard cap in step 4, though, is a pure client-side silence timer with no dependency on this route — it still fires on schedule either way, so under Auto a recording that goes quiet for `LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS` still ends and sends itself even before the gateway ships this route; it just never ends *early* on a genuinely finished sentence until it does.
 
 Each spoken response bubble is also **tap-to-replay** — tap it to hear the reply again. (Replay is a per-response affordance, not a dock toggle.) Empty or silent recordings are **skipped automatically** by silence detection — there is no manual "skip silent" control.
 
@@ -127,6 +147,7 @@ On the **Hermes** backend an orchestrating persona's spoken turn never spawns an
 | `Agent` toggle missing | Expected unless `LIFEOS_AGENT_BACKEND_URL` is set. |
 | `Hermes` toggle missing | Expected unless `LIFEOS_HERMES_BACKEND_URL` is set. |
 | `Listening` never triggers recording | Expected until the gateway ships `POST /api/voice/transcribe` — see above. |
+| Auto-mode recording never ends itself on a finished sentence, only on the hard cap or a tap | Expected until the gateway ships `POST /api/voice/transcribe` — see above; the hard cap alone still fires on schedule. |
 
 ---
 

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -725,11 +725,26 @@ class TestChatConfigEndpoint:
         monkeypatch.setattr("api.routes.chat.settings.chat_default_voice", False, raising=False)
         assert client.get("/api/chat/config").json() == {
             "default_voice": False, "secure_url": "",
-            "remote_model_available": False, "remote_model_label": ""}
+            "remote_model_available": False, "remote_model_label": "",
+            "voice_endpoint_silence_ms": 1600, "voice_endpoint_hard_cap_ms": 3000,
+            "voice_endpoint_semantic": False}
         monkeypatch.setattr("api.routes.chat.settings.chat_default_voice", True, raising=False)
         assert client.get("/api/chat/config").json() == {
             "default_voice": True, "secure_url": "",
-            "remote_model_available": False, "remote_model_label": ""}
+            "remote_model_available": False, "remote_model_label": "",
+            "voice_endpoint_silence_ms": 1600, "voice_endpoint_hard_cap_ms": 3000,
+            "voice_endpoint_semantic": False}
+
+    # voice_endpoint_* (#718) drive the web client's smart turn endpointing
+    # VAD timing in auto-mode voice recording — see web/chat/voice.js.
+    def test_voice_endpoint_settings_reflect_config(self, client, monkeypatch):
+        monkeypatch.setattr("api.routes.chat.settings.voice_endpoint_silence_ms", 2200, raising=False)
+        monkeypatch.setattr("api.routes.chat.settings.voice_endpoint_hard_cap_ms", 4500, raising=False)
+        monkeypatch.setattr("api.routes.chat.settings.voice_endpoint_semantic", True, raising=False)
+        data = client.get("/api/chat/config").json()
+        assert data["voice_endpoint_silence_ms"] == 2200
+        assert data["voice_endpoint_hard_cap_ms"] == 4500
+        assert data["voice_endpoint_semantic"] is True
 
     # secure_url is the web client's one-tap escape from an insecure context to
     # the HTTPS origin the mic needs (#516).

--- a/tests/test_voice_endpointing_ui_browser.py
+++ b/tests/test_voice_endpointing_ui_browser.py
@@ -1,0 +1,424 @@
+"""Browser tests for smart turn endpointing in auto-mode voice recording (#718).
+
+While the **Auto** dock toggle is on, `web/chat/voice.js` now decides *when a
+recording ends* on its own, layered on top of Auto-continue's existing
+"reopen the mic after a reply" behavior. Pipeline: an energy VAD on the live
+recording stream (the same technique `handleListenFrame()` uses for #710 wake
+detection) detects trailing silence following speech; once it crosses
+`LIFEOS_VOICE_ENDPOINT_SILENCE_MS`, the recording-so-far is transcribed via
+the same bare-STT route (`POST /api/voice/transcribe`) Listening's wake check
+already uses; `isTranscriptComplete()` decides whether that sounds like a
+finished thought. Complete finalizes through `stopRecordingAndSend()` -- the
+exact function a manual stop-tap calls, never a parallel submit path.
+Incomplete keeps recording. `LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS` of continuous
+silence finalizes regardless, so an ambiguous/unreachable check can never
+hang the mic open.
+
+Like the sibling wake-word/wake-chime suites, the live onaudioprocess VAD
+can't run headless without real audio hardware, so these tests drive the
+pipeline from its exported test seams -- `window.lifeChatVoice.
+checkEndpointCandidate(samples, sampleRate)` and `...finalizeEndpointing()`
+-- the same seam pattern `checkForWakeWord()` established
+(tests/test_voice_listening_wake_word_ui_browser.py). Both are the REAL
+functions the live silence timer calls once its thresholds are crossed;
+nothing here is a parallel/fake implementation of that logic.
+
+`isTranscriptComplete()`, the pure completeness heuristic, is tested directly
+with no page/recording/network involved at all -- exported specifically to
+make the word list testable on its own (see its doc comment in
+`web/chat/voice.js`).
+
+No `requires_server` marker (serves `web/` itself from an ephemeral port, the
+same pattern as tests/test_voice_mic_block_ui_browser.py), so this runs at
+pre-push (`browser and not requires_server`).
+"""
+import http.server
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+
+class _ChatHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the chat SPA the way api/main.py does: `/chat` is index.html and
+    the module tree hangs off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/chat", "/"):
+            return str(WEB_DIR / "index.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def chat_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _ChatHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# Installed before any app JS runs. Mirrors
+# tests/test_voice_listening_wake_word_ui_browser.py's instrument script
+# (fake getUserMedia/MediaRecorder, a fetch stub) with two additions:
+#   - /api/voice/transcribe can be deferred (window.__deferTranscribe) and
+#     resolved on demand (window.__resolveTranscribe()) so a test can pause
+#     mid-round-trip and act (e.g. a manual stop) before it completes --
+#     the same pattern test_voice_wake_chime_ui_browser.py uses for the
+#     chime's `ended` event.
+#   - A MediaRecorder.stop() call counter (window.__recorderStopCalls),
+#     alongside the existing start-call counter -- stopMediaRecorder() in
+#     voice.js calls `.stop()` unconditionally the moment
+#     stopRecordingAndSend() reaches it, regardless of what the resulting
+#     blob's silence-detection later decides to do with it, so this is a
+#     reliable, audio-content-independent signal for "did a finalize/stop
+#     actually happen" without needing genuine non-silent recorded audio
+#     (MediaRecorder audio content is not reliable headless -- see
+#     tests/test_voice_rate_toggle_playback_ui_browser.py's docstring).
+#   - A /api/voice/turn/stream call counter (window.__turnStreamCalls).
+_INSTRUMENT_SCRIPT = """
+window.__fetchLog = [];
+window.__transcribeResponse = 'turn off the lights.';
+window.__deferTranscribe = false;
+window.__pendingTranscribeResolvers = [];
+window.__turnStreamCalls = 0;
+
+function __transcribeResponseBody() {
+  return new Response(JSON.stringify({ transcript: window.__transcribeResponse }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+window.fetch = function (url, opts) {
+  var urlStr = typeof url === 'string' ? url : (url && url.url) || String(url);
+  window.__fetchLog.push(urlStr);
+  if (urlStr.indexOf('/api/voice/transcribe') !== -1) {
+    if (window.__deferTranscribe) {
+      return new Promise(function (resolve) {
+        window.__pendingTranscribeResolvers.push(function () { resolve(__transcribeResponseBody()); });
+      });
+    }
+    return Promise.resolve(__transcribeResponseBody());
+  }
+  if (urlStr.indexOf('/api/voice/turn/stream') !== -1) {
+    window.__turnStreamCalls += 1;
+    var sse = 'data: ' + JSON.stringify({ type: 'done', data: { response_text: 'ok' } }) + '\\n\\n';
+    return Promise.resolve(new Response(sse, {
+      status: 200, headers: { 'Content-Type': 'text/event-stream' },
+    }));
+  }
+  return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+};
+window.__resolveTranscribe = function () {
+  var fns = window.__pendingTranscribeResolvers;
+  window.__pendingTranscribeResolvers = [];
+  fns.forEach(function (fn) { fn(); });
+};
+
+window.__gumCalls = 0;
+navigator.mediaDevices.getUserMedia = function (constraints) {
+  window.__gumCalls += 1;
+  var ctx = new (window.AudioContext || window.webkitAudioContext)();
+  var dest = ctx.createMediaStreamDestination();
+  return Promise.resolve(dest.stream);
+};
+
+(function () {
+  window.__recorderStartCalls = 0;
+  window.__recorderStopCalls = 0;
+  var OrigMR = window.MediaRecorder;
+  function WrappedMR(stream, opts) {
+    var mr = opts ? new OrigMR(stream, opts) : new OrigMR(stream);
+    var origStart = mr.start.bind(mr);
+    mr.start = function (ms) { window.__recorderStartCalls += 1; return origStart(ms); };
+    var origStop = mr.stop.bind(mr);
+    mr.stop = function () { window.__recorderStopCalls += 1; return origStop(); };
+    return mr;
+  }
+  WrappedMR.isTypeSupported = OrigMR.isTypeSupported.bind(OrigMR);
+  window.MediaRecorder = WrappedMR;
+})();
+"""
+
+
+def _open_voice_chat(page: Page, base_url):
+    page.add_init_script(_INSTRUMENT_SCRIPT)
+    page.goto(f"{base_url}/chat?mode=voice")
+    page.wait_for_selector("#voiceListen")
+
+
+# Listening (#710) ships on by default and acquires its own mic stream the
+# instant voice mode is entered -- before a test's first `page.evaluate()`/
+# `.uncheck()` call could possibly race it off. Tests that assert on
+# `__gumCalls` (endpointing must never be a SECOND getUserMedia call) seed
+# Listening off in localStorage before the page loads, so it never starts at
+# all -- unrelated to whatever this test is actually exercising.
+def _open_voice_chat_listening_off(page: Page, base_url):
+    page.add_init_script(_INSTRUMENT_SCRIPT)
+    page.add_init_script(
+        "window.localStorage.setItem('lifeos:chat:dock_settings', "
+        "JSON.stringify({ mute: false, auto: true, fast: true, listen: false }));"
+    )
+    page.goto(f"{base_url}/chat?mode=voice")
+    page.wait_for_selector("#voiceListen")
+
+
+def _start_recording(page: Page):
+    """Auto ships on by default -- this just taps the talk button and waits
+    for a real (fake-stream) recording to actually be in progress."""
+    page.locator("#voiceTalkBtn").click()
+    page.wait_for_function(
+        "document.getElementById('voiceTalkBtn').classList.contains('recording')"
+    )
+
+
+def _is_recording(page: Page):
+    return page.evaluate(
+        "document.getElementById('voiceTalkBtn').classList.contains('recording')"
+    )
+
+
+def _check_candidate(page: Page, transcript):
+    """Sets the stubbed transcribe response, then runs the real
+    checkEndpointCandidate() pipeline with a throwaway synthetic clip --
+    content doesn't matter, the network response is stubbed regardless.
+    Returns the completeness verdict (True/False/None)."""
+    page.evaluate("(t) => { window.__transcribeResponse = t; }", transcript)
+    return page.evaluate(
+        "() => window.lifeChatVoice.checkEndpointCandidate(new Float32Array(160), 16000)"
+    )
+
+
+class TestCompletenessHeuristic:
+    """isTranscriptComplete() is a pure function -- no page interaction
+    beyond loading the module, no recording, no network."""
+
+    @pytest.mark.parametrize("transcript,expected", [
+        ("Turn off the lights.", True),
+        ("Is it raining outside?", True),
+        ("Wow!", True),
+        ('He said "stop."', True),
+        ("turn off the lights", False),          # no terminal punctuation
+        ("I want to go to the store and", False),  # trailing conjunction
+        ("I think, um", False),                  # trailing filler
+        ("coffee or", False),
+        ("if it's sunny then", False),
+        ("I was going to say... i mean", False),  # trailing filler phrase
+        ("but that's okay.", True),               # "but" mid-sentence is fine; trailing word governs
+        ("SO", False),                            # case-insensitive filler match
+        ("", False),                              # empty transcript
+        ("   ", False),                           # whitespace-only transcript
+    ])
+    def test_heuristic_cases(self, page: Page, chat_base_url, transcript, expected):
+        _open_voice_chat(page, chat_base_url)
+        result = page.evaluate(
+            "(t) => window.lifeChatVoice.isTranscriptComplete(t)", transcript
+        )
+        assert result is expected, f"isTranscriptComplete({transcript!r}) == {result}, expected {expected}"
+
+
+class TestAutoModeGating:
+    """Endpointing only ever runs while Auto + voice mode + an actual
+    recording are all true."""
+
+    def test_auto_off_no_endpointing(self, page: Page, chat_base_url):
+        """Auto off -> today's manual-stop-only behavior, byte-identical: a
+        candidate check must not even reach the transcribe route."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceAuto").uncheck()
+        _start_recording(page)
+
+        result = _check_candidate(page, "Turn off the lights.")
+
+        assert result is None
+        assert _is_recording(page) is True
+        assert page.evaluate("window.__recorderStopCalls") == 0
+        assert not any(
+            "/api/voice/transcribe" in u for u in page.evaluate("window.__fetchLog")
+        ), "a candidate check reached the transcribe route with Auto off"
+
+    def test_no_second_getusermedia_call(self, page: Page, chat_base_url):
+        """Endpointing taps the SAME recording stream -- it must never
+        acquire its own mic. Listening (#710, on by default) holds its own
+        separate stream unrelated to this, so it's seeded off here to
+        isolate endpointing's own mic usage specifically."""
+        _open_voice_chat_listening_off(page, chat_base_url)
+        _start_recording(page)
+        assert page.evaluate("window.__gumCalls") == 1
+
+        _check_candidate(page, "Turn off the lights.")
+
+        assert page.evaluate("window.__gumCalls") == 1
+
+
+class TestCandidateCompleteness:
+    """The stubbed transcribe response drives the real completeness
+    decision: complete finalizes (through the manual-stop path), incomplete
+    keeps recording."""
+
+    def test_complete_transcript_finalizes(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+
+        result = _check_candidate(page, "Turn off the lights.")
+
+        assert result is True
+        page.wait_for_function("window.__recorderStopCalls === 1")
+
+    def test_incomplete_transcript_keeps_recording(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+
+        result = _check_candidate(page, "I want to go to the store and")
+
+        assert result is False
+        assert page.evaluate("window.__recorderStopCalls") == 0
+        assert _is_recording(page) is True
+        # Still the same recording -- not restarted/duplicated.
+        assert page.evaluate("window.__recorderStartCalls") == 1
+
+    def test_empty_transcript_keeps_recording(self, page: Page, chat_base_url):
+        """An unparseable/empty transcript (e.g. the gateway route not
+        shipped yet, #relay-not-yet-shipped) must not be treated as
+        complete."""
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+
+        result = _check_candidate(page, "")
+
+        assert result is False
+        assert page.evaluate("window.__recorderStopCalls") == 0
+        assert _is_recording(page) is True
+
+
+class TestHardCapFinalize:
+    """finalizeEndpointing() is the exact function real continuous silence
+    crossing HARD_CAP_MS calls -- exercised directly since a browser test
+    can't wait out multiple real seconds of silence through the live audio
+    graph."""
+
+    def test_hard_cap_finalizes(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+
+        page.evaluate("() => window.lifeChatVoice.finalizeEndpointing()")
+
+        page.wait_for_function("window.__recorderStopCalls === 1")
+
+    def test_finalize_while_not_recording_is_a_noop(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+
+        page.evaluate("() => window.lifeChatVoice.finalizeEndpointing()")
+
+        assert page.evaluate("window.__recorderStopCalls") == 0
+
+
+class TestCancelledDuringCheck:
+    """An in-flight candidate check must not resurrect/duplicate-finalize a
+    turn the user has already ended a different way -- guards are re-checked
+    after every await, the same pattern triggerWakeRecording() uses after
+    its chime."""
+
+    def test_manual_stop_during_check_wins_stale_check_is_a_noop(
+            self, page: Page, chat_base_url):
+        _open_voice_chat_listening_off(page, chat_base_url)
+        _start_recording(page)
+
+        page.evaluate("() => { window.__deferTranscribe = true; }")
+        page.evaluate("""
+            () => {
+              window.__candidateResult = undefined;
+              window.lifeChatVoice.checkEndpointCandidate(new Float32Array(160), 16000)
+                .then((r) => { window.__candidateResult = r; });
+            }
+        """)
+        page.wait_for_function(
+            "window.__fetchLog.some((u) => u.indexOf('/api/voice/transcribe') !== -1)"
+        )
+        assert _is_recording(page) is True  # the check hasn't resolved yet
+
+        # The user taps stop for real while the candidate check is still
+        # in flight -- the SAME manual-stop path a talk-button tap always
+        # uses, independent of endpointing entirely. force=True: the
+        # .recording class drives an infinite CSS pulse animation, which
+        # fails Playwright's default "element is stable" actionability wait.
+        page.locator("#voiceTalkBtn").click(force=True)
+        page.wait_for_function("window.__recorderStopCalls === 1")
+
+        # Auto is on, so the manual stop's own empty-recording path (the
+        # fake stream is silent) re-triggers Auto-continue, starting a
+        # brand-new recording that reuses the same mic stream.
+        page.wait_for_function("window.__recorderStartCalls === 2")
+        page.wait_for_function("window.__gumCalls === 1")  # never a second getUserMedia call
+
+        # Now let the STALE check (for the recording that already ended)
+        # resolve as "complete" -- it must not finalize the NEW recording
+        # Auto-continue just started.
+        page.evaluate("(t) => { window.__transcribeResponse = t; }", "Turn off the lights.")
+        page.evaluate("() => { window.__resolveTranscribe(); }")
+
+        page.wait_for_function("window.__candidateResult !== undefined")
+        assert page.evaluate("window.__candidateResult") is None, (
+            "a stale candidate check resurrected/finalized a turn after the user "
+            "had already manually stopped it"
+        )
+        # Only the manual stop ever called .stop() -- the stale check's late
+        # "complete" verdict did not trigger a second finalize.
+        assert page.evaluate("window.__recorderStopCalls") == 1
+        assert _is_recording(page) is True  # the NEW (Auto-continue) recording is untouched
+
+    def test_no_change_during_check_still_finalizes_normally(
+            self, page: Page, chat_base_url):
+        """Control: with nothing interrupting it, a deferred-then-resolved
+        check behaves exactly like an immediate one."""
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+
+        page.evaluate("() => { window.__deferTranscribe = true; }")
+        page.evaluate("(t) => { window.__transcribeResponse = t; }", "Turn off the lights.")
+        page.evaluate("""
+            () => {
+              window.__candidateResult = undefined;
+              window.lifeChatVoice.checkEndpointCandidate(new Float32Array(160), 16000)
+                .then((r) => { window.__candidateResult = r; });
+            }
+        """)
+        page.wait_for_function(
+            "window.__fetchLog.some((u) => u.indexOf('/api/voice/transcribe') !== -1)"
+        )
+
+        page.evaluate("() => { window.__resolveTranscribe(); }")
+
+        page.wait_for_function("window.__candidateResult !== undefined")
+        assert page.evaluate("window.__candidateResult") is True
+        page.wait_for_function("window.__recorderStopCalls === 1")
+
+
+class TestBargeInSuspension:
+    """Endpointing only applies while actually recording -- never during TTS
+    playback, and never when there's no recording at all."""
+
+    def test_candidate_check_during_playback_not_recording_is_a_noop(
+            self, page: Page, chat_base_url):
+        """Not recording at all (e.g. mid-turn/TTS playback) -> no candidate
+        decision is possible."""
+        _open_voice_chat(page, chat_base_url)
+        assert _is_recording(page) is False
+
+        result = _check_candidate(page, "Turn off the lights.")
+
+        assert result is None
+        assert page.evaluate("window.__recorderStopCalls") == 0

--- a/tests/test_voice_endpointing_ui_browser.py
+++ b/tests/test_voice_endpointing_ui_browser.py
@@ -358,9 +358,11 @@ class TestCancelledDuringCheck:
         page.locator("#voiceTalkBtn").click(force=True)
         page.wait_for_function("window.__recorderStopCalls === 1")
 
-        # Auto is on, so the manual stop's own empty-recording path (the
-        # fake stream is silent) re-triggers Auto-continue, starting a
-        # brand-new recording that reuses the same mic stream.
+        # A manual stop stays stopped, even with Auto on (#721) -- so start
+        # the next recording the way a user would, by tapping again. This is
+        # the case the token guard exists for: a *different* recording is now
+        # live than the one the in-flight check transcribed.
+        _start_recording(page)
         page.wait_for_function("window.__recorderStartCalls === 2")
         page.wait_for_function("window.__gumCalls === 1")  # never a second getUserMedia call
 

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -19,7 +19,10 @@ import {
 } from './conversations.js';
 import { sendMessage, askQuestion, stopTurn } from './ask-stream.js';
 import { loadPersonas, onPersonaChange, personaOrchestrates, personaSupportsHandoff } from './persona.js';
-import { initVoice, submitTurn, checkForWakeWord } from './voice.js';
+import {
+  initVoice, submitTurn, checkForWakeWord,
+  checkEndpointCandidate, isTranscriptComplete, finalizeEndpointing,
+} from './voice.js';
 import { initBackend } from './backend.js';
 import { initModel, onModelChange } from './model.js';
 
@@ -97,4 +100,7 @@ Object.assign(window, {
 });
 
 // Voice helpers for the headless test harness (mic/audio can't run headless).
-window.lifeChatVoice = { submitTurn, checkForWakeWord };
+window.lifeChatVoice = {
+  submitTurn, checkForWakeWord,
+  checkEndpointCandidate, isTranscriptComplete, finalizeEndpointing,
+};

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -299,6 +299,7 @@ export function initVoice() {
   // syncs the Listening mic hold to dockSettings.listen, so the setting has
   // to be in memory before voice mode is first applied, not after.
   loadDockSettings();
+  loadEndpointingConfig();  // #718 -- fire-and-forget; defaults apply until it resolves
 
   const explicit = resolveExplicitVoiceMode();
   config.voiceMode = explicit === true;  // text until the server default resolves
@@ -449,6 +450,7 @@ function beginRecording(stream) {
   isRecording = true;
   setStatus('', 'Recording…');
   setTalkActive(true);
+  maybeStartEndpointing(stream);  // #718 -- no-op unless Auto + voice mode
 }
 
 function ensureAudioContext() {
@@ -473,6 +475,7 @@ function beginWebAudioRecording(stream) {
   isRecording = true;
   setStatus('', 'Recording…');
   setTalkActive(true);
+  maybeStartEndpointing(stream);  // #718 -- no-op unless Auto + voice mode
 }
 
 function releaseCapture() {
@@ -610,13 +613,18 @@ async function beginRecordingFromTap() {
 
 async function stopRecordingAndSend() {
   if (isStarting || !isRecording) return;
+  // Set (and tear down endpointing) synchronously, before the MIN_RECORD_MS
+  // await below, so a concurrent second call -- #718's hard cap and a
+  // candidate's "complete" verdict can each reach this function -- sees
+  // `!isRecording` and returns immediately instead of double-stopping.
+  isRecording = false;
+  stopEndpointing();
 
   const elapsed = Date.now() - recordStartedAt;
   if (elapsed < MIN_RECORD_MS) {
     await new Promise((r) => setTimeout(r, MIN_RECORD_MS - elapsed));
   }
 
-  isRecording = false;
   setTalkActive(false);
 
   try {
@@ -1191,6 +1199,265 @@ async function triggerWakeRecording() {
   if (!baseWakeGuardsOk()) return false;  // state may have changed during chime playback
   await beginRecordingFromTap();
   return true;
+}
+
+// --- Smart turn endpointing: pause + semantic completeness (#718) ---
+//
+// Auto-continue (above) already reopens the mic after each reply; this layers
+// on *when to stop* a recording that started that way (or from a manual tap
+// -- endpointing applies to any recording while Auto is on, not only an
+// auto-triggered one). It runs its own small WebAudio graph on the SAME
+// stream beginRecordingFromTap() already acquired -- never a second
+// getUserMedia call -- computing the same energy-VAD RMS check
+// handleListenFrame() above uses for wake detection.
+//
+// Pipeline: after SILENCE_MS of trailing silence *following speech*, the
+// recording-so-far is a *candidate* endpoint, not a final decision --
+// POSTed to the same bare-STT route (`/api/voice/transcribe`) Listening's
+// wake check already uses (no conversation/turn artifacts either way), then
+// run through isTranscriptComplete() below. Complete -> finalize through the
+// SAME path a manual stop uses (stopRecordingAndSend(), never a parallel
+// submit implementation). Incomplete -> keep recording; speech resuming
+// re-arms the candidate timer. Silence that keeps growing past HARD_CAP_MS
+// finalizes regardless of any candidate verdict, so an ambiguous or
+// unreachable check can never hang the mic open forever.
+//
+// Guards are re-checked after every await, the same pattern
+// triggerWakeRecording() uses after its chime -- a manual stop tap, a cancel,
+// or Auto/voice mode changing while a candidate round-trip is in flight must
+// never let a stale "complete" verdict resurrect or double-submit a turn the
+// user already ended a different way.
+const ENDPOINT_DEFAULT_SILENCE_MS = 1600;
+const ENDPOINT_DEFAULT_HARD_CAP_MS = 3000;
+
+// Trailing words/phrases that read as "still talking" even after a pause --
+// conjunctions/connectives that normally lead into more speech, plus common
+// spoken-filler hedges. Checked against the transcript's last word (or last
+// two, for "i mean") with trailing punctuation stripped. Deliberately
+// conservative: a false "incomplete" verdict just keeps recording a beat
+// longer, bounded by the hard cap either way; a false "complete" verdict
+// sends a fragment as the actual turn.
+const ENDPOINT_TRAILING_FILLER_WORDS = [
+  'and', 'but', 'so', 'because', 'or', 'if', 'then', 'um', 'uh', 'like',
+];
+const ENDPOINT_TRAILING_FILLER_PHRASES = ['i mean'];
+const ENDPOINT_TERMINAL_PUNCTUATION_RE = /[.?!]["')\]]*$/;
+
+// Pure heuristic -- exported (window.lifeChatVoice below) so it's testable on
+// its own, with no page/recording/network round-trip involved. Terminal
+// punctuation (. ? !) at the end -> complete. A trailing conjunction/filler
+// word, or no terminal punctuation at all, -> incomplete. Whisper frequently
+// omits end-of-utterance punctuation on short clips, so "no punctuation"
+// alone is a weak signal -- but a false negative here only costs one more
+// candidate check (or, worst case, the hard cap), never a hang, so the
+// heuristic leans toward "keep listening" over "guess complete."
+export function isTranscriptComplete(transcript) {
+  const text = (transcript || '').trim();
+  if (!text) return false;
+  const endsWithPunctuation = ENDPOINT_TERMINAL_PUNCTUATION_RE.test(text);
+  const words = text
+    .toLowerCase()
+    .replace(/[.?!,;:'"()[\]]+$/g, '')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  const lastWord = words[words.length - 1] || '';
+  const lastTwoWords = words.slice(-2).join(' ');
+  const endsWithFiller =
+    ENDPOINT_TRAILING_FILLER_WORDS.includes(lastWord)
+    || ENDPOINT_TRAILING_FILLER_PHRASES.includes(lastTwoWords);
+  if (endsWithFiller) return false;
+  return endsWithPunctuation;
+}
+
+// LIFEOS_VOICE_ENDPOINT_SILENCE_MS / _HARD_CAP_MS, read from GET
+// /api/chat/config (settings.py) the same way LIFEOS_CHAT_DEFAULT_VOICE
+// reaches fetchDefaultVoiceMode() above. Both start at the designed defaults
+// and only move if/when the (already-cached, shared) config fetch resolves
+// with a valid override, so a slow or unreachable config never blocks
+// endpointing -- it just runs on the built-in timings meanwhile. There is no
+// server-side use of these values; the settings only exist to make this
+// client-side timing operator-tunable without an env-var-free config file.
+let endpointSilenceMsSetting = ENDPOINT_DEFAULT_SILENCE_MS;
+let endpointHardCapMsSetting = ENDPOINT_DEFAULT_HARD_CAP_MS;
+
+function loadEndpointingConfig() {
+  fetchChatConfig().then((data) => {
+    const silence = Number(data.voice_endpoint_silence_ms);
+    const hardCap = Number(data.voice_endpoint_hard_cap_ms);
+    if (Number.isFinite(silence) && silence > 0) endpointSilenceMsSetting = silence;
+    if (Number.isFinite(hardCap) && hardCap > 0) endpointHardCapMsSetting = hardCap;
+  });
+}
+
+let endpointCtx = null;
+let endpointSource = null;
+let endpointProcessor = null;
+let endpointSampleRate = 0;
+let endpointFrames = [];            // Float32Array frames captured since the current recording started
+let endpointHasSpeech = false;      // at least one speech frame seen this recording
+let endpointSilenceMs = 0;          // trailing silence since the last speech frame
+let endpointCandidateFired = false; // a candidate check already ran for the current silence run
+let endpointChecking = false;       // a candidate transcribe/completeness round-trip is in flight
+// Bumped every time a NEW recording's endpointing tap is (re)installed
+// (maybeStartEndpointing()). `endpointingActive()`'s `isRecording` check
+// alone isn't enough to catch a stale candidate: Auto-continue can start a
+// brand-new recording (isRecording flips true again) in the gap between a
+// cancelled/finalized recording and a still-in-flight candidate check for
+// THAT earlier recording resolving. checkEndpointCandidate() below captures
+// this token at the start and compares it after every await, so a stale
+// verdict can never finalize a DIFFERENT (newer) recording than the one it
+// was transcribing.
+let endpointRecordingToken = 0;
+
+// Only meaningful while Auto-continue AND voice mode AND an actual recording
+// are all true -- Auto off, leaving voice mode, or the recording already
+// having ended all mean today's manual-stop-only behavior, unchanged.
+function endpointingActive() {
+  return getAutoContinue() && isVoiceMode() && isRecording;
+}
+
+function resetEndpointState() {
+  endpointFrames = [];
+  endpointHasSpeech = false;
+  endpointSilenceMs = 0;
+  endpointCandidateFired = false;
+  endpointChecking = false;
+}
+
+// A no-op when Auto is off or voice mode isn't active, so a non-auto
+// recording never pays for this graph at all.
+function maybeStartEndpointing(stream) {
+  if (!getAutoContinue() || !isVoiceMode()) return;
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  if (!Ctx) return;
+  resetEndpointState();
+  endpointRecordingToken += 1;
+  try {
+    endpointCtx = new Ctx();
+    endpointSource = endpointCtx.createMediaStreamSource(stream);
+    endpointProcessor = endpointCtx.createScriptProcessor(WAKE_PROCESSOR_BUFFER, 1, 1);
+    endpointSampleRate = endpointCtx.sampleRate;
+    endpointProcessor.onaudioprocess = handleEndpointFrame;
+    endpointSource.connect(endpointProcessor);
+    endpointProcessor.connect(endpointCtx.destination);
+  } catch (e) {
+    stopEndpointing();  // don't leave a half-wired graph behind
+  }
+}
+
+function stopEndpointing() {
+  try {
+    if (endpointProcessor) {
+      endpointProcessor.onaudioprocess = null;
+      endpointProcessor.disconnect();
+    }
+    if (endpointSource) endpointSource.disconnect();
+  } catch (_) { /* ignore */ }
+  endpointProcessor = null;
+  endpointSource = null;
+  if (endpointCtx) {
+    endpointCtx.close().catch(() => {});
+    endpointCtx = null;
+  }
+  resetEndpointState();
+}
+
+function flattenEndpointFrames() {
+  let total = 0;
+  for (const c of endpointFrames) total += c.length;
+  const flat = new Float32Array(total);
+  let off = 0;
+  for (const c of endpointFrames) { flat.set(c, off); off += c.length; }
+  return flat;
+}
+
+function handleEndpointFrame(e) {
+  if (!endpointingActive()) return;
+  const samples = new Float32Array(e.inputBuffer.getChannelData(0));
+  const frameMs = (samples.length / e.inputBuffer.sampleRate) * 1000;
+  // Always keep the "audio so far" mirror current, even while a candidate
+  // check is in flight below -- otherwise speech spoken during that
+  // round-trip would be missing from the NEXT candidate's transcript.
+  endpointFrames.push(samples);
+  if (endpointChecking) return;  // a check already owns the decision right now
+
+  const { rms } = pcmLevels(samples);
+  if (rms >= WAKE_VAD_RMS_THRESHOLD) {
+    endpointHasSpeech = true;
+    endpointSilenceMs = 0;
+    endpointCandidateFired = false;  // speech resumed -- re-arm the candidate timer
+    return;
+  }
+  if (!endpointHasSpeech) return;  // ambient silence before any speech -- not timed yet
+
+  endpointSilenceMs += frameMs;
+
+  if (endpointSilenceMs >= endpointHardCapMsSetting) {
+    finalizeEndpointing();
+    return;
+  }
+  if (!endpointCandidateFired && endpointSilenceMs >= endpointSilenceMsSetting) {
+    endpointCandidateFired = true;
+    checkEndpointCandidate(flattenEndpointFrames(), endpointSampleRate);
+  }
+}
+
+// Finalizes through the SAME path a manual stop uses -- stopRecordingAndSend()
+// -- never a parallel submit implementation. Called both by the hard cap
+// above and by a candidate check's own "complete" verdict below. Safe to call
+// more than once (the hard cap firing right around when a candidate resolves,
+// say): stopRecordingAndSend() itself guards on `!isRecording`, so whichever
+// call gets there first wins and the other is a no-op. Exported so the
+// headless test harness can exercise the hard-cap path directly -- it's the
+// exact function real continuous silence crossing HARD_CAP_MS calls, with no
+// way to wait out that much real silence through the live audio graph in a
+// browser test (see checkEndpointCandidate's doc comment for the same
+// reasoning re: candidate checks).
+export function finalizeEndpointing() {
+  if (!isRecording) return;
+  stopRecordingAndSend().catch((err) => {
+    setStatus('error', 'Error');
+    addMessage('⚠️ ' + (err?.message || 'Recording failed'), 'assistant');
+    setTalkActive(false);
+  });
+}
+
+// The candidate-endpoint pipeline. Exported (samples/sampleRate params, like
+// checkForWakeWord above) so the headless test harness can drive it directly
+// -- the live onaudioprocess VAD above can't run headless either. This is the
+// exact function handleEndpointFrame() itself calls once real silence
+// crosses SILENCE_MS; nothing here is a parallel/fake implementation of that
+// logic. Returns the completeness verdict (or null when the check never
+// reached one -- suspended, superseded, or the relay call failed) so tests
+// can assert on it directly.
+//
+// `token` pins this check to the recording it started transcribing for
+// (see endpointRecordingToken above) -- `isRecording` alone can't tell a
+// cancelled recording apart from a brand-new one Auto-continue has since
+// started, so both guard checks below compare the token too.
+export async function checkEndpointCandidate(samples, sampleRate) {
+  if (endpointChecking) return null;
+  endpointChecking = true;
+  const token = endpointRecordingToken;
+  try {
+    if (!endpointingActive() || token !== endpointRecordingToken) return null;
+    const blob = encodeWav(samples, sampleRate);
+    let transcript;
+    try {
+      transcript = await transcribeClip(blob);
+    } catch (e) {
+      return null;  // relay unreachable/erroring -- miss this candidate, the hard cap still protects us
+    }
+    // Recording ended (or Auto/voice mode changed, or a NEW recording has
+    // since started) while we awaited -- a stale verdict must never act.
+    if (!endpointingActive() || token !== endpointRecordingToken) return null;
+    const complete = isTranscriptComplete(transcript);
+    if (complete) finalizeEndpointing();
+    return complete;
+  } finally {
+    endpointChecking = false;
+  }
 }
 
 // --- thinking placeholder in the thread ---


### PR DESCRIPTION
Closes #718.

In auto mode, a turn now ends when the user finishes speaking, instead of requiring a manual stop.

- **Pause → candidate.** A second WebAudio graph taps the *same* `MediaStream` the recorder already holds (never a second `getUserMedia`); 1600ms of trailing silence after speech opens a candidate endpoint.
- **Semantic check.** The audio-so-far goes to `/api/voice/transcribe` (the bare-STT route — no conversation/turn artifacts) and `isTranscriptComplete()` decides: terminal punctuation → complete; a trailing conjunction/filler (`and, but, so, because, or, if, then, um, uh, like`, `i mean`) or no terminal punctuation → keep listening.
- **Finalize** through `stopRecordingAndSend()` — the exact path a manual stop uses, not a second submit path. `LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS` (3000) finalizes regardless, so it can never hang.
- **Gated** on Auto + voice mode + recording, so Auto-off is byte-identical to before; wake detection is already suspended while recording; TTS playback never has `isRecording` true.

Two real defects found and fixed while building it:
- `stopRecordingAndSend()` set `isRecording = false` *after* its `MIN_RECORD_MS` await, leaving a reentrancy window where the hard cap and a completeness verdict could both stop the same recording. Now set synchronously before the await.
- A per-recording token, re-checked after every await, so a stale verdict can never finalize a *different* recording than the one it transcribed.

Settings `LIFEOS_VOICE_ENDPOINT_SILENCE_MS` / `_HARD_CAP_MS` reach the client through `GET /api/chat/config`, mirroring `LIFEOS_CHAT_DEFAULT_VOICE`. `LIFEOS_VOICE_ENDPOINT_SEMANTIC` (default off) is present and exposed in that response but not yet consumed by any client code — reserved for an optional LLM classifier, documented as such in both `settings.py` and the guide.

24 new browser tests. One existing endpointing test was updated after rebasing onto #721: it waited for auto-continue to restart recording following a manual stop, which #721 deliberately removed, so it now starts the second recording with a tap — the case under test (a stale verdict must not finalize a different live recording) is unchanged.

Gates: unit scope 4,986 passed; `browser and not requires_server` 139 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)