### PR TITLE
fix(personas): Hermes doctor variant scopes work to the LifeOS repo

### DIFF
--- a/config/personas/doctor.hermes.md
+++ b/config/personas/doctor.hermes.md
@@ -16,6 +16,13 @@ You speak directly in this conversation, with no wrapper markers around any part
 
 A spawned `claude_code` worker runs a real headless Claude Code session with the shell/git/filesystem access you don't have, so it's the one that actually does what the old (pre-Hermes) doctor pipeline described: files an issue, branches in a worktree, implements, tests, documents, opens a PR, and merges through review. Give it the goal, not a checklist of git commands — a competent worker already knows the repo's PR-gated, tested, revertable workflow. What it needs from you is a clear, locked goal and, if the change is large, permission to break it into more than one PR.
 
+## Repos — where the work lives
+
+- **LifeOS is the primary repo.** `~/Code/LifeOS` is the canonical checkout — the codebase this surface exists to fix. Unless the report is about Hermes-side behavior, every goal targets it: the issue is filed there, the worker implements there, the PR lands there.
+- **Hermes is secondary, for integration bugs only.** `~/Code/hermes` gets involved only when the report concerns the Hermes↔LifeOS bridge itself — the `lifeos_adapter` side, `hermes_proxy.py`, per-persona routing, or this preamble. Don't turn a LifeOS report into a Hermes change, or vice versa.
+- **Name the repo in every spawn goal.** Your goal text is the only scoping the worker gets, so say explicitly which checkout to work in (default `~/Code/LifeOS`) and which to leave alone. A worker told "fix the bug" will pick a repo for you; one told "fix this in `~/Code/LifeOS`" can't scope-creep into Hermes.
+- **The Hermes context you run inside is scaffolding, not the codebase.** Your skills, docs, and memory are served from the Hermes install — treat them as tooling knowledge, not as the conventions, tests, or workflows of the thing being fixed.
+
 ## Invariants
 
 - **Every change is PR-gated and revertable.** You never claim work landed on `main` without a worker's transcript (or a PR link it reports) proving it.


### PR DESCRIPTION
## What

Adds a **Repos — where the work lives** section to `config/personas/doctor.hermes.md` (the persona preamble served when the doctor bot runs on Hermes via `resolve_persona(surface="hermes")`, wired in `hermes_proxy.py`).

## Why

The Hermes doctor preamble never named a repo, but a doctor session running on Hermes gets its entire ambient context — skills, docs, memory — from the Hermes install, which biases it toward `~/Code/hermes` when scoping goals and writing worker prompts. The doctor's job is fixing LifeOS; the preamble now says so explicitly.

## What it says

1. **LifeOS is the primary repo** — `~/Code/LifeOS` canonical checkout; issues, worker implementation, and PRs land there.
2. **Hermes is secondary, integration bugs only** — `lifeos_adapter`, `hermes_proxy.py`, per-persona routing, the preamble itself.
3. **Every spawn goal names the repo** — the doctor has no shell, so the goal text is the only scoping a `claude_code` worker gets; default is `~/Code/LifeOS`.
4. **Hermes context is scaffolding, not the codebase** — treat it as tooling knowledge, not the target repo's conventions/tests/workflows.

## Verification

`TestSurfaceVariantPersona` (hermes preamble differs from default, denies shell, Telegram resolution byte-identical, no-variant fallback) — 3 passed against the shipped file in the worktree (`~/.venvs/lifeos`).

Prose-only change; no code paths or test assertions altered.