### PR TITLE
feat(crm): unlimited work domains + guided first-run identity setup (#764, #763)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,13 +59,16 @@ token-*.json
 .env.local
 .env-*
 *.env
+.env.bak.*
 
 # =============================================================================
 # PERSONAL CONFIGURATION (config/)
 # =============================================================================
 config/people_dictionary.json
 config/relationship_overrides.json
+config/relationship_overrides.json.bak.*
 config/family_members.json
+config/family_members.json.bak.*
 config/linkedin_tags.json
 config/linkedin_industry_mappings.json
 config/linkedin_bad_matches.json

--- a/config/settings.py
+++ b/config/settings.py
@@ -992,6 +992,14 @@ class Settings(BaseSettings):
         alias="LIFEOS_WORK_DOMAIN_2",
         description="Second work email domain (e.g., othercompany.com) for categorizing work contacts"
     )
+    work_email_domains_extra: str = Field(
+        default="",
+        alias="LIFEOS_WORK_DOMAINS_EXTRA",
+        description="Comma-separated list of additional work email domains, "
+                    "beyond LIFEOS_WORK_DOMAIN and LIFEOS_WORK_DOMAIN_2, for "
+                    "categorizing work contacts (e.g., 'thirdcompany.com,"
+                    "fourthcompany.com')."
+    )
     gmail_draft_send_cooldown_seconds: int = Field(
         default=300,
         alias="LIFEOS_GMAIL_DRAFT_SEND_COOLDOWN_SECONDS",
@@ -1088,8 +1096,13 @@ class Settings(BaseSettings):
 
     @property
     def work_email_domains(self) -> list[str]:
-        """All configured work email domains."""
-        return [d for d in [self.work_email_domain, self.work_email_domain_2] if d]
+        """All configured work email domains, first domain then second
+        domain then any additional domains from LIFEOS_WORK_DOMAINS_EXTRA."""
+        domains = [d for d in [self.work_email_domain, self.work_email_domain_2] if d]
+        domains.extend(
+            d.strip() for d in (self.work_email_domains_extra or "").split(",") if d.strip()
+        )
+        return domains
 
     def is_sync_enabled(self, account: str, service: str) -> bool:
         """Check if sync is enabled for account+service (gmail/calendar)."""

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -243,6 +243,7 @@ Subprocess orchestration triggered from Telegram. See [claude-code-orchestration
 | `LIFEOS_MY_PERSON_ID` | str | — | Your CRM PersonEntity UUID. Set after first sync — find it via `curl "localhost:8000/api/crm/people?q=<your-name>" \| jq '.people[0].id'`. |
 | `LIFEOS_WORK_DOMAIN` | str | — | Your primary work email domain. |
 | `LIFEOS_WORK_DOMAIN_2` | str | — | Second work email domain if you have one. |
+| `LIFEOS_WORK_DOMAINS_EXTRA` | str | — | Comma-separated list of any further work email domains beyond the first two (e.g. `thirdco.com,fourthco.com`). |
 | `LIFEOS_TIMEZONE` | str | — | IANA timezone (e.g., `America/New_York`). |
 
 ## Relationships

--- a/docs/guides/first-run.md
+++ b/docs/guides/first-run.md
@@ -99,33 +99,41 @@ If you've configured Google OAuth or Slack, run the initial data sync:
 
 **Note**: First sync may take 30+ minutes depending on data volume.
 
+### After First Sync: Set Your Identity
+
+After sync completes, run the guided setup script to pick yourself out of
+the indexed people, name your partner, configure family, and set your work
+email domain(s):
+
+```bash
+~/.venvs/lifeos/bin/python scripts/setup_identity.py
+```
+
+It searches the same people list the CRM UI does, writes what you answer
+into `.env` and `config/*.json` (backing up any existing files first), and
+reports what it wrote and which names it couldn't match. Safe to re-run at
+any time. Or set `LIFEOS_MY_PERSON_ID` by hand:
+
+```bash
+curl "http://localhost:8000/api/crm/people?q=YourName" | jq '.people[0].id'
+```
+
+Then restart: `./scripts/server.sh restart`
+
+This enables relationship tracking, communication gap analysis, and other CRM features that need to know which person is "you."
+
+### Pull Full History (Optional)
+
 **This is the nightly job, not a deep pass.** It deliberately looks back
 only a narrow window (30 days for Gmail/Calendar) to stay fast — a fresh
-install won't get older history from just this. Right after it completes,
-run the one-time backfill to pull each source's full history:
+install won't get older history from just this. Run the one-time backfill
+to pull each source's full history:
 
 ```bash
 ~/.venvs/lifeos/bin/python scripts/first_backfill.py --execute
 ```
 
 See [data-and-sync.md](../specs/technical/data-and-sync.md#first-backfill-entry-point) for what it covers and how long it can take.
-
-### After First Sync: Set Your Person ID
-
-After sync completes, find your person ID and add it to `.env`:
-
-```bash
-curl "http://localhost:8000/api/crm/people?q=YourName" | jq '.people[0].id'
-```
-
-Add the result to `.env`:
-```bash
-LIFEOS_MY_PERSON_ID=<the-uuid-from-above>
-```
-
-Then restart: `./scripts/server.sh restart`
-
-This enables relationship tracking, communication gap analysis, and other CRM features that need to know which person is "you."
 
 ---
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -316,6 +316,10 @@ the repo's own source files. This checklist is that path.
    `config/family_members.example.json` — full list in
    [Configuration § Configuration Files](configuration.md#configuration-files)). You should never need
    to edit a tracked file in the repo itself to configure an instance.
+   After the first sync, `scripts/setup_identity.py` turns picking yourself,
+   your partner, and your family out of the indexed people into a guided
+   conversation instead of hand-editing those files — see
+   [First Run § After First Sync](first-run.md#after-first-sync-set-your-identity).
 2. **Connect an external Hermes.** Add `LIFEOS_HERMES_BACKEND_URL` (and
    `LIFEOS_HERMES_BACKEND_TOKEN` if Hermes requires one) directly to your
    `.env` — both are deliberately absent from `.env.example` since they're

--- a/scripts/setup_identity.py
+++ b/scripts/setup_identity.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""
+Guided first-run identity setup: owner, partner, family, work domains (#763).
+
+Turns finding your own PersonEntity ID (previously: curl the people-search
+endpoint by hand, then hand-edit config/family_members.json and
+config/relationship_overrides.json) into a short interactive conversation.
+Run this once, after the first vault sync/index completes, so there are
+indexed people to search and pick yourself and your family from.
+
+Usage:
+    ~/.venvs/lifeos/bin/python scripts/setup_identity.py
+
+Requires the LifeOS API server to be running (uses the same people-search
+endpoint the CRM UI uses -- GET /api/crm/people?q=... -- rather than reading
+the database directly). Point it at a non-default server with LIFEOS_API_URL.
+
+Safe to run more than once:
+- Existing .env / config/*.json files are merged (new values are added,
+  nothing else in the file is touched), never blindly replaced.
+- Every file this script is about to modify is backed up first
+  (<file>.bak.<UTC timestamp>) if it already exists.
+- Nothing is written until a value has actually been provided -- an
+  unanswered prompt just leaves that setting alone.
+
+This script never runs automatically -- it is only ever invoked by an
+operator, by hand.
+"""
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+PROJECT_DIR = Path(__file__).parent.parent
+ENV_PATH = PROJECT_DIR / ".env"
+ENV_EXAMPLE_PATH = PROJECT_DIR / ".env.example"
+FAMILY_CONFIG_PATH = PROJECT_DIR / "config" / "family_members.json"
+FAMILY_EXAMPLE_PATH = PROJECT_DIR / "config" / "family_members.example.json"
+RELATIONSHIP_CONFIG_PATH = PROJECT_DIR / "config" / "relationship_overrides.json"
+RELATIONSHIP_EXAMPLE_PATH = PROJECT_DIR / "config" / "relationship_overrides.example.json"
+
+API_BASE = os.environ.get("LIFEOS_API_URL", "http://localhost:8000").rstrip("/")
+
+
+# ============================================================================
+# Write/merge logic -- pure filesystem operations, unit-tested against temp
+# config directories. No network access, no prompts.
+# ============================================================================
+
+def backup_file(path: Path) -> Optional[Path]:
+    """Copy an existing file to <path>.bak.<UTC timestamp> before it's
+    modified. Returns the backup path, or None if there was nothing to back
+    up (file doesn't exist yet)."""
+    if not path.exists():
+        return None
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = path.with_name(f"{path.name}.bak.{timestamp}")
+    backup_path.write_bytes(path.read_bytes())
+    return backup_path
+
+
+def _blank_template_value(value):
+    """Blank out one top-level JSON value, keeping its container type
+    (list/dict/string) but dropping illustrative placeholder content like
+    'uuid-of-partner' or 'smith' -- an empty list/dict/string rather than
+    the template's fake sample data."""
+    if isinstance(value, list):
+        return []
+    if isinstance(value, dict):
+        return {}
+    if isinstance(value, str):
+        return ""
+    return value
+
+
+def _skeleton_from_example(example_path: Path) -> dict:
+    """Build a fresh config dict with the same top-level keys as the
+    .example template, but with all illustrative values blanked out -- so
+    a brand-new config file starts empty, not pre-populated with the
+    template's fake sample data."""
+    if not example_path.exists():
+        return {}
+    try:
+        with open(example_path) as f:
+            template = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return {key: _blank_template_value(value) for key, value in template.items()}
+
+
+def _quote_env_value(value: str) -> str:
+    """Quote an env value if it contains characters that would otherwise
+    be misread (whitespace, '#')."""
+    if value == "" or re.search(r"[\s#]", value):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return value
+
+
+def _find_env_var_line(lines: list[str], key: str) -> Optional[int]:
+    """Index of an existing KEY=... line for `key`, preferring an
+    uncommented assignment over a commented-out one. None if absent."""
+    active = re.compile(rf"^{re.escape(key)}=")
+    for i, line in enumerate(lines):
+        if active.match(line):
+            return i
+    commented = re.compile(rf"^#\s*{re.escape(key)}=")
+    for i, line in enumerate(lines):
+        if commented.match(line):
+            return i
+    return None
+
+
+def write_env_updates(env_path: Path, example_path: Path, updates: dict[str, str]) -> Optional[Path]:
+    """Merge `updates` (env var name -> value) into env_path, creating it
+    from example_path if it doesn't exist yet. Existing assignments are
+    updated in place (a commented-out one is uncommented); anything not
+    already present is appended together at the end, behind a single blank
+    line. Returns the backup path (or None if env_path didn't already
+    exist). No-op if updates is empty."""
+    if not updates:
+        return None
+    backup = backup_file(env_path)
+    if env_path.exists():
+        content = env_path.read_text()
+    elif example_path.exists():
+        content = example_path.read_text()
+    else:
+        content = ""
+    lines = content.splitlines()
+    to_append = []
+    for key, value in updates.items():
+        new_line = f"{key}={_quote_env_value(value)}"
+        idx = _find_env_var_line(lines, key)
+        if idx is not None:
+            lines[idx] = new_line
+        else:
+            to_append.append(new_line)
+    if to_append:
+        if lines and lines[-1].strip() != "":
+            lines.append("")
+        lines.extend(to_append)
+    env_path.write_text("\n".join(lines) + "\n")
+    return backup
+
+
+def merge_family_config(
+    config_path: Path,
+    example_path: Path,
+    family_last_names: Optional[list[str]] = None,
+    family_person_ids: Optional[list[str]] = None,
+) -> dict:
+    """Merge new surnames/person IDs into config/family_members.json,
+    creating it from the .example template's shape (with placeholder
+    values blanked) if it doesn't exist. Returns a report dict with the
+    backup path (if any) and the resulting config."""
+    backup = backup_file(config_path)
+    if config_path.exists():
+        with open(config_path) as f:
+            config = json.load(f)
+    else:
+        config = _skeleton_from_example(example_path)
+
+    config.setdefault("family_last_names", [])
+    config.setdefault("family_exact_names", [])
+    config.setdefault("family_person_ids", [])
+    config.setdefault("tracked_relationships", [])
+    config.setdefault("default_selected_ids", [])
+
+    if family_last_names:
+        existing = {n.lower() for n in config["family_last_names"]}
+        for name in family_last_names:
+            name = name.strip()
+            if name and name.lower() not in existing:
+                config["family_last_names"].append(name)
+                existing.add(name.lower())
+
+    if family_person_ids:
+        existing_ids = set(config["family_person_ids"])
+        for person_id in family_person_ids:
+            if person_id and person_id not in existing_ids:
+                config["family_person_ids"].append(person_id)
+                existing_ids.add(person_id)
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+    return {"path": config_path, "backup": backup, "config": config}
+
+
+def merge_relationship_overrides(
+    config_path: Path,
+    example_path: Path,
+    partner_person_id: Optional[str] = None,
+) -> dict:
+    """Merge a partner person ID into config/relationship_overrides.json,
+    creating it from the .example template's shape (with placeholder
+    values blanked) if it doesn't exist. Existing strength/circle overrides
+    are left untouched. Returns a report dict with the backup path (if
+    any) and the resulting config."""
+    backup = backup_file(config_path)
+    if config_path.exists():
+        with open(config_path) as f:
+            config = json.load(f)
+    else:
+        config = _skeleton_from_example(example_path)
+
+    config.setdefault("strength_overrides", {})
+    config.setdefault("circle_overrides", {})
+    config.setdefault("partner_person_id", "")
+
+    if partner_person_id:
+        config["partner_person_id"] = partner_person_id
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+    return {"path": config_path, "backup": backup, "config": config}
+
+
+def apply_identity_config(
+    *,
+    env_path: Path,
+    env_example_path: Path,
+    family_config_path: Path,
+    family_example_path: Path,
+    relationship_config_path: Path,
+    relationship_example_path: Path,
+    my_person_id: Optional[str] = None,
+    partner_name: Optional[str] = None,
+    partner_person_id: Optional[str] = None,
+    family_last_names: Optional[list[str]] = None,
+    family_person_ids: Optional[list[str]] = None,
+    work_email_domain: Optional[str] = None,
+    work_email_domain_2: Optional[str] = None,
+    work_email_domains_extra: Optional[list[str]] = None,
+) -> dict:
+    """Write everything the operator provided into .env and the two config
+    JSON files. Every value is optional -- an unset value is simply not
+    written. Returns a report describing what changed and where backups
+    (if any) were made."""
+    env_updates = {}
+    if my_person_id:
+        env_updates["LIFEOS_MY_PERSON_ID"] = my_person_id
+    if partner_name:
+        env_updates["LIFEOS_PARTNER_NAME"] = partner_name
+    if work_email_domain:
+        env_updates["LIFEOS_WORK_DOMAIN"] = work_email_domain
+    if work_email_domain_2:
+        env_updates["LIFEOS_WORK_DOMAIN_2"] = work_email_domain_2
+    if work_email_domains_extra:
+        env_updates["LIFEOS_WORK_DOMAINS_EXTRA"] = ",".join(work_email_domains_extra)
+
+    env_backup = write_env_updates(env_path, env_example_path, env_updates)
+
+    family_report = None
+    if family_last_names or family_person_ids:
+        family_report = merge_family_config(
+            family_config_path,
+            family_example_path,
+            family_last_names=family_last_names,
+            family_person_ids=family_person_ids,
+        )
+
+    relationship_report = None
+    if partner_person_id:
+        relationship_report = merge_relationship_overrides(
+            relationship_config_path,
+            relationship_example_path,
+            partner_person_id=partner_person_id,
+        )
+
+    return {
+        "env_updates": env_updates,
+        "env_backup": env_backup,
+        "family_report": family_report,
+        "relationship_report": relationship_report,
+    }
+
+
+# ============================================================================
+# People search (HTTP -- reuses the same endpoint the CRM UI uses, never
+# reads the database directly) and interactive prompts.
+# ============================================================================
+
+def count_indexed_people(api_base: str) -> int:
+    """How many people the CRM currently has indexed, via the same
+    endpoint the CRM UI's people list uses."""
+    resp = httpx.get(f"{api_base}/api/crm/people", params={"limit": 1}, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("total", 0)
+
+
+def search_people(api_base: str, query: str, limit: int = 10) -> list[dict]:
+    """Search indexed people by name, via GET /api/crm/people?q=..."""
+    resp = httpx.get(f"{api_base}/api/crm/people", params={"q": query, "limit": limit}, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("people", [])
+
+
+def _describe_person(person: dict) -> str:
+    bits = [person.get("canonical_name") or person.get("display_name") or "(unnamed)"]
+    if person.get("company"):
+        bits.append(person["company"])
+    if person.get("emails"):
+        bits.append(person["emails"][0])
+    return " -- ".join(bits)
+
+
+def prompt_pick_person(api_base: str, label: str, default_query: str = "") -> Optional[dict]:
+    """Search-and-select loop for one person. Returns the chosen person
+    dict, or None if the operator gives up (blank input at the search
+    prompt)."""
+    query = default_query
+    while True:
+        if not query:
+            query = input(f"Search for {label} by name (blank to skip): ").strip()
+            if not query:
+                return None
+        matches = search_people(api_base, query)
+        if not matches:
+            print(f"  No matches for '{query}'.")
+            query = ""
+            continue
+        for i, person in enumerate(matches, 1):
+            print(f"  {i}. {_describe_person(person)}")
+        choice = input("  Pick a number, 's' to search again, or blank to skip: ").strip().lower()
+        if choice == "":
+            return None
+        if choice == "s":
+            query = ""
+            continue
+        if choice.isdigit() and 1 <= int(choice) <= len(matches):
+            return matches[int(choice) - 1]
+        print("  Not a valid choice.")
+
+
+def prompt_list(prompt_text: str) -> list[str]:
+    raw = input(prompt_text).strip()
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def main() -> int:
+    print("LifeOS identity setup")
+    print(f"Using API at {API_BASE} (override with LIFEOS_API_URL)\n")
+
+    try:
+        total = count_indexed_people(API_BASE)
+    except httpx.HTTPError as e:
+        print(f"Could not reach the LifeOS API at {API_BASE}: {e}")
+        print("Is it running? Try: ./scripts/server.sh start")
+        return 1
+
+    if total == 0:
+        print("No people are indexed yet -- run the first vault sync before this script:")
+        print("  ~/.venvs/lifeos/bin/python scripts/run_all_syncs.py --execute --force")
+        return 1
+
+    print(f"{total} people are indexed. Let's find you.\n")
+
+    unmatched: list[str] = []
+
+    me = prompt_pick_person(API_BASE, "yourself")
+    my_person_id = me["id"] if me else None
+    if me:
+        print(f"You are: {_describe_person(me)}\n")
+    else:
+        print("Skipped -- you can re-run this script later to set your identity.\n")
+
+    partner_name = input("Partner's first name (blank to skip): ").strip() or None
+    partner_person_id = None
+    if partner_name:
+        partner = prompt_pick_person(API_BASE, "your partner", default_query=partner_name)
+        if partner:
+            partner_person_id = partner["id"]
+            print(f"Partner matched: {_describe_person(partner)}\n")
+        else:
+            unmatched.append(partner_name)
+            print(f"Could not match '{partner_name}' to an indexed person -- "
+                  f"LIFEOS_PARTNER_NAME will still be set.\n")
+
+    family_last_names = prompt_list(
+        "Family surnames, comma-separated (e.g. 'Smith, Jones'; blank to skip): "
+    )
+
+    family_person_ids: list[str] = []
+    family_people_names = prompt_list(
+        "Any other specific family members by name, comma-separated (blank to skip): "
+    )
+    for name in family_people_names:
+        person = prompt_pick_person(API_BASE, name, default_query=name)
+        if person:
+            family_person_ids.append(person["id"])
+            print(f"Matched: {_describe_person(person)}\n")
+        else:
+            unmatched.append(name)
+
+    domains = prompt_list(
+        "Work email domain(s), comma-separated (e.g. 'acme.com, othercompany.com'; blank to skip): "
+    )
+    work_email_domain = domains[0] if len(domains) >= 1 else None
+    work_email_domain_2 = domains[1] if len(domains) >= 2 else None
+    work_email_domains_extra = domains[2:] if len(domains) > 2 else None
+
+    report = apply_identity_config(
+        env_path=ENV_PATH,
+        env_example_path=ENV_EXAMPLE_PATH,
+        family_config_path=FAMILY_CONFIG_PATH,
+        family_example_path=FAMILY_EXAMPLE_PATH,
+        relationship_config_path=RELATIONSHIP_CONFIG_PATH,
+        relationship_example_path=RELATIONSHIP_EXAMPLE_PATH,
+        my_person_id=my_person_id,
+        partner_name=partner_name,
+        partner_person_id=partner_person_id,
+        family_last_names=family_last_names,
+        family_person_ids=family_person_ids,
+        work_email_domain=work_email_domain,
+        work_email_domain_2=work_email_domain_2,
+        work_email_domains_extra=work_email_domains_extra,
+    )
+
+    print("\n--- Done ---")
+    if report["env_updates"]:
+        print(f"Wrote to {ENV_PATH}:")
+        for key, value in report["env_updates"].items():
+            print(f"  {key}={value}")
+        if report["env_backup"]:
+            print(f"  (previous .env backed up to {report['env_backup']})")
+    else:
+        print("Nothing written to .env (no answers provided).")
+
+    if report["family_report"]:
+        print(f"Updated {report['family_report']['path']}")
+        if report["family_report"]["backup"]:
+            print(f"  (previous file backed up to {report['family_report']['backup']})")
+
+    if report["relationship_report"]:
+        print(f"Updated {report['relationship_report']['path']}")
+        if report["relationship_report"]["backup"]:
+            print(f"  (previous file backed up to {report['relationship_report']['backup']})")
+
+    if unmatched:
+        print("\nCould not match to an indexed person (recorded as text only, if at all):")
+        for name in unmatched:
+            print(f"  - {name}")
+
+    if report["env_updates"] or report["family_report"] or report["relationship_report"]:
+        print("\nRestart the server for these changes to take effect: ./scripts/server.sh restart")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup_identity.py
+++ b/scripts/setup_identity.py
@@ -55,13 +55,39 @@ API_BASE = os.environ.get("LIFEOS_API_URL", "http://localhost:8000").rstrip("/")
 def backup_file(path: Path) -> Optional[Path]:
     """Copy an existing file to <path>.bak.<UTC timestamp> before it's
     modified. Returns the backup path, or None if there was nothing to back
-    up (file doesn't exist yet)."""
+    up (file doesn't exist yet). The timestamp includes microseconds, and a
+    numeric suffix is added on top of that if a backup with that exact name
+    already exists -- so two runs in quick succession never overwrite each
+    other's backup of the pre-existing file."""
     if not path.exists():
         return None
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
     backup_path = path.with_name(f"{path.name}.bak.{timestamp}")
+    suffix = 2
+    while backup_path.exists():
+        backup_path = path.with_name(f"{path.name}.bak.{timestamp}.{suffix}")
+        suffix += 1
     backup_path.write_bytes(path.read_bytes())
     return backup_path
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write `content` to `path` via a temp file + rename, so a crash or
+    disk-full event mid-write can never leave `path` truncated or
+    half-written -- the original file is left intact until the new one is
+    fully flushed to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    try:
+        tmp_path.write_text(content)
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _atomic_write_json(path: Path, data: dict) -> None:
+    _atomic_write_text(path, json.dumps(data, indent=2) + "\n")
 
 
 def _blank_template_value(value):
@@ -93,6 +119,19 @@ def _skeleton_from_example(example_path: Path) -> dict:
     return {key: _blank_template_value(value) for key, value in template.items()}
 
 
+def _existing_partner_person_id(config_path: Path) -> str:
+    """Read the current partner_person_id out of relationship_overrides.json,
+    if it exists, purely so main() can warn about drift -- never used to
+    decide what to write."""
+    if not config_path.exists():
+        return ""
+    try:
+        with open(config_path) as f:
+            return json.load(f).get("partner_person_id", "") or ""
+    except (json.JSONDecodeError, OSError):
+        return ""
+
+
 def _quote_env_value(value: str) -> str:
     """Quote an env value if it contains characters that would otherwise
     be misread (whitespace, '#')."""
@@ -104,11 +143,18 @@ def _quote_env_value(value: str) -> str:
 
 def _find_env_var_line(lines: list[str], key: str) -> Optional[int]:
     """Index of an existing KEY=... line for `key`, preferring an
-    uncommented assignment over a commented-out one. None if absent."""
+    uncommented assignment over a commented-out one. If a key is assigned
+    more than once (a pre-existing anomaly in the file -- dotenv parsers
+    apply the last assignment), the *last* match is returned, so setting
+    the key here actually changes the effective value instead of updating
+    a line an earlier duplicate would still shadow. None if absent."""
     active = re.compile(rf"^{re.escape(key)}=")
+    last_active = None
     for i, line in enumerate(lines):
         if active.match(line):
-            return i
+            last_active = i
+    if last_active is not None:
+        return last_active
     commented = re.compile(rf"^#\s*{re.escape(key)}=")
     for i, line in enumerate(lines):
         if commented.match(line):
@@ -145,7 +191,7 @@ def write_env_updates(env_path: Path, example_path: Path, updates: dict[str, str
         if lines and lines[-1].strip() != "":
             lines.append("")
         lines.extend(to_append)
-    env_path.write_text("\n".join(lines) + "\n")
+    _atomic_write_text(env_path, "\n".join(lines) + "\n")
     return backup
 
 
@@ -187,10 +233,7 @@ def merge_family_config(
                 config["family_person_ids"].append(person_id)
                 existing_ids.add(person_id)
 
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2)
-        f.write("\n")
+    _atomic_write_json(config_path, config)
 
     return {"path": config_path, "backup": backup, "config": config}
 
@@ -219,10 +262,7 @@ def merge_relationship_overrides(
     if partner_person_id:
         config["partner_person_id"] = partner_person_id
 
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2)
-        f.write("\n")
+    _atomic_write_json(config_path, config)
 
     return {"path": config_path, "backup": backup, "config": config}
 
@@ -389,6 +429,12 @@ def main() -> int:
             unmatched.append(partner_name)
             print(f"Could not match '{partner_name}' to an indexed person -- "
                   f"LIFEOS_PARTNER_NAME will still be set.\n")
+            existing_partner_id = _existing_partner_person_id(RELATIONSHIP_CONFIG_PATH)
+            if existing_partner_id:
+                print(f"Note: {RELATIONSHIP_CONFIG_PATH} still has a partner_person_id "
+                      f"from a previous run ({existing_partner_id}) -- it will NOT be "
+                      f"changed since '{partner_name}' didn't match anyone. Re-run and "
+                      f"pick a match to update it.\n")
 
     family_last_names = prompt_list(
         "Family surnames, comma-separated (e.g. 'Smith, Jones'; blank to skip): "

--- a/scripts/setup_identity.py
+++ b/scripts/setup_identity.py
@@ -52,22 +52,40 @@ API_BASE = os.environ.get("LIFEOS_API_URL", "http://localhost:8000").rstrip("/")
 # config directories. No network access, no prompts.
 # ============================================================================
 
+def _write_bytes_matching_mode(target_path: Path, data: bytes, mode: Optional[int]) -> None:
+    """Write `data` to a brand-new `target_path`, restrictive (owner-only)
+    from the instant it's created if `mode` is given, then relaxed to
+    exactly `mode` -- so a secret-holding file (e.g. a chmod 600 .env)
+    never has a window where the umask default leaves a copy of it
+    group/world-readable."""
+    old_umask = os.umask(0o077) if mode is not None else None
+    try:
+        target_path.write_bytes(data)
+        if mode is not None:
+            os.chmod(target_path, mode & 0o777)
+    finally:
+        if old_umask is not None:
+            os.umask(old_umask)
+
+
 def backup_file(path: Path) -> Optional[Path]:
     """Copy an existing file to <path>.bak.<UTC timestamp> before it's
     modified. Returns the backup path, or None if there was nothing to back
     up (file doesn't exist yet). The timestamp includes microseconds, and a
     numeric suffix is added on top of that if a backup with that exact name
     already exists -- so two runs in quick succession never overwrite each
-    other's backup of the pre-existing file."""
+    other's backup of the pre-existing file. The backup is created with the
+    same permissions as the file it's copying (see _write_bytes_matching_mode)."""
     if not path.exists():
         return None
+    mode = path.stat().st_mode
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
     backup_path = path.with_name(f"{path.name}.bak.{timestamp}")
     suffix = 2
     while backup_path.exists():
         backup_path = path.with_name(f"{path.name}.bak.{timestamp}.{suffix}")
         suffix += 1
-    backup_path.write_bytes(path.read_bytes())
+    _write_bytes_matching_mode(backup_path, path.read_bytes(), mode)
     return backup_path
 
 
@@ -76,15 +94,14 @@ def _atomic_write_text(path: Path, content: str) -> None:
     disk-full event mid-write can never leave `path` truncated or
     half-written -- the original file is left intact until the new one is
     fully flushed to disk. Preserves the existing file's permissions
-    (.env may be chmod 600, e.g. for an API key) instead of letting the
-    new file fall back to the umask default."""
+    (.env may be chmod 600, e.g. for an API key): the temp file is created
+    owner-only from the start (see _write_bytes_matching_mode) rather than
+    briefly existing at the umask default before being tightened."""
     path.parent.mkdir(parents=True, exist_ok=True)
     existing_mode = path.stat().st_mode if path.exists() else None
     tmp_path = path.with_name(f"{path.name}.tmp-{os.getpid()}")
     try:
-        tmp_path.write_text(content)
-        if existing_mode is not None:
-            os.chmod(tmp_path, existing_mode)
+        _write_bytes_matching_mode(tmp_path, content.encode(), existing_mode)
         os.replace(tmp_path, path)
     except BaseException:
         tmp_path.unlink(missing_ok=True)

--- a/scripts/setup_identity.py
+++ b/scripts/setup_identity.py
@@ -94,14 +94,15 @@ def _atomic_write_text(path: Path, content: str) -> None:
     disk-full event mid-write can never leave `path` truncated or
     half-written -- the original file is left intact until the new one is
     fully flushed to disk. Preserves the existing file's permissions
-    (.env may be chmod 600, e.g. for an API key): the temp file is created
-    owner-only from the start (see _write_bytes_matching_mode) rather than
-    briefly existing at the umask default before being tightened."""
+    (.env may be chmod 600, e.g. for an API key), or defaults a brand-new
+    file to owner-only (0600) rather than the umask default -- these are
+    all files that hold secrets or personal data (see AGENTS.md § Privacy)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     existing_mode = path.stat().st_mode if path.exists() else None
+    mode = existing_mode if existing_mode is not None else 0o600
     tmp_path = path.with_name(f"{path.name}.tmp-{os.getpid()}")
     try:
-        _write_bytes_matching_mode(tmp_path, content.encode(), existing_mode)
+        _write_bytes_matching_mode(tmp_path, content.encode(), mode)
         os.replace(tmp_path, path)
     except BaseException:
         tmp_path.unlink(missing_ok=True)

--- a/scripts/setup_identity.py
+++ b/scripts/setup_identity.py
@@ -75,11 +75,16 @@ def _atomic_write_text(path: Path, content: str) -> None:
     """Write `content` to `path` via a temp file + rename, so a crash or
     disk-full event mid-write can never leave `path` truncated or
     half-written -- the original file is left intact until the new one is
-    fully flushed to disk."""
+    fully flushed to disk. Preserves the existing file's permissions
+    (.env may be chmod 600, e.g. for an API key) instead of letting the
+    new file fall back to the umask default."""
     path.parent.mkdir(parents=True, exist_ok=True)
+    existing_mode = path.stat().st_mode if path.exists() else None
     tmp_path = path.with_name(f"{path.name}.tmp-{os.getpid()}")
     try:
         tmp_path.write_text(content)
+        if existing_mode is not None:
+            os.chmod(tmp_path, existing_mode)
         os.replace(tmp_path, path)
     except BaseException:
         tmp_path.unlink(missing_ok=True)
@@ -127,7 +132,10 @@ def _existing_partner_person_id(config_path: Path) -> str:
         return ""
     try:
         with open(config_path) as f:
-            return json.load(f).get("partner_person_id", "") or ""
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return ""
+        return data.get("partner_person_id", "") or ""
     except (json.JSONDecodeError, OSError):
         return ""
 

--- a/tests/test_setup_identity.py
+++ b/tests/test_setup_identity.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 import pytest
 
 from scripts.setup_identity import (
+    _existing_partner_person_id,
     apply_identity_config,
     backup_file,
     merge_family_config,
@@ -398,3 +399,35 @@ class TestAtomicWrites:
             merge_family_config(config_path, example_path, family_last_names=["Chen"])
 
         assert config_path.read_text() == original
+
+    def test_env_write_preserves_existing_file_permissions(self, tmp_path):
+        """.env can hold secrets (API keys) and may be chmod 600 -- the
+        atomic replace must not silently widen that to the umask default."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("LIFEOS_USER_NAME=Sam\n")
+        env_path.chmod(0o600)
+        example_path = tmp_path / ".env.example"
+        write_env_updates(env_path, example_path, {"LIFEOS_MY_PERSON_ID": "abc-123"})
+        assert (env_path.stat().st_mode & 0o777) == 0o600
+
+
+class TestExistingPartnerPersonId:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _existing_partner_person_id(tmp_path / "missing.json") == ""
+
+    def test_reads_existing_value(self, tmp_path):
+        config_path = tmp_path / "relationship_overrides.json"
+        config_path.write_text(json.dumps({"partner_person_id": "old-id"}))
+        assert _existing_partner_person_id(config_path) == "old-id"
+
+    def test_malformed_json_returns_empty_instead_of_raising(self, tmp_path):
+        config_path = tmp_path / "relationship_overrides.json"
+        config_path.write_text("not valid json{")
+        assert _existing_partner_person_id(config_path) == ""
+
+    def test_non_dict_top_level_returns_empty_instead_of_raising(self, tmp_path):
+        """A malformed config whose top level is a list (or any non-dict)
+        must not crash a warning-only lookup."""
+        config_path = tmp_path / "relationship_overrides.json"
+        config_path.write_text(json.dumps(["not", "a", "dict"]))
+        assert _existing_partner_person_id(config_path) == ""

--- a/tests/test_setup_identity.py
+++ b/tests/test_setup_identity.py
@@ -1,0 +1,317 @@
+"""
+Tests for scripts/setup_identity.py's write/merge logic (#763).
+
+Only the pure filesystem write/merge functions are tested here -- the
+interactive search-and-prompt flow in main() is a thin wrapper around them
+and isn't exercised (no server, no stdin). Every test operates on files
+under tmp_path; nothing here ever touches a real .env or config/*.json.
+"""
+import json
+
+import pytest
+
+from scripts.setup_identity import (
+    apply_identity_config,
+    backup_file,
+    merge_family_config,
+    merge_relationship_overrides,
+    write_env_updates,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ============================================================================
+# backup_file
+# ============================================================================
+
+class TestBackupFile:
+    def test_returns_none_when_file_absent(self, tmp_path):
+        assert backup_file(tmp_path / "missing.json") is None
+
+    def test_backs_up_existing_file_unchanged(self, tmp_path):
+        target = tmp_path / "thing.json"
+        target.write_text('{"a": 1}')
+        backup = backup_file(target)
+        assert backup is not None
+        assert backup.exists()
+        assert backup.read_text() == '{"a": 1}'
+        assert backup != target
+        # Original is untouched by the backup call itself.
+        assert target.read_text() == '{"a": 1}'
+
+
+# ============================================================================
+# write_env_updates
+# ============================================================================
+
+class TestWriteEnvUpdates:
+    def test_noop_when_no_updates(self, tmp_path):
+        env_path = tmp_path / ".env"
+        example_path = tmp_path / ".env.example"
+        example_path.write_text("LIFEOS_USER_NAME=\n")
+        backup = write_env_updates(env_path, example_path, {})
+        assert backup is None
+        assert not env_path.exists()
+
+    def test_creates_from_example_when_env_missing(self, tmp_path):
+        env_path = tmp_path / ".env"
+        example_path = tmp_path / ".env.example"
+        example_path.write_text("LIFEOS_USER_NAME=\nLIFEOS_MY_PERSON_ID=\n")
+        backup = write_env_updates(env_path, example_path, {"LIFEOS_MY_PERSON_ID": "abc-123"})
+        assert backup is None  # nothing existed yet, so nothing to back up
+        content = env_path.read_text()
+        assert "LIFEOS_MY_PERSON_ID=abc-123" in content
+        assert "LIFEOS_USER_NAME=" in content
+
+    def test_merges_existing_file_preserves_unrelated_lines(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text("LIFEOS_ANTHROPIC_API_KEY=sk-real-key\nLIFEOS_USER_NAME=Sam\n")
+        example_path = tmp_path / ".env.example"
+        write_env_updates(env_path, example_path, {"LIFEOS_MY_PERSON_ID": "abc-123"})
+        content = env_path.read_text()
+        assert "LIFEOS_ANTHROPIC_API_KEY=sk-real-key" in content
+        assert "LIFEOS_USER_NAME=Sam" in content
+        assert "LIFEOS_MY_PERSON_ID=abc-123" in content
+
+    def test_updates_existing_key_in_place(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text("LIFEOS_MY_PERSON_ID=old-id\nLIFEOS_USER_NAME=Sam\n")
+        example_path = tmp_path / ".env.example"
+        write_env_updates(env_path, example_path, {"LIFEOS_MY_PERSON_ID": "new-id"})
+        lines = env_path.read_text().splitlines()
+        assert lines.count("LIFEOS_MY_PERSON_ID=new-id") == 1
+        assert not any("old-id" in line for line in lines)
+
+    def test_uncomments_existing_commented_key(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text("# LIFEOS_WORK_DOMAIN_2=othercompany.com\n")
+        example_path = tmp_path / ".env.example"
+        write_env_updates(env_path, example_path, {"LIFEOS_WORK_DOMAIN_2": "realcompany.com"})
+        content = env_path.read_text()
+        assert "LIFEOS_WORK_DOMAIN_2=realcompany.com" in content
+        assert "# LIFEOS_WORK_DOMAIN_2=othercompany.com" not in content
+
+    def test_quotes_values_with_whitespace(self, tmp_path):
+        env_path = tmp_path / ".env"
+        example_path = tmp_path / ".env.example"
+        write_env_updates(env_path, example_path, {"LIFEOS_PARTNER_NAME": "Mary Ann"})
+        assert 'LIFEOS_PARTNER_NAME="Mary Ann"' in env_path.read_text()
+
+    def test_backs_up_existing_file_before_writing(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text("LIFEOS_USER_NAME=Sam\n")
+        example_path = tmp_path / ".env.example"
+        backup = write_env_updates(env_path, example_path, {"LIFEOS_MY_PERSON_ID": "abc-123"})
+        assert backup is not None
+        assert backup.read_text() == "LIFEOS_USER_NAME=Sam\n"
+
+    def test_idempotent_run_twice_produces_same_result(self, tmp_path):
+        env_path = tmp_path / ".env"
+        example_path = tmp_path / ".env.example"
+        updates = {"LIFEOS_MY_PERSON_ID": "abc-123", "LIFEOS_PARTNER_NAME": "Sam"}
+        write_env_updates(env_path, example_path, updates)
+        first = env_path.read_text()
+        write_env_updates(env_path, example_path, updates)
+        second = env_path.read_text()
+        assert first == second
+        assert second.count("LIFEOS_MY_PERSON_ID=") == 1
+        assert second.count("LIFEOS_PARTNER_NAME=") == 1
+
+
+# ============================================================================
+# merge_family_config
+# ============================================================================
+
+class TestMergeFamilyConfig:
+    def test_fresh_install_creates_from_example_shape_without_placeholders(self, tmp_path):
+        config_path = tmp_path / "family_members.json"
+        example_path = tmp_path / "family_members.example.json"
+        example_path.write_text(json.dumps({
+            "family_last_names": ["smith", "jones"],
+            "family_exact_names": ["uncle bob"],
+            "family_person_ids": ["uuid-of-partner"],
+            "tracked_relationships": [{"name": "Parent Relationship", "person_ids": ["x"], "healthy_direction": "more"}],
+            "default_selected_ids": ["uuid-1"],
+        }))
+        report = merge_family_config(config_path, example_path, family_last_names=["Ramirez"])
+        config = json.loads(config_path.read_text())
+        # The example's placeholder sample data must never be carried over.
+        assert "smith" not in config["family_last_names"]
+        assert "uuid-of-partner" not in config["family_person_ids"]
+        assert config["tracked_relationships"] == []
+        assert config["default_selected_ids"] == []
+        # But the new value the operator gave us is there.
+        assert config["family_last_names"] == ["Ramirez"]
+        assert report["backup"] is None
+
+    def test_fresh_install_without_example_starts_empty(self, tmp_path):
+        config_path = tmp_path / "family_members.json"
+        example_path = tmp_path / "family_members.example.json"  # doesn't exist
+        merge_family_config(config_path, example_path, family_last_names=["Ramirez"])
+        config = json.loads(config_path.read_text())
+        assert config["family_last_names"] == ["Ramirez"]
+        assert config["family_person_ids"] == []
+
+    def test_merges_into_existing_file_preserves_other_keys(self, tmp_path):
+        config_path = tmp_path / "family_members.json"
+        config_path.write_text(json.dumps({
+            "family_last_names": ["Ramirez"],
+            "family_exact_names": ["grammy"],
+            "family_person_ids": ["existing-id"],
+            "tracked_relationships": [{"name": "Coparent", "person_ids": ["a", "b"], "healthy_direction": "more"}],
+            "default_selected_ids": ["existing-id"],
+        }))
+        example_path = tmp_path / "family_members.example.json"
+        report = merge_family_config(
+            config_path, example_path,
+            family_last_names=["Chen"],
+            family_person_ids=["new-id"],
+        )
+        config = json.loads(config_path.read_text())
+        assert set(config["family_last_names"]) == {"Ramirez", "Chen"}
+        assert set(config["family_person_ids"]) == {"existing-id", "new-id"}
+        # Untouched by this script.
+        assert config["family_exact_names"] == ["grammy"]
+        assert config["tracked_relationships"] == [{"name": "Coparent", "person_ids": ["a", "b"], "healthy_direction": "more"}]
+        assert config["default_selected_ids"] == ["existing-id"]
+        assert report["backup"] is not None
+
+    def test_rerun_does_not_duplicate_entries(self, tmp_path):
+        config_path = tmp_path / "family_members.json"
+        example_path = tmp_path / "family_members.example.json"
+        merge_family_config(config_path, example_path, family_last_names=["Ramirez"], family_person_ids=["id-1"])
+        merge_family_config(config_path, example_path, family_last_names=["Ramirez"], family_person_ids=["id-1"])
+        config = json.loads(config_path.read_text())
+        assert config["family_last_names"] == ["Ramirez"]
+        assert config["family_person_ids"] == ["id-1"]
+
+    def test_dedupe_is_case_insensitive_for_surnames(self, tmp_path):
+        config_path = tmp_path / "family_members.json"
+        example_path = tmp_path / "family_members.example.json"
+        config_path.write_text(json.dumps({"family_last_names": ["Ramirez"]}))
+        merge_family_config(config_path, example_path, family_last_names=["ramirez", "Chen"])
+        config = json.loads(config_path.read_text())
+        assert config["family_last_names"] == ["Ramirez", "Chen"]
+
+
+# ============================================================================
+# merge_relationship_overrides
+# ============================================================================
+
+class TestMergeRelationshipOverrides:
+    def test_fresh_install_creates_skeleton_without_placeholders(self, tmp_path):
+        config_path = tmp_path / "relationship_overrides.json"
+        example_path = tmp_path / "relationship_overrides.example.json"
+        example_path.write_text(json.dumps({
+            "strength_overrides": {"uuid-of-partner": 100.0},
+            "circle_overrides": {"uuid-of-partner": 0},
+            "partner_person_id": "",
+        }))
+        merge_relationship_overrides(config_path, example_path, partner_person_id="real-id")
+        config = json.loads(config_path.read_text())
+        assert config["strength_overrides"] == {}
+        assert config["circle_overrides"] == {}
+        assert config["partner_person_id"] == "real-id"
+
+    def test_preserves_existing_strength_and_circle_overrides(self, tmp_path):
+        config_path = tmp_path / "relationship_overrides.json"
+        config_path.write_text(json.dumps({
+            "strength_overrides": {"some-id": 80.0},
+            "circle_overrides": {"some-id": 1},
+            "partner_person_id": "",
+        }))
+        example_path = tmp_path / "relationship_overrides.example.json"
+        report = merge_relationship_overrides(config_path, example_path, partner_person_id="real-id")
+        config = json.loads(config_path.read_text())
+        assert config["strength_overrides"] == {"some-id": 80.0}
+        assert config["circle_overrides"] == {"some-id": 1}
+        assert config["partner_person_id"] == "real-id"
+        assert report["backup"] is not None
+
+    def test_no_partner_id_leaves_existing_value_untouched(self, tmp_path):
+        config_path = tmp_path / "relationship_overrides.json"
+        config_path.write_text(json.dumps({
+            "strength_overrides": {},
+            "circle_overrides": {},
+            "partner_person_id": "existing-partner-id",
+        }))
+        example_path = tmp_path / "relationship_overrides.example.json"
+        merge_relationship_overrides(config_path, example_path, partner_person_id=None)
+        config = json.loads(config_path.read_text())
+        assert config["partner_person_id"] == "existing-partner-id"
+
+
+# ============================================================================
+# apply_identity_config -- the full write/merge pass
+# ============================================================================
+
+@pytest.fixture
+def config_paths(tmp_path):
+    return dict(
+        env_path=tmp_path / ".env",
+        env_example_path=tmp_path / ".env.example",
+        family_config_path=tmp_path / "family_members.json",
+        family_example_path=tmp_path / "family_members.example.json",
+        relationship_config_path=tmp_path / "relationship_overrides.json",
+        relationship_example_path=tmp_path / "relationship_overrides.example.json",
+    )
+
+
+class TestApplyIdentityConfig:
+    def test_full_flow_writes_all_three_surfaces(self, config_paths):
+        report = apply_identity_config(
+            **config_paths,
+            my_person_id="me-id",
+            partner_name="Sam",
+            partner_person_id="partner-id",
+            family_last_names=["Ramirez"],
+            family_person_ids=["sibling-id"],
+            work_email_domain="acme.com",
+            work_email_domain_2="othercompany.com",
+            work_email_domains_extra=["thirdco.com"],
+        )
+        env_content = config_paths["env_path"].read_text()
+        assert "LIFEOS_MY_PERSON_ID=me-id" in env_content
+        assert "LIFEOS_PARTNER_NAME=Sam" in env_content
+        assert "LIFEOS_WORK_DOMAIN=acme.com" in env_content
+        assert "LIFEOS_WORK_DOMAIN_2=othercompany.com" in env_content
+        assert "LIFEOS_WORK_DOMAINS_EXTRA=thirdco.com" in env_content
+
+        family_config = json.loads(config_paths["family_config_path"].read_text())
+        assert family_config["family_last_names"] == ["Ramirez"]
+        assert family_config["family_person_ids"] == ["sibling-id"]
+
+        relationship_config = json.loads(config_paths["relationship_config_path"].read_text())
+        assert relationship_config["partner_person_id"] == "partner-id"
+
+        assert report["family_report"] is not None
+        assert report["relationship_report"] is not None
+
+    def test_no_answers_writes_nothing(self, config_paths):
+        report = apply_identity_config(**config_paths)
+        assert report["env_updates"] == {}
+        assert not config_paths["env_path"].exists()
+        assert report["family_report"] is None
+        assert not config_paths["family_config_path"].exists()
+        assert report["relationship_report"] is None
+        assert not config_paths["relationship_config_path"].exists()
+
+    def test_unmatched_partner_still_sets_name_but_not_person_id(self, config_paths):
+        """Mirrors the interactive no-match case: a partner name was given
+        but couldn't be matched to an indexed person, so partner_person_id
+        stays unset while LIFEOS_PARTNER_NAME is still recorded."""
+        report = apply_identity_config(
+            **config_paths,
+            partner_name="Sam",
+            partner_person_id=None,
+        )
+        env_content = config_paths["env_path"].read_text()
+        assert "LIFEOS_PARTNER_NAME=Sam" in env_content
+        assert report["relationship_report"] is None
+        assert not config_paths["relationship_config_path"].exists()
+
+    def test_only_work_domains_leaves_family_and_relationship_files_untouched(self, config_paths):
+        apply_identity_config(**config_paths, work_email_domain="acme.com")
+        assert not config_paths["family_config_path"].exists()
+        assert not config_paths["relationship_config_path"].exists()

--- a/tests/test_setup_identity.py
+++ b/tests/test_setup_identity.py
@@ -7,6 +7,7 @@ and isn't exercised (no server, no stdin). Every test operates on files
 under tmp_path; nothing here ever touches a real .env or config/*.json.
 """
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -19,6 +20,17 @@ from scripts.setup_identity import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+class _FrozenClock:
+    """Stand-in for the `datetime` name backup_file() uses, whose now()
+    always returns the same instant -- simulates two script runs landing
+    in the same microsecond."""
+    def __init__(self, fixed_now):
+        self._fixed_now = fixed_now
+
+    def now(self, tz=None):
+        return self._fixed_now
 
 
 # ============================================================================
@@ -39,6 +51,26 @@ class TestBackupFile:
         assert backup != target
         # Original is untouched by the backup call itself.
         assert target.read_text() == '{"a": 1}'
+
+    def test_same_second_backups_do_not_collide(self, tmp_path, monkeypatch):
+        """Two backups taken in the same wall-clock second (same
+        microsecond, in a mocked clock) must not overwrite each other --
+        the second call gets a distinct name instead of clobbering the
+        first backup."""
+        import scripts.setup_identity as si
+
+        target = tmp_path / "thing.json"
+        target.write_text("version-1")
+        fixed_now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        monkeypatch.setattr(si, "datetime", _FrozenClock(fixed_now))
+
+        first_backup = backup_file(target)
+        target.write_text("version-2")
+        second_backup = backup_file(target)
+
+        assert first_backup != second_backup
+        assert first_backup.read_text() == "version-1"
+        assert second_backup.read_text() == "version-2"
 
 
 # ============================================================================
@@ -105,6 +137,20 @@ class TestWriteEnvUpdates:
         backup = write_env_updates(env_path, example_path, {"LIFEOS_MY_PERSON_ID": "abc-123"})
         assert backup is not None
         assert backup.read_text() == "LIFEOS_USER_NAME=Sam\n"
+
+    def test_duplicate_key_updates_the_line_dotenv_actually_honors(self, tmp_path):
+        """A pre-existing, malformed .env with the same key assigned twice
+        is a pre-existing anomaly this script didn't create -- but since
+        dotenv parsers apply whichever assignment comes last, the script
+        must update *that* line, or its write would have no effect on the
+        value the app actually sees."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("LIFEOS_WORK_DOMAIN=first.com\nLIFEOS_USER_NAME=Sam\nLIFEOS_WORK_DOMAIN=second.com\n")
+        example_path = tmp_path / ".env.example"
+        write_env_updates(env_path, example_path, {"LIFEOS_WORK_DOMAIN": "real.com"})
+        lines = env_path.read_text().splitlines()
+        assert lines[0] == "LIFEOS_WORK_DOMAIN=first.com"
+        assert lines[2] == "LIFEOS_WORK_DOMAIN=real.com"
 
     def test_idempotent_run_twice_produces_same_result(self, tmp_path):
         env_path = tmp_path / ".env"
@@ -315,3 +361,40 @@ class TestApplyIdentityConfig:
         apply_identity_config(**config_paths, work_email_domain="acme.com")
         assert not config_paths["family_config_path"].exists()
         assert not config_paths["relationship_config_path"].exists()
+
+
+# ============================================================================
+# Atomic writes -- a failure partway through must never leave a target file
+# truncated or partially written.
+# ============================================================================
+
+class TestAtomicWrites:
+    def test_env_write_failure_leaves_original_file_untouched(self, tmp_path, monkeypatch):
+        import scripts.setup_identity as si
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("LIFEOS_USER_NAME=Sam\n")
+        example_path = tmp_path / ".env.example"
+
+        monkeypatch.setattr(si.os, "replace", lambda *a, **kw: (_ for _ in ()).throw(OSError("disk full")))
+        with pytest.raises(OSError):
+            write_env_updates(env_path, example_path, {"LIFEOS_MY_PERSON_ID": "abc-123"})
+
+        # The original file must be exactly as it was -- no truncation.
+        assert env_path.read_text() == "LIFEOS_USER_NAME=Sam\n"
+        # No leftover temp file.
+        assert list(tmp_path.glob(".env.tmp-*")) == []
+
+    def test_family_config_write_failure_leaves_original_file_untouched(self, tmp_path, monkeypatch):
+        import scripts.setup_identity as si
+
+        config_path = tmp_path / "family_members.json"
+        original = json.dumps({"family_last_names": ["Ramirez"], "family_person_ids": []})
+        config_path.write_text(original)
+        example_path = tmp_path / "family_members.example.json"
+
+        monkeypatch.setattr(si.os, "replace", lambda *a, **kw: (_ for _ in ()).throw(OSError("disk full")))
+        with pytest.raises(OSError):
+            merge_family_config(config_path, example_path, family_last_names=["Chen"])
+
+        assert config_path.read_text() == original

--- a/tests/test_setup_identity.py
+++ b/tests/test_setup_identity.py
@@ -134,6 +134,15 @@ class TestWriteEnvUpdates:
         assert "LIFEOS_WORK_DOMAIN_2=realcompany.com" in content
         assert "# LIFEOS_WORK_DOMAIN_2=othercompany.com" not in content
 
+    def test_brand_new_env_file_defaults_to_owner_only_permissions(self, tmp_path):
+        """.env will hold secrets (API keys) once populated -- a freshly
+        created one (no pre-existing file/permissions to preserve) should
+        default to 0600, not the umask default."""
+        env_path = tmp_path / ".env"
+        example_path = tmp_path / ".env.example"
+        write_env_updates(env_path, example_path, {"LIFEOS_MY_PERSON_ID": "abc-123"})
+        assert (env_path.stat().st_mode & 0o777) == 0o600
+
     def test_quotes_values_with_whitespace(self, tmp_path):
         env_path = tmp_path / ".env"
         example_path = tmp_path / ".env.example"

--- a/tests/test_setup_identity.py
+++ b/tests/test_setup_identity.py
@@ -53,6 +53,15 @@ class TestBackupFile:
         # Original is untouched by the backup call itself.
         assert target.read_text() == '{"a": 1}'
 
+    def test_backup_preserves_source_file_permissions(self, tmp_path):
+        """A chmod 600 .env (holding a secret) must not get a
+        group/world-readable backup copy."""
+        target = tmp_path / ".env"
+        target.write_text("LIFEOS_ANTHROPIC_API_KEY=sk-real-key\n")
+        target.chmod(0o600)
+        backup = backup_file(target)
+        assert (backup.stat().st_mode & 0o777) == 0o600
+
     def test_same_second_backups_do_not_collide(self, tmp_path, monkeypatch):
         """Two backups taken in the same wall-clock second (same
         microsecond, in a mocked clock) must not overwrite each other --

--- a/tests/test_work_email_domains.py
+++ b/tests/test_work_email_domains.py
@@ -52,6 +52,29 @@ class TestWorkEmailDomains:
         )
         assert settings.work_email_domains == ["thirdco.com", "fourthco.com"]
 
+    def test_only_second_domain_set(self, monkeypatch):
+        """LIFEOS_WORK_DOMAIN_2 alone, with no first domain, is still honored."""
+        settings = _settings(monkeypatch, LIFEOS_WORK_DOMAIN_2="othercompany.com")
+        assert settings.work_email_domains == ["othercompany.com"]
+
+    def test_first_domain_and_extra_set(self, monkeypatch):
+        """First domain ahead of the extra list, with no second domain set."""
+        settings = _settings(
+            monkeypatch,
+            LIFEOS_WORK_DOMAIN="acme.com",
+            LIFEOS_WORK_DOMAINS_EXTRA="thirdco.com,fourthco.com",
+        )
+        assert settings.work_email_domains == ["acme.com", "thirdco.com", "fourthco.com"]
+
+    def test_second_domain_and_extra_set(self, monkeypatch):
+        """Second domain ahead of the extra list, with no first domain set."""
+        settings = _settings(
+            monkeypatch,
+            LIFEOS_WORK_DOMAIN_2="othercompany.com",
+            LIFEOS_WORK_DOMAINS_EXTRA="thirdco.com,fourthco.com",
+        )
+        assert settings.work_email_domains == ["othercompany.com", "thirdco.com", "fourthco.com"]
+
     def test_first_second_and_extra_set(self, monkeypatch):
         """First domain, then second domain, ahead of the new list's entries."""
         settings = _settings(

--- a/tests/test_work_email_domains.py
+++ b/tests/test_work_email_domains.py
@@ -1,0 +1,85 @@
+"""
+Tests for Settings.work_email_domains (#764).
+
+Work email domains were hard-capped at two (LIFEOS_WORK_DOMAIN,
+LIFEOS_WORK_DOMAIN_2). LIFEOS_WORK_DOMAINS_EXTRA adds an arbitrary number
+of further domains without touching the first two, which must keep
+behaving exactly as before for an already-configured install.
+"""
+import pytest
+
+from config.settings import Settings
+
+pytestmark = pytest.mark.unit
+
+
+def _settings(monkeypatch, **env):
+    """Build an isolated Settings instance with only the given env vars set."""
+    for key in (
+        "LIFEOS_WORK_DOMAIN",
+        "LIFEOS_WORK_DOMAIN_2",
+        "LIFEOS_WORK_DOMAINS_EXTRA",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return Settings(_env_file=None)
+
+
+class TestWorkEmailDomains:
+    def test_none_set(self, monkeypatch):
+        settings = _settings(monkeypatch)
+        assert settings.work_email_domains == []
+
+    def test_only_first_domain_set(self, monkeypatch):
+        """Unchanged from current behavior."""
+        settings = _settings(monkeypatch, LIFEOS_WORK_DOMAIN="acme.com")
+        assert settings.work_email_domains == ["acme.com"]
+
+    def test_first_and_second_domain_set(self, monkeypatch):
+        """Unchanged from current behavior."""
+        settings = _settings(
+            monkeypatch,
+            LIFEOS_WORK_DOMAIN="acme.com",
+            LIFEOS_WORK_DOMAIN_2="othercompany.com",
+        )
+        assert settings.work_email_domains == ["acme.com", "othercompany.com"]
+
+    def test_only_extra_list_set(self, monkeypatch):
+        settings = _settings(
+            monkeypatch,
+            LIFEOS_WORK_DOMAINS_EXTRA="thirdco.com,fourthco.com",
+        )
+        assert settings.work_email_domains == ["thirdco.com", "fourthco.com"]
+
+    def test_first_second_and_extra_set(self, monkeypatch):
+        """First domain, then second domain, ahead of the new list's entries."""
+        settings = _settings(
+            monkeypatch,
+            LIFEOS_WORK_DOMAIN="acme.com",
+            LIFEOS_WORK_DOMAIN_2="othercompany.com",
+            LIFEOS_WORK_DOMAINS_EXTRA="thirdco.com,fourthco.com",
+        )
+        assert settings.work_email_domains == [
+            "acme.com",
+            "othercompany.com",
+            "thirdco.com",
+            "fourthco.com",
+        ]
+
+    def test_extra_list_ignores_blank_entries_and_whitespace(self, monkeypatch):
+        settings = _settings(
+            monkeypatch,
+            LIFEOS_WORK_DOMAINS_EXTRA=" thirdco.com ,, fourthco.com ,",
+        )
+        assert settings.work_email_domains == ["thirdco.com", "fourthco.com"]
+
+    def test_existing_vars_still_named_and_readable_directly(self, monkeypatch):
+        """LIFEOS_WORK_DOMAIN / LIFEOS_WORK_DOMAIN_2 are not removed or renamed."""
+        settings = _settings(
+            monkeypatch,
+            LIFEOS_WORK_DOMAIN="acme.com",
+            LIFEOS_WORK_DOMAIN_2="othercompany.com",
+        )
+        assert settings.work_email_domain == "acme.com"
+        assert settings.work_email_domain_2 == "othercompany.com"


### PR DESCRIPTION
Two CRM personalization items from the second-user portability audit.

- #764 — `LIFEOS_WORK_DOMAINS_EXTRA` accepts a list of additional work domains. The two legacy settings keep working with identical precedence and order; an install using only those resolves exactly the same list as today.
- #763 — `scripts/setup_identity.py`: an interactive, run-once first-run script that picks the owner and partner from already-indexed people via the people-search endpoint, collects family surnames and work domains, and writes the identity settings and config files. Atomic writes, timestamped backups before any replace, `.env` permissions preserved (new files 0600), duplicate-key-aware `.env` updates, safe to re-run. Backup patterns added to `.gitignore`.

Adversarially reviewed with Codex — five rounds on the setup script; real findings fixed (non-atomic writes, backup collisions, dotenv last-occurrence semantics, permission windows, uncommitted-backup risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw