### PR TITLE
feat(voice): exit recording after 10s of silence with no speech (#723)

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -281,6 +281,11 @@ async def chat_config():
     `web/chat/voice.js`. `voice_endpoint_semantic` is reserved for a future
     optional completeness classifier and is currently unwired on the client
     (see `config/settings.py`'s `voice_endpoint_semantic` docstring).
+
+    `voice_idle_timeout_ms` (#723) is a disjoint timing knob for the opposite
+    situation those two govern: no speech at all yet in the recording. After
+    this much silence with nothing spoken, the client stops and discards the
+    recording rather than leaving the mic open indefinitely.
     """
     return {
         "default_voice": bool(settings.chat_default_voice),
@@ -290,6 +295,7 @@ async def chat_config():
         "voice_endpoint_silence_ms": settings.voice_endpoint_silence_ms,
         "voice_endpoint_hard_cap_ms": settings.voice_endpoint_hard_cap_ms,
         "voice_endpoint_semantic": bool(settings.voice_endpoint_semantic),
+        "voice_idle_timeout_ms": settings.voice_idle_timeout_ms,
     }
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -220,6 +220,20 @@ class Settings(BaseSettings):
         description="Continuous silence (ms) in auto-mode voice recording that finalizes "
                     "the turn regardless of the completeness check, so it can never hang"
     )
+    # Idle timeout (#723): a disjoint budget from the two above, for the
+    # opposite situation -- no speech at all yet this recording, so there is
+    # no trailing silence for voice_endpoint_silence_ms/_hard_cap_ms to
+    # measure. After this much silence with nothing spoken, the client stops
+    # and discards the recording (no turn submitted) rather than leaving the
+    # mic open indefinitely. Read by GET /api/chat/config -> web/chat/voice.js,
+    # same pattern as the two settings above -- also a pure client-side
+    # timing knob, not used anywhere server-side.
+    voice_idle_timeout_ms: int = Field(
+        default=10000,
+        alias="LIFEOS_VOICE_IDLE_TIMEOUT_MS",
+        description="Silence (ms) with no speech detected at all in auto-mode voice "
+                    "recording before the client stops and discards it unsubmitted"
+    )
     # Reserved for an optional LLM completeness classifier for ambiguous
     # candidate transcripts (no terminal punctuation, no trailing filler word
     # either) — see isTranscriptComplete()'s doc comment in web/chat/voice.js.

--- a/docs/guides/voice-setup.md
+++ b/docs/guides/voice-setup.md
@@ -61,8 +61,9 @@ These variables are read by `config/settings.py` (aliases shown). They are **not
 | `LIFEOS_VOICE_ENDPOINT_SILENCE_MS` | `1600` | Smart turn endpointing (below): trailing silence, in ms, after speech before a candidate endpoint check runs. |
 | `LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS` | `3000` | Smart turn endpointing: continuous silence, in ms, that finalizes the turn regardless of any completeness verdict. |
 | `LIFEOS_VOICE_ENDPOINT_SEMANTIC` | `false` | Reserved for an optional LLM completeness classifier — **not implemented**; flipping it currently has no effect. The heuristic alone governs completeness. |
+| `LIFEOS_VOICE_IDLE_TIMEOUT_MS` | `10000` | Idle timeout (below): silence, in ms, with **no speech detected at all** in the recording before it's stopped and discarded unsubmitted. |
 
-These three, along with `default_voice`/`secure_url`/the remote-model fields, are read by the web client from `GET /api/chat/config` — the endpointing pair are pure client-side VAD timing knobs with no server-side use; they exist as settings only so that timing is operator-tunable without editing `web/chat/voice.js`.
+These four, along with `default_voice`/`secure_url`/the remote-model fields, are read by the web client from `GET /api/chat/config` — the endpointing/idle-timeout settings are pure client-side VAD timing knobs with no server-side use; they exist as settings only so that timing is operator-tunable without editing `web/chat/voice.js`.
 
 Restart the API after editing `.env`:
 
@@ -110,7 +111,7 @@ In voice mode the text composer is replaced by the dock:
 - Four dock toggles (state saved per browser):
   - **Mute** — suppress spoken playback (the reply still returns as text).
   - **2×** — play spoken replies at double speed.
-  - **Auto** — auto-continue: after a reply finishes, start listening for the next turn without another tap. While Auto is on, a recording also **ends itself** once you sound done — see "Smart turn endpointing" below — instead of always waiting for another tap.
+  - **Auto** — auto-continue: after a reply finishes, start listening for the next turn without another tap. While Auto is on, a recording also **ends itself**: once you sound done, see "Smart turn endpointing" below; if you never say anything at all, see "Idle timeout" below — instead of always waiting for another tap.
   - **Listening** — wake-word mode, default off (#710). While on, the page holds its own mic stream and runs a local energy-based VAD (no third-party wake-word engine, no Web Speech API — that ships audio to Google). When it hears a speech burst end, it POSTs the short clip to `${voice gateway}/api/voice/transcribe` and fuzzy-matches the transcript against "Hermes" (tolerating whisper-isms like "Hermès" or "her mes" — see `matchesWakeWord()` in `web/chat/voice.js`); a match plays a short confirmation chime, then starts recording exactly as a talk-button tap would. Detection is suspended while recording, while a turn is in flight, and while a spoken reply or the chime is playing (so the assistant — or the chime itself — can never wake it), and resumes after. Leaving voice mode or unchecking Listening releases its mic entirely. **Requires a `/api/voice/transcribe` route on the voice gateway that does not exist yet as of this writing** — see the note below.
 
 ### The wake-confirmation chime
@@ -144,6 +145,15 @@ While Auto is on, ending a recording with a cancel phrase discards it instead of
 The matcher (`isCancelUtterance()` in `web/chat/voice.js`) is **trailing-anchored**: it normalizes the transcript (lowercase, strip trailing punctuation) and checks whether the *end* of it is one of `cancel`, `cancel that`, `never mind`, `nevermind`, `forget it`, `scratch that`. This is deliberate — a substring match would treat "cancel my 3pm with Dana" as a cancellation, silently eating a legitimate request that happens to contain the word "cancel." Trailing-anchoring means that request is transcribed and submitted normally; only an utterance that *ends with* one of those phrases (most commonly the whole utterance, e.g. "Cancel.") is treated as a cancel.
 
 Cancel detection reuses the exact candidate-pause transcript step 2 above already fetches — there is no separate check interval, timer, or additional STT call for it. Its accuracy and latency are therefore identical to endpointing's own: a cancel is only noticed at the next candidate pause, gated by the same `LIFEOS_VOICE_ENDPOINT_SILENCE_MS`/`LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS` settings above.
+### Idle timeout
+
+Smart turn endpointing above is entirely about trailing silence *after* speech — it has nothing to measure if you never say anything at all in a given recording. Without a separate guard, a recording nobody ever spoke into (you stepped away, a false wake trigger, or a reply that just didn't need a follow-up) would sit open indefinitely, since the hard cap in step 4 above only starts counting once speech has been heard.
+
+The **idle timeout** covers exactly that gap: if a recording captures `LIFEOS_VOICE_IDLE_TIMEOUT_MS` (default 10000ms) of silence with **no speech detected at all**, the client stops recording and **discards** it — no turn is submitted, no conversation or turn artifacts are created — through the same discard path (`handleSkippedEmptyRecording()` in `web/chat/voice.js`) an empty/silent manual stop already uses. Like a manual stop, this never re-arms Auto-continue, so the mic does not reopen on its own; getting back into recording after an idle exit takes an explicit act — the wake word (with Listening on) or a tap on the talk button. Listening's own mic hold is an independent stream from the recording, so wake detection keeps working normally through an idle exit with no extra step.
+
+The discriminator between the two timers — smart-turn-endpointing's trailing-silence timers and the idle timeout — is simply whether any speech has been detected yet in the current recording, using the same energy-VAD signal `handleEndpointFrame()` already computes for step 1 above: once speech has been heard, endpointing's timers own the rest of that recording; until then, the idle timeout owns it. The two can never fire for the same recording, since each covers a mutually exclusive phase of it (before vs. after the first speech is heard).
+
+Like smart turn endpointing, the idle timeout only ever runs while Auto is on, voice mode is active, and a recording is actually in progress — with Auto off, a recording with no speech is already discarded without a turn on a manual stop-tap (silence detection has skipped empty/silent recordings since before this feature), so there is nothing further for Auto-off to change.
 
 ### The bare-STT gateway route (not yet shipped)
 

--- a/tests/test_persona_api.py
+++ b/tests/test_persona_api.py
@@ -727,13 +727,13 @@ class TestChatConfigEndpoint:
             "default_voice": False, "secure_url": "",
             "remote_model_available": False, "remote_model_label": "",
             "voice_endpoint_silence_ms": 1600, "voice_endpoint_hard_cap_ms": 3000,
-            "voice_endpoint_semantic": False}
+            "voice_endpoint_semantic": False, "voice_idle_timeout_ms": 10000}
         monkeypatch.setattr("api.routes.chat.settings.chat_default_voice", True, raising=False)
         assert client.get("/api/chat/config").json() == {
             "default_voice": True, "secure_url": "",
             "remote_model_available": False, "remote_model_label": "",
             "voice_endpoint_silence_ms": 1600, "voice_endpoint_hard_cap_ms": 3000,
-            "voice_endpoint_semantic": False}
+            "voice_endpoint_semantic": False, "voice_idle_timeout_ms": 10000}
 
     # voice_endpoint_* (#718) drive the web client's smart turn endpointing
     # VAD timing in auto-mode voice recording — see web/chat/voice.js.
@@ -745,6 +745,14 @@ class TestChatConfigEndpoint:
         assert data["voice_endpoint_silence_ms"] == 2200
         assert data["voice_endpoint_hard_cap_ms"] == 4500
         assert data["voice_endpoint_semantic"] is True
+
+    # voice_idle_timeout_ms (#723): disjoint from voice_endpoint_* above --
+    # governs a recording that captured no speech at all, not trailing
+    # silence after speech.
+    def test_voice_idle_timeout_setting_reflects_config(self, client, monkeypatch):
+        monkeypatch.setattr("api.routes.chat.settings.voice_idle_timeout_ms", 7500, raising=False)
+        data = client.get("/api/chat/config").json()
+        assert data["voice_idle_timeout_ms"] == 7500
 
     # secure_url is the web client's one-tap escape from an insecure context to
     # the HTTPS origin the mic needs (#516).

--- a/tests/test_voice_endpointing_ui_browser.py
+++ b/tests/test_voice_endpointing_ui_browser.py
@@ -46,6 +46,15 @@ make the word list testable on its own (see its doc comment in
 No `requires_server` marker (serves `web/` itself from an ephemeral port, the
 same pattern as tests/test_voice_mic_block_ui_browser.py), so this runs at
 pre-push (`browser and not requires_server`).
+
+The `/api/chat/config` stub below pins `voice_idle_timeout_ms` to an hour --
+every test here that opens a real (fake-stream) recording does so with Auto
+on by default, and the idle timer runs off a genuine onaudioprocess tap on
+real wall-clock time, not off anything a test seam controls. Without this,
+a slow/loaded run can cross the shipped 10s default mid-test and discard a
+recording out from under an unrelated assertion. TestIdleTimeout and
+TestIdleTimeoutThenWake are unaffected either way -- they call
+`finalizeIdleTimeout()` directly, which doesn't consult this setting.
 """
 import http.server
 import threading
@@ -110,6 +119,7 @@ window.__transcribeResponse = 'turn off the lights.';
 window.__deferTranscribe = false;
 window.__pendingTranscribeResolvers = [];
 window.__turnStreamCalls = 0;
+window.__idleTimeoutOverrideMs = null;  // set by _open_voice_chat_short_idle_timeout() below
 
 function __transcribeResponseBody() {
   return new Response(JSON.stringify({ transcript: window.__transcribeResponse }), {
@@ -133,6 +143,21 @@ window.fetch = function (url, opts) {
     var sse = 'data: ' + JSON.stringify({ type: 'done', data: { response_text: 'ok' } }) + '\\n\\n';
     return Promise.resolve(new Response(sse, {
       status: 200, headers: { 'Content-Type': 'text/event-stream' },
+    }));
+  }
+  if (urlStr.indexOf('/api/chat/config') !== -1) {
+    // A real recording started here is subject to the live idle timeout
+    // (#723) the instant Auto is on -- the default -- via a genuine
+    // onaudioprocess tap on this (silent) fake stream, ticking on real wall
+    // clock time regardless of what any test seam calls. An hour keeps that
+    // background timer from ever firing mid-test for every test EXCEPT the
+    // one that deliberately opts into a short window via
+    // window.__idleTimeoutOverrideMs (_open_voice_chat_short_idle_timeout()
+    // below) to prove the live accrual/threshold path itself, not just
+    // finalizeIdleTimeout() called directly.
+    var idleMs = window.__idleTimeoutOverrideMs || 3600000;
+    return Promise.resolve(new Response(JSON.stringify({ voice_idle_timeout_ms: idleMs }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
     }));
   }
   return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
@@ -171,6 +196,22 @@ navigator.mediaDevices.getUserMedia = function (constraints) {
 
 def _open_voice_chat(page: Page, base_url):
     page.add_init_script(_INSTRUMENT_SCRIPT)
+    page.goto(f"{base_url}/chat?mode=voice")
+    page.wait_for_selector("#voiceListen")
+
+
+# Overrides window.__idleTimeoutOverrideMs (set after _INSTRUMENT_SCRIPT so
+# it wins) so /api/chat/config reports a short voice_idle_timeout_ms instead
+# of the suite-wide one-hour default above. Used by exactly one test
+# (test_idle_timeout_fires_from_real_silence_not_just_the_seam below) that
+# proves the LIVE trigger -- handleEndpointFrame() accruing endpointIdleMs on
+# real onaudioprocess callbacks against the silent fake stream and calling
+# finalizeIdleTimeout() itself once it crosses the threshold -- rather than
+# a test calling finalizeIdleTimeout() directly the way every other test in
+# this class does.
+def _open_voice_chat_short_idle_timeout(page: Page, base_url, ms):
+    page.add_init_script(_INSTRUMENT_SCRIPT)
+    page.add_init_script("window.__idleTimeoutOverrideMs = %d;" % ms)
     page.goto(f"{base_url}/chat?mode=voice")
     page.wait_for_selector("#voiceListen")
 
@@ -492,10 +533,46 @@ class TestIdleTimeout:
     LIFEOS_VOICE_IDLE_TIMEOUT_MS of silence, distinct from the
     trailing-silence-after-speech timers TestHardCapFinalize above exercises.
     `finalizeIdleTimeout()` is the exact function real continuous no-speech
-    silence crossing that timeout calls -- exercised directly, the same seam
-    pattern TestHardCapFinalize uses for finalizeEndpointing(), since a
-    browser test can't wait out several real seconds of silence through the
-    live audio graph either."""
+    silence crossing that timeout calls -- exercised directly (in every test
+    below except the first), the same seam pattern TestHardCapFinalize uses
+    for finalizeEndpointing(), since a browser test can't wait out the
+    shipped 10s default's worth of real silence through the live audio graph
+    without configuring a shorter one for itself.
+
+    The first test below is the exception: it configures a short timeout via
+    `/api/chat/config` and proves the LIVE trigger -- handleEndpointFrame()
+    (the real onaudioprocess handler this suite's fetch stub above exists to
+    keep off everyone else's back) actually accruing silence and firing
+    finalizeIdleTimeout() on its own -- not just that discard-teardown
+    function behaving correctly when called directly."""
+
+    def test_idle_timeout_fires_from_real_silence_not_just_the_seam(
+            self, page: Page, chat_base_url):
+        """Every other test in this class calls `finalizeIdleTimeout()`
+        directly -- proving the discard teardown, not the trigger that's
+        supposed to call it. This test proves the trigger itself:
+        `handleEndpointFrame()`, installed as the real `onaudioprocess`
+        handler on this (silent) fake stream exactly as it would be on a
+        real mic, accrues `endpointIdleMs` on genuine `onaudioprocess`
+        callbacks and calls `finalizeIdleTimeout()` itself once that crosses
+        `LIFEOS_VOICE_IDLE_TIMEOUT_MS` -- with no test code calling
+        `finalizeIdleTimeout()` at all. A short (300ms) configured timeout
+        keeps this bounded: at the live graph's 4096-sample buffer size
+        (`WAKE_PROCESSOR_BUFFER`), one `onaudioprocess` callback is roughly
+        85-95ms at a typical 44.1/48kHz context sample rate, so a handful of
+        real callbacks cross 300ms well within the wait below. (This is the
+        exact mechanism #723's harness bug rode on elsewhere in this suite
+        -- see the `/api/chat/config` stub's doc comment above -- just
+        deliberately triggered here instead of suppressed.)"""
+        _open_voice_chat_short_idle_timeout(page, chat_base_url, 300)
+        _start_recording(page)
+
+        page.wait_for_function("window.__recorderStopCalls === 1", timeout=5000)
+
+        assert _is_recording(page) is False
+        assert page.evaluate("window.__turnStreamCalls") == 0, (
+            "the live idle timeout submitted a turn instead of discarding it"
+        )
 
     def test_idle_timeout_discards_no_submit_no_rearm_toggles_unchanged(
             self, page: Page, chat_base_url):

--- a/tests/test_voice_endpointing_ui_browser.py
+++ b/tests/test_voice_endpointing_ui_browser.py
@@ -1,4 +1,5 @@
-"""Browser tests for smart turn endpointing in auto-mode voice recording (#718).
+"""Browser tests for smart turn endpointing in auto-mode voice recording (#718)
+and the idle timeout for a recording with no speech at all (#723).
 
 While the **Auto** dock toggle is on, `web/chat/voice.js` now decides *when a
 recording ends* on its own, layered on top of Auto-continue's existing
@@ -14,14 +15,28 @@ Incomplete keeps recording. `LIFEOS_VOICE_ENDPOINT_HARD_CAP_MS` of continuous
 silence finalizes regardless, so an ambiguous/unreachable check can never
 hang the mic open.
 
+`LIFEOS_VOICE_IDLE_TIMEOUT_MS` (#723, `TestIdleTimeout`/`TestIdleTimeoutThenWake`
+below) governs the opposite, disjoint situation: no speech detected AT ALL
+yet this recording, so the trailing-silence timers above have nothing to
+measure. That much silence with nothing spoken stops the recording and
+DISCARDS it -- no turn submitted -- through `finalizeIdleTimeout()`, which
+shares `stopRecordingAndSend()`'s manual-stop discard path
+(`handleSkippedEmptyRecording()`, unaffected by #721) rather than a parallel
+teardown. The discriminator between the two feature areas is whether speech
+has been seen yet this recording (`endpointHasSpeech` in voice.js) -- a
+straight handoff at the first speech frame, never a race, since
+`endpointIdleMs` only accrues before that flip and `endpointSilenceMs` only
+after it.
+
 Like the sibling wake-word/wake-chime suites, the live onaudioprocess VAD
 can't run headless without real audio hardware, so these tests drive the
 pipeline from its exported test seams -- `window.lifeChatVoice.
-checkEndpointCandidate(samples, sampleRate)` and `...finalizeEndpointing()`
--- the same seam pattern `checkForWakeWord()` established
-(tests/test_voice_listening_wake_word_ui_browser.py). Both are the REAL
-functions the live silence timer calls once its thresholds are crossed;
-nothing here is a parallel/fake implementation of that logic.
+checkEndpointCandidate(samples, sampleRate)`, `...finalizeEndpointing()`, and
+`...finalizeIdleTimeout()` -- the same seam pattern `checkForWakeWord()`
+established (tests/test_voice_listening_wake_word_ui_browser.py). All three
+are the REAL functions the live silence timers call once their respective
+thresholds are crossed; nothing here is a parallel/fake implementation of
+that logic.
 
 `isTranscriptComplete()`, the pure completeness heuristic, is tested directly
 with no page/recording/network involved at all -- exported specifically to
@@ -199,6 +214,18 @@ def _check_candidate(page: Page, transcript):
     page.evaluate("(t) => { window.__transcribeResponse = t; }", transcript)
     return page.evaluate(
         "() => window.lifeChatVoice.checkEndpointCandidate(new Float32Array(160), 16000)"
+    )
+
+
+def _check_wake(page: Page, transcript):
+    """Sets the stubbed transcribe response, then runs the real
+    checkForWakeWord() post-capture pipeline (STT call -> match -> maybe
+    trigger) with a throwaway synthetic clip -- same seam
+    tests/test_voice_listening_wake_word_ui_browser.py drives. Returns
+    whether it triggered a recording."""
+    page.evaluate("(t) => { window.__transcribeResponse = t; }", transcript)
+    return page.evaluate(
+        "() => window.lifeChatVoice.checkForWakeWord(new Float32Array(160), 16000)"
     )
 
 
@@ -459,6 +486,70 @@ class TestEndpointTapTeardown:
         _open_voice_chat(page, chat_base_url)
         _start_recording(page)
         assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is True
+class TestIdleTimeout:
+    """Idle timeout (#723): a recording that captures no speech at all is
+    stopped and DISCARDED -- never submitted -- after
+    LIFEOS_VOICE_IDLE_TIMEOUT_MS of silence, distinct from the
+    trailing-silence-after-speech timers TestHardCapFinalize above exercises.
+    `finalizeIdleTimeout()` is the exact function real continuous no-speech
+    silence crossing that timeout calls -- exercised directly, the same seam
+    pattern TestHardCapFinalize uses for finalizeEndpointing(), since a
+    browser test can't wait out several real seconds of silence through the
+    live audio graph either."""
+
+    def test_idle_timeout_discards_no_submit_no_rearm_toggles_unchanged(
+            self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
+        assert page.locator("#voiceAuto").is_checked()
+        assert page.locator("#voiceListen").is_checked()
+
+        page.evaluate("() => window.lifeChatVoice.finalizeIdleTimeout()")
+
+        # Recording actually stopped -- and through the discard path, not a
+        # submit: no turn/stream call was ever made.
+        page.wait_for_function("window.__recorderStopCalls === 1")
+        assert _is_recording(page) is False
+        assert page.evaluate("window.__turnStreamCalls") == 0
+
+        # No auto-continue re-arm: recording never restarts on its own, even
+        # though Auto is still on (#721's fix applies here too, since the
+        # idle path shares handleSkippedEmptyRecording()'s discard teardown).
+        page.wait_for_timeout(250)
+        assert page.evaluate("window.__recorderStartCalls") == 1
+        assert _is_recording(page) is False
+
+        # Dock toggles are untouched -- this is not a user opt-out. (No
+        # localStorage assertion: an untouched default is never written back
+        # -- persistDockSettings() only fires from an explicit toggle change
+        # -- so the checkbox state above is the authoritative signal here.)
+        assert page.locator("#voiceAuto").is_checked()
+        assert page.locator("#voiceListen").is_checked()
+
+    def test_idle_timeout_while_not_recording_is_a_noop(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+
+        page.evaluate("() => window.lifeChatVoice.finalizeIdleTimeout()")
+
+        assert page.evaluate("window.__recorderStopCalls") == 0
+
+    def test_hard_cap_after_speech_submits_and_idle_timeout_never_fires(
+            self, page: Page, chat_base_url):
+        """A recording WITH speech ends through #718's hard cap (the exact
+        function real continuous silence *after* speech calls), never
+        through the idle-discard path -- and once it has, a late idle-timeout
+        call finds nothing left to act on. This is the observable half of
+        the mutual-exclusion guarantee headless tests can make: production
+        code can't literally race the two (see handleEndpointFrame()'s doc
+        comment -- endpointIdleMs only ever accrues before endpointHasSpeech
+        flips true), and recorded-audio content isn't reliably non-silent
+        headless (this fake stream is always silent, like every sibling
+        voice suite's), so `finalizeEndpointing()` -- never
+        `finalizeIdleTimeout()` -- is the function that actually fires for a
+        spoken recording; asserting that AND its no-op-after effect is as
+        far as this harness can observe the precedence rule directly."""
+        _open_voice_chat(page, chat_base_url)
+        _start_recording(page)
 
         page.evaluate("() => window.lifeChatVoice.finalizeEndpointing()")
         page.wait_for_function("window.__recorderStopCalls === 1")
@@ -477,3 +568,83 @@ class TestEndpointTapTeardown:
         page.wait_for_function("window.__recorderStopCalls === 1")
 
         assert page.evaluate("window.lifeChatVoice.isEndpointTapActive()") is False
+        page.evaluate("() => window.lifeChatVoice.finalizeIdleTimeout()")
+
+        # Still just the one stop -- the idle timeout never fired for this
+        # recording, before or after the hard cap already ended it.
+        assert page.evaluate("window.__recorderStopCalls") == 1
+
+    def test_idle_timeout_has_no_effect_on_an_already_submitted_turn(
+            self, page: Page, chat_base_url):
+        """window.lifeChatVoice.submitTurn({transcript}) is the seam sibling
+        voice suites use to simulate a turn actually being submitted, since
+        real recorded-audio content can't be driven non-silent headless
+        (see the class docstring). With no recording open at all (a
+        transcript-only submit never opens one), a stray idle-timeout call
+        has nothing to discard."""
+        _open_voice_chat(page, chat_base_url)
+
+        page.evaluate("() => { window.lifeChatVoice.submitTurn({ transcript: 'hi' }); }")
+        page.wait_for_function("window.__turnStreamCalls === 1")
+
+        page.evaluate("() => window.lifeChatVoice.finalizeIdleTimeout()")
+
+        assert page.evaluate("window.__recorderStopCalls") == 0
+
+    def test_manual_stop_silent_recording_with_auto_off_still_discards(
+            self, page: Page, chat_base_url):
+        """Auto off means no endpointing/idle-timeout infrastructure runs at
+        all (maybeStartEndpointing() no-ops -- see TestAutoModeGating above).
+        stopRecordingAndSend()'s new `discard` param defaults to false,
+        so the pre-existing manual-stop discard-without-submit-or-rearm
+        behavior (#721) for a genuinely silent recording -- reached via
+        isSilentBlob(), not discard -- must be completely unaffected."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceAuto").uncheck()
+        _start_recording(page)
+
+        # Manual stop -- the fake stream is silent, so this is the same
+        # empty/silent-recording path #721 already covers.
+        page.locator("#voiceTalkBtn").click(force=True)
+
+        page.wait_for_function("window.__recorderStopCalls === 1")
+        assert page.evaluate("window.__turnStreamCalls") == 0
+        assert _is_recording(page) is False
+
+
+class TestIdleTimeoutThenWake:
+    """Listening's wake detection holds its own mic stream, independent of
+    the recording stream an idle-timeout exit tears down -- it must resume
+    normally afterward with no extra step (baseWakeGuardsOk() in voice.js
+    only requires `!isRecording`, which the idle exit already restores)."""
+
+    def test_wake_word_after_idle_exit_records_again(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)  # Listening ships on by default
+        _start_recording(page)
+        assert page.evaluate("window.__recorderStartCalls") == 1
+
+        page.evaluate("() => window.lifeChatVoice.finalizeIdleTimeout()")
+        page.wait_for_function("window.__recorderStopCalls === 1")
+        assert _is_recording(page) is False
+
+        triggered = _check_wake(page, "Hermes")
+
+        assert triggered is True
+        page.wait_for_function("window.__recorderStartCalls === 2")
+        assert _is_recording(page) is True
+
+    def test_record_button_tap_after_idle_exit_records_again(self, page: Page, chat_base_url):
+        """Listening off after an idle exit -- getting back into recording
+        takes an explicit record-button tap instead."""
+        _open_voice_chat_listening_off(page, chat_base_url)
+        _start_recording(page)
+        assert page.evaluate("window.__recorderStartCalls") == 1
+
+        page.evaluate("() => window.lifeChatVoice.finalizeIdleTimeout()")
+        page.wait_for_function("window.__recorderStopCalls === 1")
+        assert _is_recording(page) is False
+
+        _start_recording(page)
+
+        assert page.evaluate("window.__recorderStartCalls") == 2
+        assert _is_recording(page) is True

--- a/tests/test_voice_listening_wake_word_ui_browser.py
+++ b/tests/test_voice_listening_wake_word_ui_browser.py
@@ -97,6 +97,16 @@ window.fetch = function (url, opts) {
       status: 200, headers: { 'Content-Type': 'text/event-stream' },
     }));
   }
+  if (urlStr.indexOf('/api/chat/config') !== -1) {
+    // Auto ships on by default and several tests here open a real
+    // (fake-stream) recording -- the idle timeout (#723) runs off a genuine
+    // onaudioprocess tap ticking on real wall-clock time, unrelated to
+    // anything this test drives directly. An hour keeps it from ever
+    // firing mid-test on a slow/loaded run.
+    return Promise.resolve(new Response(JSON.stringify({ voice_idle_timeout_ms: 3600000 }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    }));
+  }
   return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
 };
 

--- a/tests/test_voice_manual_stop_auto_mode_ui_browser.py
+++ b/tests/test_voice_manual_stop_auto_mode_ui_browser.py
@@ -100,6 +100,16 @@ window.fetch = function (url, opts) {
       status: 200, headers: { 'Content-Type': 'text/event-stream' },
     }));
   }
+  if (urlStr.indexOf('/api/chat/config') !== -1) {
+    // This suite is specifically about Auto-mode behavior, so several tests
+    // open a real (fake-stream) recording with Auto on -- the idle timeout
+    // (#723) runs off a genuine onaudioprocess tap ticking on real
+    // wall-clock time, unrelated to anything this test drives directly. An
+    // hour keeps it from ever firing mid-test on a slow/loaded run.
+    return Promise.resolve(new Response(JSON.stringify({ voice_idle_timeout_ms: 3600000 }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    }));
+  }
   return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
 };
 

--- a/tests/test_voice_spoken_cancel_ui_browser.py
+++ b/tests/test_voice_spoken_cancel_ui_browser.py
@@ -107,6 +107,16 @@ window.fetch = function (url, opts) {
       status: 200, headers: { 'Content-Type': 'text/event-stream' },
     }));
   }
+  if (urlStr.indexOf('/api/chat/config') !== -1) {
+    // Auto ships on by default and _start_recording() below opens a real
+    // (fake-stream) recording -- the idle timeout (#723) runs off a genuine
+    // onaudioprocess tap ticking on real wall-clock time, unrelated to
+    // anything this test drives directly. An hour keeps it from ever
+    // firing mid-test on a slow/loaded run.
+    return Promise.resolve(new Response(JSON.stringify({ voice_idle_timeout_ms: 3600000 }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    }));
+  }
   return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
 };
 window.__resolveTranscribe = function () {

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -23,6 +23,7 @@ import {
   initVoice, submitTurn, checkForWakeWord,
   checkEndpointCandidate, isTranscriptComplete, finalizeEndpointing,
   isCancelUtterance, isListenTapRunning, isEndpointTapActive,
+  finalizeIdleTimeout,
 } from './voice.js';
 import { initBackend } from './backend.js';
 import { initModel, onModelChange } from './model.js';
@@ -105,4 +106,5 @@ window.lifeChatVoice = {
   submitTurn, checkForWakeWord,
   checkEndpointCandidate, isTranscriptComplete, finalizeEndpointing,
   isCancelUtterance, isListenTapRunning, isEndpointTapActive,
+  finalizeIdleTimeout,
 };

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -749,18 +749,18 @@ function stopRecorder() {
 async function handleSkippedEmptyRecording() {
   setTalkActive(false);
   setStatus('', 'Ready');
-  // No auto-continue here (#721). stopRecordingAndSend() -- this function's
-  // only caller -- reaches it either from onTalkClick's stop branch or from
-  // its own `discard: true` branch (a spoken cancel mid-recording, #722), so
-  // every recording this handles is a deliberate stop, not a completed turn
-  // -- despite the name, that now includes a discarded non-silent recording,
-  // not only an empty/silent one. Auto-continue has to key off "a turn was
-  // submitted and its reply finished playing" (submitTurn()'s own
-  // maybeAutoContinue() call below, after `await playbackChain`) -- re-arming
-  // here as well used to treat a deliberate stop (typically a quick tap that
-  // catches too little or no audio) as if a reply had just played, instantly
-  // restarting recording with no way to stop without leaving Auto mode
-  // entirely.
+  // No auto-continue here (#721). This function's only caller,
+  // stopRecordingAndSend(), reaches it whenever the recording is being
+  // discarded rather than submitted: a manual tap-to-stop that caught too
+  // little/no audio, a #718 hard-cap/candidate finalize whose captured clip
+  // still reads as silent, or a #723 idle-timeout exit (discard) -- none
+  // of these is "a turn was submitted and its reply finished playing".
+  // Auto-continue has to key off exactly that (submitTurn()'s own
+  // maybeAutoContinue() call below, after `await playbackChain`) --
+  // re-arming here as well used to treat any of these discards as if a
+  // reply had just played, instantly restarting recording with no way to
+  // stop without leaving Auto mode entirely (#721's original bug, for the
+  // manual-stop case specifically).
 }
 
 async function beginRecordingFromTap() {
@@ -784,17 +784,28 @@ async function beginRecordingFromTap() {
   }
 }
 
-// `discard: true` (#722's spoken-cancel path) skips straight to
-// handleSkippedEmptyRecording()'s no-submit/no-auto-continue branch below
-// instead of evaluating the captured blob -- same teardown as a manual stop
-// or a silent recording, just without the isSilentBlob() check (a discard
-// doesn't care what's in the clip, so there's nothing to decode it for).
+// `discard: true` skips straight to handleSkippedEmptyRecording()'s
+// no-submit/no-auto-continue branch instead of evaluating the captured
+// blob -- the same teardown a manual stop or a silent recording uses, just
+// without the isSilentBlob() check. Two callers set it, for the same reason
+// from different evidence: a spoken cancel (#722), where the user's own
+// words are the instruction to throw the clip away, and an idle-timeout
+// exit (#723), which already knows from endpointHasSpeech -- the same VAD
+// signal #718's candidate/hard-cap logic keys off -- that the recording
+// captured no speech at all. Either way a discard doesn't care what's in
+// the clip, so there's nothing to decode it for, and neither can fall
+// through to submitTurn() on a blob that isSilentBlob()'s independently
+// tuned thresholds happen to judge as "not silent". Every other caller (a
+// manual tap, #718's hard cap/candidate finalize) omits it and keeps the
+// isSilentBlob()-decided behavior exactly.
 async function stopRecordingAndSend({ discard = false } = {}) {
   if (isStarting || !isRecording) return;
   // Set (and tear down endpointing) synchronously, before the MIN_RECORD_MS
-  // await below, so a concurrent second call -- #718's hard cap and a
-  // candidate's "complete" verdict can each reach this function -- sees
-  // `!isRecording` and returns immediately instead of double-stopping.
+  // await below, so a concurrent second call -- #718's hard cap, a
+  // candidate's "complete" verdict, and #723's idle timeout can each reach
+  // this function -- sees `!isRecording` and returns immediately instead of
+  // double-stopping. Goes through setIsRecording() so the wake tap's
+  // suspension follows the recording state (#724).
   setIsRecording(false);
   stopEndpointing();
 
@@ -1526,6 +1537,32 @@ async function triggerWakeRecording() {
 // regardless of any candidate verdict, so an ambiguous or unreachable check
 // can never hang the mic open forever.
 //
+// Idle timeout (#723): a THIRD, disjoint budget for the opposite situation --
+// no speech at ALL yet this recording, so SILENCE_MS/HARD_CAP_MS above (both
+// scoped to trailing silence *after* speech) have nothing to measure. Without
+// this, a recording nobody ever spoke into (walked away, wake-triggered by
+// noise, reply didn't need one) sits open forever: the hard cap can't save it
+// because endpointHasSpeech never flips true, so endpointSilenceMs never even
+// starts accruing. After IDLE_TIMEOUT_MS of this, stop and DISCARD -- submit
+// nothing, no turn/conversation artifacts -- via the SAME manual-stop
+// discard path an empty/silent recording already uses
+// (handleSkippedEmptyRecording(), reached through stopRecordingAndSend()'s
+// discard param below), never a parallel teardown. Crucially this must
+// never re-arm auto-continue (that re-arm is exactly what would reopen the
+// mic in a loop) -- see stopRecordingAndSend()'s doc comment: the discard
+// branch it shares with a manual empty-recording stop has had no
+// maybeAutoContinue() call since #721, so this path inherits that for free.
+//
+// Precedence vs. #718 is a straight handoff, not a race: endpointIdleMs (idle
+// timeout's own counter) only accrues while `!endpointHasSpeech`, and
+// endpointSilenceMs (#718's) only starts once `endpointHasSpeech` is true --
+// see handleEndpointFrame() below. The very first speech frame flips
+// endpointHasSpeech permanently true for the rest of THIS recording (nothing
+// resets it back to false except a brand-new recording's
+// resetEndpointState()), so the two counters can never both be live at once.
+// Speech seen this recording -> #718 owns the ending, always. No speech at
+// all -> idle timeout owns it, always.
+//
 // Guards are re-checked after every await, the same pattern
 // triggerWakeRecording() uses after its chime -- a manual stop tap, a cancel,
 // or Auto/voice mode changing while a candidate round-trip is in flight must
@@ -1533,6 +1570,7 @@ async function triggerWakeRecording() {
 // user already ended a different way.
 const ENDPOINT_DEFAULT_SILENCE_MS = 1600;
 const ENDPOINT_DEFAULT_HARD_CAP_MS = 3000;
+const ENDPOINT_DEFAULT_IDLE_TIMEOUT_MS = 10000;
 
 // Trailing words/phrases that read as "still talking" even after a pause --
 // conjunctions/connectives that normally lead into more speech, plus common
@@ -1605,23 +1643,27 @@ export function isCancelUtterance(transcript) {
   });
 }
 
-// LIFEOS_VOICE_ENDPOINT_SILENCE_MS / _HARD_CAP_MS, read from GET
-// /api/chat/config (settings.py) the same way LIFEOS_CHAT_DEFAULT_VOICE
-// reaches fetchDefaultVoiceMode() above. Both start at the designed defaults
-// and only move if/when the (already-cached, shared) config fetch resolves
-// with a valid override, so a slow or unreachable config never blocks
-// endpointing -- it just runs on the built-in timings meanwhile. There is no
-// server-side use of these values; the settings only exist to make this
-// client-side timing operator-tunable without an env-var-free config file.
+// LIFEOS_VOICE_ENDPOINT_SILENCE_MS / _HARD_CAP_MS / _IDLE_TIMEOUT_MS, read
+// from GET /api/chat/config (settings.py) the same way LIFEOS_CHAT_DEFAULT_VOICE
+// reaches fetchDefaultVoiceMode() above. All three start at the designed
+// defaults and only move if/when the (already-cached, shared) config fetch
+// resolves with a valid override, so a slow or unreachable config never
+// blocks endpointing -- it just runs on the built-in timings meanwhile.
+// There is no server-side use of these values; the settings only exist to
+// make this client-side timing operator-tunable without an env-var-free
+// config file.
 let endpointSilenceMsSetting = ENDPOINT_DEFAULT_SILENCE_MS;
 let endpointHardCapMsSetting = ENDPOINT_DEFAULT_HARD_CAP_MS;
+let endpointIdleTimeoutMsSetting = ENDPOINT_DEFAULT_IDLE_TIMEOUT_MS;
 
 function loadEndpointingConfig() {
   fetchChatConfig().then((data) => {
     const silence = Number(data.voice_endpoint_silence_ms);
     const hardCap = Number(data.voice_endpoint_hard_cap_ms);
+    const idleTimeout = Number(data.voice_idle_timeout_ms);
     if (Number.isFinite(silence) && silence > 0) endpointSilenceMsSetting = silence;
     if (Number.isFinite(hardCap) && hardCap > 0) endpointHardCapMsSetting = hardCap;
+    if (Number.isFinite(idleTimeout) && idleTimeout > 0) endpointIdleTimeoutMsSetting = idleTimeout;
   });
 }
 
@@ -1632,6 +1674,7 @@ let endpointSampleRate = 0;
 let endpointFrames = [];            // Float32Array frames captured since the current recording started
 let endpointHasSpeech = false;      // at least one speech frame seen this recording
 let endpointSilenceMs = 0;          // trailing silence since the last speech frame
+let endpointIdleMs = 0;             // (#723) silence elapsed while NO speech has been seen yet this recording
 let endpointCandidateFired = false; // a candidate check already ran for the current silence run
 let endpointChecking = false;       // a candidate transcribe/completeness round-trip is in flight
 // Bumped every time a NEW recording's endpointing tap is (re)installed
@@ -1656,6 +1699,7 @@ function resetEndpointState() {
   endpointFrames = [];
   endpointHasSpeech = false;
   endpointSilenceMs = 0;
+  endpointIdleMs = 0;
   endpointCandidateFired = false;
   endpointChecking = false;
 }
@@ -1732,7 +1776,15 @@ function handleEndpointFrame(e) {
     endpointCandidateFired = false;  // speech resumed -- re-arm the candidate timer
     return;
   }
-  if (!endpointHasSpeech) return;  // ambient silence before any speech -- not timed yet
+  if (!endpointHasSpeech) {
+    // No speech at all yet this recording (#723) -- a disjoint silence
+    // budget from endpointSilenceMs below, which only starts once speech has
+    // been seen. See the "Idle timeout" doc comment above this section for
+    // why the two can never both be counting.
+    endpointIdleMs += frameMs;
+    if (endpointIdleMs >= endpointIdleTimeoutMsSetting) finalizeIdleTimeout();
+    return;
+  }
 
   endpointSilenceMs += frameMs;
 
@@ -1779,6 +1831,20 @@ export function finalizeEndpointing() {
 // there's no real-timer path to it that a browser test can't otherwise
 // reach, so checkEndpointCandidate() itself is the only test seam needed.
 function discardEndpointing() {
+  if (!isRecording) return;
+  stopRecordingAndSend({ discard: true }).catch((err) => {
+// Idle-timeout finalize (#723) -- stops and DISCARDS, never submits. Also
+// through stopRecordingAndSend(), but with its `discard` param set:
+// this is the SAME handleSkippedEmptyRecording() teardown a manual stop on
+// an empty/silent recording already uses (see stopRecordingAndSend()'s doc
+// comment), not a parallel discard implementation -- and that path has had
+// no auto-continue re-arm since #721, so this inherits that for free. Same
+// `!isRecording` guard/no-op-if-already-stopped reasoning as
+// finalizeEndpointing() above. Exported for the same headless-test reason:
+// it's the exact function real continuous no-speech silence crossing
+// IDLE_TIMEOUT_MS calls, with no way to wait out that much real silence
+// through the live audio graph in a browser test.
+export function finalizeIdleTimeout() {
   if (!isRecording) return;
   stopRecordingAndSend({ discard: true }).catch((err) => {
     setStatus('error', 'Error');

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -1833,6 +1833,12 @@ export function finalizeEndpointing() {
 function discardEndpointing() {
   if (!isRecording) return;
   stopRecordingAndSend({ discard: true }).catch((err) => {
+    setStatus('error', 'Error');
+    addMessage('⚠️ ' + (err?.message || 'Recording failed'), 'assistant');
+    setTalkActive(false);
+  });
+}
+
 // Idle-timeout finalize (#723) -- stops and DISCARDS, never submits. Also
 // through stopRecordingAndSend(), but with its `discard` param set:
 // this is the SAME handleSkippedEmptyRecording() teardown a manual stop on


### PR DESCRIPTION
Closes #723.

A recording that captures **no speech at all** for 10s stops and discards — nothing is submitted. Returning to recording takes the wake word or a record-button tap.

**Precedence is structural, not a timing race.** `endpointIdleMs` accrues only while `!endpointHasSpeech`; #718's `endpointSilenceMs` only accrues once speech has been seen; and the first speech frame flips `endpointHasSpeech` permanently true for that recording. So it is a one-way handoff at the first speech frame: speech seen ⇒ #718 owns the ending and submits; no speech ⇒ the idle timeout owns it and discards. A silent recording can never produce a turn.

Discard reuses `stopRecordingAndSend({ discard: true })` — the same teardown a manual stop and a spoken cancel use — so it inherits the no-auto-continue-re-arm property from #721 rather than reimplementing it. Toggles stay checked; wake detection resumes normally after an idle exit. `LIFEOS_VOICE_IDLE_TIMEOUT_MS` (default 10000) reaches the client through `/api/chat/config` alongside #718's settings.

**Test-harness note:** the headless fake mic stream is always silent, so a live idle timer would discard recordings mid-test in suites that are not about it. The four suites that open a real recording stub a long `voice_idle_timeout_ms`; the six that never start one are untouched.

Gates: unit scope 5,005 passed; `browser and not requires_server` 213 passed in 69s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)