### PR TITLE
fix(api): task-tag descriptions forbid uninvited routing tags (#804)

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -24,7 +24,16 @@ class CreateTaskRequest(BaseModel):
     description: str = Field(..., min_length=1, description="Task description")
     priority: Optional[str] = Field(default="", description="Priority: high, medium, low, or empty")
     due_date: Optional[str] = Field(default=None, description="Due date (YYYY-MM-DD)")
-    tags: Optional[list[str]] = Field(default=None, description="List of tags (e.g., ['work', 'urgent'])")
+    tags: Optional[list[str]] = Field(
+        default=None,
+        description="List of tags (e.g., ['work', 'urgent']). Add exactly the "
+                    "tags the operator named. A routing tag (agent/local/claude/"
+                    "codex/cloud/cloud-haiku/cloud-sonnet) only if the operator "
+                    "explicitly named that engine — these tags are operator-"
+                    "authority and outrank every routing safeguard, so inventing "
+                    "one injects your own engine preference at the highest-"
+                    "precedence slot.",
+    )
     reminder_id: Optional[str] = Field(default=None, description="Associated reminder ID")
     dry_run: Optional[bool] = Field(
         default=False,
@@ -63,7 +72,14 @@ class UpdateTaskRequest(BaseModel):
     context: Optional[str] = None
     priority: Optional[str] = None
     due_date: Optional[str] = None
-    tags: Optional[list[str]] = None
+    tags: Optional[list[str]] = Field(
+        default=None,
+        description="Replaces the task's tag list. Add exactly the tags the "
+                    "operator named. A routing tag (agent/local/claude/codex/"
+                    "cloud/cloud-haiku/cloud-sonnet) only if the operator "
+                    "explicitly named that engine — these tags are operator-"
+                    "authority and outrank every routing safeguard.",
+    )
 
 
 class TaskResponse(BaseModel):

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -413,7 +413,12 @@ TOOL_DEFINITIONS = [
                         "Full set of tags for the task (for create or update). On update, "
                         "this REPLACES the existing tag list — to add a tag to a task, "
                         "first 'list' or fetch the task, then send the union of existing "
-                        "+ new tags. Strip leading '#'."
+                        "+ new tags. Strip leading '#'. Add exactly the tags the operator "
+                        "named — a routing tag (agent/local/claude/codex/cloud/cloud-haiku/"
+                        "cloud-sonnet) only if the operator explicitly named that engine; "
+                        "these tags are operator-authority and outrank every routing "
+                        "safeguard, so inventing one injects your own engine preference at "
+                        "the highest-precedence slot."
                     ),
                 },
                 "status": {

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -942,7 +942,7 @@ class LifeOSMCPServer:
                     "context": {"type": "string", "description": "Context/category (Work, Personal, Finance, etc.)", "default": "Inbox"},
                     "priority": {"type": "string", "description": "Priority: high, medium, low"},
                     "due_date": {"type": "string", "description": "Due date in YYYY-MM-DD format"},
-                    "tags": {"type": "array", "items": {"type": "string"}, "description": "Tags for classification"},
+                    "tags": {"type": "array", "items": {"type": "string"}, "description": "Add exactly the tags the operator named. A routing tag (agent/local/claude/codex/cloud/cloud-haiku/cloud-sonnet) only if the operator explicitly named that engine — these tags are operator-authority and outrank every routing safeguard, so inventing one injects your own engine preference at the highest-precedence slot."},
                     "reminder_id": {"type": "string", "description": "Linked reminder ID"},
                     "dry_run": {"type": "boolean", "description": "When true with an #agent tag, returns preflight routing + cost estimate without creating the task. Used for prompt-engineering iteration. Default: false."}
                 },
@@ -967,7 +967,7 @@ class LifeOSMCPServer:
                     "context": {"type": "string", "description": "New context"},
                     "priority": {"type": "string", "description": "New priority (high, medium, low)"},
                     "due_date": {"type": "string", "description": "New due date (YYYY-MM-DD)"},
-                    "tags": {"type": "array", "items": {"type": "string"}, "description": "New tags"}
+                    "tags": {"type": "array", "items": {"type": "string"}, "description": "New tags (replaces existing). Add exactly the tags the operator named — a routing tag (agent/local/claude/codex/cloud/cloud-haiku/cloud-sonnet) only if the operator explicitly named that engine; these tags are operator-authority and outrank every routing safeguard."}
                 },
                 "required": ["task_id"]
             },

--- a/tests/test_agent_tools_tasks.py
+++ b/tests/test_agent_tools_tasks.py
@@ -131,3 +131,13 @@ class TestManageTasksFilterDocs:
         lowered = desc.lower()
         assert "every status" in lowered
         assert "cancelled" in lowered and "todo" in lowered
+
+    def test_tags_rule_forbids_uninvited_routing_tags(self, props):
+        """#804: an assistant that invents a routing tag (#local, #claude, ...)
+        on a task the operator didn't ask to be routed launders its own engine
+        preference into the highest-precedence slot — routing tags outrank
+        every other routing safeguard. The tags field must say so."""
+        desc = props["tags"]["description"]
+        assert "operator named" in desc
+        assert "operator-authority and outrank every routing safeguard" in desc
+        assert "codex" in desc and "cloud" in desc

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -162,6 +162,35 @@ class TestMCPServerToolDiscovery:
         )
         assert "items" in tags_schema, "'tags' array schema is missing 'items'"
 
+    def test_task_tags_description_forbids_uninvited_routing_tags(self, openapi_spec):
+        """#804: an assistant filing a task must add exactly the tags the
+        operator named — a routing tag (#local/#claude/#codex/#cloud*) only
+        if the operator explicitly named that engine, because routing tags
+        are operator-authority and outrank every other routing safeguard.
+        Pin the rule text on both lifeos_task_create and lifeos_task_update's
+        `tags` field, since it's their OpenAPI-derived description (sourced
+        from CreateTaskRequest/UpdateTaskRequest in api/routes/tasks.py) that
+        an MCP client actually reads before calling the tool.
+        """
+        import importlib.util
+        from unittest.mock import patch
+        spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        with patch.object(module.LifeOSMCPServer, "_load_openapi_spec", lambda self: None):
+            server = module.LifeOSMCPServer()
+        server.openapi_spec = openapi_spec
+        server._build_tools_from_spec()
+
+        for tool_name in ("lifeos_task_create", "lifeos_task_update"):
+            tool = next(t for t in server.tools if t["name"] == tool_name)
+            desc = tool["inputSchema"]["properties"]["tags"]["description"]
+            assert "operator named" in desc, f"{tool_name}: missing 'operator named' in {desc!r}"
+            assert "operator-authority and outrank every routing safeguard" in desc, (
+                f"{tool_name}: missing the authority rationale in {desc!r}"
+            )
+
 
 @pytest.mark.requires_server
 class TestMCPServerAPICalls:


### PR DESCRIPTION
Closes #804.

The operator asked an assistant to file a vault task with `#agent`; the assistant added `#local` on its own. Routing tags are operator-authority — they outrank preflight, title corroboration, and the default route — so an assistant inventing one injects its preference at the highest-precedence slot.

The rule now lives at the actual repro path and every sibling surface, traced rather than guessed: `CreateTaskRequest`/`UpdateTaskRequest` field descriptions in `api/routes/tasks.py` (the source of truth — they flow through the OpenAPI spec into the `lifeos_task_create`/`lifeos_task_update` MCP schemas served to Hermes/Claude Code/Codex, confirmed via `_build_tools_from_spec`), the in-repo `manage_tasks` agent tool (`agent_tools.py`, the native chat/Telegram path), and `mcp_server.py`'s hardcoded fallback schemas kept in sync for degraded sessions. One phrasing everywhere: add exactly the tags the operator named; routing tags only when the operator named the engine.

Surveyed and deliberately untouched, with reasoning in the report: personas (none create vault tasks in prose — the doctor spawns workers via a different mechanism; journal calls the now-fixed tool), the scheduler's executor-tag pass-through (deterministic operator config, no LLM invention), and operator-facing docs.

Prompt-level behavior isn't unit-testable — stated, not implied; presence tests pin the rule text on both the OpenAPI-derived schema (the real path) and the agent tool. Gate: 5,102 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)