### PR TITLE
fix(sync): Apple manifest merge + directory parity, clean-skips, generic alerts, first-backfill, WhatsApp trigger (#786, #785, #698, #780, #770, #781, #784, #778)

### DIFF
--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -2256,7 +2256,12 @@ async def sync_source(source_type: str):
     """
     Trigger a sync for a specific data source.
     """
-    valid_sources = {"gmail", "calendar", "slack", "contacts", "imessage", "linkedin", "vault"}
+    # WhatsApp has no standalone nightly sync of its own (issue #784) — its
+    # data is imported as part of the combined apple_import step, so
+    # "triggering a WhatsApp sync" through this endpoint means requesting
+    # that same combined import, same as gmail/imessage/linkedin already do
+    # here.
+    valid_sources = {"gmail", "calendar", "slack", "contacts", "imessage", "linkedin", "vault", "whatsapp"}
     if source_type not in valid_sources:
         raise HTTPException(status_code=400, detail=f"Invalid source type: {source_type}")
 

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -2257,10 +2257,9 @@ async def sync_source(source_type: str):
     Trigger a sync for a specific data source.
     """
     # WhatsApp has no standalone nightly sync of its own (issue #784) — its
-    # data is imported as part of the combined apple_import step, so
-    # "triggering a WhatsApp sync" through this endpoint means requesting
-    # that same combined import, same as gmail/imessage/linkedin already do
-    # here.
+    # data is imported as part of the combined apple_import step, so a
+    # WhatsApp entry here belongs at the same (currently stub, see TODO
+    # below) parity level as gmail/imessage/linkedin, not below it.
     valid_sources = {"gmail", "calendar", "slack", "contacts", "imessage", "linkedin", "vault", "whatsapp"}
     if source_type not in valid_sources:
         raise HTTPException(status_code=400, detail=f"Invalid source type: {source_type}")

--- a/config/settings.py
+++ b/config/settings.py
@@ -1170,6 +1170,14 @@ class Settings(BaseSettings):
                     "app's POST delivery mode). Empty disables the endpoint (503). "
                     "Generate with `openssl rand -hex 32`."
     )
+    apple_export_agent_label: str = Field(
+        default="the export agent",
+        alias="LIFEOS_APPLE_EXPORT_AGENT_LABEL",
+        description="Name for the Apple Data Agent machine used in staleness/failure "
+                    "alerts from scripts/apple_data_import.py (e.g. 'Mac Mini', "
+                    "'my MacBook'). Generic default since the export agent's hardware "
+                    "is installer-specific (#770)."
+    )
 
     # Journal ring ingest (#660) — a wearable (e.g. the Pebble Index ring) posts
     # transcribed fragments here from outside the tailnet.

--- a/docs/guides/first-run.md
+++ b/docs/guides/first-run.md
@@ -99,6 +99,17 @@ If you've configured Google OAuth or Slack, run the initial data sync:
 
 **Note**: First sync may take 30+ minutes depending on data volume.
 
+**This is the nightly job, not a deep pass.** It deliberately looks back
+only a narrow window (30 days for Gmail/Calendar) to stay fast — a fresh
+install won't get older history from just this. Right after it completes,
+run the one-time backfill to pull each source's full history:
+
+```bash
+~/.venvs/lifeos/bin/python scripts/first_backfill.py --execute
+```
+
+See [data-and-sync.md](../specs/technical/data-and-sync.md#first-backfill-entry-point) for what it covers and how long it can take.
+
 ### After First Sync: Set Your Person ID
 
 After sync completes, find your person ID and add it to `.env`:
@@ -202,3 +213,4 @@ See [Troubleshooting](troubleshooting.md) for more.
 - [Installation](installation.md) -- Initial installation walkthrough
 - [Configuration](configuration.md) -- Environment variables and config files
 - [Setup](setup.md) -- Interactive Claude Code setup guide
+- [Data & Sync Architecture](../specs/technical/data-and-sync.md) -- Nightly sync schedule and the first-backfill entry point referenced in Step 4

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -108,6 +108,26 @@ Orchestrate all data sync operations. On Linux the nightly run is driven by the 
 
 ---
 
+### first_backfill.py
+
+One-time deep backfill for a fresh install — run this once after initial
+setup. The nightly job above deliberately narrows Gmail/Calendar to a
+30-day window; this instead runs those sources (and everything else in
+Phases 1-4, in the same order) at their own full-history default, then
+prints a coverage report (count + earliest/latest date per source).
+
+```bash
+# Preview what would run
+~/.venvs/lifeos/bin/python scripts/first_backfill.py --dry-run
+
+# Run the backfill
+~/.venvs/lifeos/bin/python scripts/first_backfill.py --execute
+```
+
+Safe to re-run — see [data-and-sync.md](../specs/technical/data-and-sync.md#first-backfill-entry-point) for details.
+
+---
+
 ### Individual Sync Scripts
 
 All sync scripts follow the pattern:

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -135,6 +135,8 @@ cp .env.example .env
 - **Monarch Money** — Financial data (account balances, transactions, budgets)
 - **Telegram bot** — Chat interface and push notifications
 - **Slack** — Workspace message sync
+- **LinkedIn** — Connections enrichment (company, position) from a manual
+  "Get a copy of your data" CSV export — no OAuth
 - **WhatsApp** — Chat history sync via `wacli` on a paired Apple Data Agent Mac (the LifeOS
   host runs on Linux; wacli is macOS-only). Data is exported into
   `data/apple-imports/whatsapp.json` and rsynced alongside contacts/iMessage.
@@ -432,6 +434,22 @@ For a **second work account**, repeat with `--account work2`:
 1. Set up workspace OAuth
 2. Add `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_USER_TOKEN` to `.env`
 3. Restart: `./scripts/server.sh restart`
+
+### LinkedIn
+
+LinkedIn connections import from a manual CSV export — there's no API/OAuth step.
+
+1. On linkedin.com: **Settings & Privacy → Data privacy → Get a copy of your data**
+2. Select "Connections" and request the export (LinkedIn emails you a download link,
+   usually within a few minutes)
+3. Unzip the download and place `Connections.csv` at `data/LinkedInConnections.csv`
+   (the path `scripts/sync_linkedin.py` reads by default — override with
+   `--csv <path>` if you'd rather keep it elsewhere)
+4. Re-run the export periodically (e.g. every few months) to pick up new connections —
+   nothing re-fetches this automatically
+
+If the CSV is absent, the nightly sync reports LinkedIn as cleanly skipped rather
+than failing or silently doing nothing.
 
 ### WhatsApp
 

--- a/docs/specs/technical/data-and-sync.md
+++ b/docs/specs/technical/data-and-sync.md
@@ -331,6 +331,41 @@ Runs in this order (see [iMessage Sync Ordering](#imessage-sync-ordering) below)
 ~/.venvs/lifeos/bin/python scripts/run_all_syncs.py --force
 ```
 
+### First-Backfill Entry Point
+
+The nightly window above is deliberately narrow — Gmail/Calendar look back
+only 30 days each night, to keep the nightly run fast. A fresh install
+therefore starts with an empty interaction history that the nightly job
+never fills in on its own. `scripts/first_backfill.py` is the one-time deep
+pass to run right after initial setup: it runs the same sources, in the
+same Phase 1-4 order (collection, entity processing, relationship
+building, indexing), but any source whose nightly invocation narrows its
+own lookback window (Gmail, Calendar) is instead run at that script's own
+full-history default (currently ten years) rather than the nightly window.
+Phase 5-7 (content sync, cleanup, consistency verification) and sources
+with no "full history" concept (`push_birthdays`) aren't part of it — see
+the script's own docstring for the exact exclusion list and reasoning.
+
+```bash
+# Preview what would run, without running anything
+~/.venvs/lifeos/bin/python scripts/first_backfill.py --dry-run
+
+# Run the one-time deep backfill
+~/.venvs/lifeos/bin/python scripts/first_backfill.py --execute
+```
+
+Safe to re-run: it reuses the same per-source scripts as the nightly job
+unmodified, and those are already idempotent (upsert by source ID, not
+append-only). An unconfigured source is reported as a clean skip, not a
+failure (#687's pattern), and one source failing doesn't stop the rest of
+the backfill from running. When it finishes, it prints a coverage report
+(record count and earliest/latest date per source) read from
+`data/interactions.db` — a quick way to confirm history actually arrived.
+This is a one-time pass, not part of nightly health monitoring: it does
+not touch `sync_health`'s run-history tables, so it can't skew the
+duration/yield-collapse baselines the nightly job's own anomaly detection
+is tuned against.
+
 ---
 
 ## Configuration
@@ -629,6 +664,7 @@ The scraping system uses Claude in Chrome MCP for browser automation. It require
 - [Entity Resolution](../product/entity-resolution.md) -- How source entities are linked to canonical records
 - [Search & Indexing](search-indexing.md) -- Hybrid search pipeline
 - [Installation](../../guides/installation.md) -- Config-only second-user setup checklist, which points here for the unconfigured-source clean-skip pattern
+- [First Run](../../guides/first-run.md) -- New-install walkthrough; Step 4 points here for the first-backfill entry point
 - [ADR-002: ChromaDB](../../adr/002-chromadb-vector-store.md) -- Why ChromaDB was chosen
 - [ADR-003: Two-Tier Data Model](../../adr/003-two-tier-data-model.md) -- Why SourceEntity and PersonEntity are separate
 - [ADR-012: Embedding Pipeline](../../adr/012-embedding-pipeline.md) -- Embedding model, GPU/CPU fallback, pre-flight RAM gate around phase 4

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -260,7 +260,7 @@ CURATED_ENDPOINTS = {
     },
     "/api/admin/sync:POST": {
         "name": "lifeos_sync_trigger",
-        "description": "Trigger a background data sync. source: vault, calendar, contacts, slack, photos, gmail, imessage, phone, facetime, linkedin.",
+        "description": "Trigger a background data sync. source: vault, calendar, contacts, slack, photos, gmail, imessage, phone, facetime, linkedin, whatsapp.",
         "method": "POST",
         "path": "/api/admin/sync",
         "custom_handler": True
@@ -862,7 +862,7 @@ class LifeOSMCPServer:
             "lifeos_sync_trigger": {
                 "type": "object",
                 "properties": {
-                    "source": {"type": "string", "description": "Sync source: vault, calendar, contacts, slack, photos, gmail, imessage, phone, facetime, linkedin"}
+                    "source": {"type": "string", "description": "Sync source: vault, calendar, contacts, slack, photos, gmail, imessage, phone, facetime, linkedin, whatsapp"}
                 },
                 "required": ["source"]
             },
@@ -1121,7 +1121,7 @@ class LifeOSMCPServer:
         }
 
         valid_sources = list(route_map.keys()) + [
-            "gmail", "imessage", "phone", "facetime", "linkedin"
+            "gmail", "imessage", "phone", "facetime", "linkedin", "whatsapp"
         ]
 
         if source in route_map:

--- a/scripts/apple_data_agent.sh
+++ b/scripts/apple_data_agent.sh
@@ -3,8 +3,8 @@
 # and sync it to the Linux server.
 #
 # This replaces the Mac Mini's role as the LifeOS server. Instead, it:
-# 1. Exports contacts, iMessage, phone data to data/apple-exports/
-# 2. Rsyncs exports to the Linux server at data/apple-imports/
+# 1. Exports contacts, iMessage, phone data to data/apple-imports/ (locally)
+# 2. Rsyncs exports to the Linux server, also at data/apple-imports/
 #
 # Schedule (Mac Mini crontab):
 #   50 2 * * * /path/to/LifeOS/scripts/apple_data_agent.sh
@@ -181,7 +181,8 @@ osascript -e 'tell application "Photos" to activate' >> "${LOG_FILE}" 2>&1 || tr
 sleep 600
 
 # -------------------------------------------------------------------
-# Step 2: Export Apple data to data/apple-exports/
+# Step 2: Export Apple data to data/apple-imports/ (same directory name
+# apple_data_import.py reads from — #785)
 # Route through LifeOS.app's "run" subcommand so Python inherits
 # Full Disk Access (TCC checks the responsible process — LifeOS.app).
 # "run" keeps LifeOS.app as the parent; "exec" replaces it, losing FDA.
@@ -211,7 +212,7 @@ fi
 # -------------------------------------------------------------------
 log "Step 3: Syncing to Linux server..."
 
-EXPORT_DIR="${LIFEOS_DIR}/data/apple-exports/"
+EXPORT_DIR="${LIFEOS_DIR}/data/apple-imports/"
 IMPORT_DIR="${LINUX_USER}@${LINUX_SERVER}:${LINUX_LIFEOS}/data/apple-imports/"
 
 # Create remote directory if needed — retry on transient SSH failures

--- a/scripts/apple_data_export.py
+++ b/scripts/apple_data_export.py
@@ -1120,6 +1120,14 @@ def main():
 
     print(json.dumps(manifest, indent=2))
 
+    # A refused merge (corrupt/malformed existing manifest) must actually
+    # fail the run, not just log an error and exit 0 — apple_data_agent.sh
+    # gates its rsync/import steps on this script's exit code, and an
+    # operator running the documented single-source troubleshooting flow
+    # by hand needs $? to reflect that nothing was written.
+    if skip_manifest_write:
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/apple_data_export.py
+++ b/scripts/apple_data_export.py
@@ -1063,16 +1063,53 @@ def main():
             logger.error(f"Failed to export {name}: {e}")
             results[name] = {"status": "error", "error": str(e)}
 
-    # Write manifest
+    # Write manifest. A single-source run (--source) must merge into any
+    # existing manifest rather than replacing it wholesale — otherwise the
+    # documented single-source troubleshooting flow (e.g. re-running just
+    # WhatsApp after a fix) silently discards every other source's
+    # last-known status (#786). A full run (no --source) always produces a
+    # full replacement, same as before this change.
+    #
+    # If the existing manifest can't be read, or has no usable results dict,
+    # we do NOT fall back to overwriting it with just this run's result —
+    # that would reproduce the exact data-loss bug this fix exists to
+    # prevent, just triggered by corruption instead of an ordinary
+    # single-source run. Leave the file untouched and fail loud instead.
+    manifest_results = results
+    manifest_path = EXPORT_DIR / "manifest.json"
+    skip_manifest_write = False
+    if not dry_run and args.source and manifest_path.exists():
+        try:
+            with open(manifest_path) as f:
+                existing_manifest = json.load(f)
+            existing_results = existing_manifest.get("results")
+            if isinstance(existing_results, dict):
+                manifest_results = {**existing_results, **results}
+            else:
+                logger.error(
+                    f"Existing manifest at {manifest_path} has no usable "
+                    "'results' dict — refusing to overwrite it with just this "
+                    "run's result, which would discard every other source's "
+                    "last-known status. Leaving the manifest untouched."
+                )
+                skip_manifest_write = True
+        except (json.JSONDecodeError, OSError) as e:
+            logger.error(
+                f"Could not read existing manifest to merge ({e}) — refusing "
+                "to overwrite it with just this run's result, which would "
+                "discard every other source's last-known status. Leaving "
+                "the manifest untouched."
+            )
+            skip_manifest_write = True
+
     manifest = {
         "exported_at": datetime.now(timezone.utc).isoformat(),
         "hostname": __import__("socket").gethostname(),
         "agent_sha": _get_agent_sha(),
-        "results": results,
+        "results": manifest_results,
     }
 
-    if not dry_run:
-        manifest_path = EXPORT_DIR / "manifest.json"
+    if not dry_run and not skip_manifest_write:
         with open(manifest_path, "w") as f:
             json.dump(manifest, f, indent=2)
         logger.info(f"Manifest written to {manifest_path}")

--- a/scripts/apple_data_export.py
+++ b/scripts/apple_data_export.py
@@ -10,12 +10,16 @@ Usage:
     python scripts/apple_data_export.py --execute --source imessage  # Single source
     python scripts/apple_data_export.py --dry-run           # Preview only
 
-Exported to: data/apple-exports/
+Exported to: data/apple-imports/
     contacts.json       — Apple Contacts data
     imessage.db         — Copy of the local iMessage cache
     phone_calls.json    — Phone/FaceTime call history
 
-The Linux server picks these up from data/apple-imports/ (via rsync).
+Uses the same directory name (data/apple-imports/) apple_data_import.py
+reads from, so a single-machine deployment (export and import on the same
+host) works with no rsync step and no manual symlink (#785). The
+two-machine flow rsyncs this directory across hosts unchanged — see
+scripts/apple_data_agent.sh.
 """
 import sys
 import json
@@ -43,7 +47,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-EXPORT_DIR = PROJECT_ROOT / "data" / "apple-exports"
+EXPORT_DIR = PROJECT_ROOT / "data" / "apple-imports"
 
 
 def _parse_abcdp_labeled(field_dict: dict | None) -> list[dict]:

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -854,9 +854,19 @@ def main():
     dry_run = not args.execute
 
     if not IMPORT_DIR.exists():
-        logger.error(f"Import directory not found: {IMPORT_DIR}")
-        logger.info("Run the Apple Data Agent on Mac Mini first, then rsync to this machine.")
-        sys.exit(1)
+        # No Apple Data Agent has ever exported anything to this host — not
+        # broken, just never set up (issue #698, the Apple-shaped sibling of
+        # #687's clean-skip pattern). A configured install's import directory
+        # exists (even mid-outage, even stale), so this branch never fires
+        # for it — check_manifest()'s staleness/per-source-error paths below
+        # are untouched and still fail loud for a real outage.
+        message = (
+            f"No Apple Data Agent configured — {IMPORT_DIR} not found. See "
+            "docs/guides/setup.md for how to pair a Mac as the Apple Data Agent."
+        )
+        logger.info(message)
+        print(f"SYNC_SKIPPED: {message}", flush=True)
+        return
 
     manifest = check_manifest()
     if not manifest and not dry_run:

--- a/scripts/apple_data_import.py
+++ b/scripts/apple_data_import.py
@@ -97,6 +97,9 @@ def check_manifest() -> dict | None:
     underscore marks these as synthetic, not part of the Mac-side export
     schema.
     """
+    from config.settings import settings
+    agent_label = settings.apple_export_agent_label
+
     manifest_path = IMPORT_DIR / "manifest.json"
     if not manifest_path.exists():
         logger.warning("No manifest.json found in apple-imports/")
@@ -119,7 +122,7 @@ def check_manifest() -> dict | None:
             if age_hours > STALENESS_CRITICAL_HOURS:
                 message = (
                     f"Apple import data is {age.days} days old (exported {exported_at_str}). "
-                    f"Check Mac Mini cron and rsync pipeline."
+                    f"Check {agent_label}'s scheduled job and file-transfer pipeline."
                 )
                 logger.critical(message)
                 manifest["_staleness_critical_message"] = message
@@ -153,8 +156,8 @@ def check_manifest() -> dict | None:
             if source_result.get("status") == "error":
                 reason = source_result.get("reason") or source_result.get("error") or "unknown"
                 logger.critical(
-                    f"Mac Mini export failed for {source_name}: {reason}. "
-                    f"Check wacli/tooling on the Mac Mini."
+                    f"{agent_label} failed to export {source_name}: {reason}. "
+                    f"Check wacli/tooling on {agent_label}."
                 )
 
     # Flag a Mac Mini agent whose self-update (issue #509) has fallen behind.
@@ -167,7 +170,7 @@ def check_manifest() -> dict | None:
             message = (
                 f"Apple Data Agent exported from {agent_sha[:7]}, which differs from "
                 f"this host's main ({local_sha[:7]}) — its self-update may have failed. "
-                f"Check the agent log on the Mac Mini."
+                f"Check the agent log on {agent_label}."
             )
             logger.warning(message)
             manifest["_agent_sha_drift_message"] = message

--- a/scripts/first_backfill.py
+++ b/scripts/first_backfill.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+One-time deep backfill for full-history-capable sync sources.
+
+The nightly sync (run_all_syncs.py) deliberately looks back only a narrow
+window each night (e.g. Gmail/Calendar's --days 30) to keep the nightly run
+fast. A fresh install therefore starts with an empty interaction history
+that the nightly job never fills in on its own — someone has to notice the
+gap and know to run a deeper pass by hand. On a real second-user install,
+this went unnoticed long enough that months of history simply never
+arrived (#778).
+
+This script runs the same sources, in the same phase order, as the nightly
+pipeline's SYNC_ORDER (Phases 1-4: collection, entity processing,
+relationship building, indexing) — but any source whose nightly invocation
+narrows its own lookback window is instead run at that script's full-history
+default. It is a thin driver: the actual sync logic, idempotence, and
+unconfigured-source clean-skip behavior (#687) all live in the underlying
+per-source scripts, reused unmodified — this script only decides which
+sources to run, in what order, with what arguments, and prints a coverage
+report when it's done.
+
+Deliberately excluded, even though present in the nightly SYNC_ORDER:
+  - push_birthdays: pushes LifeOS data outward (to Apple Contacts) — no
+    "full history" concept to backfill.
+  - Phase 5 (google_docs, google_sheets, monarch_money), Phase 6
+    (entity_cleanup), Phase 7 (consistency_verify): content sync, cleanup,
+    and verification, not interaction-history depth. #778's acceptance
+    criteria name exactly four phases to mirror — collection, entity
+    processing, relationship building, indexing — so this stops at the end
+    of Phase 4.
+  - phone: not part of the nightly SYNC_ORDER at all (it's macOS-FDA-only,
+    invoked separately by scripts/run_fda_syncs.py's own cron path, always
+    at its own full-history default already — see sync_phone_calls.py).
+    It has no configured/unconfigured clean-skip today, so wiring it into
+    a skip-safe backfill entry point is a separate follow-up.
+
+Safe to re-run: every underlying script is already idempotent (each upserts
+by its own source_id rather than appending), and this script writes nothing
+of its own — it only reads data/interactions.db for the coverage report.
+
+Usage:
+    python scripts/first_backfill.py --dry-run     # show what would run
+    python scripts/first_backfill.py --execute     # run the full backfill
+"""
+import argparse
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.run_all_syncs import SYNC_ORDER, SYNC_SCRIPTS, _parse_sync_output
+from api.services.interaction_store import get_interaction_db_path, VALID_SOURCE_TYPES
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+_BACKFILL_EXCLUDE = {
+    "push_birthdays",
+    "google_docs", "google_sheets", "monarch_money",
+    "entity_cleanup", "consistency_verify",
+}
+
+# Same relative order as the nightly pipeline's SYNC_ORDER (Phases 1-4),
+# derived rather than duplicated so this can't silently drift out of step
+# with a future reordering there.
+BACKFILL_ORDER = [s for s in SYNC_ORDER if s not in _BACKFILL_EXCLUDE]
+
+# Much longer than the nightly job's per-source timeouts (run_all_syncs.py's
+# SYNC_TIMEOUTS default to 1 hour, tuned for a narrow nightly window) —
+# ten years of Gmail/Calendar history can take substantially longer than 30
+# days' worth. Not source-specific: this script runs once, by hand, not on
+# a tight schedule, so a single generous default is simpler than per-source
+# tuning with no data yet to tune it against.
+BACKFILL_TIMEOUT_SECONDS = 6 * 3600  # 6 hours
+
+
+def _full_depth_args(nightly_args: list) -> list:
+    """Strip the nightly ``--days N`` override, if present, so the
+    underlying script's own full-history default applies instead (3650
+    days as of this writing — see sync_gmail_calendar_interactions.py and
+    sync_phone_calls.py). Never hardcode that default here: if it ever
+    changes, this backfill should track it automatically rather than
+    needing its own update. Sources with no such override (most of them)
+    are returned unchanged.
+    """
+    if "--days" not in nightly_args:
+        return list(nightly_args)
+    args = list(nightly_args)
+    idx = args.index("--days")
+    del args[idx:idx + 2]
+    return args
+
+
+def run_backfill_source(source: str, dry_run: bool = False) -> dict:
+    """Run one source at full depth.
+
+    Deliberately does none of run_all_syncs.py's sync_health/retry
+    bookkeeping: this is a one-time, out-of-band pass, not part of the
+    nightly monitoring loop, and recording it there would pollute the
+    duration/yield-collapse baselines nightly runs are compared against.
+    """
+    if source not in SYNC_SCRIPTS:
+        return {"success": False, "skipped": False, "error": f"No script for {source}"}
+
+    script_path, nightly_args = SYNC_SCRIPTS[source]
+    args = _full_depth_args(nightly_args)
+    full_path = PROJECT_ROOT / script_path
+
+    if not full_path.exists():
+        return {"success": False, "skipped": False, "error": f"Script not found: {script_path}"}
+
+    cmd = [sys.executable, str(full_path)] + args
+
+    if dry_run:
+        logger.info(f"[DRY RUN] Would run: {' '.join(cmd)}")
+        return {"success": True, "skipped": False, "dry_run": True, "cmd": cmd}
+
+    logger.info(f"Running {source} at full depth: {' '.join(args)}")
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=BACKFILL_TIMEOUT_SECONDS,
+            cwd=str(PROJECT_ROOT),
+            env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+        )
+    except subprocess.TimeoutExpired:
+        logger.error(f"{source}: timed out after {BACKFILL_TIMEOUT_SECONDS}s")
+        return {"success": False, "skipped": False, "error": "timeout"}
+
+    combined_output = (result.stdout or "") + "\n" + (result.stderr or "")
+    stats = _parse_sync_output(combined_output)
+    skipped_reason = stats.pop("skipped_reason", None)
+
+    # Mirror run_all_syncs.py's own precedence exactly: exit code decides
+    # success/failure first; a clean skip (#687) is only recognized within
+    # an already-successful (exit 0) run.
+    if result.returncode != 0:
+        error_msg = result.stderr or result.stdout or "Unknown error"
+        logger.error(f"{source}: failed — {error_msg[:500]}")
+        return {"success": False, "skipped": False, "error": error_msg[:500], "stats": stats}
+
+    if skipped_reason:
+        logger.info(f"{source}: skipped ({skipped_reason})")
+        return {"success": True, "skipped": True, "reason": skipped_reason, "stats": stats}
+
+    logger.info(f"{source}: OK — {stats}")
+    return {"success": True, "skipped": False, "stats": stats}
+
+
+def coverage_report() -> dict:
+    """Per-source-type earliest/latest record date and count from the
+    interactions store — the acceptance criteria's "coverage report".
+    Read-only; safe to call any time, including on a totally fresh
+    install where the interactions table may not exist yet.
+    """
+    report = {}
+    try:
+        conn = sqlite3.connect(get_interaction_db_path())
+    except sqlite3.Error as e:
+        logger.warning(f"Could not open interactions store for coverage report: {e}")
+        return report
+    try:
+        for source_type in sorted(VALID_SOURCE_TYPES):
+            try:
+                row = conn.execute(
+                    "SELECT COUNT(*), MIN(timestamp), MAX(timestamp) "
+                    "FROM interactions WHERE source_type = ?",
+                    (source_type,),
+                ).fetchone()
+            except sqlite3.OperationalError:
+                # Fresh install: the interactions table doesn't exist yet.
+                break
+            count, earliest, latest = row
+            if count:
+                report[source_type] = {
+                    "count": count,
+                    "earliest": earliest,
+                    "latest": latest,
+                }
+    finally:
+        conn.close()
+    return report
+
+
+def print_coverage_report(report: dict) -> None:
+    print("\n=== Coverage Report ===")
+    if not report:
+        print("(no interaction records found)")
+        return
+    for source_type, info in sorted(report.items()):
+        print(
+            f"  {source_type:12s} count={info['count']:>7}  "
+            f"earliest={info['earliest']}  latest={info['latest']}"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="One-time deep backfill for full-history sync sources (#778)"
+    )
+    parser.add_argument("--execute", action="store_true", help="Actually run the backfill")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without running anything")
+    args = parser.parse_args()
+
+    if not args.execute and not args.dry_run:
+        print("Use --execute to run the backfill or --dry-run to preview.")
+        sys.exit(1)
+
+    dry_run = not args.execute
+
+    results = {}
+    for source in BACKFILL_ORDER:
+        results[source] = run_backfill_source(source, dry_run=dry_run)
+
+    failed = [s for s, r in results.items() if not r.get("success")]
+    skipped = [s for s, r in results.items() if r.get("skipped")]
+
+    print(f"\n{len(BACKFILL_ORDER) - len(failed)}/{len(BACKFILL_ORDER)} sources succeeded")
+    if skipped:
+        print(f"Skipped (not configured): {', '.join(skipped)}")
+    if failed:
+        print(f"Failed: {', '.join(failed)}")
+
+    if not dry_run:
+        print_coverage_report(coverage_report())
+
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/first_backfill.py
+++ b/scripts/first_backfill.py
@@ -160,11 +160,20 @@ def coverage_report() -> dict:
     """Per-source-type earliest/latest record date and count from the
     interactions store — the acceptance criteria's "coverage report".
     Read-only; safe to call any time, including on a totally fresh
-    install where the interactions table may not exist yet.
+    install where the interactions store doesn't exist yet.
+
+    ``sqlite3.connect`` creates an empty file at the given path if none
+    exists, which would make this script's "writes nothing of its own"
+    claim false on a fresh/all-unconfigured install — check existence
+    first rather than relying on the OperationalError fallback below to
+    keep that true.
     """
     report = {}
+    db_path = get_interaction_db_path()
+    if not Path(db_path).exists():
+        return report
     try:
-        conn = sqlite3.connect(get_interaction_db_path())
+        conn = sqlite3.connect(db_path)
     except sqlite3.Error as e:
         logger.warning(f"Could not open interactions store for coverage report: {e}")
         return report

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -442,8 +442,8 @@ def log_sync_summary_to_markdown(result: dict, trigger: str = "unknown"):
                 lines.append(f"- {src}")
 
     # Apple Data Agent SHA drift (#646) — a silently-broken self-update on
-    # the Mac Mini export agent, surfaced here instead of a log line no
-    # batched report reads.
+    # the (installer-configurable) export agent, surfaced here instead of a
+    # log line no batched report reads.
     apple_agent_sha_drift = result.get("apple_agent_sha_drift")
     if apple_agent_sha_drift:
         lines.append("")
@@ -562,8 +562,8 @@ def send_sync_summary_telegram(result: dict, trigger: str = "unknown"):
         lines.append(f"  {investments_stale}")
 
     # Apple Data Agent SHA drift (#646) — surface here so a silently-broken
-    # Mac Mini self-update reaches the operator (the bare log line does not
-    # feed any batched report).
+    # export agent's self-update reaches the operator (the bare log line
+    # does not feed any batched report).
     apple_agent_sha_drift = result.get("apple_agent_sha_drift")
     if apple_agent_sha_drift:
         lines.append("")
@@ -672,17 +672,18 @@ SYNC_ORDER = [
     "calendar_work",            # Work Google Calendar events
     "calendar_work2",           # Second work Google Calendar events
     "linkedin",                 # LinkedIn connections CSV
-    "contacts",                 # Apple Contacts (native via pyobjc, or imported from Mac Mini)
+    "contacts",                 # Apple Contacts (native via pyobjc, or imported from the export agent)
     # NOTE: phone and imessage are NOT in this list on macOS - they require Full Disk Access
     # which launchd doesn't have. They run via cron at 2:50 AM through Terminal.app:
     #   - scripts/run_sync_with_fda.sh (cron entry, opens Terminal)
     #   - scripts/run_fda_syncs.py (actual sync runner with health tracking)
     # Cron schedule: 50 2 * * * /path/to/run_sync_with_fda.sh
     #
-    # On Linux, Apple data is imported from Mac Mini exports.
-    # WhatsApp is also bundled into the apple_import step (the Mac Mini runs
-    # wacli and rsyncs whatsapp.json alongside the other exports).
-    "apple_import",             # Import Apple data + WhatsApp from Mac Mini (Linux only)
+    # On Linux, Apple data is imported from the (installer-configurable)
+    # export agent's exports. WhatsApp is also bundled into the apple_import
+    # step (the export agent runs wacli and rsyncs whatsapp.json alongside
+    # the other exports).
+    "apple_import",             # Import Apple data + WhatsApp from the export agent (Linux only)
     "slack",                    # Slack users + DM messages
 
     # === Phase 2: Entity Processing ===

--- a/scripts/sync_imessage_interactions.py
+++ b/scripts/sync_imessage_interactions.py
@@ -45,16 +45,42 @@ def sync_imessage_interactions(dry_run: bool = True, limit: int = None) -> dict:
     """
     from api.services.imessage import get_imessage_store, join_imessages_to_entities
 
-    # STEP 1: Export new messages from Apple's Messages database
+    # STEP 1: Export new messages from Apple's Messages database.
+    #
+    # This only applies when running directly on a macOS host with Full Disk
+    # Access granted for ~/Library/Messages/chat.db. On Linux (the
+    # maintainer's configured setup) — or a Mac with no Messages database, or
+    # no Full Disk Access granted yet — this step is a routine no-op, not an
+    # error: on Linux, messages instead arrive via apple_data_import.py's
+    # rsync'd imessage.db, and steps 2/3 below process those regardless
+    # (issue #698, the imessage-shaped sibling of #687's clean-skip pattern).
+    #
+    # Only these two specific "not configured for this host" signatures are
+    # treated as a silent skip. Anything else is left to propagate, so a
+    # configured export that genuinely breaks (corrupt db, disk full, ...)
+    # still fails the run loud with the real traceback in stderr — not
+    # swallowed behind a misleading benign log line.
     logger.info("Exporting new messages from Messages.app database...")
     imessage_store = get_imessage_store()
     export_stats = {}
-    try:
-        export_stats = imessage_store.export_from_source()
-        logger.info(f"Exported {export_stats['messages_exported']} new messages")
-    except Exception as e:
-        logger.error(f"Failed to export messages: {e}")
-        # Continue anyway - we can still sync existing messages
+    if sys.platform != "darwin":
+        logger.info(
+            "Not running on macOS — iMessage arrives via apple_data_import.py "
+            "instead, nothing to export directly here"
+        )
+    elif not imessage_store.SOURCE_DB_PATH.exists():
+        logger.info(f"No Messages.app database at {imessage_store.SOURCE_DB_PATH} — nothing to export")
+    else:
+        try:
+            export_stats = imessage_store.export_from_source()
+            logger.info(f"Exported {export_stats['messages_exported']} new messages")
+        except PermissionError as e:
+            logger.info(
+                f"Skipping direct iMessage export — Full Disk Access not granted "
+                f"for the Messages database ({e}). Grant Full Disk Access to the "
+                "Python binary in System Settings → Privacy & Security, then "
+                "see docs/guides/setup.md."
+            )
 
     # STEP 2: Link exported messages to PersonEntity records
     # Always run linking — on Linux, messages arrive via apple_data_import.py

--- a/scripts/sync_linkedin.py
+++ b/scripts/sync_linkedin.py
@@ -41,6 +41,20 @@ def sync_linkedin(csv_path: str = DEFAULT_CSV_PATH, dry_run: bool = True) -> dic
     csv_file = Path(csv_path)
     if not csv_file.exists():
         logger.warning(f"LinkedIn CSV not found: {csv_path}")
+        # Declare the skip so the orchestrator records SKIPPED instead of a
+        # zero-stat "success" that looks identical to a healthy, quiet
+        # source forever (#780, same pattern as Monarch/Photos/Slack via
+        # #687). This script runs as a subprocess (run_all_syncs.py invokes
+        # it with ["--execute"]) — only stdout/stderr is ever seen
+        # downstream, so the returned dict alone never reaches the parser;
+        # the marker line is what actually matters.
+        print(
+            "SYNC_SKIPPED: LinkedIn connections CSV not found at "
+            f"{csv_path} — export it via LinkedIn Settings → "
+            "\"Get a copy of your data\" → Connections.csv (see "
+            "docs/guides/setup.md)",
+            flush=True,
+        )
         return {"status": "skipped", "reason": "csv_not_found"}
 
     if dry_run:

--- a/scripts/sync_monarch_money.py
+++ b/scripts/sync_monarch_money.py
@@ -102,23 +102,33 @@ def _failure_message(e: Exception) -> str:
     transient. run_all_syncs.py's `_is_transient_failure` can never match
     an empty message, so those runs never got the automatic retry that
     already exists for transient failures. Falling back to the exception's
-    class name (and any HTTP status/response detail it carries) gives
+    class name (and any HTTP status code it carries) gives
     `_is_transient_failure` something to match — e.g. a bare
     `ConnectTimeout` or `ReadTimeout` already matches its patterns by class
     name alone, no new signature needed. A non-empty `str(e)` is returned
     unchanged (#781).
+
+    Deliberately does not include a response body: Monarch is a financial
+    data source, an error body could carry account/personal detail, and
+    the "never log real personal data" boundary applies even to the rare
+    empty-message path this only runs on. Attribute lookups are wrapped in
+    a broad except so a third-party exception with a misbehaving
+    `response`/`status_code` property can never itself crash the failure
+    handler it's meant to describe.
     """
     message = str(e)
     if message:
         return message
     parts = [type(e).__name__]
-    response = getattr(e, "response", None)
-    status = getattr(e, "status_code", None) or getattr(response, "status_code", None)
-    if status is not None:
-        parts.append(f"status={status}")
-    body = getattr(response, "text", None) if response is not None else None
-    if body:
-        parts.append(body)
+    try:
+        response = getattr(e, "response", None)
+        status = getattr(e, "status_code", None)
+        if status is None and response is not None:
+            status = getattr(response, "status_code", None)
+        if status is not None:
+            parts.append(f"status={status}")
+    except Exception:
+        pass
     return parts[0] if len(parts) == 1 else f"{parts[0]} ({'; '.join(parts[1:])})"
 
 

--- a/scripts/sync_monarch_money.py
+++ b/scripts/sync_monarch_money.py
@@ -92,6 +92,36 @@ async def sync_monarch(dry_run: bool = True, month: str | None = None) -> dict:
     return result
 
 
+def _failure_message(e: Exception) -> str:
+    """Build the message recorded for a Monarch sync failure.
+
+    ``str(e)`` comes back empty for some exceptions the Monarch client
+    library raises — observed in production: two of eighty-one monthly
+    runs failed on first attempt with a blank error string, and both
+    succeeded moments later on a plain retry, meaning the failure was
+    transient. run_all_syncs.py's `_is_transient_failure` can never match
+    an empty message, so those runs never got the automatic retry that
+    already exists for transient failures. Falling back to the exception's
+    class name (and any HTTP status/response detail it carries) gives
+    `_is_transient_failure` something to match — e.g. a bare
+    `ConnectTimeout` or `ReadTimeout` already matches its patterns by class
+    name alone, no new signature needed. A non-empty `str(e)` is returned
+    unchanged (#781).
+    """
+    message = str(e)
+    if message:
+        return message
+    parts = [type(e).__name__]
+    response = getattr(e, "response", None)
+    status = getattr(e, "status_code", None) or getattr(response, "status_code", None)
+    if status is not None:
+        parts.append(f"status={status}")
+    body = getattr(response, "text", None) if response is not None else None
+    if body:
+        parts.append(body)
+    return parts[0] if len(parts) == 1 else f"{parts[0]} ({'; '.join(parts[1:])})"
+
+
 def main():
     parser = argparse.ArgumentParser(description='Sync Monarch Money to vault')
     parser.add_argument('--execute', action='store_true', help='Actually sync (default is dry run)')
@@ -128,11 +158,19 @@ def main():
                 logger.warning(f"Could not record sync completion: {e}")
 
     except Exception as e:
-        logger.error(f"Monarch Money sync failed: {e}")
+        failure_message = _failure_message(e)
+        # This also feeds run_all_syncs.py's transient-failure retry check:
+        # this script runs as a subprocess, and on nonzero exit that check
+        # classifies against captured stdout/stderr (which the logger call
+        # below writes to) — an empty str(e) here left nothing after
+        # "sync failed: " for the classifier to match, silently defeating
+        # the retry (#781). Use the same enriched message on both this log
+        # line and the sync_health record below.
+        logger.error(f"Monarch Money sync failed: {failure_message}")
         if run_id is not None:
             try:
                 from api.services.sync_health import record_sync_complete, SyncStatus
-                record_sync_complete(run_id, status=SyncStatus.FAILED, error_message=str(e))
+                record_sync_complete(run_id, status=SyncStatus.FAILED, error_message=failure_message)
             except Exception:
                 pass
         sys.exit(1)

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -1363,6 +1363,77 @@ class TestAgentShaImport:
 
 
 # ---------------------------------------------------------------------------
+# Export agent label in alerts (issue #770) — no hardcoded hardware name
+# ---------------------------------------------------------------------------
+
+class TestExportAgentLabelInAlerts:
+    """Alert wording must not assume any specific machine by default, and
+    must honor an installer's LIFEOS_APPLE_EXPORT_AGENT_LABEL override."""
+
+    def test_default_label_names_no_specific_hardware(self, tmp_path, monkeypatch):
+        """Default wording (no override set) must not mention Mac Mini or
+        any other specific hardware."""
+        import scripts.apple_data_import as import_mod
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir()
+        very_stale = datetime.now(timezone.utc) - timedelta(days=10)
+        manifest = {
+            "exported_at": very_stale.isoformat(),
+            "hostname": "test-host",
+            "results": {"whatsapp": {"status": "error", "reason": "wacli not installed"}},
+        }
+        with open(import_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", import_dir)
+
+        result = import_mod.check_manifest()
+
+        staleness_msg = result["_staleness_critical_message"]
+        assert "Mac Mini" not in staleness_msg
+        assert "export agent" in staleness_msg
+
+    def test_label_override_is_used_in_staleness_and_error_alerts(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from config.settings import settings
+        import scripts.apple_data_import as import_mod
+
+        monkeypatch.setattr(settings, "apple_export_agent_label", "my MacBook")
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir()
+        very_stale = datetime.now(timezone.utc) - timedelta(days=10)
+        manifest = {
+            "exported_at": very_stale.isoformat(),
+            "hostname": "test-host",
+            "results": {"whatsapp": {"status": "error", "reason": "wacli not installed"}},
+        }
+        with open(import_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", import_dir)
+
+        with caplog.at_level(logging.CRITICAL):
+            result = import_mod.check_manifest()
+
+        assert "my MacBook" in result["_staleness_critical_message"]
+        assert any(
+            "my MacBook" in r.message and "whatsapp" in r.message
+            for r in caplog.records
+        )
+
+    def test_default_setting_value_matches_current_hardcoded_wording_intent(self):
+        """Regression guard: the default must be the generic label, not
+        empty or a specific machine name — a fresh clone must see no
+        difference in *meaning*, only in no longer naming hardware."""
+        from config.settings import Settings
+
+        assert Settings().apple_export_agent_label == "the export agent"
+
+
+# ---------------------------------------------------------------------------
 # WhatsApp export (issue #677) — a failed `wacli sync` must not export as
 # status "ok", a 405 "Client outdated" must be diagnosed as client-version
 # (not auth), and a genuine auth failure must still be diagnosed as auth.

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -13,6 +13,22 @@ pytestmark = pytest.mark.unit
 
 
 # ---------------------------------------------------------------------------
+# Export/import directory name reconciliation — issue #785
+# ---------------------------------------------------------------------------
+
+class TestExportImportDirectoryNamesAgree:
+    """Export and import must agree on the shared handoff directory name so
+    a single-machine deployment (both steps on the same host, no rsync)
+    works with no manual symlink."""
+
+    def test_export_and_import_dirs_resolve_to_the_same_path(self):
+        from scripts.apple_data_export import EXPORT_DIR
+        from scripts.apple_data_import import IMPORT_DIR
+
+        assert EXPORT_DIR == IMPORT_DIR
+
+
+# ---------------------------------------------------------------------------
 # Contacts plist parsing
 # ---------------------------------------------------------------------------
 

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -1856,6 +1856,65 @@ class TestPhoneImport:
 
 
 # ---------------------------------------------------------------------------
+# main() — missing import dir is a clean skip, not a hard failure (#698)
+# ---------------------------------------------------------------------------
+
+class TestMissingImportDirIsCleanSkip:
+    """A fresh install with no Apple Data Agent ever configured must skip
+    cleanly (exit 0, SYNC_SKIPPED marker) instead of failing loud every
+    night — the apple_import-shaped sibling of #687's clean-skip pattern."""
+
+    def test_missing_import_dir_does_not_raise_and_prints_sync_skipped(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        import scripts.apple_data_import as import_mod
+
+        missing_dir = tmp_path / "does-not-exist"
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", missing_dir)
+        monkeypatch.setattr(import_mod.sys, "argv", ["apple_data_import.py", "--execute"])
+
+        # main() must fall through cleanly (no SystemExit) — a hard
+        # sys.exit(1) here is exactly the regression this issue fixes.
+        import_mod.main()
+
+        printed = capsys.readouterr().out
+        assert "SYNC_SKIPPED:" in printed
+        assert "Apple Data Agent" in printed
+
+    def test_existing_import_dir_with_manifest_is_unaffected(self, tmp_path, monkeypatch):
+        """A configured install (dir exists) must not take the new skip
+        branch at all — #646 behavior (staleness, per-source errors) is
+        untouched."""
+        import scripts.apple_data_import as import_mod
+
+        import_dir = tmp_path / "apple-imports"
+        import_dir.mkdir()
+        fresh = datetime.now(timezone.utc) - timedelta(hours=1)
+        manifest = {
+            "exported_at": fresh.isoformat(),
+            "hostname": "test-host",
+            "results": {"contacts": {"status": "ok"}},
+        }
+        with open(import_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f)
+
+        monkeypatch.setattr(import_mod, "IMPORT_DIR", import_dir)
+
+        def _stub(dry_run=False, **kwargs):
+            return {"status": "ok", "created": 0}
+
+        for name in (
+            "import_contacts", "import_imessage", "import_phone_calls",
+            "import_photos_faces", "import_whatsapp", "import_health",
+        ):
+            monkeypatch.setattr(import_mod, name, _stub)
+        monkeypatch.setattr(import_mod.sys, "argv", ["apple_data_import.py", "--execute"])
+
+        # Falls through cleanly — no SYNC_SKIPPED, no exception.
+        import_mod.main()
+
+
+# ---------------------------------------------------------------------------
 # main() — critical staleness must fail the run (issue #646)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -1024,6 +1024,201 @@ class TestAgentShaExport:
 
 
 # ---------------------------------------------------------------------------
+# Manifest merge on partial (single-source) export runs — issue #786
+# ---------------------------------------------------------------------------
+
+class TestManifestMergeOnPartialExport:
+    """A single-source export run must merge into the existing manifest
+    rather than replacing it, so other sources' last-known status survives.
+    A full (no --source) run must remain a full replacement, unchanged."""
+
+    def _fake_source(self, dry_run=False):
+        return {"status": "ok", "count": 1, "path": "fake"}
+
+    def test_single_source_run_preserves_other_sources(self, tmp_path, monkeypatch):
+        import scripts.apple_data_export as export_mod
+
+        existing_manifest = {
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "hostname": "old-host",
+            "agent_sha": "oldsha123",
+            "results": {
+                "contacts": {"status": "ok", "count": 5},
+                "imessage": {"status": "ok", "count": 10},
+                "phone": {"status": "error", "error": "boom"},
+                "photos": {"status": "ok", "count": 2},
+                "whatsapp": {"status": "error", "reason": "wacli outdated"},
+            },
+        }
+        (tmp_path / "manifest.json").write_text(json.dumps(existing_manifest))
+
+        monkeypatch.setattr(export_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(export_mod, "EXPORT_DIR", tmp_path)
+        monkeypatch.setattr(export_mod, "_get_agent_sha", lambda: "newsha456")
+        monkeypatch.setattr(
+            export_mod.sys, "argv",
+            ["apple_data_export.py", "--execute", "--source", "whatsapp"],
+        )
+        monkeypatch.setattr(export_mod, "export_whatsapp", self._fake_source)
+
+        export_mod.main()
+
+        manifest = json.loads((tmp_path / "manifest.json").read_text())
+        results = manifest["results"]
+        # The run source reflects the new result...
+        assert results["whatsapp"] == {"status": "ok", "count": 1, "path": "fake"}
+        # ...and every other source's prior entry is untouched.
+        assert results["contacts"] == {"status": "ok", "count": 5}
+        assert results["imessage"] == {"status": "ok", "count": 10}
+        assert results["phone"] == {"status": "error", "error": "boom"}
+        assert results["photos"] == {"status": "ok", "count": 2}
+
+    def test_single_source_run_with_no_existing_manifest_writes_just_that_source(
+        self, tmp_path, monkeypatch
+    ):
+        """Fresh install: no manifest yet, single-source run — today's
+        behavior for a fresh install must be unchanged."""
+        import scripts.apple_data_export as export_mod
+
+        monkeypatch.setattr(export_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(export_mod, "EXPORT_DIR", tmp_path)
+        monkeypatch.setattr(export_mod, "_get_agent_sha", lambda: "newsha456")
+        monkeypatch.setattr(
+            export_mod.sys, "argv",
+            ["apple_data_export.py", "--execute", "--source", "contacts"],
+        )
+        monkeypatch.setattr(export_mod, "export_contacts", self._fake_source)
+
+        export_mod.main()
+
+        manifest = json.loads((tmp_path / "manifest.json").read_text())
+        assert manifest["results"] == {"contacts": {"status": "ok", "count": 1, "path": "fake"}}
+
+    def test_full_run_still_fully_replaces_manifest(self, tmp_path, monkeypatch):
+        """Regression guard: an all-sources run (no --source) must remain a
+        byte-for-byte full replacement — this is the maintainer's nightly
+        path and must not gain merge semantics."""
+        import scripts.apple_data_export as export_mod
+
+        existing_manifest = {
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "hostname": "old-host",
+            "agent_sha": "oldsha123",
+            "results": {
+                "contacts": {"status": "ok", "count": 999},
+                "stale_source_no_longer_run": {"status": "ok", "count": 1},
+            },
+        }
+        (tmp_path / "manifest.json").write_text(json.dumps(existing_manifest))
+
+        monkeypatch.setattr(export_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(export_mod, "EXPORT_DIR", tmp_path)
+        monkeypatch.setattr(export_mod, "_get_agent_sha", lambda: "newsha456")
+        monkeypatch.setattr(export_mod.sys, "argv", ["apple_data_export.py", "--execute"])
+
+        for name in (
+            "export_contacts",
+            "export_imessage",
+            "export_phone_calls",
+            "export_photos_faces",
+            "export_whatsapp",
+        ):
+            monkeypatch.setattr(export_mod, name, self._fake_source)
+
+        export_mod.main()
+
+        manifest = json.loads((tmp_path / "manifest.json").read_text())
+        # Only the five real sources from this run — the stale leftover key
+        # from the old manifest must NOT survive a full run.
+        assert set(manifest["results"].keys()) == {
+            "contacts", "imessage", "phone", "photos", "whatsapp",
+        }
+        assert manifest["results"]["contacts"] == {"status": "ok", "count": 1, "path": "fake"}
+
+    def test_single_source_dry_run_does_not_write_manifest(self, tmp_path, monkeypatch):
+        """Out of scope for #786: dry-run stays preview-only, no manifest
+        write at all, merge or otherwise."""
+        import scripts.apple_data_export as export_mod
+
+        existing_manifest = {
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "hostname": "old-host",
+            "results": {"contacts": {"status": "ok", "count": 5}},
+        }
+        (tmp_path / "manifest.json").write_text(json.dumps(existing_manifest))
+
+        monkeypatch.setattr(export_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(export_mod, "EXPORT_DIR", tmp_path)
+        monkeypatch.setattr(
+            export_mod.sys, "argv",
+            ["apple_data_export.py", "--dry-run", "--source", "whatsapp"],
+        )
+        monkeypatch.setattr(export_mod, "export_whatsapp", self._fake_source)
+
+        export_mod.main()
+
+        # manifest.json on disk is exactly what it was before — untouched.
+        on_disk = json.loads((tmp_path / "manifest.json").read_text())
+        assert on_disk == existing_manifest
+
+    def test_single_source_run_with_corrupt_manifest_leaves_it_untouched(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A single-source run must never fall back to overwriting an
+        unreadable/corrupt manifest with just its own result — that would
+        reproduce the exact data-loss bug #786 fixes, just triggered by
+        corruption instead of an ordinary single-source run."""
+        import scripts.apple_data_export as export_mod
+
+        (tmp_path / "manifest.json").write_text("{not valid json")
+
+        monkeypatch.setattr(export_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(export_mod, "EXPORT_DIR", tmp_path)
+        monkeypatch.setattr(
+            export_mod.sys, "argv",
+            ["apple_data_export.py", "--execute", "--source", "whatsapp"],
+        )
+        monkeypatch.setattr(export_mod, "export_whatsapp", self._fake_source)
+
+        with caplog.at_level(logging.ERROR):
+            export_mod.main()
+
+        # The corrupt file on disk is untouched — not replaced with a
+        # partial (whatsapp-only) manifest.
+        assert (tmp_path / "manifest.json").read_text() == "{not valid json"
+        assert any(r.levelno == logging.ERROR for r in caplog.records)
+
+    def test_single_source_run_with_non_dict_results_leaves_it_untouched(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Same guard, for a manifest that parses but whose 'results' key
+        isn't a dict (unexpected shape) — still must not be overwritten."""
+        import scripts.apple_data_export as export_mod
+
+        existing_manifest = {
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "hostname": "old-host",
+            "results": "not-a-dict",
+        }
+        (tmp_path / "manifest.json").write_text(json.dumps(existing_manifest))
+
+        monkeypatch.setattr(export_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(export_mod, "EXPORT_DIR", tmp_path)
+        monkeypatch.setattr(
+            export_mod.sys, "argv",
+            ["apple_data_export.py", "--execute", "--source", "whatsapp"],
+        )
+        monkeypatch.setattr(export_mod, "export_whatsapp", self._fake_source)
+
+        with caplog.at_level(logging.ERROR):
+            export_mod.main()
+
+        on_disk = json.loads((tmp_path / "manifest.json").read_text())
+        assert on_disk == existing_manifest
+        assert any(r.levelno == logging.ERROR for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
 # Agent self-update SHA (issue #509) — import side
 # ---------------------------------------------------------------------------
 

--- a/tests/test_apple_pipeline.py
+++ b/tests/test_apple_pipeline.py
@@ -1197,8 +1197,13 @@ class TestManifestMergeOnPartialExport:
         monkeypatch.setattr(export_mod, "export_whatsapp", self._fake_source)
 
         with caplog.at_level(logging.ERROR):
-            export_mod.main()
+            with pytest.raises(SystemExit) as exc_info:
+                export_mod.main()
 
+        # A refused merge must fail the run (apple_data_agent.sh gates its
+        # rsync/import steps on this exit code) — exit 0 here would launder
+        # the refusal into an apparent success.
+        assert exc_info.value.code == 1
         # The corrupt file on disk is untouched — not replaced with a
         # partial (whatsapp-only) manifest.
         assert (tmp_path / "manifest.json").read_text() == "{not valid json"
@@ -1227,8 +1232,10 @@ class TestManifestMergeOnPartialExport:
         monkeypatch.setattr(export_mod, "export_whatsapp", self._fake_source)
 
         with caplog.at_level(logging.ERROR):
-            export_mod.main()
+            with pytest.raises(SystemExit) as exc_info:
+                export_mod.main()
 
+        assert exc_info.value.code == 1
         on_disk = json.loads((tmp_path / "manifest.json").read_text())
         assert on_disk == existing_manifest
         assert any(r.levelno == logging.ERROR for r in caplog.records)

--- a/tests/test_first_backfill.py
+++ b/tests/test_first_backfill.py
@@ -204,6 +204,21 @@ class TestCoverageReport:
 
         assert fb.coverage_report() == {}
 
+    def test_missing_database_is_not_created_as_a_side_effect(self, tmp_path, monkeypatch):
+        """sqlite3.connect silently creates an empty file at a missing
+        path -- this script claims to write nothing of its own (a totally
+        fresh or all-unconfigured install has no interactions.db yet), so
+        calling the "read-only" coverage report must not leave one behind
+        (Codex review of #778)."""
+        import scripts.first_backfill as fb
+
+        db_path = tmp_path / "interactions.db"
+        monkeypatch.setattr(fb, "get_interaction_db_path", lambda: str(db_path))
+
+        fb.coverage_report()
+
+        assert not db_path.exists()
+
     def test_reports_count_and_date_range_per_source(self, tmp_path, monkeypatch):
         import scripts.first_backfill as fb
 

--- a/tests/test_first_backfill.py
+++ b/tests/test_first_backfill.py
@@ -1,0 +1,332 @@
+"""Tests for scripts/first_backfill.py, the one-time deep backfill entry
+point for full-history-capable sync sources (issue #778).
+
+The nightly sync (run_all_syncs.py) deliberately narrows Gmail/Calendar to
+a 30-day window; a fresh install never gets its older history filled in on
+its own. These tests pin: which sources the backfill covers and in what
+order (mirroring the nightly SYNC_ORDER's Phases 1-4), that it widens only
+the sources whose nightly args actually narrow a window, that an
+unconfigured source is treated as a clean skip rather than a failure, that
+a failed source doesn't abort the rest of the run, and that re-running the
+orchestrator issues the exact same commands both times (the property that
+makes it safe to re-run — actual row-level idempotence lives in the
+underlying per-source scripts, reused unmodified here).
+"""
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestBackfillOrder:
+    def test_excludes_sources_with_no_full_history_concept(self):
+        import scripts.first_backfill as fb
+
+        for excluded in (
+            "push_birthdays", "google_docs", "google_sheets", "monarch_money",
+            "entity_cleanup", "consistency_verify",
+        ):
+            assert excluded not in fb.BACKFILL_ORDER
+
+    def test_preserves_nightly_relative_order(self):
+        """Every source the backfill does cover must appear in exactly the
+        same relative order as the nightly SYNC_ORDER — the acceptance
+        criteria's "same dependency order as the nightly pipeline's
+        phases"."""
+        import scripts.first_backfill as fb
+
+        nightly_positions = {s: i for i, s in enumerate(fb.SYNC_ORDER)}
+        backfill_positions = [nightly_positions[s] for s in fb.BACKFILL_ORDER]
+        assert backfill_positions == sorted(backfill_positions)
+
+    def test_covers_the_full_history_capable_sources(self):
+        import scripts.first_backfill as fb
+
+        for expected in (
+            "gmail_personal", "gmail_work", "gmail_work2",
+            "calendar_personal", "calendar_work", "calendar_work2",
+        ):
+            assert expected in fb.BACKFILL_ORDER
+
+
+class TestFullDepthArgs:
+    def test_strips_nightly_days_override(self):
+        import scripts.first_backfill as fb
+
+        nightly_args = ["--execute", "--gmail-only", "--account", "personal", "--days", "30"]
+        assert fb._full_depth_args(nightly_args) == [
+            "--execute", "--gmail-only", "--account", "personal",
+        ]
+
+    def test_leaves_sources_without_days_flag_unchanged(self):
+        import scripts.first_backfill as fb
+
+        nightly_args = ["--execute"]
+        assert fb._full_depth_args(nightly_args) == ["--execute"]
+
+    def test_does_not_mutate_the_input_list(self):
+        """SYNC_SCRIPTS is shared, module-level state — run_all_syncs.py's
+        nightly job reads the same list objects. Stripping --days must
+        never mutate them in place (#778's regression guard: "the nightly
+        sync job's existing per-source arguments shall be unchanged")."""
+        import scripts.first_backfill as fb
+
+        original = ["--execute", "--gmail-only", "--account", "personal", "--days", "30"]
+        snapshot = list(original)
+        fb._full_depth_args(original)
+        assert original == snapshot
+
+    def test_nightly_sync_scripts_definitions_are_unchanged(self):
+        """Importing this module must not alter run_all_syncs.py's own
+        SYNC_SCRIPTS — the nightly job's args are a separate, untouched
+        concern."""
+        import scripts.first_backfill as fb
+
+        assert fb.SYNC_SCRIPTS["gmail_personal"][1] == [
+            "--execute", "--gmail-only", "--account", "personal", "--days", "30",
+        ]
+        assert fb.SYNC_SCRIPTS["calendar_work2"][1] == [
+            "--execute", "--calendar-only", "--account", "work2", "--days", "30",
+        ]
+
+
+class TestRunBackfillSource:
+    def test_dry_run_does_not_invoke_subprocess(self, monkeypatch):
+        import scripts.first_backfill as fb
+
+        called = []
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: called.append(1))
+
+        result = fb.run_backfill_source("gmail_personal", dry_run=True)
+
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        assert called == []
+
+    def test_dry_run_command_omits_the_nightly_days_window(self, monkeypatch):
+        import scripts.first_backfill as fb
+
+        result = fb.run_backfill_source("gmail_personal", dry_run=True)
+        assert "--days" not in result["cmd"]
+
+    def test_unknown_source_errors_without_subprocess_call(self, monkeypatch):
+        import scripts.first_backfill as fb
+
+        called = []
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: called.append(1))
+
+        result = fb.run_backfill_source("not-a-real-source", dry_run=False)
+
+        assert result["success"] is False
+        assert called == []
+
+    def test_successful_run_is_reported_as_such(self, monkeypatch):
+        import scripts.first_backfill as fb
+
+        fake = MagicMockResult(returncode=0, stdout='SYNC_STATS:{"processed": 5}\n', stderr="")
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: fake)
+
+        result = fb.run_backfill_source("gmail_personal", dry_run=False)
+
+        assert result["success"] is True
+        assert result["skipped"] is False
+        assert result["stats"]["processed"] == 5
+
+    def test_command_actually_run_omits_the_nightly_days_window(self, monkeypatch):
+        """The regression guard for the whole issue: full-depth sources
+        must actually be invoked without the nightly's narrow window."""
+        import scripts.first_backfill as fb
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return MagicMockResult(returncode=0, stdout="SYNC_STATS:{}\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        fb.run_backfill_source("calendar_work", dry_run=False)
+
+        assert "--days" not in captured["cmd"]
+        assert "--calendar-only" in captured["cmd"]
+        assert "work" in captured["cmd"]
+
+    def test_unconfigured_source_is_a_clean_skip_not_a_failure(self, monkeypatch):
+        """Consistent with #687: a source with nothing configured must be
+        reported as skipped, never as a failure, so one missing
+        integration doesn't fail the whole backfill."""
+        import scripts.first_backfill as fb
+
+        fake = MagicMockResult(
+            returncode=0,
+            stdout="SYNC_SKIPPED: gmail not configured for work2\n",
+            stderr="",
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: fake)
+
+        result = fb.run_backfill_source("gmail_work2", dry_run=False)
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+
+    def test_nonzero_exit_is_a_real_failure(self, monkeypatch):
+        fake = MagicMockResult(returncode=1, stdout="", stderr="boom")
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: fake)
+
+        import scripts.first_backfill as fb
+        result = fb.run_backfill_source("gmail_personal", dry_run=False)
+
+        assert result["success"] is False
+        assert result["skipped"] is False
+        assert "boom" in result["error"]
+
+    def test_timeout_is_a_failure_not_a_crash(self, monkeypatch):
+        import scripts.first_backfill as fb
+
+        def fake_run(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="x", timeout=1)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = fb.run_backfill_source("gmail_personal", dry_run=False)
+        assert result["success"] is False
+
+
+class TestCoverageReport:
+    def test_empty_database_reports_nothing(self, tmp_path, monkeypatch):
+        import scripts.first_backfill as fb
+
+        db_path = tmp_path / "interactions.db"  # never created — no table
+        monkeypatch.setattr(fb, "get_interaction_db_path", lambda: str(db_path))
+
+        assert fb.coverage_report() == {}
+
+    def test_reports_count_and_date_range_per_source(self, tmp_path, monkeypatch):
+        import scripts.first_backfill as fb
+
+        db_path = tmp_path / "interactions.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE interactions (id TEXT, timestamp TEXT, source_type TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO interactions VALUES (?, ?, ?)",
+            [
+                ("1", "2020-01-01T00:00:00+00:00", "gmail"),
+                ("2", "2024-06-15T00:00:00+00:00", "gmail"),
+                ("3", "2023-03-01T00:00:00+00:00", "calendar"),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr(fb, "get_interaction_db_path", lambda: str(db_path))
+
+        report = fb.coverage_report()
+
+        assert report["gmail"]["count"] == 2
+        assert report["gmail"]["earliest"] == "2020-01-01T00:00:00+00:00"
+        assert report["gmail"]["latest"] == "2024-06-15T00:00:00+00:00"
+        assert report["calendar"]["count"] == 1
+        assert "slack" not in report  # no rows for this source_type
+
+
+class MagicMockResult:
+    """Minimal stand-in for subprocess.CompletedProcess."""
+
+    def __init__(self, returncode, stdout, stderr):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TestMainOrchestration:
+    def test_runs_sources_in_backfill_order(self, monkeypatch):
+        import scripts.first_backfill as fb
+
+        call_order = []
+
+        def fake_run_source(source, dry_run=False):
+            call_order.append(source)
+            return {"success": True, "skipped": False, "stats": {}}
+
+        monkeypatch.setattr(fb, "run_backfill_source", fake_run_source)
+        monkeypatch.setattr(fb, "coverage_report", lambda: {})
+        monkeypatch.setattr(sys, "argv", ["first_backfill.py", "--execute"])
+
+        fb.main()
+
+        assert call_order == fb.BACKFILL_ORDER
+
+    def test_a_failed_source_does_not_abort_the_rest(self, monkeypatch):
+        import scripts.first_backfill as fb
+
+        call_order = []
+
+        def fake_run_source(source, dry_run=False):
+            call_order.append(source)
+            if source == "gmail_work":
+                return {"success": False, "skipped": False, "error": "boom"}
+            return {"success": True, "skipped": False, "stats": {}}
+
+        monkeypatch.setattr(fb, "run_backfill_source", fake_run_source)
+        monkeypatch.setattr(fb, "coverage_report", lambda: {})
+        monkeypatch.setattr(sys, "argv", ["first_backfill.py", "--execute"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            fb.main()
+
+        assert call_order == fb.BACKFILL_ORDER  # every source still ran
+        assert exc_info.value.code == 1  # but the run is reported as failed
+
+    def test_all_succeeding_exits_zero(self, monkeypatch):
+        import scripts.first_backfill as fb
+
+        monkeypatch.setattr(
+            fb, "run_backfill_source",
+            lambda source, dry_run=False: {"success": True, "skipped": False, "stats": {}},
+        )
+        monkeypatch.setattr(fb, "coverage_report", lambda: {})
+        monkeypatch.setattr(sys, "argv", ["first_backfill.py", "--execute"])
+
+        fb.main()  # must not raise SystemExit
+
+    def test_rerun_issues_identical_commands(self, monkeypatch):
+        """The orchestration-level half of #778's idempotence criterion:
+        this script keeps no local state between runs, so re-running it
+        against an install that already has full history issues the exact
+        same commands both times. Row-level dedup is the underlying
+        scripts' own, already-established responsibility."""
+        import scripts.first_backfill as fb
+
+        commands_by_run = [[], []]
+
+        def make_fake_run(bucket):
+            def fake_run(cmd, **kwargs):
+                bucket.append(cmd)
+                return MagicMockResult(returncode=0, stdout="SYNC_STATS:{}\n", stderr="")
+            return fake_run
+
+        monkeypatch.setattr(subprocess, "run", make_fake_run(commands_by_run[0]))
+        for source in fb.BACKFILL_ORDER:
+            fb.run_backfill_source(source, dry_run=False)
+
+        monkeypatch.setattr(subprocess, "run", make_fake_run(commands_by_run[1]))
+        for source in fb.BACKFILL_ORDER:
+            fb.run_backfill_source(source, dry_run=False)
+
+        assert commands_by_run[0] == commands_by_run[1]
+
+    def test_no_execute_or_dry_run_flag_exits_with_usage_message(self, monkeypatch, capsys):
+        import scripts.first_backfill as fb
+
+        monkeypatch.setattr(sys, "argv", ["first_backfill.py"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            fb.main()
+
+        assert exc_info.value.code == 1
+        assert "--execute" in capsys.readouterr().out

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -679,6 +679,79 @@ def test_sync_trigger_known_source_routes_to_the_right_endpoint():
 
 
 @pytest.mark.unit
+def test_sync_trigger_whatsapp_is_no_longer_invalid():
+    """WhatsApp has no dedicated route_map entry — it has no standalone
+    nightly sync of its own, its data arrives via the combined apple_import
+    step (#784) — so it must fall through to the same fallback-list
+    handling gmail/imessage/linkedin already get, not "Invalid source"."""
+    from unittest.mock import MagicMock
+    server = _fresh_server()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"status": "queued"}
+    fake_response.raise_for_status = MagicMock()
+    fake.post.return_value = fake_response
+    server.client = fake
+
+    result = server._handle_sync_trigger({"source": "whatsapp"})
+    assert result == {"status": "queued"}
+    called_url = fake.post.call_args[0][0]
+    assert called_url.endswith("/api/crm/sources/whatsapp/sync")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source,expected_url_suffix",
+    [
+        ("vault", "/api/admin/reindex"),
+        ("calendar", "/api/admin/calendar/sync"),
+        ("contacts", "/api/crm/contacts/sync"),
+        ("slack", "/api/crm/slack/sync"),
+        ("photos", "/api/photos/sync"),
+        ("gmail", "/api/crm/sources/gmail/sync"),
+        ("imessage", "/api/crm/sources/imessage/sync"),
+        ("phone", "/api/crm/sources/phone/sync"),
+        ("facetime", "/api/crm/sources/facetime/sync"),
+        ("linkedin", "/api/crm/sources/linkedin/sync"),
+        ("whatsapp", "/api/crm/sources/whatsapp/sync"),
+    ],
+)
+def test_sync_trigger_every_source_routes_as_expected(source, expected_url_suffix):
+    """Regression guard for #784: every pre-existing source must keep
+    routing exactly as it does today, with whatsapp now joining the
+    fallback list rather than replacing or shifting anything."""
+    from unittest.mock import MagicMock
+    server = _fresh_server()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"status": "ok"}
+    fake_response.raise_for_status = MagicMock()
+    fake.post.return_value = fake_response
+    server.client = fake
+
+    server._handle_sync_trigger({"source": source})
+    called_url = fake.post.call_args[0][0]
+    assert called_url.endswith(expected_url_suffix)
+
+
+@pytest.mark.unit
+def test_sync_source_route_accepts_whatsapp():
+    """The MCP-level tests above only check the outgoing request URL
+    against a mocked client — they'd pass even if the underlying
+    `POST /api/crm/sources/{source_type}/sync` route (api/routes/crm.py)
+    still 400'd on "whatsapp". Exercise the real route directly (#784);
+    it does no DB access, so this is safe as a unit test."""
+    from fastapi.testclient import TestClient
+    from api.main import app
+
+    response = TestClient(app).post("/api/crm/sources/whatsapp/sync")
+    assert response.status_code == 200
+    assert response.json()["source_type"] == "whatsapp"
+
+
+@pytest.mark.unit
 def test_sync_trigger_downstream_non_2xx_is_an_error():
     """A downstream route that correctly raises on failure (the safe
     pattern every other curated write endpoint follows) must still surface
@@ -800,7 +873,7 @@ class TestWriteEndpointNeverReturnsSuccessShapedFailure:
         server = module.LifeOSMCPServer.__new__(module.LifeOSMCPServer)
         for source in (
             "vault", "calendar", "contacts", "slack", "photos",
-            "gmail", "imessage", "phone", "facetime", "linkedin",
+            "gmail", "imessage", "phone", "facetime", "linkedin", "whatsapp",
         ):
             fake_client = MagicMock()
             server.client = fake_client

--- a/tests/test_sync_imessage_interactions_export_skip.py
+++ b/tests/test_sync_imessage_interactions_export_skip.py
@@ -1,0 +1,130 @@
+"""Tests for scripts/sync_imessage_interactions.py's direct-export step
+(issue #698, the imessage-shaped sibling of #687's clean-skip pattern).
+
+STEP 1 of sync_imessage_interactions() tries to export straight from the
+local Messages.app database. On a host that isn't configured for that (not
+macOS, no Messages.app database, or no Full Disk Access granted yet) this
+must be a silent no-op — steps 2/3 (linking + syncing whatever's already in
+data/imessage.db, which on Linux arrives via apple_data_import.py) must
+still run. A genuine failure of a working export must still propagate so
+the run fails loud.
+"""
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _build_imessage_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE messages (
+            rowid INTEGER PRIMARY KEY,
+            text TEXT,
+            timestamp TEXT NOT NULL,
+            is_from_me INTEGER NOT NULL,
+            handle TEXT NOT NULL,
+            handle_normalized TEXT,
+            service TEXT NOT NULL,
+            person_entity_id TEXT
+        );
+        CREATE TABLE sync_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _build_interactions_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE interactions (id TEXT, person_id TEXT, timestamp TEXT, "
+        "source_type TEXT, title TEXT, snippet TEXT, source_link TEXT, "
+        "source_id TEXT, created_at TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestImessageExportStepCleanSkip:
+    def _run(
+        self,
+        tmp_path,
+        monkeypatch,
+        platform,
+        source_db_exists,
+        export_side_effect=None,
+    ):
+        import scripts.sync_imessage_interactions as mod
+
+        imessage_db = tmp_path / "imessage.db"
+        _build_imessage_db(imessage_db)
+        interactions_db = tmp_path / "interactions.db"
+        _build_interactions_db(interactions_db)
+
+        monkeypatch.setattr(mod.sys, "platform", platform)
+        monkeypatch.setattr(mod, "get_imessage_db_path", lambda: str(imessage_db))
+        monkeypatch.setattr(mod, "get_interaction_db_path", lambda: str(interactions_db))
+        monkeypatch.setattr(mod, "get_person_entity_store", lambda: MagicMock())
+        monkeypatch.setattr(mod, "get_source_entity_store", lambda: MagicMock())
+
+        fake_store = MagicMock()
+        fake_store.SOURCE_DB_PATH = tmp_path / "chat.db"
+        if source_db_exists:
+            fake_store.SOURCE_DB_PATH.touch()
+        if export_side_effect is not None:
+            fake_store.export_from_source.side_effect = export_side_effect
+        else:
+            fake_store.export_from_source.return_value = {
+                "messages_exported": 0,
+                "messages_skipped": 0,
+            }
+
+        with patch("api.services.imessage.get_imessage_store", return_value=fake_store), \
+             patch("api.services.imessage.join_imessages_to_entities", return_value={"messages_updated": 0}):
+            result = mod.sync_imessage_interactions(dry_run=True)
+
+        return result, fake_store
+
+    def test_non_macos_skips_export_without_attempting_it(self, tmp_path, monkeypatch):
+        """The maintainer's configured Linux host: step 1 never applies
+        there (messages arrive via apple_data_import.py instead) — must not
+        even attempt the direct export, and must not error."""
+        result, fake_store = self._run(
+            tmp_path, monkeypatch, platform="linux", source_db_exists=True,
+        )
+        fake_store.export_from_source.assert_not_called()
+        assert result["errors"] == 0
+
+    def test_macos_no_messages_db_skips_export(self, tmp_path, monkeypatch):
+        """A Mac that has never used Messages.app — no chat.db at all."""
+        result, fake_store = self._run(
+            tmp_path, monkeypatch, platform="darwin", source_db_exists=False,
+        )
+        fake_store.export_from_source.assert_not_called()
+        assert result["errors"] == 0
+
+    def test_macos_no_full_disk_access_skips_cleanly(self, tmp_path, monkeypatch):
+        """No FDA granted yet — the documented not-configured state for a
+        fresh macOS install. Must not fail the run."""
+        result, fake_store = self._run(
+            tmp_path, monkeypatch, platform="darwin", source_db_exists=True,
+            export_side_effect=PermissionError(
+                "Cannot read the iMessage database ... Grant Full Disk Access ..."
+            ),
+        )
+        fake_store.export_from_source.assert_called_once()
+        assert result["errors"] == 0
+
+    def test_macos_genuine_export_failure_propagates(self, tmp_path, monkeypatch):
+        """FDA-granted-but-genuinely-broken (e.g. a locked/corrupt db) must
+        still fail loud, not be swallowed as a routine skip."""
+        with pytest.raises(sqlite3.OperationalError):
+            self._run(
+                tmp_path, monkeypatch, platform="darwin", source_db_exists=True,
+                export_side_effect=sqlite3.OperationalError("database is locked"),
+            )

--- a/tests/test_sync_linkedin.py
+++ b/tests/test_sync_linkedin.py
@@ -1,0 +1,71 @@
+"""Tests for scripts/sync_linkedin.py's clean-skip path (issue #780).
+
+Before this fix, a missing data/LinkedInConnections.csv already returned a
+{"status": "skipped", "reason": "csv_not_found"} dict internally, but this
+script runs as a subprocess (run_all_syncs.py's SYNC_SOURCES entry), so only
+what lands on stdout/stderr is ever parsed downstream — the returned dict
+was discarded, and the SYNC_SKIPPED marker _parse_sync_output actually looks
+for was never printed. The result: an absent CSV recorded as a normal,
+zero-stat "success", indistinguishable from a healthy but quiet source.
+These tests pin that the marker is now printed, and that a present CSV's
+behavior is unchanged.
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestSyncLinkedinSkip:
+    def test_missing_csv_prints_marker_and_returns_skip(self, tmp_path, capsys):
+        from scripts.sync_linkedin import sync_linkedin
+
+        missing_csv = tmp_path / "does-not-exist.csv"
+
+        result = sync_linkedin(csv_path=str(missing_csv), dry_run=False)
+
+        assert result == {"status": "skipped", "reason": "csv_not_found"}
+        captured = capsys.readouterr()
+        assert "SYNC_SKIPPED:" in captured.out
+        assert str(missing_csv) in captured.out
+
+    def test_missing_csv_dry_run_also_returns_skip_without_marker_requirement(
+        self, tmp_path
+    ):
+        """Dry run isn't parsed downstream (run_all_syncs.py always invokes
+        with --execute) — behavior here is unchanged: still reports skipped,
+        marker presence doesn't matter for this path."""
+        from scripts.sync_linkedin import sync_linkedin
+
+        missing_csv = tmp_path / "does-not-exist.csv"
+        result = sync_linkedin(csv_path=str(missing_csv), dry_run=True)
+        assert result == {"status": "skipped", "reason": "csv_not_found"}
+
+    def test_present_csv_configured_run_is_unaffected(self, tmp_path, monkeypatch, capsys):
+        """Regression guard: a present, valid CSV must produce byte-identical
+        stats and behavior to before this fix — no SYNC_SKIPPED marker, same
+        result shape."""
+        from scripts.sync_linkedin import sync_linkedin
+
+        csv_path = tmp_path / "Connections.csv"
+        csv_path.write_text("First Name,Last Name\nJane,Doe\n")
+
+        fake_results = {
+            "connections_processed": 1,
+            "entities_created": 1,
+            "entities_updated": 0,
+            "connections_skipped": 0,
+        }
+        monkeypatch.setattr(
+            "api.services.people_aggregator.sync_linkedin_to_v2",
+            lambda csv_path, entity_resolver: fake_results,
+        )
+        monkeypatch.setattr(
+            "api.services.entity_resolver.get_entity_resolver", lambda: object()
+        )
+
+        result = sync_linkedin(csv_path=str(csv_path), dry_run=False)
+
+        assert result == fake_results
+        captured = capsys.readouterr()
+        assert "SYNC_SKIPPED:" not in captured.out
+        assert "SYNC_STATS:" in captured.out

--- a/tests/test_sync_monarch_money.py
+++ b/tests/test_sync_monarch_money.py
@@ -119,3 +119,97 @@ class TestMainRecordsSkipStatus:
 
         assert exc_info.value.code == 1
         assert recorded["status"] == SyncStatus.FAILED
+
+    def test_empty_exception_message_falls_back_to_class_name(self, monkeypatch):
+        """A bare exception with no message (issue #781) must still record
+        something an operator — and run_all_syncs.py's transient-failure
+        classifier, which reads this same subprocess's stderr — can act
+        on, rather than an empty string that matches nothing."""
+        from api.services.sync_health import SyncStatus
+        from scripts.sync_monarch_money import main
+
+        monkeypatch.setattr("api.services.monarch.is_monarch_configured", lambda: True)
+
+        class BrokenClient:
+            async def write_monthly_report(self, year, month, dry_run=False):
+                raise ConnectionError()  # str(e) == ""
+
+        monkeypatch.setattr("api.services.monarch.get_monarch_client", lambda: BrokenClient())
+
+        recorded = {}
+        self._patch_sync_health(monkeypatch, recorded)
+        monkeypatch.setattr(sys, "argv", ["sync_monarch_money.py", "--execute"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        assert recorded["status"] == SyncStatus.FAILED
+        error_message = recorded["kwargs"]["error_message"]
+        assert error_message
+        assert "ConnectionError" in error_message
+
+    def test_normal_exception_message_unchanged(self, monkeypatch):
+        """An exception with a real message must be recorded exactly as
+        before this change — no class-name prefix added when it isn't
+        needed (#781's acceptance criteria: behavior-preserving)."""
+        from api.services.sync_health import SyncStatus
+        from scripts.sync_monarch_money import main
+
+        monkeypatch.setattr("api.services.monarch.is_monarch_configured", lambda: True)
+
+        class BrokenClient:
+            async def write_monthly_report(self, year, month, dry_run=False):
+                raise RuntimeError("session invalid, re-auth required")
+
+        monkeypatch.setattr("api.services.monarch.get_monarch_client", lambda: BrokenClient())
+
+        recorded = {}
+        self._patch_sync_health(monkeypatch, recorded)
+        monkeypatch.setattr(sys, "argv", ["sync_monarch_money.py", "--execute"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        assert recorded["status"] == SyncStatus.FAILED
+        assert recorded["kwargs"]["error_message"] == "session invalid, re-auth required"
+
+
+class TestFailureMessageEnrichment:
+    """Unit tests for _failure_message()'s fallback construction (#781)."""
+
+    def test_empty_message_uses_class_name(self):
+        from scripts.sync_monarch_money import _failure_message
+
+        assert _failure_message(ConnectionError()) == "ConnectionError"
+
+    def test_non_empty_message_returned_unchanged(self):
+        from scripts.sync_monarch_money import _failure_message
+
+        e = RuntimeError("session invalid, re-auth required")
+        assert _failure_message(e) == "session invalid, re-auth required"
+
+    def test_empty_message_with_status_code_attr_included(self):
+        from scripts.sync_monarch_money import _failure_message
+
+        class HTTPError(Exception):
+            pass
+
+        e = HTTPError()
+        e.status_code = 429
+        assert _failure_message(e) == "HTTPError (status=429)"
+
+    def test_empty_message_with_response_status_and_body_included(self):
+        from scripts.sync_monarch_money import _failure_message
+
+        class FakeResponse:
+            status_code = 500
+            text = "Internal Server Error"
+
+        class HTTPError(Exception):
+            pass
+
+        e = HTTPError()
+        e.response = FakeResponse()
+        assert _failure_message(e) == "HTTPError (status=500; Internal Server Error)"

--- a/tests/test_sync_monarch_money.py
+++ b/tests/test_sync_monarch_money.py
@@ -149,10 +149,14 @@ class TestMainRecordsSkipStatus:
         assert error_message
         assert "ConnectionError" in error_message
 
-    def test_normal_exception_message_unchanged(self, monkeypatch):
+    def test_normal_exception_message_unchanged(self, monkeypatch, caplog):
         """An exception with a real message must be recorded exactly as
         before this change — no class-name prefix added when it isn't
-        needed (#781's acceptance criteria: behavior-preserving)."""
+        needed (#781's acceptance criteria: behavior-preserving). Also
+        pins the emitted log text, since that's what run_all_syncs.py's
+        transient-failure classifier actually reads (this script runs as
+        a subprocess and the classifier inspects captured stderr)."""
+        import logging
         from api.services.sync_health import SyncStatus
         from scripts.sync_monarch_money import main
 
@@ -168,8 +172,11 @@ class TestMainRecordsSkipStatus:
         self._patch_sync_health(monkeypatch, recorded)
         monkeypatch.setattr(sys, "argv", ["sync_monarch_money.py", "--execute"])
 
-        with pytest.raises(SystemExit) as exc_info:
-            main()
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert "Monarch Money sync failed: session invalid, re-auth required" in caplog.text
 
         assert exc_info.value.code == 1
         assert recorded["status"] == SyncStatus.FAILED
@@ -200,16 +207,41 @@ class TestFailureMessageEnrichment:
         e.status_code = 429
         assert _failure_message(e) == "HTTPError (status=429)"
 
-    def test_empty_message_with_response_status_and_body_included(self):
+    def test_empty_message_with_response_status_included_no_body(self):
+        """Status code is included; response body is deliberately excluded
+        (Monarch is a financial data source — an error body could carry
+        account/personal detail, and the "never log real personal data"
+        boundary applies even on this fallback path)."""
         from scripts.sync_monarch_money import _failure_message
 
         class FakeResponse:
             status_code = 500
-            text = "Internal Server Error"
+            text = "Internal Server Error: account 1234-5678 over limit"
 
         class HTTPError(Exception):
             pass
 
         e = HTTPError()
         e.response = FakeResponse()
-        assert _failure_message(e) == "HTTPError (status=500; Internal Server Error)"
+        message = _failure_message(e)
+        assert message == "HTTPError (status=500)"
+        assert "1234-5678" not in message
+
+    def test_misbehaving_response_property_does_not_crash(self):
+        """A third-party exception whose `response`/`status_code`
+        attributes raise on access must not itself crash the failure
+        handler it's meant to describe — fall back to just the class
+        name."""
+        from scripts.sync_monarch_money import _failure_message
+
+        class BoomResponse:
+            @property
+            def status_code(self):
+                raise RuntimeError("not decoded yet")
+
+        class HTTPError(Exception):
+            pass
+
+        e = HTTPError()
+        e.response = BoomResponse()
+        assert _failure_message(e) == "HTTPError"


### PR DESCRIPTION
Eight sync-layer fixes from the second-user portability audit. A configured, working source produces identical results and identical `SYNC_STATS` after these; only unconfigured and partial-run paths change.

- #786 — partial Apple export runs merge into the shared manifest instead of clobbering other sources' entries; a corrupt existing manifest now fails loud (exit 1) rather than falling through.
- #785 — export and import agree on the shared data directory name; same-Mac export+import needs no symlink.
- #698 — `apple_import` and `imessage` skip cleanly with a named reason on a host with no Apple Data Agent, mirroring #687.
- #780 — LinkedIn emits the `SYNC_SKIPPED:` marker on stdout when its CSV is absent, so an unconfigured source is no longer misparsed as a zero-stat success.
- #770 — Apple-import alerts no longer name a specific hardware model.
- #781 — Monarch failures always carry a non-empty message (exception type + status code, never a response body), so the existing transient-retry classifier can match them.
- #784 — `lifeos_sync_trigger` and the underlying route accept `whatsapp` (maintainer-approved MCP change; additive; brings WhatsApp to parity with the route's current stub behavior).
- #778 — `scripts/first_backfill.py`: full-depth first-run pass over the collection→indexing phases with a coverage report; re-runnable; never creates its own database.

Adversarially reviewed with Codex per issue; real findings fixed (manifest fail-loud, response-body log leak, empty-DB creation). Follow-up filed as #820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw