### PR TITLE
fix(linkedin): skip the export preamble when loading Connections.csv

### DIFF
--- a/api/services/people_aggregator.py
+++ b/api/services/people_aggregator.py
@@ -638,6 +638,40 @@ class PersonRecord:
         return cls(**data)
 
 
+def _skip_linkedin_preamble(f) -> None:
+    """Advance ``f`` past LinkedIn's export preamble to the real header row.
+
+    A Connections.csv straight from "Export Your Data" does not start with the
+    header. LinkedIn prepends a notes block:
+
+        Notes:
+        "When exporting your connection data, you may notice that some of the
+        email addresses are missing. ..."
+        <blank line>
+        First Name,Last Name,URL,Email Address,Company,Position,Connected On
+
+    Handing that to DictReader makes "Notes:" the sole fieldname, so every row
+    yields empty First/Last Name and the whole import silently skips — a
+    zero-record "success" on a file that is perfectly good.
+
+    Scans a bounded number of lines for the header, then seeks back to its
+    start. A file that already begins with the header (previously de-preambled
+    by hand) is left untouched, so this is safe on both shapes.
+    """
+    probe_limit = 10
+    for _ in range(probe_limit):
+        pos = f.tell()
+        line = f.readline()
+        if not line:
+            break
+        if 'First Name' in line and 'Last Name' in line:
+            f.seek(pos)
+            return
+    # No header found within the probe window — rewind and let DictReader try,
+    # preserving the previous behaviour rather than consuming the file.
+    f.seek(0)
+
+
 def load_linkedin_connections(csv_path: str) -> list[dict]:
     """
     Load LinkedIn connections from CSV export.
@@ -655,6 +689,7 @@ def load_linkedin_connections(csv_path: str) -> list[dict]:
     connections = []
     try:
         with open(csv_path, 'r', encoding='utf-8') as f:
+            _skip_linkedin_preamble(f)
             reader = csv.DictReader(f)
             for row in reader:
                 connections.append({

--- a/tests/test_linkedin_csv_preamble.py
+++ b/tests/test_linkedin_csv_preamble.py
@@ -1,0 +1,69 @@
+"""LinkedIn Connections.csv preamble handling.
+
+A Connections.csv straight from LinkedIn's "Export Your Data" does not begin
+with the header row — it prepends a notes block. Feeding that to DictReader
+makes "Notes:" the only fieldname, so every row yields empty names and the
+import silently skips all of them: a zero-record "success" on a good file.
+"""
+import pytest
+
+from api.services.people_aggregator import load_linkedin_connections
+
+pytestmark = pytest.mark.unit
+
+
+HEADER = "First Name,Last Name,URL,Email Address,Company,Position,Connected On\n"
+ROWS = (
+    'Jonathan,"Shaffer, Ph.D.",https://www.linkedin.com/in/jonshaffer,,'
+    'University of Vermont,Assistant Professor of Sociology,24 Jun 2026\n'
+    "Jade,Martinez,https://www.linkedin.com/in/jade-martinez,,SEIU,"
+    "Senior Coordinator,21 Jun 2026\n"
+)
+PREAMBLE = (
+    "Notes:\n"
+    '"When exporting your connection data, you may notice that some of the '
+    'email addresses are missing. You will only see email addresses for '
+    'connections who have allowed this."\n'
+    "\n"
+)
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "Connections.csv"
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+class TestLinkedInPreamble:
+
+    def test_raw_export_with_preamble_is_parsed(self, tmp_path):
+        conns = load_linkedin_connections(_write(tmp_path, PREAMBLE + HEADER + ROWS))
+        assert len(conns) == 2
+        assert conns[0]["first_name"] == "Jonathan"
+        assert conns[0]["last_name"] == "Shaffer, Ph.D."
+        assert conns[0]["company"] == "University of Vermont"
+        assert conns[1]["first_name"] == "Jade"
+
+    def test_already_stripped_file_still_works(self, tmp_path):
+        """Files de-preambled by hand must keep working."""
+        conns = load_linkedin_connections(_write(tmp_path, HEADER + ROWS))
+        assert len(conns) == 2
+        assert conns[0]["first_name"] == "Jonathan"
+
+    def test_quoted_comma_in_last_name_survives(self, tmp_path):
+        """The preamble skip must not break normal CSV quoting."""
+        conns = load_linkedin_connections(_write(tmp_path, PREAMBLE + HEADER + ROWS))
+        assert conns[0]["last_name"] == "Shaffer, Ph.D."
+
+    def test_linkedin_url_and_connected_on_mapped(self, tmp_path):
+        conns = load_linkedin_connections(_write(tmp_path, PREAMBLE + HEADER + ROWS))
+        assert conns[0]["linkedin_url"].endswith("/jonshaffer")
+        assert conns[0]["connected_on"] == "24 Jun 2026"
+
+    def test_file_without_header_does_not_consume_rows(self, tmp_path):
+        """No recognisable header: fall back, don't silently eat the file."""
+        conns = load_linkedin_connections(_write(tmp_path, "a,b,c\n1,2,3\n"))
+        assert conns == [] or all(not c["first_name"] for c in conns)
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_linkedin_connections(str(tmp_path / "nope.csv")) == []


### PR DESCRIPTION
## Problem

A `Connections.csv` straight from LinkedIn's "Export Your Data" does **not** begin with the header row. LinkedIn prepends a notes block:

```
Notes:
"When exporting your connection data, you may notice that some of the
 email addresses are missing. ..."
<blank line>
First Name,Last Name,URL,Email Address,Company,Position,Connected On
```

`load_linkedin_connections` handed that straight to `csv.DictReader`, making `Notes:` the sole fieldname. Every row then yielded empty `First Name`/`Last Name` and was skipped — a **zero-record "success" on a perfectly good file**, with nothing logged to suggest the file had been misread.

The function's own docstring names the raw export as the expected input (`Data source: LinkedIn "Export Your Data" → Connections.csv`), so this was broken for the documented shape. It only ever worked if the operator stripped the preamble by hand first.

## Change

`_skip_linkedin_preamble()` scans a bounded window (10 lines) for the header, seeks back to its start, and lets `DictReader` take over.

- A file that **already** starts with the header is untouched — previously de-preambled files keep working.
- If no header is found in the window, it rewinds and behaves exactly as before rather than consuming the file.

## Verification on a real export

862-connection file from LinkedIn:

| | Before | After |
|---|---|---|
| Connections parsed | **0** | **862** |
| With company | — | 835 |

The subsequent sync created **616 source entities**, updated **225 people**, 0 errors. After the full downstream pipeline: 837 people carry a `linkedin_url` and **837 relationship edges are flagged `is_linkedin_connection`**.

## Testing

6 new tests: the raw export with preamble, an already-stripped file, quoted commas in names (`"Shaffer, Ph.D."`) surviving the seek, URL/`Connected On` mapping, a headerless file not being consumed, and a missing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RqASCyAbmEt6AQBhRbW9e