### PR TITLE
fix(voice): server-cancelled turns no longer resurrect a phantom bubble or leave the UI stuck (#827)

### DIFF
--- a/tests/test_voice_network_resilience_ui_browser.py
+++ b/tests/test_voice_network_resilience_ui_browser.py
@@ -410,6 +410,13 @@ class TestRetryReconciliation:
         expect(page.locator("#messages .message.user")).to_have_count(1)
         expect(page.locator("#messages .message.user")).to_have_text("first try")
         expect(page.locator(".voice-turn-status.failed")).to_have_count(0)
+        # The retried submitTurn() clears heldRecording only once its `done`
+        # frame lands -- everything asserted above is already true the
+        # instant the click fires (a reconciled bubble needs no round trip),
+        # so waiting on "Ready" (set right after `heldRecording = null` in
+        # submitTurn's success path) is what actually orders this assertion
+        # after the retry's async completion, instead of racing it.
+        expect(page.locator("#statusText")).to_have_text("Ready")
         assert _user_texts(page) == ["first try"]
         assert page.evaluate("() => window.lifeChatVoice.hasHeldRecording()") is False
 

--- a/tests/test_voice_transcript_ui_browser.py
+++ b/tests/test_voice_transcript_ui_browser.py
@@ -277,19 +277,34 @@ class TestEagerTranscriptRendering:
         this tab's own Cancel button. The eagerly-rendered bubble must not
         survive that path either, even though this tab's activeTurnAbort was
         never triggered locally."""
+        # '__gate' holds the stream open between 'transcript' and 'cancelled'
+        # so the mid-turn state (bubble rendered, Cancel button shown) can be
+        # asserted deterministically instead of racing the ~10ms it'd
+        # otherwise take the mock to run straight through to 'cancelled'.
         _open_voice_chat(
             page,
             chat_base_url,
             frames=[
+                {"type": "started", "turn_id": "turn-1"},
                 {"type": "transcript", "text": "remind me to call mom"},
+                "__gate",
                 {"type": "cancelled"},
             ],
         )
         _fire_turn(page, blob=None)
         expect(page.locator("#messages .message.user")).to_have_count(1)
+        expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn visible")
+        _release(page)
         page.wait_for_function(
             "document.querySelectorAll('#messages .message.user').length === 0"
         )
+        # This path never runs cancelActiveTurn() (no local Cancel tap), so
+        # it's the only place proving submitTurn()'s own AbortError handling
+        # resets the thinking placeholder, Cancel button, and status text
+        # itself rather than assuming a local cancel handler already did.
+        expect(page.locator("#messages .message.assistant .typing")).to_have_count(0)
+        expect(page.locator("#statusText")).to_have_text("Ready")
+        expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn")
 
     def test_failed_turn_keeps_the_user_bubble(self, page: Page, chat_base_url):
         """A turn that errors out is not a cancellation -- the user really did

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -2495,6 +2495,10 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
   showThinking();
   activeTurnId = null;
   activeTurnAbort = new AbortController();
+  // Captured so the catch below (#827) can tell "this turn's own controller
+  // is still current" from "a newer turn already replaced it" -- distinct
+  // from activeTurnAbort itself, which a later submitTurn() call reassigns.
+  const ownAbortController = activeTurnAbort;
 
   // #801 -- hold the recording until the turn *definitively* completes (see
   // `heldRecording`'s own comment). Set here, unconditionally, so a fresh
@@ -2593,9 +2597,11 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
       // clobbering a next turn that started in the meantime. A turn
       // cancelled server-side (the 'cancelled' SSE branch above, reachable
       // with no local cancelActiveTurn() call -- see #827) never goes
-      // through that reset, and activeTurnAbort is still this turn's own
-      // controller in that case, so do it here instead.
-      if (activeTurnAbort) {
+      // through that reset, and activeTurnAbort is still THIS turn's own
+      // controller in that case -- checked by identity, not mere presence,
+      // so a stale turn settling after a newer one has already started
+      // can't stomp on the newer turn's UI either.
+      if (activeTurnAbort === ownAbortController) {
         clearThinking();
         showCancel(false);
         setStatus('', 'Ready');

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -2586,7 +2586,22 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
     setStatus('', 'Ready');
     await maybeAutoContinue();  // re-record if Auto-continue is on
   } catch (err) {
-    if (err?.name === 'AbortError') return;  // cancelled — the cancel handler resets UI
+    if (err?.name === 'AbortError') {
+      // A local Cancel-button tap runs cancelActiveTurn() synchronously
+      // before this ever settles -- it already reset thinking/cancel/status
+      // and nulled activeTurnAbort, so redoing that here would risk
+      // clobbering a next turn that started in the meantime. A turn
+      // cancelled server-side (the 'cancelled' SSE branch above, reachable
+      // with no local cancelActiveTurn() call -- see #827) never goes
+      // through that reset, and activeTurnAbort is still this turn's own
+      // controller in that case, so do it here instead.
+      if (activeTurnAbort) {
+        clearThinking();
+        showCancel(false);
+        setStatus('', 'Ready');
+      }
+      return;
+    }
     clearThinking();
     showCancel(false);
     // #801 -- a mid-stream drop (the SSE stream died after a genuine `ok`

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -2199,11 +2199,17 @@ function parseSseChunk(buffer, onEvent) {
   const remainder = lines.pop() || '';
   for (const line of lines) {
     if (!line.startsWith('data: ')) continue;
+    let event;
     try {
-      onEvent(JSON.parse(line.slice(6)));
+      event = JSON.parse(line.slice(6));
     } catch {
-      /* ignore malformed chunks */
+      continue; // ignore malformed chunks
     }
+    // Outside the try: `cancelled`/`error` events intentionally throw from
+    // onEvent (handleEvent, below) to unwind consumeTurnStream's read loop --
+    // that must propagate to submitTurn()'s catch, not get swallowed here
+    // alongside a genuine JSON.parse failure.
+    onEvent(event);
   }
   return remainder;
 }


### PR DESCRIPTION
Filed as two flaky browser tests; turned out to be two production bugs in `web/chat/voice.js`.

- `parseSseChunk()` wrapped both `JSON.parse` and the `onEvent` callback in the malformed-JSON try/catch, so the intentional AbortError thrown by the `cancelled`/`error` handlers was swallowed as a "bad chunk". The stream then ended "without a response", terminal-failure handling re-created a phantom "🎤 Voice message" bubble ~10 ms after the cancel had cleared it — the race the test was catching. Only `JSON.parse` is guarded now.
- With the cancel propagating correctly, a **server-initiated** cancel reached `submitTurn`'s AbortError branch, which assumed a local Cancel tap had already reset the UI — so the thinking placeholder, Cancel button and status stuck on "Thinking…" forever. Now reset there, guarded by turn identity (`activeTurnAbort === ownAbortController`) so a stale late-settling turn can't wipe a newer one's UI (Codex caught the truthiness version).
- The retry-tap test's own race (asserting `hasHeldRecording()` before the retried turn's async completion) is fixed with a deterministic wait on the Ready status.

Before/after: 9/10 and 6/10 → 20/20 and 20/20 across two independent batches; full server-free browser scope 248/248 twice. Pre-existing residual filed as #832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw