### PR TITLE
fix(voice): scope every turn-cleanup path to the turn that owns it; fix the auto-update lock tests' real race (#832, #833)

### DIFF
--- a/tests/test_auto_update_macos.py
+++ b/tests/test_auto_update_macos.py
@@ -13,6 +13,7 @@ emulating for these tests since every call site is a single named command).
 """
 from __future__ import annotations
 
+import fcntl
 import os
 import stat
 import subprocess
@@ -79,25 +80,66 @@ def _run_sourced(repo: Path, call: str, env_extra: dict | None = None) -> subpro
     )
 
 
-def _wait_until_lock_held(lock_path: Path, timeout: float = 5.0) -> None:
+def _wait_until_lock_held(lock_path: Path, timeout: float = 30.0) -> None:
     """Poll until some other process holds an exclusive-incompatible lock on
     lock_path — i.e. until a background holder has actually acquired, not
-    just been spawned."""
+    just been spawned.
+
+    This is #833's actual root cause (found on review, by finally
+    reproducing it under the full unit suite rather than this file alone --
+    a single-file run can't reproduce it at all, since --dist loadscope puts
+    one file's tests on one worker with no intra-file concurrency; the flake
+    needs genuine system-wide contention from the OTHER 16 workers' worth of
+    tests). Two contributing problems, both fixed here:
+
+    1. The probe used to shell out to the external `flock`(1) CLI on every
+       poll iteration -- a fresh fork+exec per attempt, compounding exactly
+       the process-spawn contention this is trying to survive. It now calls
+       `fcntl.flock()` directly (LOCK_EX | LOCK_NB, released immediately),
+       matching what the real `flock` CLI does under the hood but without
+       spawning a process to do it.
+    2. A short (formerly 5s, then 30s -- still not enough under sustained
+       reproduction load) timeout assumed the HOLDER's own bash-spawns-
+       python3-spawns-flock startup chain gets scheduled promptly; under
+       heavy parallel load that alone can take longer, raising TimeoutError
+       here even though the holder genuinely would have acquired the lock
+       given more time -- not a hung/broken holder, just a slow one.
+       `_start_shared_lock_holder`'s own `seconds` safety cap was bumped for
+       a related but distinct reason (see its docstring)."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        probe = subprocess.run(["flock", "-x", "-n", str(lock_path), "-c", "true"])
-        if probe.returncode != 0:
-            return
+        try:
+            with open(lock_path, "a") as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        except BlockingIOError:
+            return  # someone else holds it
+        except FileNotFoundError:
+            pass  # not created yet -- keep polling
         time.sleep(0.05)
     raise TimeoutError(f"lock at {lock_path} was never acquired by the holder")
 
 
-def _start_shared_lock_holder(lock_path: Path, seconds: float = 5.0) -> subprocess.Popen:
+def _start_shared_lock_holder(lock_path: Path, seconds: float = 60.0) -> subprocess.Popen:
     """Spawn a single process — no fork/exec split — that opens lock_path,
     holds a SHARED flock, and sleeps. Deliberately not the `flock` CLI: it
     forks a child to run the given command while the parent (the pid Popen
     would return) keeps the fd open, so killing that parent alone does not
-    release the lock. This one-liner IS the process holding the lock."""
+    release the lock. This one-liner IS the process holding the lock.
+
+    `seconds` is a safety cap, not the intended hold duration (found on
+    review, #833/F6) — every caller already calls `holder.terminate()` in
+    its own `finally`, which kills this process (and so releases the flock)
+    essentially instantly regardless of how much of `seconds` remains: no
+    signal handler is installed, so SIGTERM's default disposition (die
+    immediately) applies even mid-`time.sleep()`. The bug was treating
+    `seconds` as short (5, formerly) and load-bearing: under heavy parallel
+    load (many xdist workers, or other agents' test runs sharing this box),
+    the wall-clock time between spawning this holder and the calling test's
+    own assertion actually getting scheduled could exceed that short window,
+    so the holder released the lock on its own, naturally, before the test
+    ever checked it. A generous default removes that race without changing
+    how any test actually ends the hold."""
     return subprocess.Popen([
         sys.executable, "-c",
         f"import fcntl, time\n"
@@ -286,7 +328,7 @@ def test_lock_acquire_defers_while_a_sync_holds_the_shared_lock(tmp_path: Path):
     # (not env-overridable) formula the script itself resolves.
     lock_path = repo / "home" / ".lifeos" / "sync.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    holder = _start_shared_lock_holder(lock_path, seconds=5)
+    holder = _start_shared_lock_holder(lock_path)
     try:
         _wait_until_lock_held(lock_path)
         result = _run_sourced(repo, 'sync_in_progress_lock_acquire; echo "rc=$?"')
@@ -746,8 +788,11 @@ def _run_main_macos(
     fake_home = repo / "home"
     fake_home.mkdir(exist_ok=True)
     env = dict(os.environ)
-    env["HOME"] = str(fake_home)
     env.update(env_extra or {})
+    # Set AFTER env_extra, not before (#833/F7, matching _run_sourced()'s own
+    # fix and comment above) -- so env_extra can never defeat this function's
+    # isolation, the same way it silently could here otherwise.
+    env["HOME"] = str(fake_home)
     return subprocess.run(
         ["bash", "-c", f'source scripts/auto-update-macos.sh && {quiet_stubs}{extra_stubs} main'],
         cwd=repo, env=env, capture_output=True, text=True, timeout=30,
@@ -774,7 +819,7 @@ def test_main_skips_when_sync_lock_is_held(tmp_path: Path):
     # Matches _run_main_macos()'s fake $HOME/.lifeos/sync.lock.
     lock_path = repo / "home" / ".lifeos" / "sync.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    holder = _start_shared_lock_holder(lock_path, seconds=5)
+    holder = _start_shared_lock_holder(lock_path)
     try:
         _wait_until_lock_held(lock_path)
         result = _run_main_macos(repo, active_since=code_epoch - 3600)

--- a/tests/test_auto_update_macos.py
+++ b/tests/test_auto_update_macos.py
@@ -59,13 +59,20 @@ def _run_sourced(repo: Path, call: str, env_extra: dict | None = None) -> subpro
     alone reads .env, so an override would silently split-brain the sync
     and this script onto two different lock files) — so isolation from the
     real machine's actual lock file means pointing $HOME at a directory
-    under the synthetic repo instead."""
+    under the synthetic repo instead.
+
+    HOME is set AFTER layering in env_extra, not before (found on review,
+    #833) — a caller building env_extra from `dict(os.environ)` (e.g. to
+    tweak just PATH) carries the real $HOME along with it, and applying
+    env_extra second would silently defeat this function's whole isolation
+    guarantee, sending sync_in_progress_lock_acquire against the real
+    machine's actual `~/.lifeos/sync.lock` instead of the synthetic one."""
     script = repo / "scripts" / "auto-update-macos.sh"
     fake_home = repo / "home"
     fake_home.mkdir(exist_ok=True)
     env = dict(os.environ)
-    env["HOME"] = str(fake_home)
     env.update(env_extra or {})
+    env["HOME"] = str(fake_home)
     return subprocess.run(
         ["bash", "-c", f'source "{script}" && {call}'],
         cwd=repo, env=env, capture_output=True, text=True, timeout=30,
@@ -810,12 +817,17 @@ def test_main_skips_when_api_service_not_running(tmp_path: Path):
     if not AUTO_UPDATE_MACOS.exists():
         pytest.skip("scripts/auto-update-macos.sh not present")
     repo, _origin, _code_epoch = _make_policy_repo_macos(tmp_path)
-    result = subprocess.run(
-        ["bash", "-c",
-         'source scripts/auto-update-macos.sh && '
-         'api_active_since_epoch() { return 1; }; '
-         'launchctl() { return 0; }; api_pid() { echo ""; }; curl() { return 0; }; main'],
-        cwd=repo, capture_output=True, text=True, timeout=30,
+    # Found on review (#833): unlike every sibling test here, this one used a
+    # bare subprocess.run() with no `env=` override, so main()'s
+    # sync_in_progress_lock_acquire resolved SYNC_LOCK_FILE against the REAL
+    # $HOME — a shared machine's actual `~/.lifeos/sync.lock`, contended by
+    # concurrent test runs and real syncs alike. _run_main_macos() gives this
+    # test the same isolated fake $HOME its neighbors use; active_since is
+    # irrelevant here (extra_stubs's override wins, last-definition-wins in
+    # bash) since the point of this test is that no ground truth exists.
+    result = _run_main_macos(
+        repo, active_since=0,
+        extra_stubs='api_active_since_epoch() { return 1; }; ',
     )
     assert result.returncode == 0, (result.stdout, result.stderr)
     log = (repo / "logs" / "auto-update-macos.log").read_text()

--- a/tests/test_deploy_drift.py
+++ b/tests/test_deploy_drift.py
@@ -24,6 +24,7 @@ pulls, or restarts anything for real).
 """
 from __future__ import annotations
 
+import fcntl
 import os
 import stat
 import subprocess
@@ -236,15 +237,24 @@ def _run_sourced(repo: Path, call: str, env_extra: dict | None = None) -> subpro
     reads .env) — so isolation from the real machine's actual lock file
     means pointing $HOME itself at a directory under the synthetic repo,
     the same technique test_lock_is_visible_across_two_different_checkouts_
-    sharing_home already uses to prove the real default formula, not a
-    test-only escape hatch. A test that specifically wants the process's
-    real $HOME passes its own env_extra with that key set back."""
+    sharing_home already uses to prove the real default formula (that test
+    builds its own env directly rather than calling this helper, precisely
+    because it needs two checkouts to share one $HOME instead of each
+    getting its own).
+
+    HOME is set AFTER layering in env_extra, not before (#833/F7) — a caller
+    building env_extra from `dict(os.environ)` (e.g. to tweak PATH) carries
+    the real $HOME along with it, and applying env_extra second would
+    silently defeat this function's whole isolation guarantee. No caller
+    here has ever needed the reverse (getting the real $HOME back via
+    env_extra); if one someday does, it should build its own env rather than
+    reopening this hole."""
     script = repo / "scripts" / "auto-deploy.sh"
     fake_home = repo / "home"
     fake_home.mkdir(exist_ok=True)
     env = dict(os.environ)
-    env["HOME"] = str(fake_home)
     env.update(env_extra or {})
+    env["HOME"] = str(fake_home)
     return subprocess.run(
         ["bash", "-c", f'source "{script}" && {call}'],
         cwd=repo, env=env, capture_output=True, text=True, timeout=30,
@@ -489,20 +499,42 @@ def test_auto_deploy_syntax_and_sourced_functions_defined(tmp_path: Path):
     assert result.stdout.count("function") == 11, result.stdout
 
 
-def _wait_until_lock_held(lock_path: Path, timeout: float = 5.0) -> None:
+def _wait_until_lock_held(lock_path: Path, timeout: float = 30.0) -> None:
     """Poll until some other process holds an exclusive-incompatible lock on
     lock_path — i.e. until a background holder has actually acquired, not
-    just been spawned."""
+    just been spawned.
+
+    #833's actual root cause (found on review), reproduced here too since
+    this file's own lock-holder tests use the identical pattern. Two
+    contributing problems, both fixed here (see
+    tests/test_auto_update_macos.py's copy of this same function for the
+    full writeup, including the reproduction numbers):
+
+    1. The probe used to shell out to the external `flock`(1) CLI on every
+       poll iteration -- a fresh fork+exec per attempt, compounding exactly
+       the process-spawn contention this is trying to survive. It now calls
+       `fcntl.flock()` directly instead.
+    2. A short (formerly 5s, then 30s) timeout assumed the HOLDER's own
+       bash-spawns-python3-spawns-flock startup chain gets scheduled
+       promptly, which doesn't hold under the genuine system-wide
+       contention a full `-m unit` run creates -- a single-file run can't
+       reproduce this at all, since --dist loadscope puts each file on one
+       worker with no intra-file concurrency."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        probe = subprocess.run(["flock", "-x", "-n", str(lock_path), "-c", "true"])
-        if probe.returncode != 0:
-            return
+        try:
+            with open(lock_path, "a") as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        except BlockingIOError:
+            return  # someone else holds it
+        except FileNotFoundError:
+            pass  # not created yet -- keep polling
         time.sleep(0.05)
     raise TimeoutError(f"lock at {lock_path} was never acquired by the holder")
 
 
-def _start_shared_lock_holder(lock_path: Path, seconds: float = 5.0) -> subprocess.Popen:
+def _start_shared_lock_holder(lock_path: Path, seconds: float = 60.0) -> subprocess.Popen:
     """Spawn a single process — no fork/exec split — that opens lock_path,
     holds a SHARED flock, and sleeps. Deliberately not the `flock` CLI: it
     forks a child to run the given command while the parent (the pid Popen
@@ -510,7 +542,17 @@ def _start_shared_lock_holder(lock_path: Path, seconds: float = 5.0) -> subproce
     release the lock (the forked child inherits its own copy of the fd).
     This one-liner IS the process holding the lock, so killing this exact
     pid releases it immediately — mirroring what
-    run_all_syncs.py's _acquire_sync_lock() actually does."""
+    run_all_syncs.py's _acquire_sync_lock() actually does.
+
+    `seconds` is a safety cap, not the intended hold duration (found on
+    review, #833/F6, applied here too for the same reason) — every caller
+    already calls `holder.terminate()`/`.kill()` in its own `finally`, which
+    ends this process (and so releases the flock) essentially instantly
+    regardless of how much of `seconds` remains. A short fixed value here
+    used to race the CALLING TEST's own scheduling under heavy parallel
+    load: if the wall-clock time between spawning this holder and the test's
+    assertion actually running exceeded it, the holder had already released
+    the lock naturally, before the test ever checked it."""
     return subprocess.Popen([
         sys.executable, "-c",
         f"import fcntl, time\n"
@@ -581,7 +623,7 @@ def test_lock_acquire_defers_while_a_sync_holds_the_shared_lock(tmp_path: Path):
     # Matches _run_sourced()'s fake $HOME/.lifeos/sync.lock.
     lock_path = repo / "home" / ".lifeos" / "sync.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    holder = _start_shared_lock_holder(lock_path, seconds=5)
+    holder = _start_shared_lock_holder(lock_path)
     try:
         _wait_until_lock_held(lock_path)
         result = _run_sourced(repo, 'sync_in_progress_lock_acquire; echo "rc=$?"')
@@ -603,7 +645,7 @@ def test_lock_released_immediately_when_holder_is_sigkilled(tmp_path: Path):
     # Matches _run_sourced()'s fake $HOME/.lifeos/sync.lock.
     lock_path = repo / "home" / ".lifeos" / "sync.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    holder = _start_shared_lock_holder(lock_path, seconds=30)
+    holder = _start_shared_lock_holder(lock_path)
     try:
         _wait_until_lock_held(lock_path)
         holder.kill()  # SIGKILL — no signal handler, no cleanup path runs
@@ -646,8 +688,8 @@ def test_two_overlapping_syncs_are_both_recognized_as_in_progress(tmp_path: Path
     # Matches _run_sourced()'s fake $HOME/.lifeos/sync.lock.
     lock_path = repo / "home" / ".lifeos" / "sync.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    a = _start_shared_lock_holder(lock_path, seconds=5)
-    b = _start_shared_lock_holder(lock_path, seconds=5)
+    a = _start_shared_lock_holder(lock_path)
+    b = _start_shared_lock_holder(lock_path)
     try:
         _wait_until_lock_held(lock_path)
         result = _run_sourced(repo, 'sync_in_progress_lock_acquire; echo "rc=$?"')
@@ -690,7 +732,7 @@ def test_lock_is_visible_across_two_different_checkouts_sharing_home(tmp_path: P
     env = dict(os.environ)
     env["HOME"] = str(shared_home)
 
-    holder = _start_shared_lock_holder(default_lock_path, seconds=5)
+    holder = _start_shared_lock_holder(default_lock_path)
     try:
         _wait_until_lock_held(default_lock_path)
         script_a = checkout_a / "scripts" / "auto-deploy.sh"
@@ -973,11 +1015,12 @@ def _run_main(repo: Path, state: Path, venv: Path, env_extra: dict | None = None
     env["LIFEOS_AGENT_SESSIONS_DB"] = str(repo / "data" / "agent_sessions.db")
     env["PYTHONPATH"] = str(REPO_ROOT)
     # Isolated by default — see _run_sourced()'s comment on why this is a
-    # $HOME override, not a sync-lock-specific one.
+    # $HOME override, not a sync-lock-specific one, and on why it's set
+    # AFTER env_extra rather than before (#833/F7).
     fake_home = repo / "home"
     fake_home.mkdir(exist_ok=True)
-    env["HOME"] = str(fake_home)
     env.update(env_extra or {})
+    env["HOME"] = str(fake_home)
     return subprocess.run(
         ["bash", "-c", "source scripts/auto-deploy.sh && main"],
         cwd=repo, env=env, capture_output=True, text=True, timeout=30,

--- a/tests/test_voice_turn_ownership_ui_browser.py
+++ b/tests/test_voice_turn_ownership_ui_browser.py
@@ -91,19 +91,36 @@ window.__gatesOpen = {};
 window.__cancelLog = [];
 window.__releaseTurn = function (i) { window.__gatesOpen[i] = true; };
 
+// GET .../audio/{turnId} -- handleMidStreamDrop()'s pollForCompletedAudio().
+// Gate release-controlled like the SSE streams above, for the same reason
+// (independence from whatever submitTurn()'s own supersession abort does to
+// the signal); __audioProbeSawSignal records whether a signal was actually
+// passed, so a test can prove the wiring (#832/F5) without racing an abort's
+// timing against the gate.
+window.__audioGateOpen = false;
+window.__audioFound = false;
+window.__audioProbeSawSignal = false;
+
 (function () {
   window.fetch = function (url, opts) {
     var urlStr = typeof url === 'string' ? url : (url && url.url) || String(url);
-    var signal = opts && opts.signal;
-    function abortError() { return new DOMException('Turn cancelled', 'AbortError'); }
 
     if (urlStr.indexOf('/api/voice/turn/stream') !== -1) {
       var idx = window.__turnCallCount++;
       var frames = (window.__turnQueue[idx] || {}).frames || [];
+      // Deliberately NOT abort-aware (unlike the other voice test files'
+      // gates): submitTurn() now actively aborts a superseded turn's own
+      // AbortController the moment a newer turn starts (#832/F2), which
+      // would otherwise tear this stream down before a '__gate'-held frame
+      // ever reaches handleEvent -- exactly the frame these tests exist to
+      // deliver. A frame already in flight over the wire can still arrive
+      // after a client-side abort in the real world (the same race #832/F1's
+      // consumeTurnStream()-entry comment describes for postTurnStart()), so
+      // gate release alone -- never the signal -- controls delivery here,
+      // to test that race and the supersession-abort path independently.
       function waitForGate() {
-        return new Promise(function (resolve, reject) {
+        return new Promise(function (resolve) {
           (function poll() {
-            if (signal && signal.aborted) return reject(abortError());
             if (window.__gatesOpen[idx]) return resolve();
             setTimeout(poll, 10);
           })();
@@ -114,11 +131,10 @@ window.__releaseTurn = function (i) { window.__gatesOpen[i] = true; };
           var enc = new TextEncoder();
           var i = 0;
           (function next() {
-            if (signal && signal.aborted) return controller.error(abortError());
             if (i >= frames.length) return controller.close();
             var frame = frames[i++];
             if (frame === '__gate') {
-              return waitForGate().then(next, function (e) { controller.error(e); });
+              return waitForGate().then(next);
             }
             if (frame === '__error') {
               return controller.error(new TypeError('Failed to fetch'));
@@ -139,6 +155,19 @@ window.__releaseTurn = function (i) { window.__gatesOpen[i] = true; };
       var m = urlStr.match(/\\/turn\\/([^/]+)\\/cancel/);
       window.__cancelLog.push(m ? decodeURIComponent(m[1]) : urlStr);
       return Promise.resolve(new Response('{}', { status: 200 }));
+    }
+
+    if (urlStr.indexOf('/api/voice/audio/') !== -1) {
+      if (opts && opts.signal) window.__audioProbeSawSignal = true;
+      return new Promise(function (resolve) {
+        (function poll() {
+          if (window.__audioGateOpen) {
+            resolve(new Response(null, { status: window.__audioFound ? 200 : 404 }));
+            return;
+          }
+          setTimeout(poll, 10);
+        })();
+      });
     }
 
     return Promise.resolve(new Response('{}', {
@@ -181,13 +210,28 @@ def _set_queue(page: Page, turns):
 
 def _fire_turn(page: Page):
     """Starts submitTurn() without awaiting it, so mid-turn state can be
-    inspected. Playwright only awaits a *returned* promise. Never passes a
-    blob (headless -- nothing here exercises heldRecording)."""
-    page.evaluate("() => { window.lifeChatVoice.submitTurn({ blob: null }); }")
+    inspected -- Playwright only awaits a promise page.evaluate() itself
+    returns. The promise is stashed on window.__turns (in fire order, which
+    matches window.__turnQueue's fetch-call order: submitTurn()'s first
+    await is its own POST) so _await_turn() can wait on it precisely later,
+    instead of a sleep-and-hope (#832/F4). Never passes a blob (headless --
+    nothing here exercises heldRecording)."""
+    page.evaluate(
+        "() => { window.__turns = window.__turns || []; "
+        "window.__turns.push(window.lifeChatVoice.submitTurn({ blob: null })); }"
+    )
 
 
 def _release(page: Page, idx: int):
     page.evaluate("(i) => window.__releaseTurn(i)", idx)
+
+
+def _await_turn(page: Page, idx: int):
+    """Awaits the idx-th fired turn's own submitTurn() call settling --
+    submitTurn() always resolves (its catch never rethrows), so this is safe
+    to call unconditionally once that turn is expected to have finished
+    settling (typically right after releasing its gate)."""
+    page.evaluate("(i) => window.__turns[i]", idx)
 
 
 def _thread(page: Page):
@@ -238,7 +282,7 @@ class TestOverlappingTurnOwnership:
         # A's 'started' event (a decoy turn_id) and its 'done' both arrive
         # only now, well after B took over.
         _release(page, 0)
-        page.wait_for_timeout(200)  # let A's now-unblocked promise chain settle
+        _await_turn(page, 0)  # wait for A's own submitTurn() promise to settle, never a sleep (#832/F4)
 
         # Every bit of B's still-in-flight bookkeeping must be untouched:
         # A's 'started' must not have overwritten activeTurnId, its 'done'
@@ -252,10 +296,17 @@ class TestOverlappingTurnOwnership:
         expect(page.locator("#statusText")).to_have_text("Thinking…")
         assert _is_loading(page) is True
 
+        # A's late 'started' frame carried its id, and by then it was already
+        # superseded -- consumeTurnStream()'s 'started' handler POSTs a
+        # best-effort cancel for it right then (#832/F2), since the earlier
+        # supersession abort (fired when B started, before A's id was known)
+        # could only close the connection, not tell the server to stop.
+        assert page.evaluate("() => window.__cancelLog") == ["turn-A-stale"]
+
         # Cancel must still target the NEWER turn (activeTurnId === 'turn-B',
         # not A's decoy) -- proof activeTurnId/activeTurnAbort survived.
         page.evaluate("() => window.lifeChatVoice.cancelActiveTurn()")
-        assert page.evaluate("() => window.__cancelLog") == ["turn-B"]
+        assert page.evaluate("() => window.__cancelLog") == ["turn-A-stale", "turn-B"]
         expect(page.locator("#messages .message.user")).to_have_count(0)
         expect(page.locator("#statusText")).to_have_text("Ready")
         assert _is_loading(page) is False
@@ -281,14 +332,20 @@ class TestOverlappingTurnOwnership:
         expect(page.locator("#messages .message.user")).to_have_count(2)
         expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn visible")
         assert _user_texts(page) == ["first", "second"]
+        # A's id was already known (its 'started' frame arrived before B ever
+        # started), so B's own supersession logic could cancel it immediately
+        # -- no need to wait for anything server-side (#832/F2).
+        assert page.evaluate("() => window.__cancelLog") == ["turn-A"]
 
-        # A's server-side cancel arrives only now. Unguarded, clearUserTranscript()
-        # would delete whatever turnTranscriptEl currently points at -- B's
-        # "second" bubble, not A's already-rendered "first" -- exactly the bug
-        # #832 describes ("a slow server cancel arriving after the user has
-        # moved on").
+        # A's server-side cancel arrives only now anyway (a real, if now rarer,
+        # race -- see the fetch mock's own comment on why gate release, not
+        # the abort signal, controls delivery here). Unguarded,
+        # clearUserTranscript() would delete whatever turnTranscriptEl
+        # currently points at -- B's "second" bubble, not A's already-
+        # rendered "first" -- exactly the bug #832 describes ("a slow server
+        # cancel arriving after the user has moved on").
         _release(page, 0)
-        page.wait_for_timeout(200)
+        _await_turn(page, 0)
 
         assert _user_texts(page) == ["first", "second"]
         expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn visible")
@@ -297,7 +354,7 @@ class TestOverlappingTurnOwnership:
 
         # Cancel still targets B, not stale A.
         page.evaluate("() => window.lifeChatVoice.cancelActiveTurn()")
-        assert page.evaluate("() => window.__cancelLog") == ["turn-B"]
+        assert page.evaluate("() => window.__cancelLog") == ["turn-A", "turn-B"]
         # B's own (uncompleted, undone) bubble is dropped by the real cancel;
         # A's already-rendered "first" is untouched history either way.
         assert _user_texts(page) == ["first"]
@@ -320,7 +377,7 @@ class TestOverlappingTurnOwnership:
 
         # A's definitive 'error' frame arrives only now.
         _release(page, 0)
-        page.wait_for_timeout(200)
+        _await_turn(page, 0)
 
         # A's failure must never surface -- no "⚠️ boom" message, no failed-
         # status row, and B's own status/thinking/cancel state untouched.
@@ -334,6 +391,119 @@ class TestOverlappingTurnOwnership:
         assert page.evaluate("() => window.__cancelLog") == ["turn-B"]
         expect(page.locator("#statusText")).to_have_text("Ready")
         assert _is_loading(page) is False
+
+    def test_cancel_button_click_targets_the_newer_turn(self, page: Page, chat_base_url):
+        """Every other test here calls cancelActiveTurn() directly (the
+        exported test seam). This one instead drives the real Cancel button
+        (onTalkClick's sibling handler, voice.js:492-495 -- `if (voiceBusy ||
+        clipInFlight) cancelActiveTurn()`), so the UI wiring itself is
+        proven, not just the function it calls (#832/F10)."""
+        _open_voice_chat(page, chat_base_url)
+        _set_queue(page, [
+            {"frames": [
+                "__gate",
+                {"type": "started", "turn_id": "turn-A-stale"},
+                {"type": "done", "data": {"transcript": "first", "response_text": "first-response"}},
+            ]},
+            {"frames": [
+                {"type": "started", "turn_id": "turn-B"},
+                {"type": "transcript", "text": "second"},
+                "__gate",
+                {"type": "done", "data": {"transcript": "second", "response_text": "second-response"}},
+            ]},
+        ])
+        _fire_turn(page)  # turn A -- stalls before it ever processes a frame
+        _fire_turn(page)  # turn B -- overlaps A; becomes the current turn
+        expect(page.locator("#messages .message.user")).to_have_text("second")
+        expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn visible")
+
+        page.locator("#voiceCancelBtn").click()
+
+        # The click reaches cancelActiveTurn() (voiceBusy is true for B), which
+        # targets whatever is CURRENT -- turn-B, never A's decoy id.
+        assert page.evaluate("() => window.__cancelLog") == ["turn-B"]
+        expect(page.locator("#messages .message.user")).to_have_count(0)
+        expect(page.locator("#statusText")).to_have_text("Ready")
+        assert _is_loading(page) is False
+
+        # A's late success still must not resurrect anything once it arrives.
+        _release(page, 0)
+        _await_turn(page, 0)
+        assert _thread(page) == []
+        expect(page.locator("#statusText")).to_have_text("Ready")
+
+    def test_midstream_drop_poll_is_abort_aware(self, page: Page, chat_base_url):
+        """#832/F5: pollForCompletedAudio() used to run its own ~3s budget
+        deaf to cancellation -- neither its inter-attempt sleep nor its HEAD
+        fetch carried the turn's own AbortController signal, so nothing
+        stopped it early: not a Cancel tap, not a newer turn's own
+        supersession abort. Proven here by checking the signal was actually
+        passed through to the probe's fetch call, not by racing an abort
+        against the poll's timing (flaky either way this could be fixed)."""
+        _open_voice_chat(page, chat_base_url)
+        _set_queue(page, [
+            {"frames": [
+                {"type": "started", "turn_id": "turn-A"},
+                {"type": "transcript", "text": "first"},
+                "__error",
+            ]},
+        ])
+        _fire_turn(page)
+        expect(page.locator("#statusText")).to_have_text("Reconnecting…")
+        assert page.evaluate("() => window.__audioProbeSawSignal") is True
+        page.evaluate("() => { window.__audioGateOpen = true; }")  # let it finish cleanly
+        _await_turn(page, 0)
+
+    @pytest.mark.parametrize("audio_found", [True, False])
+    def test_midstream_drop_poll_completing_late_does_not_clobber_the_newer_turn(
+            self, page: Page, chat_base_url, audio_found):
+        """Production's real trigger for this overlap is cancelActiveTurn()
+        firing while this poll is in flight, then a fresh recording starting
+        (see test_cancel_button_click_targets_the_newer_turn and the abort-
+        wiring test above) -- but handleMidStreamDrop()'s own isOwnTurn
+        checks are the backstop regardless of what aborts what, so this
+        proves THEM directly: even if this turn's poll were to reach a
+        verdict despite already being superseded (the audio-probe gate here
+        is deliberately release-only, decoupled from the abort signal, same
+        reasoning as the SSE streams' own gates above), neither a 'found' nor
+        a 'not found' verdict may act on shared state B now owns (#832/F5)."""
+        _open_voice_chat(page, chat_base_url)
+        page.evaluate("(found) => { window.__audioFound = found; }", audio_found)
+        _set_queue(page, [
+            {"frames": [
+                {"type": "started", "turn_id": "turn-A"},
+                {"type": "transcript", "text": "first"},
+                "__error",
+            ]},
+            {"frames": [
+                {"type": "started", "turn_id": "turn-B"},
+                {"type": "transcript", "text": "second"},
+                "__gate",
+            ]},
+        ])
+        _fire_turn(page)  # turn A -- mid-stream drop right after 'transcript'
+        expect(page.locator("#statusText")).to_have_text("Reconnecting…")
+
+        _fire_turn(page)  # turn B -- overlaps A; becomes the current turn
+        # A's own bubble ("first") isn't retracted by a mid-stream drop
+        # (matching handleTerminalFailure()'s existing "keeps the user
+        # bubble" behavior on any failure) -- both are present at this point.
+        expect(page.locator("#messages .message.user")).to_have_count(2)
+        assert _user_texts(page) == ["first", "second"]
+
+        # A's poll resolves only now, well after B took over.
+        page.evaluate("() => { window.__audioGateOpen = true; }")
+        _await_turn(page, 0)
+
+        # Neither outcome may touch B: no "tap to hear it" message (the
+        # `found` branch), no failed-status row (the `!found` branch), and
+        # B's own status/thinking/cancel state untouched either way.
+        assert _user_texts(page) == ["first", "second"]
+        assert "tap to hear it" not in "".join(_assistant_texts(page))
+        expect(page.locator(".voice-turn-status.failed")).to_have_count(0)
+        expect(page.locator("#statusText")).to_have_text("Thinking…")
+        expect(page.locator("#messages .message.assistant .typing")).to_have_count(1)
+        assert _is_loading(page) is True
 
     def test_single_turn_success_is_unaffected(self, page: Page, chat_base_url):
         """Sanity check alongside the overlapping-turn cases above: with no
@@ -352,3 +522,132 @@ class TestOverlappingTurnOwnership:
         expect(page.locator("#statusText")).to_have_text("Ready")
         expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn")
         assert _is_loading(page) is False
+
+
+# --- post-playback continuation guard (df9bf88, #832 follow-up) -----------
+#
+# submitTurn()'s tail after `await playbackChain` -- showCancel(false);
+# setStatus('', 'Ready'); await maybeAutoContinue() -- runs only if this turn
+# is still current. Tapping Cancel while a completed turn's reply is still
+# playing (cancelActiveTurn()'s "stop playback" use, once `turnDone`) is
+# exactly what settles playbackChain early and ALSO already resets
+# activeTurnAbort itself -- so by the time this resumes, isOwnTurn() is
+# already false regardless of whether some OTHER turn has started. Unguarded,
+# maybeAutoContinue() would re-arm a fresh recording anyway (the #721
+# regression this guard prevents, in the "stop playback" variant rather than
+# the "manual recording stop" one #721 was originally about) -- confirmed by
+# checking getUserMedia call count directly, not by asserting silence.
+#
+# Needs real playback (unlike the rest of this file, which runs muted) to put
+# submitTurn() genuinely inside `await playbackChain` when Cancel is tapped,
+# so this uses the real-WAV-clip + instrumented-Audio-element pattern
+# tests/test_voice_manual_stop_auto_mode_ui_browser.py and
+# tests/test_voice_rate_toggle_playback_ui_browser.py already establish,
+# rather than this file's own gate-driven SSE mock.
+_PLAYBACK_INSTRUMENT_SCRIPT = """
+window.__turnClipUrl = null;
+window.fetch = function (url, opts) {
+  var urlStr = typeof url === 'string' ? url : (url && url.url) || String(url);
+  if (urlStr.indexOf('/api/voice/turn/stream') !== -1) {
+    var sse = 'data: ' + JSON.stringify({ type: 'started', turn_id: 'turn-playback' }) + '\\n\\n'
+            + 'data: ' + JSON.stringify({ type: 'main_audio', url: window.__turnClipUrl }) + '\\n\\n'
+            + 'data: ' + JSON.stringify({ type: 'done', data: { response_text: 'ok' } }) + '\\n\\n';
+    return Promise.resolve(new Response(sse, {
+      status: 200, headers: { 'Content-Type': 'text/event-stream' },
+    }));
+  }
+  if (urlStr.indexOf('/cancel') !== -1) {
+    return Promise.resolve(new Response('{}', { status: 200 }));
+  }
+  return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+};
+
+window.__gumCalls = 0;
+navigator.mediaDevices.getUserMedia = function (constraints) {
+  window.__gumCalls += 1;
+  var ctx = new (window.AudioContext || window.webkitAudioContext)();
+  var dest = ctx.createMediaStreamDestination();
+  return Promise.resolve(dest.stream);
+};
+
+(function () {
+  window.__audioPlayingCount = 0;
+  var proto = HTMLMediaElement.prototype;
+  var origPlay = proto.play;
+  proto.play = function () {
+    if (!this.__wired832) {
+      this.__wired832 = true;
+      this.addEventListener('playing', function () { window.__audioPlayingCount += 1; });
+      var onEnd = function () { window.__audioPlayingCount = Math.max(0, window.__audioPlayingCount - 1); };
+      this.addEventListener('ended', onEnd);
+      this.addEventListener('pause', onEnd);
+    }
+    var p = origPlay.call(this);
+    p.catch(function () {});
+    return p;
+  };
+})();
+
+window.__makeWav = function (ms, sampleRate) {
+  sampleRate = sampleRate || 8000;
+  var n = Math.round((ms / 1000) * sampleRate);
+  var dataBytes = n * 2;
+  var buf = new ArrayBuffer(44 + dataBytes);
+  var view = new DataView(buf);
+  function writeStr(offset, str) {
+    for (var i = 0; i < str.length; i++) view.setUint8(offset + i, str.charCodeAt(i));
+  }
+  writeStr(0, 'RIFF');
+  view.setUint32(4, 36 + dataBytes, true);
+  writeStr(8, 'WAVE');
+  writeStr(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeStr(36, 'data');
+  view.setUint32(40, dataBytes, true);
+  var bytes = new Uint8Array(buf);
+  var binary = '';
+  var chunk = 0x8000;
+  for (var i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+  }
+  return 'data:audio/wav;base64,' + btoa(binary);
+};
+"""
+
+
+def _open_playback_chat(page: Page, base_url, *, auto):
+    settings = {"mute": False, "auto": auto, "fast": False, "listen": False}
+    page.add_init_script(
+        "try { window.localStorage.setItem('lifeos:chat:dock_settings', "
+        + json.dumps(json.dumps(settings))
+        + "); } catch (e) {}"
+    )
+    page.add_init_script(_PLAYBACK_INSTRUMENT_SCRIPT)
+    page.goto(f"{base_url}/chat?mode=voice")
+    page.wait_for_selector("#voiceTalkBtn")
+
+
+class TestPostPlaybackCancelGuard:
+    def test_cancel_during_playback_does_not_rearm_auto_continue(self, page: Page, chat_base_url):
+        _open_playback_chat(page, chat_base_url, auto=True)
+        clip_url = page.evaluate("window.__makeWav(3000)")  # long enough to tap Cancel mid-playback
+        page.evaluate("(u) => { window.__turnClipUrl = u; }", clip_url)
+        page.evaluate("() => { window.lifeChatVoice.submitTurn({ transcript: 'hi' }); }")
+
+        page.wait_for_function("window.__audioPlayingCount > 0")
+        page.locator("#voiceCancelBtn").click()  # the real "stop playback" tap
+        page.wait_for_function("window.__audioPlayingCount === 0")
+
+        # Settle well past submitTurn()'s own resumption and give a would-be
+        # re-arm every chance to fire before asserting it didn't.
+        page.wait_for_timeout(600)
+        assert page.evaluate("window.__gumCalls") == 0, (
+            "auto-continue re-armed a recording after Cancel stopped mid-reply playback"
+        )
+        expect(page.locator("#statusText")).to_have_text("Ready")

--- a/tests/test_voice_turn_ownership_ui_browser.py
+++ b/tests/test_voice_turn_ownership_ui_browser.py
@@ -1,0 +1,354 @@
+"""Browser tests for turn-ownership across overlapping voice turns (#832).
+
+`submitTurn()`'s cleanup (the `finally`, the AbortError branch, mid-stream-
+drop recovery, terminal failure) and the SSE handlers in `consumeTurnStream()`
+all touch module-level state shared across turns -- `activeTurnId`,
+`activeTurnAbort`, `voiceBusy`, `state.isLoading`, the thinking placeholder,
+the user-transcript bubble, the Cancel button, the status text. A turn whose
+own async work (network retry, SSE stream, mid-stream recovery poll) settles
+*after* a newer turn has already started must not touch any of that -- the
+newer turn now owns it. `isOwnTurn()` (an identity check against the settling
+turn's own captured `AbortController`, the pattern #827 introduced for one
+branch and #832 generalized to every exit path) is what prevents it.
+
+Drives `submitTurn()`/`cancelActiveTurn()` directly (the seam voice.js
+exports so a headless harness can run turns without a real mic -- same
+pattern as tests/test_voice_transcript_ui_browser.py). Two turns are put in
+flight at once by firing `submitTurn()` twice without ever cancelling the
+first -- a real trigger per #832's own issue (a slow server response, or a
+double Retry tap, reconciling after the user has already moved on) -- and
+each gets its own independently-gated SSE stream via `window.__turnQueue`,
+so "the older turn settles AFTER the newer one already exists" is an
+observable, deterministic state rather than a timing race.
+
+Serves `web/` itself from an ephemeral port and replaces `window.fetch`
+outright -- the same self-contained pattern as
+tests/test_voice_transcript_ui_browser.py and
+tests/test_voice_network_resilience_ui_browser.py. No `requires_server`
+marker, so this runs at pre-push (`browser and not requires_server`).
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+
+class _ChatHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the chat SPA the way api/main.py does: `/chat` is index.html and
+    the module tree hangs off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/chat", "/"):
+            return str(WEB_DIR / "index.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def chat_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _ChatHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# Installed before any app JS runs. Each POST to /api/voice/turn/stream
+# consumes the NEXT entry of window.__turnQueue, in call order -- so firing
+# submitTurn() twice gives the first call turn 0's frames/gate and the second
+# call turn 1's, independently. A '__gate' entry in a turn's frame list
+# stalls its stream until window.__releaseTurn(<that turn's queue index>) is
+# called; '__error' errors the stream's controller in place instead of
+# enqueuing an SSE frame (a mid-stream connection drop, not a clean end).
+_FETCH_MOCK = """
+// Dock toggles default to auto-continue/listening ON, which makes voice.js
+// re-acquire the mic once a turn finishes -- getUserMedia can't run headless.
+// Muted playback for the same reason.
+try {
+  window.localStorage.setItem(
+    'lifeos:chat:dock_settings',
+    JSON.stringify({ mute: true, auto: false, fast: false, listen: false })
+  );
+} catch (e) { /* storage unavailable -- assertions below will say so */ }
+
+window.__turnQueue = [];
+window.__turnCallCount = 0;
+window.__gatesOpen = {};
+window.__cancelLog = [];
+window.__releaseTurn = function (i) { window.__gatesOpen[i] = true; };
+
+(function () {
+  window.fetch = function (url, opts) {
+    var urlStr = typeof url === 'string' ? url : (url && url.url) || String(url);
+    var signal = opts && opts.signal;
+    function abortError() { return new DOMException('Turn cancelled', 'AbortError'); }
+
+    if (urlStr.indexOf('/api/voice/turn/stream') !== -1) {
+      var idx = window.__turnCallCount++;
+      var frames = (window.__turnQueue[idx] || {}).frames || [];
+      function waitForGate() {
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (signal && signal.aborted) return reject(abortError());
+            if (window.__gatesOpen[idx]) return resolve();
+            setTimeout(poll, 10);
+          })();
+        });
+      }
+      var body = new ReadableStream({
+        start: function (controller) {
+          var enc = new TextEncoder();
+          var i = 0;
+          (function next() {
+            if (signal && signal.aborted) return controller.error(abortError());
+            if (i >= frames.length) return controller.close();
+            var frame = frames[i++];
+            if (frame === '__gate') {
+              return waitForGate().then(next, function (e) { controller.error(e); });
+            }
+            if (frame === '__error') {
+              return controller.error(new TypeError('Failed to fetch'));
+            }
+            controller.enqueue(enc.encode('data: ' + JSON.stringify(frame) + '\\n\\n'));
+            // A real macrotask between frames, so the client observably
+            // processes one before the next arrives.
+            setTimeout(next, 10);
+          })();
+        },
+      });
+      return Promise.resolve(new Response(body, {
+        status: 200, headers: { 'Content-Type': 'text/event-stream' },
+      }));
+    }
+
+    if (urlStr.indexOf('/cancel') !== -1) {
+      var m = urlStr.match(/\\/turn\\/([^/]+)\\/cancel/);
+      window.__cancelLog.push(m ? decodeURIComponent(m[1]) : urlStr);
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    }
+
+    return Promise.resolve(new Response('{}', {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    }));
+  };
+})();
+"""
+
+
+def _wait_for_backend_ready(page: Page):
+    """`config.backend` starts null (the same value the lifeos default resolves
+    to), so only awaiting initBackend()'s stashed promise proves resolution ran."""
+    page.evaluate(
+        "async () => {"
+        "  while (!(window.lifeChat && window.lifeChat.backendReady)) {"
+        "    await new Promise((r) => setTimeout(r, 10));"
+        "  }"
+        "  await window.lifeChat.backendReady;"
+        "}"
+    )
+
+
+def _open_voice_chat(page: Page, base_url):
+    page.add_init_script(_FETCH_MOCK)
+    page.goto(f"{base_url}/chat?mode=voice")
+    page.wait_for_selector("#voiceTalkBtn")
+    _wait_for_backend_ready(page)
+
+
+def _set_queue(page: Page, turns):
+    """`turns` is a list of {"frames": [...]} dicts, consumed in fetch-call
+    order -- turns[0] is whichever submitTurn() call fires first."""
+    page.evaluate(
+        "(q) => { window.__turnQueue = JSON.parse(q); window.__turnCallCount = 0; "
+        "window.__gatesOpen = {}; window.__cancelLog = []; }",
+        json.dumps(turns),
+    )
+
+
+def _fire_turn(page: Page):
+    """Starts submitTurn() without awaiting it, so mid-turn state can be
+    inspected. Playwright only awaits a *returned* promise. Never passes a
+    blob (headless -- nothing here exercises heldRecording)."""
+    page.evaluate("() => { window.lifeChatVoice.submitTurn({ blob: null }); }")
+
+
+def _release(page: Page, idx: int):
+    page.evaluate("(i) => window.__releaseTurn(i)", idx)
+
+
+def _thread(page: Page):
+    return page.evaluate(
+        "() => [...document.querySelectorAll('#messages .message')].map("
+        "  (m) => [m.className, (m.querySelector('.message-content')||{}).textContent || ''])"
+    )
+
+
+def _user_texts(page: Page):
+    return [text for cls, text in _thread(page) if "user" in cls]
+
+
+def _assistant_texts(page: Page):
+    return [text for cls, text in _thread(page) if "assistant" in cls]
+
+
+def _is_loading(page: Page):
+    return page.evaluate("() => window.lifeChat.state.isLoading")
+
+
+class TestOverlappingTurnOwnership:
+    """AC (#832): a stale turn settling late must not clobber a newer turn's
+    id/abort/busy/loading state, and Cancel must still target the newer
+    turn."""
+
+    def test_late_success_does_not_clobber_the_newer_turn(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _set_queue(page, [
+            {"frames": [
+                "__gate",
+                {"type": "started", "turn_id": "turn-A-stale"},
+                {"type": "done", "data": {"transcript": "first", "response_text": "first-response"}},
+            ]},
+            {"frames": [
+                {"type": "started", "turn_id": "turn-B"},
+                {"type": "transcript", "text": "second"},
+                "__gate",
+                {"type": "done", "data": {"transcript": "second", "response_text": "second-response"}},
+            ]},
+        ])
+        _fire_turn(page)  # turn A -- stalls before it ever processes a frame
+        _fire_turn(page)  # turn B -- overlaps A; becomes the current turn
+        expect(page.locator("#messages .message.user")).to_have_text("second")
+        expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn visible")
+        expect(page.locator("#statusText")).to_have_text("Thinking…")
+
+        # A's 'started' event (a decoy turn_id) and its 'done' both arrive
+        # only now, well after B took over.
+        _release(page, 0)
+        page.wait_for_timeout(200)  # let A's now-unblocked promise chain settle
+
+        # Every bit of B's still-in-flight bookkeeping must be untouched:
+        # A's 'started' must not have overwritten activeTurnId, its 'done'
+        # must not have rendered "first"/"first-response" or reset the
+        # thinking placeholder/Cancel button/status text B still owns. The
+        # only assistant-side element left is still B's own typing placeholder.
+        assert _user_texts(page) == ["second"]
+        expect(page.locator("#messages .message.assistant")).to_have_count(1)
+        expect(page.locator("#messages .message.assistant .typing")).to_have_count(1)
+        expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn visible")
+        expect(page.locator("#statusText")).to_have_text("Thinking…")
+        assert _is_loading(page) is True
+
+        # Cancel must still target the NEWER turn (activeTurnId === 'turn-B',
+        # not A's decoy) -- proof activeTurnId/activeTurnAbort survived.
+        page.evaluate("() => window.lifeChatVoice.cancelActiveTurn()")
+        assert page.evaluate("() => window.__cancelLog") == ["turn-B"]
+        expect(page.locator("#messages .message.user")).to_have_count(0)
+        expect(page.locator("#statusText")).to_have_text("Ready")
+        assert _is_loading(page) is False
+
+    def test_late_server_cancel_does_not_clobber_the_newer_turns_bubble(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _set_queue(page, [
+            {"frames": [
+                {"type": "started", "turn_id": "turn-A"},
+                {"type": "transcript", "text": "first"},
+                "__gate",
+                {"type": "cancelled"},
+            ]},
+            {"frames": [
+                {"type": "started", "turn_id": "turn-B"},
+                {"type": "transcript", "text": "second"},
+                "__gate",
+            ]},
+        ])
+        _fire_turn(page)  # turn A -- renders "first", then stalls before its cancel frame
+        expect(page.locator("#messages .message.user")).to_have_text("first")
+        _fire_turn(page)  # turn B -- overlaps A; becomes the current turn
+        expect(page.locator("#messages .message.user")).to_have_count(2)
+        expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn visible")
+        assert _user_texts(page) == ["first", "second"]
+
+        # A's server-side cancel arrives only now. Unguarded, clearUserTranscript()
+        # would delete whatever turnTranscriptEl currently points at -- B's
+        # "second" bubble, not A's already-rendered "first" -- exactly the bug
+        # #832 describes ("a slow server cancel arriving after the user has
+        # moved on").
+        _release(page, 0)
+        page.wait_for_timeout(200)
+
+        assert _user_texts(page) == ["first", "second"]
+        expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn visible")
+        expect(page.locator("#statusText")).to_have_text("Thinking…")
+        assert _is_loading(page) is True
+
+        # Cancel still targets B, not stale A.
+        page.evaluate("() => window.lifeChatVoice.cancelActiveTurn()")
+        assert page.evaluate("() => window.__cancelLog") == ["turn-B"]
+        # B's own (uncompleted, undone) bubble is dropped by the real cancel;
+        # A's already-rendered "first" is untouched history either way.
+        assert _user_texts(page) == ["first"]
+        expect(page.locator("#statusText")).to_have_text("Ready")
+
+    def test_late_definitive_failure_does_not_clobber_the_newer_turn(self, page: Page, chat_base_url):
+        _open_voice_chat(page, chat_base_url)
+        _set_queue(page, [
+            {"frames": ["__gate", {"type": "error", "message": "boom"}]},
+            {"frames": [
+                {"type": "started", "turn_id": "turn-B"},
+                {"type": "transcript", "text": "second"},
+                "__gate",
+            ]},
+        ])
+        _fire_turn(page)  # turn A -- stalls before its definitive server error
+        _fire_turn(page)  # turn B -- overlaps A; becomes the current turn
+        expect(page.locator("#messages .message.user")).to_have_text("second")
+        expect(page.locator("#statusText")).to_have_text("Thinking…")
+
+        # A's definitive 'error' frame arrives only now.
+        _release(page, 0)
+        page.wait_for_timeout(200)
+
+        # A's failure must never surface -- no "⚠️ boom" message, no failed-
+        # status row, and B's own status/thinking/cancel state untouched.
+        assert "⚠️ boom" not in "".join(_assistant_texts(page))
+        expect(page.locator(".voice-turn-status.failed")).to_have_count(0)
+        expect(page.locator("#statusText")).to_have_text("Thinking…")
+        expect(page.locator("#messages .message.assistant .typing")).to_have_count(1)
+        assert _is_loading(page) is True
+
+        page.evaluate("() => window.lifeChatVoice.cancelActiveTurn()")
+        assert page.evaluate("() => window.__cancelLog") == ["turn-B"]
+        expect(page.locator("#statusText")).to_have_text("Ready")
+        assert _is_loading(page) is False
+
+    def test_single_turn_success_is_unaffected(self, page: Page, chat_base_url):
+        """Sanity check alongside the overlapping-turn cases above: with no
+        second turn ever started, a lone turn's own cleanup still runs
+        exactly as before -- the ownership check is never false for it."""
+        _open_voice_chat(page, chat_base_url)
+        _set_queue(page, [
+            {"frames": [
+                {"type": "started", "turn_id": "turn-solo"},
+                {"type": "transcript", "text": "solo"},
+                {"type": "done", "data": {"transcript": "solo", "response_text": "solo-response"}},
+            ]},
+        ])
+        _fire_turn(page)
+        expect(page.locator("#messages .message.assistant")).to_have_text("solo-response")
+        expect(page.locator("#statusText")).to_have_text("Ready")
+        expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn")
+        assert _is_loading(page) is False

--- a/tests/test_voice_turn_ownership_ui_browser.py
+++ b/tests/test_voice_turn_ownership_ui_browser.py
@@ -30,6 +30,7 @@ marker, so this runs at pre-push (`browser and not requires_server`).
 import http.server
 import json
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -100,27 +101,34 @@ window.__releaseTurn = function (i) { window.__gatesOpen[i] = true; };
 window.__audioGateOpen = false;
 window.__audioFound = false;
 window.__audioProbeSawSignal = false;
+window.__audioProbeCallCount = 0;
 
 (function () {
   window.fetch = function (url, opts) {
     var urlStr = typeof url === 'string' ? url : (url && url.url) || String(url);
+    var signal = opts && opts.signal;
+    function abortError() { return new DOMException('Turn cancelled', 'AbortError'); }
 
     if (urlStr.indexOf('/api/voice/turn/stream') !== -1) {
       var idx = window.__turnCallCount++;
       var frames = (window.__turnQueue[idx] || {}).frames || [];
-      // Deliberately NOT abort-aware (unlike the other voice test files'
-      // gates): submitTurn() now actively aborts a superseded turn's own
-      // AbortController the moment a newer turn starts (#832/F2), which
-      // would otherwise tear this stream down before a '__gate'-held frame
-      // ever reaches handleEvent -- exactly the frame these tests exist to
-      // deliver. A frame already in flight over the wire can still arrive
-      // after a client-side abort in the real world (the same race #832/F1's
-      // consumeTurnStream()-entry comment describes for postTurnStart()), so
-      // gate release alone -- never the signal -- controls delivery here,
-      // to test that race and the supersession-abort path independently.
+      // Abort-aware (found on independent review, #832/N1): a real fetch()
+      // errors its body stream the instant its own signal aborts, and
+      // reading it resumes into a single synchronous
+      // reader.read()-resolves -> parseSseChunk -> handleEvent block -- so a
+      // frame is either processed before the abort (this turn was still own
+      // when it arrived) or never delivered at all. A previous version of
+      // this mock ignored the signal so a '__gate'-held frame could still be
+      // released after supersession's own abort() had already fired,
+      // exercising a branch (consumeTurnStream()'s 'started' handler's
+      // late-id best-effort cancel) that a real browser can't actually
+      // reach this way -- see test_late_success_does_not_clobber_the_newer_
+      // turn's own comment for what that branch is still real
+      // defense-in-depth against instead.
       function waitForGate() {
-        return new Promise(function (resolve) {
+        return new Promise(function (resolve, reject) {
           (function poll() {
+            if (signal && signal.aborted) return reject(abortError());
             if (window.__gatesOpen[idx]) return resolve();
             setTimeout(poll, 10);
           })();
@@ -131,10 +139,11 @@ window.__audioProbeSawSignal = false;
           var enc = new TextEncoder();
           var i = 0;
           (function next() {
+            if (signal && signal.aborted) return controller.error(abortError());
             if (i >= frames.length) return controller.close();
             var frame = frames[i++];
             if (frame === '__gate') {
-              return waitForGate().then(next);
+              return waitForGate().then(next, function (e) { controller.error(e); });
             }
             if (frame === '__error') {
               return controller.error(new TypeError('Failed to fetch'));
@@ -159,6 +168,7 @@ window.__audioProbeSawSignal = false;
 
     if (urlStr.indexOf('/api/voice/audio/') !== -1) {
       if (opts && opts.signal) window.__audioProbeSawSignal = true;
+      window.__audioProbeCallCount += 1;
       return new Promise(function (resolve) {
         (function poll() {
           if (window.__audioGateOpen) {
@@ -296,17 +306,27 @@ class TestOverlappingTurnOwnership:
         expect(page.locator("#statusText")).to_have_text("Thinking…")
         assert _is_loading(page) is True
 
-        # A's late 'started' frame carried its id, and by then it was already
-        # superseded -- consumeTurnStream()'s 'started' handler POSTs a
-        # best-effort cancel for it right then (#832/F2), since the earlier
-        # supersession abort (fired when B started, before A's id was known)
-        # could only close the connection, not tell the server to stop.
-        assert page.evaluate("() => window.__cancelLog") == ["turn-A-stale"]
+        # A's decoy 'started'/'done' frames never actually arrive: the gate
+        # mock is abort-aware (see its own comment), and submitTurn()'s
+        # supersession already aborted A's controller the moment B started --
+        # before A's id was ever known, so there is nothing for the 'started'
+        # handler's else-branch (consumeTurnStream()'s own best-effort late-
+        # cancel, #832/F2) to reach here. That branch is real defense-in-depth
+        # for a genuine race a live network can still produce (an already-
+        # in-flight frame landing microtasks after abort() -- see #832/F1's
+        # postTurnStart()-resolves-post-abort comment for the same class of
+        # race), but this specific "gate held before the id was ever sent"
+        # shape can't reach it: an aborted stream never gets to deliver a
+        # frame that was never even in flight yet. Confirmed empirically
+        # (#832/N1): the only way to make it reach that branch is to hold
+        # the mock's gate open through an abort, which a real `fetch()`
+        # cannot do once its own signal fires.
+        assert page.evaluate("() => window.__cancelLog") == []
 
         # Cancel must still target the NEWER turn (activeTurnId === 'turn-B',
         # not A's decoy) -- proof activeTurnId/activeTurnAbort survived.
         page.evaluate("() => window.lifeChatVoice.cancelActiveTurn()")
-        assert page.evaluate("() => window.__cancelLog") == ["turn-A-stale", "turn-B"]
+        assert page.evaluate("() => window.__cancelLog") == ["turn-B"]
         expect(page.locator("#messages .message.user")).to_have_count(0)
         expect(page.locator("#statusText")).to_have_text("Ready")
         assert _is_loading(page) is False
@@ -454,6 +474,50 @@ class TestOverlappingTurnOwnership:
         page.evaluate("() => { window.__audioGateOpen = true; }")  # let it finish cleanly
         _await_turn(page, 0)
 
+    def test_sleep_abortable_actually_interrupts_the_poll_wait(self, page: Page, chat_base_url):
+        """#832/N5: it's not enough for pollForCompletedAudio()'s inter-
+        attempt sleep (sleepAbortable()) to merely accept a signal parameter
+        -- it has to actually register an abort listener and reject early,
+        or a cancellation arriving during that 1500ms wait (rather than
+        during the HEAD fetch itself, already proven by the wiring test
+        above) would still block the turn for the rest of the interval.
+        Times how long cancelActiveTurn() takes to actually unblock the
+        turn, rather than asserting on the interval's exact length, since
+        the real behavior under test is "does the abort cut the wait short,"
+        not "how long is the configured interval." Never a sleep-based wait
+        for the moment to act -- the gate keeps the probe resolving
+        instantly on the FIRST attempt so window.__audioProbeCallCount is a
+        precise, non-racy signal that attempt 2 is now in its sleep."""
+        _open_voice_chat(page, chat_base_url)
+        page.evaluate(
+            "() => { window.__audioFound = false; window.__audioGateOpen = true; "
+            "window.__audioProbeCallCount = 0; }"
+        )
+        _set_queue(page, [
+            {"frames": [
+                {"type": "started", "turn_id": "turn-A"},
+                {"type": "transcript", "text": "first"},
+                "__error",
+            ]},
+        ])
+        _fire_turn(page)
+        # First HEAD attempt resolved (not found) -- pollForCompletedAudio()
+        # is now inside sleepAbortable()'s ~1500ms wait before attempt 2.
+        page.wait_for_function("window.__audioProbeCallCount >= 1")
+
+        started = time.monotonic()
+        page.evaluate("() => window.lifeChatVoice.cancelActiveTurn()")
+        _await_turn(page, 0)
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 1.0, (
+            f"cancelActiveTurn() took {elapsed:.2f}s to unblock the turn -- "
+            "sleepAbortable() did not actually abort on cancellation"
+        )
+        # And the abort really did cut the wait short, not race a
+        # coincidentally-fast interval: no second attempt was ever made.
+        assert page.evaluate("() => window.__audioProbeCallCount") == 1
+
     @pytest.mark.parametrize("audio_found", [True, False])
     def test_midstream_drop_poll_completing_late_does_not_clobber_the_newer_turn(
             self, page: Page, chat_base_url, audio_found):
@@ -523,6 +587,27 @@ class TestOverlappingTurnOwnership:
         expect(page.locator("#voiceCancelBtn")).to_have_class("voice-cancel-btn")
         assert _is_loading(page) is False
 
+    # N3 (#832, "if cheap") asked for a committed test of F9's identity-
+    # checked heldRecording clear on the stale-SUCCESS early return
+    # specifically. Attempted and dropped after verifying it was vacuous:
+    # with this file's gate mock realistically abort-aware (N1), gating A's
+    # stream before any frame means submitTurn()'s own supersession abort()
+    # (fired the instant B starts) kills A via the AbortError branch before
+    # A ever reaches 'done' -- so a test built that way never exercises the
+    # success-path clear at all (confirmed: it still passed with the
+    # identity check reverted to an unconditional `heldRecording = null`).
+    # Reaching the success early-return with `data` genuinely populated
+    # despite being superseded needs the SAME class of narrow race N1's own
+    # comment on postTurnStart() describes (a promise already settled before
+    # its abort registers) -- real, but not deterministically constructible
+    # in this mock without reintroducing the non-realistic always-open gate
+    # N1 asked to remove. F9's clear is verified by code inspection instead:
+    # every other call site that nulls heldRecording unconditionally
+    # (recoverCompletedTurn(), the failed-status dismiss button) already
+    # runs only once ownership or DOM removal has independently guaranteed
+    # it's operating on the current turn's own slot -- this early-return is
+    # the one place that guarantee doesn't hold, which is exactly why it
+    # alone needed the identity check.
 
 # --- post-playback continuation guard (df9bf88, #832 follow-up) -----------
 #
@@ -545,14 +630,41 @@ class TestOverlappingTurnOwnership:
 # tests/test_voice_rate_toggle_playback_ui_browser.py already establish,
 # rather than this file's own gate-driven SSE mock.
 _PLAYBACK_INSTRUMENT_SCRIPT = """
-window.__turnClipUrl = null;
+// Each POST to /api/voice/turn/stream consumes the NEXT entry of
+// window.__turnQueue, in call order -- same convention as this file's main
+// SSE mock (_FETCH_MOCK above), so two overlapping submitTurn() calls can
+// each get independently-gated frames. '__gate' stalls a turn's stream
+// until window.__gatesOpen[<that turn's queue index>] is set true.
+window.__turnQueue = [];
+window.__turnCallCount = 0;
+window.__gatesOpen = {};
 window.fetch = function (url, opts) {
   var urlStr = typeof url === 'string' ? url : (url && url.url) || String(url);
   if (urlStr.indexOf('/api/voice/turn/stream') !== -1) {
-    var sse = 'data: ' + JSON.stringify({ type: 'started', turn_id: 'turn-playback' }) + '\\n\\n'
-            + 'data: ' + JSON.stringify({ type: 'main_audio', url: window.__turnClipUrl }) + '\\n\\n'
-            + 'data: ' + JSON.stringify({ type: 'done', data: { response_text: 'ok' } }) + '\\n\\n';
-    return Promise.resolve(new Response(sse, {
+    var idx = window.__turnCallCount++;
+    var frames = (window.__turnQueue[idx] || {}).frames || [];
+    function waitForGate() {
+      return new Promise(function (resolve) {
+        (function poll() {
+          if (window.__gatesOpen[idx]) return resolve();
+          setTimeout(poll, 10);
+        })();
+      });
+    }
+    var body = new ReadableStream({
+      start: function (controller) {
+        var enc = new TextEncoder();
+        var i = 0;
+        (function next() {
+          if (i >= frames.length) return controller.close();
+          var frame = frames[i++];
+          if (frame === '__gate') return waitForGate().then(next);
+          controller.enqueue(enc.encode('data: ' + JSON.stringify(frame) + '\\n\\n'));
+          setTimeout(next, 10);
+        })();
+      },
+    });
+    return Promise.resolve(new Response(body, {
       status: 200, headers: { 'Content-Type': 'text/event-stream' },
     }));
   }
@@ -572,12 +684,19 @@ navigator.mediaDevices.getUserMedia = function (constraints) {
 
 (function () {
   window.__audioPlayingCount = 0;
+  // Every URL that actually reached a real 'playing' event (#832/N4) --
+  // not merely passed to play(), since a rejected play() promise is silent
+  // and would make "URL X was never really heard" a false pass.
+  window.__playedUrls = [];
   var proto = HTMLMediaElement.prototype;
   var origPlay = proto.play;
   proto.play = function () {
     if (!this.__wired832) {
       this.__wired832 = true;
-      this.addEventListener('playing', function () { window.__audioPlayingCount += 1; });
+      this.addEventListener('playing', function () {
+        window.__audioPlayingCount += 1;
+        window.__playedUrls.push(this.src);
+      });
       var onEnd = function () { window.__audioPlayingCount = Math.max(0, window.__audioPlayingCount - 1); };
       this.addEventListener('ended', onEnd);
       this.addEventListener('pause', onEnd);
@@ -633,12 +752,43 @@ def _open_playback_chat(page: Page, base_url, *, auto):
     page.wait_for_selector("#voiceTalkBtn")
 
 
+def _set_playback_queue(page: Page, turns):
+    """`turns` is a list of {"frames": [...]} dicts, consumed in fetch-call
+    order -- same convention as _set_queue() above."""
+    page.evaluate(
+        "(q) => { window.__turnQueue = JSON.parse(q); window.__turnCallCount = 0; "
+        "window.__gatesOpen = {}; }",
+        json.dumps(turns),
+    )
+
+
+def _fire_playback_turn(page: Page, transcript="hi"):
+    """Starts submitTurn() without awaiting it, stashing the promise on
+    window.__turns the same way _fire_turn() does for the muted mock, so
+    _await_playback_turn() can wait on it precisely."""
+    page.evaluate(
+        "(t) => { window.__turns = window.__turns || []; "
+        "window.__turns.push(window.lifeChatVoice.submitTurn({ transcript: t })); }",
+        transcript,
+    )
+
+
+def _await_playback_turn(page: Page, idx: int):
+    page.evaluate("(i) => window.__turns[i]", idx)
+
+
 class TestPostPlaybackCancelGuard:
     def test_cancel_during_playback_does_not_rearm_auto_continue(self, page: Page, chat_base_url):
         _open_playback_chat(page, chat_base_url, auto=True)
         clip_url = page.evaluate("window.__makeWav(3000)")  # long enough to tap Cancel mid-playback
-        page.evaluate("(u) => { window.__turnClipUrl = u; }", clip_url)
-        page.evaluate("() => { window.lifeChatVoice.submitTurn({ transcript: 'hi' }); }")
+        _set_playback_queue(page, [
+            {"frames": [
+                {"type": "started", "turn_id": "turn-playback"},
+                {"type": "main_audio", "url": clip_url},
+                {"type": "done", "data": {"response_text": "ok"}},
+            ]},
+        ])
+        _fire_playback_turn(page)
 
         page.wait_for_function("window.__audioPlayingCount > 0")
         page.locator("#voiceCancelBtn").click()  # the real "stop playback" tap
@@ -651,3 +801,69 @@ class TestPostPlaybackCancelGuard:
             "auto-continue re-armed a recording after Cancel stopped mid-reply playback"
         )
         expect(page.locator("#statusText")).to_have_text("Ready")
+
+
+class TestStaleAudioNeverPlays:
+    def test_stale_turns_audio_never_plays_and_newer_turns_status_survives(
+            self, page: Page, chat_base_url):
+        """#832/N4: F1 was the HIGH-severity finding in independent review
+        and had no committed regression test -- consumeTurnStream()'s
+        'status_audio'/'main_audio' handlers gated `setStatus` on isOwnTurn
+        but left `enqueueClip()` ungated, so a stale turn's own clip queued
+        onto the shared playbackChain a newer turn's `await playbackChain`
+        then waited on and played, audibly, over the newer turn's own reply.
+        Needs real playback (this file's main mock runs muted), so this
+        reuses TestPostPlaybackCancelGuard's real-WAV-clip instrumentation,
+        extended to two independently-gated overlapping turns."""
+        _open_playback_chat(page, chat_base_url, auto=False)
+        # Distinct durations, not just distinct variable names: __makeWav()
+        # is deterministic, so two equal-duration clips produce byte-
+        # identical data: URIs -- indistinguishable in __playedUrls. All
+        # short: enqueueClip() appends to the ONE shared playbackChain, so if
+        # F1's bug were present, A's clips would queue in BEHIND B's still-
+        # playing one rather than fail outright -- short clips let the whole
+        # chain (B's own, and A's if the bug is back) fully drain within the
+        # test instead of a long B clip masking a late, buggy A playback.
+        clip_a_status = page.evaluate("window.__makeWav(210)")
+        clip_a_main = page.evaluate("window.__makeWav(220)")
+        clip_b_status = page.evaluate("window.__makeWav(230)")
+        clip_b_main = page.evaluate("window.__makeWav(240)")
+        _set_playback_queue(page, [
+            {"frames": [
+                "__gate",
+                {"type": "status_audio", "url": clip_a_status, "message": "stale status"},
+                {"type": "main_audio", "url": clip_a_main},
+                {"type": "done", "data": {"response_text": "stale-done"}},
+            ]},
+            {"frames": [
+                {"type": "started", "turn_id": "turn-B"},
+                {"type": "transcript", "text": "second"},
+                {"type": "status_audio", "url": clip_b_status, "message": "B status"},
+                {"type": "main_audio", "url": clip_b_main},
+                "__gate",  # never released -- B just needs to stay current
+            ]},
+        ])
+        _fire_playback_turn(page)  # turn A -- stalls before any frame
+        _fire_playback_turn(page)  # turn B -- overlaps A; becomes the current turn
+
+        page.wait_for_function("window.__audioPlayingCount > 0")  # B's own clip(s) playing
+        expect(page.locator("#statusText")).to_have_text("B status")
+
+        # A's frames arrive only now, well after B took over.
+        page.evaluate("() => { window.__gatesOpen[0] = true; }")
+        _await_playback_turn(page, 0)
+
+        # Let the whole shared chain fully drain -- B's own clips, and (in
+        # the buggy case) any of A's queued in behind them -- before
+        # inspecting what actually played.
+        page.wait_for_function("window.__audioPlayingCount === 0", timeout=5000)
+        page.wait_for_timeout(200)  # settle past the chain's own .then() bookkeeping
+
+        played = page.evaluate("() => window.__playedUrls")
+        assert clip_a_status not in played, "a stale turn's spoken status clip was heard"
+        assert clip_a_main not in played, "a stale turn's main reply clip was heard"
+        # Sanity: B's own clips genuinely did play -- this isn't passing
+        # because nothing played at all.
+        assert clip_b_status in played
+        assert clip_b_main in played
+        expect(page.locator("#statusText")).to_have_text("B status")

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -2627,6 +2627,14 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
     }
 
     await playbackChain;
+    // A tap on Cancel during playback (the "stop playback" use of that
+    // button once a reply has already landed -- see cancelActiveTurn()'s own
+    // comment) is exactly what settles `playbackChain` early, and that same
+    // tap already reset activeTurnAbort/voiceBusy/status itself. Checked
+    // again here, after the await, for the same reason as everywhere else in
+    // this function (#832): don't redo that reset onto whatever turn is
+    // current by the time this resumes.
+    if (!isOwnTurn(ownAbortController)) return;
     showCancel(false);
     setStatus('', 'Ready');
     await maybeAutoContinue();  // re-record if Auto-continue is on

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -2277,12 +2277,21 @@ async function consumeTurnStream(response, ownTurn) {
         activeTurnId = event.turn_id;
         showCancel(true);
       } else {
-        // Already superseded by the time this arrived -- the abort() fired
-        // at supersession time could only close the connection, not tell
-        // the server to stop (and if this turn hadn't even reached `started`
-        // yet, submitTurn()'s supersession had no id to cancel with at all).
-        // Finish that job now that the id is known, so the turn doesn't run
-        // to completion (LLM + TTS) unseen.
+        // Defense-in-depth, not the common case (found on independent
+        // review, #832/N1): a real fetch() errors its body stream the
+        // instant its own AbortController fires, and reading it resumes
+        // into one synchronous reader.read()-resolves -> parseSseChunk ->
+        // handleEvent block -- so a turn superseded BEFORE its `started`
+        // frame was ever sent can't reach this branch at all in a real
+        // browser; the connection is simply gone before the id exists to
+        // act on. This exists for the narrower, still-real race where the
+        // frame was already in flight over the wire a moment before the
+        // abort (the same class of race #832/F1's postTurnStart()-resolves-
+        // after-abort comment describes) -- close enough behind the abort
+        // that this handler still runs once more before the stream
+        // actually tears down. Either way, finish the job the abort alone
+        // couldn't: tell the server to stop, so the turn doesn't run to
+        // completion (LLM + TTS) unseen.
         postTurnCancel(event.turn_id);
       }
     }
@@ -2544,18 +2553,16 @@ function handleTerminalFailure(message) {
   );
 }
 
-// `ownTurn` is checked at every point this async function is about to touch
-// module state shared across turns: once up front (a newer turn may already
-// own things by the time this is even called) and again after the poll's
-// await (a newer turn may have started while it ran) -- #832, generalizing
-// the identity check #827 introduced for one branch. Nothing awaits between
-// either check and the state it guards, so neither window can go stale
-// between the check and the touch. The poll itself also carries `ownTurn`'s
-// own signal (#832/F5), so a supersession's abort() ends it immediately
-// rather than after its full ~3s budget regardless of this function's own
-// checks.
+// `ownTurn` is checked after the poll's await -- a newer turn may have
+// started while it ran (#832, generalizing the identity check #827
+// introduced for one branch). No entry-time check: this function's only
+// caller already checks isOwnTurn() with no await before calling it (found
+// on independent review, #832/N2 -- a prior version of this comment claimed
+// an entry-time race that the code couldn't actually produce), so an
+// identical check here would never fire. The poll itself also carries
+// `ownTurn`'s own signal (#832/F5), so a supersession's abort() ends it
+// immediately rather than after its full ~3s budget.
 async function handleMidStreamDrop(err, ownTurn) {
-  if (!isOwnTurn(ownTurn)) return;
   const turnId = activeTurnId;
   if (turnId) {
     setStatus('loading', 'Reconnecting…');

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -53,18 +53,24 @@ let voiceBusy = false;
 
 let activeTurnId = null;
 let activeTurnAbort = null;
-// True if `token` — an AbortController some submitTurn() call captured as
-// its own right after creating it (see `ownAbortController` below) — still
-// identifies the turn currently in flight. False once a newer turn has
+// True if `token` — an object `{ abort, id }` some submitTurn() call
+// captured as its own right after creating it (see `ownTurn` below) — still
+// identifies the turn currently in flight (by its AbortController's
+// identity, not its `id`: `id` starts null and is filled in only once the
+// server's `started` frame arrives, so it can't be the thing distinguishing
+// "mine" from "not mine" at submit time). False once a newer turn has
 // replaced it, whether via a fresh submitTurn() call or cancelActiveTurn()
 // clearing it first. Every settling path below (the success reconciliation,
 // the AbortError branch, mid-stream-drop recovery, terminal failure, and the
 // SSE handlers in consumeTurnStream) checks this before touching module
 // state shared across turns, so a stale turn settling late can't clobber a
 // newer turn's bookkeeping (#832) — the identity check #827 introduced for
-// one branch, generalized to every exit path.
+// one branch, generalized to every exit path. `token.id`, once known, is
+// used the other way around: to actively cancel a turn that's ALREADY been
+// superseded (submitTurn()'s own supersession below, and the `started`
+// handler's late-id case) rather than to decide what's superseded.
 function isOwnTurn(token) {
-  return activeTurnAbort === token;
+  return activeTurnAbort === token.abort;
 }
 let activeAudios = [];
 let playbackChain = Promise.resolve();
@@ -2227,9 +2233,26 @@ function parseSseChunk(buffer, onEvent) {
   return remainder;
 }
 
-async function consumeTurnStream(response, ownAbortController) {
-  playbackChain = Promise.resolve();
-  reportedPlaybackFailure = false;
+// Best-effort: tells the relay a turn is over so it can stop running (LLM +
+// TTS) rather than finish unseen. Fire-and-forget, same as every other
+// cancel-POST in this file -- nothing here can act on a failure to reach the
+// gateway, and this is already the "as a courtesy" cleanup path, not the
+// primary abort mechanism (the AbortController is that).
+function postTurnCancel(turnId) {
+  fetch(`${endpoints.voice}/turn/${encodeURIComponent(turnId)}/cancel`, { method: 'POST' }).catch(() => {});
+}
+
+async function consumeTurnStream(response, ownTurn) {
+  // Found on review (#832/F1): the reset below is reachable even when this
+  // turn has ALREADY been superseded -- a fetch() promise can resolve with a
+  // Response even after its signal fires (the abort races the "headers
+  // already arrived" resolution), so postTurnStart() returning doesn't
+  // guarantee this turn is still current by the time its OWN consumeTurnStream
+  // call is entered. Gated like everything else that touches shared state.
+  if (isOwnTurn(ownTurn)) {
+    playbackChain = Promise.resolve();
+    reportedPlaybackFailure = false;
+  }
   let doneData = null;
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
@@ -2243,13 +2266,28 @@ async function consumeTurnStream(response, ownAbortController) {
     // (#832); `doneData` is this call's own local, so it's always safe to
     // set regardless.
     if (event.type === 'started') {
-      if (isOwnTurn(ownAbortController)) {
+      // Recorded on `ownTurn` itself unconditionally (#832/F2), even when
+      // this turn no longer owns anything -- submitTurn()'s own supersession
+      // logic can only abort+cancel a turn whose id it already knows, and a
+      // turn superseded before its `started` frame arrived has no id to give
+      // it yet. Filling this in lets a turn cancel itself the moment its own
+      // id becomes known, below.
+      ownTurn.id = event.turn_id;
+      if (isOwnTurn(ownTurn)) {
         activeTurnId = event.turn_id;
         showCancel(true);
+      } else {
+        // Already superseded by the time this arrived -- the abort() fired
+        // at supersession time could only close the connection, not tell
+        // the server to stop (and if this turn hadn't even reached `started`
+        // yet, submitTurn()'s supersession had no id to cancel with at all).
+        // Finish that job now that the id is known, so the turn doesn't run
+        // to completion (LLM + TTS) unseen.
+        postTurnCancel(event.turn_id);
       }
     }
     if (event.type === 'transcript') {
-      if (isOwnTurn(ownAbortController)) renderUserTranscript(event.text);
+      if (isOwnTurn(ownTurn)) renderUserTranscript(event.text);
     }
     if (event.type === 'cancelled') {
       // This frame means the turn was cancelled server-side -- possibly by
@@ -2260,7 +2298,7 @@ async function consumeTurnStream(response, ownAbortController) {
       // turn leaves no trace either -- idempotent if cancelActiveTurn()
       // already ran. Gated the same as every other branch here: a newer
       // turn's own bubble must survive a stale cancel arriving late (#832).
-      if (isOwnTurn(ownAbortController)) clearUserTranscript();
+      if (isOwnTurn(ownTurn)) clearUserTranscript();
       throw new DOMException('Turn cancelled', 'AbortError');
     }
     if (event.type === 'error') {
@@ -2277,13 +2315,17 @@ async function consumeTurnStream(response, ownAbortController) {
       throw error;
     }
     if (event.type === 'status_audio') {
-      if (event.message && isOwnTurn(ownAbortController)) setStatus('loading', event.message);  // spoken status text
-      if (shouldPlayAudio() && event.url) {
+      if (event.message && isOwnTurn(ownTurn)) setStatus('loading', event.message);  // spoken status text
+      // Gated (#832/F1): ungated, a stale turn's own clip queues onto the
+      // shared playbackChain a newer turn's `await playbackChain` then waits
+      // on -- the newer turn's status text stays right, but the user hears
+      // the stale turn's audio play out anyway.
+      if (isOwnTurn(ownTurn) && shouldPlayAudio() && event.url) {
         enqueueClip(event.url);
       }
     }
     if (event.type === 'main_audio') {
-      if (shouldPlayAudio() && event.url) {
+      if (isOwnTurn(ownTurn) && shouldPlayAudio() && event.url) {
         enqueueClip(event.url);
       }
     }
@@ -2434,13 +2476,43 @@ async function backoffBeforeRetry(attempt, signal) {
 const MIDSTREAM_POLL_ATTEMPTS = 3;
 const MIDSTREAM_POLL_INTERVAL_MS = 1500;
 
-async function pollForCompletedAudio(turnId) {
+// Rejects like waitForRetry() does if `signal` fires first -- same shape,
+// separate function because this poll's interval is fixed (never jittered),
+// and test_voice_network_resilience_ui_browser.py already asserts on that
+// exact 1500ms spacing via page.clock.fast_forward(1600).
+function sleepAbortable(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) { reject(new DOMException('Turn cancelled', 'AbortError')); return; }
+    const timer = setTimeout(() => { cleanup(); resolve(); }, ms);
+    const onAbort = () => { cleanup(); reject(new DOMException('Turn cancelled', 'AbortError')); };
+    function cleanup() {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+    }
+    signal.addEventListener('abort', onAbort);
+  });
+}
+
+// `signal` (#832/F5): this poll used to run its own ~3s budget deaf to
+// cancellation -- neither a Cancel tap nor a newer turn superseding this one
+// (submitTurn()'s own abort() on supersession) stopped it, because its sleep
+// was a bare setTimeout and its HEAD fetch carried no signal at all. Both are
+// wired to the turn's own AbortController now, so aborting it (from either
+// source) ends the poll immediately instead of after its full budget.
+async function pollForCompletedAudio(turnId, signal) {
   for (let i = 0; i < MIDSTREAM_POLL_ATTEMPTS; i += 1) {
-    if (i > 0) await new Promise((r) => setTimeout(r, MIDSTREAM_POLL_INTERVAL_MS));
+    if (i > 0) {
+      try {
+        await sleepAbortable(MIDSTREAM_POLL_INTERVAL_MS, signal);
+      } catch (e) {
+        return false; // aborted mid-wait -- no verdict, same as "not found"
+      }
+    }
     try {
-      const res = await fetch(`${endpoints.voice}/audio/${encodeURIComponent(turnId)}`, { method: 'HEAD' });
+      const res = await fetch(`${endpoints.voice}/audio/${encodeURIComponent(turnId)}`, { method: 'HEAD', signal });
       if (res.ok) return true;
     } catch (e) {
+      if (e?.name === 'AbortError') return false;
       /* unreachable -- keep polling within the budget, same as "not found yet" */
     }
   }
@@ -2472,20 +2544,23 @@ function handleTerminalFailure(message) {
   );
 }
 
-// `ownAbortController` is checked at every point this async function is
-// about to touch module state shared across turns: once up front (a newer
-// turn may already own things by the time this is even called) and again
-// after the poll's await (a newer turn may have started while it ran) --
-// #832, generalizing the identity check #827 introduced for one branch.
-// Nothing awaits between either check and the state it guards, so neither
-// window can go stale between the check and the touch.
-async function handleMidStreamDrop(err, ownAbortController) {
-  if (!isOwnTurn(ownAbortController)) return;
+// `ownTurn` is checked at every point this async function is about to touch
+// module state shared across turns: once up front (a newer turn may already
+// own things by the time this is even called) and again after the poll's
+// await (a newer turn may have started while it ran) -- #832, generalizing
+// the identity check #827 introduced for one branch. Nothing awaits between
+// either check and the state it guards, so neither window can go stale
+// between the check and the touch. The poll itself also carries `ownTurn`'s
+// own signal (#832/F5), so a supersession's abort() ends it immediately
+// rather than after its full ~3s budget regardless of this function's own
+// checks.
+async function handleMidStreamDrop(err, ownTurn) {
+  if (!isOwnTurn(ownTurn)) return;
   const turnId = activeTurnId;
   if (turnId) {
     setStatus('loading', 'Reconnecting…');
-    const completed = await pollForCompletedAudio(turnId);
-    if (!isOwnTurn(ownAbortController)) return;
+    const completed = await pollForCompletedAudio(turnId, ownTurn.abort.signal);
+    if (!isOwnTurn(ownTurn)) return;
     if (completed) {
       recoverCompletedTurn(turnId);
       return;
@@ -2525,18 +2600,41 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
   // `transcript` SSE event instead.
   renderUserTranscript(transcript);
   showThinking();
+
+  // #832/F2: this turn supersedes whatever was still active -- abort its
+  // connection and, if its id is already known, tell the relay to stop
+  // running it too (best-effort; if the id isn't known yet, the `started`
+  // handler above finishes this job the moment that turn learns its own id).
+  // Captured before either module var is reassigned below.
+  const supersededAbort = activeTurnAbort;
+  const supersededId = activeTurnId;
+  if (supersededAbort) {
+    supersededAbort.abort();
+    if (supersededId) postTurnCancel(supersededId);
+  }
+
   activeTurnId = null;
   activeTurnAbort = new AbortController();
-  // Captured so the catch below (#827) can tell "this turn's own controller
-  // is still current" from "a newer turn already replaced it" -- distinct
-  // from activeTurnAbort itself, which a later submitTurn() call reassigns.
-  const ownAbortController = activeTurnAbort;
+  // Captured so the checks below (#827, generalized by #832) can tell "this
+  // turn's own controller is still current" from "a newer turn already
+  // replaced it" -- distinct from activeTurnAbort itself, which a later
+  // submitTurn() call reassigns. `id` starts null and is filled in by
+  // consumeTurnStream()'s `started` handler once the relay assigns one --
+  // carried on this object (not just mirrored to activeTurnId) so it
+  // survives being superseded (see the supersession comment above).
+  const ownTurn = { abort: activeTurnAbort, id: null };
 
   // #801 -- hold the recording until the turn *definitively* completes (see
   // `heldRecording`'s own comment). Set here, unconditionally, so a fresh
   // recording AND a manual retry (which passes the same blob back in) both
   // keep exactly one slot current.
   if (blob) heldRecording = { blob, mime };
+  // #832/F9: identifies THIS turn's own held-recording object (or null if it
+  // never set one), distinct from `heldRecording` itself, which a later
+  // submitTurn() call can reassign to a different object. Used below to
+  // clear it on a stale-success early return WITHOUT clobbering a newer
+  // turn's own held recording if that turn has since set its own.
+  const ownHeldRecording = blob ? heldRecording : null;
 
   const form = new FormData();
   if (blob) form.append('audio', blob, blobFilename(mime));
@@ -2570,26 +2668,32 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
   // why they differ).
   let turnAccepted = false;
   try {
-    const res = await postTurnStart(form, activeTurnAbort.signal);
+    const res = await postTurnStart(form, ownTurn.abort.signal);
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
       // Guarded like every other settling touch below (#832): a newer turn
       // may already own the thinking placeholder by the time this awaited
       // response comes back.
-      if (isOwnTurn(ownAbortController)) clearThinking();
+      if (isOwnTurn(ownTurn)) clearThinking();
       throw new Error(data.detail || `Request failed (${res.status})`);
     }
     turnAccepted = true;
 
-    const data = await consumeTurnStream(res, ownAbortController);
+    const data = await consumeTurnStream(res, ownTurn);
     if (!data) {
-      if (isOwnTurn(ownAbortController)) clearThinking();
+      if (isOwnTurn(ownTurn)) clearThinking();
       throw new Error('Turn ended without a response');
     }
-    if (!isOwnTurn(ownAbortController)) {
+    if (!isOwnTurn(ownTurn)) {
       // A newer turn already owns everything below -- this stale turn has
       // nothing left to reconcile into shared state (#832). The stream was
-      // still fully drained by consumeTurnStream() above either way.
+      // still fully drained by consumeTurnStream() above either way. This
+      // turn DID complete successfully server-side, though, so it has
+      // nothing left to retry -- clear heldRecording (#832/F9), but only if
+      // it's still THIS turn's own object: a newer turn that has since
+      // submitted its own recording already overwrote it, and that one must
+      // survive to be retried if the newer turn later fails.
+      if (heldRecording === ownHeldRecording) heldRecording = null;
       return;
     }
 
@@ -2634,7 +2738,7 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
     // again here, after the await, for the same reason as everywhere else in
     // this function (#832): don't redo that reset onto whatever turn is
     // current by the time this resumes.
-    if (!isOwnTurn(ownAbortController)) return;
+    if (!isOwnTurn(ownTurn)) return;
     showCancel(false);
     setStatus('', 'Ready');
     await maybeAutoContinue();  // re-record if Auto-continue is on
@@ -2650,14 +2754,14 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
       // controller in that case -- checked by identity, not mere presence,
       // so a stale turn settling after a newer one has already started
       // can't stomp on the newer turn's UI either.
-      if (isOwnTurn(ownAbortController)) {
+      if (isOwnTurn(ownTurn)) {
         clearThinking();
         showCancel(false);
         setStatus('', 'Ready');
       }
       return;
     }
-    if (!isOwnTurn(ownAbortController)) return; // superseded -- nothing left to report (#832)
+    if (!isOwnTurn(ownTurn)) return; // superseded -- nothing left to report (#832)
     clearThinking();
     showCancel(false);
     // #801 -- a mid-stream drop (the SSE stream died after a genuine `ok`
@@ -2667,7 +2771,7 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
     // told us definitively it failed) goes straight to the ordinary
     // failed+Retry state.
     if (turnAccepted && !err?.voiceTurnDefinitive) {
-      await handleMidStreamDrop(err, ownAbortController);
+      await handleMidStreamDrop(err, ownTurn);
     } else {
       setStatus('error', 'Error');
       handleTerminalFailure(err?.message || 'Voice turn failed');
@@ -2679,7 +2783,7 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
     // one reset every prior version of this code applied unconditionally
     // (#832), so it gets the same identity check as everywhere else rather
     // than relying on that invariant holding forever.
-    if (isOwnTurn(ownAbortController)) {
+    if (isOwnTurn(ownTurn)) {
       activeTurnId = null;
       activeTurnAbort = null;
       voiceBusy = false;
@@ -2697,9 +2801,7 @@ function showCancel(on) {
 // playback after done" case without faking real audio element timing.
 export function cancelActiveTurn() {
   activeTurnAbort?.abort();
-  if (activeTurnId) {
-    fetch(`${endpoints.voice}/turn/${encodeURIComponent(activeTurnId)}/cancel`, { method: 'POST' }).catch(() => {});
-  }
+  if (activeTurnId) postTurnCancel(activeTurnId);
   playbackChain = Promise.resolve();
   stopAllAudio();
   clearThinking();

--- a/web/chat/voice.js
+++ b/web/chat/voice.js
@@ -53,6 +53,19 @@ let voiceBusy = false;
 
 let activeTurnId = null;
 let activeTurnAbort = null;
+// True if `token` — an AbortController some submitTurn() call captured as
+// its own right after creating it (see `ownAbortController` below) — still
+// identifies the turn currently in flight. False once a newer turn has
+// replaced it, whether via a fresh submitTurn() call or cancelActiveTurn()
+// clearing it first. Every settling path below (the success reconciliation,
+// the AbortError branch, mid-stream-drop recovery, terminal failure, and the
+// SSE handlers in consumeTurnStream) checks this before touching module
+// state shared across turns, so a stale turn settling late can't clobber a
+// newer turn's bookkeeping (#832) — the identity check #827 introduced for
+// one branch, generalized to every exit path.
+function isOwnTurn(token) {
+  return activeTurnAbort === token;
+}
 let activeAudios = [];
 let playbackChain = Promise.resolve();
 // Whether a real clip is currently loading/playing, on *either* the shared
@@ -2214,7 +2227,7 @@ function parseSseChunk(buffer, onEvent) {
   return remainder;
 }
 
-async function consumeTurnStream(response) {
+async function consumeTurnStream(response, ownAbortController) {
   playbackChain = Promise.resolve();
   reportedPlaybackFailure = false;
   let doneData = null;
@@ -2223,12 +2236,20 @@ async function consumeTurnStream(response) {
   let buffer = '';
 
   const handleEvent = (event) => {
+    // A turn's events arrive progressively over the life of this stream --
+    // long enough for a newer turn to have started in the meantime (the user
+    // cancelled and immediately re-recorded). `isOwnTurn` gates every branch
+    // below that would otherwise touch module state a newer turn now owns
+    // (#832); `doneData` is this call's own local, so it's always safe to
+    // set regardless.
     if (event.type === 'started') {
-      activeTurnId = event.turn_id;
-      showCancel(true);
+      if (isOwnTurn(ownAbortController)) {
+        activeTurnId = event.turn_id;
+        showCancel(true);
+      }
     }
     if (event.type === 'transcript') {
-      renderUserTranscript(event.text);
+      if (isOwnTurn(ownAbortController)) renderUserTranscript(event.text);
     }
     if (event.type === 'cancelled') {
       // This frame means the turn was cancelled server-side -- possibly by
@@ -2237,8 +2258,9 @@ async function consumeTurnStream(response) {
       // can just as easily be cancelled from elsewhere (another tab/device
       // on the same conversation). Clear here too so an externally-cancelled
       // turn leaves no trace either -- idempotent if cancelActiveTurn()
-      // already ran.
-      clearUserTranscript();
+      // already ran. Gated the same as every other branch here: a newer
+      // turn's own bubble must survive a stale cancel arriving late (#832).
+      if (isOwnTurn(ownAbortController)) clearUserTranscript();
       throw new DOMException('Turn cancelled', 'AbortError');
     }
     if (event.type === 'error') {
@@ -2255,7 +2277,7 @@ async function consumeTurnStream(response) {
       throw error;
     }
     if (event.type === 'status_audio') {
-      if (event.message) setStatus('loading', event.message);  // spoken status text
+      if (event.message && isOwnTurn(ownAbortController)) setStatus('loading', event.message);  // spoken status text
       if (shouldPlayAudio() && event.url) {
         enqueueClip(event.url);
       }
@@ -2450,11 +2472,21 @@ function handleTerminalFailure(message) {
   );
 }
 
-async function handleMidStreamDrop(err) {
+// `ownAbortController` is checked at every point this async function is
+// about to touch module state shared across turns: once up front (a newer
+// turn may already own things by the time this is even called) and again
+// after the poll's await (a newer turn may have started while it ran) --
+// #832, generalizing the identity check #827 introduced for one branch.
+// Nothing awaits between either check and the state it guards, so neither
+// window can go stale between the check and the touch.
+async function handleMidStreamDrop(err, ownAbortController) {
+  if (!isOwnTurn(ownAbortController)) return;
   const turnId = activeTurnId;
   if (turnId) {
     setStatus('loading', 'Reconnecting…');
-    if (await pollForCompletedAudio(turnId)) {
+    const completed = await pollForCompletedAudio(turnId);
+    if (!isOwnTurn(ownAbortController)) return;
+    if (completed) {
       recoverCompletedTurn(turnId);
       return;
     }
@@ -2541,15 +2573,24 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
     const res = await postTurnStart(form, activeTurnAbort.signal);
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
-      clearThinking();
+      // Guarded like every other settling touch below (#832): a newer turn
+      // may already own the thinking placeholder by the time this awaited
+      // response comes back.
+      if (isOwnTurn(ownAbortController)) clearThinking();
       throw new Error(data.detail || `Request failed (${res.status})`);
     }
     turnAccepted = true;
 
-    const data = await consumeTurnStream(res);
+    const data = await consumeTurnStream(res, ownAbortController);
     if (!data) {
-      clearThinking();
+      if (isOwnTurn(ownAbortController)) clearThinking();
       throw new Error('Turn ended without a response');
+    }
+    if (!isOwnTurn(ownAbortController)) {
+      // A newer turn already owns everything below -- this stale turn has
+      // nothing left to reconcile into shared state (#832). The stream was
+      // still fully drained by consumeTurnStream() above either way.
+      return;
     }
 
     if (data.conversation_id) {
@@ -2601,13 +2642,14 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
       // controller in that case -- checked by identity, not mere presence,
       // so a stale turn settling after a newer one has already started
       // can't stomp on the newer turn's UI either.
-      if (activeTurnAbort === ownAbortController) {
+      if (isOwnTurn(ownAbortController)) {
         clearThinking();
         showCancel(false);
         setStatus('', 'Ready');
       }
       return;
     }
+    if (!isOwnTurn(ownAbortController)) return; // superseded -- nothing left to report (#832)
     clearThinking();
     showCancel(false);
     // #801 -- a mid-stream drop (the SSE stream died after a genuine `ok`
@@ -2617,16 +2659,24 @@ export async function submitTurn({ blob, mime, transcript, retryBubble } = {}) {
     // told us definitively it failed) goes straight to the ordinary
     // failed+Retry state.
     if (turnAccepted && !err?.voiceTurnDefinitive) {
-      await handleMidStreamDrop(err);
+      await handleMidStreamDrop(err, ownAbortController);
     } else {
       setStatus('error', 'Error');
       handleTerminalFailure(err?.message || 'Voice turn failed');
     }
   } finally {
-    activeTurnId = null;
-    activeTurnAbort = null;
-    voiceBusy = false;
-    state.isLoading = false;
+    // Every branch above already bails out (via `return`) once it detects a
+    // newer turn has taken over, so in practice this only ever runs while
+    // still current -- but it's the very last thing this turn does, and the
+    // one reset every prior version of this code applied unconditionally
+    // (#832), so it gets the same identity check as everywhere else rather
+    // than relying on that invariant holding forever.
+    if (isOwnTurn(ownAbortController)) {
+      activeTurnId = null;
+      activeTurnAbort = null;
+      voiceBusy = false;
+      state.isLoading = false;
+    }
   }
 }
 


### PR DESCRIPTION
**#832** — generalizes #827's identity guard into a turn-ownership token (`ownTurn = {abort, id}`) threaded through every settling path in `web/chat/voice.js`: stream handlers, `!res.ok`/`!data`, success reconciliation, the post-playback tail, both catch branches, `finally`, and mid-stream-drop recovery. A stale turn can no longer reset a newer turn's id/abort/busy/loading state, status or Cancel button — and, found in review, can no longer *play its audio* over the newer turn (both `enqueueClip` sites and the playback-chain reset were ungated). `pollForCompletedAudio` is now abort-aware (the only production-reachable trigger: its ~3 s non-abortable poll window after a cancel). A superseded turn is aborted and best-effort server-cancelled. Single-turn exit paths are unchanged — reviewer-tabulated path by path.

Tests: new `test_voice_turn_ownership_ui_browser.py` (late success / late server cancel / late failure with real promise awaits, real Cancel-button click, real-WAV stale-audio test, abort-aware sleep test, mid-stream-drop found/not-found ownership pair). An 18-mutation battery by the independent reviewer confirms each guard is caught; the one branch a real `fetch` cannot reach is documented as defense-in-depth rather than asserted.

**#833** — the flake's real cause was `_wait_until_lock_held` forking the `flock` CLI every 50 ms, compounding the process-spawn contention it was measuring; now in-process `fcntl.flock`, waiter timeout 30 s, holder sleep a 60 s safety cap. Same fix applied to `test_deploy_drift.py`'s copies; HOME-last ordering applied to all four helpers; two `dict(os.environ)` HOME leaks fixed. 2 failures in 8 full-suite runs before, 6/6 clean after.

Reviewed twice by an independent Claude reviewer (Codex out of credits): first pass DO NOT LAND (3 blockers, all fixed and re-verified by mutation), second pass LAND.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw