### PR TITLE
feat(voice): show a live-mic dot while the wake tap is actually capturing

### DIFF
--- a/tests/test_voice_listening_wake_word_ui_browser.py
+++ b/tests/test_voice_listening_wake_word_ui_browser.py
@@ -3,10 +3,11 @@
 Covers the fourth dock checkbox end to end at the JS layer: it renders
 unchecked by default, persists like its siblings (mute/2x/auto), holds and
 releases its own mic stream (never the one the talk button reuses across
-taps), and its post-capture pipeline -- STT round-trip, wake-word fuzzy
-match, and entering recording -- is reachable and correctly gated even
-though headless Chromium can't produce a real spoken "Hermes" for the VAD's
-energy analysis to detect.
+taps), surfaces that hold as a live-mic dot on its own label (#813), and its
+post-capture pipeline -- STT round-trip, wake-word fuzzy match, and entering
+recording -- is reachable and correctly gated even though headless Chromium
+can't produce a real spoken "Hermes" for the VAD's energy analysis to
+detect.
 
 The real getUserMedia energy analysis (handleListenFrame() in
 web/chat/voice.js) can't run headless without genuine audio hardware, so
@@ -245,6 +246,15 @@ def _check_wake(page: Page, transcript):
 def _is_recording(page: Page):
     return page.evaluate(
         "document.getElementById('voiceTalkBtn').classList.contains('recording')"
+    )
+
+
+def _dot_is_live(page: Page):
+    """#813 -- the live-mic dot's own class, used where the dock as a whole
+    is hidden (text mode) and `to_be_visible()` would pass for the wrong
+    reason."""
+    return page.evaluate(
+        "document.getElementById('voiceListenDot').classList.contains('live')"
     )
 
 
@@ -663,3 +673,131 @@ class TestListeningSuspension:
 
         assert triggered is False, "a wake match fired while auto-continue was already recording"
         assert page.evaluate("window.__recorderStartCalls") == 1
+
+
+class TestListeningLiveIndicator:
+    """#813: the dock's live-mic dot. It tracks the *capture*, not the
+    checkbox -- on only while the wake tap actually holds an unsuspended
+    mic, off whenever the tap is suspended (playback/recording) or
+    Listening is released. The distinction is the whole point: the checkbox
+    stays checked through a whole turn, so a checkbox-driven dot would
+    claim the mic was live at exactly the moments it isn't."""
+
+    def test_dot_is_live_while_listening_holds_the_mic(self, page: Page, chat_base_url):
+        """Voice mode with the default-on toggle -- the dot appears as soon
+        as the wake tap has the mic, without any user action."""
+        _open_voice_chat(page, chat_base_url)
+        page.wait_for_function("window.__gumCalls === 1")
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+
+        expect(page.locator("#voiceListenDot")).to_be_visible()
+        assert _dot_is_live(page) is True
+
+    def test_dot_disappears_when_listening_is_unchecked(self, page: Page, chat_base_url):
+        """Unchecking releases the mic entirely (stopListening()), so the
+        dot must go with it."""
+        _open_voice_chat(page, chat_base_url)
+        page.wait_for_function("window.__gumCalls === 1")
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+        assert _dot_is_live(page) is True
+
+        page.locator("#voiceListen").uncheck()
+
+        page.wait_for_function("window.__stopCalls > 0")
+        expect(page.locator("#voiceListenDot")).not_to_be_visible()
+        assert _dot_is_live(page) is False
+
+        # ...and comes back when Listening is switched on again.
+        page.locator("#voiceListen").check()
+        page.wait_for_function("window.__gumCalls === 2")
+        expect(page.locator("#voiceListenDot")).to_be_visible()
+
+    def test_dot_is_not_live_when_listening_starts_off(self, page: Page, chat_base_url):
+        """A visitor who opted out previously (persisted unchecked) enters
+        voice mode with no mic held at all -- no dot, ever, until they opt
+        back in."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceListen").uncheck()
+        page.reload()
+        page.wait_for_selector("#voiceListen")
+
+        expect(page.locator("#voiceListen")).not_to_be_checked()
+        expect(page.locator("#voiceListenDot")).not_to_be_visible()
+        assert page.evaluate("window.__gumCalls") == 0
+
+    def test_dot_disappears_during_tts_playback_and_returns_after(
+            self, page: Page, chat_base_url):
+        """The tap is suspended for the whole clip (#734/#740) -- the mic
+        is genuinely not listening, so the dot must not say it is. The
+        checkbox stays checked throughout, which is exactly why the dot is
+        driven by updateListenSuspension() instead."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceAuto").uncheck()  # isolate from auto-continue
+        page.locator("#voiceListen").check()
+        page.wait_for_function("window.__gumCalls === 1")
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+        assert _dot_is_live(page) is True
+
+        clip_url = page.evaluate("window.__makeWav(500)")
+        page.evaluate("(u) => { window.__turnClipUrl = u; }", clip_url)
+        page.evaluate("() => { window.lifeChatVoice.submitTurn({ transcript: 'hi' }); }")
+        page.wait_for_function("window.__audioPlayingCount > 0")
+
+        expect(page.locator("#voiceListenDot")).not_to_be_visible()
+        # The toggle itself never moved -- only the capture did.
+        expect(page.locator("#voiceListen")).to_be_checked()
+
+        page.wait_for_function("window.__audioPlayingCount === 0", timeout=5000)
+
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+        expect(page.locator("#voiceListenDot")).to_be_visible()
+
+    def test_dot_disappears_while_recording_and_returns_after(
+            self, page: Page, chat_base_url):
+        """Same for the recording window (#724): the wake tap is suspended
+        while the talk button holds its own stream, so the Listening dot is
+        off -- the recording button's own pulse is the live signal then."""
+        _open_voice_chat(page, chat_base_url)
+        page.locator("#voiceAuto").uncheck()  # isolate from auto-continue
+        page.locator("#voiceListen").check()
+        page.wait_for_function("window.__gumCalls === 1")
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+        assert _dot_is_live(page) is True
+
+        page.locator("#voiceTalkBtn").click()
+        page.wait_for_function(
+            "document.getElementById('voiceTalkBtn').classList.contains('recording')"
+        )
+
+        expect(page.locator("#voiceListenDot")).not_to_be_visible()
+        expect(page.locator("#voiceListen")).to_be_checked()
+
+        # force=True: the .recording class drives an infinite CSS pulse that
+        # can fail Playwright's default actionability "element is stable"
+        # wait on the stop tap (see the suspension suite above).
+        page.locator("#voiceTalkBtn").click(force=True)  # stop
+        page.wait_for_function(
+            "!document.getElementById('voiceTalkBtn').classList.contains('recording')"
+        )
+
+        page.wait_for_function("() => window.lifeChatVoice.isListenTapRunning() === true")
+        expect(page.locator("#voiceListenDot")).to_be_visible()
+
+    def test_dot_is_not_live_in_text_mode(self, page: Page, chat_base_url):
+        """Leaving voice mode releases Listening's mic (applyVoiceMode() ->
+        stopListening()). The dock is hidden there anyway, so this asserts
+        the class itself is cleared -- the dot must not be left mid-pulse,
+        ready to reappear stale when voice mode comes back."""
+        _open_voice_chat(page, chat_base_url)
+        page.wait_for_function("window.__gumCalls === 1")
+        assert _dot_is_live(page) is True
+
+        page.locator("#modeTextBtn").click()
+
+        page.wait_for_function("window.__stopCalls > 0")
+        assert _dot_is_live(page) is False
+
+        # And it comes back on re-entering voice mode, since the mic does.
+        page.locator("#modeVoiceBtn").click()
+        page.wait_for_function("window.__gumCalls === 2")
+        expect(page.locator("#voiceListenDot")).to_be_visible()

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -124,14 +124,32 @@ function setClipInFlight(value) {
 // taps-inventory block above ensureAudioContext() for why an open capture
 // is a second, independent hazard from main-thread contention.
 function updateListenSuspension() {
-  if (!listenAudioCtx) return;
   const shouldSuspend = clipInFlight || isRecording;
+  // #813 -- the dock's live-mic dot mirrors exactly what this function does
+  // to the tap, so it can never claim the mic is live while the capture is
+  // suspended. Computed before the `listenAudioCtx` bail-out below so the
+  // "Listening isn't running at all" case turns the dot off too.
+  updateListenIndicator(!!listenStream && !shouldSuspend);
+  if (!listenAudioCtx) return;
   if (shouldSuspend && listenAudioCtx.state === 'running') {
     listenAudioCtx.suspend().catch(() => {});
   } else if (!shouldSuspend && listenAudioCtx.state === 'suspended') {
     listenAudioCtx.resume().catch(() => {});
   }
   setListenTracksEnabled(!shouldSuspend);
+}
+
+// #813 -- the dock's only signal that the mic is currently open. Driven
+// solely by updateListenSuspension() above and stopListening() below, both
+// of which own the real "is the wake tap holding a live capture" state, so
+// the dot can't drift from it: it is deliberately NOT tied to the Listening
+// checkbox, which stays checked through playback and recording while the
+// capture itself is suspended (and stays checked outside voice mode, where
+// no mic is held at all).
+function updateListenIndicator(live) {
+  const dot = elements.voiceListenDot;
+  if (!dot) return;
+  dot.classList.toggle('live', !!live);
 }
 
 // Every write to `isRecording` goes through here (#724), for the same
@@ -1458,6 +1476,7 @@ function stopListening() {
   listenSpeechMs = 0;
   listenSilenceMs = 0;
   listenChecking = false;
+  updateListenIndicator(false);  // #813 -- no mic held, so no live dot
 }
 
 // Test seam (#734): whether the wake tap's own AudioContext is actually

--- a/web/index.html
+++ b/web/index.html
@@ -1112,6 +1112,25 @@
             cursor: pointer;
         }
 
+        /* Live-mic indicator on the Listening label (#813). Hidden unless
+           voice.js adds `.live`, which it does only while the wake tap is
+           actually holding an unsuspended capture — so the dot disappears
+           during playback/recording and whenever Listening is off, rather
+           than tracking the checkbox. Reuses the `pulse` keyframes the
+           header status dot already uses. */
+        .listen-dot {
+            display: none;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--success);
+        }
+
+        .listen-dot.live {
+            display: inline-block;
+            animation: pulse 1.4s ease-in-out infinite;
+        }
+
         /* Replayable voice responses (tap to replay) */
         .message.replayable {
             cursor: pointer;
@@ -2952,7 +2971,9 @@
                     <label class="dock-toggle"><input type="checkbox" id="voiceMute"> Mute</label>
                     <label class="dock-toggle"><input type="checkbox" id="voiceFast" checked> 2×</label>
                     <label class="dock-toggle"><input type="checkbox" id="voiceAuto" checked> Auto</label>
-                    <label class="dock-toggle"><input type="checkbox" id="voiceListen" checked> Listening</label>
+                    <!-- The dot only renders while the wake tap actually holds a
+                         live mic — see .listen-dot / updateListenIndicator(). -->
+                    <label class="dock-toggle"><input type="checkbox" id="voiceListen" checked> Listening<span class="listen-dot" id="voiceListenDot" role="status" aria-label="Microphone is live"></span></label>
                 </div>
             </div>
         </footer>
@@ -3194,6 +3215,7 @@
                     voiceFast: document.getElementById('voiceFast'),
                     voiceAuto: document.getElementById('voiceAuto'),
                     voiceListen: document.getElementById('voiceListen'),
+                    voiceListenDot: document.getElementById('voiceListenDot'),
                     modeTextBtn: document.getElementById('modeTextBtn'),
                     modeVoiceBtn: document.getElementById('modeVoiceBtn'),
                     backendLifeos: document.getElementById('backendLifeos'),


### PR DESCRIPTION
Fixes #813.

Salvaged from #agent task `7ac7d7cb` (the claude_code session committed this and was interrupted by the host reboot while running its gate). Adds a pulsing dot on the voice dock's Listening label, driven solely by `updateListenSuspension()`/`stopListening()` — the two owners of the wake tap's real capture state — so it is on only while the tap holds an unsuspended mic, and off during playback, recording, or when Listening is off. Reuses the header status dot's `pulse` keyframes.

Browser tests cover on/suspend/resume/off transitions in `tests/test_voice_listening_wake_word_ui_browser.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)