### PR TITLE
fix(voice): un-capture the wake mic during playback, not just un-read it (#740)

### DIFF
--- a/tests/test_voice_listening_wake_word_ui_browser.py
+++ b/tests/test_voice_listening_wake_word_ui_browser.py
@@ -281,16 +281,40 @@ class TestListeningToggleBasics:
 
 class TestListeningMicLifecycle:
     """Only meaningful in voice mode; releases the mic entirely on
-    toggle-off or on leaving voice mode."""
+    toggle-off or on leaving voice mode.
+
+    #740 note: the constraints assertions below check `__lastGumConstraints`
+    -- the object actually passed to `navigator.mediaDevices.getUserMedia()`
+    -- rather than reading the resulting track's `getConstraints()`/
+    `getSettings()`. Verified empirically (real Chromium, not a guess): a
+    track from `AudioContext.createMediaStreamDestination()` -- what the fake
+    `getUserMedia()` stub above returns, since headless Chromium has no real
+    microphone to hand back a genuine device track -- reports
+    `getConstraints() === {}` and a `getSettings()` with only generic
+    WebAudio fields (channelCount/deviceId/latency/sampleRate/sampleSize),
+    none of echoCancellation/noiseSuppression/autoGainControl, regardless of
+    what was requested. A synthetic stream never had real device constraints
+    applied to it in the first place, so asserting on it would test nothing;
+    the call-site object is the only place this suite can meaningfully
+    observe what was requested."""
 
     def test_entering_voice_mode_requests_mic_with_the_default_on(
             self, page: Page, chat_base_url):
         """Listening is on by default, so the mic hold is acquired by entering
-        voice mode itself — no dock click required."""
+        voice mode itself — no dock click required. #740: the wake stream is
+        requested with echoCancellation/noiseSuppression/autoGainControl all
+        explicitly off — unlike the plain `{ audio: true }` the recording
+        path still uses (see WAKE_STREAM_CONSTRAINTS in voice.js)."""
         _open_voice_chat(page, chat_base_url)
         page.wait_for_function("window.__gumCalls === 1")
 
-        assert page.evaluate("window.__lastGumConstraints") == {"audio": True}
+        assert page.evaluate("window.__lastGumConstraints") == {
+            "audio": {
+                "echoCancellation": False,
+                "noiseSuppression": False,
+                "autoGainControl": False,
+            }
+        }
 
     def test_re_enabling_after_opting_out_requests_mic_again(
             self, page: Page, chat_base_url):
@@ -305,7 +329,13 @@ class TestListeningMicLifecycle:
         page.locator("#voiceListen").check()
         page.wait_for_function("window.__gumCalls === 2")
 
-        assert page.evaluate("window.__lastGumConstraints") == {"audio": True}
+        assert page.evaluate("window.__lastGumConstraints") == {
+            "audio": {
+                "echoCancellation": False,
+                "noiseSuppression": False,
+                "autoGainControl": False,
+            }
+        }
 
     def test_leaving_voice_mode_stops_the_tracks(self, page: Page, chat_base_url):
         _open_voice_chat(page, chat_base_url)
@@ -517,6 +547,47 @@ class TestListeningSuspension:
 
         # And detection genuinely works again, not just the graph being
         # nominally "running" -- a real wake match still triggers recording.
+        triggered = _check_wake(page, "Hermes")
+        assert triggered is True
+        assert page.evaluate("window.__recorderStartCalls") == 1
+
+    def test_wake_track_itself_disables_during_playback_and_reenables_after(
+            self, page: Page, chat_base_url):
+        """#740: #734 believed listenAudioCtx.suspend() (above) fully
+        deactivated the wake tap during playback, but suspend() only stops
+        the graph's *processing* -- the underlying MediaStreamTrack keeps
+        capturing regardless, which is the actual mechanism behind the
+        popping that persisted after #734 shipped (confirmed on real
+        hardware: it correlates exactly with the Listening toggle).
+        isListenTrackEnabled() checks the wake stream's own track.enabled
+        state directly -- independent of, and in addition to, the context
+        suspend/resume this suite already covers -- and __gumCalls/
+        __stopCalls confirm disabling the track never touches the mic
+        permission: no second getUserMedia, no track stop, so no re-prompt
+        across the cycle."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceAuto").uncheck()  # isolate from auto-continue, as above
+        page.locator("#voiceListen").check()
+        page.wait_for_function("window.__gumCalls === 1")
+        page.wait_for_function("() => window.lifeChatVoice.isListenTrackEnabled() === true")
+
+        clip_url = page.evaluate("window.__makeWav(500)")
+        page.evaluate("(u) => { window.__turnClipUrl = u; }", clip_url)
+        page.evaluate("() => { window.lifeChatVoice.submitTurn({ transcript: 'hi' }); }")
+        page.wait_for_function("window.__audioPlayingCount > 0")
+
+        page.wait_for_function("() => window.lifeChatVoice.isListenTrackEnabled() === false")
+        assert page.evaluate("window.__gumCalls") == 1
+        assert page.evaluate("window.__stopCalls") == 0
+
+        page.wait_for_function("window.__audioPlayingCount === 0", timeout=5000)
+
+        page.wait_for_function("() => window.lifeChatVoice.isListenTrackEnabled() === true")
+        assert page.evaluate("window.__gumCalls") == 1
+        assert page.evaluate("window.__stopCalls") == 0
+
+        # Wake detection genuinely works again after the track re-enables --
+        # not just the flag flipping back.
         triggered = _check_wake(page, "Hermes")
         assert triggered is True
         assert page.evaluate("window.__recorderStartCalls") == 1

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -22,7 +22,7 @@ import { loadPersonas, onPersonaChange, personaOrchestrates, personaSupportsHand
 import {
   initVoice, submitTurn, checkForWakeWord,
   checkEndpointCandidate, isTranscriptComplete, finalizeEndpointing,
-  isCancelUtterance, isListenTapRunning, isEndpointTapActive,
+  isCancelUtterance, isListenTapRunning, isListenTrackEnabled, isEndpointTapActive,
   finalizeIdleTimeout,
 } from './voice.js';
 import { initBackend } from './backend.js';
@@ -105,6 +105,6 @@ Object.assign(window, {
 window.lifeChatVoice = {
   submitTurn, checkForWakeWord,
   checkEndpointCandidate, isTranscriptComplete, finalizeEndpointing,
-  isCancelUtterance, isListenTapRunning, isEndpointTapActive,
+  isCancelUtterance, isListenTapRunning, isListenTrackEnabled, isEndpointTapActive,
   finalizeIdleTimeout,
 };

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -103,6 +103,14 @@ function setClipInFlight(value) {
 // processing without touching the mic stream or the node wiring, so a wake
 // match still works the instant recording ends, with zero extra
 // getUserMedia calls.
+//
+// #740: suspend()/resume() above are NOT enough on their own -- they stop
+// the graph's *processing*, but the underlying MediaStreamTrack keeps
+// capturing regardless, so the same shouldSuspend condition below also
+// drives setListenTracksEnabled(), which disables/re-enables the wake
+// stream's own tracks in lockstep. See that function's comment and the
+// taps-inventory block above ensureAudioContext() for why an open capture
+// is a second, independent hazard from main-thread contention.
 function updateListenSuspension() {
   if (!listenAudioCtx) return;
   const shouldSuspend = clipInFlight || isRecording;
@@ -111,6 +119,7 @@ function updateListenSuspension() {
   } else if (!shouldSuspend && listenAudioCtx.state === 'suspended') {
     listenAudioCtx.resume().catch(() => {});
   }
+  setListenTracksEnabled(!shouldSuspend);
 }
 
 // Every write to `isRecording` goes through here (#724), for the same
@@ -491,6 +500,9 @@ async function acquireMicStream() {
   for (const delay of backoffMs) {
     if (delay) await new Promise((r) => setTimeout(r, delay));
     try {
+      // Deliberately plain `{ audio: true }`, unlike WAKE_STREAM_CONSTRAINTS
+      // (Listening section, below) -- see that constant's comment for the
+      // reasoning (#740).
       return await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch (err) {
       lastErr = err;
@@ -615,6 +627,32 @@ function beginRecording(stream) {
 // and running regardless, same contention, different trigger.
 // `updateListenSuspension()` (by `setClipInFlight()`/`setIsRecording()`)
 // generalizes the fix to both conditions at once.
+//
+// A second, independent hazard (#740): main-thread contention is not the
+// only way an unneeded tap degrades playback. `AudioContext.suspend()`
+// stops the graph's *processing*, but it does NOT stop the underlying
+// `MediaStreamTrack` -- the microphone capture itself stays live regardless
+// of whether anything reads it. #734's fix above was necessary but not
+// sufficient: it shipped believing `listenAudioCtx.suspend()` fully
+// deactivated the wake tap during playback, and on real hardware it did
+// not -- popping persisted, correlating exactly with the Listening toggle,
+// because the capture was never actually stopped. An open capture, on its
+// own, degrades output independently of CPU: `getUserMedia({ audio: true })`
+// (the un-narrowed constraints, before #740) enables echoCancellation --
+// which has to reference the current output signal to cancel it, hooking
+// the output path for as long as the capture stays open -- and a live
+// capture can also force a play-and-record audio session on some platforms,
+// which can resample or otherwise degrade output. Both last exactly as long
+// as the track is capturing, not as long as the graph is processing.
+// **The correct invariant is that the mic must not merely be un-read during
+// playback, it must be un-captured**: `track.enabled = false` on top of
+// `AudioContext.suspend()`, not instead of it (the suspend/resume is still
+// correct and worth keeping for its own reason -- CPU). See
+// `setListenTracksEnabled()` and `WAKE_STREAM_CONSTRAINTS` in the Listening
+// section below for the fix, and `isListenTrackEnabled()` for the browser
+// test seam that distinguishes "capturing" from "processing" the way
+// `isListenTapRunning()` already distinguishes "processing" from
+// "detecting".
 //
 // Anyone adding a fourth tap (or re-enabling one of these outside its
 // documented window) must account for the aggregate main-thread cost across
@@ -1243,6 +1281,31 @@ function playWakeChime() {
   }).catch(() => {});  // belt-and-suspenders -- loadWakeChimeManifest() already never throws
 }
 
+// #740 -- getUserMedia constraints for the wake stream specifically (see
+// startListening() below), deliberately different from the plain
+// `{ audio: true }` acquireMicStream() (the talk-button/recording path)
+// still uses. Bare `audio: true` accepts the browser's defaults, which
+// enable echoCancellation, noiseSuppression, and autoGainControl.
+// Echo cancellation in particular has to reference the current output
+// signal to cancel it, so an AEC-enabled capture hooks the output path for
+// as long as it stays open -- and with Listening shipping on by default,
+// that's the entire time voice mode is open, including through every TTS
+// playback. The wake detector is a simple energy VAD plus a whisper
+// round-trip on the captured burst; it gets no benefit from any of the
+// three, and detection is already suspended during playback
+// (updateListenSuspension() below), so the assistant's own voice leaking
+// into an un-cancelled capture is harmless -- nothing reads it while a clip
+// plays. The *recording* stream (acquireMicStream()) deliberately keeps the
+// browser defaults: AEC/NS/AGC genuinely help transcription quality of the
+// user's own speech, and unlike the wake stream, the recording stream is
+// only open for user-directed capture -- not held open, armed, through
+// playback -- so it isn't implicated by this bug (see #740: popping
+// correlates exactly with the Listening toggle, not with whether a prior
+// recording's stream is still cached).
+const WAKE_STREAM_CONSTRAINTS = {
+  audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
+};
+
 let listenStream = null;
 let listenAudioCtx = null;
 let listenSource = null;
@@ -1252,6 +1315,38 @@ let listenSpeechMs = 0;
 let listenSilenceMs = 0;
 let listenInBurst = false;
 let listenChecking = false;  // an STT round-trip for an already-captured burst is in flight
+
+// #740 -- disables/re-enables the wake stream's own MediaStreamTracks,
+// called by updateListenSuspension() above in lockstep with
+// listenAudioCtx.suspend()/resume(). AudioContext.suspend() only stops
+// *processing* what the track produces; the browser keeps the underlying
+// capture itself live regardless, which is exactly the mechanism #734
+// missed -- an open capture forces a play-and-record audio session (and,
+// were WAKE_STREAM_CONSTRAINTS not already off, would keep an AEC pipeline
+// hooked to the output) for as long as any track feeding it stays live, not
+// just while something reads its output. Per spec, `track.enabled = false`
+// stops the track from producing anything (silence instead) without
+// touching the permission grant, so toggling it back never re-prompts and
+// never requires a fresh getUserMedia call -- same no-extra-acquisition
+// guarantee the context suspend/resume already provides. No-op when
+// Listening isn't running (listenStream null).
+function setListenTracksEnabled(enabled) {
+  if (!listenStream) return;
+  for (const t of listenStream.getAudioTracks()) t.enabled = enabled;
+}
+
+// Test seam (#740): whether the wake stream's own tracks are currently
+// capturing, as opposed to isListenTapRunning() below (whether the
+// AudioContext graph is processing). The two are set in lockstep by
+// updateListenSuspension() but are independent browser-level states -- this
+// lets a browser test assert the capture itself stops, not just the
+// context, closing the exact gap #734 missed.
+export function isListenTrackEnabled() {
+  if (!listenStream) return null;
+  const tracks = listenStream.getAudioTracks();
+  if (tracks.length === 0) return null;
+  return tracks.every((t) => t.enabled === true);
+}
 
 // The shared guards: recording, a turn in flight, or TTS playing
 // (clipInFlight -- the self-trigger guard, independent of the mute toggle,
@@ -1283,7 +1378,13 @@ async function startListening() {
   if (micBlockReason()) return;  // same preconditions as the talk button; fail silent here
   let stream;
   try {
-    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    // #740 -- the wake stream is requested WITHOUT the browser's default
+    // audio-processing chain (echoCancellation/noiseSuppression/
+    // autoGainControl all explicitly off), unlike acquireMicStream() below
+    // (the talk-button/recording path), which deliberately keeps the
+    // defaults. See WAKE_STREAM_CONSTRAINTS for the reasoning -- this is a
+    // considered split, not an oversight.
+    stream = await navigator.mediaDevices.getUserMedia(WAKE_STREAM_CONSTRAINTS);
   } catch (e) {
     return;  // denied/unavailable -- Listening just doesn't run
   }


### PR DESCRIPTION
Closes #740.

Popping tracked the Listening toggle exactly and survived #734, which proves the mechanism was not CPU contention: `AudioContext.suspend()` stops the tap reading the mic but leaves the `MediaStreamTrack` **capturing**. An open capture degrades output on its own — bare `getUserMedia({ audio: true })` enables `echoCancellation`, which must reference the output signal to cancel against it, and a live capture can force a play-and-record audio session that resamples output. Both last as long as the track captures, not as long as the graph processes.

- The wake stream opens with `echoCancellation`/`noiseSuppression`/`autoGainControl` off — an energy VAD plus a whisper round-trip needs none of them, and detection is already suspended during playback.
- Its tracks are disabled while a clip is in flight, wired through the existing `updateListenSuspension()` so one place still owns when the tap is inactive. The context suspend/resume stays, on its own CPU merits.
- The **recording** stream deliberately keeps the defaults: AEC/NS/AGC help transcribe the user's own speech, and it is not held open through playback, consistent with the symptom tracking Listening specifically.
- No track is stopped, so there is no re-acquisition and no permission prompt (`__gumCalls` unchanged across a cycle, asserted).

The taps-inventory documentation is corrected: it framed this hazard as main-thread CPU only. It now states that an open capture degrades playback independently of CPU, names `AudioContext.suspend()`'s insufficiency as the exact miss that cost a round trip, and gives the invariant — during playback the mic must be **un-captured**, not merely un-read.

Test note recorded honestly: a synthetic headless stream reports no applied constraints regardless of what is requested, so the tests assert the constraints actually passed to `getUserMedia` plus a new seam checking `track.enabled` directly, rather than asserting something meaningless.

Gates: unit scope 5,014 passed; `browser and not requires_server` 214 passed in 71.6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)