### PR TITLE
fix(sync): skip push_birthdays fast when Contacts access is not granted

### DIFF
--- a/scripts/push_birthdays_to_contacts.py
+++ b/scripts/push_birthdays_to_contacts.py
@@ -42,6 +42,30 @@ def get_apple_contacts_with_email():
         )
         return {}
 
+    # Fail fast when Contacts access has not been granted. A fetch with
+    # authorization status notDetermined makes macOS try to raise a consent
+    # prompt; under launchd/cron there is no GUI session to show it, so the
+    # call BLOCKS INDEFINITELY rather than erroring. Observed on a Mac mini as
+    # a 60-minute sync timeout every night, which also dependency-skipped
+    # downstream sources — all from a source that had 12 birthdays to push.
+    #
+    # Only skip when nobody could answer a prompt. Interactively (a human at a
+    # TTY) fall through and let macOS ask, since that is how the grant gets
+    # created in the first place — skipping there would make the permission
+    # effectively ungrantable.
+    status = Contacts.CNContactStore.authorizationStatusForEntityType_(0)
+    CN_AUTHORIZED = 3
+    if status != CN_AUTHORIZED and not sys.stdin.isatty():
+        state = {0: "notDetermined", 1: "restricted", 2: "denied"}.get(status, str(status))
+        print(
+            "SYNC_SKIPPED: Apple Contacts access not granted "
+            f"(authorization status: {state}). Grant Contacts access to the "
+            "Python binary in System Settings -> Privacy & Security -> "
+            "Contacts, or run this script once from a terminal to be prompted.",
+            flush=True,
+        )
+        return {}
+
     store = Contacts.CNContactStore.alloc().init()
 
     keys_to_fetch = [

--- a/tests/test_push_birthdays_contacts_auth.py
+++ b/tests/test_push_birthdays_contacts_auth.py
@@ -1,0 +1,86 @@
+"""Contacts authorization pre-check for push_birthdays_to_contacts.
+
+A CNContactStore fetch with authorization status notDetermined makes macOS try
+to raise a consent prompt. Under launchd/cron there is no GUI session to show
+it, so the call blocks indefinitely instead of erroring — seen in production as
+a 60-minute nightly sync timeout that also dependency-skipped downstream
+sources, from a source with 12 birthdays to push.
+"""
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+NOT_DETERMINED, RESTRICTED, DENIED, AUTHORIZED = 0, 1, 2, 3
+
+
+def _install_fake_contacts(status):
+    """Stub the macOS-only Contacts module so this runs on any platform."""
+    mod = types.ModuleType("Contacts")
+    mod.CNContactStore = MagicMock()
+    mod.CNContactStore.authorizationStatusForEntityType_ = MagicMock(return_value=status)
+    mod.CNContactIdentifierKey = "id"
+    mod.CNContactGivenNameKey = "given"
+    mod.CNContactFamilyNameKey = "family"
+    mod.CNContactEmailAddressesKey = "emails"
+    mod.CNContactBirthdayKey = "birthday"
+    mod.CNContactFetchRequest = MagicMock()
+    return mod
+
+
+def _run(status, isatty, capsys):
+    from scripts import push_birthdays_to_contacts as mod
+
+    fake = _install_fake_contacts(status)
+    with patch.dict(sys.modules, {"Contacts": fake}), \
+         patch.object(sys.stdin, "isatty", return_value=isatty):
+        result = mod.get_apple_contacts_with_email()
+    return result, capsys.readouterr().out
+
+
+class TestContactsAuthPrecheck:
+
+    @pytest.mark.parametrize("status", [NOT_DETERMINED, RESTRICTED, DENIED])
+    def test_unauthorized_non_interactive_skips_instead_of_blocking(self, status, capsys):
+        """The scheduled case: declare a skip rather than hang on a prompt."""
+        result, out = _run(status, isatty=False, capsys=capsys)
+        assert result == {}
+        assert "SYNC_SKIPPED" in out
+        assert "Contacts access not granted" in out
+
+    def test_skip_message_names_the_actual_status(self, capsys):
+        _, out = _run(DENIED, isatty=False, capsys=capsys)
+        assert "denied" in out
+
+    def test_unauthorized_but_interactive_does_not_skip(self, capsys):
+        """A human at a TTY must still get macOS's prompt.
+
+        Skipping here would make the permission effectively ungrantable.
+        """
+        from scripts import push_birthdays_to_contacts as mod
+
+        fake = _install_fake_contacts(NOT_DETERMINED)
+        with patch.dict(sys.modules, {"Contacts": fake}), \
+             patch.object(sys.stdin, "isatty", return_value=True):
+            mod.get_apple_contacts_with_email()
+
+        out = capsys.readouterr().out
+        assert "SYNC_SKIPPED" not in out
+        # Fell through to real store construction rather than short-circuiting.
+        assert fake.CNContactStore.alloc.called
+
+    def test_authorized_proceeds_normally(self, capsys):
+        from scripts import push_birthdays_to_contacts as mod
+
+        fake = _install_fake_contacts(AUTHORIZED)
+        with patch.dict(sys.modules, {"Contacts": fake}), \
+             patch.object(sys.stdin, "isatty", return_value=False):
+            mod.get_apple_contacts_with_email()
+
+        out = capsys.readouterr().out
+        assert "SYNC_SKIPPED" not in out
+        assert fake.CNContactStore.alloc.called


### PR DESCRIPTION
## Problem

A `CNContactStore` fetch with authorization status `notDetermined` makes macOS try to raise a consent prompt. Under launchd/cron there is no GUI session to show it, so the call **blocks indefinitely** rather than erroring.

Observed on a Mac mini: `push_birthdays` hit the 60-minute sync timeout **every night**, was recorded as a failed source, and cascaded — dependency-skipping downstream work. All from a source with **12 birthdays** to push.

Probed directly on the affected host:

```
Contacts authorization: 0 notDetermined
```

The symptom reads as slowness, which is why it sat unfixed: a 60-minute timeout looks like a big job, not a missing permission.

## Change

Pre-check the authorization status and emit `SYNC_SKIPPED` with the actual state and the remedy, matching the existing skip path for a Linux host with no pyobjc:

```
SYNC_SKIPPED: Apple Contacts access not granted (authorization status:
notDetermined). Grant Contacts access to the Python binary in System
Settings -> Privacy & Security -> Contacts, or run this script once from
a terminal to be prompted.
```

The runner then records `skipped` **with a reason** rather than a 60-minute failure or a green zero-record "success" — the silent-green failure mode this codebase has been bitten by repeatedly (#495, #497, the yield-collapse work).

### One design detail

It only skips when `stdin` is **not** a TTY. Interactively it falls through and lets macOS prompt, because that prompt is how the grant gets created in the first place — skipping there would make the permission effectively ungrantable.

## Verification on the affected host

| | Before | After |
|---|---|---|
| Wall time | 60 min (timeout) | **0s** |
| Runner outcome | `failed`, cascades to dependents | `skipped` with reason |

```
[INFO] Sync completed for run_id=241: skipped
[INFO] Sync skipped for push_birthdays: Apple Contacts access not granted ...
```

## Not to be confused with `photos`

The sibling source `photos` was failing the same way but for a **different permission** — Full Disk Access on the `.photoslibrary` bundle, not Contacts. It is unaffected by this change and now completes under launchd in seconds once FDA is granted. Verified separately under launchd, `rc=0`, 0 errors.

## Testing

6 new tests: `notDetermined`/`restricted`/`denied` all skip, the message names the real status, `authorized` proceeds normally, and the interactive TTY case falls through instead of skipping. The macOS-only `Contacts` module is stubbed so they run anywhere.

Full unit suite: **5,030 passed, 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RqASCyAbmEt6AQBhRbW9e