### PR TITLE
feat(crm): ignore mass meetings as a source of interactions and scores

### DIFF
--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -413,8 +413,9 @@ class InteractionStore:
             cursor = conn.execute(
                 """
                 INSERT INTO interactions
-                (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (id, person_id, timestamp, source_type, title, snippet, source_link, source_id, created_at,
+                 source_account, attendee_count)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(source_type, source_id) DO UPDATE SET
                     timestamp = excluded.timestamp
                 WHERE interactions.timestamp = ? AND excluded.timestamp != ?
@@ -429,6 +430,8 @@ class InteractionStore:
                     interaction.source_link,
                     interaction.source_id,
                     interaction.created_at.isoformat(),
+                    interaction.source_account,
+                    interaction.attendee_count,
                     UNDATED_SENTINEL.isoformat(),
                     UNDATED_SENTINEL.isoformat(),
                 ),
@@ -504,6 +507,8 @@ class InteractionStore:
                 interaction.source_link,
                 interaction.source_id,
                 interaction.created_at.isoformat(),
+                interaction.source_account,
+                interaction.attendee_count,
             ))
             affected_person_ids.add(resolved_id)
 
@@ -540,8 +545,8 @@ class InteractionStore:
                 """
                 INSERT INTO interactions
                 (id, person_id, timestamp, source_type, title, snippet,
-                 source_link, source_id, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 source_link, source_id, created_at, source_account, attendee_count)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(source_type, source_id) DO NOTHING
                 """,
                 rows,
@@ -612,8 +617,8 @@ class InteractionStore:
                     """
                     INSERT INTO interactions
                     (id, person_id, timestamp, source_type, title, snippet,
-                     source_link, source_id, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     source_link, source_id, created_at, source_account, attendee_count)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(source_type, source_id) DO NOTHING
                     """,
                     rows,
@@ -834,9 +839,14 @@ class InteractionStore:
                     COUNT(*) as count
                 FROM interactions
                 WHERE person_id = ? AND timestamp > ?
+                  AND NOT (source_type = 'calendar' AND COALESCE(attendee_count, 0) > ?)
                 GROUP BY source_type, subtype, source_account
             """,
-                (person_id, cutoff.isoformat()),
+                (
+                    person_id,
+                    cutoff.isoformat(),
+                    InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT,
+                ),
             )
 
             results = []

--- a/api/services/relationship_discovery.py
+++ b/api/services/relationship_discovery.py
@@ -21,6 +21,7 @@ from api.services.relationship import (
     TYPE_INFERRED,
 )
 from api.utils.datetime_utils import make_aware as _ensure_tz_aware
+from config.people_config import InteractionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,9 @@ def discover_from_calendar(
     cutoff = datetime.now(timezone.utc) - timedelta(days=days_back)
 
     # Get all calendar interactions with source_id containing participant AND timestamp
+    # Mass meetings are excluded: attending the same 90-person standing call is
+    # no evidence two people know each other, and each occurrence would otherwise
+    # contribute N*(N-1)/2 candidate pairs to the graph.
     query = """
         SELECT
             substr(source_id, 1, instr(source_id, ':') - 1) as event_id,
@@ -139,9 +143,13 @@ def discover_from_calendar(
         WHERE source_type = 'calendar'
           AND source_id LIKE '%:%'
           AND timestamp >= ?
+          AND COALESCE(attendee_count, 0) <= ?
     """
 
-    cursor = conn.execute(query, (cutoff.isoformat(),))
+    cursor = conn.execute(
+        query,
+        (cutoff.isoformat(), InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT),
+    )
 
     # Group by event, resolving participants to person IDs
     # Also track event timestamps

--- a/config/people_config.py
+++ b/config/people_config.py
@@ -121,6 +121,17 @@ class InteractionConfig:
     # Snippet length for interaction preview
     SNIPPET_LENGTH: int = 100
 
+    # Mass meetings carry no relationship signal: sitting in the same 90-person
+    # standing call says nothing about whether two people know each other. They
+    # are also combinatorially expensive — a single occurrence with N attendees
+    # yields one interaction per attendee and N*(N-1)/2 candidate pairs for
+    # relationship discovery, so one weekly all-hands can dominate a whole
+    # calendar history.
+    #
+    # Counted in *other* attendees (self already excluded), so the default
+    # ignores any event with more than 50 people besides the owner.
+    MASS_MEETING_ATTENDEE_LIMIT: int = 50
+
 
 def get_vault_contexts_for_domain(domain: str) -> list[str]:
     """

--- a/scripts/purge_mass_meeting_interactions.py
+++ b/scripts/purge_mass_meeting_interactions.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Purge calendar interactions belonging to mass meetings.
+
+Sitting in the same 90-person standing call is no evidence that two people know
+each other, so `sync_gmail_calendar_interactions.py` no longer creates rows for
+events above `InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT`. This removes the
+rows that were written before that guard existed.
+
+The read paths already ignore these rows, so this is a housekeeping step —
+it reclaims space and makes raw interaction counts honest.
+
+Usage:
+    python3 scripts/purge_mass_meeting_interactions.py            # dry run
+    python3 scripts/purge_mass_meeting_interactions.py --execute
+"""
+import argparse
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from api.services.interaction_store import get_interaction_db_path
+from config.people_config import InteractionConfig
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def purge(limit: int, dry_run: bool = True) -> dict:
+    """Delete calendar interactions for events with more than `limit` attendees.
+
+    Returns a stats dict; `SYNC_STATS:` is not emitted because this is a manual
+    tool rather than a registered sync source.
+    """
+    conn = sqlite3.connect(get_interaction_db_path())
+    try:
+        where = "source_type = 'calendar' AND COALESCE(attendee_count, 0) > ?"
+
+        total = conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
+        doomed = conn.execute(
+            f"SELECT COUNT(*) FROM interactions WHERE {where}", (limit,)
+        ).fetchone()[0]
+        events = conn.execute(
+            f"SELECT COUNT(DISTINCT substr(source_id, 1, instr(source_id, ':') - 1)) "
+            f"FROM interactions WHERE {where} AND source_id LIKE '%:%'",
+            (limit,),
+        ).fetchone()[0]
+        people = conn.execute(
+            f"SELECT COUNT(DISTINCT person_id) FROM interactions WHERE {where}",
+            (limit,),
+        ).fetchone()[0]
+
+        logger.info(f"Attendee limit           : {limit}")
+        logger.info(f"Interactions in database : {total:,}")
+        logger.info(f"Mass-meeting rows        : {doomed:,} ({doomed / total:.1%})")
+        logger.info(f"  across events          : {events:,}")
+        logger.info(f"  touching people        : {people:,}")
+
+        if dry_run:
+            logger.info("Dry run — nothing deleted. Re-run with --execute to apply.")
+        elif doomed:
+            with conn:
+                conn.execute(f"DELETE FROM interactions WHERE {where}", (limit,))
+            logger.info(f"Deleted {doomed:,} rows.")
+            logger.info("Run scripts/sync_person_stats.py --execute to refresh person stats.")
+        else:
+            logger.info("Nothing to delete.")
+
+        return {
+            "total": total,
+            "mass_meeting_rows": doomed,
+            "events": events,
+            "people": people,
+            "deleted": 0 if dry_run else doomed,
+        }
+    finally:
+        conn.close()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute", action="store_true", help="Actually delete (default: dry run)")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT,
+        help="Other-attendee count above which a meeting is ignored",
+    )
+    args = parser.parse_args(argv)
+
+    purge(limit=args.limit, dry_run=not args.execute)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_gmail_calendar_interactions.py
+++ b/scripts/sync_gmail_calendar_interactions.py
@@ -31,6 +31,7 @@ from api.services.google_auth import GoogleAccount
 from api.services.entity_resolver import get_entity_resolver
 from api.services.person_entity import get_person_entity_store
 from api.services.interaction_store import get_interaction_db_path
+from config.people_config import InteractionConfig
 from api.services.gmail_skip_cache import get_gmail_skip_cache
 from api.services.source_entity import (
     get_source_entity_store,
@@ -551,6 +552,7 @@ def sync_calendar_interactions(
         'no_person': 0,
         'errors': 0,
         'source_entities_created': 0,
+        'mass_meeting_skipped': 0,
     }
 
     # Track affected person_ids for stats refresh
@@ -613,6 +615,12 @@ def sync_calendar_interactions(
             # Count other attendees (excluding self) for meeting size classification
             # This is used to determine calendar_1on1 vs calendar_small_group vs calendar_large_meeting
             other_attendee_count = len(attendees)  # All attendees here are "other" (self excluded by resolver)
+
+            # Mass meetings are not evidence of a relationship — drop the whole
+            # event rather than emit one interaction per attendee.
+            if other_attendee_count > InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT:
+                stats['mass_meeting_skipped'] += 1
+                continue
 
             for attendee in attendees:
                 # Create unique source_id per event+attendee
@@ -910,7 +918,7 @@ def main(argv=None):
                 dry_run=dry_run,
             )
             all_stats[f'calendar_{account.value}'] = stats
-            logger.info(f"Calendar {account.value}: events={stats['events_fetched']}, inserted={stats['interactions_inserted']}, source_entities={stats['source_entities_created']}, exists={stats['already_exists']}, errors={stats['errors']}")
+            logger.info(f"Calendar {account.value}: events={stats['events_fetched']}, inserted={stats['interactions_inserted']}, source_entities={stats['source_entities_created']}, exists={stats['already_exists']}, mass_meetings_skipped={stats['mass_meeting_skipped']}, errors={stats['errors']}")
 
     if dry_run:
         logger.info("\nDRY RUN - no changes made. Use --execute to apply.")

--- a/tests/test_interaction_store.py
+++ b/tests/test_interaction_store.py
@@ -17,6 +17,7 @@ from api.services.interaction_store import (
     create_calendar_interaction,
     create_vault_interaction,
 )
+from config.people_config import InteractionConfig
 
 pytestmark = pytest.mark.unit
 
@@ -1062,3 +1063,94 @@ class TestBackupRetention:
         removed = _prune_backups(tmp_path, now=now)
         assert removed == []
         assert len(list(tmp_path.glob("*.backup"))) == 3
+
+
+class TestMassMeetingExclusion:
+    """
+    Mass meetings must not contribute to relationship scoring.
+
+    A 90-person standing call yields one interaction row per attendee, so a
+    single weekly series can dominate a whole calendar history and inflate
+    strength scores for people who have never actually spoken.
+    """
+
+    @pytest.fixture
+    def temp_store(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            store = InteractionStore(f.name, strict=False)
+            yield store
+            Path(f.name).unlink(missing_ok=True)
+
+    @staticmethod
+    def _calendar(store, person_id, attendee_count, title="Meeting"):
+        store.add(Interaction(
+            id=str(uuid.uuid4()),
+            person_id=person_id,
+            timestamp=datetime.now(),
+            source_type="calendar",
+            title=title,
+            attendee_count=attendee_count,
+        ))
+
+    def _subtypes(self, store, person_id):
+        return {
+            r["subtype"]: r["count"]
+            for r in store.get_interaction_counts_with_subtypes(person_id)
+        }
+
+    def test_meeting_over_limit_is_excluded(self, temp_store):
+        """An event above the attendee limit contributes nothing."""
+        self._calendar(temp_store, "p1", InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT + 1)
+
+        assert self._subtypes(temp_store, "p1") == {}
+
+    def test_meeting_at_limit_is_kept(self, temp_store):
+        """The limit is exclusive — exactly at the limit still counts."""
+        self._calendar(temp_store, "p1", InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT)
+
+        assert self._subtypes(temp_store, "p1") == {"calendar_large_meeting": 1}
+
+    def test_small_meetings_are_unaffected(self, temp_store):
+        """Ordinary meetings keep their existing subtype buckets."""
+        self._calendar(temp_store, "p1", 1)
+        self._calendar(temp_store, "p1", 3)
+        self._calendar(temp_store, "p1", 10)
+
+        assert self._subtypes(temp_store, "p1") == {
+            "calendar_1on1": 1,
+            "calendar_small_group": 1,
+            "calendar_large_meeting": 1,
+        }
+
+    def test_null_attendee_count_is_kept(self, temp_store):
+        """
+        Rows predating the attendee_count column must survive.
+
+        `NULL > 50` is NULL in SQL, so a naive NOT(...) filter would silently
+        drop every legacy row instead of keeping it.
+        """
+        self._calendar(temp_store, "p1", None)
+
+        counts = temp_store.get_interaction_counts_with_subtypes("p1")
+        assert sum(r["count"] for r in counts) == 1
+
+    def test_non_calendar_sources_are_never_filtered(self, temp_store):
+        """The limit applies only to calendar rows."""
+        temp_store.add(Interaction(
+            id=str(uuid.uuid4()),
+            person_id="p1",
+            timestamp=datetime.now(),
+            source_type="gmail",
+            title="→ Subject",
+        ))
+
+        counts = temp_store.get_interaction_counts_with_subtypes("p1")
+        assert sum(r["count"] for r in counts) == 1
+
+    def test_mass_meeting_does_not_drown_out_real_contact(self, temp_store):
+        """The regression this guards: one 1:1 must not be buried by a big series."""
+        for _ in range(100):
+            self._calendar(temp_store, "p1", 91, title="Rise Leadership Call")
+        self._calendar(temp_store, "p1", 1, title="Coffee")
+
+        assert self._subtypes(temp_store, "p1") == {"calendar_1on1": 1}


### PR DESCRIPTION
## Problem

The calendar sync emits **one interaction row per attendee**, so a single large recurring meeting can dominate an entire calendar history — even though sitting in the same 90-person standing call is no evidence that two people know each other.

Worst case found in production:

| Title | Rows | Events | Attendees/event | Span |
|---|---|---|---|---|
| Rise Leadership Call | **14,471** | 158 | 91.6 | 2018-06 → 2021-06 |

That one series is **53% of that user's entire calendar history**, and 69% of their calendar rows come from meetings with >50 other attendees. Each of those ~92 people accrued 158 interactions with the owner without ever having spoken to them. A second account shows the same shape at smaller scale (3,533 rows, 13%).

**The existing weight doesn't solve it.** `calendar_large_meeting` is priced at 2.0 vs 6.0 for a 1:1 — but the bucket is flat, so 6 attendees and 92 attendees are valued identically. 158 mass-meeting rows still outweigh 50 genuine 1:1s.

**Relationship discovery is worse.** `discover_from_calendar` pairs every attendee with every other, so one 92-person occurrence contributes N*(N-1)/2 = 4,186 candidate pairs to the graph.

## Change

Drop these events entirely, above a configurable limit on *other* attendees (`InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT`, default 50).

| Layer | Behaviour |
|---|---|
| Ingestion | Skips the event rather than emitting a row per attendee; reports `mass_meetings_skipped` |
| Scoring | `get_interaction_counts_with_subtypes` excludes them — rows written before this change stop counting immediately |
| Relationship discovery | Excluded from the shared-event pair search |
| Cleanup | `scripts/purge_mass_meeting_interactions.py` removes pre-existing rows (dry-run by default) |

Filtering at read time as well as ingestion means the fix takes effect without requiring the purge, and the purge stays optional and separate.

### NULL safety

Both read-path filters use `COALESCE(attendee_count, 0)`. The obvious spelling is wrong and silently destructive:

```sql
-- WRONG: NULL > 50 is NULL, NOT (NULL) is NULL -> row excluded
AND NOT (attendee_count > ?)
```

That would drop every legacy row with an unset `attendee_count` instead of keeping it. There is a test pinning this.

## Incidental fix

`InteractionStore.add()`, `add_many()` and `batch_add()` all dropped `source_account` and `attendee_count`. Both are fields of the `Interaction` dataclass and are read back by `from_row()`, but only the sync script's raw SQL ever wrote them.

This is load-bearing here: without it, any calendar interaction added through the store carries a NULL `attendee_count` and bypasses the new guard entirely.

## Verification

Against live data:

- Dry-run calendar sync: `mass_meetings_skipped=55`, considers 2,943 fewer rows (`exists` 16,916 → 13,973)
- Purge dry-run: 3,533 rows across 61 events touching 639 people
- Full suite: **5,570 passed, 9 skipped, 0 failures** (+6 new tests over the 5,564 baseline)

New tests cover: over-limit exclusion, the boundary being exclusive, small meetings unaffected, NULL `attendee_count` retained, non-calendar sources never filtered, and the headline regression — 100 mass-meeting rows must not bury a single 1:1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)