### PR TITLE
feat(investments): make the Schwab sync directory configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -393,6 +393,12 @@ LIFEOS_RELATIONSHIP_FOLDER=Relationship
 # MONARCH_PASSWORD=
 # LIFEOS_MONARCH_VAULT_DIR=Personal/Finance/Monarch
 
+# Investments snapshot — directory a separate Schwab export pipeline (not part
+# of this repo) writes summary.json/portfolio.json into. Leave unset if you
+# don't run that pipeline; the investments API and chat tool report "not
+# synced yet" cleanly.
+# LIFEOS_INVESTMENTS_SYNC_DIR=~/Code/Sync/investments
+
 # =============================================================================
 # BACKUP (optional)
 # =============================================================================

--- a/api/routes/investments.py
+++ b/api/routes/investments.py
@@ -19,11 +19,13 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException
 
+from config.settings import settings
+
 router = APIRouter(prefix="/api/investments", tags=["investments"])
 
 logger = logging.getLogger(__name__)
 
-SYNC_DIR = os.path.expanduser("~/Code/Sync/investments")
+SYNC_DIR = os.path.expanduser(settings.investments_sync_dir)
 
 # Freshness alerting (#448): the macbook pipeline refreshes on weekdays (~18:30)
 # and Syncthing delivers here. A weekend plus the weekday cadence can leave the

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -3184,7 +3184,7 @@ async def _tool_search_finances(inp: dict) -> str:
         # (see api/routes/investments.py). Read from disk — no client needed.
         import json as _json
         import os as _os
-        path = _os.path.expanduser("~/Code/Sync/investments/summary.json")
+        path = _os.path.expanduser(_os.path.join(settings.investments_sync_dir, "summary.json"))
         if not _os.path.exists(path):
             return "Investments snapshot not synced yet (macbook refresh hasn't run)."
         with open(path) as f:

--- a/config/settings.py
+++ b/config/settings.py
@@ -1201,6 +1201,20 @@ class Settings(BaseSettings):
                     "LIFEOS_VAULT_PATH, same convention as LIFEOS_AGENT_OUTPUT_DIR."
     )
 
+    # Investments (Schwab pipeline snapshot, #767). A separate export pipeline
+    # (not part of this repo) writes summary.json/portfolio.json here; the API
+    # route and the search_finances "investments" tool both read from it.
+    # Defaults to the maintainer's existing Syncthing-synced folder so an
+    # unconfigured clone sees no data (clean "not synced" message) rather than
+    # an error, same convention as code_dir/monarch_vault_dir above.
+    investments_sync_dir: str = Field(
+        default="~/Code/Sync/investments",
+        alias="LIFEOS_INVESTMENTS_SYNC_DIR",
+        description="Directory summary.json/portfolio.json are read from for "
+                    "the investments API route and the search_finances "
+                    "'investments' chat tool action. Expanduser'd at read time."
+    )
+
     # Backup directory
     backup_path: str = Field(
         default="./data/backups",

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -364,6 +364,14 @@ Auth tokens are cached at `data/monarch_session.pickle` after first login. Re-au
 
 Both `MONARCH_EMAIL`/`MONARCH_PASSWORD` unset AND no cached session at `data/monarch_session.pickle` means Monarch isn't configured — the nightly sync records it as skipped rather than failed. Any other failure (bad session, wrong password, network) still fails the run.
 
+### Investments Snapshot
+
+| Variable | Type | Default | Sets |
+|---|---|---|---|
+| `LIFEOS_INVESTMENTS_SYNC_DIR` | path | `~/Code/Sync/investments` | Directory `summary.json`/`portfolio.json` are read from by the investments API route and the `search_finances` "investments" chat tool action. |
+
+This directory is populated by a separate Schwab export pipeline outside this repo, not by LifeOS itself. Without that pipeline (or with this unset and the default directory absent), the API route and chat tool both report a clean "not synced yet" — there is no error and nothing else to configure.
+
 ## Configuration Files
 
 A handful of operator-tunable files live alongside the env vars. All are gitignored.

--- a/tests/test_investments.py
+++ b/tests/test_investments.py
@@ -98,6 +98,23 @@ def test_route_and_tool_resolve_same_configured_directory():
     assert os.path.dirname(tool_path) == inv.SYNC_DIR == os.path.expanduser(settings.investments_sync_dir)
 
 
+def test_route_sync_dir_tracks_the_setting_on_import(monkeypatch, tmp_path):
+    """SYNC_DIR is cached at module-import time from settings.investments_sync_dir
+    (not a separate hardcoded literal) — reloading the route module under a
+    changed setting must pick up the new directory."""
+    import importlib
+
+    monkeypatch.setattr(settings, "investments_sync_dir", str(tmp_path))
+    reloaded = importlib.reload(inv)
+    try:
+        assert reloaded.SYNC_DIR == str(tmp_path)
+    finally:
+        # Restore the real default and re-reload so later tests (and any
+        # module-level state other tests rely on) see the normal module back.
+        monkeypatch.undo()
+        importlib.reload(inv)
+
+
 def _write_summary(tmp_path, age_days: float):
     """Write a summary.json and backdate its mtime by age_days."""
     p = tmp_path / "summary.json"

--- a/tests/test_investments.py
+++ b/tests/test_investments.py
@@ -14,6 +14,7 @@ import pytest
 
 from api.routes import investments as inv
 from api.services.agent_tools import _tool_search_finances
+from config.settings import settings
 
 pytestmark = pytest.mark.unit
 
@@ -63,6 +64,38 @@ async def test_search_finances_investments_lists_all_positions(tmp_path, monkeyp
     assert "SPCX — SpaceX Class A (SPV)" in out
     # Positions without a desc (the FIL fillers) keep the bare-ticker line.
     assert "FIL01:" in out
+
+
+# ---------------------------------------------------------------------------
+# Configurable sync directory (#767) — default-matches-hardcoded-path is
+# covered by tests/test_settings.py; these cover the two call sites.
+# ---------------------------------------------------------------------------
+
+async def test_search_finances_investments_not_configured_is_clean(tmp_path, monkeypatch):
+    """When the configured directory has no summary.json, the tool returns a
+    clean message rather than raising."""
+    monkeypatch.setattr(settings, "investments_sync_dir", str(tmp_path / "nowhere"))
+    out = await _tool_search_finances({"action": "investments"})
+    assert "not synced yet" in out.lower()
+
+
+async def test_search_finances_investments_reads_configured_dir(tmp_path, monkeypatch):
+    """The chat-tool lookup honors LIFEOS_INVESTMENTS_SYNC_DIR (via settings),
+    not a hardcoded path, and reads the same directory the API route uses."""
+    monkeypatch.setattr(settings, "investments_sync_dir", str(tmp_path))
+    (tmp_path / "summary.json").write_text(json.dumps(_snapshot_with_many_positions()))
+
+    out = await _tool_search_finances({"action": "investments"})
+
+    assert "Positions (20):" in out
+
+
+def test_route_and_tool_resolve_same_configured_directory():
+    """The API route's SYNC_DIR (cached at import time) and the chat tool's
+    lookup (resolved per-call from settings.investments_sync_dir) must land
+    on the identical directory — no independent hardcoded path in either."""
+    tool_path = os.path.expanduser(os.path.join(settings.investments_sync_dir, "summary.json"))
+    assert os.path.dirname(tool_path) == inv.SYNC_DIR == os.path.expanduser(settings.investments_sync_dir)
 
 
 def _write_summary(tmp_path, age_days: float):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -157,3 +157,28 @@ def test_monarch_vault_dir_from_env(monkeypatch):
 
     s = Settings()
     assert s.monarch_vault_dir == "Personal/Money/Monarch"
+
+
+def test_investments_sync_dir_default_matches_hardcoded_path():
+    """LIFEOS_INVESTMENTS_SYNC_DIR must default to exactly the path that was
+    previously hardcoded (~/Code/Sync/investments) in both api/routes/
+    investments.py and the search_finances 'investments' chat tool (#767) —
+    an install that never sets this var must see the same directory it
+    always has.
+
+    Asserts the FIELD default, not a live instance, so a host-level override
+    can't turn this into a false failure.
+    """
+    from config.settings import Settings
+
+    assert Settings.model_fields["investments_sync_dir"].default == "~/Code/Sync/investments"
+
+
+def test_investments_sync_dir_from_env(monkeypatch):
+    """LIFEOS_INVESTMENTS_SYNC_DIR should be configurable via env var, same
+    convention as LIFEOS_MONARCH_VAULT_DIR (#767)."""
+    monkeypatch.setenv("LIFEOS_INVESTMENTS_SYNC_DIR", "/tmp/some/other/investments")
+    from config.settings import Settings
+
+    s = Settings()
+    assert s.investments_sync_dir == "/tmp/some/other/investments"


### PR DESCRIPTION
## Summary
- Adds `LIFEOS_INVESTMENTS_SYNC_DIR` (default `~/Code/Sync/investments`, matching the previously-hardcoded path).
- Both `api/routes/investments.py` and the `search_finances` "investments" chat-tool action (`api/services/agent_tools.py`) now read the same setting instead of the tool carrying its own independent hardcoded path.
- No behavior change for an already-configured install: default reproduces today's hardcoded path exactly.
- Missing/absent directory (no `summary.json`) already returned a clean "not synced yet" message from the chat tool and a 404 from the API route — preserved, now sourced from the configurable directory.

## Test plan
- [x] `tests/test_investments.py` — new tests: chat tool returns clean message when the configured dir has no `summary.json`; chat tool reads from a configured dir; route's `SYNC_DIR` and the tool's resolved directory match.
- [x] `tests/test_settings.py` — new tests: field default matches the previously-hardcoded path; setting is configurable via env var.
- [x] Full existing `tests/test_investments.py` + `tests/test_settings.py` suites pass (36 passed).

Fixes #767

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw