### PR TITLE
fix(voice): suspend the wake tap during playback to stop audio artifacts (#734)

### DIFF
--- a/tests/test_voice_endpointing_ui_browser.py
+++ b/tests/test_voice_endpointing_ui_browser.py
@@ -424,3 +424,56 @@ class TestBargeInSuspension:
 
         assert result is None
         assert page.evaluate("window.__recorderStopCalls") == 0
+
+
+class TestEndpointTapTeardown:
+    """The endpointing ScriptProcessorNode (#734's tap #3 -- see the
+    audio-taps inventory above ensureAudioContext() in voice.js) must be
+    connected only while a recording it governs is actually in progress, and
+    disconnected on every path that ends that recording -- a live callback
+    left behind after the recording ends is exactly the class of bug #734
+    fixed for the wake tap. `isEndpointTapActive()` checks the tap directly
+    (`!!endpointProcessor`) rather than inferring teardown indirectly."""
+
+    def test_active_while_recording(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is False
+
+        _start_recording(page)
+
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is True
+
+    def test_torn_down_on_manual_stop(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is True
+
+        # force=True: the .recording class drives an infinite CSS pulse
+        # animation, which fails Playwright's default actionability wait.
+        page.locator("#voiceTalkBtn").click(force=True)
+        page.wait_for_function("window.__recorderStopCalls === 1")
+
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is False
+
+    def test_torn_down_on_hard_cap_finalize(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is True
+
+        page.evaluate("() => window.lifeChatVoice.finalizeEndpointing()")
+        page.wait_for_function("window.__recorderStopCalls === 1")
+
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is False
+
+    def test_torn_down_on_candidate_complete_finalize(self, page: Page, chat_base_url):
+        """The "submit" path -- a candidate check verdicting complete finalizes
+        through the same stopRecordingAndSend() call a manual stop uses."""
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is True
+
+        result = _check_candidate(page, "Turn off the lights.")
+        assert result is True
+        page.wait_for_function("window.__recorderStopCalls === 1")
+
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is False

--- a/tests/test_voice_listening_wake_word_ui_browser.py
+++ b/tests/test_voice_listening_wake_word_ui_browser.py
@@ -129,6 +129,41 @@ navigator.mediaDevices.getUserMedia = function (constraints) {
   window.MediaRecorder = WrappedMR;
 })();
 
+// Overrides AudioContext.prototype's `state`/suspend()/resume() with a
+// JS-tracked stand-in, defaulting new contexts to 'running' (#734). Real
+// Chrome autoplay policy suspends a context created with no prior user
+// gesture on the page until later explicitly resumed or auto-unlocked by
+// the browser's per-origin media-engagement heuristics (accumulated real
+// usage history a fresh/headless browser never has) -- neither of those
+// apply to a synthetic Playwright session, so a *real* listenAudioCtx here
+// would start (and stay) 'suspended' regardless of the fix under test,
+// which is the wrong baseline: the bug this suite tests is about a tap
+// that IS running contending with playback, matching the real device the
+// issue was filed from. The override only changes what `.state` reports
+// and what suspend()/resume() toggle -- createScriptProcessor/
+// createMediaStreamSource/etc. all still hit the real implementation, so
+// the live onaudioprocess graph keeps working exactly as before.
+(function () {
+  window.__ctxSuspendCalls = 0;
+  window.__ctxResumeCalls = 0;
+  var proto = (window.AudioContext || window.webkitAudioContext).prototype;
+  var stateMap = new WeakMap();
+  Object.defineProperty(proto, 'state', {
+    configurable: true,
+    get: function () { return stateMap.has(this) ? stateMap.get(this) : 'running'; },
+  });
+  proto.suspend = function () {
+    window.__ctxSuspendCalls += 1;
+    stateMap.set(this, 'suspended');
+    return Promise.resolve();
+  };
+  proto.resume = function () {
+    window.__ctxResumeCalls += 1;
+    stateMap.set(this, 'running');
+    return Promise.resolve();
+  };
+})();
+
 (function () {
   window.__audioPlayingCount = 0;
   var proto = HTMLMediaElement.prototype;
@@ -401,6 +436,45 @@ class TestListeningSuspension:
         triggered_after = _check_wake(page, "Hermes")
 
         assert triggered_after is True, "Listening did not resume after TTS playback ended"
+        assert page.evaluate("window.__recorderStartCalls") == 1
+
+    def test_wake_tap_graph_itself_suspends_during_playback_and_resumes_after(
+            self, page: Page, chat_base_url):
+        """#734: the wake tap's callback must actually stop firing while a
+        clip plays, not merely have its output ignored (the old bug --
+        canDetectWake() already returned False here, but the still-connected
+        ScriptProcessorNode kept its onaudioprocess callback running on the
+        main thread, contending with playback). isListenTapRunning() checks
+        the graph's own AudioContext.state directly, and __gumCalls/
+        __stopCalls confirm the suspend/resume cycle never touches the mic
+        permission -- no second getUserMedia, no track stop."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceAuto").uncheck()  # isolate from auto-continue, as above
+        page.locator("#voiceListen").check()
+        page.wait_for_function("window.__gumCalls === 1")
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+
+        clip_url = page.evaluate("window.__makeWav(500)")
+        page.evaluate("(u) => { window.__turnClipUrl = u; }", clip_url)
+        page.evaluate("() => { window.lifeChatVoice.submitTurn({ transcript: 'hi' }); }")
+        page.wait_for_function("window.__audioPlayingCount > 0")
+
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === false")
+        # The mic hold itself is untouched by the suspend -- no re-prompt, no
+        # second acquisition, no track stop.
+        assert page.evaluate("window.__gumCalls") == 1
+        assert page.evaluate("window.__stopCalls") == 0
+
+        page.wait_for_function("window.__audioPlayingCount === 0", timeout=5000)
+
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+        assert page.evaluate("window.__gumCalls") == 1
+        assert page.evaluate("window.__stopCalls") == 0
+
+        # And detection genuinely works again, not just the graph being
+        # nominally "running" -- a real wake match still triggers recording.
+        triggered = _check_wake(page, "Hermes")
+        assert triggered is True
         assert page.evaluate("window.__recorderStartCalls") == 1
 
     def test_auto_continue_takes_over_after_tts_instead_of_the_wake_word(

--- a/tests/test_voice_spoken_cancel_ui_browser.py
+++ b/tests/test_voice_spoken_cancel_ui_browser.py
@@ -271,13 +271,17 @@ class TestCancelDiscardsRecording:
     def test_cancel_tears_down_endpointing_cleanly(self, page: Page, chat_base_url):
         """No lingering timer/graph after a discard -- the talk button
         starts a fresh recording normally afterward, the same signal
-        tests/test_voice_endpointing_ui_browser.py's stale-check test uses."""
+        tests/test_voice_endpointing_ui_browser.py's stale-check test uses.
+        Also checked directly via isEndpointTapActive() (#734's tap
+        inventory) rather than only inferred through the restart."""
         _open_voice_chat_listening_off(page, chat_base_url)
         _start_recording(page)
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is True
 
         _check_candidate(page, "scratch that")
         page.wait_for_function("window.__recorderStopCalls === 1")
         assert _is_recording(page) is False
+        assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is False
 
         _start_recording(page)
         page.wait_for_function("window.__recorderStartCalls === 2")

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -22,7 +22,7 @@ import { loadPersonas, onPersonaChange, personaOrchestrates, personaSupportsHand
 import {
   initVoice, submitTurn, checkForWakeWord,
   checkEndpointCandidate, isTranscriptComplete, finalizeEndpointing,
-  isCancelUtterance,
+  isCancelUtterance, isListenTapRunning, isEndpointTapActive,
 } from './voice.js';
 import { initBackend } from './backend.js';
 import { initModel, onModelChange } from './model.js';
@@ -104,5 +104,5 @@ Object.assign(window, {
 window.lifeChatVoice = {
   submitTurn, checkForWakeWord,
   checkEndpointCandidate, isTranscriptComplete, finalizeEndpointing,
-  isCancelUtterance,
+  isCancelUtterance, isListenTapRunning, isEndpointTapActive,
 };

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -73,6 +73,29 @@ let clipInFlight = false;
 let thinkingEl = null;
 let ttsAudio = null;
 
+// Every write to `clipInFlight` goes through here (#734) rather than
+// assigning the module variable directly, so the wake tap's AudioContext
+// (`listenAudioCtx`, set up in startListening() below) suspends/resumes in
+// lockstep with it. `ScriptProcessorNode.onaudioprocess` runs on the main
+// thread regardless of whether handleListenFrame() has anything useful to
+// do with the frame -- while a clip plays, that node stayed connected and
+// kept firing even though canDetectWake()'s own clipInFlight guard already
+// made every call a no-op, and the live callback contended with playback.
+// suspend()/resume() stop and restart the whole graph's processing without
+// touching the mic stream or the node wiring, so a wake match still works
+// after a playback cycle with zero extra getUserMedia calls. Both branches
+// are no-ops when Listening isn't running (listenAudioCtx null) or the
+// context is already in the target state.
+function setClipInFlight(value) {
+  clipInFlight = value;
+  if (!listenAudioCtx) return;
+  if (value && listenAudioCtx.state === 'running') {
+    listenAudioCtx.suspend().catch(() => {});
+  } else if (!value && listenAudioCtx.state === 'suspended') {
+    listenAudioCtx.resume().catch(() => {});
+  }
+}
+
 // Dock defaults for a first-time visitor (no stored settings yet). 2x playback,
 // auto-continue, and wake-word listening are on so voice mode is conversational
 // out of the box: speak, hear the reply at 2x, and be heard again without
@@ -493,6 +516,51 @@ function beginRecording(stream) {
   maybeStartEndpointing(stream);  // #718 -- no-op unless Auto + voice mode
 }
 
+// --- Audio taps: inventory and the main-thread-contention invariant (#734) ---
+//
+// This file runs up to three independent `ScriptProcessorNode`s, each on its
+// own `AudioContext`:
+//   1. `audioProcessor` (below, iOS WebAudio recorder path) -- connected only
+//      while actually recording on that platform; torn down by
+//      releaseCapture() the instant recording stops.
+//   2. `listenProcessor` (startListening()/stopListening(), "Listening"
+//      section below) -- connected for as long as voice mode + the Listening
+//      toggle are both on, which since #710 shipping the toggle on by
+//      default means essentially the whole time voice mode is open,
+//      including while a reply is playing.
+//   3. `endpointProcessor` (maybeStartEndpointing()/stopEndpointing(), "Smart
+//      turn endpointing" section below) -- connected only while a recording
+//      that Auto-continue governs is in progress; torn down on every stop
+//      path via stopRecordingAndSend()'s synchronous stopEndpointing() call.
+//
+// `ScriptProcessorNode` is deprecated specifically because its
+// `onaudioprocess` callback runs on the **main thread** -- every connected
+// node is a periodic main-thread callback, and playback (decoding, DOM/UI
+// work, GC) competes with it for the same thread. On real hardware that
+// contention is audible: scratchy, popping playback. It does NOT show up as
+// a test failure -- headless suites don't render real audio -- so this is a
+// listen-to-it-on-a-real-device regression class, which is why the rule is
+// written down here instead of left to be rediscovered.
+//
+// The invariant: **a tap that isn't actively needed must be disconnected or
+// have its `AudioContext` suspended -- not merely have its output ignored.**
+// Bug #734 was exactly this mistake: `handleListenFrame()` correctly
+// suspended *detection* while a clip played (`canDetectWake()`'s
+// `clipInFlight` guard) but left `listenProcessor` connected and firing --
+// the callback kept running on the main thread for no purpose the entire
+// time a reply was audible. The fix (`setClipInFlight()` above) suspends
+// `listenAudioCtx` itself in lockstep with `clipInFlight`, so the callback
+// stops firing rather than merely discarding what it computes. Suspend, not
+// `getUserMedia`-releasing teardown: the mic stream and node wiring survive
+// untouched, so resuming never re-prompts for mic permission.
+//
+// Anyone adding a fourth tap (or re-enabling one of these outside its
+// documented window) must account for the aggregate main-thread cost across
+// whichever taps can be simultaneously connected, not just their own. If a
+// genuine need for more concurrent taps emerges, the real fix is migrating
+// to `AudioWorklet` (runs off the main thread, the supported replacement for
+// `ScriptProcessorNode`) rather than adding another main-thread callback to
+// the pile -- deferred here as a larger, separate change.
 function ensureAudioContext() {
   const Ctx = window.AudioContext || window.webkitAudioContext;
   if (!Ctx) return;
@@ -749,7 +817,7 @@ function playSingleUrl(url) {
   // (unlockTtsAudio()'s guard, and onTalkClick's/the cancel button's
   // stop-vs-continue branch) need precisely "is a real clip currently
   // loading or playing right now", not "is a turn nominally still running".
-  clipInFlight = true;
+  setClipInFlight(true);
   let promise;
   if (useSharedTtsAudio()) {
     const audio = getTtsAudioElement();
@@ -769,7 +837,7 @@ function playSingleUrl(url) {
       audio.play().catch(reject);
     });
   }
-  return promise.finally(() => { clipInFlight = false; });
+  return promise.finally(() => { setClipInFlight(false); });
 }
 
 function enqueueClip(url) {
@@ -814,7 +882,7 @@ function stopAllAudio() {
   // its own `.finally()` never clears clipInFlight on its own -- reset it
   // explicitly here so a stopped clip doesn't leave unlockTtsAudio() (or
   // the stop-vs-continue checks above) permanently guarded off.
-  clipInFlight = false;
+  setClipInFlight(false);
 }
 
 function isBenignPlaybackError(err) {
@@ -912,6 +980,11 @@ async function maybeAutoContinue() {
 }
 
 // --- Listening: wake-word ("Hermes") detection (#710) ---
+//
+// `listenProcessor` below is tap #2 of the audio-taps inventory documented
+// above ensureAudioContext() -- see that comment for the main-thread-
+// contention invariant this section's suspend/resume machinery
+// (setClipInFlight()) exists to satisfy.
 //
 // A fourth dock toggle, default off, persisted like its siblings (dockSettings
 // above). While on and in voice mode, this holds its *own* mic stream --
@@ -1030,7 +1103,7 @@ function playWakeChimeShared(url) {
   if (clipInFlight) return Promise.resolve();
   const audio = getTtsAudioElement();
   if (!activeAudios.includes(audio)) activeAudios.push(audio);
-  clipInFlight = true;
+  setClipInFlight(true);
   const settle = playUrlOnElement(audio, url).catch(() => {});
   return Promise.race([
     settle,
@@ -1044,7 +1117,7 @@ function playWakeChimeShared(url) {
     // beyond that: the next real clip's own playUrlOnElement() call always
     // reassigns both before playing, so nothing here can leak into it.
     audio.__abortPlayback?.();
-  }).finally(() => { clipInFlight = false; });
+  }).finally(() => { setClipInFlight(false); });
 }
 
 // Plays one randomly-chosen chime and resolves once it's done. Never
@@ -1155,6 +1228,17 @@ function stopListening() {
   listenSpeechMs = 0;
   listenSilenceMs = 0;
   listenChecking = false;
+}
+
+// Test seam (#734): whether the wake tap's own AudioContext is actually
+// running right now, as opposed to merely "detection would accept a frame
+// if one arrived" (canDetectWake() above, which stays false for several
+// other reasons -- recording, a turn in flight -- that have nothing to do
+// with the graph being suspended). Lets a browser test assert the graph
+// itself stops processing while a clip plays and starts again once it ends,
+// rather than inferring it indirectly through wake-match side effects.
+export function isListenTapRunning() {
+  return !!(listenAudioCtx && listenAudioCtx.state === 'running');
 }
 
 function handleListenFrame(e) {
@@ -1308,6 +1392,11 @@ async function triggerWakeRecording() {
 }
 
 // --- Smart turn endpointing: pause + semantic completeness (#718) ---
+//
+// `endpointProcessor` below is tap #3 of the audio-taps inventory documented
+// above ensureAudioContext() -- see that comment for the main-thread-
+// contention invariant (connected only while actually needed, torn down via
+// stopEndpointing() on every stop path).
 //
 // Auto-continue (above) already reopens the mic after each reply; this layers
 // on *when to stop* a recording that started that way (or from a manual tap
@@ -1501,6 +1590,14 @@ function stopEndpointing() {
     endpointCtx = null;
   }
   resetEndpointState();
+}
+
+// Test seam (#734): whether the endpointing tap is currently wired up, so a
+// browser test can assert it's torn down after every stop path (manual stop,
+// hard-cap finalize, spoken-cancel discard) rather than inferring it
+// indirectly.
+export function isEndpointTapActive() {
+  return !!endpointProcessor;
 }
 
 function flattenEndpointFrames() {


### PR DESCRIPTION
Closes #734.

Spoken replies had become scratchy with popping. Cause: `handleListenFrame()` dropped its accumulated frames while a clip played (`canDetectWake()` returns false on `clipInFlight`) but left `listenProcessor` **connected and firing** — so its `onaudioprocess` callback kept running on the main thread throughout playback, competing with it. Detection was suspended; the CPU work was not. Listening shipping on by default made this steady state for every session rather than an opt-in edge case.

The alternative suspect — 2x playback, whose default flipped on in the same release — was ruled out by history: `FAST_PLAYBACK_RATE`/`preservesPitch` are unchanged since #368 and were exercised by opt-in users without artifacts, while always-on Listening is genuinely new for every default session and maps exactly to "steady state, during playback."

- `setClipInFlight()` now funnels all four `clipInFlight` writes and suspends/resumes `listenAudioCtx` in lockstep, stopping the callback entirely during a clip.
- The mic stream is never touched: a new test asserts the tap goes running → suspended → running across a real playback cycle while `__gumCalls` stays at 1 and `__stopCalls` at 0. Verified to actually catch the regression by reverting the fix and confirming the test fails.
- The endpointing tap was confirmed already torn down on every stop path (submit, manual stop, spoken cancel, hard cap); explicit assertions were added rather than leaving it inferred.

**Documented the trap in code**, per the operator: an authoritative block above `ensureAudioContext()` inventories all three `ScriptProcessorNode` taps, explains the main-thread hazard, and states the invariant plainly — *a tap that is not actively needed must be disconnected or its context suspended, not merely have its output ignored* — noting this class of regression is audible on hardware but invisible to tests, and naming `AudioWorklet` as the migration path if a fourth tap is ever needed. Recommended follow-up: migrate all three taps to `AudioWorklet`.

Gates: unit scope 5,004 passed; `browser and not requires_server` 199 passed in 72.7s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)