### PR TITLE
fix(chat): make the idle voice record button white

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1148,7 +1148,7 @@
             width: 54px;
             height: 54px;
             border-radius: 50%;
-            background: var(--accent);
+            background: #fff;
             transition: all 0.15s ease;
         }
 


### PR DESCRIPTION
## Summary

The circular shutter/record button in the chat voice dock rendered its core in `--accent` (#e94560, a red-pink) when idle. That's close enough to the `--error` red used for the *recording* state that the button read as already-armed at a glance. Idle is now white.

## Change

`web/index.html` — `.shutter-core` background `var(--accent)` → `#fff`. One line. The `.voice-talk-btn.shutter.recording .shutter-core` override (`var(--error)`) and the pulse animation are untouched, so the recording state is unchanged and now clearly distinct from idle.

The UI is dark-theme only (`--bg-tertiary` #0f3460 behind the button), so white has strong contrast.

## Verification

Computed styles in a headless Chromium against the running server:

- idle: `rgb(255, 255, 255)`
- `.recording`: `rgb(244, 67, 54)`

Full pre-push suite green (5061 unit + 214 server-free browser).

## Note (unrelated, pre-existing)

13 agent-worker preflight/clarification tests fail on `main` **on this machine** because they read the host's real `.env` (`LIFEOS_AGENT_DEFAULT_ROUTE=claude_code`) rather than pinning `settings.agent_default_route`. Clearing that var makes all 166 pass. Introduced by the #751/#752 default-route work; worth a follow-up issue to isolate those tests from the ambient env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)