### PR TITLE
fix(agent-worker): run top-level CLI dispatch off the tick thread (#753)

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -426,12 +426,16 @@ class Worker:
         # bot. Bypassed entirely when a test injects `_claude_code_executor`.
         self._claude_code_executors: dict[str, object] = {}
         self._codex_executor = codex_executor  # lazily instantiated on first /codex task
-        # Spawned CLI children (claude_code/codex) are long-running subprocesses.
-        # Running them off the tick keeps the poll loop free to claim new tasks
-        # and dispatch siblings. Bounded so concurrent subprocesses stay capped;
-        # tests inject a _SynchronousPool for deterministic dispatch. `_cli_inflight`
-        # guards against the next tick re-dispatching a child that's been submitted
-        # but hasn't yet flipped CLAIMED→RUNNING.
+        # CLI dispatches (claude_code/codex) are long-running subprocesses — both
+        # spawned children/operator root-spawns AND top-level #agent tasks routed
+        # to a CLI engine (#753) go through this pool via _submit_cli_dispatch.
+        # Running them off the tick keeps the poll loop free to claim new tasks,
+        # dispatch siblings, and keep servicing sleeps/managed-polling/clarification
+        # while a session's subprocess runs (up to its budget wall, 4h by default).
+        # Bounded so concurrent subprocesses stay capped; tests inject a
+        # _SynchronousPool for deterministic dispatch. `_cli_inflight` guards
+        # against a re-scan re-dispatching a session that's been submitted but
+        # hasn't yet flipped CLAIMED→RUNNING.
         self._cli_pool = cli_pool or ThreadPoolExecutor(
             max_workers=max(2, 2 * settings.agent_max_concurrent_managed),
             thread_name_prefix="cli-dispatch",
@@ -797,7 +801,13 @@ class Worker:
                 self._submit_cli_dispatch(session, pending, self._dispatch_codex_session)
 
     def _submit_cli_dispatch(self, session, pending, dispatch_fn) -> None:
-        """Run a CLI child's dispatch on the pool instead of inline.
+        """Run a claude_code/codex dispatch (`_dispatch_claude_code_session` or
+        `_dispatch_codex_session`) on the pool instead of inline.
+
+        Shared by two callers: `_dispatch_spawned_sessions` (spawned children
+        and operator root-spawns, #299) and `_dispatch` (top-level `#agent`
+        tasks routed to a CLI engine, #753) — both hand the same long-running
+        subprocess call off the tick thread through the same pool + guard.
 
         Guards with `_cli_inflight` so a re-scan on the next tick doesn't submit
         the same session twice in the window between submission and the
@@ -2287,6 +2297,15 @@ class Worker:
         # operator-/claude-style entry path can be reused unchanged. The task
         # title is the prompt; working_dir is picked from the description so
         # the CLI runs inside the relevant project.
+        #
+        # #753: these subprocesses can run for the session's full budget wall
+        # (up to 4h) — calling _dispatch_*_session inline here would block
+        # this tick thread for that whole span, starving every other tick
+        # responsibility (new claims, sleeping-session wakes, managed
+        # polling, clarification processing/timeouts) exactly like a spawned
+        # CLI child would. Reuse _submit_cli_dispatch — the same pool +
+        # _cli_inflight machinery spawned sessions already use (#299) — so a
+        # top-level #agent task gets the identical off-tick treatment.
         if pre.routing in (ROUTE_CLAUDE_CODE, ROUTE_CODEX):
             from api.services.directory_resolver import resolve_working_directory
             working_dir = resolve_working_directory(title)
@@ -2301,9 +2320,9 @@ class Worker:
             if pre.routing == ROUTE_CLAUDE_CODE:
                 payload["plan_mode"] = False  # /claude expects this key
                 pending[0]["content"] = json.dumps(payload)
-                self._dispatch_claude_code_session(session, pending)
+                self._submit_cli_dispatch(session, pending, self._dispatch_claude_code_session)
             else:
-                self._dispatch_codex_session(session, pending)
+                self._submit_cli_dispatch(session, pending, self._dispatch_codex_session)
             return
 
         # Should not reach here — routing was validated in preflight.

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -103,14 +103,15 @@ poll → spend tracker check (`can_start_task(default_budget)`)
          atomic swap #agent → #agent-running   (race-free via swap-tag API)
          create session row + transcript "claim" event
          run preflight (Haiku) → PreflightResult
-             routing in {local, claude, ask}
+             routing in {local, claude, claude_code, codex, ask}
              expected_output in {text, file, external_action, structured}
              ambiguity: question | null
              sane: bool
          dispatch on routing:
-             local  → LocalExecutor.execute(session, task)
-             claude → ManagedExecutor.start(session, task)
-             ask    → Telegram clarification, park at #agent-blocked
+             local              → LocalExecutor.execute(session, task)              — inline, tick thread
+             claude             → ManagedExecutor.start(session, task)              — inline, tick thread
+             claude_code / codex → _submit_cli_dispatch(...)                        — off-tick, on _cli_pool (#753)
+             ask                → Telegram clarification, park at #agent-blocked
          on terminal outcome:
              COMPLETED → mark task done in vault + swap to #agent-completed
                          + write Agent Output note (one-off, or prepend for recurring)
@@ -287,9 +288,9 @@ Lineage budgets: every session tracks `root_session_id` + `spawn_depth`. Budget 
 - **Provenance** is marked with the additive `sessions.origin = 'operator'` column. The worker's `_dispatch_spawned_sessions` skip is relaxed to claim parentless sessions when `origin='operator'`, so they dispatch alongside spawned children without colliding with the top-level `#agent` claim path (which uses NULL origin). The prompt is enqueued as a pending message and drained as the task description on dispatch.
 - Operator sessions are root sessions (`parent_session_id=None`), so their terminal notifications surface to the operator and register a replyable follow-up (Phase 1 / #234). Because they have no backing vault task, `_handle_outcome` and `_resume_as_followup` skip the vault mutations (`_complete_task` / `_swap_tag` / `_set_task_status`) for `origin='operator'` — gated on `has_vault_task` — while still sending the notification + follow-up. The prompt is enqueued *before* the session row is created so the worker can never observe a CLAIMED operator session whose prompt hasn't landed. Default budget comes from the `agent_default_*` settings; local concurrency cap of 1 means operator local spawns queue behind running ones.
 
-### Off-tick CLI dispatch (#299)
+### Off-tick CLI dispatch (#299, #753)
 
-Spawned `claude_code` / `codex` children are long-running subprocesses. `_dispatch_spawned_sessions` runs them on a bounded `ThreadPoolExecutor` (`_cli_pool`, sized `2 × agent_max_concurrent_managed`) via `_submit_cli_dispatch`, rather than inline — so one delegated child can't park the poll loop and starve new `#agent` claims or sibling dispatch. An `_cli_inflight` set (lock-guarded) prevents a re-scan from re-submitting a child in the window before its executor flips the row `CLAIMED→RUNNING`; for CLI routes the guard is checked *before* draining pending messages so a skipped re-scan can't discard them. Per-routing concurrency stays bounded at `lifeos_agent_spawn` time (`count_active_by_routing`), independent of dispatch timing. The `local` route stays inline (in-process, GPU-bound, cap 1). `stop()` calls `shutdown(wait=False, cancel_futures=True)`; children still running are reconciled by `resume_pending()` on restart. Tests inject a `_SynchronousPool` for deterministic dispatch.
+`claude_code` / `codex` sessions are long-running subprocesses — up to the session's budget wall (14,400s by default) — so their dispatch always runs on a bounded `ThreadPoolExecutor` (`_cli_pool`, sized `2 × agent_max_concurrent_managed`) via `_submit_cli_dispatch`, never inline on the tick thread. This applies to both callers: `_dispatch_spawned_sessions` (spawned children and operator root-spawns) and `_dispatch`'s `ROUTE_CLAUDE_CODE`/`ROUTE_CODEX` branch (top-level `#agent` tasks, #753) — a single delegated child or top-level CLI task can no longer park the poll loop and starve new `#agent` claims, sleeping-session wakes, managed polling, or clarification processing/timeouts. Preflight and the fast blocked/failed/sanity short-circuits still run inline on the tick thread; only the `execute()`/`resume()` subprocess call and everything downstream of its outcome (vault tag swap, Telegram notify) move to the pool, since `_dispatch_claude_code_session`/`_dispatch_codex_session` own outcome handling themselves rather than going through `_handle_outcome`. An `_cli_inflight` set (lock-guarded) prevents a re-scan from re-submitting the same session in the window before its executor flips the row `CLAIMED→RUNNING`; for CLI routes the guard is checked *before* draining pending messages so a skipped re-scan can't discard them. Per-routing concurrency stays bounded at `lifeos_agent_spawn` time (`count_active_by_routing`), independent of dispatch timing. The `local` route stays inline (in-process, GPU-bound, cap 1). `stop()` calls `shutdown(wait=False, cancel_futures=True)`; sessions still running are reconciled by `resume_pending()` on restart. Tests inject a `_SynchronousPool` for deterministic dispatch.
 
 ### Delegation tier + single-message (#349)
 

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -8,6 +8,9 @@ pause, sleeps wake-up.
 from __future__ import annotations
 
 import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -18,6 +21,7 @@ from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
     STATUS_BUDGET_EXCEEDED,
+    STATUS_CLAIMED,
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_RUNNING,
@@ -109,7 +113,8 @@ class FakeApi:
         return httpx.Response(404)
 
 
-def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_executor):
+def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_executor,
+                  claude_code_executor=None, codex_executor=None, cli_pool=None):
     transport = httpx.MockTransport(api.handler)
     client = httpx.Client(transport=transport, base_url="http://api")
     sent: list[str] = []
@@ -133,6 +138,9 @@ def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_execut
         http_client=client,
         preflight_caller=preflight_caller,
         local_executor=local_executor,
+        claude_code_executor=claude_code_executor,
+        codex_executor=codex_executor,
+        cli_pool=cli_pool,
     )
     w._sent_telegram = sent  # type: ignore[attr-defined]
     w._sent_with_ids = sent_with_ids  # type: ignore[attr-defined]
@@ -1848,3 +1856,243 @@ def test_worker_pauses_at_daily_cap(tmp_path: Path):
     )
     assert w.tick() == 0
     assert executor.calls == []
+
+
+# ---------------------------------------------------------------------------
+# #753 — top-level #agent CLI-routed tasks dispatch off the tick thread
+#
+# Before this fix, `_dispatch()`'s ROUTE_CLAUDE_CODE/ROUTE_CODEX branch called
+# `_dispatch_claude_code_session`/`_dispatch_codex_session` inline, so the
+# whole CLI subprocess ran synchronously inside tick()'s claim loop — up to
+# the session's 14,400s budget wall. Nothing else in tick() (new claims,
+# sleeping-session wakes, managed polling, clarification processing/timeouts)
+# ran while that subprocess was in flight. The fix reuses `_submit_cli_dispatch`
+# — the same pool + `_cli_inflight` machinery spawned CLI children already use
+# (#299, test_agent_worker_async_cli_dispatch.py) — for the top-level path too.
+# ---------------------------------------------------------------------------
+
+class _CapturingPool:
+    """Records submitted callables without running them, so a test can
+    assert a top-level CLI dispatch was handed off (not run inline) and then
+    run it on demand. Mirrors the pool in test_agent_worker_async_cli_dispatch.py."""
+
+    def __init__(self):
+        self.submitted: list = []
+
+    def submit(self, fn, *args, **kwargs):
+        self.submitted.append((fn, args, kwargs))
+        return None
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        pass
+
+    def run_all(self) -> None:
+        for fn, args, kwargs in self.submitted:
+            fn(*args, **kwargs)
+
+
+@pytest.mark.unit
+def test_top_level_cli_task_dispatched_off_tick_not_inline(tmp_path: Path):
+    """A top-level #agent task routed to claude_code must be handed to the
+    CLI pool, not executed inline in tick() — the fix's core claim, proven
+    by a pool that records submissions without running them. Once the
+    submitted work is run (as the real pool thread would), the full
+    outcome-handling path (vault tag swap, task completion, Telegram) still
+    fires — it's the same `_dispatch_claude_code_session` used by spawned
+    sessions, just called on a pool thread instead of the tick thread."""
+    calls: list = []
+
+    class _Executor:
+        def execute(self, session, task):
+            calls.append((session.task_id, task.get("description")))
+            return ExecutorOutcome(status=STATUS_COMPLETED, final_text="all done")
+
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent"]},
+    ])
+    pool = _CapturingPool()
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude_code"),
+                     local_executor=None,
+                     claude_code_executor=_Executor(),
+                     cli_pool=pool)
+
+    handled = w.tick()
+
+    assert handled == 1
+    # Handed to the pool, NOT run inline — tick() returned before the
+    # (would-be long) subprocess ever started.
+    assert len(pool.submitted) == 1
+    assert calls == []
+    assert COMPLETED_TAG not in api.tasks["t1"]["tags"]
+
+    # Running the submitted work exercises the outcome-handling path exactly
+    # as the real pool thread would.
+    pool.run_all()
+
+    assert calls == [("t1", "do the thing")]
+    assert COMPLETED_TAG in api.tasks["t1"]["tags"]
+    assert api.tasks["t1"]["status"] == "done"
+    assert any("all done" in t for t in w._sent_telegram)  # type: ignore[attr-defined]
+    assert w._cli_inflight == set()
+
+
+@pytest.mark.unit
+def test_second_cli_task_claimed_and_runs_while_first_blocks(tmp_path: Path):
+    """Live bug repro (#753): two #agent tasks routed to claude_code — the
+    second must be claimed and start running while the first is still mid
+    execute(), instead of sitting unclaimed for the first task's entire run.
+    Uses a real ThreadPoolExecutor (not a synchronous stub) since this is
+    specifically a concurrency claim."""
+    start_evt = threading.Event()
+    release_evt = threading.Event()
+
+    class _Executor:
+        def execute(self, session, task):
+            if task.get("description") == "slow task":
+                start_evt.set()
+                assert release_evt.wait(timeout=5), "test deadlocked waiting for release"
+                return ExecutorOutcome(status=STATUS_COMPLETED, final_text="slow done")
+            return ExecutorOutcome(status=STATUS_COMPLETED, final_text="fast done")
+
+    api = FakeApi(tasks=[
+        {"id": "t-slow", "description": "slow task", "status": "todo", "tags": ["agent"]},
+        {"id": "t-fast", "description": "fast task", "status": "todo", "tags": ["agent"]},
+    ])
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude_code"),
+                     local_executor=None,
+                     claude_code_executor=_Executor(),
+                     cli_pool=ThreadPoolExecutor(max_workers=4))
+    try:
+        handled = w.tick()
+        # Both tasks claimed and dispatched in the same tick — tick() did not
+        # block on the slow task's execute().
+        assert handled == 2
+        assert start_evt.wait(timeout=2), "slow task never reached execute() on the pool"
+
+        # The fast task, submitted to the same pool, finishes without
+        # waiting on the slow one — proves real concurrency, not just
+        # deferred-then-serial execution.
+        deadline = time.time() + 5
+        while time.time() < deadline and COMPLETED_TAG not in api.tasks["t-fast"]["tags"]:
+            time.sleep(0.02)
+        assert COMPLETED_TAG in api.tasks["t-fast"]["tags"]
+        # The slow one is genuinely still blocked at this point.
+        assert COMPLETED_TAG not in api.tasks["t-slow"]["tags"]
+    finally:
+        release_evt.set()
+        w._cli_pool.shutdown(wait=True)
+
+    assert COMPLETED_TAG in api.tasks["t-slow"]["tags"]
+
+
+@pytest.mark.unit
+def test_clarification_processing_continues_while_cli_task_blocks(tmp_path: Path):
+    """(#753) A blocked CLI subprocess must not starve clarification
+    processing for an unrelated, already-blocked local session — the tick
+    thread has to stay free to keep servicing the rest of the worker's
+    responsibilities while the CLI task runs on the pool."""
+    block_evt = threading.Event()
+    release_evt = threading.Event()
+
+    class _Executor:
+        def execute(self, session, task):
+            block_evt.set()
+            assert release_evt.wait(timeout=5), "test deadlocked waiting for release"
+            return ExecutorOutcome(status=STATUS_COMPLETED, final_text="slow done")
+
+    api = FakeApi(tasks=[
+        {"id": "t-slow", "description": "slow task", "status": "todo", "tags": ["agent"]},
+        {"id": "t-other", "description": "other task", "status": "blocked",
+         "tags": [BLOCKED_TAG, "local"]},
+    ])
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude_code"),
+                     local_executor=None,
+                     claude_code_executor=_Executor(),
+                     cli_pool=ThreadPoolExecutor(max_workers=4))
+    try:
+        w.tick()  # dispatches t-slow onto the pool; must return without waiting
+        assert block_evt.wait(timeout=2), "slow task never reached execute()"
+
+        # Seed the unrelated BLOCKED local-routed session with an answered
+        # clarification, exactly as a live worker would have parked one from
+        # an earlier tick.
+        local_stub = _StubExecutor(outcome=ExecutorOutcome(
+            status=STATUS_COMPLETED, final_text="answered",
+        ))
+        w._local_executor = local_stub
+        other = w.session_store.create(task_id="t-other", routing="local",
+                                        status=STATUS_BLOCKED, expected_output="text")
+        w.session_store.create_pending_question(
+            other.session_id, "t-other", "which file?", sent_message_id=555,
+        )
+        w.session_store.deposit_answer(555, "the config file")
+
+        # This must complete promptly — proving the tick thread isn't stuck
+        # behind the still-blocked slow task.
+        w._process_clarification_answers()
+
+        assert local_stub.calls == [("t-other", "other task")]
+    finally:
+        release_evt.set()
+        w._cli_pool.shutdown(wait=True)
+
+
+@pytest.mark.unit
+def test_cli_inflight_guard_covers_top_level_dispatch(tmp_path: Path):
+    """(#753) Top-level CLI dispatch shares `_cli_inflight` with the spawned
+    path (#299) — a session submitted to the pool but not yet flipped
+    CLAIMED→RUNNING must not be submitted a second time, mirroring
+    test_inflight_guard_prevents_double_dispatch_across_ticks for spawned
+    children."""
+    calls: list = []
+
+    class _Executor:
+        def execute(self, session, task):
+            calls.append(session.task_id)
+            return ExecutorOutcome(status=STATUS_COMPLETED, final_text="done")
+
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent"]},
+    ])
+    pool = _CapturingPool()  # never runs -> the session stays "in flight"
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude_code"),
+                     local_executor=None,
+                     claude_code_executor=_Executor(),
+                     cli_pool=pool)
+    w.session_store.create(task_id="t1", status=STATUS_CLAIMED)
+    task = {"id": "t1", "description": "do the thing", "tags": []}
+
+    w._dispatch(task)
+    w._dispatch(task)  # a second dispatch attempt before the pool thread runs
+
+    assert len(pool.submitted) == 1
+    assert calls == []
+
+
+@pytest.mark.unit
+def test_resume_pending_rolls_back_top_level_cli_session_same_as_before(tmp_path: Path):
+    """(#753) resume_pending()'s startup-recovery semantics for a top-level
+    claude_code/codex #agent session are unchanged by routing dispatch
+    through the pool — a crash-time CLAIMED/RUNNING session still rolls back
+    to #agent for retry, exactly as before this fix."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "do the thing", "status": "in_progress",
+         "tags": [RUNNING_TAG]},
+    ])
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude_code"),
+                     local_executor=None)
+    w.session_store.create(task_id="t1", routing="claude_code", status=STATUS_RUNNING)
+
+    n = w.resume_pending()
+
+    assert n == 1
+    refreshed = w.session_store.get("t1")
+    assert refreshed.status == STATUS_FAILED
+    assert AGENT_TAG in api.tasks["t1"]["tags"]
+    assert RUNNING_TAG not in api.tasks["t1"]["tags"]
+    assert api.tasks["t1"]["status"] == "todo"


### PR DESCRIPTION
Closes #753.

A top-level `#agent` task routed to `claude_code`/`codex` ran its entire CLI subprocess synchronously inside `tick()`'s claim loop — one task could freeze the worker for its full budget wall (up to 4h). While blocked, nothing else ticked: no new claims (observed live — a second task sat unclaimed for the first's whole runtime), no sleeping-session wakes, no managed polling, no clarification processing.

The fix reuses the machinery spawned sessions already had: the `ROUTE_CLAUDE_CODE`/`ROUTE_CODEX` branch of `_dispatch` now goes through `_submit_cli_dispatch` — the same `_cli_pool` + `_cli_inflight` submit/discard pattern `_dispatch_spawned_sessions` uses — instead of calling the dispatch function inline. No new marshaling scheme: the dispatch functions already own their outcome handling (notify, vault tag reconciliation, the #400/#411 re-execute guards) and were already designed to run on a pool thread for the spawned path. Preflight and the fast blocked/failed short-circuits stay on the tick thread.

`resume_pending()` and `stop()` operate generically on the pool and session status, so both apply unchanged — covered by a regression test. Store writes go through per-call SQLite connections, as the spawned path already relied on.

Tests: with a blocking stub executor, a second task is claimed and completes while the first is mid-`execute()`; clarification processing continues during a blocked run; the inflight guard prevents double-submit across ticks; outcome handling still fires from the pool thread; startup reconciliation unchanged. `ROUTE_LOCAL` and managed dispatch untouched.

Gate: unit scope 5,057 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)