### PR TITLE
fix(api): keep validation errors serializable

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -38,6 +38,7 @@ from dotenv import load_dotenv
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 import logging
+import json
 import socket
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -335,13 +336,20 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     """Convert validation errors to 400 with clear messages."""
     errors = exc.errors()
 
-    # Sanitize errors for JSON serialization (convert bytes to string)
-    sanitized_errors = []
-    for error in errors:
-        sanitized = dict(error)
-        if "input" in sanitized and isinstance(sanitized["input"], bytes):
-            sanitized["input"] = sanitized["input"].decode("utf-8", errors="replace")
-        sanitized_errors.append(sanitized)
+    def json_safe(value):
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        if isinstance(value, dict):
+            return {str(key): json_safe(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [json_safe(item) for item in value]
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError):
+            return str(value)
+        return value
+
+    sanitized_errors = [json_safe(error) for error in errors]
 
     # Check if this is an empty query error
     for error in errors:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,21 @@ def pytest_configure(config):
     _install_anthropic_request_guard()
 
 
+@pytest.fixture(autouse=True)
+def isolate_agent_default_route(request, monkeypatch):
+    """Keep agent-worker tests independent from the developer's .env."""
+    agent_worker_tests = {
+        "test_agent_worker_preflight.py",
+        "test_agent_worker_clarifications.py",
+        "test_agent_worker_loop.py",
+        "test_operator_spawn.py",
+    }
+    if request.node.fspath.basename in agent_worker_tests:
+        from config.settings import settings
+
+        monkeypatch.setattr(settings, "agent_default_route", "")
+
+
 # ---------------------------------------------------------------------------
 # Unmarked-test guard (#682)
 #

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -41,6 +41,7 @@ class TestAskStreamEndpoint:
         """Should return 400 for whitespace-only question."""
         response = client.post("/api/ask/stream", json={"question": "   "})
         assert response.status_code == 400
+        assert "Question cannot be empty" in str(response.json()["detail"])
 
     def test_stream_returns_event_stream(self, client):
         """Response should be text/event-stream."""

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -182,6 +182,13 @@ class TestSearchRequestValidation:
         )
         assert response.status_code in [400, 415, 422]
 
+    def test_whitespace_query_returns_validation_message(self, client):
+        response = client.post("/api/search", json={"query": "   "})
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "Query cannot be empty"
+        assert "Query cannot be empty" in str(response.json()["detail"])
+
     def test_handles_extra_fields(self, client):
         """Should ignore extra fields gracefully."""
         response = client.post("/api/search", json={


### PR DESCRIPTION
## Summary

- keep agent-worker tests independent from LIFEOS_AGENT_DEFAULT_ROUTE in the developer environment
- recursively normalize validation error details so custom validators return their intended 400 response
- assert that whitespace validation responses retain their user-facing messages

## Testing

- Not run locally: the configured LifeOS virtualenv is unavailable and the system environment lacks `python-frontmatter`.
- `git diff --check`

Fixes #755
Fixes #577