### PR TITLE
test(vectorstore): guard the suite against the production ChromaDB collections; purge tool for stray fixture rows (#828)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "integration: Tests that require running server or external APIs",
     "browser: Browser-based UI tests using Playwright",
     "requires_server: Tests that require the API server to be running. On a browser test this is what separates it from the server-free set (`browser and not requires_server`) that the pre-push hook runs.",
+    "uses_live_vectorstore: Tests that legitimately construct a VectorStore against a real production collection on the live ChromaDB server (opts out of the conftest guard added for #828).",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/cleanup_vectorstore_tmp_rows.py
+++ b/scripts/cleanup_vectorstore_tmp_rows.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+One-off cleanup for #828: remove stray rows written by a test run that
+indexed a synthetic tmp vault into the live ChromaDB collection instead of
+an isolated one.
+
+The stray rows this was written for have a `file_path` like
+`/tmp/tmpXXXXXXXX/vault/...` — an absolute path under an OS temp
+directory, carrying real vault `note_type` values (Personal/Work/ML). Real
+vault documents are always indexed under the configured vault root, never
+under `/tmp`, and non-vault sources (calendar events, Slack messages) use
+*relative* pseudo-paths ("calendar/<event-id>"), not absolute ones — so a
+strict `/tmp/` prefix check can't match either, only the actual debris.
+
+Dry-run by default; pass --apply to actually delete. Always paginates
+`collection.get()` with a bounded `limit`/`offset` rather than fetching
+everything at once — the live collection has ~45k rows, and fetching them
+all in one `.get()` risks chromadb's sqlite backend hitting "too many SQL
+variables".
+
+Usage:
+    python3 scripts/cleanup_vectorstore_tmp_rows.py               # dry run
+    python3 scripts/cleanup_vectorstore_tmp_rows.py --apply        # delete
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+DEFAULT_PAGE_SIZE = 500
+DEFAULT_DELETE_BATCH_SIZE = 200
+
+
+def is_stray_tmp_row(file_path: str) -> bool:
+    """True only for an absolute file_path rooted at an OS temp directory.
+
+    - Real vault documents always store an absolute, resolved path under
+      the configured vault root (see `indexer.py`) — never under `/tmp`.
+    - Non-vault sources (calendar events, Slack messages) use relative
+      pseudo-paths, which can't start with `/tmp/` either.
+    - A prefix check (not a substring check) so a real document that merely
+      *mentions* "/tmp/" somewhere in its path is never swept up.
+    """
+    return bool(file_path) and file_path.startswith("/tmp/")
+
+
+def find_stray_rows(collection, page_size: int = DEFAULT_PAGE_SIZE) -> list[tuple[str, str]]:
+    """Page through `collection` and return (id, file_path) for every row
+    whose file_path looks like tmp-vault test debris."""
+    stray: list[tuple[str, str]] = []
+    offset = 0
+    while True:
+        page = collection.get(limit=page_size, offset=offset, include=["metadatas"])
+        ids = page.get("ids") or []
+        if not ids:
+            break
+        metadatas = page.get("metadatas") or []
+        for row_id, meta in zip(ids, metadatas):
+            file_path = (meta or {}).get("file_path", "")
+            if is_stray_tmp_row(file_path):
+                stray.append((row_id, file_path))
+        offset += len(ids)
+        if len(ids) < page_size:
+            break
+    return stray
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--apply", action="store_true", help="Actually delete the stray rows (default: dry run)")
+    parser.add_argument("--collection", default="lifeos_vault", help="Collection to scan (default: lifeos_vault)")
+    parser.add_argument("--page-size", type=int, default=DEFAULT_PAGE_SIZE, help="Rows per .get() page")
+    parser.add_argument("--delete-batch-size", type=int, default=DEFAULT_DELETE_BATCH_SIZE)
+    args = parser.parse_args()
+
+    from api.services.vectorstore import VectorStore
+
+    store = VectorStore(collection_name=args.collection)
+    total = store.get_document_count()
+    print(f"Collection '{args.collection}': {total} total row(s)")
+
+    stray = find_stray_rows(store._collection, page_size=args.page_size)
+    print(f"Found {len(stray)} stray row(s) with a file_path under /tmp/")
+
+    preview_limit = 20
+    for row_id, file_path in stray[:preview_limit]:
+        print(f"  {row_id}  {file_path}")
+    if len(stray) > preview_limit:
+        print(f"  ... and {len(stray) - preview_limit} more")
+
+    if not stray:
+        print("Nothing to clean up.")
+        return
+
+    if not args.apply:
+        print("\nDry run only — pass --apply to delete these rows.")
+        return
+
+    ids = [row_id for row_id, _ in stray]
+    deleted = 0
+    for i in range(0, len(ids), args.delete_batch_size):
+        batch = ids[i:i + args.delete_batch_size]
+        store._collection.delete(ids=batch)
+        deleted += len(batch)
+    print(f"\nDeleted {deleted} row(s) from '{args.collection}'.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanup_vectorstore_tmp_rows.py
+++ b/scripts/cleanup_vectorstore_tmp_rows.py
@@ -5,12 +5,15 @@ indexed a synthetic tmp vault into the live ChromaDB collection instead of
 an isolated one.
 
 The stray rows this was written for have a `file_path` like
-`/tmp/tmpXXXXXXXX/vault/...` — an absolute path under an OS temp
-directory, carrying real vault `note_type` values (Personal/Work/ML). Real
-vault documents are always indexed under the configured vault root, never
-under `/tmp`, and non-vault sources (calendar events, Slack messages) use
-*relative* pseudo-paths ("calendar/<event-id>"), not absolute ones — so a
-strict `/tmp/` prefix check can't match either, only the actual debris.
+`/tmp/tmpXXXXXXXX/vault/...` (or, on macOS, under `/var/folders/...` /
+`/private/var/folders/...` — `tempfile`'s actual default there) — an
+absolute path under an OS temp directory, carrying real vault `note_type`
+values (Personal/Work/ML). Real vault documents are always indexed under
+the configured vault root, never under a temp directory, and non-vault
+sources (calendar events, Slack messages) use *relative* pseudo-paths
+("calendar/<event-id>", "slack:<channel>:<ts>"), not absolute ones — so a
+prefix check against `TEMP_PREFIXES` can't match either, only the actual
+debris.
 
 Dry-run by default; pass --apply to actually delete. Always paginates
 `collection.get()` with a bounded `limit`/`offset` rather than fetching
@@ -28,27 +31,32 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from api.services.interaction_store import TEMP_PREFIXES  # noqa: E402
+
 DEFAULT_PAGE_SIZE = 500
 DEFAULT_DELETE_BATCH_SIZE = 200
+DEFAULT_PREVIEW_LIMIT = 20
 
 
-def is_stray_tmp_row(file_path: str, vault_root: "Path | None" = None) -> bool:
+def is_stray_tmp_row(file_path, vault_root: "Path | None" = None) -> bool:
     """True only for an absolute file_path rooted at an OS temp directory.
 
     - Real vault documents always store an absolute, resolved path under
-      the configured vault root (see `indexer.py`) — never under `/tmp`.
+      the configured vault root (see `indexer.py`) — never under a temp
+      directory.
     - Non-vault sources (calendar events, Slack messages) use relative
-      pseudo-paths, which can't start with `/tmp/` either.
-    - A prefix check (not a substring check) so a real document that merely
-      *mentions* "/tmp/" somewhere in its path is never swept up.
-
-    `vault_root`, when given, is an extra belt-and-suspenders check: on the
-    off chance a real install's vault happens to live under `/tmp` (an
-    unusual but not impossible configuration), a path under the *actual
-    configured* vault root is never treated as stray even if it also
-    happens to start with `/tmp/`.
+      pseudo-paths, which can't match a `TEMP_PREFIXES` prefix either.
+    - Matched with a trailing separator (not a bare/substring check) so a
+      real document that merely *mentions* one of these prefixes, or lives
+      under an unrelated directory that happens to share the prefix string
+      (e.g. `/tmp-backup/...`), is never swept up.
+    - `file_path` isn't guaranteed to be a string (chromadb metadata is
+      whatever was written) — a non-string value is never treated as a
+      match rather than raising.
     """
-    if not file_path or not file_path.startswith("/tmp/"):
+    if not isinstance(file_path, str) or not file_path:
+        return False
+    if not any(file_path.startswith(prefix + "/") for prefix in TEMP_PREFIXES):
         return False
     if vault_root is not None:
         try:
@@ -72,7 +80,7 @@ def find_stray_rows(
         if not ids:
             break
         metadatas = page.get("metadatas") or []
-        for row_id, meta in zip(ids, metadatas):
+        for row_id, meta in zip(ids, metadatas, strict=True):
             file_path = (meta or {}).get("file_path", "")
             if is_stray_tmp_row(file_path, vault_root=vault_root):
                 stray.append((row_id, file_path))
@@ -82,44 +90,75 @@ def find_stray_rows(
     return stray
 
 
+def _connect_collection(collection_name: str):
+    """Connect directly via chromadb, bypassing `VectorStore` -- this script
+    only ever reads metadata and deletes by id, so it has no use for
+    `VectorStore`'s embedding-service load (heavy, GPU-touching) or its
+    `get_or_create_collection` (which would silently create an empty
+    collection on a typo'd `--collection`, masking the mistake instead of
+    failing it)."""
+    import chromadb
+    from chromadb.config import Settings as ChromaSettings
+
+    from config.settings import settings
+
+    host_port = settings.chroma_url.replace("http://", "").replace("https://", "")
+    parts = host_port.split(":")
+    host = parts[0]
+    port = int(parts[1]) if len(parts) > 1 else 8000
+
+    client = chromadb.HttpClient(host=host, port=port, settings=ChromaSettings(anonymized_telemetry=False))
+    return client.get_collection(collection_name)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--apply", action="store_true", help="Actually delete the stray rows (default: dry run)")
     parser.add_argument("--collection", default="lifeos_vault", help="Collection to scan (default: lifeos_vault)")
     parser.add_argument("--page-size", type=int, default=DEFAULT_PAGE_SIZE, help="Rows per .get() page")
     parser.add_argument("--delete-batch-size", type=int, default=DEFAULT_DELETE_BATCH_SIZE)
+    parser.add_argument(
+        "--preview-limit", type=int, default=DEFAULT_PREVIEW_LIMIT,
+        help="Rows to print in a dry run (default: 20). Ignored with --apply, which always prints every row removed.",
+    )
     args = parser.parse_args()
 
-    from api.services.vectorstore import VectorStore
     from config.settings import settings
 
-    store = VectorStore(collection_name=args.collection)
-    total = store.get_document_count()
+    try:
+        collection = _connect_collection(args.collection)
+    except Exception as e:
+        print(f"Collection '{args.collection}' does not exist or is unreachable: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    total = collection.count()
     print(f"Collection '{args.collection}': {total} total row(s)")
 
     vault_root = Path(settings.vault_path).resolve()
-    stray = find_stray_rows(store._collection, page_size=args.page_size, vault_root=vault_root)
-    print(f"Found {len(stray)} stray row(s) with a file_path under /tmp/")
-
-    preview_limit = 20
-    for row_id, file_path in stray[:preview_limit]:
-        print(f"  {row_id}  {file_path}")
-    if len(stray) > preview_limit:
-        print(f"  ... and {len(stray) - preview_limit} more")
+    stray = find_stray_rows(collection, page_size=args.page_size, vault_root=vault_root)
+    print(f"Found {len(stray)} stray row(s) under a temp-directory prefix")
 
     if not stray:
         print("Nothing to clean up.")
         return
 
     if not args.apply:
+        for row_id, file_path in stray[:args.preview_limit]:
+            print(f"  {row_id}  {file_path}")
+        if len(stray) > args.preview_limit:
+            print(f"  ... and {len(stray) - args.preview_limit} more")
         print("\nDry run only — pass --apply to delete these rows.")
         return
 
-    ids = [row_id for row_id, _ in stray]
+    # --apply: print the full record of what's being removed (issue's
+    # acceptance criteria calls for "a record of what was removed"), not
+    # just a truncated preview.
     deleted = 0
-    for i in range(0, len(ids), args.delete_batch_size):
-        batch = ids[i:i + args.delete_batch_size]
-        store._collection.delete(ids=batch)
+    for i in range(0, len(stray), args.delete_batch_size):
+        batch = stray[i:i + args.delete_batch_size]
+        collection.delete(ids=[row_id for row_id, _ in batch])
+        for row_id, file_path in batch:
+            print(f"  deleted  {row_id}  {file_path}")
         deleted += len(batch)
     print(f"\nDeleted {deleted} row(s) from '{args.collection}'.")
 

--- a/scripts/cleanup_vectorstore_tmp_rows.py
+++ b/scripts/cleanup_vectorstore_tmp_rows.py
@@ -32,7 +32,7 @@ DEFAULT_PAGE_SIZE = 500
 DEFAULT_DELETE_BATCH_SIZE = 200
 
 
-def is_stray_tmp_row(file_path: str) -> bool:
+def is_stray_tmp_row(file_path: str, vault_root: "Path | None" = None) -> bool:
     """True only for an absolute file_path rooted at an OS temp directory.
 
     - Real vault documents always store an absolute, resolved path under
@@ -41,11 +41,27 @@ def is_stray_tmp_row(file_path: str) -> bool:
       pseudo-paths, which can't start with `/tmp/` either.
     - A prefix check (not a substring check) so a real document that merely
       *mentions* "/tmp/" somewhere in its path is never swept up.
+
+    `vault_root`, when given, is an extra belt-and-suspenders check: on the
+    off chance a real install's vault happens to live under `/tmp` (an
+    unusual but not impossible configuration), a path under the *actual
+    configured* vault root is never treated as stray even if it also
+    happens to start with `/tmp/`.
     """
-    return bool(file_path) and file_path.startswith("/tmp/")
+    if not file_path or not file_path.startswith("/tmp/"):
+        return False
+    if vault_root is not None:
+        try:
+            if Path(file_path).is_relative_to(vault_root):
+                return False
+        except (TypeError, ValueError):
+            pass
+    return True
 
 
-def find_stray_rows(collection, page_size: int = DEFAULT_PAGE_SIZE) -> list[tuple[str, str]]:
+def find_stray_rows(
+    collection, page_size: int = DEFAULT_PAGE_SIZE, vault_root: "Path | None" = None
+) -> list[tuple[str, str]]:
     """Page through `collection` and return (id, file_path) for every row
     whose file_path looks like tmp-vault test debris."""
     stray: list[tuple[str, str]] = []
@@ -58,7 +74,7 @@ def find_stray_rows(collection, page_size: int = DEFAULT_PAGE_SIZE) -> list[tupl
         metadatas = page.get("metadatas") or []
         for row_id, meta in zip(ids, metadatas):
             file_path = (meta or {}).get("file_path", "")
-            if is_stray_tmp_row(file_path):
+            if is_stray_tmp_row(file_path, vault_root=vault_root):
                 stray.append((row_id, file_path))
         offset += len(ids)
         if len(ids) < page_size:
@@ -75,12 +91,14 @@ def main():
     args = parser.parse_args()
 
     from api.services.vectorstore import VectorStore
+    from config.settings import settings
 
     store = VectorStore(collection_name=args.collection)
     total = store.get_document_count()
     print(f"Collection '{args.collection}': {total} total row(s)")
 
-    stray = find_stray_rows(store._collection, page_size=args.page_size)
+    vault_root = Path(settings.vault_path).resolve()
+    stray = find_stray_rows(store._collection, page_size=args.page_size, vault_root=vault_root)
     print(f"Found {len(stray)} stray row(s) with a file_path under /tmp/")
 
     preview_limit = 20

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,12 @@ import os
 
 import pytest
 
+# Lightweight (no chromadb/torch at module scope) -- used below to build
+# _LIVE_VECTORSTORE_COLLECTIONS without hardcoding these as string literals.
+from api.services.calendar_indexer import CALENDAR_COLLECTION
+from api.services.person_indexer import PERSON_COLLECTION
+from api.services.slack_indexer import SLACK_COLLECTION
+
 # git exports GIT_DIR (absolute when the invoker is a linked worktree) to hook
 # subprocesses — and the pre-push hook runs this suite. Tests that spawn `git`
 # in tmp fixture repos would inherit it and silently operate on the REAL repo:
@@ -312,17 +318,21 @@ def _isolate_vault_indexer_stores(tmp_path, monkeypatch):
 
 
 # Collection names `VectorStore` actually writes to on a real install:
-# ``lifeos_vault`` (the class default, and the one ``get_vector_store()``'s
-# process-wide singleton resolves to), ``lifeos_people``
-# (``api/services/person_indexer.py::PERSON_COLLECTION``), ``lifeos_slack``
-# (``api/services/slack_indexer.py::SLACK_COLLECTION``), and
-# ``lifeos_calendar`` (``api/services/calendar_indexer.py::CALENDAR_COLLECTION``,
-# declared there even though that indexer currently writes through the
-# vault-default singleton instead — see #828 investigation). Kept here rather
-# than imported from those modules to avoid a reverse dependency (they import
-# ``VectorStore`` from ``api.services.vectorstore``, not the other way round).
+# `VectorStore`'s own class default (also what `get_vector_store()`'s
+# process-wide singleton resolves to) plus every non-vault indexer's own
+# explicit collection constant (imported at the top of this file).
+#
+# `CALENDAR_COLLECTION` is dead in practice: `CalendarIndexer` writes through
+# the vault-default `get_vector_store()` singleton instead of a collection of
+# its own (see #828 investigation) -- kept in the guard's blocklist anyway,
+# in case that ever changes.
 _LIVE_VECTORSTORE_COLLECTIONS = frozenset(
-    {"lifeos_vault", "lifeos_people", "lifeos_slack", "lifeos_calendar"}
+    {
+        "lifeos_vault",  # VectorStore's own class default -- not exported as a constant
+        PERSON_COLLECTION,
+        SLACK_COLLECTION,
+        CALENDAR_COLLECTION,
+    }
 )
 
 
@@ -337,14 +347,15 @@ def _guard_live_vectorstore_collections(request, monkeypatch):
     elsewhere in this file, there is no local persist-dir to redirect to.
     ``_isolate_vault_indexer_stores`` above isolates the vault-indexing path
     by renaming the collection before construction; this fixture is the
-    backstop for every *other* call site. About thirty rows with
+    backstop for every *other* call site. 45 rows with
     ``/tmp/tmpXXXXXXXX/vault/...`` file_paths and real vault ``note_type``
-    values turned up in the live ``lifeos_vault`` collection (#828) — almost
-    certainly debris from a test run that predates (or bypassed) that
-    per-collection isolation.
+    values turned up in the live ``lifeos_vault`` collection (#828) —
+    debris from `test_indexer.py`/`test_integration.py`/`test_people.py`'s
+    `tempfile.TemporaryDirectory()`-based vault fixtures, predating (or
+    bypassing) that per-collection isolation.
 
     Rather than patch each of the many ``VectorStore()`` / ``get_vector_store()``
-    call sites individually (``api/routes/{admin,chat,search}.py``,
+    call sites individually (``api/routes/{admin,ask,chat,search}.py``,
     ``api/services/{hybrid_search,person_indexer,slack_indexer,calendar_indexer}.py``),
     this patches the class's ``__init__`` in place: every one of those call
     sites imported the same class object (``from api.services.vectorstore
@@ -358,20 +369,32 @@ def _guard_live_vectorstore_collections(request, monkeypatch):
     in place is enough and doesn't disturb ``_isolate_vault_indexer_stores``'s
     own wrapper (it still resolves to the same, now-guarded, class).
 
-    Tests that legitimately need the real store opt in with
-    ``@pytest.mark.uses_live_vectorstore`` (e.g. ``test_admin.py``'s
-    ``/api/admin/status`` checks, ``test_search_api.py``'s ``/api/search``
-    integration tests — both read-only, both require ``TestClient(app)``
-    wired to the real service to mean anything).
+    One caller is structurally outside this guard's reach:
+    ``api/services/relationship_discovery.py``'s Slack-discovery path calls
+    ``chromadb.HttpClient`` directly rather than going through
+    ``VectorStore`` at all (read-only; already patched in its own tests).
+
+    Every current caller in the test suite is fully mocked, so no test
+    currently needs to opt in — but a future test that genuinely requires
+    the real service can with ``@pytest.mark.uses_live_vectorstore``.
     """
     if request.node.get_closest_marker("uses_live_vectorstore"):
         return
 
+    import inspect
+
     import api.services.vectorstore as vectorstore_mod
 
     _real_init = vectorstore_mod.VectorStore.__init__
+    _real_sig = inspect.signature(_real_init)
 
-    def _guarded_init(self, collection_name="lifeos_vault", server_url=None):
+    def _guarded_init(self, *args, **kwargs):
+        # Bind against the real __init__'s own signature (rather than
+        # hardcoding its parameter names/defaults here) so a future change
+        # to that signature can't silently make this check stop working.
+        bound = _real_sig.bind_partial(self, *args, **kwargs)
+        bound.apply_defaults()
+        collection_name = bound.arguments.get("collection_name")
         if collection_name in _LIVE_VECTORSTORE_COLLECTIONS:
             pytest.fail(
                 f"{request.node.nodeid} constructed "
@@ -382,38 +405,52 @@ def _guard_live_vectorstore_collections(request, monkeypatch):
                 "@pytest.mark.uses_live_vectorstore if it must legitimately "
                 "talk to the live store (#828)."
             )
-        _real_init(self, collection_name=collection_name, server_url=server_url)
+        _real_init(self, *args, **kwargs)
 
     monkeypatch.setattr(vectorstore_mod.VectorStore, "__init__", _guarded_init)
 
 
 @pytest.fixture(autouse=True)
 def _reset_vectorstore_singletons(monkeypatch):
-    """Clear the process-wide VectorStore/HybridSearch singleton caches
-    around every test (#828 follow-up).
+    """Clear every process-wide singleton that can hold a live
+    VectorStore/HybridSearch/*Indexer instance, around every test (#828
+    follow-up).
 
-    ``api.services.vectorstore.get_vector_store()`` and
-    ``api.routes.search``'s own separate ``get_vector_store()`` /
-    ``get_hybrid_search()`` each memoize a real instance in a module-level
-    global the first time they're called. A test marked
-    ``uses_live_vectorstore`` (e.g. ``test_search_api.py``) legitimately
-    populates one of these with a REAL, live-connected instance — and
-    because xdist reuses one process for many tests (``--dist loadscope``
-    groups by module, but a worker still runs many modules over its
-    lifetime), a *later*, unmarked test in the same worker that happens to
-    call the same getter would silently receive that already-constructed
-    live instance without ever calling ``VectorStore.__init__`` again —
-    completely bypassing the guard above, which can only see construction,
-    not reuse. Reset before and after every test so no test can ever
-    inherit another test's cached singleton, live or otherwise.
+    A handful of modules memoize a real instance in a module-level global
+    the first time their getter is called: ``api.services.vectorstore``'s
+    own ``get_vector_store()``; ``api.routes.search`` and ``api.routes.ask``
+    each have their own separate ``get_vector_store()`` / ``get_hybrid_search()``
+    pair; ``api.services.slack_indexer.get_slack_indexer()`` and
+    ``api.services.calendar_indexer.get_calendar_indexer()`` (the latter
+    also cached a second time, under the same name, in ``api.main`` once
+    startup calls it) each hold a real ``VectorStore``-backed indexer that
+    *writes* to a live collection. If a future test legitimately populates
+    one of these with a real, live-connected instance (via
+    ``@pytest.mark.uses_live_vectorstore``), xdist reusing one process for
+    many tests (``--dist loadscope`` groups by module, but a worker still
+    runs many modules over its lifetime) means a *later*, unmarked test in
+    the same worker that calls the same getter would silently receive that
+    already-constructed live instance without ever calling
+    ``VectorStore.__init__`` again — completely bypassing the guard above,
+    which can only see construction, not reuse. Reset before and after
+    every test so no test can ever inherit another test's cached singleton,
+    live or otherwise.
     """
+    import api.main as main_mod
+    import api.routes.ask as ask_route_mod
     import api.routes.search as search_route_mod
+    import api.services.calendar_indexer as calendar_indexer_mod
+    import api.services.slack_indexer as slack_indexer_mod
     import api.services.vectorstore as vectorstore_mod
 
     def _clear():
         monkeypatch.setattr(vectorstore_mod, "_vector_store", None)
         monkeypatch.setattr(search_route_mod, "_vector_store", None)
         monkeypatch.setattr(search_route_mod, "_hybrid_search", None)
+        monkeypatch.setattr(ask_route_mod, "_hybrid_search", None)
+        monkeypatch.setattr(slack_indexer_mod, "_slack_indexer", None)
+        monkeypatch.setattr(calendar_indexer_mod, "_calendar_indexer", None)
+        monkeypatch.setattr(main_mod, "_calendar_indexer", None)
 
     _clear()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,6 +388,39 @@ def _guard_live_vectorstore_collections(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _reset_vectorstore_singletons(monkeypatch):
+    """Clear the process-wide VectorStore/HybridSearch singleton caches
+    around every test (#828 follow-up).
+
+    ``api.services.vectorstore.get_vector_store()`` and
+    ``api.routes.search``'s own separate ``get_vector_store()`` /
+    ``get_hybrid_search()`` each memoize a real instance in a module-level
+    global the first time they're called. A test marked
+    ``uses_live_vectorstore`` (e.g. ``test_search_api.py``) legitimately
+    populates one of these with a REAL, live-connected instance — and
+    because xdist reuses one process for many tests (``--dist loadscope``
+    groups by module, but a worker still runs many modules over its
+    lifetime), a *later*, unmarked test in the same worker that happens to
+    call the same getter would silently receive that already-constructed
+    live instance without ever calling ``VectorStore.__init__`` again —
+    completely bypassing the guard above, which can only see construction,
+    not reuse. Reset before and after every test so no test can ever
+    inherit another test's cached singleton, live or otherwise.
+    """
+    import api.routes.search as search_route_mod
+    import api.services.vectorstore as vectorstore_mod
+
+    def _clear():
+        monkeypatch.setattr(vectorstore_mod, "_vector_store", None)
+        monkeypatch.setattr(search_route_mod, "_vector_store", None)
+        monkeypatch.setattr(search_route_mod, "_hybrid_search", None)
+
+    _clear()
+    yield
+    _clear()
+
+
+@pytest.fixture(autouse=True)
 def _isolate_telegram_state_file(tmp_path, monkeypatch):
     """Keep tests off the production Telegram offset file (#357).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,82 @@ def _isolate_vault_indexer_stores(tmp_path, monkeypatch):
             pass
 
 
+# Collection names `VectorStore` actually writes to on a real install:
+# ``lifeos_vault`` (the class default, and the one ``get_vector_store()``'s
+# process-wide singleton resolves to), ``lifeos_people``
+# (``api/services/person_indexer.py::PERSON_COLLECTION``), ``lifeos_slack``
+# (``api/services/slack_indexer.py::SLACK_COLLECTION``), and
+# ``lifeos_calendar`` (``api/services/calendar_indexer.py::CALENDAR_COLLECTION``,
+# declared there even though that indexer currently writes through the
+# vault-default singleton instead — see #828 investigation). Kept here rather
+# than imported from those modules to avoid a reverse dependency (they import
+# ``VectorStore`` from ``api.services.vectorstore``, not the other way round).
+_LIVE_VECTORSTORE_COLLECTIONS = frozenset(
+    {"lifeos_vault", "lifeos_people", "lifeos_slack", "lifeos_calendar"}
+)
+
+
+@pytest.fixture(autouse=True)
+def _guard_live_vectorstore_collections(request, monkeypatch):
+    """Fail loudly if a test constructs a ``VectorStore`` against a real
+    production collection on the live ChromaDB server (#828).
+
+    ``VectorStore`` always opens a real HTTP connection
+    (``chromadb.HttpClient`` to ``settings.chroma_url``, which defaults to
+    the maintainer's real server) — unlike the SQLite-backed stores
+    elsewhere in this file, there is no local persist-dir to redirect to.
+    ``_isolate_vault_indexer_stores`` above isolates the vault-indexing path
+    by renaming the collection before construction; this fixture is the
+    backstop for every *other* call site. About thirty rows with
+    ``/tmp/tmpXXXXXXXX/vault/...`` file_paths and real vault ``note_type``
+    values turned up in the live ``lifeos_vault`` collection (#828) — almost
+    certainly debris from a test run that predates (or bypassed) that
+    per-collection isolation.
+
+    Rather than patch each of the many ``VectorStore()`` / ``get_vector_store()``
+    call sites individually (``api/routes/{admin,chat,search}.py``,
+    ``api/services/{hybrid_search,person_indexer,slack_indexer,calendar_indexer}.py``),
+    this patches the class's ``__init__`` in place: every one of those call
+    sites imported the same class object (``from api.services.vectorstore
+    import VectorStore``, or via ``get_vector_store()`` which resolves the
+    bare name in ``vectorstore.py``'s own globals either way), so mutating
+    its ``__init__`` catches all of them regardless of which module's
+    namespace holds the reference — unlike #652's ``SessionStore`` fix,
+    which had to swap the *class name* because that bug was about a default
+    argument bound once at class-definition time; here we're validating an
+    incoming argument, not changing a default, so patching the method
+    in place is enough and doesn't disturb ``_isolate_vault_indexer_stores``'s
+    own wrapper (it still resolves to the same, now-guarded, class).
+
+    Tests that legitimately need the real store opt in with
+    ``@pytest.mark.uses_live_vectorstore`` (e.g. ``test_admin.py``'s
+    ``/api/admin/status`` checks, ``test_search_api.py``'s ``/api/search``
+    integration tests — both read-only, both require ``TestClient(app)``
+    wired to the real service to mean anything).
+    """
+    if request.node.get_closest_marker("uses_live_vectorstore"):
+        return
+
+    import api.services.vectorstore as vectorstore_mod
+
+    _real_init = vectorstore_mod.VectorStore.__init__
+
+    def _guarded_init(self, collection_name="lifeos_vault", server_url=None):
+        if collection_name in _LIVE_VECTORSTORE_COLLECTIONS:
+            pytest.fail(
+                f"{request.node.nodeid} constructed "
+                f"VectorStore(collection_name={collection_name!r}), which "
+                "points at a live production ChromaDB collection. Isolate "
+                "the test with a throwaway collection name (see "
+                "_isolate_vault_indexer_stores above), or mark it "
+                "@pytest.mark.uses_live_vectorstore if it must legitimately "
+                "talk to the live store (#828)."
+            )
+        _real_init(self, collection_name=collection_name, server_url=server_url)
+
+    monkeypatch.setattr(vectorstore_mod.VectorStore, "__init__", _guarded_init)
+
+
 @pytest.fixture(autouse=True)
 def _isolate_telegram_state_file(tmp_path, monkeypatch):
     """Keep tests off the production Telegram offset file (#357).

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -20,23 +20,27 @@ class TestAdminEndpoints:
         """Create test client."""
         return TestClient(app)
 
-    @pytest.mark.uses_live_vectorstore  # /api/admin/status reads the real VectorStore for document_count (#828)
     def test_status_endpoint_exists(self, client):
         """Status endpoint should exist."""
-        response = client.get("/api/admin/status")
+        # /api/admin/status's VectorStore() call is already wrapped in its
+        # own try/except that falls back to document_count=0 (admin.py:46-53)
+        # -- these tests only care about the response shape/status, not a
+        # real count, so mock VectorStore rather than reaching the live
+        # store (#828).
+        with patch('api.routes.admin.VectorStore'):
+            response = client.get("/api/admin/status")
         assert response.status_code == 200
 
-    @pytest.mark.uses_live_vectorstore  # /api/admin/status reads the real VectorStore for document_count (#828)
     def test_status_returns_structure(self, client):
         """Status should return required fields."""
-        response = client.get("/api/admin/status")
+        with patch('api.routes.admin.VectorStore'):
+            response = client.get("/api/admin/status")
         data = response.json()
 
         assert "status" in data
         assert "document_count" in data
         assert "vault_path" in data
 
-    @pytest.mark.uses_live_vectorstore  # /api/admin/status reads the real VectorStore for document_count (#828)
     def test_status_ignores_stale_running_reindex_job(self, client):
         """#768: a `reindex_vault` job stuck "running" because the process
         that was executing it restarted mid-job (e.g. an unrelated
@@ -50,14 +54,14 @@ class TestAdminEndpoints:
             started_at="2020-01-01T00:00:00+00:00", completed_at=None,
             attempts=1, max_attempts=3, priority=10, error=None,
         )
-        with patch('api.routes.admin.get_job_queue') as mock_jq:
+        with patch('api.routes.admin.VectorStore'), \
+                patch('api.routes.admin.get_job_queue') as mock_jq:
             mock_jq.return_value.list_jobs.return_value = [stale_job]
             mock_jq.return_value.process_start_time = "2026-08-27T00:00:00+00:00"
             response = client.get("/api/admin/status")
             data = response.json()
             assert data["status"] != "reindexing"
 
-    @pytest.mark.uses_live_vectorstore  # /api/admin/status reads the real VectorStore for document_count (#828)
     def test_status_reports_reindexing_for_a_genuinely_running_job(self, client):
         """Regression guard: a job actually claimed by this process (started
         after process_start_time) must still report "reindexing"."""
@@ -69,7 +73,8 @@ class TestAdminEndpoints:
             started_at="2026-08-27T00:00:01+00:00", completed_at=None,
             attempts=1, max_attempts=3, priority=10, error=None,
         )
-        with patch('api.routes.admin.get_job_queue') as mock_jq:
+        with patch('api.routes.admin.VectorStore'), \
+                patch('api.routes.admin.get_job_queue') as mock_jq:
             mock_jq.return_value.list_jobs.return_value = [live_job]
             mock_jq.return_value.process_start_time = "2026-08-27T00:00:00+00:00"
             response = client.get("/api/admin/status")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -20,11 +20,13 @@ class TestAdminEndpoints:
         """Create test client."""
         return TestClient(app)
 
+    @pytest.mark.uses_live_vectorstore  # /api/admin/status reads the real VectorStore for document_count (#828)
     def test_status_endpoint_exists(self, client):
         """Status endpoint should exist."""
         response = client.get("/api/admin/status")
         assert response.status_code == 200
 
+    @pytest.mark.uses_live_vectorstore  # /api/admin/status reads the real VectorStore for document_count (#828)
     def test_status_returns_structure(self, client):
         """Status should return required fields."""
         response = client.get("/api/admin/status")
@@ -34,6 +36,7 @@ class TestAdminEndpoints:
         assert "document_count" in data
         assert "vault_path" in data
 
+    @pytest.mark.uses_live_vectorstore  # /api/admin/status reads the real VectorStore for document_count (#828)
     def test_status_ignores_stale_running_reindex_job(self, client):
         """#768: a `reindex_vault` job stuck "running" because the process
         that was executing it restarted mid-job (e.g. an unrelated
@@ -54,6 +57,7 @@ class TestAdminEndpoints:
             data = response.json()
             assert data["status"] != "reindexing"
 
+    @pytest.mark.uses_live_vectorstore  # /api/admin/status reads the real VectorStore for document_count (#828)
     def test_status_reports_reindexing_for_a_genuinely_running_job(self, client):
         """Regression guard: a job actually claimed by this process (started
         after process_start_time) must still report "reindexing"."""

--- a/tests/test_ask_api.py
+++ b/tests/test_ask_api.py
@@ -9,14 +9,45 @@ P1.3 Acceptance Criteria:
 - Claude API errors return graceful error response
 - Empty question returns 400 error
 """
-import pytest
+from unittest.mock import patch, MagicMock
 
-# These tests use TestClient which initializes the app (slow)
-pytestmark = pytest.mark.slow
-from unittest.mock import patch, MagicMock, AsyncMock
+import pytest
 from fastapi.testclient import TestClient
 
+import api.routes.ask as ask_route_mod
 from api.main import app
+
+# These tests use TestClient which initializes the app (slow).
+pytestmark = pytest.mark.slow
+
+
+class _StubHybridSearch:
+    """Deterministic stand-in for HybridSearch (#828): these tests are
+    about /api/ask's retrieval -> prompt -> synthesis wiring and response
+    shape (source dedup, field presence), not the live vault's actual
+    content -- and Claude synthesis is already mocked per-test via
+    `get_claude_response`, so retrieval should be too.
+    """
+
+    def __init__(self, chunks=None):
+        self.chunks = chunks if chunks is not None else list(_DEFAULT_CHUNKS)
+
+    def search(self, query, top_k=10, date_from=None, date_to=None, **_kwargs):
+        return self.chunks[:top_k]
+
+
+# Two chunks share a file_path so test_ask_deduplicates_sources actually
+# exercises the route's dedup-by-file_path logic.
+_DEFAULT_CHUNKS = [
+    {"content": "Budget is $1M for Q1.", "file_name": "budget.md", "file_path": "/vault/budget.md", "score": 0.9},
+    {"content": "More budget detail.", "file_name": "budget.md", "file_path": "/vault/budget.md", "score": 0.8},
+    {"content": "Other note content.", "file_name": "other.md", "file_path": "/vault/other.md", "score": 0.5},
+]
+
+
+@pytest.fixture(autouse=True)
+def _stub_hybrid_search(monkeypatch):
+    monkeypatch.setattr(ask_route_mod, "get_hybrid_search", lambda: _StubHybridSearch())
 
 
 class TestAskEndpoint:
@@ -182,7 +213,7 @@ class TestSynthesizerService:
             synth = Synthesizer()
             # Reset the cached client so the mock takes effect
             synth._client = mock_client
-            result = synth.synthesize("Test prompt")
+            synth.synthesize("Test prompt")
 
             mock_client.create.assert_called_once()
 
@@ -197,7 +228,7 @@ class TestSynthesizerService:
 
         # Should raise after retries (handled at route level)
         try:
-            result = synth.synthesize("Test prompt")
-        except Exception as e:
+            synth.synthesize("Test prompt")
+        except Exception:
             # Re-raising is acceptable if handled at route level
             pass

--- a/tests/test_cleanup_vectorstore_tmp_rows.py
+++ b/tests/test_cleanup_vectorstore_tmp_rows.py
@@ -7,6 +7,8 @@ source" — so most of this file is about what the selector must *not*
 match, using the same fake-collection pattern as
 `test_vault_root_check.py::_StubCollection`.
 """
+from pathlib import Path
+
 import pytest
 
 from scripts.cleanup_vectorstore_tmp_rows import find_stray_rows, is_stray_tmp_row
@@ -51,6 +53,17 @@ class TestIsStrayTmpRow:
 
     def test_empty_path_does_not_match(self):
         assert not is_stray_tmp_row("")
+
+    def test_vault_root_check_wins_even_under_tmp(self):
+        """Belt-and-suspenders: if the *configured* vault root itself lives
+        under /tmp (an unusual but possible setup), a real document there
+        must never be treated as stray."""
+        vault_root = Path("/tmp/my-real-vault")
+        assert not is_stray_tmp_row("/tmp/my-real-vault/Personal/journal.md", vault_root=vault_root)
+
+    def test_a_sibling_tmp_dir_still_matches_with_vault_root_set(self):
+        vault_root = Path("/tmp/my-real-vault")
+        assert is_stray_tmp_row("/tmp/tmp8f2k3a9x/vault/note.md", vault_root=vault_root)
 
 
 class TestFindStrayRows:

--- a/tests/test_cleanup_vectorstore_tmp_rows.py
+++ b/tests/test_cleanup_vectorstore_tmp_rows.py
@@ -1,0 +1,89 @@
+"""Tests for the #828 one-off cleanup script
+(`scripts/cleanup_vectorstore_tmp_rows.py`).
+
+The acceptance criterion this backs is that the selector "must not touch
+any row whose path is under the configured vault root or any non-vault
+source" — so most of this file is about what the selector must *not*
+match, using the same fake-collection pattern as
+`test_vault_root_check.py::_StubCollection`.
+"""
+import pytest
+
+from scripts.cleanup_vectorstore_tmp_rows import find_stray_rows, is_stray_tmp_row
+
+pytestmark = pytest.mark.unit
+
+
+class _PagingStubCollection:
+    """Fakes just enough of a ChromaDB collection's `.get()` to exercise
+    `find_stray_rows`'s pagination — a list of (id, file_path) rows, served
+    back a `limit`-sized page at a time starting at `offset`."""
+
+    def __init__(self, rows: list[tuple[str, str]]):
+        self._rows = rows
+
+    def get(self, limit=None, offset=0, include=None):
+        page = self._rows[offset:offset + limit]
+        return {
+            "ids": [row_id for row_id, _ in page],
+            "metadatas": [{"file_path": path} for _, path in page],
+        }
+
+
+class TestIsStrayTmpRow:
+    def test_matches_a_tmp_vault_path(self):
+        assert is_stray_tmp_row("/tmp/tmp8f2k3a9x/vault/Work/ML/meeting.md")
+
+    def test_does_not_match_a_real_vault_path(self):
+        assert not is_stray_tmp_row("/home/nathan/LifeOS Vault/Work/ML/meeting.md")
+
+    def test_does_not_match_a_relative_calendar_pseudo_path(self):
+        assert not is_stray_tmp_row("calendar/abc123")
+
+    def test_does_not_match_a_relative_slack_pseudo_path(self):
+        assert not is_stray_tmp_row("slack/C123/1700000000.000100")
+
+    def test_does_not_match_a_path_merely_mentioning_tmp(self):
+        """Prefix check, not substring — a real note path that happens to
+        contain "/tmp/" elsewhere (e.g. a vault subfolder literally named
+        "tmp") must not be treated as debris."""
+        assert not is_stray_tmp_row("/home/nathan/LifeOS Vault/tmp/notes.md")
+
+    def test_empty_path_does_not_match(self):
+        assert not is_stray_tmp_row("")
+
+
+class TestFindStrayRows:
+    def test_finds_only_the_tmp_rows_across_a_mixed_collection(self):
+        rows = [
+            ("id1", "/home/nathan/LifeOS Vault/Personal/journal.md"),
+            ("id2", "/tmp/tmp8f2k3a9x/vault/Work/ML/meeting.md"),
+            ("id3", "calendar/abc123"),
+            ("id4", "/tmp/tmpzz11xy00/vault/Personal/journal.md"),
+            ("id5", "slack/C123/1700000000.000100"),
+        ]
+        collection = _PagingStubCollection(rows)
+
+        stray = find_stray_rows(collection, page_size=2)
+
+        assert stray == [
+            ("id2", "/tmp/tmp8f2k3a9x/vault/Work/ML/meeting.md"),
+            ("id4", "/tmp/tmpzz11xy00/vault/Personal/journal.md"),
+        ]
+
+    def test_empty_collection_returns_no_rows(self):
+        collection = _PagingStubCollection([])
+        assert find_stray_rows(collection) == []
+
+    def test_pages_past_a_full_first_page(self):
+        """The exact bug this pagination guards against: a naive `.get()`
+        with no limit would risk "too many SQL variables" on a large live
+        collection, so `find_stray_rows` must keep paging past a full page
+        instead of stopping after the first `page_size` rows."""
+        rows = [(f"id{i}", "/home/nathan/LifeOS Vault/note.md") for i in range(5)]
+        rows.append(("id_stray", "/tmp/tmp8f2k3a9x/vault/note.md"))
+        collection = _PagingStubCollection(rows)
+
+        stray = find_stray_rows(collection, page_size=2)
+
+        assert stray == [("id_stray", "/tmp/tmp8f2k3a9x/vault/note.md")]

--- a/tests/test_cleanup_vectorstore_tmp_rows.py
+++ b/tests/test_cleanup_vectorstore_tmp_rows.py
@@ -36,6 +36,18 @@ class TestIsStrayTmpRow:
     def test_matches_a_tmp_vault_path(self):
         assert is_stray_tmp_row("/tmp/tmp8f2k3a9x/vault/Work/ML/meeting.md")
 
+    def test_matches_a_macos_var_folders_path(self):
+        """`tempfile` on macOS defaults to `/var/folders/...`, not `/tmp/`."""
+        assert is_stray_tmp_row("/var/folders/zz/tmp8f2k3a9x/T/vault/note.md")
+
+    def test_matches_a_macos_private_var_folders_path(self):
+        """The resolved (symlink-followed) form of the same macOS tmp path."""
+        assert is_stray_tmp_row("/private/var/folders/zz/tmp8f2k3a9x/T/vault/note.md")
+
+    def test_non_string_file_path_does_not_match(self):
+        assert not is_stray_tmp_row(None)
+        assert not is_stray_tmp_row(123)
+
     def test_does_not_match_a_real_vault_path(self):
         assert not is_stray_tmp_row("/home/nathan/LifeOS Vault/Work/ML/meeting.md")
 
@@ -43,7 +55,8 @@ class TestIsStrayTmpRow:
         assert not is_stray_tmp_row("calendar/abc123")
 
     def test_does_not_match_a_relative_slack_pseudo_path(self):
-        assert not is_stray_tmp_row("slack/C123/1700000000.000100")
+        # Real format per api/services/slack_indexer.py: "slack:{channel_id}:{ts}"
+        assert not is_stray_tmp_row("slack:C123:1700000000.000100")
 
     def test_does_not_match_a_path_merely_mentioning_tmp(self):
         """Prefix check, not substring — a real note path that happens to
@@ -53,6 +66,12 @@ class TestIsStrayTmpRow:
 
     def test_empty_path_does_not_match(self):
         assert not is_stray_tmp_row("")
+
+    def test_a_sibling_directory_sharing_the_prefix_string_does_not_match(self):
+        """Matched with a trailing separator, not a bare prefix — a real
+        directory that happens to start with the same characters (e.g.
+        `/tmp-backup/...`) is a different directory, not `/tmp`."""
+        assert not is_stray_tmp_row("/tmp-backup/vault/note.md")
 
     def test_vault_root_check_wins_even_under_tmp(self):
         """Belt-and-suspenders: if the *configured* vault root itself lives
@@ -73,7 +92,7 @@ class TestFindStrayRows:
             ("id2", "/tmp/tmp8f2k3a9x/vault/Work/ML/meeting.md"),
             ("id3", "calendar/abc123"),
             ("id4", "/tmp/tmpzz11xy00/vault/Personal/journal.md"),
-            ("id5", "slack/C123/1700000000.000100"),
+            ("id5", "slack:C123:1700000000.000100"),
         ]
         collection = _PagingStubCollection(rows)
 

--- a/tests/test_full_health_check.py
+++ b/tests/test_full_health_check.py
@@ -19,6 +19,24 @@ from fastapi.testclient import TestClient
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _stub_vault_root_sanity_vectorstore(monkeypatch):
+    """`full_health_check()`'s vault-root sanity check (#762) reaches the
+    real `get_vector_store()` singleton whenever the vault_search probe
+    reports "ok" -- which, on a host that happens to have a live LifeOS API
+    + ChromaDB running (as the maintainer's does), it does. That's a
+    live-store touch none of this file's tests need; stub it to raise,
+    which `_check_vault_root_sanity`'s own `except Exception` already
+    treats as a benign hiccup -- the same fail-closed behavior this file's
+    module docstring already relies on for the OTHER live probes
+    `full_health_check()` makes (#828).
+    """
+    monkeypatch.setattr(
+        "api.services.vectorstore.get_vector_store",
+        MagicMock(side_effect=Exception("no live vector store in tests (#828)")),
+    )
+
+
 def test_health_api_key_configured_true_with_key():
     from unittest.mock import patch
     from api.main import app

--- a/tests/test_model_readout.py
+++ b/tests/test_model_readout.py
@@ -12,6 +12,8 @@ override the way an actually-observed turn can) — those tests call
 `api/routes/hermes_proxy.py` calls from a real turn's `usage` event.
 """
 
+from unittest.mock import MagicMock
+
 import httpx
 import pytest
 from fastapi import FastAPI, Request
@@ -217,6 +219,16 @@ async def test_health_full_includes_the_model_readout(monkeypatch):
     monkeypatch.setattr(main.settings, "llm_backend", "anthropic")
     monkeypatch.setattr(main.settings, "anthropic_model", "claude-haiku-4-5")
     monkeypatch.setattr(main.settings, "hermes_backend_url", "")
+    # `full_health_check()`'s vault-root sanity check (#762) reaches the
+    # real `get_vector_store()` singleton whenever the vault_search probe
+    # reports "ok" -- which it does on a host that happens to have a live
+    # LifeOS API + ChromaDB running. That's a live-store touch this test
+    # doesn't need; stub it to raise, which `_check_vault_root_sanity`'s own
+    # `except Exception` already treats as a benign hiccup (#828).
+    monkeypatch.setattr(
+        "api.services.vectorstore.get_vector_store",
+        MagicMock(side_effect=Exception("no live vector store in tests (#828)")),
+    )
 
     result = await main.full_health_check()
 

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -10,13 +10,14 @@ P1.2 Acceptance Criteria:
 - Invalid filters return 400 with clear message
 """
 import pytest
-
-# These tests use TestClient which initializes the app (slow)
-pytestmark = pytest.mark.slow
-from datetime import datetime, timedelta
 from fastapi.testclient import TestClient
 
 from api.main import app
+
+# These tests use TestClient which initializes the app (slow), and hit
+# /api/search unmocked -- they need the real VectorStore/live ChromaDB
+# collection to mean anything (#828).
+pytestmark = [pytest.mark.slow, pytest.mark.uses_live_vectorstore]
 
 
 class TestSearchEndpoint:

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -12,12 +12,49 @@ P1.2 Acceptance Criteria:
 import pytest
 from fastapi.testclient import TestClient
 
+import api.routes.search as search_route_mod
 from api.main import app
 
-# These tests use TestClient which initializes the app (slow), and hit
-# /api/search unmocked -- they need the real VectorStore/live ChromaDB
-# collection to mean anything (#828).
-pytestmark = [pytest.mark.slow, pytest.mark.uses_live_vectorstore]
+# These tests use TestClient which initializes the app (slow).
+pytestmark = pytest.mark.slow
+
+
+class _StubHybridSearch:
+    """Deterministic stand-in for HybridSearch (#828): these tests are
+    about /api/search's request/response contract (result shape, filter
+    pass-through, top_k truncation) -- none of them need the live
+    ChromaDB collection's actual content, and depending on it coupled
+    these tests to whatever embedding model and documents the live vault
+    happens to have.
+    """
+
+    def __init__(self, results=None):
+        self.results = results if results is not None else list(_DEFAULT_RESULTS)
+
+    def search(self, query, top_k=20, date_from=None, date_to=None, **_kwargs):
+        return self.results[:top_k]
+
+
+_DEFAULT_RESULTS = [
+    {
+        "content": f"Stub result {i} about test content.",
+        "file_path": f"/vault/Work/note{i}.md",
+        "file_name": f"note{i}.md",
+        "note_type": "Work" if i % 2 == 0 else "Personal",
+        "modified_date": "2025-06-01T00:00:00+00:00",
+        "people": ["Alex"] if i == 0 else [],
+        "tags": ["test"],
+        "score": 1.0 - i * 0.1,
+        "semantic_score": 0.9 - i * 0.1,
+        "recency_score": 0.5,
+    }
+    for i in range(8)
+]
+
+
+@pytest.fixture(autouse=True)
+def _stub_hybrid_search(monkeypatch):
+    monkeypatch.setattr(search_route_mod, "get_hybrid_search", lambda: _StubHybridSearch())
 
 
 class TestSearchEndpoint:

--- a/tests/test_vectorstore_test_isolation.py
+++ b/tests/test_vectorstore_test_isolation.py
@@ -1,0 +1,109 @@
+"""Regression coverage for the #828 conftest guard
+(``_guard_live_vectorstore_collections``) and its interaction with the
+existing #288 vault-indexer isolation (``_isolate_vault_indexer_stores``).
+
+Mirrors ``tests/test_session_store_test_isolation.py``'s approach for #652:
+nothing here exercises the guard fixture explicitly (it's autouse), so
+these tests are already running under it. What's asserted is the thing
+#828 was actually about — a bare ``VectorStore(collection_name=...)``
+pointed at a real production collection name must fail loudly instead of
+silently opening a connection to the live server.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_bare_vectorstore_against_production_collection_fails_loudly():
+    """A test that (accidentally or otherwise) constructs a ``VectorStore``
+    pointed at the real ``lifeos_vault`` collection must be stopped before
+    it ever opens a connection — this is the exact shape of bug #828 found:
+    stray `/tmp/tmpXXXXXXXX/vault/...` rows in the live collection."""
+    from api.services.vectorstore import VectorStore
+
+    with pytest.raises(pytest.fail.Exception, match="uses_live_vectorstore"):
+        VectorStore(collection_name="lifeos_vault")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "collection_name",
+    ["lifeos_vault", "lifeos_people", "lifeos_slack", "lifeos_calendar"],
+)
+def test_every_known_production_collection_is_guarded(collection_name):
+    """All four real collection names (vault default, plus the person/slack/
+    calendar indexers' explicit ones) must trip the guard, not just the
+    default."""
+    from api.services.vectorstore import VectorStore
+
+    with pytest.raises(pytest.fail.Exception):
+        VectorStore(collection_name=collection_name)
+
+
+@pytest.mark.unit
+def test_isolated_collection_name_is_not_guarded():
+    """A test-scoped collection name (the pattern
+    ``_isolate_vault_indexer_stores`` and ``test_vectorstore.py`` both use)
+    must pass straight through — the guard only blocks the known production
+    names, not test isolation itself.
+
+    ``chromadb.HttpClient`` and the (heavy, GPU-loading) embedding service
+    are both mocked so this stays a true ``unit`` test rather than
+    incidentally becoming a ``slow`` one.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from api.services.vectorstore import VectorStore
+
+    with patch("chromadb.HttpClient") as mock_client, \
+            patch("api.services.embeddings.get_embedding_service", return_value=MagicMock()):
+        mock_client.return_value.get_or_create_collection.return_value = object()
+        store = VectorStore(collection_name="lifeos_vault_test_828")
+        assert store.collection_name == "lifeos_vault_test_828"
+
+
+@pytest.mark.unit
+def test_bare_indexer_service_never_reaches_a_production_collection_name(tmp_path):
+    """Regression guard for the #288 fixture's actual job: a bare
+    ``IndexerService()`` construction (the shape ``test_indexer.py``,
+    ``test_integration.py``, and ``test_people.py`` all use) must resolve
+    to a throwaway collection, never the live ``lifeos_vault`` — this is
+    what #828's stray rows imply happened at some point in the past. If
+    ``_isolate_vault_indexer_stores`` ever regressed, the guard fixture
+    above would fail this test loudly rather than let it silently open a
+    real connection.
+
+    ``chromadb.HttpClient`` and the embedding service are mocked so this
+    exercises the isolation/guard wiring without becoming a ``slow`` test.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from api.services.indexer import IndexerService
+
+    with patch("chromadb.HttpClient") as mock_client, \
+            patch("api.services.embeddings.get_embedding_service", return_value=MagicMock()):
+        mock_client.return_value.get_or_create_collection.return_value = object()
+        indexer = IndexerService(vault_path=str(tmp_path / "vault"), db_path=str(tmp_path / "db"))
+        try:
+            assert indexer.vector_store.collection_name != "lifeos_vault"
+        finally:
+            indexer.stop()
+
+
+@pytest.mark.unit
+@pytest.mark.uses_live_vectorstore
+def test_marker_opts_a_test_out_of_the_guard():
+    """The opt-in marker used by test_admin.py / test_search_api.py must
+    actually suppress the guard, exercising the composition those files
+    rely on (this test's own marker, above)."""
+    from unittest.mock import MagicMock, patch
+
+    from api.services.vectorstore import VectorStore
+
+    with patch("chromadb.HttpClient") as mock_client, \
+            patch("api.services.embeddings.get_embedding_service", return_value=MagicMock()):
+        mock_client.return_value.get_or_create_collection.return_value = object()
+        # Would raise pytest.fail.Exception without the marker above.
+        store = VectorStore(collection_name="lifeos_vault")
+        assert store.collection_name == "lifeos_vault"

--- a/tests/test_vectorstore_test_isolation.py
+++ b/tests/test_vectorstore_test_isolation.py
@@ -92,11 +92,39 @@ def test_bare_indexer_service_never_reaches_a_production_collection_name(tmp_pat
 
 
 @pytest.mark.unit
+def test_vectorstore_singletons_are_reset_before_every_test():
+    """#828 follow-up: every process-wide singleton that can hold a live
+    VectorStore/HybridSearch/*Indexer instance must be `None` at the start
+    of any test, regardless of what ran before it in this worker process
+    (xdist reuses one process across many tests). This is what
+    `_reset_vectorstore_singletons` in conftest.py exists to guarantee --
+    without it, a test that legitimately populated one of these with a
+    real instance would leak it to whatever test happens to run next in
+    the same worker, bypassing the construction-time guard entirely
+    (the guard only sees `VectorStore.__init__`, not singleton reuse)."""
+    import api.main as main_mod
+    import api.routes.ask as ask_route_mod
+    import api.routes.search as search_route_mod
+    import api.services.calendar_indexer as calendar_indexer_mod
+    import api.services.slack_indexer as slack_indexer_mod
+    import api.services.vectorstore as vectorstore_mod
+
+    assert vectorstore_mod._vector_store is None
+    assert search_route_mod._vector_store is None
+    assert search_route_mod._hybrid_search is None
+    assert ask_route_mod._hybrid_search is None
+    assert slack_indexer_mod._slack_indexer is None
+    assert calendar_indexer_mod._calendar_indexer is None
+    assert main_mod._calendar_indexer is None
+
+
+@pytest.mark.unit
 @pytest.mark.uses_live_vectorstore
 def test_marker_opts_a_test_out_of_the_guard():
-    """The opt-in marker used by test_admin.py / test_search_api.py must
-    actually suppress the guard, exercising the composition those files
-    rely on (this test's own marker, above)."""
+    """The opt-in marker exists precisely so a future test that legitimately
+    needs the live store can bypass the guard -- no current test needs it
+    (test_admin.py and test_search_api.py were both converted to mock the
+    store instead), so this test exercises the marker directly."""
     from unittest.mock import MagicMock, patch
 
     from api.services.vectorstore import VectorStore


### PR DESCRIPTION
The live `lifeos_vault` collection carried 45 rows from `tests/test_indexer.py:32-33,227-228`, `tests/test_integration.py:26-27` and `tests/test_people.py:245-246` tmp-vault fixtures — debris predating the #288 isolation fixture. Purged today with the new script (45,378 → 45,333; record kept alongside the data dir).

- `tests/conftest.py`: an autouse guard patches `VectorStore.__init__` in place (every call site resolves the same class) and `pytest.fail`s any construction against `lifeos_vault`/`lifeos_people`/`lifeos_slack`/`lifeos_calendar` unless the test carries `@pytest.mark.uses_live_vectorstore`; signature-bound via `inspect` so a future parameter doesn't break every test. Collection names imported from their modules, not mirrored.
- All seven memoizing store singletons (`api.services.vectorstore`, `api.routes.search` ×2, `api.routes.ask`, slack/calendar indexers, `api.main`) reset around every test — closes the reuse path a construction guard can't see. Test asserts they're empty at every test start.
- Running the guard found four previously unmocked live-store reaches — `test_admin.py`, `test_search_api.py`, `test_ask_api.py`, and the health-check tests via #762's vault-root probe — all now stubbed; no test in the suite needs the opt-out marker today.
- `scripts/cleanup_vectorstore_tmp_rows.py`: dry-run by default, uses the repo's `TEMP_PREFIXES` (so macOS `/var/folders` debris is covered), excludes anything under the resolved vault root, pages bounded reads, deletes by id in batches, prints every deleted `(id, path)` under `--apply`, uses `get_collection` so a typo'd name can't create a collection.

Independent adversarial review (Claude, standing in for Codex) proved the selector exhaustively against all 45,378 rows plus both other collections; all its findings addressed. Full unit scope 5,558 passed; live row count unchanged across every suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw