### PR TITLE
fix(health): api_key_configured and local_llm report honestly

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -537,9 +537,18 @@ async def full_health_check():
             "detail": f"LIFEOS_LLM_BACKEND={backend!r}, local LLM not in use",
         }
     else:
-        from api.services.llm_client import LocalLLMClient
         start = time.time()
-        reachable = await LocalLLMClient().ais_available()
+        try:
+            from api.services.llm_client import LocalLLMClient
+            reachable = await LocalLLMClient().ais_available()
+        except Exception as e:
+            # ais_available() already catches its own network errors and
+            # returns False; this is belt-and-suspenders against anything
+            # else (e.g. client construction) so a local-LLM problem always
+            # surfaces as this row's error, never a 500 from the whole
+            # /health/full endpoint.
+            reachable = False
+            logger.warning(f"local_llm reachability probe raised unexpectedly: {e}")
         elapsed = int((time.time() - start) * 1000)
         if reachable:
             results["checks"]["local_llm"] = {
@@ -593,6 +602,32 @@ async def full_health_check():
         json_body={"query": "test", "top_k": 1}
     )
 
+    # 3b. Vault-root sanity check (#762) — the request/response check above
+    # only confirms search returns *something*, not that what it returns
+    # still lives where the vault is currently configured. A moved/deleted
+    # vault can leave the index serving stale content from the old location
+    # while that check keeps passing. Additive only: a healthy, unmoved
+    # vault continues to report "ok" exactly as before; this only downgrades
+    # an already-"ok" row to "degraded" on detected drift, and never touches
+    # anything when the base check itself already failed.
+    if results["checks"].get("vault_search", {}).get("status") == "ok":
+        try:
+            from api.services.vectorstore import get_vector_store, sample_paths_match_vault_root
+            sample = get_vector_store().sample_file_paths(limit=5)
+            all_match, mismatched = sample_paths_match_vault_root(sample, settings.vault_path)
+            if not all_match:
+                results["checks"]["vault_search"]["status"] = "degraded"
+                results["checks"]["vault_search"]["detail"] = (
+                    f"{len(mismatched)}/{len(sample)} sampled indexed path(s) fall outside "
+                    f"the configured vault root ({settings.vault_path.resolve()}), e.g. "
+                    f"{mismatched[0]}"
+                )
+        except Exception as e:
+            # Never let this additive sanity check take down the primary
+            # vault_search result — a vector-store hiccup here is already
+            # visible via the chromadb_server check above.
+            logger.warning(f"vault-root sanity check failed: {e}")
+
     # 3. Calendar Upcoming (GET /api/calendar/upcoming)
     await test_endpoint(
         "calendar_upcoming",
@@ -617,8 +652,13 @@ async def full_health_check():
     # so all three Google rows report the same not-configured shape (#697).
     from api.services.google_auth import get_google_auth, GoogleAccount
     if not get_google_auth(GoogleAccount.PERSONAL).credentials_path.exists():
+        # Same shape as test_endpoint()'s error rows below (status/latency_ms/
+        # error) so a monitor parsing "error" rows doesn't need a special
+        # case for this one — latency_ms is 0 since this is a local
+        # filesystem check, not a network call.
         results["checks"]["gmail_search"] = {
             "status": "error",
+            "latency_ms": 0,
             "error": "Google credentials not configured (personal account)",
         }
         results["errors"].append("gmail_search: Google credentials not configured (personal account)")

--- a/api/main.py
+++ b/api/main.py
@@ -362,7 +362,7 @@ async def health_check():
     from config.settings import settings
 
     checks = {
-        "api_key_configured": bool(settings.local_llm_url and settings.local_llm_url.strip()),
+        "api_key_configured": bool(settings.anthropic_api_key and settings.anthropic_api_key.strip()),
         "reminder_scheduler": _reminder_scheduler.is_alive() if _reminder_scheduler else False,
     }
 
@@ -523,12 +523,37 @@ async def full_health_check():
             results["errors"].append(f"{name}: {str(e)}")
             return False
 
-    # 1. Config check — local LLM URL
-    if settings.local_llm_url and settings.local_llm_url.strip():
-        results["checks"]["local_llm"] = {"status": "ok", "detail": f"configured ({settings.local_llm_url})"}
+    # 1. Local LLM — `local_llm_url` has a non-empty default regardless of
+    # whether the local backend is actually in use, so a bare "is the URL
+    # string set" check always said "ok" even on an install that talks only
+    # to Anthropic and has nothing listening on that port (#697). Report
+    # not-in-use when the backend isn't "local" (truthful and not a
+    # failure — excluded from the `failed` count below same as "ok"); only
+    # when the backend is "local" do we actually probe reachability.
+    backend = (settings.llm_backend or "anthropic").strip().lower()
+    if backend != "local":
+        results["checks"]["local_llm"] = {
+            "status": "not_in_use",
+            "detail": f"LIFEOS_LLM_BACKEND={backend!r}, local LLM not in use",
+        }
     else:
-        results["checks"]["local_llm"] = {"status": "error", "error": "not configured"}
-        results["errors"].append("local_llm_url: not configured")
+        from api.services.llm_client import LocalLLMClient
+        start = time.time()
+        reachable = await LocalLLMClient().ais_available()
+        elapsed = int((time.time() - start) * 1000)
+        if reachable:
+            results["checks"]["local_llm"] = {
+                "status": "ok",
+                "latency_ms": elapsed,
+                "detail": f"reachable ({settings.local_llm_url})",
+            }
+        else:
+            results["checks"]["local_llm"] = {
+                "status": "error",
+                "latency_ms": elapsed,
+                "error": f"unreachable ({settings.local_llm_url})",
+            }
+            results["errors"].append(f"local_llm: unreachable ({settings.local_llm_url})")
 
     # 2. ChromaDB Server (direct health check)
     start = time.time()
@@ -582,12 +607,27 @@ async def full_health_check():
         params={"q": "meeting"}
     )
 
-    # 5. Gmail Search (GET /api/gmail/search)
-    await test_endpoint(
-        "gmail_search",
-        "GET", "/api/gmail/search",
-        params={"q": "in:inbox", "max_results": 1}
-    )
+    # 5. Gmail Search (GET /api/gmail/search) — GmailService.search() catches
+    # credential errors internally and returns an empty list (by design, so
+    # chat/agent callers degrade gracefully rather than raising), so hitting
+    # the endpoint directly always reports "ok, 0 emails" even with zero
+    # Google credentials configured — unlike calendar/drive below, whose
+    # routes let a missing-credentials FileNotFoundError surface as a 401.
+    # Preflight a plain file-existence check for the account this probe uses
+    # so all three Google rows report the same not-configured shape (#697).
+    from api.services.google_auth import get_google_auth, GoogleAccount
+    if not get_google_auth(GoogleAccount.PERSONAL).credentials_path.exists():
+        results["checks"]["gmail_search"] = {
+            "status": "error",
+            "error": "Google credentials not configured (personal account)",
+        }
+        results["errors"].append("gmail_search: Google credentials not configured (personal account)")
+    else:
+        await test_endpoint(
+            "gmail_search",
+            "GET", "/api/gmail/search",
+            params={"q": "in:inbox", "max_results": 1}
+        )
 
     # 6. Drive Search - Personal (GET /api/drive/search)
     await test_endpoint(

--- a/api/main.py
+++ b/api/main.py
@@ -602,32 +602,6 @@ async def full_health_check():
         json_body={"query": "test", "top_k": 1}
     )
 
-    # 3b. Vault-root sanity check (#762) — the request/response check above
-    # only confirms search returns *something*, not that what it returns
-    # still lives where the vault is currently configured. A moved/deleted
-    # vault can leave the index serving stale content from the old location
-    # while that check keeps passing. Additive only: a healthy, unmoved
-    # vault continues to report "ok" exactly as before; this only downgrades
-    # an already-"ok" row to "degraded" on detected drift, and never touches
-    # anything when the base check itself already failed.
-    if results["checks"].get("vault_search", {}).get("status") == "ok":
-        try:
-            from api.services.vectorstore import get_vector_store, sample_paths_match_vault_root
-            sample = get_vector_store().sample_file_paths(limit=5)
-            all_match, mismatched = sample_paths_match_vault_root(sample, settings.vault_path)
-            if not all_match:
-                results["checks"]["vault_search"]["status"] = "degraded"
-                results["checks"]["vault_search"]["detail"] = (
-                    f"{len(mismatched)}/{len(sample)} sampled indexed path(s) fall outside "
-                    f"the configured vault root ({settings.vault_path.resolve()}), e.g. "
-                    f"{mismatched[0]}"
-                )
-        except Exception as e:
-            # Never let this additive sanity check take down the primary
-            # vault_search result — a vector-store hiccup here is already
-            # visible via the chromadb_server check above.
-            logger.warning(f"vault-root sanity check failed: {e}")
-
     # 3. Calendar Upcoming (GET /api/calendar/upcoming)
     await test_endpoint(
         "calendar_upcoming",

--- a/api/main.py
+++ b/api/main.py
@@ -362,6 +362,11 @@ async def health_check():
     from config.settings import settings
 
     checks = {
+        # Literally "is ANTHROPIC_API_KEY set" (#697's acceptance criteria),
+        # not "is an LLM available" — an install running fully on
+        # LIFEOS_LLM_BACKEND=local with no Anthropic key at all is a
+        # supported configuration that will still report degraded here,
+        # since this field only ever meant the Anthropic key specifically.
         "api_key_configured": bool(settings.anthropic_api_key and settings.anthropic_api_key.strip()),
         "reminder_scheduler": _reminder_scheduler.is_alive() if _reminder_scheduler else False,
     }

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -194,8 +194,13 @@ class TestHealthCheck:
         except httpx.ConnectError:
             pytest.skip("Server not running")
 
-    def test_health_returns_degraded_without_llm_url(self):
-        """Health should return degraded status if local LLM URL missing."""
+    def test_health_returns_degraded_without_api_key(self):
+        """Health should return degraded status if the Anthropic API key is missing.
+
+        `api_key_configured` reflects whether ANTHROPIC_API_KEY is actually
+        set (#697) — it used to check `local_llm_url`, which has a
+        non-empty default and so could never report false.
+        """
         # This is a unit test of the health logic
         from fastapi.testclient import TestClient
         from unittest.mock import patch, MagicMock
@@ -203,9 +208,9 @@ class TestHealthCheck:
         from api.main import app
         client = TestClient(app)
 
-        # Mock settings to have no LLM URL
+        # Mock settings to have no Anthropic API key
         mock_settings = MagicMock()
-        mock_settings.local_llm_url = ""
+        mock_settings.anthropic_api_key = ""
 
         with patch('config.settings.settings', mock_settings):
             response = client.get("/health")

--- a/tests/test_full_health_check.py
+++ b/tests/test_full_health_check.py
@@ -1,0 +1,148 @@
+"""Unit tests for the health-honesty fixes in `GET /health` and `GET /health/full`
+(api/main.py, #697): `api_key_configured` must reflect the Anthropic API key
+rather than the local-LLM URL (which has a non-empty default regardless of
+configuration), and the `local_llm` / `gmail_search` rows in `/health/full`
+must not report "ok" for a service that is neither running nor in use.
+
+`full_health_check()` also probes several other live endpoints (vault
+search, calendar, drive, ...) via real HTTP calls to `settings.port` — that
+behavior predates this file (see `test_health_full_includes_the_model_readout`
+in tests/test_model_readout.py) and is unaffected by these changes; those
+calls simply fail closed (caught, reported as an "error" row) when nothing
+is listening, which is fine for the fields under test here.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+
+def test_health_api_key_configured_true_with_key():
+    from unittest.mock import patch
+    from api.main import app
+
+    mock_settings = MagicMock()
+    mock_settings.anthropic_api_key = "sk-ant-fake-value"
+    mock_settings.local_llm_url = ""  # must no longer influence this field
+
+    client = TestClient(app)
+    with patch("config.settings.settings", mock_settings):
+        response = client.get("/health")
+    data = response.json()
+    assert data["checks"]["api_key_configured"] is True
+
+
+def test_health_api_key_configured_false_without_key():
+    from unittest.mock import patch
+    from api.main import app
+
+    mock_settings = MagicMock()
+    mock_settings.anthropic_api_key = ""
+    # A non-empty local_llm_url (the actual default) must not make this
+    # field true — that was exactly the #697 bug.
+    mock_settings.local_llm_url = "http://localhost:8080"
+
+    client = TestClient(app)
+    with patch("config.settings.settings", mock_settings):
+        response = client.get("/health")
+    data = response.json()
+    assert data["checks"]["api_key_configured"] is False
+    assert data["status"] == "degraded"
+
+
+async def test_full_health_local_llm_not_in_use_when_backend_not_local(monkeypatch):
+    import api.main as main
+
+    monkeypatch.setattr(main.settings, "llm_backend", "anthropic")
+
+    result = await main.full_health_check()
+
+    assert result["checks"]["local_llm"]["status"] == "not_in_use"
+    # Not-in-use must not count as a failure for the overall summary.
+    assert "local_llm" not in [
+        k for k, v in result["checks"].items() if v["status"] == "error"
+    ]
+
+
+async def test_full_health_local_llm_probes_reachability_when_backend_local(monkeypatch):
+    import api.main as main
+
+    monkeypatch.setattr(main.settings, "llm_backend", "local")
+    monkeypatch.setattr(main.settings, "local_llm_url", "http://stub-local-llm")
+
+    async def _reachable(self):
+        return True
+
+    monkeypatch.setattr(
+        "api.services.llm_client.LocalLLMClient.ais_available", _reachable
+    )
+
+    result = await main.full_health_check()
+
+    assert result["checks"]["local_llm"]["status"] == "ok"
+
+
+async def test_full_health_local_llm_reports_error_when_unreachable(monkeypatch):
+    import api.main as main
+
+    monkeypatch.setattr(main.settings, "llm_backend", "local")
+    monkeypatch.setattr(main.settings, "local_llm_url", "http://stub-local-llm")
+
+    async def _unreachable(self):
+        return False
+
+    monkeypatch.setattr(
+        "api.services.llm_client.LocalLLMClient.ais_available", _unreachable
+    )
+
+    result = await main.full_health_check()
+
+    assert result["checks"]["local_llm"]["status"] == "error"
+    assert "local_llm" in [
+        k for k, v in result["checks"].items() if v["status"] == "error"
+    ]
+
+
+async def test_full_health_gmail_search_reports_not_configured_shape(monkeypatch):
+    """No Google credentials on disk: gmail_search must report the same
+    not-configured ("error") shape as calendar/drive, not "ok, 0 emails" —
+    GmailService.search() swallows the underlying FileNotFoundError and
+    returns an empty list, which used to mask this at the endpoint level."""
+    import api.main as main
+    from api.services import google_auth
+
+    class _MissingCredsAuth:
+        credentials_path = type("P", (), {"exists": lambda self: False})()
+
+    monkeypatch.setattr(
+        google_auth, "get_google_auth", lambda account_type=None: _MissingCredsAuth()
+    )
+
+    result = await main.full_health_check()
+
+    assert result["checks"]["gmail_search"]["status"] == "error"
+
+
+async def test_full_health_gmail_search_runs_normally_when_configured(monkeypatch):
+    """With credentials present, behavior is unchanged: the real endpoint is
+    still probed (not short-circuited by the new not-configured check).
+    `full_health_check()` defines its endpoint probe as an inner closure, so
+    we can't patch it directly — assert indirectly instead: the row must not
+    be pre-filled with the not-configured shape when credentials exist."""
+    import api.main as main
+    from api.services import google_auth
+
+    class _ConfiguredAuth:
+        credentials_path = type("P", (), {"exists": lambda self: True})()
+
+    monkeypatch.setattr(
+        google_auth, "get_google_auth", lambda account_type=None: _ConfiguredAuth()
+    )
+
+    result = await main.full_health_check()
+
+    assert result["checks"]["gmail_search"]["status"] in ("ok", "error")
+    if result["checks"]["gmail_search"]["status"] == "error":
+        assert "not configured" not in result["checks"]["gmail_search"].get("error", "")


### PR DESCRIPTION
## Summary
- `/health`'s `api_key_configured` checked `local_llm_url` (non-empty default), so it could never report false even with no `ANTHROPIC_API_KEY` set. Now checks the actual key.
- `/health/full`'s `local_llm` row reported "ok" purely because the URL string was non-empty — now reports `not_in_use` when `LIFEOS_LLM_BACKEND` isn't "local", and actually probes reachability when it is.
- `gmail_search` in `/health/full` reported "ok, 0 emails" with zero Google credentials configured (the underlying `GmailService.search()` swallows the credentials error and returns an empty list), while calendar/drive correctly surfaced a 401. `gmail_search` now reports the same not-configured shape as its siblings.

No existing field is removed or renamed; a fully-configured install (Anthropic key present, or local backend + reachable server, or Google creds present) reports exactly as it does today.

Fixes #697

## Test plan
- [x] `tests/test_full_health_check.py` (new) — unit tests for all three fixes: api_key_configured true/false, local_llm not_in_use/ok/error, gmail_search not-configured/normal
- [x] `tests/test_e2e_flow.py::TestHealthCheck::test_health_returns_degraded_without_api_key` — updated to mock the Anthropic key instead of the local LLM URL (this test encoded the exact bug being fixed)
- [x] `tests/test_model_readout.py` — full suite still green (uses `full_health_check()` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw