### PR TITLE
fix(agent-worker): a preflight verdict parks a task instead of destroying it (#747, #748)

### DIFF
--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -78,6 +78,16 @@ class PreflightResult:
     ambiguity: PreflightAmbiguity | None = None
     sane: bool = True
     sane_reason: str = ""
+    # True only when a sane=False verdict is grounded in something the *code*
+    # established deterministically — an empty title, a preflight-call
+    # failure/unparseable reply, or a title matched against
+    # `_DESTRUCTIVE_TITLE_RE` — rather than merely the model's own inferred
+    # "this isn't executable" opinion (#747). The worker fails the task
+    # closed (cancels it) only when this is True; a non-fatal sane=False is
+    # parked like an ambiguous task instead, since a cheap classifier
+    # ignoring the prompt's "mundane tasks are sane" rule has already been
+    # observed to silently destroy real work. Meaningless when sane is True.
+    sane_fatal: bool = False
     # Whether the cloud (API) route was *asked for* rather than inferred (#584).
     # Only an explicit request — a `#cloud*` tag, or a model/engine named in the
     # title — may dispatch to the Anthropic API without confirmation; an
@@ -203,6 +213,86 @@ def build_preflight_prompt(title: str, tags: list[str]) -> str:
 
 _JSON_BLOCK = re.compile(r"\{.*\}", re.DOTALL)
 
+# Phrasings the preflight model uses when it smuggles a method-of-execution /
+# engine-selection question into `ambiguity` instead of leaving it null
+# (#748) — e.g. "Should this task be routed to a local agent for code
+# implementation, or is it a design/specification task for a human
+# engineer?". The prompt already forbids this explicitly, but this is the
+# *second* observed case of the model ignoring an explicit negative
+# constraint (see `_DESTRUCTIVE_TITLE_RE` / #747), so the code cannot rely on
+# prompt compliance alone. There's no structural field distinguishing
+# ambiguity "kinds" today — adding one would just move the same compliance
+# risk into a different JSON key the model could also ignore — so this
+# inspects the question prose directly.
+#
+# Kept deliberately narrow: BOTH halves must match. A genuine missing-
+# referent ambiguity can innocently contain a word like "engineer" or
+# "agent" (e.g. "send the update to the engineer" with no named engineer)
+# without being a routing question at all — matching on either half alone
+# would swallow that case, and a swallowed real ambiguity is worse than one
+# extra question to the operator.
+_ROUTING_DECISION_RE = re.compile(
+    r"(?i)\b(should\s+(this|it)\s+(task\s+)?be\s+(routed|handled|assigned|executed|done)\b"
+    r"|which\s+(model|engine|agent)\s+should\b"
+    r"|(is\s+this|or\s+is\s+(this|it))\s+(a\s+)?(design|specification|spec)\b)"
+)
+_EXECUTOR_NOUN_RE = re.compile(
+    r"(?i)\b(local\s+agent|human\s+engineer|code\s+implementation|"
+    r"design(?:/|\s+or\s+)?specification|a\s+human\b|which\s+engine\b|"
+    r"which\s+model\b|rout(?:e|ed|es|ing)\b)"
+)
+
+
+def _is_routing_flavored_ambiguity(question: str) -> bool:
+    """True when an `ambiguity.question` is actually a method-of-execution /
+    routing question (#748), not a genuine missing-referent ambiguity."""
+    return bool(
+        _ROUTING_DECISION_RE.search(question or "")
+        and _EXECUTOR_NOUN_RE.search(question or "")
+    )
+
+
+# Deterministic destructive-title check (#747). Matched against the title
+# directly — NOT inferred from the model's `sane_reason` prose — so the code
+# can independently confirm a fail-closed verdict rather than trust a single
+# cheap model's judgement. Deliberately narrow, mirroring the prompt's own
+# examples ("rm -rf /", "delete all my data") plus a couple of obviously
+# analogous shapes: a broad matcher would start catching mundane tasks that
+# merely mention deletion (e.g. "delete the stale draft email"), which is
+# exactly the false-positive failure mode #747 exists to fix.
+_DESTRUCTIVE_TITLE_RE = re.compile(
+    r"(?i)\brm\s+-rf\b"
+    r"|\bdelete\s+all\s+(my\s+)?(data|files|everything)\b"
+    r"|\bwipe\s+(the\s+)?(disk|drive|database|everything)\b"
+    r"|\bformat\s+(the\s+)?(disk|drive)\b"
+    r"|\bdrop\s+(the\s+)?database\b"
+)
+
+
+def _apply_sanity_gate(result: PreflightResult, title: str) -> PreflightResult:
+    """Establish `sane_fatal` independent of the model's own claim (#747).
+
+    A title matching `_DESTRUCTIVE_TITLE_RE` is always sane=False and fatal,
+    regardless of what the model returned — this is the one case the code
+    can confirm on its own, so it isn't weakened by (or dependent on) the
+    model's compliance in either direction: a model that missed an obvious
+    destructive shape doesn't get to leave it running, and a model whose
+    sane_reason merely *describes* something as destructive without this
+    pattern present doesn't get automatic fatal status from that alone.
+
+    Every other sane=False is left exactly as constructed: the empty-title
+    short-circuit and the LLM-call/parse-error fallbacks already set
+    `sane_fatal=True` directly (genuine code-level failures), and a parsed
+    LLM reply defaults `sane_fatal=False` (the model's own inferred opinion,
+    non-fatal — the worker parks it instead of cancelling the task).
+    """
+    if _DESTRUCTIVE_TITLE_RE.search(title or ""):
+        result.sane = False
+        result.sane_fatal = True
+        if not result.sane_reason:
+            result.sane_reason = "title matches a destructive-command pattern"
+    return result
+
 
 def parse_preflight_response(text: str) -> PreflightResult:
     """Parse the LLM's reply into a PreflightResult.
@@ -228,6 +318,7 @@ def parse_preflight_response(text: str) -> PreflightResult:
             ambiguity=None,
             sane=False,
             sane_reason=f"preflight parse error: {exc}",
+            sane_fatal=True,  # genuine preflight error, not a model opinion — keep fail-closed
             raw={},
         )
 
@@ -250,7 +341,19 @@ def parse_preflight_response(text: str) -> PreflightResult:
     ambiguity = None
     amb_raw = raw.get("ambiguity")
     if isinstance(amb_raw, dict) and amb_raw.get("question"):
-        ambiguity = PreflightAmbiguity(question=str(amb_raw["question"]))
+        question = str(amb_raw["question"])
+        if _is_routing_flavored_ambiguity(question):
+            # #748: the model put a method-of-execution / engine-selection
+            # question into `ambiguity` despite the prompt explicitly
+            # excluding those ("Method-of-execution questions ... are NOT
+            # ambiguity"). Routing (including LIFEOS_AGENT_DEFAULT_ROUTE,
+            # #707) owns that decision, not the operator-facing block —
+            # leave ambiguity null so the task isn't blocked on it.
+            logger.info(
+                "preflight ambiguity suppressed as routing-flavored: %r", question,
+            )
+        else:
+            ambiguity = PreflightAmbiguity(question=question)
 
     return PreflightResult(
         budget=budget,
@@ -606,16 +709,18 @@ def _apply_cost_gates(result: PreflightResult) -> PreflightResult:
 
 def _finish(result: PreflightResult, tags_list: list[str], title: str = "") -> PreflightResult:
     """Shared post-processing pipeline for every `run_preflight` return path:
-    tag overrides > default route (#707) > preset class > cost gates —
-    matching the precedence tags > explicit LLM route > default route > ask.
+    sanity gate (#747) > tag overrides > default route (#707) > preset class
+    > cost gates — matching the precedence tags > explicit LLM route >
+    default route > ask.
 
-    Centralized (rather than each return path chaining the four calls
-    itself) so `original_routing` is captured exactly once, right after the
+    Centralized (rather than each return path chaining the calls itself) so
+    `original_routing` is captured exactly once, right after the
     parse/short-circuit result is built and before `_apply_tag_overrides`
     (the only thing that mutates `result.routing` ahead of the default-route
     hook) gets a chance to change it. See `_apply_default_route` for why that
     pre-tag-override value matters.
     """
+    result = _apply_sanity_gate(result, title)
     original_routing = result.routing
     result = _apply_tag_overrides(result, tags_list, title)
     result = _apply_default_route(result, original_routing)
@@ -645,6 +750,7 @@ def run_preflight(
                 ambiguity=None,
                 sane=False,
                 sane_reason="task title is empty",
+                sane_fatal=True,  # deterministic — the code confirmed this itself
                 raw={},
             ),
             tags_list,
@@ -666,6 +772,7 @@ def run_preflight(
                 ambiguity=None,
                 sane=False,
                 sane_reason=f"preflight error: {exc}",
+                sane_fatal=True,  # genuine preflight error, not a model opinion — keep fail-closed
                 raw={},
             ),
             tags_list,

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -2177,6 +2177,7 @@ class Worker:
             "ambiguity": pre.ambiguity.question if pre.ambiguity else None,
             "sane": pre.sane,
             "sane_reason": pre.sane_reason,
+            "sane_fatal": pre.sane_fatal,
             "budget": {
                 "wall_seconds": pre.budget.wall_seconds,
                 "max_tokens": pre.budget.max_tokens,
@@ -2199,16 +2200,35 @@ class Worker:
         )
         session = self.session_store.get(task_id)  # refresh
 
-        # Sanity gate.
-        if not pre.sane:
+        # Sanity gate (#747). Only a *fatal* sane=False fails the task
+        # closed — an empty title, a preflight-call error, or a title the
+        # code itself matched as a deterministically destructive shape (see
+        # `preflight._DESTRUCTIVE_TITLE_RE`). Everything else is the
+        # classifier's own inferred "this isn't executable" opinion, which
+        # has been observed ignoring the prompt's "mundane tasks are sane"
+        # rule — treating that single cheap-model judgement as authoritative
+        # would silently cancel real work, so it's parked below instead,
+        # same as an ambiguous task: a wrong inference costs one question,
+        # not the task.
+        if not pre.sane and pre.sane_fatal:
             self._mark_failed(
                 session, task,
                 f"preflight flagged task as unsafe to run: {pre.sane_reason}",
             )
             return
 
-        # Ambiguity / ask-routing → block on user input (Issue F closes this loop).
+        # Ambiguity / ask-routing / non-fatal sanity objection → block on
+        # user input (Issue F closes this loop). Each contributes its own
+        # sentence so the operator can tell a sanity objection apart from a
+        # genuine ambiguity or an engine-choice question at a glance, rather
+        # than seeing one generic "blocked" string.
         question_parts: list[str] = []
+        if not pre.sane:
+            question_parts.append(
+                f"Preflight flagged this task as possibly not executable: "
+                f"{pre.sane_reason} Reply to confirm it should run as-is, "
+                f"or edit/retag the task in the vault."
+            )
         if pre.ambiguity:
             question_parts.append(pre.ambiguity.question)
         if pre.routing == ROUTE_ASK:

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -292,6 +292,8 @@ def test_routing_ask_lands_in_blocked_with_model_question(tmp_path: Path):
 
 @pytest.mark.unit
 def test_insane_task_lands_in_failed(tmp_path: Path):
+    """A deterministically destructive title (matched by the code, not the
+    model's prose) still fails closed — #747 must not weaken this guard."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "rm -rf /", "status": "todo", "tags": ["agent", "local"]},
     ])
@@ -303,6 +305,86 @@ def test_insane_task_lands_in_failed(tmp_path: Path):
     assert executor.calls == []
     assert FAILED_TAG in api.tasks["t1"]["tags"]
     assert w.session_store.get("t1").status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_mundane_sane_false_task_lands_in_blocked_not_cancelled(tmp_path: Path):
+    """#747: a preflight sanity rejection of an ordinary, non-destructive
+    title must park the task (blocked, still actionable) rather than
+    cancel it — the model's own 'not executable' opinion is not fatal."""
+    api = FakeApi(tasks=[
+        {"id": "t1",
+         "description": "Display the transcribed message immediately after sending",
+         "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run"))
+    preflight = _golden_preflight(
+        routing="local", sane=False,
+        sane_reason="This is a product specification or feature request, not a task an agent can execute.",
+    )
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    # Never ran, but critically NOT cancelled — parked and still actionable.
+    assert executor.calls == []
+    assert FAILED_TAG not in api.tasks["t1"]["tags"]
+    assert BLOCKED_TAG in api.tasks["t1"]["tags"]
+    assert api.tasks["t1"]["status"] != "cancelled"
+    assert w.session_store.get("t1").status == STATUS_BLOCKED
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert any("not executable" in s and "flagged" in s for s in sent)
+
+
+@pytest.mark.unit
+def test_sane_false_and_ambiguous_blocked_messages_are_distinguishable(tmp_path: Path):
+    """#747 + #748 interaction: a parked sanity objection and a genuine
+    ambiguity must produce distinguishable operator-facing text, not one
+    generic 'blocked' string."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run"))
+    preflight = _golden_preflight(
+        routing="local", sane=False, sane_reason="looks like a spec, not a task",
+        ambiguity={"question": "Which John — John Doe or John Smith?"},
+    )
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    assert BLOCKED_TAG in api.tasks["t1"]["tags"]
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    combined = " ".join(sent)
+    assert "looks like a spec" in combined
+    assert "Which John" in combined
+    # The two objections are textually distinct, not collapsed into one line.
+    assert "looks like a spec" not in "Which John — John Doe or John Smith?"
+
+
+@pytest.mark.unit
+def test_routing_flavored_ambiguity_does_not_block(tmp_path: Path):
+    """#748: a method-of-execution question smuggled into `ambiguity` must
+    not block the task — routing decides."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "Turn the record button white when idle",
+         "status": "todo", "tags": ["agent", "local"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="ran"))
+    preflight = _golden_preflight(
+        routing="local",
+        ambiguity={
+            "question": (
+                "Should this task be routed to a local agent for code "
+                "implementation, or is it a design/specification task for "
+                "a human engineer?"
+            ),
+        },
+    )
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    assert executor.calls != []
+    assert BLOCKED_TAG not in api.tasks["t1"]["tags"]
+    assert COMPLETED_TAG in api.tasks["t1"]["tags"]
 
 
 @pytest.mark.unit

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -75,6 +75,142 @@ def test_preflight_sanity_failure_passed_through():
     assert "destructive" in result.sane_reason
 
 
+# ---------------------------------------------------------------------------
+# #747 — a sanity rejection must park, not cancel, unless the code itself can
+# confirm the title is empty, deterministically destructive, or preflight
+# itself failed. `sane_fatal` is the signal the worker uses to distinguish.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_sane_false_on_mundane_title_is_not_fatal():
+    """Repro of the live #747 bug: the model rejects a routine UI task as
+    'not executable'. The title itself is ordinary — the classifier's own
+    inferred opinion must not be treated as fatal."""
+    reply = _golden_reply(
+        sane=False,
+        sane_reason="This is a product specification or feature request, not a task an agent can execute.",
+    )
+    result = pf.run_preflight(
+        title="Display the user's transcribed message immediately after sending",
+        tags=["agent"], caller=_stub(reply),
+    )
+    assert result.sane is False
+    assert result.sane_fatal is False
+
+
+@pytest.mark.unit
+def test_sane_false_destructive_title_is_fatal():
+    """The model's own sane=false on an actually-destructive title is
+    corroborated by the deterministic check — stays fatal."""
+    reply = _golden_reply(sane=False, sane_reason="destructive: 'rm -rf /'")
+    result = pf.run_preflight(title="rm -rf /", tags=["agent"], caller=_stub(reply))
+    assert result.sane is False
+    assert result.sane_fatal is True
+
+
+@pytest.mark.unit
+def test_destructive_title_is_fatal_even_if_model_claims_sane():
+    """The destructive-shape guard must not be weakened by (or dependent on)
+    model compliance: even a model that wrongly says sane=true on an
+    obviously destructive title gets overridden by the deterministic check."""
+    reply = _golden_reply(sane=True, sane_reason="")
+    result = pf.run_preflight(title="delete all my data", tags=["agent"], caller=_stub(reply))
+    assert result.sane is False
+    assert result.sane_fatal is True
+
+
+@pytest.mark.unit
+def test_empty_title_sanity_failure_is_fatal():
+    def fail(prompt):
+        raise AssertionError("LLM should not have been called for empty title")
+
+    result = pf.run_preflight(title="   ", tags=["agent"], caller=fail)
+    assert result.sane is False
+    assert result.sane_fatal is True
+
+
+@pytest.mark.unit
+def test_preflight_llm_error_sanity_failure_is_fatal():
+    def boom(prompt):
+        raise RuntimeError("haiku is down")
+
+    result = pf.run_preflight(title="x", tags=["agent"], caller=boom)
+    assert result.sane is False
+    assert result.sane_fatal is True
+
+
+@pytest.mark.unit
+def test_preflight_unparseable_reply_sanity_failure_is_fatal():
+    result = pf.run_preflight(title="x", tags=["agent"], caller=_stub("totally not json"))
+    assert result.sane is False
+    assert result.sane_fatal is True
+
+
+# ---------------------------------------------------------------------------
+# #748 — a routing/method-of-execution question smuggled into `ambiguity`
+# must not block; routing (including the default route) owns that decision.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_routing_flavored_ambiguity_is_suppressed():
+    """Repro of the live #748 bug: the model raises 'should this go to a
+    local agent or is it a design task for a human engineer' as ambiguity.
+    That's a routing question, not a blocking ambiguity."""
+    reply = _golden_reply(
+        routing="ask",
+        routing_reason="No explicit model cue or capability inference.",
+        ambiguity={
+            "question": (
+                "Should this task be routed to a local agent for code "
+                "implementation, or is it a design/specification task for "
+                "a human engineer?"
+            ),
+        },
+    )
+    result = pf.run_preflight(
+        title="Turn the inactive record button white when not recording",
+        tags=["agent"], caller=_stub(reply),
+    )
+    assert result.ambiguity is None
+
+
+@pytest.mark.unit
+def test_genuine_missing_referent_ambiguity_still_blocks():
+    """A real missing-referent ambiguity must not be swallowed by the
+    routing-flavored matcher."""
+    reply = _golden_reply(
+        ambiguity={"question": "Which John — John Doe or John Smith?"},
+    )
+    result = pf.run_preflight(title="reply to John", tags=["agent"], caller=_stub(reply))
+    assert result.ambiguity is not None
+    assert "John" in result.ambiguity.question
+
+
+@pytest.mark.unit
+def test_default_route_applies_when_ambiguity_is_routing_flavored(monkeypatch):
+    """#707's default route must not be defeated by a spurious routing-
+    flavored ambiguity — this was the concrete way #748 broke #707."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+    reply = _golden_reply(
+        routing="ask",
+        routing_reason="No explicit model cue or capability inference.",
+        ambiguity={
+            "question": (
+                "Should this task be routed to a local agent for code "
+                "implementation, or is it a design/specification task for "
+                "a human engineer?"
+            ),
+        },
+    )
+    result = pf.run_preflight(
+        title="Turn the inactive record button white when not recording",
+        tags=["agent"], caller=_stub(reply),
+    )
+    assert result.ambiguity is None
+    assert result.routing == pf.ROUTE_LOCAL
+
+
 @pytest.mark.unit
 def test_preflight_handles_json_in_code_fence():
     """Some models like to wrap output in ```json fences."""


### PR DESCRIPTION
Closes #747. Closes #748.

Two live `#agent` tasks were lost to preflight misjudgements. One routine UI request was marked `sane: false` — *"a product specification or feature request, not a task an agent can execute"* — and **cancelled in the vault**. Another was blocked on an `ambiguity` of *"should this be routed to a local agent, or is it a design task for a human engineer?"*.

The prompt already forbids both: sanity rejection is *"ONLY for empty/garbage titles or obviously destructive shapes... Mundane tasks are sane"*, and *"method-of-execution questions are NOT ambiguity"*. A small model broke the same kind of rule twice, and the code treated one cheap judgement as authoritative. So neither fix is a prompt tweak — the code now checks independently.

**Sanity verdicts park, they don't cancel.** New `PreflightResult.sane_fatal` is set only by code-established facts — the empty-title short-circuit, an LLM-call exception, a JSON parse failure — plus a deterministic `_DESTRUCTIVE_TITLE_RE` matched against the **title**, never the model's prose. That regex is checked regardless of what the model said, so a model that *misses* an obviously destructive title still fails closed, while a model's opinion alone can never manufacture fatality. Any other `sane=false` now parks at `#agent-blocked` with its own message — *"Preflight flagged this task as possibly not executable: … Reply to confirm it should run as-is, or edit/retag the task"* — reusing the existing reply-to-resume machinery.

**Routing questions are not task ambiguity.** `_is_routing_flavored_ambiguity()` requires **both** a decision-about-executor phrase and an execution-mode noun before suppressing an ambiguity, and logs when it does. Deliberately narrow: swallowing a genuine missing-referent ambiguity is worse than one extra question. Suppression happens before `_finish`, so #707's default route (gated on `ambiguity is None`) applies with no change — the exact case that was blocking.

Operator messages stay distinguishable rather than collapsing into one generic string: a parked sanity objection, a genuine ambiguity (the model's question verbatim), and an engine ask each read differently and concatenate as separate sentences.

The #584 unconfirmed-cloud downgrade and #707's gates are untouched and still green; tag precedence and cost gates unchanged. 14 new tests.

Gate: unit scope 5,047 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)