### PR TITLE
fix(api): keep validation errors serializable

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -38,6 +38,7 @@ from dotenv import load_dotenv
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 import hashlib
+import json
 import logging
 import os
 import socket
@@ -406,13 +407,20 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     """Convert validation errors to 400 with clear messages."""
     errors = exc.errors()
 
-    # Sanitize errors for JSON serialization (convert bytes to string)
-    sanitized_errors = []
-    for error in errors:
-        sanitized = dict(error)
-        if "input" in sanitized and isinstance(sanitized["input"], bytes):
-            sanitized["input"] = sanitized["input"].decode("utf-8", errors="replace")
-        sanitized_errors.append(sanitized)
+    def json_safe(value):
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        if isinstance(value, dict):
+            return {str(key): json_safe(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [json_safe(item) for item in value]
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError):
+            return str(value)
+        return value
+
+    sanitized_errors = [json_safe(error) for error in errors]
 
     # Check if this is an empty query error
     for error in errors:

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -41,6 +41,7 @@ class TestAskStreamEndpoint:
         """Should return 400 for whitespace-only question."""
         response = client.post("/api/ask/stream", json={"question": "   "})
         assert response.status_code == 400
+        assert "Question cannot be empty" in str(response.json()["detail"])
 
     def test_stream_returns_event_stream(self, client):
         """Response should be text/event-stream."""

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -182,6 +182,13 @@ class TestSearchRequestValidation:
         )
         assert response.status_code in [400, 415, 422]
 
+    def test_whitespace_query_returns_validation_message(self, client):
+        response = client.post("/api/search", json={"query": "   "})
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "Query cannot be empty"
+        assert "Query cannot be empty" in str(response.json()["detail"])
+
     def test_handles_extra_fields(self, client):
         """Should ignore extra fields gracefully."""
         response = client.post("/api/search", json={


### PR DESCRIPTION
## Summary

Custom Pydantic validators place exception values in validation contexts. The global handler left those values untouched, so JSON encoding raised another exception and turned user input errors into bare 500 responses.

Recursively normalize validation details before building the response, preserving the existing 400 status and user-facing messages. Add regression assertions for whitespace-only search and streaming questions.

## Testing

- `python -m py_compile api/main.py tests/test_search_api.py tests/test_chat_api.py`
- `git diff --check`
- Pytest not run locally: the configured LifeOS virtualenv is unavailable and the system environment lacks `python-frontmatter`.

Fixes #577