### PR TITLE
fix(voice): suspend the wake tap while recording and release the mic on exit (#724)

### DIFF
--- a/tests/test_voice_listening_wake_word_ui_browser.py
+++ b/tests/test_voice_listening_wake_word_ui_browser.py
@@ -329,6 +329,40 @@ class TestListeningMicLifecycle:
 
         page.wait_for_function("window.__gumCalls === 2")
 
+    def test_leaving_voice_mode_releases_the_talk_buttons_mic_too(
+            self, page: Page, chat_base_url):
+        """#724: `micStream` -- the talk button's own stream, acquired lazily
+        by requestMicInGesture() the first time it's needed -- used to never
+        be released at all: applyVoiceMode() only ever tore down Listening's
+        separate hold on leaving voice mode, so once a session had recorded
+        even once the mic stayed live regardless of mode for the rest of the
+        page's life. Verified with Listening off throughout so the only live
+        stream in play is the record path's own -- isolates this from
+        TestListeningMicLifecycle's other tests, which are all about
+        Listening's stream instead."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceListen").uncheck()
+        page.wait_for_function("window.__stopCalls > 0")  # Listening's own hold releasing
+        stop_calls_before = page.evaluate("window.__stopCalls")
+
+        page.locator("#voiceTalkBtn").click()
+        page.wait_for_function(
+            "document.getElementById('voiceTalkBtn').classList.contains('recording')"
+        )
+        # force=True: the .recording class drives an infinite CSS pulse that
+        # can fail Playwright's default actionability "element is stable"
+        # wait on the stop tap (see _tap_talk() in the sibling suite).
+        page.locator("#voiceTalkBtn").click(force=True)  # stop
+        page.wait_for_function(
+            "!document.getElementById('voiceTalkBtn').classList.contains('recording')"
+        )
+        # Stopping the recorder itself never touches the stream's tracks.
+        assert page.evaluate("window.__stopCalls") == stop_calls_before
+
+        page.locator("#modeTextBtn").click()  # leave voice mode
+
+        page.wait_for_function(f"window.__stopCalls > {stop_calls_before}")
+
 
 class TestListeningWakeMatch:
     """A stubbed STT response drives the real match/trigger pipeline."""
@@ -476,6 +510,51 @@ class TestListeningSuspension:
         triggered = _check_wake(page, "Hermes")
         assert triggered is True
         assert page.evaluate("window.__recorderStartCalls") == 1
+
+    def test_wake_tap_graph_suspends_during_recording_and_resumes_after(
+            self, page: Page, chat_base_url):
+        """#724: the same main-thread-contention bug #734 fixed for TTS
+        playback also applied to the recording window -- canDetectWake()'s
+        own `!isRecording` guard already made detection a no-op the entire
+        time a recording was in progress, but `listenProcessor` itself
+        stayed connected and running regardless, contending with the
+        recorder's/endpointer's own taps for nothing. Same isListenTapRunning()
+        seam as the playback-suspension test above, this time driven by a
+        real recording started the same way a talk-button tap would."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceAuto").uncheck()  # isolate from auto-continue
+        page.locator("#voiceListen").check()
+        page.wait_for_function("window.__gumCalls === 1")
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+
+        page.locator("#voiceTalkBtn").click()
+        page.wait_for_function(
+            "document.getElementById('voiceTalkBtn').classList.contains('recording')"
+        )
+
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === false")
+        # The record path's own (separate, #724-documented) stream acquisition
+        # -- Listening's own hold is untouched, no re-prompt, no track stop.
+        assert page.evaluate("window.__gumCalls") == 2
+        assert page.evaluate("window.__stopCalls") == 0
+
+        # force=True: the .recording class drives an infinite CSS pulse that
+        # can fail Playwright's default actionability "element is stable"
+        # wait on the stop tap (see _tap_talk() in the sibling suite).
+        page.locator("#voiceTalkBtn").click(force=True)  # stop
+        page.wait_for_function(
+            "!document.getElementById('voiceTalkBtn').classList.contains('recording')"
+        )
+
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+        assert page.evaluate("window.__gumCalls") == 2
+        assert page.evaluate("window.__stopCalls") == 0
+
+        # And detection genuinely works again -- a real wake match still
+        # triggers a second recording.
+        triggered = _check_wake(page, "Hermes")
+        assert triggered is True
+        assert page.evaluate("window.__recorderStartCalls") == 2
 
     def test_auto_continue_takes_over_after_tts_instead_of_the_wake_word(
             self, page: Page, chat_base_url):

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -76,24 +76,48 @@ let ttsAudio = null;
 // Every write to `clipInFlight` goes through here (#734) rather than
 // assigning the module variable directly, so the wake tap's AudioContext
 // (`listenAudioCtx`, set up in startListening() below) suspends/resumes in
-// lockstep with it. `ScriptProcessorNode.onaudioprocess` runs on the main
-// thread regardless of whether handleListenFrame() has anything useful to
-// do with the frame -- while a clip plays, that node stayed connected and
-// kept firing even though canDetectWake()'s own clipInFlight guard already
-// made every call a no-op, and the live callback contended with playback.
-// suspend()/resume() stop and restart the whole graph's processing without
-// touching the mic stream or the node wiring, so a wake match still works
-// after a playback cycle with zero extra getUserMedia calls. Both branches
+// lockstep with it -- see updateListenSuspension() just below, which also
+// covers the `isRecording` half of the same problem (#724). Both branches
 // are no-ops when Listening isn't running (listenAudioCtx null) or the
 // context is already in the target state.
 function setClipInFlight(value) {
   clipInFlight = value;
+  updateListenSuspension();
+}
+
+// Shared by setClipInFlight() above and the `isRecording` writes in
+// beginRecording()/beginWebAudioRecording()/stopRecordingAndSend() below
+// (routed through setIsRecording(), #724): suspends the wake tap's
+// AudioContext whenever a clip is playing OR a recording is in progress,
+// resumes when neither. `ScriptProcessorNode.onaudioprocess` runs on the
+// main thread regardless of whether handleListenFrame() has anything useful
+// to do with the frame -- #734 covered the playback case, but the recording
+// case had the identical shape and was still open: `listenProcessor` stayed
+// connected and running for the entire time a recording was in progress,
+// even though canDetectWake()'s own `!isRecording` guard already made every
+// call a no-op (wake detection is meaningless while already recording), so
+// the live callback was pure main-thread overhead contending with the
+// recorder's/endpointer's own taps for that whole window -- exactly the
+// aggregate-cost concern the taps-inventory doc above ensureAudioContext()
+// warns about. suspend()/resume() stop and restart the whole graph's
+// processing without touching the mic stream or the node wiring, so a wake
+// match still works the instant recording ends, with zero extra
+// getUserMedia calls.
+function updateListenSuspension() {
   if (!listenAudioCtx) return;
-  if (value && listenAudioCtx.state === 'running') {
+  const shouldSuspend = clipInFlight || isRecording;
+  if (shouldSuspend && listenAudioCtx.state === 'running') {
     listenAudioCtx.suspend().catch(() => {});
-  } else if (!value && listenAudioCtx.state === 'suspended') {
+  } else if (!shouldSuspend && listenAudioCtx.state === 'suspended') {
     listenAudioCtx.resume().catch(() => {});
   }
+}
+
+// Every write to `isRecording` goes through here (#724), for the same
+// reason setClipInFlight() above exists -- see updateListenSuspension().
+function setIsRecording(value) {
+  isRecording = value;
+  updateListenSuspension();
 }
 
 // Dock defaults for a first-time visitor (no stored settings yet). 2x playback,
@@ -418,6 +442,11 @@ function applyVoiceMode() {
   // re-acquires it. startListening()/stopListening() are both idempotent.
   if (isVoiceMode() && isListeningEnabled()) startListening();
   else stopListening();
+  // The record path's own stream releases the same way on leaving voice mode
+  // (#724, see releaseMicStream()'s own doc comment) -- unlike Listening's
+  // it is NOT re-acquired on entering voice mode; it stays lazily acquired
+  // by the next tap or wake trigger, same as always.
+  if (!isVoiceMode()) releaseMicStream();
 }
 
 function setTalkActive(on) {
@@ -487,6 +516,29 @@ function requestMicInGesture() {
   });
 }
 
+// The talk-button's own stream, `micStream` -- lazily acquired above by
+// requestMicInGesture() the first time it's needed -- used to never be
+// released at all: applyVoiceMode() only ever tore down Listening's
+// separate hold on leaving voice mode, never this one, so once a session
+// had recorded even once the mic stayed live for the rest of the page's
+// life regardless of mode (#724). Guarded on `!isRecording && !isStarting`
+// so this never yanks the stream out from under a recording that's already
+// in progress or in the brief async gap while one is starting -- leaving
+// voice mode mid-recording keeps today's existing (unrelated, unchanged)
+// behavior of that recording continuing to completion; this only closes the
+// gap for the common case of leaving voice mode with nothing actively
+// recording, which is what "no lingering live mic hold" is about. Unlike
+// Listening's stream, this one is never re-acquired on *entering* voice
+// mode -- it never was, before this fix either -- it stays lazy, acquired
+// only by the next actual tap or wake trigger.
+function releaseMicStream() {
+  if (isRecording || isStarting) return;
+  if (micStream) {
+    for (const t of micStream.getTracks()) t.stop();
+    micStream = null;
+  }
+}
+
 function setupMediaRecorder(stream) {
   if (mediaRecorder && mediaRecorder.state !== 'inactive') {
     try { mediaRecorder.stop(); } catch (_) { /* ignore */ }
@@ -510,7 +562,7 @@ function beginRecording(stream) {
   setupMediaRecorder(stream);
   mediaRecorder.start(250);
   recordStartedAt = Date.now();
-  isRecording = true;
+  setIsRecording(true);
   setStatus('', 'Recording…');
   setTalkActive(true);
   maybeStartEndpointing(stream);  // #718 -- no-op unless Auto + voice mode
@@ -526,8 +578,12 @@ function beginRecording(stream) {
 //   2. `listenProcessor` (startListening()/stopListening(), "Listening"
 //      section below) -- connected for as long as voice mode + the Listening
 //      toggle are both on, which since #710 shipping the toggle on by
-//      default means essentially the whole time voice mode is open,
-//      including while a reply is playing.
+//      default means essentially the whole time voice mode is open. Its
+//      `AudioContext` is suspended (not disconnected -- see the invariant
+//      below) whenever a clip is playing or a recording is in progress
+//      (updateListenSuspension(), #734 + #724), so "connected" here is about
+//      the node wiring's lifetime, not whether it's actually processing at
+//      any given moment.
 //   3. `endpointProcessor` (maybeStartEndpointing()/stopEndpointing(), "Smart
 //      turn endpointing" section below) -- connected only while a recording
 //      that Auto-continue governs is in progress; torn down on every stop
@@ -552,7 +608,13 @@ function beginRecording(stream) {
 // `listenAudioCtx` itself in lockstep with `clipInFlight`, so the callback
 // stops firing rather than merely discarding what it computes. Suspend, not
 // `getUserMedia`-releasing teardown: the mic stream and node wiring survive
-// untouched, so resuming never re-prompts for mic permission.
+// untouched, so resuming never re-prompts for mic permission. #724 found the
+// identical gap for the *recording* window -- `canDetectWake()`'s
+// `!isRecording` guard already made detection a no-op the whole time a
+// recording was in progress, but `listenProcessor` itself stayed connected
+// and running regardless, same contention, different trigger.
+// `updateListenSuspension()` (by `setClipInFlight()`/`setIsRecording()`)
+// generalizes the fix to both conditions at once.
 //
 // Anyone adding a fourth tap (or re-enabling one of these outside its
 // documented window) must account for the aggregate main-thread cost across
@@ -580,7 +642,7 @@ function beginWebAudioRecording(stream) {
   audioSource.connect(audioProcessor);
   audioProcessor.connect(audioCtx.destination);
   recordStartedAt = Date.now();
-  isRecording = true;
+  setIsRecording(true);
   setStatus('', 'Recording…');
   setTalkActive(true);
   maybeStartEndpointing(stream);  // #718 -- no-op unless Auto + voice mode
@@ -733,7 +795,7 @@ async function stopRecordingAndSend({ discard = false } = {}) {
   // await below, so a concurrent second call -- #718's hard cap and a
   // candidate's "complete" verdict can each reach this function -- sees
   // `!isRecording` and returns immediately instead of double-stopping.
-  isRecording = false;
+  setIsRecording(false);
   stopEndpointing();
 
   const elapsed = Date.now() - recordStartedAt;
@@ -997,6 +1059,44 @@ async function maybeAutoContinue() {
 // beginRecordingFromTap() -- the same function the talk button itself calls
 // -- so a wake trigger is indistinguishable from a tap.
 //
+// Investigated for #724 (merge the two streams into one getUserMedia hold)
+// and kept separate. Findings, so the next agent doesn't relitigate this
+// from scratch:
+//   - No hard technical incompatibility rules a shared stream out. A
+//     `MediaRecorder` and a live `MediaStreamAudioSourceNode` CAN read the
+//     same `MediaStream` concurrently (each track supports multiple
+//     consumers) -- and on iOS specifically (`useWebAudioRecorder` above)
+//     the record path doesn't even use `MediaRecorder`; it uses the same
+//     `createMediaStreamSource`-based approach this section does, so that
+//     candidate conflict doesn't apply there either.
+//   - Merging streams would NOT touch the actual cost #724 was filed to
+//     reduce. The "second always-on audio graph" (battery/CPU) is a
+//     `ScriptProcessorNode`/`AudioContext` count problem, not a
+//     `getUserMedia` count problem -- fixed narrowly instead, by extending
+//     the exact suspend/resume pattern #734 built (setClipInFlight()) to
+//     also cover the recording window (updateListenSuspension()/
+//     setIsRecording(), same section above ensureAudioContext()). That
+//     closes the real contention with zero stream-lifetime changes.
+//   - Merging would NOT reliably reduce permission prompts either: a
+//     granted mic permission is scoped to the page's origin, not to any
+//     particular `getUserMedia` call or stream -- a second call on an
+//     already-granted origin does not re-prompt on its own. (#724's own
+//     issue text concedes this: permission persistence is an origin-level
+//     browser setting, not something this file's call count controls.)
+//   - What a merge WOULD cost: reference-counted release across three
+//     independent consumers (the recorder/`audioProcessor`, `listenProcessor`,
+//     `endpointProcessor`), each currently owned exclusively by its own
+//     stream and free to `track.stop()` it without asking. A shared stream
+//     means none of them may ever be the one to stop a track the others
+//     still want -- real, tractable complexity, but complexity in exchange
+//     for a benefit (one fewer live hardware capture) that's speculative
+//     beyond a single iOS Safari user report, while the codebase's own
+//     history (#734's whole existence) is evidence WebKit's iOS audio-graph
+//     behavior is fragile territory worth extra caution in, not less. Given
+//     voice mode is reported working well on both Linux desktop and iPhone
+//     today, that trade isn't worth taking without a reproducible failure
+//     to actually fix. Revisit if one shows up.
+//
 // `${endpoints.voice}/transcribe` is forwarded by the existing generic
 // `/api/voice/*` reverse proxy (api/routes/voice.py) with no LifeOS-side
 // route change. It does NOT exist in whisper-relay as of this writing --
@@ -1201,6 +1301,12 @@ async function startListening() {
   // graph's output; it never writes to that output buffer, so nothing here
   // is actually audible.
   listenProcessor.connect(listenAudioCtx.destination);
+  // Covers the edge case of the Listening toggle being switched on while a
+  // recording (or clip) is already in progress -- without this the freshly
+  // created context would start (and stay) in the 'running' state
+  // regardless of `isRecording`/`clipInFlight` until the next write to
+  // either one happened to flip it (#724).
+  updateListenSuspension();
 }
 
 // Releases the mic entirely -- called on toggle-off and on leaving voice


### PR DESCRIPTION
Closes #724.

Investigated whether the wake-word and recording streams should share one `getUserMedia`. **Conclusion: keep them separate**, with the reasoning now documented in `voice.js` beside the existing "deliberately never micStream" comment so it isn't relitigated.

Findings: there is no hard incompatibility (a `MediaRecorder` and a live `MediaStreamAudioSourceNode` can share a stream, and the iOS path doesn't use `MediaRecorder` at all), and no history documents a concrete bug behind the separation — but the benefit is marginal. Permission prompting is governed by the origin-level grant, not the call count, and the real cost the issue described — a second always-on audio graph — is an `AudioContext`/tap problem, not a stream problem. Merging would add reference-counted release across three consumers on a platform this codebase has already found fragile, for a speculative gain.

Two real gaps found and fixed instead:

- **The recording mic was never released.** `micStream`, once acquired, was not stopped anywhere — including on leaving voice mode — so a live hardware capture lingered indefinitely. `releaseMicStream()` now runs from `applyVoiceMode()` on exit, guarded on `!isRecording && !isStarting`, and the stream stays lazily re-acquired by the next tap or wake trigger.
- **The wake tap now also suspends during recording.** #734 suspended it during playback; `updateListenSuspension()` extends that to active recording via `setIsRecording()`, so the second audio graph isn't running its main-thread callback while a recording's own tap is live — the actual contention the issue was reaching for.

2 new tests. Gates: unit scope 5,004 passed; `browser and not requires_server` 205 passed in 68.6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)