### PR TITLE
fix(sync): run strengths after vault_reindex so new people get scored

### DIFF
--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -704,12 +704,21 @@ SYNC_ORDER = [
     # refresh here to catch anything missed (photos, edge cases, timestamps)
     "person_stats_full",        # Full refresh of all PersonEntity counts + timestamps
     "relationship_discovery",   # Discover relationships, populate edge weights
-    "strengths",                # Calculate relationship strength scores
     "push_birthdays",           # Push LifeOS birthdays to Apple Contacts
 
     # === Phase 4: Vector Store Indexing ===
     # Index content with fresh people data available for entity resolution
     "vault_reindex",            # Full reindex with LLM summaries (no timeout)
+    # `strengths` runs AFTER vault_reindex, not with the other Phase 3
+    # relationship work, because vault_reindex *creates people* from vault
+    # mentions. Ranked before it, those people are never scored: they get a
+    # NULL relationship_strength and NULL dunbar_circle until the following
+    # night. Observed on a real install as 243 circle-less people, all of them
+    # created by that night's own vault_reindex (7354 people in the store vs
+    # 7084 seen by strengths). sync_strengths.py's own docstring already says
+    # it "should run after all other syncs"; this makes the ordering match.
+    # It stays ahead of crm_vectorstore so indexed people carry fresh scores.
+    "strengths",                # Calculate relationship strength scores
     "crm_vectorstore",          # Index CRM people for semantic search
 
     # === Phase 5: Content Sync ===

--- a/tests/test_run_all_syncs.py
+++ b/tests/test_run_all_syncs.py
@@ -1257,3 +1257,37 @@ class TestPersonalGoogleGating:
             result = run_all_syncs(dry_run=True)
 
         assert result["results"]["gmail_personal"]["reason"] == "google_account_not_configured"
+
+
+class TestSyncOrderInvariants:
+    """Ordering constraints in SYNC_ORDER that are easy to break silently.
+
+    These assert on the real SYNC_ORDER, not the test fixture, because the
+    bug they guard against is a reordering of the production list.
+    """
+
+    def _pos(self, source):
+        from scripts.run_all_syncs import SYNC_ORDER
+        assert source in SYNC_ORDER, f"{source} missing from SYNC_ORDER"
+        return SYNC_ORDER.index(source)
+
+    def test_strengths_runs_after_vault_reindex(self):
+        """vault_reindex creates people from vault mentions.
+
+        Scoring before it leaves those people with a NULL relationship_strength
+        and NULL dunbar_circle until the next night. Seen on a real install as
+        243 circle-less people, all created by that night's own vault_reindex.
+        """
+        assert self._pos("strengths") > self._pos("vault_reindex")
+
+    def test_strengths_runs_before_crm_vectorstore(self):
+        """People indexed for semantic search should carry fresh scores."""
+        assert self._pos("strengths") < self._pos("crm_vectorstore")
+
+    def test_strengths_runs_after_relationship_discovery(self):
+        """Strength is computed from relationship edges, so edges come first."""
+        assert self._pos("strengths") > self._pos("relationship_discovery")
+
+    def test_strengths_runs_after_person_stats_full(self):
+        """Interaction counts feed the strength computation."""
+        assert self._pos("strengths") > self._pos("person_stats_full")


### PR DESCRIPTION
## Summary

`vault_reindex` **creates** PersonEntities from vault mentions, but `strengths` ranked everyone before it in Phase 3. People created by a night's own `vault_reindex` were therefore never scored that night — leaving `relationship_strength` and `dunbar_circle` NULL until the following run.

## Evidence

Observed on a real install: **243 people with no circle**, every one `category=work` with NULL strength. The arithmetic pins the cause — `strengths` processed **7,084** people while the store afterwards held **7,354**. That 270 difference is exactly what `vault_reindex` created after it had already run. 25 carried `sources: ["granola"]`, from meeting notes imported hours earlier.

They were not *failing*: recomputing strength for all 242 succeeds with **zero exceptions**. They simply weren't in the snapshot `strengths` iterated.

`sync_strengths.py`'s own docstring already says it "should run after all other syncs to ensure strengths reflect [everything]" — the ordering now matches its stated intent. `strengths` stays ahead of `crm_vectorstore` so indexed people carry fresh scores.

## Verification

Ran the chain in the new order on the affected install:

| Metric | Before | After |
|---|---|---|
| NULL circles | 243 | **1** |
| NULL strength | 243 | **1** |

The remaining 1 is a `hidden=1` person, excluded from `get_all()` by design — correct behavior, not a gap.

## Testing

4 invariants asserted against the **real** `SYNC_ORDER` rather than the test fixture, since the regression being guarded is a reordering of the production list: strengths after `vault_reindex`, after `relationship_discovery`, after `person_stats_full`, and before `crm_vectorstore`.

Full suite green (4,994 unit + 213 browser via pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RqASCyAbmEt6AQBhRbW9e