### PR TITLE
test(agent-worker): isolate default route from environment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,21 @@ def pytest_configure(config):
     _install_anthropic_request_guard()
 
 
+@pytest.fixture(autouse=True)
+def isolate_agent_default_route(request, monkeypatch):
+    """Keep agent-worker tests independent from the developer's .env."""
+    agent_worker_tests = {
+        "test_agent_worker_preflight.py",
+        "test_agent_worker_clarifications.py",
+        "test_agent_worker_loop.py",
+        "test_operator_spawn.py",
+    }
+    if request.node.fspath.basename in agent_worker_tests:
+        from config.settings import settings
+
+        monkeypatch.setattr(settings, "agent_default_route", "")
+
+
 # ---------------------------------------------------------------------------
 # Unmarked-test guard (#682)
 #


### PR DESCRIPTION
## Summary

The agent-worker tests currently inherit LIFEOS_AGENT_DEFAULT_ROUTE from the developer's `.env`, changing ambiguity behavior and making a clean test run host-dependent.

This adds an autouse fixture scoped to the affected test modules that clears the setting; tests which exercise a configured route continue to set it explicitly.

## Testing

- Not run locally: the configured LifeOS virtualenv is unavailable and the system environment lacks `python-frontmatter`.
- `git diff --check`

Fixes #755