### PR TITLE
fix(crm): page the Slack ChromaDB scan so relationship discovery survives 32k+ messages

### DIFF
--- a/api/services/relationship_discovery.py
+++ b/api/services/relationship_discovery.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from api.services.person_entity import PersonEntity, get_person_entity_store
+from api.services.person_entity import get_person_entity_store
 from api.services.interaction_store import get_interaction_store, get_interaction_db_path
 from api.services.relationship import (
     Relationship,
@@ -42,6 +42,41 @@ def _datetime_gt(a: datetime | None, b: datetime | None) -> bool:
 # Discovery window (days to look back)
 # Use a large number to process all available history
 DISCOVERY_WINDOW_DAYS = 3650  # ~10 years - effectively all available data
+
+# Page size for ChromaDB metadata scans. A single unbounded get() asks the
+# backing SQLite for one bind parameter per matched row, so anything at or
+# above SQLITE_MAX_VARIABLE_NUMBER (32766 by default) fails outright with
+# "too many SQL variables". Page well under that ceiling.
+CHROMA_SCAN_PAGE_SIZE = 5000
+
+
+def _iter_chroma_metadatas(collection, cutoff_date: str, page_size: int = CHROMA_SCAN_PAGE_SIZE):
+    """
+    Yield metadata dicts from a ChromaDB collection, newest-cutoff filtered.
+
+    The date filter is applied here rather than pushed down as a `where`
+    clause: LifeOS indexes `modified_date` as a "YYYY-MM-DD" string, and
+    ChromaDB's `$gte` operator only accepts ints and floats. Zero-padded
+    ISO dates compare correctly as strings, which is what the callers'
+    first/last-seen tracking already relies on.
+
+    Pages rather than fetching everything at once so the scan does not
+    break when the collection outgrows SQLite's bind-parameter ceiling.
+    """
+    offset = 0
+    while True:
+        page = collection.get(include=["metadatas"], limit=page_size, offset=offset)
+        metadatas = (page or {}).get("metadatas") or []
+        if not metadatas:
+            return
+
+        for meta in metadatas:
+            if (meta.get("modified_date") or "") >= cutoff_date:
+                yield meta
+
+        if len(metadatas) < page_size:
+            return
+        offset += len(metadatas)
 
 
 def discover_from_calendar(
@@ -1004,19 +1039,13 @@ def discover_from_slack_direct(
     # Get all Slack messages (limit to recent ones)
     cutoff_date = (datetime.now(timezone.utc) - timedelta(days=days_back)).strftime('%Y-%m-%d')
 
-    # Query messages with date filter
     try:
-        results = collection.get(
-            where={"modified_date": {"$gte": cutoff_date}},
-            include=["metadatas"],
-            limit=50000,  # Reasonable limit
-        )
+        metadatas = list(_iter_chroma_metadatas(collection, cutoff_date))
     except Exception as e:
-        # Fallback: get all and filter
-        logger.info(f"Date filter failed ({e}), getting all messages")
-        results = collection.get(include=["metadatas"], limit=50000)
+        logger.warning(f"Could not scan Slack messages in ChromaDB: {e}")
+        return []
 
-    if not results or not results.get('metadatas'):
+    if not metadatas:
         logger.info("No Slack messages found in ChromaDB")
         return []
 
@@ -1025,7 +1054,7 @@ def discover_from_slack_direct(
     person_first_seen: dict[str, str] = {}
     person_last_seen: dict[str, str] = {}
 
-    for meta in results['metadatas']:
+    for meta in metadatas:
         # Parse people field (JSON array of Slack user IDs)
         people_json = meta.get('people', '[]')
         try:
@@ -1362,7 +1391,6 @@ def get_suggested_connections(
     """
     person_store = get_person_entity_store()
     relationship_store = get_relationship_store()
-    interaction_store = get_interaction_store()
 
     person = person_store.get_by_id(person_id)
     if not person:
@@ -1426,7 +1454,6 @@ def get_connection_overlap(person_a_id: str, person_b_id: str) -> dict:
     """
     person_store = get_person_entity_store()
     relationship_store = get_relationship_store()
-    interaction_store = get_interaction_store()
 
     person_a = person_store.get_by_id(person_a_id)
     person_b = person_store.get_by_id(person_b_id)

--- a/tests/test_relationship_discovery.py
+++ b/tests/test_relationship_discovery.py
@@ -20,6 +20,7 @@ from api.services.relationship_discovery import (
     discover_from_imessage_direct,
     discover_from_whatsapp_direct,
     discover_from_phone_calls,
+    _iter_chroma_metadatas,
     discover_linkedin_connections,
     run_full_discovery,
     get_suggested_connections,
@@ -461,3 +462,85 @@ class TestGetConnectionOverlap:
             # Relationship dict exists but shows no connection
             assert result.get('relationship') is not None
             assert result['relationship']['exists'] is False
+
+
+class TestChromaMetadataScan:
+    """
+    Tests for the paged ChromaDB metadata scan.
+
+    Regression cover for the nightly-sync outage where a single unbounded
+    get() over the Slack collection failed with "too many SQL variables"
+    once it grew past SQLite's bind-parameter ceiling, and for the
+    `$gte`-on-a-string date filter that had silently never worked.
+    """
+
+    @staticmethod
+    def _collection(metadatas):
+        """A fake ChromaDB collection that serves `metadatas` via limit/offset."""
+        collection = MagicMock()
+
+        def _get(include=None, limit=None, offset=0, **kwargs):
+            assert "where" not in kwargs, "date filter must not be pushed down to ChromaDB"
+            return {"metadatas": metadatas[offset:offset + limit]}
+
+        collection.get.side_effect = _get
+        return collection
+
+    def test_pages_through_collection_larger_than_page_size(self):
+        """All rows are returned even when the collection spans many pages."""
+        metadatas = [{"modified_date": "2026-01-01", "n": i} for i in range(250)]
+        collection = self._collection(metadatas)
+
+        result = list(_iter_chroma_metadatas(collection, "2020-01-01", page_size=100))
+
+        assert [m["n"] for m in result] == list(range(250))
+        assert collection.get.call_count == 3
+
+    def test_never_requests_more_than_page_size_at_once(self):
+        """No single get() may exceed the page size — that is what broke."""
+        metadatas = [{"modified_date": "2026-01-01"} for _ in range(40000)]
+        collection = self._collection(metadatas)
+
+        list(_iter_chroma_metadatas(collection, "2020-01-01", page_size=5000))
+
+        assert collection.get.call_count == 9
+        for call in collection.get.call_args_list:
+            assert call.kwargs["limit"] == 5000
+
+    def test_applies_cutoff_date_as_string_comparison(self):
+        """The cutoff filters rows, using lexicographic ISO date ordering."""
+        metadatas = [
+            {"modified_date": "2025-12-31", "n": 0},
+            {"modified_date": "2026-01-01", "n": 1},
+            {"modified_date": "2026-06-15", "n": 2},
+        ]
+        collection = self._collection(metadatas)
+
+        result = list(_iter_chroma_metadatas(collection, "2026-01-01", page_size=10))
+
+        assert [m["n"] for m in result] == [1, 2]
+
+    def test_row_missing_modified_date_is_excluded(self):
+        """A row with no usable date does not slip past the cutoff."""
+        collection = self._collection([{"n": 0}, {"modified_date": None, "n": 1}])
+
+        result = list(_iter_chroma_metadatas(collection, "2026-01-01", page_size=10))
+
+        assert result == []
+
+    def test_stops_when_collection_size_is_an_exact_page_multiple(self):
+        """A full final page is followed by one empty page, then termination."""
+        metadatas = [{"modified_date": "2026-01-01"} for _ in range(200)]
+        collection = self._collection(metadatas)
+
+        result = list(_iter_chroma_metadatas(collection, "2020-01-01", page_size=100))
+
+        assert len(result) == 200
+        assert collection.get.call_count == 3
+
+    def test_empty_collection_yields_nothing(self):
+        """An empty collection terminates after a single get()."""
+        collection = self._collection([])
+
+        assert list(_iter_chroma_metadatas(collection, "2020-01-01")) == []
+        assert collection.get.call_count == 1


### PR DESCRIPTION
## Problem

The nightly sync failed four nights running (Aug 27–30). `relationship_discovery` raised:

```
chromadb.errors.InternalError: Error executing plan: Internal error:
error returned from database: (code: 1) too many SQL variables
```

That single failure cascaded — `strengths`, `crm_vectorstore`, `entity_cleanup` and `consistency_verify` were all dependency-skipped and went stale for four days, and backup retention was skipped each night ("1 source failed, so existing backups are preserved").

## Root cause

Two bugs, the second only visible once the first hit scale.

**1. The date filter never worked.** LifeOS indexes `modified_date` as a `"YYYY-MM-DD"` string, and ChromaDB's `$gte` only accepts ints and floats:

```
ValueError: Expected operand value to be an int or a float for operator $gte,
got 2016-09-01 in get.
```

Every run since this code landed in March fell through to the `except` branch, so the date window was silently never applied.

**2. The fallback fetched the whole collection in one call.** `collection.get(include=["metadatas"], limit=50000)` makes ChromaDB bind one SQL parameter per matched row. Once `lifeos_slack` passed SQLite's `SQLITE_MAX_VARIABLE_NUMBER` (32,766 by default), the query failed outright.

The collection holds **33,306 documents**. It crossed that line between the Aug 26 run (last green) and the Aug 27 run (first red).

## Fix

Extract the scan into `_iter_chroma_metadatas()`, which:

- **pages at 5,000 rows** via `limit`/`offset`, so no single query approaches the parameter ceiling; and
- **applies the cutoff in Python**, where zero-padded ISO dates compare correctly as strings — which is what the caller's existing first/last-seen tracking already relies on.

A scan failure now logs a warning and yields no Slack relationships, matching the adjacent connect-failure handler, rather than aborting the source and its four dependents.

## Verification

Against the live 33,306-document collection:

| Check | Result |
|---|---|
| Full scan (cutoff `2016-09-01`, nightly `days_back=3650`) | 33,306 metadatas in **2.6s** |
| Cutoff actually filters (`2026-08-01`) | 4,102 metadatas |
| Previous behaviour | hard failure |

At the nightly `days_back=3650` the cutoff admits every row, so **nightly yield is unchanged** — this restores the old fetch-everything behaviour without the crash.

6 new tests cover multi-page traversal, the page-size ceiling, cutoff filtering, missing/`None` dates, the exact-page-multiple boundary, and the empty collection. The fake collection asserts no `where` clause is pushed down, so the string-`$gte` bug cannot silently return.

## Note on scope

This file carries three pre-existing ruff violations (unused `PersonEntity` import; two dead `interaction_store` assignments) — identical errors exist on clean `main`. The pre-commit hook lints changed files, so they blocked the commit and are removed here. Unrelated to the fix; happy to split them out if preferred.

## Pre-existing test failures (not from this change)

The full suite in `~/Code/LifeOS` shows 25 failures in `test_agent_worker_*` / `test_operator_spawn`. They are `ANTHROPIC_API_KEY`-dependent and reproduce identically on clean `main` (5,542 passed there vs 5,548 here — the delta is exactly the 6 new tests). The pre-push gate, which runs without `.env`, passes clean: **5,564 unit + 259 browser**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)