### PR TITLE
test(indexer): wait on the watcher's observable output instead of a fixed sleep (#839)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ Run categories:
 """
 import gc
 import os
+import time
 
 import pytest
 
@@ -35,6 +36,24 @@ from api.services.slack_indexer import SLACK_COLLECTION
 # resolve via their own cwd.
 for _var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"):
     os.environ.pop(_var, None)
+
+
+def wait_for_condition(predicate, timeout: float, interval: float = 0.2):
+    """Poll ``predicate`` until it returns truthy, or ``timeout`` seconds pass.
+
+    Returns the last value ``predicate()`` produced (truthy on success, falsy
+    if the timeout was reached). Used by the file-watcher tests
+    (test_indexer.py, test_integration.py) to wait on the watcher's actual
+    observable output instead of a fixed ``time.sleep`` that can undershoot
+    ``VaultEventHandler``'s batch-processing delay (#839) — callers should
+    derive ``timeout`` from that delay rather than guessing a duration.
+    """
+    deadline = time.monotonic() + timeout
+    result = predicate()
+    while not result and time.monotonic() < deadline:
+        time.sleep(interval)
+        result = predicate()
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -10,17 +10,14 @@ P1.1 Acceptance Criteria:
 NOTE: Imports are deferred to avoid loading heavy dependencies (ChromaDB,
 sentence-transformers) during pytest collection, which would slow down unit tests.
 """
+import tempfile
+import time
+from pathlib import Path
+
 import pytest
 
 # These tests require ChromaDB and file watching (slow)
 pytestmark = pytest.mark.slow
-
-# Standard library imports are fine at module level (lightweight)
-import tempfile
-import time
-import os
-from pathlib import Path
-from datetime import datetime
 
 
 class TestIndexerService:
@@ -260,6 +257,9 @@ class TestFileWatcher:
 
     def test_detects_new_file_creation(self, indexer, temp_vault):
         """New file should be indexed automatically."""
+        from tests.conftest import wait_for_condition
+        from api.services.indexer import VaultEventHandler
+
         # Start watching
         indexer.start_watching()
         time.sleep(0.5)  # Let watcher initialize
@@ -271,8 +271,14 @@ class TestFileWatcher:
 This is freshly created content about testing.
 """)
 
-        # Wait for indexing (should be within 5 seconds)
-        time.sleep(3)
+        # Wait for the watcher's batch debounce to flush and index the file,
+        # rather than sleeping a fixed duration that can undershoot it (#839).
+        def _indexed():
+            return any(fp.endswith("new_note.md") for fp in indexer.vector_store.get_all_file_paths())
+
+        assert wait_for_condition(_indexed, timeout=VaultEventHandler._BATCH_DELAY + 30), (
+            "watcher did not index the new file within the timeout"
+        )
 
         # Search for the new content
         results = indexer.vector_store.search("freshly created testing")
@@ -304,6 +310,9 @@ This is freshly created content about testing.
 
     def test_detects_file_deletion(self, indexer, temp_vault):
         """Deleted file should be removed from index."""
+        from tests.conftest import wait_for_condition
+        from api.services.indexer import VaultEventHandler
+
         # Create and index file
         test_file = temp_vault / "to_delete.md"
         test_file.write_text("# To Delete\n\nThis will be deleted.")
@@ -320,8 +329,14 @@ This is freshly created content about testing.
         # Delete the file
         test_file.unlink()
 
-        # Wait for deletion to process (debounce + processing)
-        time.sleep(4)
+        # Wait for the watcher's batch debounce to flush and remove the file,
+        # rather than sleeping a fixed duration that can undershoot it (#839).
+        def _removed():
+            return not any(fp.endswith("to_delete.md") for fp in indexer.vector_store.get_all_file_paths())
+
+        assert wait_for_condition(_removed, timeout=VaultEventHandler._BATCH_DELAY + 30), (
+            "watcher did not remove the deleted file from the index within the timeout"
+        )
 
         # Search should not find the content
         results = indexer.vector_store.search("will be deleted")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,16 +5,14 @@ Tests end-to-end workflows with real components.
 NOTE: Imports are deferred to avoid loading heavy dependencies (ChromaDB,
 sentence-transformers) during pytest collection, which would slow down unit tests.
 """
+import tempfile
+import time
+from pathlib import Path
+
 import pytest
 
 # These are full integration tests requiring ChromaDB (slow)
 pytestmark = pytest.mark.slow
-
-# Standard library imports are fine at module level (lightweight)
-import tempfile
-import time
-from pathlib import Path
-from datetime import datetime
 
 
 class TestFullIndexingWorkflow:
@@ -202,7 +200,8 @@ This document describes the technical architecture of the LifeOS system.
 
     def test_watch_and_update(self, test_vault, temp_db):
         """File changes should be detected and indexed."""
-        from api.services.indexer import IndexerService
+        from api.services.indexer import IndexerService, VaultEventHandler
+        from tests.conftest import wait_for_condition
 
         indexer = IndexerService(
             vault_path=str(test_vault),
@@ -210,7 +209,6 @@ This document describes the technical architecture of the LifeOS system.
         )
 
         indexer.index_all()
-        initial_count = indexer.vector_store.get_document_count()
 
         # Start watching
         indexer.start_watching()
@@ -223,8 +221,14 @@ This document describes the technical architecture of the LifeOS system.
 Had an interesting thought about product strategy today.
 """)
 
-        # Wait for indexing
-        time.sleep(4)
+        # Wait for the watcher's batch debounce to flush and index the file,
+        # rather than sleeping a fixed duration that can undershoot it (#839).
+        def _indexed():
+            return any(fp.endswith("new_thought.md") for fp in indexer.vector_store.get_all_file_paths())
+
+        assert wait_for_condition(_indexed, timeout=VaultEventHandler._BATCH_DELAY + 30), (
+            "watcher did not index the new file within the timeout"
+        )
 
         # Search should find new content
         results = indexer.vector_store.search("product strategy insight")


### PR DESCRIPTION
The three file-watcher tests were deterministic failures, not races: `VaultEventHandler` gained a 5 s batch debounce (`_BATCH_DELAY`) after they were written, and they still slept 3–4 s before asserting (0/10 passes for two of them). They now poll the vector store's indexed file paths for the created/deleted file with a bounded wait derived from `_BATCH_DELAY` — paths rather than a semantic search, so ranking under load can't hide the file. No product change; no assertion weakened. 5/5 per test, 15/15 across both files, live collection untouched (45,334 before and after).

Also clears the pre-existing lint in both files (stdlib imports above `pytestmark`, unused imports, a dead local) that the pre-commit hook was rejecting — nobody could commit to these files until it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqkS7e3ZUHSjYQscNVwDtw