### PR TITLE
feat(launchd): package the local LLM server for macOS (#830)

### DIFF
--- a/config/launchd/com.lifeos.llm.plist.template
+++ b/config/launchd/com.lifeos.llm.plist.template
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LifeOS Local LLM (llama-server) launchd configuration template.
+
+  Opt-in (#774/#830): only installed by scripts/setup-launchd.sh when
+  LIFEOS_LOCAL_LLM_AUTOSTART=true — mirrors the same env var gating
+  lifeos-llm.service on the systemd side
+  (config/systemd/lifeos-llm.service). A fresh install with this unset
+  stays exactly as inert as it is today; nothing here changes what an
+  already-configured host has loaded.
+
+  Model source: `-hf <repo>` (default, llama.cpp manages the HuggingFace
+  cache) or `-m <gguf>` (with an optional mmproj flag for vision models)
+  when LIFEOS_LLM_MODEL_PATH is set (local override for a stale HF cache — see
+  docs/guides/agent-worker-setup.md). scripts/setup-launchd.sh computes
+  these the same way scripts/setup-systemd.sh does and fills in the
+  model-source-args marker line below (see inject_llm_source_args in that
+  script) with one <string> per argument token — a launchd
+  ProgramArguments array can't hold a single space-separated string the
+  way systemd's ExecStart= line can. That marker line's exact text must
+  stay unique in this file (nothing else in the file may contain it
+  literally) since it's matched and replaced by line, not substituted
+  in place.
+
+  No ROCBLAS_USE_HIPBLASLT here (unlike the systemd unit): that variable
+  tunes AMD's hipBLASLt/rocBLAS backend, which doesn't exist on macOS —
+  llama-server uses the Metal backend on Apple Silicon instead, with no
+  equivalent tuning flag needed.
+
+  launchd has no StartLimitBurst equivalent: KeepAlive below restarts on
+  every non-zero exit, forever, throttled only by ThrottleInterval — a
+  persistently bad model path (e.g. a typo'd LIFEOS_LLM_MODEL_PATH)
+  restart-loops indefinitely instead of giving up after N attempts the way
+  systemd's StartLimitBurst/StartLimitIntervalSec would. Watch
+  logs/llama-server.log if this service won't stay up.
+
+  To use:
+  1. Copy this file to com.lifeos.llm.plist
+  2. Replace __HOME__ with your home directory path
+  3. Replace __LIFEOS_PATH__ with your LifeOS project path
+  4. Replace __LLAMA_CPP_DIR__ with your llama.cpp checkout path
+  5. Replace the model-source-args marker line in ProgramArguments below
+     with the model source <string> args (see scripts/setup-launchd.sh)
+  6. Copy to ~/Library/LaunchAgents/
+  7. Run: launchctl load ~/Library/LaunchAgents/com.lifeos.llm.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.lifeos.llm</string>
+
+    <!-- Routed through launchd-env-wrapper.sh so the process gets .env at
+         start, the same way lifeos-llm.service gets it via systemd's
+         EnvironmentFile= (#776). -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LIFEOS_PATH__/scripts/launchd-env-wrapper.sh</string>
+        <string>__LIFEOS_PATH__</string>
+        <string>__LLAMA_CPP_DIR__/build/bin/llama-server</string>
+        __LLM_SOURCE_ARGS_LINES__
+        <string>-ngl</string>
+        <string>99</string>
+        <string>-fa</string>
+        <string>on</string>
+        <string>--jinja</string>
+        <string>--no-mmap</string>
+        <string>-c</string>
+        <string>32768</string>
+        <string>--host</string>
+        <string>0.0.0.0</string>
+        <string>--port</string>
+        <string>8080</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__LLAMA_CPP_DIR__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__HOME__/.venvs/lifeos/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <!-- Auto-start on boot -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart only on a non-zero exit — mirrors lifeos-llm.service's
+         Restart=on-failure. This plist is only ever installed when
+         LIFEOS_LOCAL_LLM_AUTOSTART=true, so there's no launchd analog
+         needed for systemd's separate "installed but disabled" state. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <!-- Restart throttle: wait 10 seconds before restart (matches the
+         systemd unit's RestartSec=10) -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Log files (matches the systemd unit's StandardOutput/StandardError
+         both pointing at logs/llama-server.log) -->
+    <key>StandardOutPath</key>
+    <string>__LIFEOS_PATH__/logs/llama-server.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LIFEOS_PATH__/logs/llama-server.log</string>
+</dict>
+</plist>

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -58,11 +58,25 @@ The minimal setup (Steps 1–7 below) works identically on macOS and Linux —
 Anthropic API key, vault, ChromaDB, working `/chat`. Past that point, most of
 the packaged "keep itself healthy unattended" automation is Linux-only:
 **17 systemd units** ship for Linux (sync, three crash-restart watchdogs,
-autodeploy, agent worker, MCP-HTTP, local LLM) versus **3 launchd templates**
-for macOS (`com.lifeos.api`, `com.lifeos.crm-sync`, and an unused
-`com.lifeos.chromadb` — ChromaDB uses a cron watchdog instead, see Step 3).
-See [launchd-setup.md](launchd-setup.md) for why macOS-as-primary-server was
-superseded by the Linux migration and what's preserved from it.
+autodeploy, agent worker, MCP-HTTP, local LLM) versus **6 launchd templates**
+for macOS: `com.lifeos.api` and `com.lifeos.crm-sync` (always generated);
+`com.lifeos.agent-worker`, `com.lifeos.mcp-http`, and `com.lifeos.llm`
+(each installed only when its matching opt-in env var is set — the same
+env var that gates its systemd counterpart: `LIFEOS_AGENT_WORKER_AUTOSTART`,
+`LIFEOS_MCP_BEARER_TOKEN`, and `LIFEOS_LOCAL_LLM_AUTOSTART` respectively);
+and an unused `com.lifeos.chromadb` — ChromaDB uses a cron watchdog instead,
+see Step 3. See [launchd-setup.md](launchd-setup.md) for why
+macOS-as-primary-server was superseded by the Linux migration and what's
+preserved from it.
+
+**The local LLM is packaged for macOS too (#830).** Setting
+`LIFEOS_LOCAL_LLM_AUTOSTART=true` in `.env` before running
+`./scripts/setup-launchd.sh` installs `com.lifeos.llm`, running
+`llama-server` against the same `-hf <repo>` / `-m <gguf>` model-source
+config `LIFEOS_LLM_MODEL`/`LIFEOS_LLM_MODEL_PATH` drive on Linux — llama.cpp
+builds natively on Apple Silicon (Metal backend) so this is the same binary
+and flags, just supervised by launchd instead of systemd. See
+[Local LLM (optional)](#local-llm-optional) below.
 
 **Nightly sync does have a packaged macOS path.** `./scripts/setup-launchd.sh`
 (Phase 8 of [setup.md](setup.md)) installs `com.lifeos.crm-sync`, a launchd
@@ -84,10 +98,9 @@ ever):
 
 **What you're living without, either way:** if a sync run hangs or crashes,
 nothing restarts it until the next scheduled tick (no `lifeos-watchdog`
-equivalent); pushing to `main` doesn't auto-redeploy the running server (no
-`lifeos-autodeploy`); and the agent worker and MCP-HTTP bridge aren't
-packaged for launchd at all. None of that blocks chat, search, or manual
-sync runs — it's the unattended-operations layer, and it's Linux-only today.
+equivalent); and pushing to `main` doesn't auto-redeploy the running server
+(no `lifeos-autodeploy`). None of that blocks chat, search, or manual sync
+runs — it's the unattended-operations layer, and it's Linux-only today.
 
 ---
 
@@ -268,6 +281,10 @@ sudo systemctl restart lifeos-llm
 ```
 
 The first start with a new model downloads the GGUF file. Subsequent starts use the cached file in `~/.cache/llama.cpp/`.
+
+On macOS, reinstall and restart via launchd instead: re-run
+`./scripts/setup-launchd.sh <vault-path> --yes` (no `sudo`), then
+`launchctl unload ~/Library/LaunchAgents/com.lifeos.llm.plist && launchctl load ~/Library/LaunchAgents/com.lifeos.llm.plist`.
 
 ---
 

--- a/docs/guides/launchd-setup.md
+++ b/docs/guides/launchd-setup.md
@@ -13,9 +13,11 @@
 **If you're setting up LifeOS to run *on* a Mac** (not just for Apple Data
 Agent export), see [Installation § Running LifeOS on macOS as the
 Host](installation.md#running-lifeos-on-macos-as-the-host) for what's
-packaged today (`com.lifeos.api`, `com.lifeos.crm-sync`) versus what's
-Linux-only (crash-restart watchdogs, autodeploy, agent worker, MCP-HTTP) and
-a cron/launchd snippet for nightly sync.
+packaged today (`com.lifeos.api` and `com.lifeos.crm-sync` always;
+`com.lifeos.agent-worker`, `com.lifeos.mcp-http`, and `com.lifeos.llm` as
+opt-in launchd equivalents of their systemd units) versus what's still
+Linux-only (crash-restart watchdogs, autodeploy) and a cron/launchd snippet
+for nightly sync.
 
 ## If you have a Mac in the system today
 

--- a/scripts/setup-launchd.sh
+++ b/scripts/setup-launchd.sh
@@ -86,18 +86,33 @@ _sed_escape_replacement() {
     printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/&/\\\&/g' -e 's/|/\\|/g'
 }
 
+# XML-escape a value for safe use inside a plist <string> element (found on
+# review, #830): a path containing `&`, `<`, or `>` (e.g. `/Users/x/R&D/model.gguf`
+# — a real-world directory name) produces invalid XML if dropped in raw,
+# which then fails plutil validation and aborts the whole install. `&` must
+# be escaped first, or escaping `<`/`>` afterward would double-escape it.
+_xml_escape() {
+    printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
 # Substitute the __HOME__/__LIFEOS_PATH__/__VAULT_PATH__/__LLAMA_CPP_DIR__
 # placeholder convention into a template, writing the result to $2.
 # llama_dir ($6) is optional — templates that don't reference
 # __LLAMA_CPP_DIR__ (everything but com.lifeos.llm.plist.template) simply
-# ignore it.
+# ignore it. __LLAMA_CPP_DIR__ is XML-escaped before the sed-escape (composed,
+# not either alone — sed-escape alone would leave a raw `&` in the plist,
+# and XML-escaping alone would leave literal `&` from `&amp;` unescaped for
+# sed's own replacement syntax). __HOME__/__LIFEOS_PATH__/__VAULT_PATH__
+# intentionally keep their existing sed-only behavior — locked in by
+# test_generate_plist_handles_sed_metacharacters_in_values, unrelated to
+# this new placeholder.
 generate_plist() {
     local template="$1" output="$2" home="$3" lifeos_path="$4" vault_path="$5" llama_dir="$6"
     local esc_home esc_lifeos_path esc_vault_path esc_llama_dir
     esc_home=$(_sed_escape_replacement "$home")
     esc_lifeos_path=$(_sed_escape_replacement "$lifeos_path")
     esc_vault_path=$(_sed_escape_replacement "$vault_path")
-    esc_llama_dir=$(_sed_escape_replacement "$llama_dir")
+    esc_llama_dir=$(_sed_escape_replacement "$(_xml_escape "$llama_dir")")
     sed -e "s|__HOME__|$esc_home|g" \
         -e "s|__LIFEOS_PATH__|$esc_lifeos_path|g" \
         -e "s|__VAULT_PATH__|$esc_vault_path|g" \
@@ -113,12 +128,17 @@ generate_plist() {
 # removes the marker line itself. Only ever called for com.lifeos.llm.plist
 # — no other template has this marker, so check_placeholders would (rightly)
 # fail any plist where this was skipped by mistake.
+#
+# Each token is XML-escaped (found on review, #830): these come straight
+# from operator-supplied LIFEOS_LLM_MODEL/_MODEL_PATH/_MMPROJ_PATH, and a
+# path containing `&`, `<`, or `>` would otherwise produce invalid XML that
+# fails plutil validation and aborts the whole install.
 inject_llm_source_args() {
     local plist="$1"
     local args_file tok
     args_file=$(mktemp)
     for tok in "${LLM_SOURCE_ARGS_TOKENS[@]}"; do
-        printf '        <string>%s</string>\n' "$tok" >> "$args_file"
+        printf '        <string>%s</string>\n' "$(_xml_escape "$tok")" >> "$args_file"
     done
     sed -e "/__LLM_SOURCE_ARGS_LINES__/r $args_file" -e "/__LLM_SOURCE_ARGS_LINES__/d" "$plist" > "$plist.tmp"
     mv "$plist.tmp" "$plist"

--- a/scripts/setup-launchd.sh
+++ b/scripts/setup-launchd.sh
@@ -24,6 +24,10 @@ ENV_FILE="$LIFEOS_PATH/.env"
 # what's actually baked into the generated plist. Tests get an isolated venv
 # by pointing $HOME at a sandbox, same as everything else __HOME__-derived.
 VENV_DIR="$HOME/.venvs/lifeos"
+# Same convention as scripts/setup-systemd.sh's LLAMA_DIR: a shell env var
+# override, else ~/llama.cpp default. Feeds __LLAMA_CPP_DIR__ in
+# com.lifeos.llm.plist.template.
+LLAMA_DIR="${LIFEOS_LLAMA_DIR:-$HOME/llama.cpp}"
 
 # Read a KEY=value from .env, same convention as scripts/setup-systemd.sh's
 # and scripts/auto-deploy.sh's own _read_env — stripping quotes, whitespace,
@@ -35,15 +39,42 @@ _read_env() {
     echo "${val:-$default}"
 }
 
-# Opt-in gates for the two conditionally-installed services (#774) — same
-# env vars, same defaults, as scripts/setup-systemd.sh's Linux install, so
-# a single .env controls both platforms identically.
+# Opt-in gates for the three conditionally-installed services (#774, #830)
+# — same env vars, same defaults, as scripts/setup-systemd.sh's Linux
+# install, so a single .env controls all three identically on both
+# platforms.
 AGENT_WORKER_AUTOSTART=$(_read_env "LIFEOS_AGENT_WORKER_AUTOSTART" "false" | tr '[:upper:]' '[:lower:]')
 case "$AGENT_WORKER_AUTOSTART" in
     true|1|yes) AGENT_WORKER_AUTOSTART="true" ;;
     *)          AGENT_WORKER_AUTOSTART="false" ;;
 esac
 MCP_BEARER_TOKEN=$(_read_env "LIFEOS_MCP_BEARER_TOKEN" "")
+LLM_AUTOSTART=$(_read_env "LIFEOS_LOCAL_LLM_AUTOSTART" "false" | tr '[:upper:]' '[:lower:]')
+case "$LLM_AUTOSTART" in
+    true|1|yes) LLM_AUTOSTART="true" ;;
+    *)          LLM_AUTOSTART="false" ;;
+esac
+
+# Model source args for com.lifeos.llm.plist — same computation as
+# scripts/setup-systemd.sh's LLM_SOURCE_ARGS: `-hf <repo>` by default, or
+# `-m <gguf> [--mmproj <mmproj>]` when LIFEOS_LLM_MODEL_PATH overrides a
+# stale HuggingFace cache (see docs/guides/agent-worker-setup.md). Kept as
+# an array, not a joined string, because launchd's ProgramArguments is a
+# real argv array — each token needs its own <string> element; see
+# inject_llm_source_args below.
+LLM_MODEL=$(_read_env "LIFEOS_LLM_MODEL" "unsloth/gemma-4-26B-A4B-it-GGUF")
+LLM_MODEL_PATH=$(_read_env "LIFEOS_LLM_MODEL_PATH" "")
+LLM_MMPROJ_PATH=$(_read_env "LIFEOS_LLM_MMPROJ_PATH" "")
+if [ -n "$LLM_MODEL_PATH" ]; then
+    LLM_SOURCE_ARGS_TOKENS=("-m" "$LLM_MODEL_PATH")
+    if [ -n "$LLM_MMPROJ_PATH" ]; then
+        LLM_SOURCE_ARGS_TOKENS+=("--mmproj" "$LLM_MMPROJ_PATH")
+    fi
+    LLM_SOURCE_DISPLAY="$LLM_MODEL_PATH (local file)"
+else
+    LLM_SOURCE_ARGS_TOKENS=("-hf" "$LLM_MODEL")
+    LLM_SOURCE_DISPLAY="$LLM_MODEL (HuggingFace)"
+fi
 
 # --- Generation ------------------------------------------------------------
 
@@ -55,18 +86,43 @@ _sed_escape_replacement() {
     printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/&/\\\&/g' -e 's/|/\\|/g'
 }
 
-# Substitute the __HOME__/__LIFEOS_PATH__/__VAULT_PATH__ placeholder
-# convention into a template, writing the result to $2.
+# Substitute the __HOME__/__LIFEOS_PATH__/__VAULT_PATH__/__LLAMA_CPP_DIR__
+# placeholder convention into a template, writing the result to $2.
+# llama_dir ($6) is optional — templates that don't reference
+# __LLAMA_CPP_DIR__ (everything but com.lifeos.llm.plist.template) simply
+# ignore it.
 generate_plist() {
-    local template="$1" output="$2" home="$3" lifeos_path="$4" vault_path="$5"
-    local esc_home esc_lifeos_path esc_vault_path
+    local template="$1" output="$2" home="$3" lifeos_path="$4" vault_path="$5" llama_dir="$6"
+    local esc_home esc_lifeos_path esc_vault_path esc_llama_dir
     esc_home=$(_sed_escape_replacement "$home")
     esc_lifeos_path=$(_sed_escape_replacement "$lifeos_path")
     esc_vault_path=$(_sed_escape_replacement "$vault_path")
+    esc_llama_dir=$(_sed_escape_replacement "$llama_dir")
     sed -e "s|__HOME__|$esc_home|g" \
         -e "s|__LIFEOS_PATH__|$esc_lifeos_path|g" \
         -e "s|__VAULT_PATH__|$esc_vault_path|g" \
+        -e "s|__LLAMA_CPP_DIR__|$esc_llama_dir|g" \
         "$template" > "$output"
+}
+
+# The launchd analog of scripts/setup-systemd.sh's single LLM_SOURCE_ARGS
+# string: ProgramArguments is a real argv array, so each token
+# (LLM_SOURCE_ARGS_TOKENS, computed above) needs its own <string> element
+# rather than one space-joined string. sed's `r` command inserts a file's
+# raw content immediately after the matched line; the paired `d` then
+# removes the marker line itself. Only ever called for com.lifeos.llm.plist
+# — no other template has this marker, so check_placeholders would (rightly)
+# fail any plist where this was skipped by mistake.
+inject_llm_source_args() {
+    local plist="$1"
+    local args_file tok
+    args_file=$(mktemp)
+    for tok in "${LLM_SOURCE_ARGS_TOKENS[@]}"; do
+        printf '        <string>%s</string>\n' "$tok" >> "$args_file"
+    done
+    sed -e "/__LLM_SOURCE_ARGS_LINES__/r $args_file" -e "/__LLM_SOURCE_ARGS_LINES__/d" "$plist" > "$plist.tmp"
+    mv "$plist.tmp" "$plist"
+    rm -f "$args_file"
 }
 
 # --- Validation (#776) -------------------------------------------------------
@@ -307,6 +363,12 @@ service_skip_reason() {
                 return 1
             fi
             ;;
+        *.llm.plist)
+            if [ "$LLM_AUTOSTART" != "true" ]; then
+                echo "set LIFEOS_LOCAL_LLM_AUTOSTART=true to enable"
+                return 1
+            fi
+            ;;
     esac
     return 0
 }
@@ -380,6 +442,14 @@ if [ -n "$MCP_BEARER_TOKEN" ]; then
 else
     echo "  MCP HTTP:     disabled (set LIFEOS_MCP_BEARER_TOKEN to enable)"
 fi
+if [ "$LLM_AUTOSTART" = "true" ]; then
+    echo "  Local LLM:    enabled ($LLM_SOURCE_DISPLAY)"
+else
+    echo "  Local LLM:    disabled (set LIFEOS_LOCAL_LLM_AUTOSTART=true to enable)"
+fi
+if [ -n "$LLM_MODEL_PATH" ] && [ ! -f "$LLM_MODEL_PATH" ]; then
+    echo "  WARNING: LIFEOS_LLM_MODEL_PATH=$LLM_MODEL_PATH does not exist"
+fi
 echo ""
 
 if [ "$AUTO_YES" = false ]; then
@@ -402,7 +472,10 @@ for template in "$LAUNCHD_DIR"/*.plist.template; do
     if [ -f "$template" ]; then
         output="${template%.template}"
         filename=$(basename "$output")
-        generate_plist "$template" "$output" "$HOME" "$LIFEOS_PATH" "$VAULT_PATH"
+        generate_plist "$template" "$output" "$HOME" "$LIFEOS_PATH" "$VAULT_PATH" "$LLAMA_DIR"
+        if [ "$filename" = "com.lifeos.llm.plist" ]; then
+            inject_llm_source_args "$output"
+        fi
         echo "  Generated: $filename"
     fi
 done
@@ -496,6 +569,9 @@ echo "   launchctl load ~/Library/LaunchAgents/com.lifeos.api.plist"
 echo "   launchctl load ~/Library/LaunchAgents/com.lifeos.crm-sync.plist"
 if [ "$AGENT_WORKER_AUTOSTART" = "true" ]; then
     echo "   launchctl load ~/Library/LaunchAgents/com.lifeos.agent-worker.plist"
+fi
+if [ "$LLM_AUTOSTART" = "true" ]; then
+    echo "   launchctl load ~/Library/LaunchAgents/com.lifeos.llm.plist"
 fi
 if [ -n "$MCP_BEARER_TOKEN" ]; then
     echo "   launchctl load ~/Library/LaunchAgents/com.lifeos.mcp-http.plist"

--- a/tests/test_launchd_setup.py
+++ b/tests/test_launchd_setup.py
@@ -22,6 +22,7 @@ import re
 import shutil
 import stat
 import subprocess
+import xml.dom.minidom
 from pathlib import Path
 
 import pytest
@@ -146,6 +147,19 @@ def test_sed_escape_replacement_round_trips_special_characters(tmp_path: Path):
     result = _run_sourced(repo, r'''esc=$(_sed_escape_replacement 'a&b\c|d'); printf 'X__T__Y' | sed "s|__T__|$esc|g"''')
     assert result.returncode == 0, result.stderr
     assert result.stdout == r'Xa&b\c|dY'
+
+
+@pytest.mark.unit
+def test_xml_escape_escapes_ampersand_lt_gt(tmp_path: Path):
+    """#830: values that flow into a plist <string> element (llama.cpp dir,
+    model-source args) need real XML escaping, not just sed-safety — a raw
+    `&`, `<`, or `>` is invalid XML outside an entity reference."""
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    repo = _make_sandbox(tmp_path)
+    result = _run_sourced(repo, r'''_xml_escape 'R&D <models> here' ''')
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "R&amp;D &lt;models&gt; here"
 
 
 @pytest.mark.unit
@@ -1033,6 +1047,44 @@ def test_main_installs_llm_with_model_path_override(tmp_path: Path):
     assert f"<string>-m</string>\n        <string>{model_path}</string>" in text
     assert f"<string>--mmproj</string>\n        <string>{mmproj_path}</string>" in text
     assert "<string>-hf</string>" not in text
+
+
+@pytest.mark.unit
+def test_main_installs_llm_with_ampersand_in_model_path(tmp_path: Path):
+    """Found on review: a real-world directory name like `R&D` in
+    LIFEOS_LLM_MODEL_PATH produced invalid plist XML (a bare `&` is not
+    legal outside an entity reference) — the stubbed plutil in other tests
+    doesn't catch this since it always exits 0, so this test parses the
+    installed plist as real XML instead."""
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    if not _LLM_TEMPLATE.exists():
+        pytest.skip("llm plist template not present")
+    repo, vault, fake_home, _venv = _make_main_sandbox(tmp_path, _GOOD_TEMPLATE)
+    _add_real_template(repo, _LLM_TEMPLATE)
+    _add_llama_server_binary(fake_home)
+    model_dir = tmp_path / "R&D"
+    model_dir.mkdir()
+    model_path = model_dir / "model.gguf"
+    model_path.write_text("fake gguf")
+    (repo / ".env").write_text(
+        f"LIFEOS_LOCAL_LLM_AUTOSTART=true\nLIFEOS_LLM_MODEL_PATH={model_path}\n",
+        encoding="utf-8",
+    )
+    bindir = _stub_plutil_ok(repo)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(fake_home)
+    result = subprocess.run(
+        ["bash", "scripts/setup-launchd.sh", str(vault), "--yes"],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    installed = fake_home / "Library" / "LaunchAgents" / "com.lifeos.llm.plist"
+    text = installed.read_text()
+    assert "R&amp;D" in text
+    assert "R&D" not in text  # the raw, unescaped form must not appear
+    xml.dom.minidom.parseString(text)  # raises ExpatError if not well-formed
 
 
 @pytest.mark.unit

--- a/tests/test_launchd_setup.py
+++ b/tests/test_launchd_setup.py
@@ -18,6 +18,7 @@ and fixture templates, with `plutil` stubbed since it's macOS-only.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -869,6 +870,256 @@ def test_main_rerun_with_autostart_still_enabled_leaves_agent_worker_untouched(t
     second = run()
     assert second.returncode == 0, (second.stdout, second.stderr)
     assert "Unchanged: com.lifeos.agent-worker.plist" in second.stdout
+    assert installed.stat().st_mtime == before_mtime
+
+
+# ---------------------------------------------------------------------------
+# #830 — conditionally-installed local LLM (llama-server) service
+# ---------------------------------------------------------------------------
+_LLM_TEMPLATE = REPO_ROOT / "config" / "launchd" / "com.lifeos.llm.plist.template"
+
+
+def _add_llama_server_binary(fake_home: Path) -> Path:
+    """Stub a llama.cpp checkout at the default __LLAMA_CPP_DIR__ location
+    (fake_home/llama.cpp, matching LLAMA_DIR="${LIFEOS_LLAMA_DIR:-$HOME/llama.cpp}"
+    in setup-launchd.sh) so check_paths_exist's WorkingDirectory/binary
+    checks pass. Returns the llama.cpp dir."""
+    llama_dir = fake_home / "llama.cpp"
+    binary = llama_dir / "build" / "bin" / "llama-server"
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+    return llama_dir
+
+
+@pytest.mark.unit
+def test_generate_plist_substitutes_llama_cpp_dir_placeholder(tmp_path: Path):
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    repo = _make_sandbox(tmp_path)
+    template = repo / "t.plist.template"
+    template.write_text(
+        "<dict><key>WorkingDirectory</key><string>__LLAMA_CPP_DIR__</string></dict>",
+        encoding="utf-8",
+    )
+    output = repo / "t.plist"
+    result = _run_sourced(
+        repo,
+        f'generate_plist "{template}" "{output}" "/home/op" "/proj" "/vault" "/opt/llama.cpp"',
+    )
+    assert result.returncode == 0, result.stderr
+    text = output.read_text()
+    assert "__LLAMA_CPP_DIR__" not in text
+    assert "/opt/llama.cpp" in text
+
+
+@pytest.mark.unit
+def test_inject_llm_source_args_replaces_marker_with_one_string_per_token(tmp_path: Path):
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    repo = _make_sandbox(tmp_path)
+    plist = repo / "p.plist"
+    plist.write_text(
+        "<array>\n"
+        "        <string>/bin/llama-server</string>\n"
+        "        __LLM_SOURCE_ARGS_LINES__\n"
+        "        <string>-ngl</string>\n"
+        "</array>\n",
+        encoding="utf-8",
+    )
+    result = _run_sourced(
+        repo,
+        f'LLM_SOURCE_ARGS_TOKENS=("-hf" "some/repo"); inject_llm_source_args "{plist}"',
+    )
+    assert result.returncode == 0, result.stderr
+    text = plist.read_text()
+    assert "__LLM_SOURCE_ARGS_LINES__" not in text
+    assert "<string>-hf</string>" in text
+    assert "<string>some/repo</string>" in text
+    # Order preserved and no stray duplication of the surrounding lines.
+    assert text.count("<string>-ngl</string>") == 1
+    assert text.index("<string>-hf</string>") < text.index("<string>some/repo</string>")
+
+
+@pytest.mark.unit
+def test_main_skips_llm_by_default(tmp_path: Path):
+    """Same 'fresh install stays exactly as inert as it is today' contract
+    as agent-worker/mcp-http: with no opt-in set, nothing is installed."""
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    if not _LLM_TEMPLATE.exists():
+        pytest.skip("llm plist template not present")
+    repo, vault, fake_home, _venv = _make_main_sandbox(tmp_path, _GOOD_TEMPLATE)
+    _add_real_template(repo, _LLM_TEMPLATE)
+    _add_llama_server_binary(fake_home)
+    bindir = _stub_plutil_ok(repo)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(fake_home)
+    result = subprocess.run(
+        ["bash", "scripts/setup-launchd.sh", str(vault), "--yes"],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "Local LLM:    disabled" in result.stdout
+    assert "Skipped: com.lifeos.llm.plist" in result.stdout
+    agents = fake_home / "Library" / "LaunchAgents"
+    assert not (agents / "com.lifeos.llm.plist").exists()
+    assert (agents / "com.lifeos.api.plist").exists()  # unaffected
+
+
+@pytest.mark.unit
+def test_main_installs_llm_when_autostart_enabled(tmp_path: Path):
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    if not _LLM_TEMPLATE.exists():
+        pytest.skip("llm plist template not present")
+    repo, vault, fake_home, _venv = _make_main_sandbox(tmp_path, _GOOD_TEMPLATE)
+    _add_real_template(repo, _LLM_TEMPLATE)
+    _add_llama_server_binary(fake_home)
+    (repo / ".env").write_text("LIFEOS_LOCAL_LLM_AUTOSTART=true\n", encoding="utf-8")
+    bindir = _stub_plutil_ok(repo)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(fake_home)
+    result = subprocess.run(
+        ["bash", "scripts/setup-launchd.sh", str(vault), "--yes"],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "Local LLM:    enabled" in result.stdout
+    installed = fake_home / "Library" / "LaunchAgents" / "com.lifeos.llm.plist"
+    assert installed.exists(), (result.stdout, result.stderr)
+    text = installed.read_text()
+    assert not re.search(r"__[A-Z_]+__", text), text  # no leftover placeholders
+    assert "<string>-hf</string>" in text
+    assert "<string>unsloth/gemma-4-26B-A4B-it-GGUF</string>" in text
+    assert "launchctl load ~/Library/LaunchAgents/com.lifeos.llm.plist" in result.stdout
+
+
+@pytest.mark.unit
+def test_main_installs_llm_with_model_path_override(tmp_path: Path):
+    """LIFEOS_LLM_MODEL_PATH/_MMPROJ_PATH switch the args to `-m`/`--mmproj`
+    — same override scripts/setup-systemd.sh honors for a stale HF cache."""
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    if not _LLM_TEMPLATE.exists():
+        pytest.skip("llm plist template not present")
+    repo, vault, fake_home, _venv = _make_main_sandbox(tmp_path, _GOOD_TEMPLATE)
+    _add_real_template(repo, _LLM_TEMPLATE)
+    _add_llama_server_binary(fake_home)
+    model_path = tmp_path / "model.gguf"
+    model_path.write_text("fake gguf")
+    mmproj_path = tmp_path / "mmproj.gguf"
+    mmproj_path.write_text("fake mmproj")
+    (repo / ".env").write_text(
+        "LIFEOS_LOCAL_LLM_AUTOSTART=true\n"
+        f"LIFEOS_LLM_MODEL_PATH={model_path}\n"
+        f"LIFEOS_LLM_MMPROJ_PATH={mmproj_path}\n",
+        encoding="utf-8",
+    )
+    bindir = _stub_plutil_ok(repo)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(fake_home)
+    result = subprocess.run(
+        ["bash", "scripts/setup-launchd.sh", str(vault), "--yes"],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "WARNING" not in result.stdout, result.stdout
+    installed = fake_home / "Library" / "LaunchAgents" / "com.lifeos.llm.plist"
+    text = installed.read_text()
+    assert f"<string>-m</string>\n        <string>{model_path}</string>" in text
+    assert f"<string>--mmproj</string>\n        <string>{mmproj_path}</string>" in text
+    assert "<string>-hf</string>" not in text
+
+
+@pytest.mark.unit
+def test_main_warns_when_model_path_configured_but_missing(tmp_path: Path):
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    if not _LLM_TEMPLATE.exists():
+        pytest.skip("llm plist template not present")
+    repo, vault, fake_home, _venv = _make_main_sandbox(tmp_path, _GOOD_TEMPLATE)
+    _add_real_template(repo, _LLM_TEMPLATE)
+    _add_llama_server_binary(fake_home)
+    (repo / ".env").write_text(
+        "LIFEOS_LOCAL_LLM_AUTOSTART=true\nLIFEOS_LLM_MODEL_PATH=/no/such/model.gguf\n",
+        encoding="utf-8",
+    )
+    bindir = _stub_plutil_ok(repo)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(fake_home)
+    result = subprocess.run(
+        ["bash", "scripts/setup-launchd.sh", str(vault), "--yes"],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "WARNING: LIFEOS_LLM_MODEL_PATH=/no/such/model.gguf does not exist" in result.stdout
+
+
+@pytest.mark.unit
+def test_main_aborts_install_when_llama_server_binary_missing(tmp_path: Path):
+    """check_paths_exist validates the actual llama-server binary
+    (ProgramArguments item 3) and WorkingDirectory the same way it already
+    does for uvicorn/mcp_server.py — an operator who enables the local LLM
+    before building llama.cpp gets a named error, not a broken install.
+    A single failing plist aborts the whole run (existing behavior), so
+    even com.lifeos.api.plist must not be installed."""
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    if not _LLM_TEMPLATE.exists():
+        pytest.skip("llm plist template not present")
+    repo, vault, fake_home, _venv = _make_main_sandbox(tmp_path, _GOOD_TEMPLATE)
+    _add_real_template(repo, _LLM_TEMPLATE)
+    # Deliberately no _add_llama_server_binary(fake_home) call.
+    (repo / ".env").write_text("LIFEOS_LOCAL_LLM_AUTOSTART=true\n", encoding="utf-8")
+    bindir = _stub_plutil_ok(repo)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(fake_home)
+    result = subprocess.run(
+        ["bash", "scripts/setup-launchd.sh", str(vault), "--yes"],
+        cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode != 0, (result.stdout, result.stderr)
+    assert "llama-server" in result.stdout
+    agents = fake_home / "Library" / "LaunchAgents"
+    assert not (agents / "com.lifeos.llm.plist").exists()
+    assert not (agents / "com.lifeos.api.plist").exists()
+
+
+@pytest.mark.unit
+def test_main_rerun_with_llm_autostart_still_enabled_leaves_it_untouched(tmp_path: Path):
+    if not SETUP_LAUNCHD.exists():
+        pytest.skip("scripts/setup-launchd.sh not present")
+    if not _LLM_TEMPLATE.exists():
+        pytest.skip("llm plist template not present")
+    repo, vault, fake_home, _venv = _make_main_sandbox(tmp_path, _GOOD_TEMPLATE)
+    _add_real_template(repo, _LLM_TEMPLATE)
+    _add_llama_server_binary(fake_home)
+    (repo / ".env").write_text("LIFEOS_LOCAL_LLM_AUTOSTART=true\n", encoding="utf-8")
+    bindir = _stub_plutil_ok(repo)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(fake_home)
+
+    def run():
+        return subprocess.run(
+            ["bash", "scripts/setup-launchd.sh", str(vault), "--yes"],
+            cwd=repo, env=env, capture_output=True, text=True, timeout=30,
+        )
+
+    first = run()
+    assert first.returncode == 0, (first.stdout, first.stderr)
+    installed = fake_home / "Library" / "LaunchAgents" / "com.lifeos.llm.plist"
+    before_mtime = installed.stat().st_mtime
+
+    second = run()
+    assert second.returncode == 0, (second.stdout, second.stderr)
+    assert "Unchanged: com.lifeos.llm.plist" in second.stdout
     assert installed.stat().st_mtime == before_mtime
 
 


### PR DESCRIPTION
Closes the one gap the v4.1.0 docs sweep couldn't document truthfully: macOS now gets a launchd template for the local LLM server, mirroring `config/systemd/lifeos-llm.service` (same flags; the ROCm-only env var deliberately omitted). Gated by the same `LIFEOS_LOCAL_LLM_AUTOSTART=true` that gates the Linux unit — skipped entirely when unset, validated by the existing placeholder/path checks (now also refusing install when the `llama-server` binary is absent), never auto-loaded. launchd's variable-length argv (`-hf <repo>` vs `-m <gguf> [--mmproj …]`) is injected one `<string>` per token; operator paths are XML-escaped — Codex caught that a path containing `&` would have produced invalid XML and aborted the whole install.

Honest note in the template and docs: launchd's KeepAlive has no StartLimitBurst equivalent, so a persistently bad model path restart-loops, throttled only by `ThrottleInterval`. An existing macOS install is unaffected until its operator re-runs `setup-launchd.sh`. Two installation-guide lines that still called the agent worker and MCP-HTTP "Linux-only" (false since #774) corrected alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw