### PR TITLE
fix(voice): play the wake chime on the shared unlocked audio element on mobile (#725)

### DIFF
--- a/tests/test_voice_wake_chime_ui_browser.py
+++ b/tests/test_voice_wake_chime_ui_browser.py
@@ -6,10 +6,21 @@ set at `web/chat/wake-sounds/` (described by `web/chat/wake-sounds/manifest.json
 -- see docs/guides/voice-setup.md for the set and its attribution) before
 handing off to `beginRecordingFromTap()`, the same function a talk-button tap
 calls. This suite never touches the real bundled files or the real fetch of
-`manifest.json` -- it stubs the manifest response and intercepts
-`Audio.play()` the same way the sibling suite intercepts
-`getUserMedia`/`MediaRecorder`, so it also stands in for a build that ships
-without the bundled assets (the graceful-absence behavior under test).
+`manifest.json` -- it stubs the manifest response (the repo now ships real
+audio under `web/chat/wake-sounds/`, but this suite keeps using fake
+filenames for determinism) and intercepts `HTMLMediaElement`'s `src`/`play()`
+at the prototype level, so it also stands in for a build that ships without
+the bundled assets (the graceful-absence behavior under test).
+
+#725: the chime used to always play via a fresh `new Audio()` -- an element
+never unlocked by a user gesture, which iOS/Android's autoplay policy
+silently blocks. `playWakeChime()` now branches on `useSharedTtsAudio()`:
+mobile plays through the same shared, gesture-unlocked `<audio>` element
+(`getTtsAudioElement()`) every other non-gesture voice playback already
+uses, via `playUrlOnElement()`; desktop keeps the original fresh-element
+path. The `src`/`play()` interception below is prototype-level (not a
+constructor wrap alone) specifically so it catches both: the shared
+element's `.src` is assigned directly, not via `new Audio(url)`.
 
 Covers:
   - A populated manifest: a chime is attempted against a
@@ -20,10 +31,20 @@ Covers:
     state that changed during playback (e.g. Listening toggled off) still
     blocks the recording that would otherwise follow.
   - A stalled chime resolves via its ~1500ms safety timeout rather than
-    hanging the wake indefinitely.
+    hanging the wake indefinitely -- on both the desktop and shared-element
+    paths, since they're separate code (playWakeChimeStandalone() vs.
+    playWakeChimeShared()).
   - An absent/404 manifest and an explicitly empty `{"sounds": []}` manifest
     both fall through to today's behavior: immediate recording, no audio
     ever attempted, no error surfaced.
+  - Mobile (Android UA): the chime plays on the *same* element
+    `unlockTtsAudio()` already constructed and unlocked, not a second, still
+    -locked one.
+  - Desktop (default UA): unchanged -- no shared/unlock element is ever
+    touched; the chime still gets its own fresh `<audio>`.
+  - The #608 regression guard: a wake match while a real TTS clip is still
+    in flight on the shared element must not let the chime steal it (and
+    the real clip must finish undisturbed).
 
 Like tests/test_voice_listening_wake_word_ui_browser.py, this drives the
 pipeline through the real `window.lifeChatVoice.checkForWakeWord(samples,
@@ -43,6 +64,8 @@ from playwright.sync_api import Page
 pytestmark = [pytest.mark.browser, pytest.mark.slow]
 
 WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+ANDROID_UA = "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
 
 
 class _ChatHandler(http.server.SimpleHTTPRequestHandler):
@@ -72,25 +95,81 @@ def chat_base_url():
         server.server_close()
 
 
+# These suites measure chime/recording behavior, not dock configuration. The
+# shipped dock defaults (2x/Auto/Listening on) would otherwise inject an
+# auto-continue re-record after a real submitTurn() (used by the
+# clip-in-flight guard test below) and shift what "no chime attempted" means.
+# Mirrors tests/test_voice_rate_toggle_playback_ui_browser.py's own baseline
+# for the same reason. `_enable_listening()` below flips the checkbox itself
+# rather than relying on a shipped `listen: true` default.
+_DOCK_BASELINE = (
+    "try { window.localStorage.setItem('lifeos:chat:dock_settings', "
+    "JSON.stringify({ mute: false, auto: false, fast: false, listen: false })); } "
+    "catch (e) {}"
+)
+
 # Installed before any app JS runs. window.fetch stubs the wake-word STT
-# round-trip (always matches "Hermes" unless a test overrides it) and the
-# chime manifest fetch (`window.__manifestResponse`, default two fake
-# entries -- `null` simulates a 404, i.e. the directory not existing at
-# all). getUserMedia returns a real (silent) MediaStream so WebAudio/
-# MediaRecorder accept it without touching real hardware.
+# round-trip (always matches "Hermes" unless a test overrides it), the chime
+# manifest fetch (`window.__manifestResponse`, default two fake entries --
+# `null` simulates a 404, i.e. the directory not existing at all), and the
+# voice-turn SSE stream (`window.__mockAudio`, a one-shot-per-turn queue --
+# used only by the clip-in-flight guard test, harmless elsewhere). getUserMedia
+# returns a real (silent) MediaStream so WebAudio/MediaRecorder accept it
+# without touching real hardware.
 #
-# `Audio` is wrapped so a chime clip (URL under /static/chat/wake-sounds/)
-# never actually loads a file that doesn't exist in this repo: play()
-# records the attempt in `window.__audioLog` and queues a resolver in
-# `window.__pendingChimeResolvers` that a test fires explicitly via
-# `window.__resolveChime()` to simulate the clip's `ended` event at a time
-# of the test's choosing -- letting tests assert on state *during* chime
-# playback before finishing it. A chime that's never resolved this way
-# exercises playWakeChime()'s own ~1500ms safety timeout instead.
+# Audio interception is at the `HTMLMediaElement.prototype` level (`src`
+# setter + `play()`), not just a wrapped `Audio` constructor -- #725's mobile
+# path assigns `.src` directly on a *reused* element (`getTtsAudioElement()`),
+# it doesn't construct a fresh one per clip the way desktop and the old code
+# did. A src assignment under `/static/chat/wake-sounds/` never hits the real
+# network (this repo's fixture doesn't ship files matching the fake names
+# below, and no real audio decode needs to happen for these tests): it's
+# logged to `window.__audioLog`, marked pending, and the element's
+# `readyState` is shadowed to report itself immediately decodable, so
+# `playUrlOnElement()`'s synchronous-vs-`canplaythrough` branch doesn't wait
+# on an event this stub will never fire. A test resolves a pending chime's
+# `play()` (a promise that never settles on its own) via
+# `window.__resolveChime()`, simulating the clip's `ended` event at a time of
+# the test's choosing. Non-chime `src` assignments (the shared element's
+# SILENT_WAV unlock ping, and the guard test's real WAV clips) pass straight
+# through to native `src`/`play()` -- real (silent, local data-URI) playback,
+# real `ended` timing.
 _INSTRUMENT_SCRIPT = """
 window.__fetchLog = [];
 window.__transcribeResponse = 'hermes';
 window.__manifestResponse = { sounds: ['chime-a.mp3', 'chime-b.mp3'] };
+window.__mockAudio = [];
+
+window.__makeWav = function (ms, sampleRate) {
+  sampleRate = sampleRate || 8000;
+  var n = Math.round((ms / 1000) * sampleRate);
+  var dataBytes = n * 2;
+  var buf = new ArrayBuffer(44 + dataBytes);
+  var view = new DataView(buf);
+  var writeStr = function (offset, str) {
+    for (var i = 0; i < str.length; i++) view.setUint8(offset + i, str.charCodeAt(i));
+  };
+  writeStr(0, 'RIFF');
+  view.setUint32(4, 36 + dataBytes, true);
+  writeStr(8, 'WAVE');
+  writeStr(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeStr(36, 'data');
+  view.setUint32(40, dataBytes, true);
+  var bytes = new Uint8Array(buf);
+  var binary = '';
+  var chunk = 0x8000;
+  for (var i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+  }
+  return 'data:audio/wav;base64,' + btoa(binary);
+};
 
 window.fetch = function (url, opts) {
   var urlStr = typeof url === 'string' ? url : (url && url.url) || String(url);
@@ -107,6 +186,13 @@ window.fetch = function (url, opts) {
     return Promise.resolve(new Response(JSON.stringify(window.__manifestResponse), {
       status: 200, headers: { 'Content-Type': 'application/json' },
     }));
+  }
+  if (urlStr.indexOf('/api/voice/turn/stream') !== -1) {
+    var cfg = window.__mockAudio.shift() || { ms: 100, tag: 'default' };
+    var clipUrl = window.__makeWav(cfg.ms) + '#' + cfg.tag;
+    var sse = 'data: ' + JSON.stringify({ type: 'main_audio', url: clipUrl }) + '\\n\\n';
+    sse += 'data: ' + JSON.stringify({ type: 'done', data: { response_text: 'ok ' + cfg.tag } }) + '\\n\\n';
+    return Promise.resolve(new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
   }
   return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
 };
@@ -132,32 +218,61 @@ navigator.mediaDevices.getUserMedia = function (constraints) {
   window.MediaRecorder = WrappedMR;
 })();
 
-window.__audioLog = [];
+window.__audioLog = [];             // {id, src, chime} for every `.src` assignment
+window.__constructedAudioIds = [];  // one entry per `new Audio()` call, in order
+window.__playLog = [];              // {id, src, chime} for every play() call
 window.__pendingChimeResolvers = [];
+
 (function () {
   var OrigAudio = window.Audio;
+  var nextId = 0;
   window.Audio = function (src) {
-    var a = new OrigAudio();
-    window.__audioLog.push(src || '');
-    var isChime = typeof src === 'string' && src.indexOf('/static/chat/wake-sounds/') !== -1;
-    if (isChime) {
-      // Deliberately never assign the real `src` -- this repo commits no
-      // real audio into the test fixture, and setting `.src` on a genuine
-      // <audio> element would make the browser actually fetch it, 404 against
-      // the ephemeral test server, and fire a *real* native `error` event
-      // before the test ever calls window.__resolveChime(). Playback is
-      // instead driven entirely by that explicit call.
-      a.play = function () {
-        window.__pendingChimeResolvers.push(function () { a.dispatchEvent(new Event('ended')); });
-        return Promise.resolve();
-      };
-    } else if (src !== undefined) {
-      a.src = src;
-    }
-    return a;
+    var el = new OrigAudio();
+    el.__id = ++nextId;
+    window.__constructedAudioIds.push(el.__id);
+    if (src !== undefined) el.src = src;
+    return el;
   };
   window.Audio.prototype = OrigAudio.prototype;
+
+  var proto = HTMLMediaElement.prototype;
+  var srcDesc = Object.getOwnPropertyDescriptor(proto, 'src');
+  Object.defineProperty(proto, 'src', {
+    get: function () { return srcDesc.get.call(this); },
+    set: function (v) {
+      var isChime = typeof v === 'string' && v.indexOf('/static/chat/wake-sounds/') !== -1;
+      this.__pendingChime = isChime;
+      window.__audioLog.push({ id: this.__id, src: v || '', chime: isChime });
+      if (isChime) {
+        try {
+          Object.defineProperty(this, 'readyState', {
+            configurable: true, value: HTMLMediaElement.HAVE_ENOUGH_DATA,
+          });
+        } catch (e) { /* ignore */ }
+      } else {
+        try { delete this.readyState; } catch (e) { /* ignore */ }
+        srcDesc.set.call(this, v);
+      }
+    },
+  });
+
+  var origPlay = proto.play;
+  proto.play = function () {
+    var chime = !!this.__pendingChime;
+    window.__playLog.push({ id: this.__id, src: this.src, chime: chime });
+    if (chime) {
+      var self = this;
+      return new Promise(function (resolve) {
+        window.__pendingChimeResolvers.push(function () {
+          self.dispatchEvent(new Event('ended'));
+          resolve();
+        });
+      });
+    }
+    return origPlay.call(this);
+  };
 })();
+
 window.__resolveChime = function () {
   var fns = window.__pendingChimeResolvers;
   window.__pendingChimeResolvers = [];
@@ -168,11 +283,17 @@ window.__resolveChime = function () {
 _NO_MANIFEST_OVERRIDE = object()
 
 
-def _open_voice_chat(page: Page, base_url, manifest=_NO_MANIFEST_OVERRIDE):
+def _open_voice_chat(page: Page, base_url, manifest=_NO_MANIFEST_OVERRIDE, android=False):
     """`manifest=None` simulates an absent/404 manifest (web/chat/wake-sounds/
     not present at all); a dict overrides `window.__manifestResponse` with
     that JSON; omitting it entirely keeps the instrument script's own
-    default (two fake chime entries)."""
+    default (two fake chime entries). `android=True` sets a mobile UA so
+    `useSharedTtsAudio()` takes the shared-element path (#725)."""
+    if android:
+        page.add_init_script(
+            "Object.defineProperty(navigator, 'userAgent', { value: %r });" % ANDROID_UA
+        )
+    page.add_init_script(_DOCK_BASELINE)
     page.add_init_script(_INSTRUMENT_SCRIPT)
     if manifest is not _NO_MANIFEST_OVERRIDE:
         # Runs after the instrument script's own init script (both are
@@ -209,9 +330,7 @@ def _is_recording(page: Page):
 
 
 def _chime_attempted(page: Page):
-    return page.evaluate(
-        "window.__audioLog.some((u) => u && u.indexOf('/static/chat/wake-sounds/') !== -1)"
-    )
+    return page.evaluate("window.__audioLog.some((e) => e.chime)")
 
 
 class TestChimePlaysBeforeRecording:
@@ -221,13 +340,10 @@ class TestChimePlaysBeforeRecording:
 
         _fire_wake_check(page)
 
-        page.wait_for_function(
-            "window.__audioLog.some((u) => u && u.indexOf('/static/chat/wake-sounds/') !== -1)"
-        )
+        page.wait_for_function("window.__audioLog.some((e) => e.chime)")
         # A real chime URL, not the manifest fetch itself.
         chime_url = next(
-            u for u in page.evaluate("window.__audioLog")
-            if u and "/static/chat/wake-sounds/" in u
+            e["src"] for e in page.evaluate("window.__audioLog") if e["chime"]
         )
         assert chime_url in (
             "/static/chat/wake-sounds/chime-a.mp3",
@@ -247,16 +363,14 @@ class TestChimePlaysBeforeRecording:
         page.wait_for_function("window.__wakeResult === true")
 
     def test_stalled_chime_resolves_via_safety_timeout(self, page: Page, chat_base_url):
-        """Never call __resolveChime() -- playWakeChime()'s own ~1500ms cap
-        must still let recording begin."""
+        """Never call __resolveChime() -- playWakeChimeStandalone()'s own
+        ~1500ms cap must still let recording begin."""
         _open_voice_chat(page, chat_base_url)
         _enable_listening(page)
 
         _fire_wake_check(page)
 
-        page.wait_for_function(
-            "window.__audioLog.some((u) => u && u.indexOf('/static/chat/wake-sounds/') !== -1)"
-        )
+        page.wait_for_function("window.__audioLog.some((e) => e.chime)")
         assert _is_recording(page) is False
 
         page.wait_for_function(
@@ -273,9 +387,7 @@ class TestGuardsRecheckedAfterChime:
         _enable_listening(page)
 
         _fire_wake_check(page)
-        page.wait_for_function(
-            "window.__audioLog.some((u) => u && u.indexOf('/static/chat/wake-sounds/') !== -1)"
-        )
+        page.wait_for_function("window.__audioLog.some((e) => e.chime)")
 
         page.locator("#voiceListen").uncheck()
         page.evaluate("window.__resolveChime()")
@@ -332,3 +444,158 @@ class TestNoManifestIsIdentitcalToNoChime:
         assert _is_recording(page) is True
         assert _chime_attempted(page) is False
         assert errors == []
+
+
+class TestMobileSharedElement:
+    """#725: on iOS/Android the chime must route through the shared,
+    gesture-unlocked `<audio>` element (getTtsAudioElement()) instead of a
+    fresh `new Audio()` -- a fresh element is never unlocked, so mobile
+    silently dropped the chime while every other voice playback (which
+    already used the shared element) worked fine."""
+
+    def test_chime_plays_on_the_shared_element_not_a_fresh_audio(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url, android=True)
+        _enable_listening(page)
+
+        _fire_wake_check(page)
+        page.wait_for_function("window.__audioLog.some((e) => e.chime)")
+
+        # unlockTtsAudio() (called synchronously in triggerWakeRecording(),
+        # before the chime) constructs the one shared element via
+        # getTtsAudioElement(). The chime must reuse it, not build a second,
+        # still-locked one.
+        constructed = page.evaluate("window.__constructedAudioIds")
+        assert len(constructed) == 1, (
+            f"expected exactly one Audio() construction (the shared unlock element), "
+            f"got {len(constructed)} -- the chime built a fresh, un-unlocked element instead "
+            f"of reusing the shared one: {constructed}"
+        )
+        shared_id = constructed[0]
+
+        chime_src_sets = [e for e in page.evaluate("window.__audioLog") if e["chime"]]
+        assert chime_src_sets and all(e["id"] == shared_id for e in chime_src_sets), (
+            f"chime src was set on a different element than the shared unlock one: {chime_src_sets}"
+        )
+
+        chime_plays = [e for e in page.evaluate("window.__playLog") if e["chime"]]
+        assert chime_plays and all(e["id"] == shared_id for e in chime_plays), (
+            f"chime play() happened on a different element than the shared unlock one: {chime_plays}"
+        )
+
+        # The shared element's unlock ping (SILENT_WAV) is a real, non-chime
+        # src assignment on that same element, ahead of the chime's -- proof
+        # this really is the gesture-unlocked element the mobile fix routes
+        # through, not a coincidentally-matching id.
+        events = page.evaluate("window.__audioLog")
+        assert events[0]["id"] == shared_id and events[0]["chime"] is False, (
+            f"expected the shared element's first src assignment to be the SILENT_WAV "
+            f"unlock ping, not the chime: {events}"
+        )
+
+        page.evaluate("window.__resolveChime()")
+        page.wait_for_function(
+            "document.getElementById('voiceTalkBtn').classList.contains('recording')"
+        )
+        assert page.evaluate("window.__recorderStartCalls") == 1
+
+    def test_stalled_shared_chime_resolves_via_safety_timeout(self, page: Page, chat_base_url):
+        """Never call __resolveChime() -- playWakeChimeShared()'s own
+        Promise.race timeout (separate code from the desktop path's) must
+        still let recording begin."""
+        _open_voice_chat(page, chat_base_url, android=True)
+        _enable_listening(page)
+
+        _fire_wake_check(page)
+        page.wait_for_function("window.__audioLog.some((e) => e.chime)")
+        assert _is_recording(page) is False
+
+        page.wait_for_function(
+            "document.getElementById('voiceTalkBtn').classList.contains('recording')",
+            timeout=3000,
+        )
+        assert page.evaluate("window.__recorderStartCalls") == 1
+
+
+class TestDesktopUnchanged:
+    """Desktop has no autoplay-unlock requirement to route around, so
+    unlockTtsAudio() no-ops there (useSharedTtsAudio() is false) and the
+    chime keeps constructing its own fresh, throwaway `<audio>` exactly like
+    before #725."""
+
+    def test_desktop_chime_never_touches_a_shared_unlock_element(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)  # no android=True -- desktop UA
+        _enable_listening(page)
+
+        _fire_wake_check(page)
+        page.wait_for_function("window.__audioLog.some((e) => e.chime)")
+
+        events = page.evaluate("window.__audioLog")
+        # On mobile there's always a prior non-chime (SILENT_WAV) src
+        # assignment from unlockTtsAudio() on the element the chime then
+        # reuses. Desktop must have none -- unlockTtsAudio() is a no-op
+        # there, so the chime's own src-set is the only assignment, on a
+        # fresh element built just for it.
+        assert not any(not e["chime"] for e in events), (
+            f"a non-chime src assignment happened on desktop -- "
+            f"unlockTtsAudio() shouldn't touch anything here: {events}"
+        )
+        assert len(page.evaluate("window.__constructedAudioIds")) == 1
+
+        page.evaluate("window.__resolveChime()")
+        page.wait_for_function(
+            "document.getElementById('voiceTalkBtn').classList.contains('recording')"
+        )
+        assert page.evaluate("window.__recorderStartCalls") == 1
+
+
+class TestClipInFlightGuard:
+    """#608 regression guard, applied to the new shared-element chime path:
+    a wake match while a real TTS clip is still loading/playing on the
+    shared element must not let the chime steal it out from under that
+    clip. baseWakeGuardsOk() (checked at the very top of
+    triggerWakeRecording(), before the chime's manifest fetch even starts)
+    already requires `!clipInFlight`, which playSingleUrl() sets true
+    *before* the real clip's own `.src` assignment -- so by the time this
+    test observes that assignment, clipInFlight is already guaranteed true."""
+
+    def test_wake_during_a_real_clip_does_not_steal_it(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url, android=True)
+        _enable_listening(page)
+
+        # Start a real (400ms) turn without awaiting it -- this is what
+        # holds clipInFlight true on the shared element for the window this
+        # test needs.
+        page.evaluate("window.__mockAudio.push({ms: 400, tag: 't1'})")
+        page.evaluate("""
+            () => {
+              window.__turnDone = false;
+              window.lifeChatVoice.submitTurn({ transcript: 'hi' })
+                .then(() => { window.__turnDone = true; });
+            }
+        """)
+        page.wait_for_function(
+            "window.__audioLog.some((e) => !e.chime && e.src.indexOf('t1') !== -1)"
+        )
+
+        # Real clip is now in flight. A wake match arriving in this window
+        # must be refused, not steal the element.
+        _fire_wake_check(page)
+        page.wait_for_function("window.__wakeResult !== undefined")
+
+        assert page.evaluate("window.__wakeResult") is False
+        assert not any(e["chime"] for e in page.evaluate("window.__audioLog")), (
+            "the chime touched the shared element's src while a real clip "
+            "was still in flight -- #608 regression"
+        )
+        assert _is_recording(page) is False
+
+        # The real clip must still finish on its own, undisturbed.
+        page.wait_for_function("window.__turnDone === true", timeout=3000)
+        real_src_sets = [
+            e for e in page.evaluate("window.__audioLog")
+            if not e["chime"] and "t1" in e["src"]
+        ]
+        assert len(real_src_sets) == 1, (
+            f"expected exactly one src assignment for the real clip, got "
+            f"{len(real_src_sets)} -- it was reassigned mid-flight: {real_src_sets}"
+        )

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -924,32 +924,90 @@ function loadWakeChimeManifest() {
   return wakeChimeManifestPromise;
 }
 
-// Plays one randomly-chosen chime and resolves once it's done -- on `ended`,
-// on a safety timeout (a long or stalled clip must never hang the wake), or
-// immediately if there's nothing to play. Never rejects: a missing/broken
-// sound file degrades to "no chime", not a wake failure.
+// Desktop path: a fresh, throwaway `<audio>` per chime, same as before #725.
+// Desktop's autoplay policy doesn't require a prior gesture-unlocked element
+// the way iOS/Android's does (this whole file's shared-element machinery
+// exists only to route around that mobile restriction), so there's nothing
+// to gain from sharing `ttsAudio` here -- and not sharing means a wake chime
+// can never contend with `ttsAudio` for desktop, whose per-clip `new Audio()`
+// path (playSingleUrl()'s non-shared branch) has no equivalent contention to
+// begin with. Resolves on `ended`, on the safety timeout (a long/stalled
+// clip must never hang the wake), or immediately on a synchronous throw.
+// Never rejects.
+function playWakeChimeStandalone(url) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    const timer = setTimeout(finish, WAKE_CHIME_TIMEOUT_MS);
+    const settleAndClear = () => { clearTimeout(timer); finish(); };
+    try {
+      const audio = new Audio(url);
+      audio.addEventListener('ended', settleAndClear);
+      audio.addEventListener('error', settleAndClear);
+      audio.play().catch(settleAndClear);
+    } catch (e) {
+      settleAndClear();
+    }
+  });
+}
+
+// Mobile path (#725): the chime used to play via `new Audio()` -- an element
+// never unlocked by a user gesture. iOS/Android block that unconditionally,
+// and the wake path has no gesture of its own (it fires from the wake-word
+// STT callback), so the chime was always silent there. Every other
+// non-gesture playback on this platform (status/main TTS audio) already
+// solves this by routing through the single shared element `unlockTtsAudio()`
+// unlocked from an earlier tap -- this does the same, via the same
+// `playUrlOnElement()` helper real clips use, rather than a second
+// playback routine.
+//
+// Guarded against the #608 hazard `unlockTtsAudio()` itself guards against:
+// touching `.src` while a real clip is mid-load/playback on this element
+// would abandon that clip's `oncanplaythrough` the same way. Callers only
+// ever reach this once `baseWakeGuardsOk()` (which requires `!clipInFlight`)
+// has already passed in `triggerWakeRecording()` -- but that check happens
+// before `loadWakeChimeManifest()`'s promise settles, which is always at
+// least one microtask away (even cached, `.then()` never runs synchronously)
+// and, on an uncached first load, a real network round-trip. A real clip
+// could start in that window (a turn's `status_audio`/`main_audio` event
+// firing), so the guard here is load-bearing, not defensive-only.
+// If it fires, the chime is simply skipped -- no chime is the existing,
+// accepted degraded behavior (see loadWakeChimeManifest()'s own doc comment)
+// and is far preferable to stealing a real reply out from under the user.
+function playWakeChimeShared(url) {
+  if (clipInFlight) return Promise.resolve();
+  const audio = getTtsAudioElement();
+  if (!activeAudios.includes(audio)) activeAudios.push(audio);
+  clipInFlight = true;
+  const settle = playUrlOnElement(audio, url).catch(() => {});
+  return Promise.race([
+    settle,
+    new Promise((resolve) => setTimeout(resolve, WAKE_CHIME_TIMEOUT_MS)),
+  ]).then(() => {
+    // Whichever settled first: if the timeout won while the clip was still
+    // loading/playing, abort it explicitly rather than leaving it to finish
+    // on its own -- the same mechanism stopAllAudio() uses. A no-op if the
+    // clip already finished (playUrlOnElement()'s own finish() already
+    // nulled __abortPlayback in that case). Doesn't touch `.src`/playbackRate
+    // beyond that: the next real clip's own playUrlOnElement() call always
+    // reassigns both before playing, so nothing here can leak into it.
+    audio.__abortPlayback?.();
+  }).finally(() => { clipInFlight = false; });
+}
+
+// Plays one randomly-chosen chime and resolves once it's done. Never
+// rejects: a missing/broken sound file, or a guard refusing to touch the
+// shared element, degrades to "no chime", not a wake failure.
 function playWakeChime() {
   return loadWakeChimeManifest().then((sounds) => {
     if (!sounds.length) return;
     const name = sounds[Math.floor(Math.random() * sounds.length)];
-    return new Promise((resolve) => {
-      let settled = false;
-      const finish = () => {
-        if (settled) return;
-        settled = true;
-        resolve();
-      };
-      const timer = setTimeout(finish, WAKE_CHIME_TIMEOUT_MS);
-      const settleAndClear = () => { clearTimeout(timer); finish(); };
-      try {
-        const audio = new Audio(WAKE_CHIME_DIR + encodeURIComponent(name));
-        audio.addEventListener('ended', settleAndClear);
-        audio.addEventListener('error', settleAndClear);
-        audio.play().catch(settleAndClear);
-      } catch (e) {
-        settleAndClear();
-      }
-    });
+    const url = WAKE_CHIME_DIR + encodeURIComponent(name);
+    return useSharedTtsAudio() ? playWakeChimeShared(url) : playWakeChimeStandalone(url);
   }).catch(() => {});  // belt-and-suspenders -- loadWakeChimeManifest() already never throws
 }
 


### PR DESCRIPTION
Closes #725.

The wake chime was inaudible on iPhone. `playWakeChime()` used `new Audio(...)` — an element never unlocked by a user gesture — while all other voice playback on iOS/Android routes through the single gesture-unlocked shared element for exactly that reason. The chime also fires from the wake-word STT callback, so there is no gesture in the call stack; the rejected `play()` was swallowed, leaving a silent failure that still recorded correctly.

- Mobile (`useSharedTtsAudio()`) plays through `getTtsAudioElement()` + `playUrlOnElement()` — the same function real TTS clips use, not a second playback routine.
- Desktop keeps the prior per-clip path verbatim (extracted into a named function); it has no unlock requirement, so sharing would only add contention with the real TTS element.
- **#608 guard:** `triggerWakeRecording()` checks `clipInFlight` synchronously, but `playWakeChime()` first awaits the manifest — even a cached one resolves via a microtask — so a clip could start in that gap. The shared path re-checks `clipInFlight` immediately before touching `.src`, mirroring `unlockTtsAudio()`. A browser test starts a real clip, fires a wake check while it is genuinely in flight, and asserts the chime never touches `.src` and the real clip completes undisturbed.
- Still never blocks the wake: raced against the existing 1500ms cap, never rejects, and aborts a stalled clip through the same mechanism `stopAllAudio()` uses.

Known, accepted side effect of the reuse: with the 2x toggle on, the chime plays at 2x as well.

Gates: unit scope 4,986 passed; `browser and not requires_server` 143 passed (post-rebase onto #718).

🤖 Generated with [Claude Code](https://claude.com/claude-code)