### PR TITLE
fix(resolver): read the vault path at call time, not import time (#837)

### DIFF
--- a/api/services/directory_resolver.py
+++ b/api/services/directory_resolver.py
@@ -22,7 +22,6 @@ _LIFEOS_WORDS = [
 _CODE_WORDS = ["script", "code", "function", "cron"]
 
 _HOME = os.path.expanduser("~")
-_VAULT_DIR = str(settings.vault_path)
 _CODE_DIR = os.path.expanduser(settings.code_dir)
 _LIFEOS_DIR = os.path.join(_CODE_DIR, "LifeOS")
 
@@ -56,10 +55,10 @@ def resolve_working_directory(task: str) -> str:
     # 1. Vault/notes keywords
     for phrase in _VAULT_PHRASES:
         if phrase in task_lower:
-            return _VAULT_DIR
+            return str(settings.vault_path)
     for word in _VAULT_WORDS:
         if re.search(rf"\b{word}\b", task_lower):
-            return _VAULT_DIR
+            return str(settings.vault_path)
 
     # 2. LifeOS-specific keywords
     for phrase in _LIFEOS_PHRASES:

--- a/tests/test_directory_resolver.py
+++ b/tests/test_directory_resolver.py
@@ -68,6 +68,16 @@ class TestResolveWorkingDirectory:
         result = self._resolve("sync my notes")
         assert result == VAULT_DIR
 
+    def test_vault_path_honors_late_monkeypatch(self, monkeypatch, tmp_path):
+        """#837: the resolver must read settings.vault_path at call time,
+        not cache it into a module-level constant at import time — otherwise
+        whichever test imports the module first under xdist fixes the value
+        for every later test in that worker, even ones that monkeypatch
+        settings.vault_path (as test_vault_write_route.py does) before this
+        resolver is ever called."""
+        monkeypatch.setattr(settings, "vault_path", tmp_path)
+        assert self._resolve("open the vault") == str(tmp_path)
+
     @patch("api.services.directory_resolver.Path")
     def test_project_name_match(self, mock_path_cls):
         """Project directory names should be matched in task."""


### PR DESCRIPTION
`api/services/directory_resolver.py` bound `_VAULT_DIR` at module import, so under xdist whichever test first imported it in a worker fixed the value for every later test — a monkeypatched temp path could leak into unrelated tests, or a patch could be ignored. The two call sites now read `settings.vault_path` at call time. Production is unaffected: every caller already imports the module lazily inside a per-task function, so the read never crossed the settings-initialization boundary either way, and the per-call cost is an attribute access.

Test added for a late monkeypatch (no module reload, no host `.env`). 20 consecutive `-n auto --dist loadscope` runs of the vault-path neighborhood: 208 passed each, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw