### PR TITLE
fix(crm): apply the mass-meeting limit to direct calendar discovery too

### DIFF
--- a/api/services/relationship_discovery.py
+++ b/api/services/relationship_discovery.py
@@ -250,6 +250,10 @@ def discover_from_calendar_direct(
     This is MY calendar, so I am implicitly at every event.
     Creates relationships between ME and each attendee, with event count as shared_events_count.
 
+    Mass meetings are excluded on the same terms as discover_from_calendar:
+    being one of 90 people on a standing call is not a relationship with the
+    owner either.
+
     Args:
         days_back: Days to look back
         min_events: Minimum events to count (default 1 - any shared event counts)
@@ -286,11 +290,20 @@ def discover_from_calendar_direct(
           AND timestamp >= ?
           AND person_id IS NOT NULL
           AND person_id != ?
+          AND COALESCE(attendee_count, 0) <= ?
         GROUP BY person_id
         HAVING COUNT(DISTINCT substr(source_id, 1, instr(source_id, ':') - 1)) >= ?
     """
 
-    cursor = conn.execute(query, (cutoff.isoformat(), my_person_id, min_events))
+    cursor = conn.execute(
+        query,
+        (
+            cutoff.isoformat(),
+            my_person_id,
+            InteractionConfig.MASS_MEETING_ATTENDEE_LIMIT,
+            min_events,
+        ),
+    )
 
     relationships = []
     for row in cursor:


### PR DESCRIPTION
## Problem

#847 added `MASS_MEETING_ATTENDEE_LIMIT` to `discover_from_calendar`, but missed `discover_from_calendar_direct` — which builds owner↔attendee relationships from the same `interactions` table.

The result is an inconsistency: attendee↔attendee pairs from a 90-person standing call are correctly ignored, while owner↔attendee pairs from that same call are not. Being one of 90 people on a call is not a relationship with the owner either.

## Change

Two lines: the same `COALESCE(attendee_count, 0) <= ?` filter and bound parameter, plus a docstring note. NULL-safe for the same reason as the other filters — `NULL > 50` is `NULL`, so the naive `NOT (...)` spelling would silently drop legacy rows.

## Scope note

`scripts/purge_mass_meeting_interactions.py` deletes the rows this query would have read, so **an already-purged database is correct without this change**. Both production instances were purged before this PR was written, which is why it isn't urgent.

What it fixes is the case where the purge hasn't run: a fresh install, a restored backup, or a database where someone raised the limit and re-synced. The guard is what makes correctness independent of whether the one-off cleanup was ever executed — the same reason #847 filters at read time as well as at ingestion.

## Verification

- `tests/test_relationship_discovery.py` + `tests/test_interaction_store.py`: 86 passed
- Full suite via pre-push gate: **5,570 passed, 9 skipped** unit; **259 passed** server-free browser
- ruff clean

No new tests: this applies an already-tested predicate to a second query. The existing NULL-safety and boundary tests from #847 cover the semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)