### PR TITLE
fix(crm): stop backfill-only yield baselines and anchor owner strength

### DIFF
--- a/api/services/relationship_metrics.py
+++ b/api/services/relationship_metrics.py
@@ -13,12 +13,12 @@ Interaction weights are applied per source_type (e.g., imessage=1.5, gmail=0.8).
 See config/relationship_weights.py for all weights.
 """
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Optional
 
 from api.services.person_entity import PersonEntity, get_person_entity_store, compute_person_category
 from api.services.interaction_store import get_interaction_store
-from api.services.source_entity import get_source_entity_store, SOURCE_TYPES
+from api.services.source_entity import SOURCE_TYPES
 
 # Import weights from centralized config
 from config.relationship_weights import (
@@ -31,7 +31,6 @@ from config.relationship_weights import (
     get_interaction_weight,
     compute_weighted_interaction_count,
     compute_weighted_interaction_count_detailed,
-    INTERACTION_TYPE_WEIGHTS,
     USE_LOG_FREQUENCY_SCALING,
     LIFETIME_FREQUENCY_ENABLED,
     LIFETIME_FREQUENCY_WEIGHT,
@@ -270,6 +269,11 @@ def compute_relationship_strength_weighted(
     return round(strength * 100, 1)
 
 
+# Relationship strength for the CRM owner. Fixed rather than computed -- see
+# the short-circuit in compute_strength_for_person.
+SELF_STRENGTH = 100.0
+
+
 def compute_strength_for_person(person: PersonEntity) -> float:
     """
     Compute relationship strength for a PersonEntity.
@@ -292,6 +296,15 @@ def compute_strength_for_person(person: PersonEntity) -> float:
     """
     from api.services.relationship import get_relationship_store, TYPE_FAMILY
     from config.settings import settings
+
+    # The CRM owner is not a relationship to be scored. Their strength would
+    # otherwise be computed from interactions *with themselves* -- whatever
+    # happens to be self-addressed mail, self-invited calendar events, notes
+    # they appear in -- which produced a nonsensical 94.3 on Taylor's install,
+    # ranking her below her own partner in her own CRM. Anchor it at the
+    # maximum so "me" always sorts first and never drifts with mailbox noise.
+    if settings.my_person_id and person.id == settings.my_person_id:
+        return SELF_STRENGTH
 
     interaction_store = get_interaction_store()
 

--- a/api/services/sync_health.py
+++ b/api/services/sync_health.py
@@ -683,6 +683,12 @@ def _row_yield(row) -> int:
     )
 
 
+# Minimum number of *productive* runs before a source's yield history is
+# considered a trustworthy baseline. One productive run is the initial backfill;
+# its yield is a corpus size, not a nightly rate. See get_typical_yield.
+YIELD_MIN_PRODUCTIVE_RUNS = 3
+
+
 def get_typical_yield(source: str, n: int = 10) -> Optional[float]:
     """Median records produced across the last ``n`` *productive* runs of ``source``.
 
@@ -697,7 +703,24 @@ def get_typical_yield(source: str, n: int = 10) -> Optional[float]:
     redefine "typical" as zero, after which nothing can ever look wrong —
     exactly how `entity_cleanup` went unnoticed from Feb 2026.
 
-    Returns None when the source has no productive history to compare against.
+    Returns None when the source has no productive history to compare against,
+    or when it has fewer than ``YIELD_MIN_PRODUCTIVE_RUNS`` productive runs.
+
+    The minimum exists because a *single* productive run is almost always the
+    initial backfill, whose yield is the entire historical corpus rather than a
+    nightly rate. Taking the median of one sample pins "typical" at that
+    backfill forever -- and since zero-yield runs are excluded above, nothing
+    can ever bring it down. On a fresh install every quiet night then trips
+    yield collapse: observed on Taylor's day-old deployment, where gmail_work
+    backfilled 3028 records once and every incremental night after produced 0
+    for a mailbox that genuinely had no new mail.
+
+    Requiring three productive runs makes the median resistant to that single
+    outlier. The cost is a warm-up window in which a source that backfilled and
+    then genuinely died looks the same as one that is simply quiet -- we cannot
+    distinguish them from one productive sample, and a detector that cries wolf
+    every night is worse than one that waits, because an alert channel that is
+    always red gets ignored.
     """
     conn = get_sync_health_db()
     try:
@@ -719,7 +742,7 @@ def get_typical_yield(source: str, n: int = 10) -> Optional[float]:
     finally:
         conn.close()
 
-    if not rows:
+    if len(rows) < YIELD_MIN_PRODUCTIVE_RUNS:
         return None
     return float(statistics.median(_row_yield(row) for row in rows))
 

--- a/tests/test_relationship_metrics.py
+++ b/tests/test_relationship_metrics.py
@@ -190,3 +190,59 @@ class TestRelationshipStrength:
         )
         # Check it's a reasonable precision (1 decimal for 0-100 scale)
         assert len(str(strength).split(".")[-1]) <= 1
+
+
+class TestSelfStrength:
+    """The CRM owner's strength is anchored, not computed.
+
+    Regression guard: computing it from interactions scores the owner against
+    *themselves* -- self-addressed mail, self-invited events, notes they appear
+    in -- which put the owner at 94.3 on a real install, ranking them below
+    their own partner in their own CRM.
+    """
+
+    def _owner(self, person_id="owner-id"):
+        from api.services.person_entity import PersonEntity
+        return PersonEntity(id=person_id, canonical_name="Owner", display_name="Owner")
+
+    def test_owner_is_pinned_to_max(self, monkeypatch):
+        from config.settings import settings
+        from api.services import relationship_metrics as rm
+
+        person = self._owner()
+        monkeypatch.setattr(settings, "my_person_id", person.id, raising=False)
+        assert rm.compute_strength_for_person(person) == rm.SELF_STRENGTH
+        assert rm.SELF_STRENGTH == 100.0
+
+    def test_owner_check_precedes_interaction_lookup(self, monkeypatch):
+        """The short-circuit must not depend on the interaction store at all."""
+        from config.settings import settings
+        from api.services import relationship_metrics as rm
+
+        person = self._owner()
+        monkeypatch.setattr(settings, "my_person_id", person.id, raising=False)
+
+        def _boom():
+            raise AssertionError("interaction store must not be consulted for the owner")
+
+        monkeypatch.setattr(rm, "get_interaction_store", _boom)
+        assert rm.compute_strength_for_person(person) == rm.SELF_STRENGTH
+
+    def test_non_owner_is_not_pinned(self, monkeypatch):
+        """Everyone else still goes through the normal computation."""
+        from config.settings import settings
+        from api.services import relationship_metrics as rm
+
+        monkeypatch.setattr(settings, "my_person_id", "somebody-else", raising=False)
+        person = self._owner(person_id="not-the-owner")
+        # No interactions -> a real computation yields far below the anchor.
+        assert rm.compute_strength_for_person(person) < rm.SELF_STRENGTH
+
+    def test_unset_owner_id_does_not_pin_everyone(self, monkeypatch):
+        """A blank my_person_id must not make every person the owner."""
+        from config.settings import settings
+        from api.services import relationship_metrics as rm
+
+        monkeypatch.setattr(settings, "my_person_id", "", raising=False)
+        person = self._owner(person_id="")
+        assert rm.compute_strength_for_person(person) < rm.SELF_STRENGTH

--- a/tests/test_sync_health.py
+++ b/tests/test_sync_health.py
@@ -30,6 +30,8 @@ from api.services.sync_health import (
     reap_orphan_sync_runs,
     emit_sync_stats,
     detect_silent_source_entity_drift,
+    get_typical_yield,
+    YIELD_MIN_PRODUCTIVE_RUNS,
 )
 
 pytestmark = pytest.mark.unit
@@ -816,3 +818,53 @@ class TestRepeatedYieldStreak:
             # entirely, so it doesn't even count as a "different value" —
             # the two surrounding successes are adjacent in the result set).
             assert get_repeated_yield_streak("apple_import", 1294) == 2
+
+
+class TestTypicalYieldWarmup:
+    """A single productive run must not become the yield baseline.
+
+    Regression guard for the false-alarm loop seen on a day-old install: the
+    initial backfill is the only productive run, so the median of one sample
+    pins "typical" at the whole corpus. Because zero-yield runs are excluded
+    from the history, that baseline can never come down, and every genuinely
+    quiet night afterwards reports yield collapse forever.
+    """
+
+    def _productive(self, source, n):
+        for _ in range(n):
+            run_id = record_sync_start(source)
+            record_sync_complete(run_id, SyncStatus.SUCCESS, records_created=3028)
+
+    def test_single_productive_run_yields_no_baseline(self, temp_db):
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            self._productive("gmail_work", 1)
+            assert get_typical_yield("gmail_work") is None
+
+    def test_two_productive_runs_still_no_baseline(self, temp_db):
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            self._productive("gmail_work", 2)
+            assert get_typical_yield("gmail_work") is None
+
+    def test_baseline_appears_at_threshold(self, temp_db):
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            self._productive("gmail_work", YIELD_MIN_PRODUCTIVE_RUNS)
+            assert get_typical_yield("gmail_work") == 3028.0
+
+    def test_zero_runs_do_not_count_toward_threshold(self, temp_db):
+        """Quiet nights must not be mistaken for productive history."""
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            self._productive("gmail_work", 1)
+            for _ in range(10):
+                run_id = record_sync_start("gmail_work")
+                record_sync_complete(run_id, SyncStatus.SUCCESS, records_created=0)
+            assert get_typical_yield("gmail_work") is None
+
+    def test_backfill_outlier_does_not_dominate_median(self, temp_db):
+        """With enough samples the one-off backfill stops setting the bar."""
+        with patch('api.services.sync_health.SYNC_HEALTH_DB_PATH', temp_db):
+            run_id = record_sync_start("gmail_work")
+            record_sync_complete(run_id, SyncStatus.SUCCESS, records_created=3028)
+            for _ in range(2):
+                run_id = record_sync_start("gmail_work")
+                record_sync_complete(run_id, SyncStatus.SUCCESS, records_created=5)
+            assert get_typical_yield("gmail_work") == 5.0


### PR DESCRIPTION
## Summary

Two independent false signals found while diagnosing a day-old LifeOS install (Taylor's Mac mini).

### 1. Yield collapse fired every night on healthy data

`gmail_work` and `calendar_work` reported "produced 0 records but typically produces ~3028 — possible silent no-op" on data that was demonstrably current (3,104 work-gmail interactions, newest five hours before the run; token valid; mailbox reachable).

`get_typical_yield` takes the median of *productive* runs, and zero-yield runs are deliberately excluded so no-ops cannot redefine normal. But with exactly one productive run ever — the initial backfill — the median of that single sample pins "typical" at the entire historical corpus (3,028 records). Because zeros never lower it, **every genuinely quiet night trips the detector forever**:

```
gmail_work runs:  Aug 25 23:39 -> 3028 created   <- initial backfill
                  Aug 25 23:43 -> 0
                  Aug 25 23:45 -> 0
                  Aug 26 07:00 -> 0              <- streak = 3, alarm
```

Now requires `YIELD_MIN_PRODUCTIVE_RUNS` (3) productive samples before the baseline is trusted, so the median can outvote the backfill outlier.

**Tradeoff, stated explicitly:** during warm-up, a source that backfilled and then died looks identical to one that is merely quiet. They are indistinguishable from a single sample, and an alert channel that is always red gets ignored — which is the worse failure. Documented in the docstring.

### 2. The CRM owner was scored against themselves

`relationship_strength` for the owner was computed from interactions *with themselves* — self-addressed mail, self-invited calendar events, notes they appear in. On Taylor's install this scored her **94.3**, ranking her below her own partner in her own CRM.

Now anchored at `SELF_STRENGTH` (100.0), short-circuiting before the interaction store is consulted.

## Testing

9 new tests covering: the warm-up threshold, that zero-yield runs do not count toward it, that the backfill outlier stops dominating once there are enough samples, the owner anchor, that it precedes any store lookup, and that a blank `my_person_id` does not pin everyone.

Full unit suite: **4,994 passed, 9 skipped**. Pre-push browser suite: 100 passed.

## Note

Also drops three unused imports in `relationship_metrics.py`. These **predate this change**, but pre-commit lints touched files and the alternative was `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RqASCyAbmEt6AQBhRbW9e