### PR TITLE
fix(agent-worker): preflight ambiguity is advisory when a default route is configured (#751)

### DIFF
--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -117,6 +117,13 @@ class PreflightResult:
     # the operator before dispatching (#139 §7). Driven by
     # settings.agent_cost_confirm_threshold_dollars.
     needs_cost_confirmation: bool = False
+    # Set when a non-null `ambiguity` was demoted to advisory-only because
+    # `settings.agent_default_route` is configured (#751) — holds the
+    # original question text so the worker can log it as context (session
+    # transcript / completion note) instead of discarding it silently.
+    # `ambiguity` itself is cleared to None in the same step, since a
+    # demoted ambiguity must not block. None when nothing was demoted.
+    demoted_ambiguity: str | None = None
     raw: dict = field(default_factory=dict)  # the parsed JSON for debugging
 
 
@@ -563,40 +570,61 @@ def _apply_tag_overrides(result: PreflightResult, tags: list[str], title: str = 
 
 
 def _apply_default_route(result: PreflightResult, original_routing: str) -> PreflightResult:
-    """Apply `settings.agent_default_route` when preflight landed on `ask`
-    purely for lack of routing cues (#707) — the "nothing to ask about" case
-    on a single-executor install. Empty setting (default) is a no-op, so an
-    unset install is byte-identical to pre-#707 behavior.
+    """Apply `settings.agent_default_route` (#707), and — as of #751 — demote
+    any non-null `ambiguity` to advisory once that setting is configured and
+    valid. Empty setting (default) is a no-op, so an unset install is
+    byte-identical to pre-#707 behavior; both parts of this function are
+    gated on the setting being non-empty and valid.
 
-    Gate: `result.routing == ROUTE_ASK and result.sane and result.ambiguity
-    is None`. Deliberately NOT a string match against `routing_reason` — the
-    LLM's reason text is free-form prose ("no tag and no title cue" today,
-    but not a stable contract), so matching on it would be brittle. This one
-    structural gate covers both "lack of cues" paths:
-      - the LLM's own rule-5 answer ("none of the routing rules matched")
-      - `parse_preflight_response`'s deterministic fallback when the model
-        omitted `routing` or returned a value outside `KNOWN_ROUTES`
-    and it correctly excludes the two "ask" outcomes the issue says must
-    stay ask: ambiguity (checked directly) and sanity failures — including
-    the empty-title short-circuit and the LLM-call-failure fallback in
-    `run_preflight`, both of which set `sane=False`.
+    Two independent things happen here, in order:
 
-    One more `ask` source needs excluding that isn't in the issue's list:
-    `_apply_tag_overrides`'s #584 downgrade, which turns an *inferred*
-    (unconfirmed) cloud route into `ask` specifically so it can't
-    auto-dispatch. That result is also sane=True with ambiguity=None, so it
-    would slip through the gate above — this isn't "lack of cues", it's a
-    cue nobody confirmed, and silently routing it via the default would
-    undo the confirmation #584 exists for. Excluded via `original_routing`:
-    the routing value from BEFORE `_apply_tag_overrides` ran. Only when the
-    original LLM/parse outcome was *already* `ask` — not downgraded from
-    `claude` — do we know this is genuinely nothing-to-route-on.
+    1. **Ambiguity demotion (#751).** Configuring a default route is the
+       operator saying "run untagged tasks without asking me" — a cheap
+       classifier's hedging (`ambiguity`) shouldn't override that standing
+       instruction, regardless of what routing was ultimately picked. So
+       once the setting is confirmed non-empty and valid, any non-null
+       `result.ambiguity` is stashed on `result.demoted_ambiguity` (for the
+       worker to log as advisory context) and cleared. String-matching the
+       question text (#748's approach) is whack-a-mole — the model keeps
+       rephrasing around the pattern — so this demotes unconditionally on
+       the *value being non-null* rather than trying to classify its prose.
+       This intentionally does NOT touch `result.sane` — a non-fatal
+       `sane=False` still parks the task (#747): sanity is "should this run
+       at all", a question this setting has no bearing on, whereas ambiguity
+       is "who resolves an open question", which is exactly what a standing
+       default-route instruction answers.
+
+    2. **Route substitution (#707), unchanged.** Gate:
+       `result.routing == ROUTE_ASK and result.sane` (the `ambiguity is
+       None` half of the old gate is now always true here, since part 1 just
+       cleared it) `and original_routing == ROUTE_ASK`. Deliberately NOT a
+       string match against `routing_reason` — the LLM's reason text is
+       free-form prose ("no tag and no title cue" today, but not a stable
+       contract), so matching on it would be brittle. This one structural
+       gate covers both "lack of cues" paths:
+         - the LLM's own rule-5 answer ("none of the routing rules matched")
+         - `parse_preflight_response`'s deterministic fallback when the model
+           omitted `routing` or returned a value outside `KNOWN_ROUTES`
+       and it correctly excludes the "ask" outcome the issue says must stay
+       ask: sanity failures — including the empty-title short-circuit and
+       the LLM-call-failure fallback in `run_preflight`, both of which set
+       `sane=False`.
+
+       One more `ask` source needs excluding: `_apply_tag_overrides`'s #584
+       downgrade, which turns an *inferred* (unconfirmed) cloud route into
+       `ask` specifically so it can't auto-dispatch. That result is also
+       sane=True, so it would slip through the gate above — this isn't
+       "lack of cues", it's a cue nobody confirmed, and silently routing it
+       via the default would undo the confirmation #584 exists for.
+       Excluded via `original_routing`: the routing value from BEFORE
+       `_apply_tag_overrides` ran. Only when the original LLM/parse outcome
+       was *already* `ask` — not downgraded from `claude` — do we know this
+       is genuinely nothing-to-route-on. (Ambiguity demotion in part 1 still
+       runs on this path — the #584 downgrade blocks via `routing == ask`
+       either way, so demoting the ambiguity text just avoids a redundant
+       question, not a redundant block.)
     """
     if not settings.agent_default_route:
-        return result
-    if result.routing != ROUTE_ASK or not result.sane or result.ambiguity is not None:
-        return result
-    if original_routing != ROUTE_ASK:
         return result
 
     default_route = settings.agent_default_route
@@ -606,10 +634,26 @@ def _apply_default_route(result: PreflightResult, original_routing: str) -> Pref
         # validators), so this logs an ERROR — one line per occurrence, not a
         # crash — and falls back to `ask`, same as every other preflight
         # error path. The worker loop must never die over a typo'd env var.
+        # Deliberately checked (and returned on) BEFORE ambiguity demotion —
+        # a misconfigured setting is not a *valid* standing instruction, so
+        # it must not weaken the ambiguity block either.
         logger.error(
             "invalid LIFEOS_AGENT_DEFAULT_ROUTE=%r — must be one of %s; "
             "falling back to ask", default_route, KNOWN_ROUTES,
         )
+        return result
+
+    if result.ambiguity is not None:
+        logger.info(
+            "preflight ambiguity demoted to advisory (LIFEOS_AGENT_DEFAULT_ROUTE=%s "
+            "configured): %r", default_route, result.ambiguity.question,
+        )
+        result.demoted_ambiguity = result.ambiguity.question
+        result.ambiguity = None
+
+    if result.routing != ROUTE_ASK or not result.sane:
+        return result
+    if original_routing != ROUTE_ASK:
         return result
 
     result.routing = default_route
@@ -709,9 +753,37 @@ def _apply_cost_gates(result: PreflightResult) -> PreflightResult:
 
 def _finish(result: PreflightResult, tags_list: list[str], title: str = "") -> PreflightResult:
     """Shared post-processing pipeline for every `run_preflight` return path:
-    sanity gate (#747) > tag overrides > default route (#707) > preset class
-    > cost gates — matching the precedence tags > explicit LLM route >
-    default route > ask.
+    sanity gate (#747) > tag overrides > default route (#707, now also
+    demoting ambiguity per #751) > preset class > cost gates.
+
+    Precedence, and why each sits where it does:
+
+      1. **Sanity gate first, and orthogonal to everything below.**
+         `_apply_sanity_gate` runs before routing is decided at all, because
+         "should this run" is a different question from "how should it
+         run" — a `sane_fatal` verdict fails the task closed regardless of
+         routing/ambiguity (checked immediately in the worker, before either
+         is consulted), and a non-fatal `sane=False` parks it. Neither is
+         touched by the routing precedence below, and #751 does not change
+         this: a default route answers "who resolves an open question", not
+         "should this task run at all".
+      2. **Tags** (`_apply_tag_overrides`) — the operator retagging a task
+         is the most direct, most recent signal available; always wins.
+      3. **Explicit LLM route** — preserved by tag overrides leaving a
+         non-`ask` classifier routing alone, and by `_apply_default_route`
+         only substituting when routing is still `ask` *and* was already
+         `ask` before tag overrides ran (see `original_routing` below) — so
+         a routing the model was confident enough to name outright is never
+         overridden by the default route.
+      4. **Default route** (`_apply_default_route`, #707) — substitutes
+         `ask` for the configured route only when nothing above produced a
+         real answer. As of #751, this step *also* demotes a non-null
+         `ambiguity` to advisory (logged, not blocking) whenever the setting
+         is configured and valid — independent of whether step 4's route
+         substitution itself fires, since an explicit route (step 3) can
+         still carry a stale ambiguity the model should not have set.
+      5. **Ask** — the fallback when nothing above resolved routing, or the
+         #584 unconfirmed-cloud downgrade parked it there.
 
     Centralized (rather than each return path chaining the calls itself) so
     `original_routing` is captured exactly once, right after the

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -2175,6 +2175,10 @@ class Worker:
             "routing_reason": pre.routing_reason,
             "expected_output": pre.expected_output,
             "ambiguity": pre.ambiguity.question if pre.ambiguity else None,
+            # (#751) A default route demotes ambiguity to advisory rather than
+            # discarding it — logged here as context for whoever reads the
+            # transcript, not as a blocking question to the operator.
+            "demoted_ambiguity": pre.demoted_ambiguity,
             "sane": pre.sane,
             "sane_reason": pre.sane_reason,
             "sane_fatal": pre.sane_fatal,

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -160,7 +160,7 @@ The HTTP MCP transport exposes LifeOS tools to remote agents (primarily Anthropi
 | `LIFEOS_AGENT_MAX_CONCURRENT_LOCAL` | int | varies | Concurrent local-executor sessions. |
 | `LIFEOS_AGENT_MAX_CONCURRENT_MANAGED` | int | varies | Concurrent Managed-Agents sessions. |
 | `LIFEOS_AGENT_REMOTE_EXECUTOR` | bool | `false` | Opt-in: when the [OpenAI-compatible remote provider](#openai-compatible-remote-provider) is fully configured and the local llama-server is unreachable at session start, the local route runs the session on the remote provider instead of failing. No-op unless the remote provider is fully configured. |
-| `LIFEOS_AGENT_DEFAULT_ROUTE` | str | *(empty)* | Route preflight dispatches to instead of `ask` when a task has no routing cues at all — for a single-executor install there's nothing useful to ask about. Applies only when lack of cues, not ambiguity or a sanity failure, is why preflight would otherwise ask. Tag overrides (`#local`, `#cloud`, etc.) always win. |
+| `LIFEOS_AGENT_DEFAULT_ROUTE` | str | *(empty)* | Route preflight dispatches to instead of `ask` when a task has no routing cues at all — for a single-executor install there's nothing useful to ask about. Applies only when lack of cues, not a sanity failure, is why preflight would otherwise ask. Tag overrides (`#local`, `#cloud`, etc.) always win. When set to a valid route, also demotes any preflight `ambiguity` to advisory (logged, not blocking) instead of parking the task on the question — see [agent-worker.md](../specs/technical/agent-worker.md#preflight) for the full precedence. |
 
 ## Agent Worker — Managed Agents (Cloud)
 

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -160,6 +160,7 @@ class PreflightResult:
     ambiguity: PreflightAmbiguity | None
     sane: bool
     sane_reason: str
+    demoted_ambiguity: str | None   # #751: ambiguity text demoted to advisory, if any
     raw: dict                       # the parsed JSON for debugging
 ```
 
@@ -171,7 +172,9 @@ Routing precedence (per the prompt instructions):
 4. Title contains capability-implying phrase ("search my gmail", "google drive", "send a slack message", etc.) → claude (those tools require cloud connectors)
 5. Otherwise → `LIFEOS_AGENT_DEFAULT_ROUTE` if set, else ask (worker pauses the task and asks via Telegram)
 
-`LIFEOS_AGENT_DEFAULT_ROUTE` (empty by default) applies only when preflight would otherwise land on `ask` purely for lack of routing cues — not when ambiguity or a sanity failure is the reason, and not when the classifier inferred a cloud route that the API-consent downgrade below sends to `ask`. It exists for a single-executor install (e.g. local-only, no Claude Code/Codex/Managed Agents) where a multi-engine clarification question has nothing useful to offer. Tag overrides (`#local`, `#cloud`, etc.) always take precedence over it. An invalid value logs an error and falls back to `ask` rather than crashing the worker loop.
+`LIFEOS_AGENT_DEFAULT_ROUTE` (empty by default) applies only when preflight would otherwise land on `ask` purely for lack of routing cues — not when a sanity failure is the reason, and not when the classifier inferred a cloud route that the API-consent downgrade below sends to `ask`. It exists for a single-executor install (e.g. local-only, no Claude Code/Codex/Managed Agents) where a multi-engine clarification question has nothing useful to offer. Tag overrides (`#local`, `#cloud`, etc.) always take precedence over it. An invalid value logs an error and falls back to `ask` rather than crashing the worker loop.
+
+**Ambiguity demotion (#751).** When `LIFEOS_AGENT_DEFAULT_ROUTE` is set to a valid route, a non-null `ambiguity` no longer blocks the task, regardless of what routing was ultimately picked (default-route substitution, an explicit LLM route, or a tag override). Configuring a default route is the operator saying "run untagged tasks without asking me"; a cheap classifier's hedging shouldn't override that standing instruction — especially since string-matching the hedge's prose (the #748 fix) proved to be whack-a-mole once the model started rephrasing around the pattern. The question is preserved on `demoted_ambiguity` and logged to the session transcript as advisory context rather than discarded, and the executing agent can still ask a specific question mid-run via `lifeos_agent_user_ask` if it genuinely needs to. This is orthogonal to sanity: a non-fatal `sane=false` still parks the task even with a default route configured (#747 is about whether the task should run at all, which a default route has no bearing on), and the #584 unconfirmed-cloud downgrade still blocks (never auto-spend on inferred cloud routing). With no default route configured, ambiguity blocks exactly as before.
 
 Hardening: response is parsed defensively (handles `` ```json `` fences, partial schemas, missing keys, exceptions). On any parse failure the result defaults to `sane=false` so the worker parks the task rather than running with garbage.
 

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -388,6 +388,80 @@ def test_routing_flavored_ambiguity_does_not_block(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_default_route_demotes_ambiguity_and_runs(tmp_path: Path, monkeypatch):
+    """#751: with a default route configured, a genuine ambiguity no longer
+    blocks — it's demoted to advisory and the task runs on the default
+    route instead. Contrast with `test_ambiguous_title_lands_in_blocked`,
+    which covers the no-default-route case and must keep blocking."""
+    from config.settings import settings as _settings
+    monkeypatch.setattr(_settings, "agent_default_route", "local")
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="replied"))
+    preflight = _golden_preflight(
+        routing="ask",
+        ambiguity={"question": "Which John — John Doe or John Smith?"},
+    )
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    # Ran on the default route rather than blocking on the question.
+    assert executor.calls != []
+    assert BLOCKED_TAG not in api.tasks["t1"]["tags"]
+    assert COMPLETED_TAG in api.tasks["t1"]["tags"]
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert not any("Which John" in s for s in sent)
+
+
+@pytest.mark.unit
+def test_default_route_does_not_rescue_fatal_sanity(tmp_path: Path, monkeypatch):
+    """#751 must not weaken #747's fail-closed guard: a deterministically
+    destructive title still fails the task even with a default route
+    configured — sanity is decided before routing is even consulted."""
+    from config.settings import settings as _settings
+    monkeypatch.setattr(_settings, "agent_default_route", "local")
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "rm -rf /", "status": "todo", "tags": ["agent"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
+    preflight = _golden_preflight(routing="local", sane=False, sane_reason="destructive")
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    assert executor.calls == []
+    assert FAILED_TAG in api.tasks["t1"]["tags"]
+    assert w.session_store.get("t1").status == STATUS_FAILED
+
+
+@pytest.mark.unit
+def test_default_route_does_not_rescue_nonfatal_sanity(tmp_path: Path, monkeypatch):
+    """#751 must not weaken #747: a non-fatal sane=false (the classifier's
+    own 'not executable' opinion on a mundane title) still parks the task
+    even with a default route configured — sanity ('should this run at
+    all') is orthogonal to a default route ('who resolves an open
+    question'), and #751 only touches the latter."""
+    from config.settings import settings as _settings
+    monkeypatch.setattr(_settings, "agent_default_route", "local")
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "Display the transcribed message immediately after sending",
+         "status": "todo", "tags": ["agent"]},
+    ])
+    executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run"))
+    preflight = _golden_preflight(
+        routing="local", sane=False,
+        sane_reason="This is a product specification or feature request, not a task an agent can execute.",
+    )
+    w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
+    w.tick()
+
+    assert executor.calls == []
+    assert FAILED_TAG not in api.tasks["t1"]["tags"]
+    assert BLOCKED_TAG in api.tasks["t1"]["tags"]
+    assert w.session_store.get("t1").status == STATUS_BLOCKED
+
+
+@pytest.mark.unit
 def test_executor_budget_exceeded_sets_budget_exceeded_tag(tmp_path: Path):
     api = FakeApi(tasks=[
         {"id": "t1", "description": "long task", "status": "todo", "tags": ["agent", "local"]},

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -916,8 +916,20 @@ def test_default_route_applies_to_llm_omitted_routing(monkeypatch):
 
 
 @pytest.mark.unit
-def test_default_route_does_not_apply_on_ambiguity(monkeypatch):
-    """Set + ambiguity -> still ask."""
+def test_default_route_demotes_ambiguity_and_applies(monkeypatch):
+    """#751: with a default route configured, a non-null ambiguity on an
+    otherwise-runnable task is demoted to advisory (not discarded — it's
+    preserved on `demoted_ambiguity` for the session log) and the default
+    route applies, rather than the task blocking on the question.
+
+    This supersedes the pre-#751 `test_default_route_does_not_apply_on_ambiguity`
+    expectation (ambiguity used to hard-block even with a default route
+    configured) — the issue this fixes (#751) is specifically that a
+    configured default route is a standing "run untagged tasks without
+    asking me" instruction that a cheap classifier's hedging must not
+    override, and string-matching the hedge's prose (#748) proved to be
+    whack-a-mole once the model rephrased around the pattern.
+    """
     from config.settings import settings
     monkeypatch.setattr(settings, "agent_default_route", "local")
     reply = _golden_reply(
@@ -925,8 +937,9 @@ def test_default_route_does_not_apply_on_ambiguity(monkeypatch):
         ambiguity={"question": "Which John — John Doe or John Smith?"},
     )
     result = pf.run_preflight(title="reply to John", tags=["agent"], caller=_stub(reply))
-    assert result.routing == pf.ROUTE_ASK
-    assert result.ambiguity is not None
+    assert result.routing == pf.ROUTE_LOCAL
+    assert result.ambiguity is None
+    assert result.demoted_ambiguity == "Which John — John Doe or John Smith?"
 
 
 @pytest.mark.unit
@@ -983,6 +996,27 @@ def test_default_route_does_not_apply_to_unconfirmed_cloud_inference(monkeypatch
 
 
 @pytest.mark.unit
+def test_default_route_does_not_rescue_unconfirmed_cloud_even_with_ambiguity(monkeypatch):
+    """#751 must not weaken #584: even though a configured default route now
+    demotes ambiguity, it must not also rescue an inferred (unconfirmed)
+    cloud route from the #584 downgrade — never auto-spend on inferred
+    cloud routing, ambiguity or not."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local")
+    reply = _golden_reply(
+        routing="claude", routing_reason="implies email capability", routing_explicit=False,
+        ambiguity={"question": "Which recipient — no name given in the title?"},
+    )
+    result = pf.run_preflight(title="draft an email", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_ASK
+    assert "not explicitly requested" in result.routing_reason
+    # The ambiguity is still demoted (advisory) — it just doesn't change the
+    # #584 outcome, since routing==ask blocks independently either way.
+    assert result.ambiguity is None
+    assert result.demoted_ambiguity == "Which recipient — no name given in the title?"
+
+
+@pytest.mark.unit
 def test_default_route_invalid_value_logs_error_and_falls_back_to_ask(monkeypatch, caplog):
     """AC: an invalid value surfaces a clear error rather than silently
     asking (or crashing the worker loop) — falls back to `ask` with a
@@ -996,6 +1030,21 @@ def test_default_route_invalid_value_logs_error_and_falls_back_to_ask(monkeypatc
     assert result.routing == pf.ROUTE_ASK
     assert any("LIFEOS_AGENT_DEFAULT_ROUTE" in rec.message for rec in caplog.records)
     assert any(rec.levelno == logging.ERROR for rec in caplog.records)
+
+
+@pytest.mark.unit
+def test_default_route_invalid_value_does_not_demote_ambiguity(monkeypatch):
+    """#751 is gated on the setting being non-empty AND valid — a typo'd
+    value is not a standing instruction the operator successfully gave, so
+    ambiguity must still block exactly like the no-default-route case."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "bogus-route")
+    reply = _golden_reply(
+        ambiguity={"question": "Which John — John Doe or John Smith?"},
+    )
+    result = pf.run_preflight(title="reply to John", tags=["agent"], caller=_stub(reply))
+    assert result.ambiguity is not None
+    assert result.demoted_ambiguity is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #751.

#748's narrow prose-matcher was rephrased around in the field on its first live test — the model produced the same category of routing question in new words. Fourth observed instance of the preflight model ignoring an explicit negative constraint, so this fix stops classifying prose entirely.

When `LIFEOS_AGENT_DEFAULT_ROUTE` is configured **and valid**, any non-null `ambiguity` is demoted to advisory: stashed on `PreflightResult.demoted_ambiguity`, logged into the session transcript as context, and cleared — keyed on the value being non-null, never on what its text says. Configuring a default route is the operator's standing "run untagged tasks without asking me"; open questions move to the executing agent, which can ask mid-run with real context (`lifeos_agent_user_ask`) instead of preflight guessing from a title. With the setting unset — every fresh clone — behavior is byte-identical; an invalid value is a no-op rather than being honored as a standing instruction.

Everything fail-closed stays and is tested: `sane_fatal` still fails; a non-fatal `sane=false` still parks (#747 — sanity is "should this run at all," which a routing default has no bearing on); #584's unconfirmed-cloud downgrade still blocks; tags and explicit routes still win. One pre-existing test was inverted with justification — its premise (ambiguity always blocks even with a default route) is precisely what this changes. #748's matcher remains for installs with no default route.

Precedence documented at the seam: sanity gate → tags → explicit route → default route (now also demoting ambiguity) → ask.

Gate: unit scope 5,052 passed. Field verification (the two originally-lost tasks running end-to-end) follows deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)