### PR TITLE
fix(health): vault_search reports degraded against a vanished vault; document the agent session-store schema (#762, #791)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -445,6 +445,43 @@ async def health_raw_state(clear: bool = False):
     }
 
 
+def _check_vault_root_sanity(vault_search_check: "dict | None", vault_path) -> None:
+    """Additive sanity check for the `vault_search` row in `GET /health/full`
+    (#762). Sample a handful of indexed file paths and confirm they still
+    fall under the currently configured vault root, catching a moved/deleted
+    vault whose index keeps serving stale content from the old location — a
+    drift the base request/response probe (does search return results at
+    all) can't see, since it only confirms search returns *something*.
+
+    Mutates `vault_search_check` in place, downgrading an "ok" status to
+    "degraded" with an explanatory detail on mismatch. A no-op if the base
+    check isn't present or didn't itself report "ok" — this never turns a
+    failing check into a passing one, or vice versa, only adds a further
+    downgrade on top of an already-passing result.
+    """
+    if not vault_search_check or vault_search_check.get("status") != "ok":
+        return
+    try:
+        from api.services.vectorstore import get_vector_store, sample_paths_match_vault_root
+        sample = get_vector_store().sample_file_paths(limit=5)
+        all_match, mismatched = sample_paths_match_vault_root(sample, vault_path)
+        if not all_match:
+            vault_search_check["status"] = "degraded"
+            # Deliberately omit the mismatched paths themselves — this is an
+            # unauthenticated endpoint and a real indexed file path can
+            # reveal personal folder/file names (#697 review). The counts
+            # plus the configured root are enough for an operator to act on.
+            vault_search_check["detail"] = (
+                f"{len(mismatched)}/{len(sample)} sampled indexed path(s) fall outside "
+                f"the configured vault root ({vault_path.resolve()})"
+            )
+    except Exception as e:
+        # Never let this additive sanity check take down the primary
+        # vault_search result — a vector-store hiccup here is already
+        # visible via the chromadb_server check above.
+        logger.warning(f"vault-root sanity check failed: {e}")
+
+
 @app.get("/health/full")
 async def full_health_check():
     """
@@ -606,6 +643,13 @@ async def full_health_check():
         "POST", "/api/search",
         json_body={"query": "test", "top_k": 1}
     )
+
+    # 3b. Vault-root sanity check (#762) — the request/response check above
+    # only confirms search returns *something*, not that what it returns
+    # still lives where the vault is currently configured. A moved/deleted
+    # vault can leave the index serving stale content from the old location
+    # while that check keeps passing.
+    _check_vault_root_sanity(results["checks"].get("vault_search"), settings.vault_path)
 
     # 3. Calendar Upcoming (GET /api/calendar/upcoming)
     await test_endpoint(

--- a/api/main.py
+++ b/api/main.py
@@ -454,7 +454,10 @@ def _check_vault_root_sanity(vault_search_check: "dict | None", vault_path) -> N
     all) can't see, since it only confirms search returns *something*.
 
     Mutates `vault_search_check` in place, downgrading an "ok" status to
-    "degraded" with an explanatory detail on mismatch. A no-op if the base
+    "degraded" and adding a `vault_root_check` field explaining the mismatch
+    — the existing `detail` from the request/response probe (e.g. "1
+    results") is left untouched, since that check is preserved unchanged
+    and this is an additional signal, not a replacement. A no-op if the base
     check isn't present or didn't itself report "ok" — this never turns a
     failing check into a passing one, or vice versa, only adds a further
     downgrade on top of an already-passing result.
@@ -471,7 +474,7 @@ def _check_vault_root_sanity(vault_search_check: "dict | None", vault_path) -> N
             # unauthenticated endpoint and a real indexed file path can
             # reveal personal folder/file names (#697 review). The counts
             # plus the configured root are enough for an operator to act on.
-            vault_search_check["detail"] = (
+            vault_search_check["vault_root_check"] = (
                 f"{len(mismatched)}/{len(sample)} sampled indexed path(s) fall outside "
                 f"the configured vault root ({vault_path.resolve()})"
             )

--- a/api/main.py
+++ b/api/main.py
@@ -470,13 +470,15 @@ def _check_vault_root_sanity(vault_search_check: "dict | None", vault_path) -> N
         all_match, mismatched = sample_paths_match_vault_root(sample, vault_path)
         if not all_match:
             vault_search_check["status"] = "degraded"
-            # Deliberately omit the mismatched paths themselves — this is an
-            # unauthenticated endpoint and a real indexed file path can
-            # reveal personal folder/file names (#697 review). The counts
-            # plus the configured root are enough for an operator to act on.
+            # Deliberately omit the mismatched paths and the configured root
+            # itself — this is an unauthenticated endpoint, a real indexed
+            # file path can reveal personal folder/file names, and the vault
+            # root is typically an absolute path under the user's home
+            # directory (#697 review). The counts alone are enough for an
+            # operator to act on.
             vault_search_check["vault_root_check"] = (
                 f"{len(mismatched)}/{len(sample)} sampled indexed path(s) fall outside "
-                f"the configured vault root ({vault_path.resolve()})"
+                "the configured vault root"
             )
     except Exception as e:
         # Never let this additive sanity check take down the primary

--- a/api/services/vectorstore.py
+++ b/api/services/vectorstore.py
@@ -317,16 +317,33 @@ class VectorStore:
         return paths
 
     def sample_file_paths(self, limit: int = 5) -> list[str]:
-        """Return up to `limit` indexed file paths, without scanning the
-        whole collection (#762). Used by the vault_search health check's
-        vault-root sanity check — `get_all_file_paths()` above is the right
-        tool when every path is actually needed, but is too expensive to
-        call on every health-check request against a large vault."""
-        results = self._collection.get(limit=limit, include=["metadatas"])
+        """Return up to `limit` distinct indexed file paths, without
+        scanning the whole collection (#762). Used by the vault_search
+        health check's vault-root sanity check — `get_all_file_paths()`
+        above is the right tool when every path is actually needed, but is
+        too expensive to call on every health-check request against a large
+        vault.
+
+        Each file is indexed as several chunks (one row per chunk, all
+        sharing one `file_path`), so a raw `limit`-sized fetch risks
+        returning the same one or two files repeatedly. Over-fetch a bit
+        and dedupe to `file_path` so the sample actually spans up to
+        `limit` distinct files — still a small, bounded read regardless of
+        collection size, not a scan.
+        """
+        results = self._collection.get(limit=limit * 4, include=["metadatas"])
         paths = []
+        seen = set()
         for meta in results.get("metadatas") or []:
-            if meta and "file_path" in meta:
-                paths.append(meta["file_path"])
+            if not meta or "file_path" not in meta:
+                continue
+            path = meta["file_path"]
+            if path in seen:
+                continue
+            seen.add(path)
+            paths.append(path)
+            if len(paths) >= limit:
+                break
         return paths
 
 

--- a/api/services/vectorstore.py
+++ b/api/services/vectorstore.py
@@ -6,15 +6,13 @@ Connects to ChromaDB server via HTTP for thread-safe concurrent access.
 NOTE: Heavy dependencies (chromadb, embeddings) are imported lazily
 to speed up pytest collection for unit tests.
 """
-from typing import Optional, Any, TYPE_CHECKING
+from typing import Optional
 from datetime import datetime
+from pathlib import Path
 import json
 import math
 
 from config.settings import settings
-
-if TYPE_CHECKING:
-    import chromadb
 
 
 class VectorStore:
@@ -317,6 +315,47 @@ class VectorStore:
                 if meta and "file_path" in meta:
                     paths.add(meta["file_path"])
         return paths
+
+    def sample_file_paths(self, limit: int = 5) -> list[str]:
+        """Return up to `limit` indexed file paths, without scanning the
+        whole collection (#762). Used by the vault_search health check's
+        vault-root sanity check — `get_all_file_paths()` above is the right
+        tool when every path is actually needed, but is too expensive to
+        call on every health-check request against a large vault."""
+        results = self._collection.get(limit=limit, include=["metadatas"])
+        paths = []
+        for meta in results.get("metadatas") or []:
+            if meta and "file_path" in meta:
+                paths.append(meta["file_path"])
+        return paths
+
+
+def sample_paths_match_vault_root(
+    paths: "list[str] | set[str]", vault_root: Path
+) -> "tuple[bool, list[str]]":
+    """Classify a sample of indexed file paths against the configured vault
+    root (#762). `file_path` metadata is always stored as `str(path.resolve())`
+    (see indexer.py), so a resolved-prefix check is sufficient — no need to
+    touch the filesystem for paths that no longer exist (`Path.is_relative_to`
+    does no I/O; only `vault_root.resolve()` below might, and that's on the
+    live configured root, not on the — possibly vanished — indexed paths).
+
+    Returns `(all_match, mismatched_paths)`. An empty `paths` sample trivially
+    matches (nothing to contradict "healthy") — the caller is responsible for
+    deciding whether an empty sample itself is worth reporting.
+    """
+    root = vault_root.resolve()
+    mismatched = []
+    for p in paths:
+        try:
+            if not Path(p).is_relative_to(root):
+                mismatched.append(p)
+        except (TypeError, ValueError):
+            # Not a usable path string at all — treat as a mismatch rather
+            # than silently skipping it, since that's exactly the kind of
+            # drift this check exists to surface.
+            mismatched.append(p)
+    return (not mismatched, mismatched)
 
 
 # Singleton instance

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -12,20 +12,21 @@ Engineering view of the agent worker — the stand-alone process that consumes `
 
 1. [Architecture overview](#architecture-overview)
 2. [Component layout](#component-layout)
-3. [Lifecycle of a task](#lifecycle-of-a-task)
-4. [Session state machine](#session-state-machine)
-5. [Preflight](#preflight)
-6. [Local executor (Gemma path)](#local-executor-gemma-path)
-7. [Managed executor (Claude path)](#managed-executor-claude-path)
-8. [System prompts](#system-prompts)
-9. [Inter-agent coordination](#inter-agent-coordination)
-10. [Budget enforcement](#budget-enforcement)
-11. [Restart resumability](#restart-resumability)
-12. [Telegram clarification flow](#telegram-clarification-flow)
-13. [Transcripts](#transcripts)
-14. [Agent Output notes](#agent-output-notes)
-15. [Configuration surface](#configuration-surface)
-16. [Related Documents](#related-documents)
+3. [Session store schema](#session-store-schema)
+4. [Lifecycle of a task](#lifecycle-of-a-task)
+5. [Session state machine](#session-state-machine)
+6. [Preflight](#preflight)
+7. [Local executor (Gemma path)](#local-executor-gemma-path)
+8. [Managed executor (Claude path)](#managed-executor-claude-path)
+9. [System prompts](#system-prompts)
+10. [Inter-agent coordination](#inter-agent-coordination)
+11. [Budget enforcement](#budget-enforcement)
+12. [Restart resumability](#restart-resumability)
+13. [Telegram clarification flow](#telegram-clarification-flow)
+14. [Transcripts](#transcripts)
+15. [Agent Output notes](#agent-output-notes)
+16. [Configuration surface](#configuration-surface)
+17. [Related Documents](#related-documents)
 
 ---
 
@@ -85,6 +86,114 @@ External boundaries:
 - **HTTP**: `/api/tasks` for task CRUD, `/api/tasks/{id}/swap-tag` for atomic tag transitions, the Telegram Bot API for notifications.
 - **LLM**: `https://api.anthropic.com/v1` for Haiku preflight + Managed Agents API; `http://localhost:8080` (llama-server) for local execution.
 - **MCP**: `https://<host>/mcp` for the LifeOS MCP HTTP transport (used by Managed Agents and other remote MCP clients), and stdio MCP for local Claude Code.
+
+---
+
+## Session store schema
+
+`session_store.py` creates seven tables (SQLite, `data/agent_sessions.db` by default). The schema is deliberately permissive — new columns and tables have been added issue-by-issue rather than designed up front — so this list is read directly off the table-creation code (`_SCHEMA` in `session_store.py`) rather than written from memory; re-check the source if it looks stale.
+
+### `sessions`
+
+One row per agent session (1:1 with a claimed task, or a root-spawned operator session — see `origin` below). `task_id` is the primary key, **not** `session_id` — the two are related but distinct ids.
+
+| Column | Meaning |
+|---|---|
+| `task_id` (PK) | The `#agent` task this session was claimed from (or a synthetic id for operator sessions). |
+| `session_id` (UNIQUE) | Internal session identifier used for inter-agent addressing, transcripts, etc. |
+| `status` | One of `claimed`, `running`, `yielded`, `completed`, `failed`, `budget_exceeded`, `blocked`. |
+| `routing` | `local`, `claude`, `claude_code`, `codex`, or `ask` — which executor runs the session. |
+| `budget_json` | JSON-encoded budget (dollars / wall-clock / tokens) set at preflight. |
+| `started_at`, `last_activity_at` | Unix epoch seconds. |
+| `total_input_tokens`, `total_output_tokens` | Accumulated token counts. |
+| `total_cache_creation_tokens`, `total_cache_read_tokens` | Prompt-cache token buckets, tracked separately because they're billed at different rates than plain input tokens. |
+| `total_dollars` | **The accumulated-spend column.** Not `spend`, not `cost` — `total_dollars`. |
+| `total_active_seconds` | Accumulated active compute time. |
+| `expected_output` | `text`, `file`, `external_action`, or `structured`, set at preflight. |
+| `parent_session_id`, `root_session_id`, `spawn_depth` | Inter-agent lineage for spawned sessions. |
+| `yield_waiting_for` | JSON array of `session_id`s this session is yielded waiting on. |
+| `managed_agent_session_id` | Anthropic Managed Agents session id, for `routing="claude"` sessions. |
+| `preset_class` | Tool-filtering preset applied to a Managed Agents session at start. |
+| `origin` | NULL or `"agent"` = claimed from an `#agent` task; `"operator"` = root-spawned on demand with no backing task (#235). |
+| `claude_code_session_id` | Claude Code (or Codex) CLI session/thread id, for `routing="claude_code"`/`"codex"` — the column is reused for both; `routing` disambiguates which CLI it belongs to. |
+| `claude_code_model` | Claude tier for `routing="claude_code"` (`haiku`/`sonnet`/`opus`); NULL falls back to the CLI's own default (`opus`). |
+| `bot` | Telegram bot that owns this session's notices; NULL = primary bot (#348). |
+| `unpriced` | Sticky flag: set once any turn was priced against a model `pricing.py` doesn't recognize, so a reader can tell "$0.00 total" apart from "some turns couldn't be priced" (#669). |
+
+Indexed on `status`, `parent_session_id`, `root_session_id`, and (partial index) `status = 'yielded'`.
+
+### `pending_messages`
+
+Inter-agent messages queued for delivery to a peer/child/parent session — written by `lifeos_agent_send` for sessions that aren't actively running, and injected on resume for yielded sessions.
+
+| Column | Meaning |
+|---|---|
+| `id` (PK, autoincrement) | Row id. |
+| `session_id` | Recipient session. |
+| `sender_id` | Sending session's id. |
+| `content` | Message body. |
+| `created_at` | Unix epoch seconds. |
+| `delivered` | 0/1 — whether the recipient has consumed it. |
+
+### `pending_questions`
+
+Open clarification questions sent to the operator via Telegram, and completion-message follow-ups (an operator reply to a finished task's Telegram message that continues the thread). `kind` distinguishes the two: `"clarification"` blocks the session until answered; `"followup"` reopens an already-`completed` session and appends the reply as a new turn.
+
+| Column | Meaning |
+|---|---|
+| `id` (PK, autoincrement) | Row id. |
+| `session_id`, `task_id` | The session and task this question belongs to. |
+| `question` | Question text sent to the operator. |
+| `sent_message_id` | Telegram message id the answer is matched against. |
+| `sent_at` | Unix epoch seconds. |
+| `answer`, `answered_at` | Populated once the operator replies. |
+| `processed` | 0/1 — whether the worker has resumed the session on this answer. |
+| `timed_out` | 0/1 — set if the clarification aged out (default 72h) before an answer arrived. |
+| `kind` | `"clarification"` or `"followup"` (default `"clarification"`). |
+| `sent_message_ids` | JSON array of every Telegram chunk id for this notification (a long completion splits across multiple messages); NULL for legacy rows, which still match via `sent_message_id` alone. |
+| `bot` | Telegram bot that sent this question; NULL = primary. Scopes reply-matching so a doctor-bot reply can't collide with a primary-bot question sharing the same numeric message id (#348). |
+
+### `daily_spend`
+
+The daily $-cap ledger `spend_tracker.py` reads and increments.
+
+| Column | Meaning |
+|---|---|
+| `date` (PK) | Calendar date, as text. |
+| `total_dollars` | Total spend booked against that date. |
+
+### `messages`
+
+Conversation log for local-path (`routing="local"`) sessions only — Managed Agents sessions store their conversation in the JSONL transcript instead, since their authoritative state lives on the Anthropic side.
+
+| Column | Meaning |
+|---|---|
+| `session_id`, `turn_index` (composite PK) | Session and 0-based turn position. |
+| `role` | Turn role (e.g. `user`, `assistant`, `tool`). |
+| `content_json` | JSON-encoded turn content. |
+| `tokens_in`, `tokens_out` | Per-turn token counts. |
+| `created_at` | Unix epoch seconds. |
+
+### `sleeps`
+
+A session with a row here is yielded on a timer — the worker's main loop scans this table and resumes the session once `wake_at` has passed.
+
+| Column | Meaning |
+|---|---|
+| `session_id` (PK) | The yielded session. |
+| `wake_at` | Unix epoch seconds the session should resume at. |
+
+### `managed_cursor`
+
+Polling bookkeeping for Managed Agents sessions, one row per `task_id`.
+
+| Column | Meaning |
+|---|---|
+| `task_id` (PK) | The task this cursor belongs to. |
+| `last_event_id` | Last Managed Agents event id ingested, so polling resumes without re-processing. |
+| `accrued_session_hour_dollars` | Cumulative session-hour overhead already booked into the session's `total_dollars`. |
+| `final_text` | Most recent `agent.message` text seen across polls — cached because the final message and the terminal `session.status_idle` event can land on different polls, and a Telegram completion summary would otherwise have no text to show. |
+| `tool_loop_signature`, `tool_loop_count`, `tool_calls_since_message` | Runaway-loop detection counters (#139 §5), persisted so cross-poll signals survive worker restarts mid-session. |
 
 ---
 

--- a/tests/test_vault_root_check.py
+++ b/tests/test_vault_root_check.py
@@ -1,0 +1,180 @@
+"""Tests for the vault-root sanity check added to `vault_search` in
+`GET /health/full` (#762): the existing request/response probe only
+confirms search returns *something* — it can't tell a moved/deleted vault
+whose index still holds entries from the old location, because search keeps
+"working" against stale content. These tests cover the pure comparison
+logic (`sample_paths_match_vault_root`) directly, plus a wiring check that
+`full_health_check()` downgrades an already-passing `vault_search` row to
+"degraded" when a sample of indexed paths falls outside the configured
+vault root.
+"""
+import pytest
+
+from api.services.vectorstore import sample_paths_match_vault_root
+
+pytestmark = pytest.mark.unit
+
+
+class TestSamplePathsMatchVaultRoot:
+    def test_all_paths_under_root_match(self, tmp_path):
+        root = tmp_path / "vault"
+        root.mkdir()
+        paths = [str(root / "notes" / "a.md"), str(root / "b.md")]
+
+        all_match, mismatched = sample_paths_match_vault_root(paths, root)
+
+        assert all_match is True
+        assert mismatched == []
+
+    def test_path_outside_root_is_a_mismatch(self, tmp_path):
+        root = tmp_path / "vault"
+        root.mkdir()
+        old_location = tmp_path / "old_vault"
+        paths = [str(root / "a.md"), str(old_location / "b.md")]
+
+        all_match, mismatched = sample_paths_match_vault_root(paths, root)
+
+        assert all_match is False
+        assert mismatched == [str(old_location / "b.md")]
+
+    def test_empty_sample_trivially_matches(self, tmp_path):
+        root = tmp_path / "vault"
+        root.mkdir()
+
+        all_match, mismatched = sample_paths_match_vault_root([], root)
+
+        assert all_match is True
+        assert mismatched == []
+
+    def test_sibling_directory_with_shared_prefix_is_not_a_false_match(self, tmp_path):
+        """A naive string-prefix check (`str(p).startswith(str(root))`) would
+        wrongly treat /vault2/x.md as under /vault — is_relative_to must not
+        make that mistake."""
+        root = tmp_path / "vault"
+        root.mkdir()
+        sibling = tmp_path / "vault2"
+        paths = [str(sibling / "x.md")]
+
+        all_match, mismatched = sample_paths_match_vault_root(paths, root)
+
+        assert all_match is False
+        assert mismatched == [str(sibling / "x.md")]
+
+    def test_malformed_path_is_reported_not_silently_dropped(self, tmp_path):
+        root = tmp_path / "vault"
+        root.mkdir()
+
+        all_match, mismatched = sample_paths_match_vault_root([None], root)
+
+        assert all_match is False
+        assert mismatched == [None]
+
+
+class TestCheckVaultRootSanity:
+    """Direct tests of `_check_vault_root_sanity` (api/main.py), the helper
+    `full_health_check()` calls after the existing vault_search
+    request/response probe. Exercised in isolation — with a synthetic
+    `checks["vault_search"]` dict and a stubbed vector store — so these don't
+    depend on a live ChromaDB or a running LifeOS server."""
+
+    def test_downgrades_ok_to_degraded_on_mismatch(self, monkeypatch, tmp_path):
+        import api.main as main
+        from api.services import vectorstore as vs
+
+        old_location = tmp_path / "old_vault_location"
+
+        class _StubStore:
+            def sample_file_paths(self, limit=5):
+                return [str(old_location / "note.md")]
+
+        monkeypatch.setattr(vs, "get_vector_store", lambda: _StubStore())
+
+        check = {"status": "ok", "latency_ms": 5, "detail": "1 results"}
+        main._check_vault_root_sanity(check, tmp_path / "vault")
+
+        assert check["status"] == "degraded"
+        assert "1/1" in check["detail"]
+        # The mismatched path itself must never appear in the response —
+        # /health/full is unauthenticated, and a real indexed path can
+        # reveal personal folder/file names.
+        assert "old_vault_location" not in check["detail"]
+        assert "note.md" not in check["detail"]
+
+    def test_leaves_ok_unchanged_when_paths_match(self, monkeypatch, tmp_path):
+        import api.main as main
+        from api.services import vectorstore as vs
+
+        vault_root = tmp_path / "vault"
+
+        class _StubStore:
+            def sample_file_paths(self, limit=5):
+                return [str(vault_root / "note.md")]
+
+        monkeypatch.setattr(vs, "get_vector_store", lambda: _StubStore())
+
+        check = {"status": "ok", "latency_ms": 5, "detail": "1 results"}
+        main._check_vault_root_sanity(check, vault_root)
+
+        assert check == {"status": "ok", "latency_ms": 5, "detail": "1 results"}
+
+    def test_skips_entirely_when_base_check_did_not_pass(self, monkeypatch, tmp_path):
+        """A failing (or missing) base check is left completely untouched —
+        this is an additional signal on top of a pass, not a replacement for
+        it, and must never turn a failure into a pass or vice versa."""
+        import api.main as main
+        from api.services import vectorstore as vs
+
+        called = []
+
+        def _boom():
+            called.append(True)
+            raise AssertionError("should not be reached when base check failed")
+
+        monkeypatch.setattr(vs, "get_vector_store", _boom)
+
+        check = {"status": "error", "error": "HTTP 500: boom"}
+        main._check_vault_root_sanity(check, tmp_path / "vault")
+
+        assert check == {"status": "error", "error": "HTTP 500: boom"}
+        assert called == []
+
+        main._check_vault_root_sanity(None, tmp_path / "vault")  # no-op, must not raise
+
+    def test_vector_store_error_does_not_crash_or_change_status(self, monkeypatch, tmp_path):
+        """The sanity check is additive only — if the vector store itself
+        can't be reached for this probe, the primary vault_search result
+        (already "ok" from the request/response check) is left alone rather
+        than being dragged down by a problem visible elsewhere
+        (chromadb_server)."""
+        import api.main as main
+        from api.services import vectorstore as vs
+
+        def _boom():
+            raise RuntimeError("chromadb unreachable")
+
+        monkeypatch.setattr(vs, "get_vector_store", _boom)
+
+        check = {"status": "ok", "detail": "1 results"}
+        main._check_vault_root_sanity(check, tmp_path / "vault")
+
+        assert check == {"status": "ok", "detail": "1 results"}
+
+
+async def test_full_health_check_wires_in_the_vault_root_sanity_check(monkeypatch):
+    """Wiring check: `full_health_check()` actually calls the helper on the
+    `vault_search` row it just produced (rather than the helper existing but
+    never being invoked)."""
+    import api.main as main
+
+    called_with = {}
+
+    def _spy(vault_search_check, vault_path):
+        called_with["check"] = vault_search_check
+        called_with["vault_path"] = vault_path
+
+    monkeypatch.setattr(main, "_check_vault_root_sanity", _spy)
+
+    result = await main.full_health_check()
+
+    assert called_with.get("vault_path") == main.settings.vault_path
+    assert called_with.get("check") is result["checks"].get("vault_search")

--- a/tests/test_vault_root_check.py
+++ b/tests/test_vault_root_check.py
@@ -127,6 +127,7 @@ class TestCheckVaultRootSanity:
         from api.services import vectorstore as vs
 
         old_location = tmp_path / "old_vault_location"
+        configured_root = tmp_path / "vault"
 
         class _StubStore:
             def sample_file_paths(self, limit=5):
@@ -135,18 +136,20 @@ class TestCheckVaultRootSanity:
         monkeypatch.setattr(vs, "get_vector_store", lambda: _StubStore())
 
         check = {"status": "ok", "latency_ms": 5, "detail": "1 results"}
-        main._check_vault_root_sanity(check, tmp_path / "vault")
+        main._check_vault_root_sanity(check, configured_root)
 
         assert check["status"] == "degraded"
         # The original request/response detail is preserved unchanged — the
         # mismatch is reported in a separate field, not a replacement.
         assert check["detail"] == "1 results"
         assert "1/1" in check["vault_root_check"]
-        # The mismatched path itself must never appear in the response —
-        # /health/full is unauthenticated, and a real indexed path can
-        # reveal personal folder/file names.
+        # Neither the mismatched path nor the configured vault root itself
+        # may appear in the response — /health/full is unauthenticated, and
+        # either one can reveal personal folder/file names or the operator's
+        # home directory layout.
         assert "old_vault_location" not in check["vault_root_check"]
         assert "note.md" not in check["vault_root_check"]
+        assert str(configured_root.resolve()) not in check["vault_root_check"]
 
     def test_leaves_ok_unchanged_when_paths_match(self, monkeypatch, tmp_path):
         import api.main as main

--- a/tests/test_vault_root_check.py
+++ b/tests/test_vault_root_check.py
@@ -10,9 +10,54 @@ vault root.
 """
 import pytest
 
-from api.services.vectorstore import sample_paths_match_vault_root
+from api.services.vectorstore import VectorStore, sample_paths_match_vault_root
 
 pytestmark = pytest.mark.unit
+
+
+class _StubCollection:
+    """Stands in for a ChromaDB collection's `.get()` — enough to test
+    `VectorStore.sample_file_paths()`'s dedup logic without a real
+    ChromaDB server."""
+
+    def __init__(self, metadatas):
+        self._metadatas = metadatas
+
+    def get(self, limit=None, include=None):
+        return {"metadatas": self._metadatas[: limit or len(self._metadatas)]}
+
+
+def _store_with_collection(collection) -> VectorStore:
+    # Bypass VectorStore.__init__ (it opens a real ChromaDB HTTP connection
+    # and loads the embedding model) — only `_collection` is needed here.
+    store = object.__new__(VectorStore)
+    store._collection = collection
+    return store
+
+
+class TestSampleFilePaths:
+    def test_dedupes_chunks_from_the_same_file(self):
+        """Each file is indexed as several chunks sharing one file_path — a
+        raw limit-sized fetch could otherwise return the same file 5 times
+        over instead of sampling 5 distinct files (Codex review finding)."""
+        metadatas = (
+            [{"file_path": "/vault/a.md"}] * 3
+            + [{"file_path": "/vault/b.md"}] * 3
+            + [{"file_path": "/vault/c.md"}] * 3
+        )
+        store = _store_with_collection(_StubCollection(metadatas))
+
+        sample = store.sample_file_paths(limit=2)
+
+        assert sample == ["/vault/a.md", "/vault/b.md"]
+
+    def test_skips_rows_missing_file_path(self):
+        metadatas = [{}, {"other": "x"}, {"file_path": "/vault/a.md"}]
+        store = _store_with_collection(_StubCollection(metadatas))
+
+        sample = store.sample_file_paths(limit=5)
+
+        assert sample == ["/vault/a.md"]
 
 
 class TestSamplePathsMatchVaultRoot:
@@ -93,12 +138,15 @@ class TestCheckVaultRootSanity:
         main._check_vault_root_sanity(check, tmp_path / "vault")
 
         assert check["status"] == "degraded"
-        assert "1/1" in check["detail"]
+        # The original request/response detail is preserved unchanged — the
+        # mismatch is reported in a separate field, not a replacement.
+        assert check["detail"] == "1 results"
+        assert "1/1" in check["vault_root_check"]
         # The mismatched path itself must never appear in the response —
         # /health/full is unauthenticated, and a real indexed path can
         # reveal personal folder/file names.
-        assert "old_vault_location" not in check["detail"]
-        assert "note.md" not in check["detail"]
+        assert "old_vault_location" not in check["vault_root_check"]
+        assert "note.md" not in check["vault_root_check"]
 
     def test_leaves_ok_unchanged_when_paths_match(self, monkeypatch, tmp_path):
         import api.main as main


### PR DESCRIPTION
## Summary
- `vault_search` in `GET /health/full` only confirmed search returns *something* — not that what it returns still lives under the currently configured vault root. A moved/deleted vault can leave the index serving stale content from the old location while this check kept reporting healthy.
- Adds a sample-based sanity check (`VectorStore.sample_file_paths()`, cheap — doesn't scan the whole collection) run after the existing request/response probe passes. On a sampled path falling outside `settings.vault_path`, the row downgrades from `ok` to `degraded` with a count-based detail. The mismatched paths themselves are never included in the response (unauthenticated endpoint; a real indexed path can reveal personal file/folder names — flagged in the sibling #697 PR's Codex review and applied here proactively).
- A healthy, unmoved vault continues to report `ok` exactly as before — additive only.

Fixes #762

## Test plan
- [x] `tests/test_vault_root_check.py` (new) — unit tests for `sample_paths_match_vault_root` (match/mismatch/empty/sibling-prefix/malformed-path classification) and for `_check_vault_root_sanity` (downgrades on mismatch, no-op on a failing base check, doesn't leak paths, tolerates a vector-store error without crashing), plus a wiring test that `full_health_check()` actually calls the helper
- [x] `tests/test_model_readout.py` — full suite still green (uses `full_health_check()` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw