### PR TITLE
fix(health): vault_root sanity check sampled non-vault rows and reported a false degraded (#762 follow-up)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -467,12 +467,20 @@ def _check_vault_root_sanity(vault_search_check: "dict | None", vault_path) -> N
     check isn't present or didn't itself report "ok" — this never turns a
     failing check into a passing one, or vice versa, only adds a further
     downgrade on top of an already-passing result.
+
+    If the sample comes back empty (no vault documents were sampled — e.g.
+    a collection that is currently all non-vault content), that is absence
+    of signal, not evidence of a moved vault, so the check stays "ok" with a
+    neutral note instead of downgrading (#762 follow-up).
     """
     if not vault_search_check or vault_search_check.get("status") != "ok":
         return
     try:
         from api.services.vectorstore import get_vector_store, sample_paths_match_vault_root
         sample = get_vector_store().sample_file_paths(limit=5)
+        if not sample:
+            vault_search_check["vault_root_check"] = "no vault documents sampled"
+            return
         all_match, mismatched = sample_paths_match_vault_root(sample, vault_path)
         if not all_match:
             vault_search_check["status"] = "degraded"

--- a/api/main.py
+++ b/api/main.py
@@ -472,27 +472,43 @@ def _check_vault_root_sanity(vault_search_check: "dict | None", vault_path) -> N
     a collection that is currently all non-vault content), that is absence
     of signal, not evidence of a moved vault, so the check stays "ok" with a
     neutral note instead of downgrading (#762 follow-up).
+
+    Degrade rule (#762 second follow-up): the failure this check exists to
+    catch is a vault that *moved* — in that case NO sampled vault path is
+    under the configured root. A sample where some paths match and some
+    don't isn't that failure; it's more likely stray debris (e.g. a test
+    run that indexed documents straight into this collection, or a leftover
+    path from an old sync) sitting alongside otherwise-healthy content. So
+    this only downgrades to "degraded" when the sample contains at least one
+    vault path and *none* of them are under the root. A partial mismatch
+    stays "ok" but still surfaces a `vault_root_check` note (counts only)
+    so it's visible without being alarming.
     """
     if not vault_search_check or vault_search_check.get("status") != "ok":
         return
     try:
         from api.services.vectorstore import get_vector_store, sample_paths_match_vault_root
-        sample = get_vector_store().sample_file_paths(limit=5)
+        sample = get_vector_store().sample_file_paths(limit=50)
         if not sample:
             vault_search_check["vault_root_check"] = "no vault documents sampled"
             return
         all_match, mismatched = sample_paths_match_vault_root(sample, vault_path)
-        if not all_match:
+        matched = len(sample) - len(mismatched)
+        # Deliberately omit the mismatched paths and the configured root
+        # itself in both branches below — this is an unauthenticated
+        # endpoint, a real indexed file path can reveal personal
+        # folder/file names, and the vault root is typically an absolute
+        # path under the user's home directory (#697 review). The counts
+        # alone are enough for an operator to act on.
+        if matched == 0:
             vault_search_check["status"] = "degraded"
-            # Deliberately omit the mismatched paths and the configured root
-            # itself — this is an unauthenticated endpoint, a real indexed
-            # file path can reveal personal folder/file names, and the vault
-            # root is typically an absolute path under the user's home
-            # directory (#697 review). The counts alone are enough for an
-            # operator to act on.
             vault_search_check["vault_root_check"] = (
                 f"{len(mismatched)}/{len(sample)} sampled indexed path(s) fall outside "
                 "the configured vault root"
+            )
+        elif not all_match:
+            vault_search_check["vault_root_check"] = (
+                f"{matched}/{len(sample)} sampled vault paths under root"
             )
     except Exception as e:
         # Never let this additive sanity check take down the primary

--- a/api/services/vectorstore.py
+++ b/api/services/vectorstore.py
@@ -346,11 +346,13 @@ class VectorStore:
         sharing one `file_path`), so a raw `limit`-sized fetch risks
         returning the same one or two files repeatedly. Over-fetch a bit
         and dedupe to `file_path` so the sample actually spans up to
-        `limit` distinct files — still a small, bounded read regardless of
-        collection size, not a scan.
+        `limit` distinct files. At the health check's default `limit=50`
+        this fetches at most 250 rows — still a small, bounded read
+        regardless of collection size (250 rows out of 45k+ on a real vault
+        is well under 1%), not a scan.
         """
         results = self._collection.get(
-            limit=limit * 4,
+            limit=limit * 5,
             where={"note_type": {"$nin": _NON_VAULT_NOTE_TYPES}},
             include=["metadatas"],
         )

--- a/api/services/vectorstore.py
+++ b/api/services/vectorstore.py
@@ -11,8 +11,15 @@ from datetime import datetime
 from pathlib import Path
 import json
 import math
+import os
 
 from config.settings import settings
+
+# note_type values written by non-vault sources (api/services/calendar_indexer.py,
+# api/services/slack_indexer.py). These index real content under a relative
+# pseudo-path (e.g. "calendar/<event-id>"), not a vault document, so they must
+# never be mistaken for a vault-root sample (#762 follow-up).
+_NON_VAULT_NOTE_TYPES = ["calendar_event", "slack_message"]
 
 
 class VectorStore:
@@ -317,12 +324,23 @@ class VectorStore:
         return paths
 
     def sample_file_paths(self, limit: int = 5) -> list[str]:
-        """Return up to `limit` distinct indexed file paths, without
+        """Return up to `limit` distinct indexed *vault* file paths, without
         scanning the whole collection (#762). Used by the vault_search
         health check's vault-root sanity check — `get_all_file_paths()`
         above is the right tool when every path is actually needed, but is
         too expensive to call on every health-check request against a large
         vault.
+
+        The collection also holds non-vault sources (calendar events, Slack
+        messages) indexed under relative pseudo-paths, not real vault
+        documents. On a real vault these can dominate the front of insertion
+        order (e.g. thousands of calendar-event rows), so a plain unfiltered
+        fetch can return nothing but non-vault rows — every one of them
+        trivially "outside the vault root" and a false `degraded` (#762
+        follow-up). Push the exclusion down to ChromaDB via `where` so the
+        fetch still targets real vault rows regardless of how many non-vault
+        rows precede them, instead of over-fetching further and further to
+        try to skip past them client-side.
 
         Each file is indexed as several chunks (one row per chunk, all
         sharing one `file_path`), so a raw `limit`-sized fetch risks
@@ -331,13 +349,25 @@ class VectorStore:
         `limit` distinct files — still a small, bounded read regardless of
         collection size, not a scan.
         """
-        results = self._collection.get(limit=limit * 4, include=["metadatas"])
+        results = self._collection.get(
+            limit=limit * 4,
+            where={"note_type": {"$nin": _NON_VAULT_NOTE_TYPES}},
+            include=["metadatas"],
+        )
         paths = []
         seen = set()
         for meta in results.get("metadatas") or []:
             if not meta or "file_path" not in meta:
                 continue
             path = meta["file_path"]
+            # Defense in depth: vault documents always store an absolute,
+            # resolved path (indexer.py: `str(path.resolve())`), while every
+            # non-vault source uses a relative pseudo-path or doc id. This
+            # catches any future non-vault source we haven't added to
+            # `_NON_VAULT_NOTE_TYPES` above, without needing to keep the two
+            # lists in lockstep.
+            if not os.path.isabs(path):
+                continue
             if path in seen:
                 continue
             seen.add(path)

--- a/tests/test_vault_root_check.py
+++ b/tests/test_vault_root_check.py
@@ -18,13 +18,31 @@ pytestmark = pytest.mark.unit
 class _StubCollection:
     """Stands in for a ChromaDB collection's `.get()` — enough to test
     `VectorStore.sample_file_paths()`'s dedup logic without a real
-    ChromaDB server."""
+    ChromaDB server. Understands the `{"note_type": {"$nin": [...]}}` /
+    `{"$in": [...]}` shape of `where` clause this code actually issues, so
+    the filtering behavior is exercised, not just dedup."""
 
     def __init__(self, metadatas):
         self._metadatas = metadatas
 
-    def get(self, limit=None, include=None):
-        return {"metadatas": self._metadatas[: limit or len(self._metadatas)]}
+    def get(self, limit=None, where=None, include=None):
+        metadatas = self._metadatas
+        if where:
+            metadatas = [m for m in metadatas if self._matches(m, where)]
+        return {"metadatas": metadatas[: limit or len(metadatas)]}
+
+    @staticmethod
+    def _matches(meta, where):
+        for field, condition in where.items():
+            value = (meta or {}).get(field)
+            if isinstance(condition, dict):
+                if "$nin" in condition and value in condition["$nin"]:
+                    return False
+                if "$in" in condition and value not in condition["$in"]:
+                    return False
+            elif value != condition:
+                return False
+        return True
 
 
 def _store_with_collection(collection) -> VectorStore:
@@ -58,6 +76,70 @@ class TestSampleFilePaths:
         sample = store.sample_file_paths(limit=5)
 
         assert sample == ["/vault/a.md"]
+
+    def test_calendar_only_rows_yield_an_empty_sample(self):
+        """On a real vault, calendar-event rows (indexed under a relative
+        pseudo-path like "calendar/<event-id>") dominate the front of
+        insertion order. Before #762 follow-up, a fetch limited to the first
+        few rows could return nothing but these, and every one would be
+        flagged as "outside the vault root" — a false degraded. They must be
+        excluded from the sample entirely, not just tolerated."""
+        metadatas = [
+            {"note_type": "calendar_event", "file_path": "calendar/evt-1"},
+            {"note_type": "calendar_event", "file_path": "calendar/evt-2"},
+            {"note_type": "slack_message", "file_path": "slack/msg-1"},
+        ]
+        store = _store_with_collection(_StubCollection(metadatas))
+
+        sample = store.sample_file_paths(limit=5)
+
+        assert sample == []
+
+    def test_mixed_calendar_and_vault_rows_samples_only_vault_paths(self):
+        metadatas = [
+            {"note_type": "calendar_event", "file_path": "calendar/evt-1"},
+            {"note_type": "Personal", "file_path": "/vault/notes/a.md"},
+            {"note_type": "slack_message", "file_path": "slack/msg-1"},
+            {"note_type": "Work", "file_path": "/vault/notes/b.md"},
+        ]
+        store = _store_with_collection(_StubCollection(metadatas))
+
+        sample = store.sample_file_paths(limit=5)
+
+        assert sample == ["/vault/notes/a.md", "/vault/notes/b.md"]
+
+    def test_non_absolute_path_excluded_even_without_a_known_non_vault_note_type(self):
+        """Defense in depth: any row storing a relative path is excluded
+        regardless of its note_type, so a future non-vault source that isn't
+        (yet) added to the exclusion list still can't pollute the sample."""
+        metadatas = [
+            {"note_type": "some_future_source", "file_path": "future/doc-1"},
+            {"note_type": "Personal", "file_path": "/vault/notes/a.md"},
+        ]
+        store = _store_with_collection(_StubCollection(metadatas))
+
+        sample = store.sample_file_paths(limit=5)
+
+        assert sample == ["/vault/notes/a.md"]
+
+    def test_passes_a_note_type_exclusion_where_filter_to_the_collection(self):
+        """Pins the filter shape `sample_file_paths()` relies on ChromaDB to
+        honor — a regression here would silently turn the where-filter into
+        a no-op fetch."""
+        captured = {}
+
+        class _RecordingCollection(_StubCollection):
+            def get(self, limit=None, where=None, include=None):
+                captured["where"] = where
+                return super().get(limit=limit, where=where, include=include)
+
+        store = _store_with_collection(_RecordingCollection([]))
+
+        store.sample_file_paths(limit=5)
+
+        assert captured["where"] == {
+            "note_type": {"$nin": ["calendar_event", "slack_message"]}
+        }
 
 
 class TestSamplePathsMatchVaultRoot:
@@ -150,6 +232,26 @@ class TestCheckVaultRootSanity:
         assert "old_vault_location" not in check["vault_root_check"]
         assert "note.md" not in check["vault_root_check"]
         assert str(configured_root.resolve()) not in check["vault_root_check"]
+
+    def test_empty_sample_is_no_signal_not_degraded(self, monkeypatch, tmp_path):
+        """A sample with zero vault documents (e.g. the collection is
+        currently all calendar/Slack content) must not be treated as
+        evidence of a moved vault — absence of vault chunks in a bounded
+        sample isn't proof the vault moved (#762 follow-up)."""
+        import api.main as main
+        from api.services import vectorstore as vs
+
+        class _StubStore:
+            def sample_file_paths(self, limit=5):
+                return []
+
+        monkeypatch.setattr(vs, "get_vector_store", lambda: _StubStore())
+
+        check = {"status": "ok", "detail": "1 results"}
+        main._check_vault_root_sanity(check, tmp_path / "vault")
+
+        assert check["status"] == "ok"
+        assert check["vault_root_check"] == "no vault documents sampled"
 
     def test_leaves_ok_unchanged_when_paths_match(self, monkeypatch, tmp_path):
         import api.main as main

--- a/tests/test_vault_root_check.py
+++ b/tests/test_vault_root_check.py
@@ -253,6 +253,60 @@ class TestCheckVaultRootSanity:
         assert check["status"] == "ok"
         assert check["vault_root_check"] == "no vault documents sampled"
 
+    def test_partial_mismatch_stays_ok_with_a_counts_note(self, monkeypatch, tmp_path):
+        """The failure this check exists to catch is a vault that MOVED —
+        in that case NO sampled vault path is under the root. A sample with
+        some matches and some mismatches (e.g. debris from a test run that
+        indexed documents straight into this collection, or a stray path
+        from an old sync) isn't that failure and must not degrade — but the
+        partial mismatch is still surfaced as a counts-only note (#762
+        second follow-up)."""
+        import api.main as main
+        from api.services import vectorstore as vs
+
+        vault_root = tmp_path / "vault"
+        debris_root = tmp_path / "debris"
+        under_root = [str(vault_root / f"note{i}.md") for i in range(20)]
+        debris = [str(debris_root / f"stray{i}.md") for i in range(30)]
+
+        class _StubStore:
+            def sample_file_paths(self, limit=50):
+                return under_root + debris
+
+        monkeypatch.setattr(vs, "get_vector_store", lambda: _StubStore())
+
+        check = {"status": "ok", "detail": "1 results"}
+        main._check_vault_root_sanity(check, vault_root)
+
+        assert check["status"] == "ok"
+        assert check["vault_root_check"] == "20/50 sampled vault paths under root"
+
+    def test_all_mismatch_at_scale_still_degrades(self, monkeypatch, tmp_path):
+        """The real detection must survive the new partial-mismatch
+        tolerance: zero matches out of a larger sample is still the
+        moved-vault signal."""
+        import api.main as main
+        from api.services import vectorstore as vs
+
+        vault_root = tmp_path / "vault"
+        old_location = tmp_path / "old_vault_location"
+        mismatched = [str(old_location / f"note{i}.md") for i in range(50)]
+
+        class _StubStore:
+            def sample_file_paths(self, limit=50):
+                return mismatched
+
+        monkeypatch.setattr(vs, "get_vector_store", lambda: _StubStore())
+
+        check = {"status": "ok", "detail": "1 results"}
+        main._check_vault_root_sanity(check, vault_root)
+
+        assert check["status"] == "degraded"
+        assert (
+            check["vault_root_check"]
+            == "50/50 sampled indexed path(s) fall outside the configured vault root"
+        )
+
     def test_leaves_ok_unchanged_when_paths_match(self, monkeypatch, tmp_path):
         import api.main as main
         from api.services import vectorstore as vs


### PR DESCRIPTION
Post-deploy correction to the #762 health check that landed in #826.

**What was wrong.** `sample_file_paths()` took the first N distinct `file_path` values in insertion order. The vector store also indexes calendar events and Slack messages under relative pseudo-paths (`calendar/<id>…`), and those sort first — so every sampled path was "outside the vault root" and `vault_search` reported `degraded` on a healthy install. Observed on the maintainer's host immediately after deploy; would have reproduced on the second user's host tonight.

**Fix.**
- The sampler filters to vault rows (`where={"note_type": {"$nin": ["calendar_event", "slack_message"]}}`) plus an `os.path.isabs` guard so any future non-vault source can't pollute the sample either. Sample raised to 50 distinct paths from a bounded 250-row fetch — still not a scan.
- The degrade rule now matches the failure mode the check exists for: a moved vault means **zero** sampled vault paths are under the root. Partial mismatch reports `ok` with a counts-only note (`"20/50 sampled vault paths under root"`); an empty sample is no-signal and stays `ok`. Privacy property unchanged — no paths in the response.

**Verified** read-only against the live 45k-row store: the real `_check_vault_root_sanity()` now returns `ok` with `20/50`. The 30 non-matching paths are `/tmp/…` test fixtures a test run indexed into the production collection — filed as #828, out of scope here. 41 focused tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw