### PR TITLE
fix(crm): family surname matching misses compound names

### DIFF
--- a/api/routes/crm_models/_utils.py
+++ b/api/routes/crm_models/_utils.py
@@ -4,9 +4,10 @@ Shared utility functions for CRM route modules.
 Contains helper functions for person lookup, category computation,
 search matching, and response conversion.
 """
+import json
 import logging
 import re
-from typing import Optional
+from pathlib import Path
 
 from api.services.person_entity import PersonEntity, get_person_entity_store
 from api.services.source_entity import SourceEntity, get_source_entity_store
@@ -31,7 +32,6 @@ MY_PERSON_ID = settings.my_person_id
 # Partner ID for relationship page (loaded from relationship_overrides.json if available)
 def _load_partner_person_id() -> str:
     """Load partner person ID from relationship overrides config."""
-    import json
     config_path = Path(__file__).parent.parent.parent.parent / "config" / "relationship_overrides.json"
     if config_path.exists():
         try:
@@ -45,8 +45,6 @@ def _load_partner_person_id() -> str:
 PARTNER_PERSON_ID = _load_partner_person_id()
 
 # Family configuration - loaded from config/family_members.json
-import json
-from pathlib import Path
 
 def _load_family_config():
     """Load family configuration from JSON file."""
@@ -64,7 +62,51 @@ def _load_family_config():
             logging.getLogger(__name__).warning(f"Failed to load family config: {e}")
     return set(), set(), set()
 
+
+def _normalize_family_name(value: str) -> str:
+    """Lowercase and remove all whitespace so equivalent spellings of the
+    same name (e.g. "Van Buren" vs "VanBuren", or differing amounts of
+    internal spacing) compare equal across data sources."""
+    return re.sub(r"\s+", "", value.lower().strip())
+
+
 FAMILY_LAST_NAMES, FAMILY_EXACT_NAMES, FAMILY_PERSON_IDS = _load_family_config()
+
+
+def _check_family_config_coverage(last_names: set, exact_names: set) -> None:
+    """Warn about any configured family last name/exact name that matches
+    zero indexed people, so a typo or spelling mismatch surfaces
+    immediately instead of requiring a manual audit."""
+    if not last_names and not exact_names:
+        return
+    try:
+        people = get_person_entity_store().get_all(include_hidden=True, include_merged=True)
+    except Exception as e:
+        logger.warning(f"Could not verify family config coverage: {e}")
+        return
+
+    all_suffixes = set()
+    all_full_names = set()
+    for person in people:
+        for candidate in (person.canonical_name, person.display_name, *person.aliases):
+            if not candidate:
+                continue
+            name_parts = candidate.lower().strip().split()
+            if not name_parts:
+                continue
+            all_full_names.add("".join(name_parts))
+            for i in range(len(name_parts)):
+                all_suffixes.add("".join(name_parts[i:]))
+
+    for name in last_names:
+        if _normalize_family_name(name) not in all_suffixes:
+            logger.warning(f"Configured family last name matched zero indexed people: {name!r}")
+    for name in exact_names:
+        if _normalize_family_name(name) not in all_full_names:
+            logger.warning(f"Configured family exact name matched zero indexed people: {name!r}")
+
+
+_check_family_config_coverage(FAMILY_LAST_NAMES, FAMILY_EXACT_NAMES)
 
 
 def get_strength_override(person_id: str) -> float | None:
@@ -78,17 +120,25 @@ def is_family_member(name: str) -> bool:
     """Check if a name matches family criteria."""
     if not name:
         return False
-    name_lower = name.lower().strip()
+    name_parts = name.lower().strip().split()
+    if not name_parts:
+        return False
 
-    # Check exact name match
-    if name_lower in FAMILY_EXACT_NAMES:
+    # Normalized on every call (rather than cached at import time) so that
+    # FAMILY_LAST_NAMES/FAMILY_EXACT_NAMES can still be reloaded or
+    # monkeypatched at runtime, as existing callers already rely on.
+    normalized_exact_names = {_normalize_family_name(n) for n in FAMILY_EXACT_NAMES}
+    normalized_last_names = {_normalize_family_name(n) for n in FAMILY_LAST_NAMES}
+
+    # Check exact name match (whitespace/case-insensitive)
+    if "".join(name_parts) in normalized_exact_names:
         return True
 
-    # Check last name match
-    name_parts = name_lower.split()
-    if name_parts:
-        last_name = name_parts[-1]
-        if last_name in FAMILY_LAST_NAMES:
+    # Check last name match against every trailing word sequence, so a
+    # compound (multi-word) configured surname matches the person's full
+    # surname rather than only the final whitespace-split token.
+    for i in range(len(name_parts)):
+        if "".join(name_parts[i:]) in normalized_last_names:
             return True
 
     return False

--- a/api/services/person_entity.py
+++ b/api/services/person_entity.py
@@ -10,6 +10,7 @@ Key changes from PersonRecord:
 """
 import json
 import logging
+import re
 import sqlite3
 import uuid
 from dataclasses import dataclass, field, asdict
@@ -1188,24 +1189,75 @@ def _load_family_config():
     return set(), set(), set()
 
 
+def _normalize_family_name(value: str) -> str:
+    """Lowercase and remove all whitespace so equivalent spellings of the
+    same name (e.g. "Van Buren" vs "VanBuren", or differing amounts of
+    internal spacing) compare equal across data sources."""
+    return re.sub(r"\s+", "", value.lower().strip())
+
+
 FAMILY_LAST_NAMES, FAMILY_EXACT_NAMES, FAMILY_PERSON_IDS = _load_family_config()
+
+
+def _check_family_config_coverage(last_names: set, exact_names: set) -> None:
+    """Warn about any configured family last name/exact name that matches
+    zero indexed people, so a typo or spelling mismatch surfaces
+    immediately instead of requiring a manual audit."""
+    if not last_names and not exact_names:
+        return
+    try:
+        people = get_person_entity_store().get_all(include_hidden=True, include_merged=True)
+    except Exception as e:
+        logger.warning(f"Could not verify family config coverage: {e}")
+        return
+
+    all_suffixes = set()
+    all_full_names = set()
+    for person in people:
+        for candidate in (person.canonical_name, person.display_name, *person.aliases):
+            if not candidate:
+                continue
+            name_parts = candidate.lower().strip().split()
+            if not name_parts:
+                continue
+            all_full_names.add("".join(name_parts))
+            for i in range(len(name_parts)):
+                all_suffixes.add("".join(name_parts[i:]))
+
+    for name in last_names:
+        if _normalize_family_name(name) not in all_suffixes:
+            logger.warning(f"Configured family last name matched zero indexed people: {name!r}")
+    for name in exact_names:
+        if _normalize_family_name(name) not in all_full_names:
+            logger.warning(f"Configured family exact name matched zero indexed people: {name!r}")
+
+
+_check_family_config_coverage(FAMILY_LAST_NAMES, FAMILY_EXACT_NAMES)
 
 
 def _is_family_member(name: str) -> bool:
     """Check if a name matches family criteria."""
     if not name:
         return False
-    name_lower = name.lower().strip()
+    name_parts = name.lower().strip().split()
+    if not name_parts:
+        return False
 
-    # Check exact name match
-    if name_lower in FAMILY_EXACT_NAMES:
+    # Normalized on every call (rather than cached at import time) so that
+    # FAMILY_LAST_NAMES/FAMILY_EXACT_NAMES can still be reloaded or
+    # monkeypatched at runtime, as existing callers already rely on.
+    normalized_exact_names = {_normalize_family_name(n) for n in FAMILY_EXACT_NAMES}
+    normalized_last_names = {_normalize_family_name(n) for n in FAMILY_LAST_NAMES}
+
+    # Check exact name match (whitespace/case-insensitive)
+    if "".join(name_parts) in normalized_exact_names:
         return True
 
-    # Check last name match
-    name_parts = name_lower.split()
-    if name_parts:
-        last_name = name_parts[-1]
-        if last_name in FAMILY_LAST_NAMES:
+    # Check last name match against every trailing word sequence, so a
+    # compound (multi-word) configured surname matches the person's full
+    # surname rather than only the final whitespace-split token.
+    for i in range(len(name_parts)):
+        if "".join(name_parts[i:]) in normalized_last_names:
             return True
 
     return False

--- a/tests/test_family_matching.py
+++ b/tests/test_family_matching.py
@@ -1,0 +1,169 @@
+"""
+Tests for family-name matching (#765): compound surnames, whitespace/case
+normalization, and warning on configured names that match zero people.
+
+Family matching has two parallel implementations that must stay in sync:
+- api.routes.crm_models._utils.is_family_member
+- api.services.person_entity._is_family_member
+
+Both read module-level FAMILY_LAST_NAMES/FAMILY_EXACT_NAMES sets, which
+existing callers (e.g. tests/test_create_contact_persons.py) monkeypatch
+directly -- so these tests do the same rather than touching real config
+files.
+"""
+import pytest
+
+import api.routes.crm_models._utils as utils_mod
+import api.services.person_entity as person_entity_mod
+from api.services.person_entity import PersonEntity, PersonEntityStore
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# is_family_member (api/routes/crm_models/_utils.py)
+# ---------------------------------------------------------------------------
+
+class TestIsFamilyMemberUtils:
+    def test_existing_single_word_surname_still_matches(self, monkeypatch):
+        """Behavior that already worked must be unchanged."""
+        monkeypatch.setattr(utils_mod, "FAMILY_LAST_NAMES", {"smith"})
+        monkeypatch.setattr(utils_mod, "FAMILY_EXACT_NAMES", set())
+
+        assert utils_mod.is_family_member("John Smith") is True
+        assert utils_mod.is_family_member("Jane Doe") is False
+
+    def test_existing_exact_name_still_matches(self, monkeypatch):
+        monkeypatch.setattr(utils_mod, "FAMILY_LAST_NAMES", set())
+        monkeypatch.setattr(utils_mod, "FAMILY_EXACT_NAMES", {"uncle bob"})
+
+        assert utils_mod.is_family_member("Uncle Bob") is True
+        assert utils_mod.is_family_member("uncle bob") is True
+
+    def test_compound_surname_matches_regardless_of_internal_spacing(self, monkeypatch):
+        """A compound configured surname must match a person whose full
+        surname is that same compound name, not just its last word --
+        and must match it whether the person's name has the internal
+        space or not (e.g. contacts vs a messaging app)."""
+        monkeypatch.setattr(utils_mod, "FAMILY_LAST_NAMES", {"van buren"})
+        monkeypatch.setattr(utils_mod, "FAMILY_EXACT_NAMES", set())
+
+        # Old behavior only ever checked the last whitespace-split token
+        # ("buren"), so neither of these could ever match before this fix.
+        assert utils_mod.is_family_member("Alice Van Buren") is True
+        assert utils_mod.is_family_member("Alice VanBuren") is True
+
+        # A name that only shares the trailing word must not match.
+        assert utils_mod.is_family_member("Alice Buren") is False
+
+    def test_compound_configured_surname_with_differing_case(self, monkeypatch):
+        monkeypatch.setattr(utils_mod, "FAMILY_LAST_NAMES", {"Van Buren"})
+        monkeypatch.setattr(utils_mod, "FAMILY_EXACT_NAMES", set())
+
+        assert utils_mod.is_family_member("alice VANBUREN") is True
+
+    def test_exact_name_matches_regardless_of_internal_spacing(self, monkeypatch):
+        monkeypatch.setattr(utils_mod, "FAMILY_LAST_NAMES", set())
+        monkeypatch.setattr(utils_mod, "FAMILY_EXACT_NAMES", {"mary jane"})
+
+        assert utils_mod.is_family_member("MaryJane") is True
+        assert utils_mod.is_family_member("Mary  Jane") is True
+
+    def test_empty_and_none_name(self, monkeypatch):
+        monkeypatch.setattr(utils_mod, "FAMILY_LAST_NAMES", {"smith"})
+        monkeypatch.setattr(utils_mod, "FAMILY_EXACT_NAMES", set())
+
+        assert utils_mod.is_family_member("") is False
+        assert utils_mod.is_family_member("   ") is False
+
+
+# ---------------------------------------------------------------------------
+# _is_family_member (api/services/person_entity.py) -- must mirror the above
+# ---------------------------------------------------------------------------
+
+class TestIsFamilyMemberPersonEntity:
+    def test_existing_single_word_surname_still_matches(self, monkeypatch):
+        monkeypatch.setattr(person_entity_mod, "FAMILY_LAST_NAMES", {"smith"})
+        monkeypatch.setattr(person_entity_mod, "FAMILY_EXACT_NAMES", set())
+
+        assert person_entity_mod._is_family_member("John Smith") is True
+        assert person_entity_mod._is_family_member("Jane Doe") is False
+
+    def test_existing_exact_name_still_matches(self, monkeypatch):
+        monkeypatch.setattr(person_entity_mod, "FAMILY_LAST_NAMES", set())
+        monkeypatch.setattr(person_entity_mod, "FAMILY_EXACT_NAMES", {"uncle bob"})
+
+        assert person_entity_mod._is_family_member("Uncle Bob") is True
+
+    def test_compound_surname_matches_regardless_of_internal_spacing(self, monkeypatch):
+        monkeypatch.setattr(person_entity_mod, "FAMILY_LAST_NAMES", {"van buren"})
+        monkeypatch.setattr(person_entity_mod, "FAMILY_EXACT_NAMES", set())
+
+        assert person_entity_mod._is_family_member("Alice Van Buren") is True
+        assert person_entity_mod._is_family_member("Alice VanBuren") is True
+        assert person_entity_mod._is_family_member("Alice Buren") is False
+
+    def test_exact_name_matches_regardless_of_internal_spacing(self, monkeypatch):
+        monkeypatch.setattr(person_entity_mod, "FAMILY_LAST_NAMES", set())
+        monkeypatch.setattr(person_entity_mod, "FAMILY_EXACT_NAMES", {"mary jane"})
+
+        assert person_entity_mod._is_family_member("MaryJane") is True
+        assert person_entity_mod._is_family_member("Mary  Jane") is True
+
+
+# ---------------------------------------------------------------------------
+# _check_family_config_coverage -- warn on configured names matching no one
+# ---------------------------------------------------------------------------
+
+class TestCheckFamilyConfigCoverage:
+    def _make_store(self, tmp_path, names):
+        store = PersonEntityStore(str(tmp_path / "crm.db"))
+        for name in names:
+            store.add(PersonEntity(canonical_name=name))
+        return store
+
+    def test_warns_on_unmatched_configured_names(self, tmp_path, monkeypatch, caplog):
+        store = self._make_store(tmp_path, ["Alice Smith"])
+        monkeypatch.setattr(utils_mod, "get_person_entity_store", lambda: store)
+
+        with caplog.at_level("WARNING"):
+            utils_mod._check_family_config_coverage({"smith", "nomatchsurname"}, {"nomatchexact"})
+
+        messages = [r.message for r in caplog.records]
+        assert any("nomatchsurname" in m for m in messages)
+        assert any("nomatchexact" in m for m in messages)
+        assert not any("'smith'" in m for m in messages)
+
+    def test_no_warning_when_all_configured_names_match(self, tmp_path, monkeypatch, caplog):
+        store = self._make_store(tmp_path, ["Alice Van Buren"])
+        monkeypatch.setattr(utils_mod, "get_person_entity_store", lambda: store)
+
+        with caplog.at_level("WARNING"):
+            utils_mod._check_family_config_coverage({"van buren"}, set())
+
+        messages = [r.message for r in caplog.records]
+        assert not any("matched zero indexed people" in m for m in messages)
+
+    def test_no_op_when_no_family_names_configured(self, monkeypatch, caplog):
+        """Must not touch the entity store at all when nothing is configured
+        -- this keeps module import side-effect-free for fresh installs."""
+        def _boom():
+            raise AssertionError("should not query the entity store")
+
+        monkeypatch.setattr(utils_mod, "get_person_entity_store", _boom)
+
+        with caplog.at_level("WARNING"):
+            utils_mod._check_family_config_coverage(set(), set())
+
+        assert caplog.records == []
+
+    def test_person_entity_module_coverage_check_mirrors_utils(self, tmp_path, monkeypatch, caplog):
+        store = self._make_store(tmp_path, ["Alice Van Buren"])
+        monkeypatch.setattr(person_entity_mod, "get_person_entity_store", lambda: store)
+
+        with caplog.at_level("WARNING"):
+            person_entity_mod._check_family_config_coverage({"van buren", "missingname"}, set())
+
+        messages = [r.message for r in caplog.records]
+        assert any("missingname" in m for m in messages)
+        assert not any("'van buren'" in m for m in messages)


### PR DESCRIPTION
## Summary
- Family matching (`is_family_member` / `_is_family_member`) only ever compared a person's final whitespace-split token against the configured family last names, so a compound surname (e.g. "Van Buren") could never match, and the same compound surname spelled with vs. without an internal space across data sources produced two different tokens.
- Fixed identically in both duplicate implementations: `api/routes/crm_models/_utils.py` (`is_family_member`) and `api/services/person_entity.py` (`_is_family_member`). Merging the duplicates is explicitly out of scope per the issue.
- Normalizes whitespace/case on both sides of the comparison and checks every trailing word-sequence of the name (not just the last word), so compound configured surnames match regardless of spacing differences between sources. This is strictly additive — every name that matched before still matches (see test coverage below and Codex review).
- Adds a warning log when a configured family last/exact name matches zero indexed people, so a typo surfaces immediately. It's a no-op (never touches the entity store) when no family names are configured, so it has zero effect on fresh installs or CI.
- Along the way, fixes a latent `NameError` in `crm_models/_utils.py` (`pathlib.Path` used before being imported) that made the module fail to import whenever anything actually imported it. `api.routes.crm_models` is currently dead code (nothing else in the app imports it), which is why this had gone unnoticed — but it blocked writing/running the new unit tests for `is_family_member`, so it needed fixing to deliver this PR's test coverage.

## Test plan
- [x] New `tests/test_family_matching.py`: compound surnames matching regardless of internal spacing (with vs. without space, mixed case), existing single-word-surname and exact-name behavior unchanged, empty/blank name handling, and the zero-match warning (including the no-op-when-unconfigured case).
- [x] Existing `tests/test_create_contact_persons.py::TestCategorizationReachable` (which monkeypatches `FAMILY_LAST_NAMES` directly) still passes — confirms the normalization is computed live rather than cached, so existing monkeypatch-based tests keep working.
- [x] Ran unit suite: `test_family_matching.py`, `test_create_contact_persons.py`, `test_person_entity.py`, `test_crm_data_integrity.py`, `test_merge_people.py`, `test_split_person.py`, `test_person_stats.py`, `test_relationship_metrics.py` — 121 passed.

Fixes #765

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw