### PR TITLE
fix(scripts): stop create-worktree.sh orphaning worktrees on port-lock contention

### DIFF
--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -94,9 +94,95 @@ if [ -d "$worktree_path" ] && git worktree list --porcelain | grep -q "^worktree
   branch="$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null)" || branch="$name"
 fi
 
+# ---------------------------------------------------------------------------
+# 5. Port allocation (mkdir-based lock)
+#
+# Runs before branch resolution / worktree creation so a port-allocation
+# failure aborts cleanly with nothing created — no worktree or branch left
+# to orphan.
+# ---------------------------------------------------------------------------
+lock_dir="$worktree_dir/.port-lock"
+
+# Portable lock mtime: GNU stat uses -c, BSD/macOS stat uses -f. Try GNU
+# first (this fleet is Linux), fall back to BSD, and validate the result is
+# all-digits so a wrong-platform invocation (which can print a multi-line
+# report to stdout and still exit 0) can't leak garbage into arithmetic.
+lock_mtime() {
+  local mtime
+  mtime="$(stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null)"
+  [[ "$mtime" =~ ^[0-9]+$ ]] && echo "$mtime" || echo 0
+}
+
+allocate_port() {
+  local key="$1" range_start="$2" range_end="$3"
+
+  # Collect ports already assigned to other worktrees.
+  local used_ports=()
+  for info_file in "$worktree_dir"/*/.worktree-info; do
+    [ -f "$info_file" ] || continue
+    local p
+    p="$(grep "^${key}=" "$info_file" 2>/dev/null | cut -d= -f2)" || true
+    [ -n "$p" ] && used_ports+=("$p")
+  done
+  dbg "$key: used ports: ${used_ports[*]+"${used_ports[*]}"}"
+
+  for port in $(seq "$range_start" "$range_end"); do
+    # Skip if already assigned.
+    local skip=false
+    for used in "${used_ports[@]+"${used_ports[@]}"}"; do
+      if [ "$port" = "$used" ]; then
+        skip=true
+        break
+      fi
+    done
+    $skip && continue
+
+    # Skip if something is listening on this port.
+    if lsof -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
+      continue
+    fi
+
+    echo "$port"
+    return 0
+  done
+
+  die "no free port in range $range_start-$range_end"
+}
+
+# Acquire lock (mkdir is atomic on POSIX).
+lock_max_attempts=60          # 60 * 0.5s = 30s wall-clock timeout
+lock_attempts=0
+lock_stale_seconds=300        # Break locks older than 5 minutes
+while ! mkdir "$lock_dir" 2>/dev/null; do
+  # Break stale locks (likely from a killed process).
+  if [ -d "$lock_dir" ]; then
+    lock_age=$(( $(date +%s) - $(lock_mtime "$lock_dir") ))
+    if [ "$lock_age" -gt "$lock_stale_seconds" ]; then
+      log "breaking stale lock (age: ${lock_age}s)"
+      rmdir "$lock_dir" 2>/dev/null || true
+      continue
+    fi
+  fi
+  lock_attempts=$((lock_attempts + 1))
+  if [ "$lock_attempts" -ge "$lock_max_attempts" ]; then
+    die "timed out waiting for port allocation lock after ~30s"
+  fi
+  sleep 0.5
+done
+# Ensure lock is released on exit.
+trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
+
+api_port="$(allocate_port API_PORT 8100 8199)"
+chroma_port="$(allocate_port CHROMA_PORT 8200 8299)"
+log "allocated ports: API_PORT=$api_port CHROMA_PORT=$chroma_port"
+
+# Release lock early.
+rmdir "$lock_dir" 2>/dev/null || true
+
+
 if [ "$worktree_exists" = false ]; then
 # ---------------------------------------------------------------------------
-# 5. Branch resolution
+# 6. Branch resolution
 #
 # Candidate A: <name> (exact)
 # Candidate B: if name matches <type>-<rest>, also try <type>/<rest>
@@ -147,83 +233,12 @@ resolve_branch() {
 branch="$(resolve_branch)"
 
 # ---------------------------------------------------------------------------
-# 6. Create worktree
+# 7. Create worktree
 # ---------------------------------------------------------------------------
 git worktree add "$worktree_path" "$branch" >&2
 log "created worktree at $worktree_path on branch $branch"
 
 fi # worktree_exists
-
-# ---------------------------------------------------------------------------
-# 7. Port allocation (mkdir-based lock)
-# ---------------------------------------------------------------------------
-lock_dir="$worktree_dir/.port-lock"
-
-allocate_port() {
-  local key="$1" range_start="$2" range_end="$3"
-
-  # Collect ports already assigned to other worktrees.
-  local used_ports=()
-  for info_file in "$worktree_dir"/*/.worktree-info; do
-    [ -f "$info_file" ] || continue
-    local p
-    p="$(grep "^${key}=" "$info_file" 2>/dev/null | cut -d= -f2)" || true
-    [ -n "$p" ] && used_ports+=("$p")
-  done
-  dbg "$key: used ports: ${used_ports[*]+"${used_ports[*]}"}"
-
-  for port in $(seq "$range_start" "$range_end"); do
-    # Skip if already assigned.
-    local skip=false
-    for used in "${used_ports[@]+"${used_ports[@]}"}"; do
-      if [ "$port" = "$used" ]; then
-        skip=true
-        break
-      fi
-    done
-    $skip && continue
-
-    # Skip if something is listening on this port.
-    if lsof -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
-      continue
-    fi
-
-    echo "$port"
-    return 0
-  done
-
-  die "no free port in range $range_start-$range_end"
-}
-
-# Acquire lock (mkdir is atomic on POSIX).
-lock_max_attempts=60          # 60 * 0.5s = 30s wall-clock timeout
-lock_attempts=0
-lock_stale_seconds=300        # Break locks older than 5 minutes
-while ! mkdir "$lock_dir" 2>/dev/null; do
-  # Break stale locks (likely from a killed process).
-  if [ -d "$lock_dir" ]; then
-    lock_age=$(( $(date +%s) - $(stat -f %m "$lock_dir" 2>/dev/null || stat -c %Y "$lock_dir" 2>/dev/null || echo "0") ))
-    if [ "$lock_age" -gt "$lock_stale_seconds" ]; then
-      log "breaking stale lock (age: ${lock_age}s)"
-      rmdir "$lock_dir" 2>/dev/null || true
-      continue
-    fi
-  fi
-  lock_attempts=$((lock_attempts + 1))
-  if [ "$lock_attempts" -ge "$lock_max_attempts" ]; then
-    die "timed out waiting for port allocation lock after ~30s"
-  fi
-  sleep 0.5
-done
-# Ensure lock is released on exit.
-trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
-
-api_port="$(allocate_port API_PORT 8100 8199)"
-chroma_port="$(allocate_port CHROMA_PORT 8200 8299)"
-log "allocated ports: API_PORT=$api_port CHROMA_PORT=$chroma_port"
-
-# Release lock early.
-rmdir "$lock_dir" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # 8. Write .worktree-info metadata

--- a/tests/test_create_worktree.py
+++ b/tests/test_create_worktree.py
@@ -1,0 +1,115 @@
+"""Regression test for scripts/create-worktree.sh (#812).
+
+On GNU/Linux, `stat -f %m "$lock_dir"` doesn't mean "read mtime" — `-f` means
+FILESYSTEM status, so GNU coreutils treats `%m` as a filename, fails to find
+it, and (depending on version) can still print a multi-line filesystem
+report to stdout with exit 0. The `||` fallback to `stat -c %Y` never runs,
+that blob lands inside `$(( ... ))`, and under `set -u` bash dies with
+"File: unbound variable" — right after `git worktree add` already created
+the worktree, orphaning it.
+
+This test forces the port-lock contention path (a pre-existing, stale
+`.port-lock` dir) that triggers the mtime read, and asserts the script
+survives it cleanly: exit 0, worktree present, nothing "unbound variable"
+in stderr.
+"""
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "create-worktree.sh"
+
+
+def _git(cwd: Path, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, env=env
+    )
+
+
+def _init_repo_with_origin(root: Path) -> Path:
+    """A working repo plus a local bare "origin" remote with main pushed —
+    enough for create-worktree.sh's `git fetch origin` / `origin/main`
+    branch-resolution path, with no real network access."""
+    origin = root / "origin.git"
+    origin.mkdir()
+    assert _git(origin, "init", "-q", "--bare", "-b", "main").returncode == 0
+
+    repo = root / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("hello\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "init")
+    _git(repo, "remote", "add", "origin", str(origin))
+    push = _git(repo, "push", "-q", "origin", "main")
+    assert push.returncode == 0, push.stderr
+
+    return repo
+
+
+def test_stale_port_lock_contention_does_not_orphan_worktree(tmp_path: Path):
+    """A pre-existing, stale `.port-lock` dir forces the script down the
+    lock-contention branch that reads the lock's mtime. Acceptance: the
+    script must exit 0, hand back a real worktree, and never die on an
+    "unbound variable" from a wrong-platform `stat` invocation."""
+    repo = _init_repo_with_origin(tmp_path)
+
+    # Isolate $HOME so worktree_dir / .worktree-info / logs land entirely
+    # under tmp_path, never the real ~/.claude/worktrees.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    repo_name = repo.name  # "repo" — basename create-worktree.sh derives it as
+    worktree_dir = fake_home / ".claude" / "worktrees" / repo_name
+    worktree_dir.mkdir(parents=True)
+
+    # Pre-existing stale lock: mkdir already exists (forces contention) and
+    # its mtime is pushed well past the 300s staleness threshold.
+    lock_dir = worktree_dir / ".port-lock"
+    lock_dir.mkdir()
+    stale_time = time.time() - 400
+    os.utime(lock_dir, (stale_time, stale_time))
+
+    env = dict(os.environ)
+    env["HOME"] = str(fake_home)
+    # GIT_* vars are for CI hook invocation, not relevant to a direct
+    # subprocess call, but scrub defensively in case the test host has one set.
+    for var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"):
+        env.pop(var, None)
+
+    worktree_path = None
+    try:
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            cwd=str(repo),
+            input='{"name": "worktree-lock-test"}\n',
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, (
+            f"expected exit 0, got {result.returncode}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        assert "unbound variable" not in result.stderr
+        assert "File:" not in result.stderr  # the stray `stat -f` filesystem report
+
+        worktree_path = Path(result.stdout.strip().splitlines()[-1])
+        assert worktree_path.is_dir(), result.stderr
+        assert (worktree_path / ".git").exists()
+        assert (worktree_path / ".worktree-info").exists()
+    finally:
+        if worktree_path and worktree_path.is_dir():
+            _git(repo, "worktree", "remove", "--force", str(worktree_path))
+        shutil.rmtree(tmp_path, ignore_errors=True)


### PR DESCRIPTION
Fixes #812.

On GNU coreutils `stat -f %m "$lock_dir"` is a *filesystem* query that treats `%m` as a filename, fails on it, and still prints a multi-line filesystem report to stdout with exit 0 — so the `|| stat -c %Y` fallback never ran, the blob landed inside `$(( … ))`, and under `set -u` the script died with `File: unbound variable`. Because the port lock was taken *after* `git worktree add`, `set -e` then abandoned a fully created worktree + branch.

- `lock_mtime()`: GNU `stat -c %Y` first, BSD `stat -f %m` fallback, result validated as all-digits (else 0).
- Port-lock acquisition and allocation now run *before* branch resolution and `git worktree add`, so a port-step failure aborts before anything exists rather than handing back an orphan. Pure reordering — no new fallback logic around `.worktree-info` consumers.
- `tests/test_create_worktree.py`: hermetic regression test (temp repo + local bare origin, fake `HOME`, `GIT_*` scrubbed) that plants a stale `.port-lock` to force the contention path and asserts exit 0, worktree present, no "unbound variable". Verified to reproduce the original failure against the pre-fix script.

Gate (from the branch's own worktree): 5134 unit passed / 9 skipped; 244 server-free browser passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)