### PR TITLE
feat(tasks): harden the task store for a Kanban front-end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMe
 | How is perf traced and monitored? | [specs/technical/observability.md](docs/specs/technical/observability.md) |
 | What does `#agent` do? | [specs/product/agent-worker.md](docs/specs/product/agent-worker.md) |
 | How does the agent worker work internally? | [specs/technical/agent-worker.md](docs/specs/technical/agent-worker.md) |
+| How does the task store work internally (id-addressed writes, notes body, conflict files)? | [specs/technical/task-management.md](docs/specs/technical/task-management.md) |
+| What can I do with tasks (statuses, API, chat)? | [specs/product/task-management.md](docs/specs/product/task-management.md) |
 | How do I set up the agent worker? | [guides/agent-worker-setup.md](docs/guides/agent-worker-setup.md) |
 | How does the doctor self-repair bot work? | [guides/doctor-bot.md](docs/guides/doctor-bot.md) |
 | How do schedules (triggers + actions) work? | [guides/scheduler.md](docs/guides/scheduler.md) |

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -215,6 +215,8 @@ async def create_task(request: CreateTaskRequest):
         )
     except TaskConflictError as e:
         raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
     return TaskResponse.from_task(task)
 
 
@@ -422,6 +424,8 @@ async def update_task(task_id: str, request: UpdateTaskRequest):
         task = manager.update(task_id, **updates)
     except TaskConflictError as e:
         raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     return TaskResponse.from_task(task)

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -9,11 +9,27 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from api.services.task_manager import get_task_manager, Task
+from api.services.task_manager import get_task_manager, Task, TaskConflictError, VALID_STATUSES
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
+
+
+def _require_valid_status(status: Optional[str]) -> None:
+    """Raise 422 for an unrecognized status.
+
+    Deliberately a manual check + HTTPException rather than a pydantic
+    `field_validator` — the app's global `RequestValidationError` handler
+    (api/main.py) converts every pydantic validation failure to 400, and (as
+    a separate, pre-existing bug) can't JSON-serialize a validator's raised
+    exception object at all. Matches the pattern already used for schedules'
+    bot-name validation (api/routes/scheduler.py `_require_known_bot`)."""
+    if status is not None and status not in VALID_STATUSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid status '{status}'. Must be one of: {', '.join(sorted(VALID_STATUSES))}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -22,6 +38,14 @@ router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
 class CreateTaskRequest(BaseModel):
     description: str = Field(..., min_length=1, description="Task description")
+    context: Optional[str] = Field(default=None, description="Context/category; defaults to 'Inbox'.")
+    status: Optional[str] = Field(
+        default=None,
+        description=(
+            "Initial status; defaults to 'todo'. One of: todo, done, in_progress, "
+            "cancelled, deferred, blocked, urgent."
+        ),
+    )
     priority: Optional[str] = Field(default="", description="Priority: high, medium, low, or empty")
     due_date: Optional[str] = Field(default=None, description="Due date (YYYY-MM-DD)")
     tags: Optional[list[str]] = Field(
@@ -35,6 +59,16 @@ class CreateTaskRequest(BaseModel):
                     "precedence slot.",
     )
     reminder_id: Optional[str] = Field(default=None, description="Associated reminder ID")
+    notes: Optional[str] = Field(
+        default=None,
+        description="Multi-line notes body, stored as indented '> ' lines beneath the task line.",
+    )
+    fields: Optional[dict[str, Optional[str]]] = Field(
+        default=None,
+        description="Operator-editable inline fields (e.g. host, effort, model, "
+                    "key) plus any custom [key:: value] field. Round-trips "
+                    "untouched through any later rewrite of the task.",
+    )
     dry_run: Optional[bool] = Field(
         default=False,
         description="When true and the task carries the #agent tag, run the "
@@ -80,6 +114,16 @@ class UpdateTaskRequest(BaseModel):
                     "explicitly named that engine — these tags are operator-"
                     "authority and outrank every routing safeguard.",
     )
+    notes: Optional[str] = Field(
+        default=None,
+        description="Replaces the task's notes body (indented '> ' lines beneath the task line).",
+    )
+    fields: Optional[dict[str, Optional[str]]] = Field(
+        default=None,
+        description="Merged into the task's operator/unknown fields, not replaced: "
+                    "a string value sets that field, a null value removes it. "
+                    "Fields not mentioned are left alone.",
+    )
 
 
 class TaskResponse(BaseModel):
@@ -92,8 +136,11 @@ class TaskResponse(BaseModel):
     created_date: str
     done_date: Optional[str]
     cancelled_date: Optional[str]
+    updated_at: Optional[str]
     tags: list[str]
     reminder_id: Optional[str]
+    notes: Optional[str]
+    fields: dict[str, str]
     source_file: str
     line_number: int
 
@@ -109,8 +156,11 @@ class TaskResponse(BaseModel):
             created_date=t.created_date,
             done_date=t.done_date,
             cancelled_date=t.cancelled_date,
+            updated_at=t.updated_at,
             tags=t.tags,
             reminder_id=t.reminder_id,
+            notes=t.notes,
+            fields=t.fields,
             source_file=t.source_file,
             line_number=t.line_number,
         )
@@ -119,6 +169,15 @@ class TaskResponse(BaseModel):
 class TaskListResponse(BaseModel):
     tasks: list[TaskResponse]
     total: int
+
+
+class ConflictFile(BaseModel):
+    name: str
+    mtime: str
+
+
+class ConflictListResponse(BaseModel):
+    conflicts: list[ConflictFile]
 
 
 # ---------------------------------------------------------------------------
@@ -139,14 +198,23 @@ async def create_task(request: CreateTaskRequest):
     """
     if request.dry_run and _has_agent_tag(request.tags):
         return _build_preflight_preview(request)
+    _require_valid_status(request.status)
     manager = get_task_manager()
-    task = manager.create(
-        description=request.description,
-        priority=request.priority or "",
-        due_date=request.due_date,
-        tags=request.tags,
-        reminder_id=request.reminder_id,
-    )
+    fields = {k: v for k, v in (request.fields or {}).items() if v is not None}
+    try:
+        task = manager.create(
+            description=request.description,
+            context=request.context or "Inbox",
+            status=request.status or "todo",
+            priority=request.priority or "",
+            due_date=request.due_date,
+            tags=request.tags,
+            reminder_id=request.reminder_id,
+            notes=request.notes,
+            fields=fields,
+        )
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     return TaskResponse.from_task(task)
 
 
@@ -292,6 +360,20 @@ async def list_tags():
     return TagListResponse(tags=[TagUsage(**t) for t in manager.list_tags()])
 
 
+@router.get("/conflicts", response_model=ConflictListResponse)
+async def list_conflicts():
+    """List Syncthing conflict copies / in-progress temp files sitting in the
+    tasks folder. These are never indexed as tasks and never reindexed —
+    surfaced here so a client (the board) can warn the operator to resolve
+    them by hand in Obsidian/Syncthing.
+
+    Registered before `/{task_id}` so FastAPI doesn't treat "conflicts" as
+    a task id.
+    """
+    manager = get_task_manager()
+    return ConflictListResponse(conflicts=[ConflictFile(**c) for c in manager.list_conflicts()])
+
+
 class SwapTagResponse(BaseModel):
     swapped: bool
     reason: Optional[str] = None
@@ -313,7 +395,10 @@ async def swap_tag(
     manager = get_task_manager()
     if manager.get(task_id) is None:
         return SwapTagResponse(swapped=False, reason="task not found")
-    ok = manager.swap_tag(task_id, from_tag, to_tag)
+    try:
+        ok = manager.swap_tag(task_id, from_tag, to_tag)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     return SwapTagResponse(swapped=ok, reason=None if ok else f"tag '{from_tag}' not present")
 
 
@@ -330,9 +415,13 @@ async def get_task(task_id: str):
 @router.put("/{task_id}", response_model=TaskResponse)
 async def update_task(task_id: str, request: UpdateTaskRequest):
     """Update an existing task."""
+    _require_valid_status(request.status)
     manager = get_task_manager()
     updates = {k: v for k, v in request.model_dump().items() if v is not None}
-    task = manager.update(task_id, **updates)
+    try:
+        task = manager.update(task_id, **updates)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     return TaskResponse.from_task(task)
@@ -342,7 +431,10 @@ async def update_task(task_id: str, request: UpdateTaskRequest):
 async def complete_task(task_id: str):
     """Mark a task as done (shortcut endpoint)."""
     manager = get_task_manager()
-    task = manager.complete(task_id)
+    try:
+        task = manager.complete(task_id)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     return TaskResponse.from_task(task)
@@ -352,7 +444,10 @@ async def complete_task(task_id: str):
 async def delete_task(task_id: str):
     """Delete a task."""
     manager = get_task_manager()
-    deleted = manager.delete(task_id)
+    try:
+        deleted = manager.delete(task_id)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not deleted:
         raise HTTPException(status_code=404, detail="Task not found")
     return {"status": "deleted", "id": task_id}

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -358,9 +358,10 @@ TOOL_DEFINITIONS = [
         "name": "manage_tasks",
         "description": (
             "Manage Obsidian tasks. Actions: 'create' (new task — always lands in "
-            "Inbox; do not pass a context), 'list' (filter tasks; supports the "
-            "context filter for already-categorized tasks), 'complete' (mark task "
-            "done), 'update' (edit any field on an existing task, including tags or "
+            "Inbox; do not pass a context — status/notes/fields are accepted), "
+            "'list' (filter tasks; supports the context filter for already-"
+            "categorized tasks), 'complete' (mark task done), 'update' (edit any "
+            "field on an existing task, including tags, notes, operator fields, or "
             "moving the task to a different context), 'tags' (list every distinct "
             "tag across all tasks with usage counts — the same list is already in "
             "the system prompt; call this action only if the user explicitly asks "
@@ -429,13 +430,29 @@ TOOL_DEFINITIONS = [
                         "'urgent'. Omitting it returns tasks of EVERY status, and in an "
                         "established vault most tasks are done or cancelled — so pass "
                         "'todo' for open/outstanding work rather than listing unfiltered "
-                        "and sorting it out afterwards. Also accepted on update to change "
-                        "status."
+                        "and sorting it out afterwards. Also accepted on create (initial "
+                        "status; defaults to 'todo') and update (to change status)."
                     ),
                 },
                 "query": {
                     "type": "string",
                     "description": "Search within task descriptions (for list).",
+                },
+                "notes": {
+                    "type": "string",
+                    "description": (
+                        "Multi-line notes body for the task (create or update). "
+                        "Stored beneath the task line; replaces the existing body on update."
+                    ),
+                },
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": {"type": ["string", "null"]},
+                    "description": (
+                        "Operator-editable fields (e.g. host, effort, model, key) to set on "
+                        "the task (create or update). On update, a null value removes that "
+                        "field; other fields not mentioned are left alone."
+                    ),
                 },
             },
             "required": ["action"],
@@ -2133,11 +2150,15 @@ def _tool_person_info(inp: dict):
 def _task_create(inp: dict) -> str:
     from api.services.task_manager import get_task_manager
     tm = get_task_manager()
+    fields = {k: v for k, v in (inp.get("fields") or {}).items() if v is not None}
     task = tm.create(
         description=inp["description"],
+        status=inp.get("status") or "todo",
         priority=inp.get("priority", ""),
         due_date=inp.get("due_date"),
         tags=inp.get("tags"),
+        notes=inp.get("notes"),
+        fields=fields,
     )
     due = f", due {task.due_date}" if task.due_date else ""
     return f"Task created: \"{task.description}\" (id: {task.id}{due})"
@@ -2184,7 +2205,7 @@ def _task_complete(inp: dict) -> str:
     return f"Task completed: \"{task.description}\""
 
 
-_UPDATABLE_FIELDS = ("description", "status", "context", "priority", "due_date", "tags")
+_UPDATABLE_FIELDS = ("description", "status", "context", "priority", "due_date", "tags", "notes", "fields")
 
 
 def _task_update(inp: dict) -> str:
@@ -2195,7 +2216,10 @@ def _task_update(inp: dict) -> str:
     tm = get_task_manager()
     updates = {k: inp[k] for k in _UPDATABLE_FIELDS if k in inp and inp[k] is not None}
     if not updates:
-        return "Error: no updatable fields provided (description, status, context, priority, due_date, tags)."
+        return (
+            "Error: no updatable fields provided (description, status, context, "
+            "priority, due_date, tags, notes, fields)."
+        )
     task = tm.update(task_id, **updates)
     if not task:
         return f"Error: Task '{task_id}' not found."

--- a/api/services/atomic_write.py
+++ b/api/services/atomic_write.py
@@ -1,0 +1,38 @@
+"""Shared atomic file-write helper.
+
+Writes a temp file in the target's own directory, fsyncs it, then renames it
+into place with ``os.replace``. A reader (Obsidian, Syncthing, a watcher) that
+opens the target path mid-write always sees either the old content or the new
+content in full — never a partial write, since ``os.replace`` is atomic on
+the same filesystem and a temp file in the same directory guarantees that.
+
+Used by ``task_manager.py`` and ``scheduler_store.py`` so both vault stores
+share one atomic-write implementation instead of each hand-rolling it.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Atomically write ``content`` to ``path``, creating parent dirs as needed."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_lines(path: Path, lines: list[str]) -> None:
+    """Atomically write ``lines`` to ``path``, one per line, with a trailing newline."""
+    atomic_write_text(path, "\n".join(lines) + "\n")

--- a/api/services/atomic_write.py
+++ b/api/services/atomic_write.py
@@ -33,6 +33,22 @@ def atomic_write_text(path: Path, content: str) -> None:
         raise
 
 
-def atomic_write_lines(path: Path, lines: list[str]) -> None:
-    """Atomically write ``lines`` to ``path``, one per line, with a trailing newline."""
-    atomic_write_text(path, "\n".join(lines) + "\n")
+def atomic_write_lines(
+    path: Path,
+    lines: list[str],
+    newline: str = "\n",
+    trailing_newline: bool = True,
+) -> None:
+    """Atomically write ``lines`` to ``path``, joined by ``newline``.
+
+    ``newline`` and ``trailing_newline`` let a caller preserve a file's
+    original line-terminator convention (e.g. CRLF) and whether it ended
+    with a trailing terminator, across a rewrite that only touches a few
+    lines. ``scheduler_store.py`` never calls this helper (it writes whole
+    files via ``atomic_write_text``), so its behavior is unaffected by
+    these defaults.
+    """
+    content = newline.join(lines)
+    if trailing_newline:
+        content += newline
+    atomic_write_text(path, content)

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -46,6 +46,7 @@ from croniter import croniter
 from zoneinfo import ZoneInfo
 
 from config.settings import settings
+from api.services.atomic_write import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -398,7 +399,7 @@ class SchedulerStore:
             "last_updated": datetime.now(timezone.utc).isoformat(),
             "schedules": [e.to_dict() for e in self._entries.values()],
         }
-        self.index_path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        atomic_write_text(self.index_path, json.dumps(data, indent=2, default=str))
         self._write_dashboard()
 
     # ------------------------------------------------------------------
@@ -411,12 +412,12 @@ class SchedulerStore:
         return []
 
     def _write_inbox_lines(self, lines: list[str]):
-        self.inbox_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        atomic_write_text(self.inbox_path, "\n".join(lines) + "\n")
 
     def _ensure_inbox(self):
         if not self.inbox_path.exists():
-            self.inbox_path.write_text(
-                "---\ntype: scheduler\n---\n# Scheduler Inbox\n\n", encoding="utf-8"
+            atomic_write_text(
+                self.inbox_path, "---\ntype: scheduler\n---\n# Scheduler Inbox\n\n"
             )
 
     def _insert_block_at_top(self, block: list[str]):
@@ -662,7 +663,7 @@ class SchedulerStore:
                 return  # no-op write avoids triggering the watcher
         except Exception:
             pass
-        dashboard.write_text(content, encoding="utf-8")
+        atomic_write_text(dashboard, content)
 
     def _build_dashboard_content(self) -> str:
         now = datetime.now(timezone.utc)

--- a/api/services/task_manager.py
+++ b/api/services/task_manager.py
@@ -9,6 +9,15 @@ Task line format (Dataview inline fields):
 
 Storage: LifeOS/Tasks/{Context}.md files in the vault
 Index:   data/task_index.json for fast API queries
+
+Tasks are addressed by their ``<!-- id:xxxx -->`` comment, not by cached line
+number — a write locates its task's block by id on every mutation, exactly
+like ``scheduler_store.py`` locates schedule blocks. This is what lets a task
+survive an external edit that inserts lines above it before the file watcher
+reindexes. ``line_number``/``source_file`` on ``Task`` remain informational
+(refreshed after every write) but are never used to address a write.
+
+See docs/specs/technical/task-management.md for the full design.
 """
 import json
 import logging
@@ -16,11 +25,12 @@ import re
 import threading
 import uuid
 from dataclasses import dataclass, field, asdict
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from config.settings import settings
+from api.services.atomic_write import atomic_write_text, atomic_write_lines
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +50,27 @@ SYMBOL_TO_STATUS = {v: k for k, v in STATUS_TO_SYMBOL.items()}
 
 VALID_STATUSES = set(STATUS_TO_SYMBOL.keys())
 
+# Inline fields with a dedicated Task attribute — everything else parsed from
+# `[key:: value]` lands in `Task.fields` and round-trips untouched, which is
+# how operator fields (host, effort, model, key) and any future field survive
+# without parser changes.
+_KNOWN_FIELD_KEYS = {"due", "priority", "created", "done", "cancelled", "updated"}
+
+# Retries after an initial write attempt that loses a compare-and-swap race
+# against a concurrent external edit (see TaskManager._cas_rewrite).
+_CAS_MAX_RETRIES = 3
+
+
+class TaskConflictError(Exception):
+    """Raised when a write loses the compare-and-swap race against a
+    concurrent external edit `_CAS_MAX_RETRIES` times in a row. The route
+    layer maps this to HTTP 409."""
+
+
+class _TagAbsentError(Exception):
+    """Internal signal: swap_tag's `from_tag` is no longer present after a
+    CAS retry re-read the task (e.g. someone else already swapped it)."""
+
 
 @dataclass
 class Task:
@@ -53,8 +84,11 @@ class Task:
     created_date: str = ""  # YYYY-MM-DD
     done_date: Optional[str] = None  # YYYY-MM-DD
     cancelled_date: Optional[str] = None  # YYYY-MM-DD
+    updated_at: Optional[str] = None  # ISO-8601 with UTC offset
     tags: list[str] = field(default_factory=list)
     reminder_id: Optional[str] = None
+    notes: Optional[str] = None
+    fields: dict[str, str] = field(default_factory=dict)
     source_file: str = ""
     line_number: int = 0
 
@@ -66,11 +100,41 @@ class Task:
         # Handle tags being stored as non-list
         if "tags" in data and not isinstance(data.get("tags"), list):
             data["tags"] = []
+        if "fields" in data and not isinstance(data.get("fields"), dict):
+            data["fields"] = {}
         return cls(**{k: data[k] for k in cls.__dataclass_fields__ if k in data})
 
 
 def _today() -> str:
     return date.today().isoformat()
+
+
+def _now_iso() -> str:
+    """Current time as ISO-8601 with an explicit UTC offset."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _mtime_or_none(path: Path) -> Optional[int]:
+    try:
+        return path.stat().st_mtime_ns
+    except FileNotFoundError:
+        return None
+
+
+def _read_lines(path: Path) -> list[str]:
+    if path.exists():
+        return path.read_text(encoding="utf-8").splitlines()
+    return []
+
+
+# Syncthing conflict copies and temp files: never indexed as a task source,
+# never trigger or survive a reindex. Exposed read-only via list_conflicts().
+_CONFLICT_RE = re.compile(r"\.sync-conflict-\d{8}-\d{6}")
+
+
+def is_conflict_file(path: Path) -> bool:
+    name = path.name
+    return bool(_CONFLICT_RE.search(name)) or name.startswith(".syncthing.")
 
 
 class TaskManager:
@@ -79,6 +143,15 @@ class TaskManager:
 
     Markdown files in LifeOS/Tasks/ are the source of truth.
     data/task_index.json is a query cache rebuilt from markdown.
+
+    Writes locate their task's block by id (`_find_task_block_span`) rather
+    than by cached line number, so a concurrent external edit that shifts
+    line numbers can't misdirect a write — mirroring `SchedulerStore`. Each
+    write is protected by a compare-and-swap on the file's mtime
+    (`_cas_rewrite`): if the mtime changes between our read and our rename,
+    someone else wrote to the file in between, so we reindex (absorbing
+    their change) and retry, up to `_CAS_MAX_RETRIES` times, before raising
+    `TaskConflictError`.
     """
 
     TASKS_FOLDER = "LifeOS/Tasks"
@@ -88,7 +161,20 @@ class TaskManager:
         self.index_path = Path(index_path) if index_path else DEFAULT_INDEX_PATH
         self.tasks_dir = self.vault_path / self.TASKS_FOLDER
         self._tasks: dict[str, Task] = {}
-        self._lock = threading.Lock()
+        # Exact raw main-line text last written or seen for each task id,
+        # this process's lifetime only (never persisted — see docs/specs/
+        # technical/task-management.md "External-edit detection" for why a
+        # sidecar file isn't needed). Used to tell a genuine external edit
+        # apart from our own prior write echoing back through the watcher;
+        # comparing against this exact string (rather than reformatting the
+        # prior Task and hoping it matches) is what keeps a hand-authored
+        # line's exact formatting — no "TODO", no created date — stable
+        # across repeated reindexes instead of getting rewritten every time.
+        self._last_written_line: dict[str, str] = {}
+        # Reentrant: a CAS retry inside a mutating call (create/update/
+        # swap_tag/delete, all lock-held) invokes reindex_file(), which also
+        # takes this lock — a plain Lock would self-deadlock on that retry.
+        self._lock = threading.RLock()
 
         self.index_path.parent.mkdir(parents=True, exist_ok=True)
         self.tasks_dir.mkdir(parents=True, exist_ok=True)
@@ -118,10 +204,10 @@ class TaskManager:
         """Persist index to disk."""
         data = {
             "description": "LifeOS Task Index (cache — regenerated from vault markdown)",
-            "last_updated": datetime.utcnow().isoformat(),
+            "last_updated": _now_iso(),
             "tasks": [t.to_dict() for t in self._tasks.values()],
         }
-        self.index_path.write_text(json.dumps(data, indent=2, default=str))
+        atomic_write_text(self.index_path, json.dumps(data, indent=2, default=str))
 
     # ------------------------------------------------------------------
     # CRUD
@@ -131,38 +217,45 @@ class TaskManager:
         self,
         description: str,
         context: str = "Inbox",
+        status: str = "todo",
         priority: str = "",
         due_date: Optional[str] = None,
         tags: Optional[list[str]] = None,
         reminder_id: Optional[str] = None,
+        notes: Optional[str] = None,
+        fields: Optional[dict[str, str]] = None,
     ) -> Task:
         """Create a new task at the top of its context file, update index."""
         with self._lock:
             task = Task(
                 id=uuid.uuid4().hex[:8],
                 description=description,
-                status="todo",
+                status=status or "todo",
                 context=context,
                 priority=priority,
                 due_date=due_date,
                 created_date=_today(),
+                updated_at=_now_iso(),
                 tags=tags or [],
                 reminder_id=reminder_id,
+                notes=notes,
+                fields=dict(fields) if fields else {},
             )
-            file_path = self._get_context_file(context)
-            line = _format_task_line(task)
-            insert_at = _insert_task_at_top(file_path, line)
+            if task.status == "done" and not task.done_date:
+                task.done_date = _today()
+            if task.status == "cancelled" and not task.cancelled_date:
+                task.cancelled_date = _today()
 
-            # Bump line numbers for existing tasks in the same file that
-            # sit at or below the insertion point (pushed down by 1).
-            for t in self._tasks.values():
-                if t.source_file == str(file_path) and t.line_number >= insert_at:
-                    t.line_number += 1
+            file_path = self._get_context_file(context)
+            block = _format_task_block(task)
+            start_line = self._cas_insert_at_top(file_path, block)
 
             task.source_file = str(file_path)
-            task.line_number = insert_at
+            task.line_number = start_line
 
             self._tasks[task.id] = task
+            self._last_written_line[task.id] = block[0]
+            self._reposition_file(file_path)
             self._save_index()
             self._write_dashboard()
             logger.info(f"Created task {task.id}: {description}")
@@ -176,31 +269,56 @@ class TaskManager:
         return self.update(task_id, status="done")
 
     def update(self, task_id: str, **kwargs) -> Optional[Task]:
-        """Update a task. Supports: description, status, context, priority, due_date, tags."""
+        """Update a task. Supports: description, status, context, priority,
+        due_date, tags, notes, fields. `fields={"k": None}` removes key `k`;
+        `fields={"k": "v"}` sets it. Raises `TaskConflictError` (-> HTTP 409)
+        if the write keeps losing the CAS race against a concurrent edit."""
+        fields_patch = kwargs.pop("fields", None)
         with self._lock:
-            task = self._tasks.get(task_id)
-            if not task:
+            current = self._tasks.get(task_id)
+            if not current:
                 return None
 
-            old_context = task.context
+            old_context = current.context
             new_context = kwargs.get("context", old_context)
 
-            # Apply updates
-            for key, value in kwargs.items():
-                if key == "status" and value == "done" and task.status != "done":
-                    task.done_date = _today()
-                elif key == "status" and value == "cancelled" and task.status != "cancelled":
-                    task.cancelled_date = _today()
-                if hasattr(task, key) and value is not None:
-                    setattr(task, key, value)
+            def apply(t: Task) -> Task:
+                for key, value in kwargs.items():
+                    if key == "status" and value == "done" and t.status != "done":
+                        t.done_date = _today()
+                    elif key == "status" and value == "cancelled" and t.status != "cancelled":
+                        t.cancelled_date = _today()
+                    if hasattr(t, key) and value is not None:
+                        setattr(t, key, value)
+                if fields_patch:
+                    merged = dict(t.fields)
+                    for k, v in fields_patch.items():
+                        if v is None:
+                            merged.pop(k, None)
+                        else:
+                            merged[k] = v
+                    t.fields = merged
+                t.updated_at = _now_iso()
+                return t
 
-            # Context change = move between files
             if new_context != old_context:
+                task = apply(current)
                 self._move_task_between_files(task, old_context, new_context)
+                self._tasks[task_id] = task
             else:
-                # Rewrite line in place
-                new_line = _format_task_line(task)
-                _replace_line_in_file(Path(task.source_file), task.line_number, new_line)
+                path = Path(current.source_file)
+
+                def compute() -> Task:
+                    return apply(self._tasks[task_id])
+
+                found, task = self._cas_rewrite(path, task_id, compute)
+                if not found:
+                    self._tasks.pop(task_id, None)
+                    self._last_written_line.pop(task_id, None)
+                    self._save_index()
+                    self._write_dashboard()
+                    return None
+                self._reposition_file(path)
 
             self._save_index()
             self._write_dashboard()
@@ -219,44 +337,58 @@ class TaskManager:
         from_norm = from_tag.lstrip("#").lower()
         to_norm = to_tag.lstrip("#")  # preserve operator-provided case
         with self._lock:
-            task = self._tasks.get(task_id)
-            if not task:
+            current = self._tasks.get(task_id)
+            if not current:
                 return False
+            if not any(t.lstrip("#").lower() == from_norm for t in current.tags):
+                return False
+
+            path = Path(current.source_file)
+
+            def compute() -> Task:
+                t = self._tasks[task_id]
+                try:
+                    idx = next(
+                        i for i, tag in enumerate(t.tags)
+                        if tag.lstrip("#").lower() == from_norm
+                    )
+                except StopIteration:
+                    raise _TagAbsentError()
+                new_tags = list(t.tags)
+                new_tags[idx] = to_norm
+                t.tags = new_tags
+                t.updated_at = _now_iso()
+                return t
 
             try:
-                idx = next(
-                    i for i, t in enumerate(task.tags)
-                    if t.lstrip("#").lower() == from_norm
-                )
-            except StopIteration:
+                found, task = self._cas_rewrite(path, task_id, compute)
+            except _TagAbsentError:
+                return False
+            if not found:
+                self._tasks.pop(task_id, None)
+                self._last_written_line.pop(task_id, None)
+                self._save_index()
+                self._write_dashboard()
                 return False
 
-            new_tags = list(task.tags)
-            new_tags[idx] = to_norm
-            task.tags = new_tags
-
-            new_line = _format_task_line(task)
-            _replace_line_in_file(Path(task.source_file), task.line_number, new_line)
+            self._reposition_file(path)
             self._save_index()
             self._write_dashboard()
             logger.info(f"swap_tag {task_id}: {from_norm} → {to_norm}")
             return True
 
     def delete(self, task_id: str) -> bool:
-        """Remove a task from its file and index."""
+        """Remove a task (and any notes body) from its file and index."""
         with self._lock:
             task = self._tasks.get(task_id)
             if not task:
                 return False
 
-            _remove_line_from_file(Path(task.source_file), task.line_number)
-
-            # Adjust line numbers for tasks in same file after deleted line
-            for t in self._tasks.values():
-                if t.source_file == task.source_file and t.line_number > task.line_number:
-                    t.line_number -= 1
-
-            del self._tasks[task_id]
+            path = Path(task.source_file)
+            self._cas_rewrite(path, task_id, lambda: None)
+            self._tasks.pop(task_id, None)
+            self._last_written_line.pop(task_id, None)
+            self._reposition_file(path)
             self._save_index()
             self._write_dashboard()
             logger.info(f"Deleted task {task_id}")
@@ -302,16 +434,44 @@ class TaskManager:
             for tag, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0].lower()))
         ]
 
+    def list_conflicts(self) -> list[dict]:
+        """List Syncthing conflict/temp files sitting in the tasks folder.
+
+        Never indexed as tasks and never reindexed — surfaced here so a
+        client (the board) can warn the operator to resolve them by hand.
+        """
+        if not self.tasks_dir.exists():
+            return []
+        results = []
+        for p in self.tasks_dir.iterdir():
+            if p.is_file() and is_conflict_file(p):
+                try:
+                    mtime = datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc).isoformat()
+                except OSError:
+                    continue
+                results.append({"name": p.name, "mtime": mtime})
+        results.sort(key=lambda r: r["mtime"], reverse=True)
+        return results
+
     # ------------------------------------------------------------------
     # Reindex
     # ------------------------------------------------------------------
 
     def reindex_file(self, file_path: str):
-        """Parse a single task file and update index entries for it."""
+        """Parse a single task file and update index entries for it.
+
+        Also performs id write-back (a task line lacking `<!-- id:.. -->`
+        gets one appended, minimally, with every other byte of the line and
+        every non-task line untouched) and external-edit detection (a task
+        line that no longer matches what the API last wrote gets a fresh
+        `[updated::]` stamp; every other line is left alone).
+        """
         path = Path(file_path)
         # Dashboard.md is auto-generated; never index it as a task source.
         # (Also prevents a watcher feedback loop when we regenerate it below.)
         if path.name == "Dashboard.md":
+            return
+        if is_conflict_file(path):
             return
 
         if not path.exists():
@@ -326,49 +486,212 @@ class TaskManager:
             return
 
         with self._lock:
-            # Remove old entries for this file
-            to_remove = [tid for tid, t in self._tasks.items() if t.source_file == str(path)]
-            for tid in to_remove:
-                del self._tasks[tid]
-
-            # Parse file
             try:
                 lines = path.read_text(encoding="utf-8").splitlines()
             except Exception as e:
                 logger.warning(f"Could not read {file_path}: {e}")
                 return
 
-            for line_num, line in enumerate(lines, start=1):
-                task = _parse_task_line(line, str(path), line_num)
-                if task:
-                    self._tasks[task.id] = task
+            new_lines, file_tasks, rewrite_needed = self._reparse_lines(lines, str(path), self._tasks)
+
+            if rewrite_needed:
+                atomic_write_lines(path, new_lines)
+
+            to_remove = [tid for tid, t in self._tasks.items() if t.source_file == str(path)]
+            for tid in to_remove:
+                del self._tasks[tid]
+                self._last_written_line.pop(tid, None)
+            self._tasks.update(file_tasks)
 
             self._save_index()
             self._write_dashboard()
 
     def rebuild_index(self):
         """Full re-parse of all LifeOS/Tasks/*.md files."""
-        self._tasks.clear()
-        if not self.tasks_dir.exists():
-            self._save_index()
-            return
+        prior = self._tasks
+        rebuilt: dict[str, Task] = {}
+        if self.tasks_dir.exists():
+            for md_file in sorted(self.tasks_dir.glob("*.md")):
+                if md_file.name == "Dashboard.md" or is_conflict_file(md_file):
+                    continue
+                try:
+                    lines = md_file.read_text(encoding="utf-8").splitlines()
+                except Exception as e:
+                    logger.warning(f"Could not read {md_file}: {e}")
+                    continue
+                new_lines, file_tasks, rewrite_needed = self._reparse_lines(lines, str(md_file), prior)
+                if rewrite_needed:
+                    atomic_write_lines(md_file, new_lines)
+                rebuilt.update(file_tasks)
 
-        for md_file in sorted(self.tasks_dir.glob("*.md")):
-            if md_file.name == "Dashboard.md":
-                continue
-            try:
-                lines = md_file.read_text(encoding="utf-8").splitlines()
-            except Exception as e:
-                logger.warning(f"Could not read {md_file}: {e}")
-                continue
-            for line_num, line in enumerate(lines, start=1):
-                task = _parse_task_line(line, str(md_file), line_num)
-                if task:
-                    self._tasks[task.id] = task
-
+        self._tasks = rebuilt
+        self._last_written_line = {
+            tid: line for tid, line in self._last_written_line.items() if tid in rebuilt
+        }
         self._save_index()
         self._write_dashboard()
         logger.info(f"Rebuilt task index: {len(self._tasks)} tasks")
+
+    def _reparse_lines(
+        self, lines: list[str], file_path: str, prior: dict[str, Task]
+    ) -> tuple[list[str], dict[str, Task], bool]:
+        """Parse `lines` (belonging to `file_path`) into fresh tasks.
+
+        Returns `(new_lines, tasks_for_this_file, rewrite_needed)`. Must be
+        called with `self._lock` held (reads `prior` for reminder_id merge-
+        forward, and `self._last_written_line` for external-edit detection).
+        A task lacking an id comment gets one appended to its raw line only
+        — nothing else about that line changes. A task whose raw line
+        differs from `self._last_written_line[task.id]` (the exact text we
+        last wrote or saw for it) is treated as an external edit: the parsed
+        values win and the line is rewritten with a fresh `[updated::]`
+        stamp. A task id with no prior record at all (first time this
+        process has seen it) is taken as-is, no restamp — there is nothing
+        to compare against. Every other line — task or not — is copied
+        through byte-for-byte.
+        """
+        out_lines: list[str] = []
+        file_tasks: dict[str, Task] = {}
+        rewrite_needed = False
+        idx, n = 0, len(lines)
+        while idx < n:
+            block = _match_task_block(lines, idx, file_path)
+            if block is None:
+                out_lines.append(lines[idx])
+                idx += 1
+                continue
+            end, task, had_id = block
+            raw_main_line = lines[idx]
+            body_lines = lines[idx + 1:end]
+
+            if had_id:
+                prior_task = prior.get(task.id)
+                if prior_task is not None and prior_task.reminder_id is not None and task.reminder_id is None:
+                    task.reminder_id = prior_task.reminder_id
+                last_written = self._last_written_line.get(task.id)
+                if last_written is not None and last_written != raw_main_line:
+                    task.updated_at = _now_iso()
+                    new_main_line = _format_task_line(task)
+                    out_lines.append(new_main_line)
+                    out_lines.extend(body_lines)
+                    rewrite_needed = True
+                    self._last_written_line[task.id] = new_main_line
+                else:
+                    out_lines.append(raw_main_line)
+                    out_lines.extend(body_lines)
+                    self._last_written_line[task.id] = raw_main_line
+            else:
+                new_main_line = raw_main_line.rstrip("\n") + f" <!-- id:{task.id} -->"
+                out_lines.append(new_main_line)
+                out_lines.extend(body_lines)
+                rewrite_needed = True
+                self._last_written_line[task.id] = new_main_line
+
+            file_tasks[task.id] = task
+            idx = end
+
+        return out_lines, file_tasks, rewrite_needed
+
+    # ------------------------------------------------------------------
+    # Compare-and-swap file writes (id-addressed)
+    # ------------------------------------------------------------------
+
+    def _cas_rewrite(
+        self, path: Path, task_id: str, compute: Callable[[], Optional[Task]]
+    ) -> tuple[bool, Optional[Task]]:
+        """Rewrite (or delete) the block for `task_id` in `path`.
+
+        `compute()` is invoked fresh on every attempt against the current
+        `self._tasks[task_id]` and returns the `Task` to write, or `None` to
+        delete the block. Protected by compare-and-swap on the file's mtime:
+        read mtime, read+locate the block, compute the new content, then
+        check the mtime again right before writing. A mismatch means a
+        concurrent external writer touched the file in between — reindex
+        (absorbing their change) and retry, up to `_CAS_MAX_RETRIES` times,
+        then raise `TaskConflictError`.
+
+        Returns `(found, task_or_none)`. `found=False` means the task's block
+        was not present in the file at all (e.g. externally deleted) — not a
+        CAS conflict, so the caller should reconcile rather than retry.
+        """
+        for attempt in range(_CAS_MAX_RETRIES + 1):
+            mtime_before = _mtime_or_none(path)
+            lines = _read_lines(path)
+            span = _find_task_block_span(lines, task_id)
+            if span is None:
+                return False, None
+            result = compute()
+            start, end = span
+            new_block = _format_task_block(result) if result is not None else []
+            new_lines = lines[:start] + new_block + lines[end:]
+            mtime_now = _mtime_or_none(path)
+            if mtime_now == mtime_before:
+                atomic_write_lines(path, new_lines)
+                if result is not None:
+                    self._tasks[task_id] = result
+                    self._last_written_line[task_id] = new_block[0]
+                else:
+                    self._last_written_line.pop(task_id, None)
+                return True, result
+            if attempt < _CAS_MAX_RETRIES:
+                self.reindex_file(str(path))
+                continue
+            raise TaskConflictError(f"Too many conflicting writes to {path}")
+        raise TaskConflictError(f"Too many conflicting writes to {path}")
+
+    def _cas_insert_at_top(self, path: Path, block: list[str]) -> int:
+        """Insert `block` above the first existing task block. Returns its
+        1-indexed start line. CAS-protected: re-reads the file and retries
+        on a concurrent external write, up to `_CAS_MAX_RETRIES` times."""
+        for attempt in range(_CAS_MAX_RETRIES + 1):
+            mtime_before = _mtime_or_none(path)
+            content = path.read_text(encoding="utf-8") if path.exists() else ""
+            lines = content.splitlines()
+
+            first_idx = None
+            idx, n = 0, len(lines)
+            while idx < n:
+                b = _match_task_block(lines, idx, str(path))
+                if b is not None:
+                    first_idx = idx
+                    break
+                idx += 1
+
+            if first_idx is None:
+                new_lines = lines + block if lines else list(block)
+                insert_at = len(lines) + 1
+            else:
+                new_lines = lines[:first_idx] + block + lines[first_idx:]
+                insert_at = first_idx + 1
+
+            mtime_now = _mtime_or_none(path)
+            if mtime_now == mtime_before:
+                atomic_write_lines(path, new_lines)
+                return insert_at
+            if attempt >= _CAS_MAX_RETRIES:
+                raise TaskConflictError(f"Too many conflicting writes to {path}")
+        raise TaskConflictError(f"Too many conflicting writes to {path}")
+
+    def _reposition_file(self, path: Path):
+        """Refresh `source_file`/`line_number` for every known task in `path`
+        from its current on-disk content. Purely informational bookkeeping —
+        writes never address by these fields, only by id."""
+        if not path.exists():
+            return
+        lines = _read_lines(path)
+        idx, n = 0, len(lines)
+        while idx < n:
+            block = _match_task_block(lines, idx, str(path))
+            if block is None:
+                idx += 1
+                continue
+            end, task, had_id = block
+            if had_id:
+                existing = self._tasks.get(task.id)
+                if existing is not None:
+                    existing.source_file = str(path)
+                    existing.line_number = idx + 1
+            idx = end
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -382,26 +705,24 @@ class TaskManager:
                 f"---\ntype: tasks\ncontext: {context.lower()}\n---\n"
                 f"# {context} Tasks\n\n"
             )
-            file_path.write_text(template, encoding="utf-8")
+            atomic_write_text(file_path, template)
         return file_path
 
     def _move_task_between_files(self, task: Task, old_context: str, new_context: str):
-        """Remove from old file, append to new file."""
+        """Remove from old file, append (at top) to new file."""
         old_path = Path(task.source_file)
-        _remove_line_from_file(old_path, task.line_number)
-
-        # Adjust line numbers for tasks in old file after removed line
-        for t in self._tasks.values():
-            if t.source_file == str(old_path) and t.line_number > task.line_number:
-                t.line_number -= 1
+        self._cas_rewrite(old_path, task.id, lambda: None)
+        self._reposition_file(old_path)
 
         new_path = self._get_context_file(new_context)
-        new_line = _format_task_line(task)
-        _append_to_file(new_path, new_line)
+        block = _format_task_block(task)
+        start_line = self._cas_insert_at_top(new_path, block)
 
         task.source_file = str(new_path)
-        task.line_number = _count_lines(new_path)
+        task.line_number = start_line
         task.context = new_context
+        self._last_written_line[task.id] = block[0]
+        self._reposition_file(new_path)
 
     def _write_dashboard(self):
         """Regenerate Dashboard.md from current task state.
@@ -420,7 +741,7 @@ class TaskManager:
                 return  # No-op write avoids triggering watchers
         except Exception:
             pass
-        dashboard.write_text(content, encoding="utf-8")
+        atomic_write_text(dashboard, content)
 
     def _build_dashboard_content(self) -> str:
         tasks = list(self._tasks.values())
@@ -562,16 +883,18 @@ class TaskManager:
 # Module-level helpers (pure functions)
 # ======================================================================
 
-# Regex for parsing a task line
-_TASK_LINE_RE = re.compile(
-    r'^- \[(.)\] TODO\s+'   # checkbox + TODO keyword
-    r'(.+?)'                # description (non-greedy)
-    r'\s*$'                  # end of line
-)
-
 _INLINE_FIELD_RE = re.compile(r'\[(\w+)::\s*([^\]]*)\]')
 _TAG_RE = re.compile(r'#([\w-]+)')
 _ID_RE = re.compile(r'<!--\s*id:(\w+)\s*-->')
+# Any checkbox line counts as a task line — the literal "TODO" keyword is no
+# longer required to parse (kept only because _format_task_line still emits
+# it, for backward compatibility with existing vault content and the
+# Obsidian Tasks dashboard queries in Dashboard.md).
+_CHECKBOX_RE = re.compile(r'^- \[(.)\]\s+(?:TODO\s+)?')
+# Notes body: an indented blockquote line directly beneath a task line,
+# exactly like a scheduler entry's message_content body.
+_BODY_LINE_RE = re.compile(r'^\s+>\s?(.*)$')
+_BODY_INDENT = "    "
 
 
 def _format_task_line(task: Task) -> str:
@@ -584,11 +907,21 @@ def _format_task_line(task: Task) -> str:
         parts.append(f"[due:: {task.due_date}]")
     if task.priority:
         parts.append(f"[priority:: {task.priority}]")
-    parts.append(f"[created:: {task.created_date}]")
+    # Omitted (not emitted as an empty field) when unset, e.g. a hand-
+    # authored line that only just got its id minted on reindex — a task
+    # created through the API always has one (create() sets it to today).
+    if task.created_date:
+        parts.append(f"[created:: {task.created_date}]")
     if task.done_date:
         parts.append(f"[done:: {task.done_date}]")
     if task.cancelled_date:
         parts.append(f"[cancelled:: {task.cancelled_date}]")
+    if task.updated_at:
+        parts.append(f"[updated:: {task.updated_at}]")
+
+    # Operator + unknown fields round-trip in their original order.
+    for key, value in task.fields.items():
+        parts.append(f"[{key}:: {value}]")
 
     # Tags
     for tag in task.tags:
@@ -601,17 +934,33 @@ def _format_task_line(task: Task) -> str:
     return " ".join(parts)
 
 
+def _format_task_block(task: Task) -> list[str]:
+    """Task → its markdown checkbox line plus an indented ``> `` blockquote
+    body carrying `notes` (one line per content line). Empty notes emit no
+    body lines."""
+    lines = [_format_task_line(task)]
+    if task.notes:
+        for content_line in task.notes.split("\n"):
+            lines.append(f"{_BODY_INDENT}> {content_line}" if content_line else f"{_BODY_INDENT}>")
+    return lines
+
+
 def _parse_task_line(line: str, file_path: str, line_num: int) -> Optional[Task]:
-    """Parse one checkbox line into a Task, or None if not a task line."""
-    # Must be a checkbox line with TODO keyword
-    m = re.match(r'^- \[(.)\]\s+TODO\s+', line)
+    """Parse one checkbox line into a Task, or None if not a checkbox line.
+
+    The literal "TODO" keyword is optional — any `- [.] ...` checkbox line
+    counts as a task (see module docstring / docs/specs/technical/
+    task-management.md). A missing id gets a fresh one minted here; the
+    caller (reindex) is responsible for writing that id back to disk so it's
+    stable on the next parse.
+    """
+    m = _CHECKBOX_RE.match(line)
     if not m:
         return None
 
     symbol = m.group(1)
     status = SYMBOL_TO_STATUS.get(symbol, "todo")
 
-    # Extract the rest after "- [x] TODO "
     rest = line[m.end():]
 
     # Extract ID
@@ -619,9 +968,10 @@ def _parse_task_line(line: str, file_path: str, line_num: int) -> Optional[Task]
     task_id = id_match.group(1) if id_match else uuid.uuid4().hex[:8]
 
     # Extract inline fields
-    fields = {}
+    raw_fields = {}
     for fm in _INLINE_FIELD_RE.finditer(rest):
-        fields[fm.group(1)] = fm.group(2).strip()
+        raw_fields[fm.group(1)] = fm.group(2).strip()
+    extra_fields = {k: v for k, v in raw_fields.items() if k not in _KNOWN_FIELD_KEYS}
 
     # Extract tags
     tags = _TAG_RE.findall(rest)
@@ -641,69 +991,58 @@ def _parse_task_line(line: str, file_path: str, line_num: int) -> Optional[Task]
         description=desc,
         status=status,
         context=context,
-        priority=fields.get("priority", ""),
-        due_date=fields.get("due") or None,
-        created_date=fields.get("created", ""),
-        done_date=fields.get("done") or None,
-        cancelled_date=fields.get("cancelled") or None,
+        priority=raw_fields.get("priority", ""),
+        due_date=raw_fields.get("due") or None,
+        created_date=raw_fields.get("created", ""),
+        done_date=raw_fields.get("done") or None,
+        cancelled_date=raw_fields.get("cancelled") or None,
+        updated_at=raw_fields.get("updated") or None,
         tags=tags,
+        fields=extra_fields,
         source_file=file_path,
         line_number=line_num,
     )
 
 
-def _append_to_file(path: Path, line: str):
-    """Append a task line to file, ensuring newline before if needed."""
-    content = path.read_text(encoding="utf-8") if path.exists() else ""
-    if content and not content.endswith("\n"):
-        content += "\n"
-    content += line + "\n"
-    path.write_text(content, encoding="utf-8")
-
-
-def _insert_task_at_top(path: Path, line: str) -> int:
-    """Insert a task line above the existing first task. Returns its 1-indexed line number.
-
-    If the file has no tasks yet, appends after the header block.
-    """
-    content = path.read_text(encoding="utf-8") if path.exists() else ""
-    lines = content.splitlines()
-
-    first_task_idx = None  # 0-indexed
-    for i, existing in enumerate(lines):
-        if _parse_task_line(existing, "", i + 1) is not None:
-            first_task_idx = i
+def _match_task_block(
+    lines: list[str], idx: int, file_path: str = ""
+) -> Optional[tuple[int, Task, bool]]:
+    """If `lines[idx]` is a task line, parse it (and any body lines
+    immediately following) and return `(end, task, had_id)` — `end` is the
+    exclusive index just past the block, `had_id` says whether the raw line
+    already carried an `<!-- id:.. -->` comment. Returns None if `lines[idx]`
+    is not a task line."""
+    task = _parse_task_line(lines[idx], file_path, idx + 1)
+    if task is None:
+        return None
+    had_id = bool(_ID_RE.search(lines[idx]))
+    j, n = idx + 1, len(lines)
+    body = []
+    while j < n:
+        m = _BODY_LINE_RE.match(lines[j])
+        if not m:
             break
-
-    if first_task_idx is None:
-        # No tasks yet — append at end
-        _append_to_file(path, line)
-        return len(path.read_text(encoding="utf-8").splitlines())
-
-    new_lines = lines[:first_task_idx] + [line] + lines[first_task_idx:]
-    path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
-    return first_task_idx + 1
+        body.append(m.group(1))
+        j += 1
+    if body:
+        task.notes = "\n".join(body)
+    return j, task, had_id
 
 
-def _replace_line_in_file(path: Path, line_num: int, new_line: str):
-    """Replace a specific line (1-indexed) in a file."""
-    lines = path.read_text(encoding="utf-8").splitlines()
-    if 1 <= line_num <= len(lines):
-        lines[line_num - 1] = new_line
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def _remove_line_from_file(path: Path, line_num: int):
-    """Remove a specific line (1-indexed) from a file."""
-    lines = path.read_text(encoding="utf-8").splitlines()
-    if 1 <= line_num <= len(lines):
-        del lines[line_num - 1]
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def _count_lines(path: Path) -> int:
-    """Count lines in a file."""
-    return len(path.read_text(encoding="utf-8").splitlines())
+def _find_task_block_span(lines: list[str], task_id: str) -> Optional[tuple[int, int]]:
+    """Return the `(start, end)` line span of the block carrying `task_id`'s
+    id comment, or None if not found."""
+    idx, n = 0, len(lines)
+    while idx < n:
+        block = _match_task_block(lines, idx)
+        if block is None:
+            idx += 1
+            continue
+        end, task, had_id = block
+        if had_id and task.id == task_id:
+            return idx, end
+        idx = end
+    return None
 
 
 def _fuzzy_filter(tasks: list[Task], query: str) -> list[Task]:

--- a/api/services/task_manager.py
+++ b/api/services/task_manager.py
@@ -619,6 +619,13 @@ class TaskManager:
                     logger.warning(f"Could not read {file_path}: {e}")
                     return
 
+                # Snapshot before this attempt's parse so an abandoned
+                # attempt (retry or final skip below) can't leave behind
+                # `_last_written_line` entries seeded from a parse that
+                # never reached disk — those would let a later CAS check
+                # believe an unwritten (possibly re-minted) id's line is
+                # the last-known-good one.
+                last_written_snapshot = dict(self._last_written_line)
                 new_lines, file_tasks, rewrite_needed = self._reparse_lines(
                     lines, str(path), self._tasks
                 )
@@ -629,12 +636,18 @@ class TaskManager:
                 if mtime_now == mtime_before:
                     atomic_write_lines(path, new_lines, newline=newline, trailing_newline=trailing_newline)
                     break
+                self._last_written_line = last_written_snapshot
                 if attempt >= _CAS_MAX_RETRIES:
                     logger.warning(
                         f"reindex_file: persistent write conflict on {file_path}; "
                         "skipping the id/restamp write-back this pass"
                     )
-                    break
+                    # Abandon entirely — do not merge this parse's tasks
+                    # (some ids may have been freshly minted and never
+                    # written to disk) into the index, and do not touch
+                    # the index file or dashboard. The watcher will fire
+                    # again for whatever caused the conflict.
+                    return
                 # Someone else wrote in between — re-read and re-parse
                 # against the freshest content on the next attempt.
 
@@ -656,9 +669,22 @@ class TaskManager:
             self._write_dashboard()
 
     def rebuild_index(self):
-        """Full re-parse of all LifeOS/Tasks/*.md files."""
+        """Full re-parse of all LifeOS/Tasks/*.md files.
+
+        Ids are deduplicated across the whole rebuild, not just within a
+        single file: `seen_ids` threads forward so a task carrying an id
+        already claimed by an earlier file in this same pass is treated
+        exactly like a same-file duplicate (fresh id minted, old comment
+        stripped) rather than letting the last file parsed silently win in
+        `self._tasks`. A single-file `reindex_file` cannot make this call —
+        it has no way to tell a genuine cross-file duplicate from an
+        operator cutting a task line out of one file and pasting it into
+        another — so it always passes no `seen_ids` and keeps its existing
+        single-file semantics.
+        """
         prior = self._tasks
         rebuilt: dict[str, Task] = {}
+        seen_ids: set[str] = set()
         if self.tasks_dir.exists():
             for md_file in sorted(self.tasks_dir.glob("*.md")):
                 if md_file.name == "Dashboard.md" or is_conflict_file(md_file):
@@ -668,10 +694,13 @@ class TaskManager:
                 except Exception as e:
                     logger.warning(f"Could not read {md_file}: {e}")
                     continue
-                new_lines, file_tasks, rewrite_needed = self._reparse_lines(lines, str(md_file), prior)
+                new_lines, file_tasks, rewrite_needed = self._reparse_lines(
+                    lines, str(md_file), prior, seen_ids
+                )
                 if rewrite_needed:
                     atomic_write_lines(md_file, new_lines, newline=newline, trailing_newline=trailing_newline)
                 rebuilt.update(file_tasks)
+                seen_ids.update(file_tasks.keys())
 
         self._tasks = rebuilt
         self._last_written_line = {
@@ -682,7 +711,11 @@ class TaskManager:
         logger.info(f"Rebuilt task index: {len(self._tasks)} tasks")
 
     def _reparse_lines(
-        self, lines: list[str], file_path: str, prior: dict[str, Task]
+        self,
+        lines: list[str],
+        file_path: str,
+        prior: dict[str, Task],
+        seen_ids: Optional[set[str]] = None,
     ) -> tuple[list[str], dict[str, Task], bool]:
         """Parse `lines` (belonging to `file_path`) into fresh tasks.
 
@@ -699,10 +732,13 @@ class TaskManager:
         to compare against. Every other line — task or not — is copied
         through byte-for-byte. A checkbox line inside a fenced (``` or ~~~)
         code block is never a task line (see `_iter_lines_with_fence_state`).
-        A second block in this same file carrying an id already claimed
-        earlier in this parse is treated as if it had no id at all — its
+        A second block carrying an id already claimed earlier in this parse
+        (same-file duplicate), or already present in the caller-supplied
+        `seen_ids` (a cross-file duplicate from an earlier file in the same
+        `rebuild_index` pass — `None` when called from `reindex_file`, which
+        only ever sees one file), is treated as if it had no id at all — its
         stale/duplicated comment is replaced with a freshly minted one,
-        rather than left to fight the first occurrence for the same id on
+        rather than left to fight the earlier occurrence for the same id on
         every future parse.
         """
         out_lines: list[str] = []
@@ -724,7 +760,9 @@ class TaskManager:
             raw_main_line = lines[idx]
             body_lines = lines[idx + 1:end]
 
-            if had_id and task.id in file_tasks:
+            if had_id and (
+                task.id in file_tasks or (seen_ids is not None and task.id in seen_ids)
+            ):
                 had_id = False
                 task.id = uuid.uuid4().hex[:8]
                 raw_main_line = _ID_RE.sub("", raw_main_line).rstrip()
@@ -929,15 +967,30 @@ class TaskManager:
         raises (a source-side conflict, after the insert already
         succeeded), best-effort removes the just-inserted destination block
         before re-raising, so the task isn't left duplicated in both files.
+
+        `self._last_written_line[task.id]` is updated to the destination's
+        just-written line immediately after the insert succeeds, so that if
+        the best-effort rollback runs, its own `_external_edit_pending`
+        check compares against the destination content it should — not a
+        stale pointer at the source line — and never mistakes the freshly
+        inserted block for an unabsorbed external edit. If the rollback
+        still can't restore clean state, `self._tasks`/`_last_written_line`
+        are reset to their pre-move values before the original exception is
+        re-raised, so the index is never left pointing at a file with no
+        block for this id while the block survives intact elsewhere.
         """
         old_path = Path(task.source_file)
         old_lines = _read_lines(old_path)
         if _find_task_block_span(old_lines, task.id) is None:
             return False
 
+        prev_task = self._tasks.get(task.id)
+        prev_line = self._last_written_line.get(task.id)
+
         new_path = self._get_context_file(new_context)
         block = _format_task_block(task)
         start_line = self._cas_insert_at_top(new_path, block)
+        self._last_written_line[task.id] = block[0]
 
         try:
             self._cas_rewrite(old_path, task.id, lambda: None)
@@ -946,6 +999,12 @@ class TaskManager:
                 self._cas_rewrite(new_path, task.id, lambda: None)
             except TaskConflictError:
                 pass
+            if prev_task is not None:
+                self._tasks[task.id] = prev_task
+            if prev_line is not None:
+                self._last_written_line[task.id] = prev_line
+            else:
+                self._last_written_line.pop(task.id, None)
             raise
         self._reposition_file(old_path)
 

--- a/api/services/task_manager.py
+++ b/api/services/task_manager.py
@@ -969,11 +969,15 @@ class TaskManager:
         before re-raising, so the task isn't left duplicated in both files.
 
         `self._last_written_line[task.id]` is updated to the destination's
-        just-written line immediately after the insert succeeds, so that if
-        the best-effort rollback runs, its own `_external_edit_pending`
-        check compares against the destination content it should — not a
-        stale pointer at the source line — and never mistakes the freshly
-        inserted block for an unabsorbed external edit. If the rollback
+        just-written line only if the source-side removal raises (right
+        before the best-effort rollback), so that rollback's own
+        `_external_edit_pending` check compares against the destination
+        content it should — not a stale pointer at the source line — and
+        never mistakes the freshly inserted block for an unabsorbed
+        external edit. Leaving the pointer at the source line during the
+        ordinary (non-conflict) path avoids a spurious mismatch against the
+        untouched source line, which would otherwise trigger a needless
+        reindex and extra write on every ordinary move. If the rollback
         still can't restore clean state, `self._tasks`/`_last_written_line`
         are reset to their pre-move values before the original exception is
         re-raised, so the index is never left pointing at a file with no
@@ -990,11 +994,11 @@ class TaskManager:
         new_path = self._get_context_file(new_context)
         block = _format_task_block(task)
         start_line = self._cas_insert_at_top(new_path, block)
-        self._last_written_line[task.id] = block[0]
 
         try:
             self._cas_rewrite(old_path, task.id, lambda: None)
         except TaskConflictError:
+            self._last_written_line[task.id] = block[0]
             try:
                 self._cas_rewrite(new_path, task.id, lambda: None)
             except TaskConflictError:

--- a/api/services/task_manager.py
+++ b/api/services/task_manager.py
@@ -19,6 +19,7 @@ reindexes. ``line_number``/``source_file`` on ``Task`` remain informational
 
 See docs/specs/technical/task-management.md for the full design.
 """
+import copy
 import json
 import logging
 import re
@@ -56,9 +57,61 @@ VALID_STATUSES = set(STATUS_TO_SYMBOL.keys())
 # without parser changes.
 _KNOWN_FIELD_KEYS = {"due", "priority", "created", "done", "cancelled", "updated"}
 
+# Field keys that already address a dedicated Task attribute (or the id
+# comment itself) — accepting them through the free-form `fields` dict would
+# let a caller write a second, conflicting `[key:: value]` onto the line, or
+# forge `[id:: ...]`/`[updated:: ...]` outright. Rejected by
+# `_validate_text_fields`.
+_RESERVED_FIELD_KEYS = _KNOWN_FIELD_KEYS | {"id"}
+_FIELD_KEY_RE = re.compile(r"^\w+$")
+
 # Retries after an initial write attempt that loses a compare-and-swap race
 # against a concurrent external edit (see TaskManager._cas_rewrite).
 _CAS_MAX_RETRIES = 3
+
+
+def _validate_text_fields(
+    description: Optional[str] = None,
+    notes: Optional[str] = None,
+    fields: Optional[dict] = None,
+) -> None:
+    """Reject description/notes/fields content that would corrupt the task
+    line's format or hijack another task's id comment when written back.
+
+    A newline in `description` or a `fields` value would split the single
+    checkbox line; a `]` would truncate an inline field and leak the rest
+    into the description; an HTML comment opener (`<!--`) could forge a new
+    `<!-- id:.. -->`, hijacking another task's id on the next reindex. Notes
+    lines are allowed to be multi-line (that's their whole point) but not
+    `\\r` (would desync from the `\\n`-joined body) or `<!--`. A `fields` key
+    must be a bare word (`_format_task_line` interpolates it directly as
+    `[key:: value]`) and must not shadow a reserved key (see
+    `_RESERVED_FIELD_KEYS`).
+
+    Raises `ValueError` — never silently truncates or strips, since that
+    would surprise the caller by saving something other than what was sent.
+    The route layer maps `ValueError` to HTTP 422.
+    """
+    if description is not None:
+        for bad in ("\n", "\r", "]", "<!--"):
+            if bad in description:
+                raise ValueError(f"description must not contain {bad!r}")
+    if notes is not None:
+        for line in notes.split("\n"):
+            for bad in ("\r", "<!--"):
+                if bad in line:
+                    raise ValueError(f"notes must not contain {bad!r}")
+    if fields:
+        for key, value in fields.items():
+            if not _FIELD_KEY_RE.match(key):
+                raise ValueError(f"invalid fields key {key!r}: must match ^\\w+$")
+            if key in _RESERVED_FIELD_KEYS:
+                raise ValueError(f"'{key}' is a reserved field and cannot be set via fields")
+            if value is None:
+                continue
+            for bad in ("\n", "\r", "]", "<!--"):
+                if bad in value:
+                    raise ValueError(f"fields[{key!r}] must not contain {bad!r}")
 
 
 class TaskConflictError(Exception):
@@ -127,9 +180,30 @@ def _read_lines(path: Path) -> list[str]:
     return []
 
 
+def _read_lines_with_terminator(path: Path) -> tuple[list[str], str, bool]:
+    """Read `path` split into lines (terminators stripped) plus its detected
+    line terminator and whether it ended with a trailing terminator — both
+    needed to preserve a file's original formatting across a rewrite that
+    only touches a few lines. Reads raw bytes (not `Path.read_text`, whose
+    text-mode universal-newline translation would silently turn CRLF into
+    LF before we ever got a look at it). Missing/empty file → ([], "\n",
+    True), matching the append-a-trailing-newline default most vault files
+    already have."""
+    if not path.exists():
+        return [], "\n", True
+    raw = path.read_bytes()
+    if not raw:
+        return [], "\n", True
+    newline = "\r\n" if b"\r\n" in raw else "\n"
+    trailing_newline = raw.endswith(newline.encode("ascii"))
+    return raw.decode("utf-8").splitlines(), newline, trailing_newline
+
+
 # Syncthing conflict copies and temp files: never indexed as a task source,
 # never trigger or survive a reindex. Exposed read-only via list_conflicts().
-_CONFLICT_RE = re.compile(r"\.sync-conflict-\d{8}-\d{6}")
+# Matches the substring regardless of the timestamp/suffix that follows it,
+# per the criterion "*.sync-conflict-*" (not just Syncthing's own format).
+_CONFLICT_RE = re.compile(r"\.sync-conflict-")
 
 
 def is_conflict_file(path: Path) -> bool:
@@ -225,7 +299,18 @@ class TaskManager:
         notes: Optional[str] = None,
         fields: Optional[dict[str, str]] = None,
     ) -> Task:
-        """Create a new task at the top of its context file, update index."""
+        """Create a new task at the top of its context file, update index.
+
+        Raises `ValueError` (-> HTTP 422 at the route layer) for an
+        unrecognized `status`, or for `description`/`notes`/`fields` content
+        that would corrupt the task line or hijack another task's id — see
+        `_validate_text_fields`.
+        """
+        if status is not None and status not in VALID_STATUSES:
+            raise ValueError(
+                f"Invalid status '{status}'. Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+            )
+        _validate_text_fields(description=description, notes=notes, fields=fields)
         with self._lock:
             task = Task(
                 id=uuid.uuid4().hex[:8],
@@ -272,8 +357,19 @@ class TaskManager:
         """Update a task. Supports: description, status, context, priority,
         due_date, tags, notes, fields. `fields={"k": None}` removes key `k`;
         `fields={"k": "v"}` sets it. Raises `TaskConflictError` (-> HTTP 409)
-        if the write keeps losing the CAS race against a concurrent edit."""
+        if the write keeps losing the CAS race against a concurrent edit;
+        `ValueError` (-> HTTP 422) for an unrecognized `status` or hostile
+        `description`/`notes`/`fields` content — see `_validate_text_fields`.
+        """
         fields_patch = kwargs.pop("fields", None)
+        if "status" in kwargs and kwargs["status"] is not None and kwargs["status"] not in VALID_STATUSES:
+            raise ValueError(
+                f"Invalid status '{kwargs['status']}'. "
+                f"Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+            )
+        _validate_text_fields(
+            description=kwargs.get("description"), notes=kwargs.get("notes"), fields=fields_patch
+        )
         with self._lock:
             current = self._tasks.get(task_id)
             if not current:
@@ -283,6 +379,13 @@ class TaskManager:
             new_context = kwargs.get("context", old_context)
 
             def apply(t: Task) -> Task:
+                # Copy first — `t` is `self._tasks[task_id]` itself, and this
+                # closure is invoked fresh on every CAS retry via `compute()`
+                # (see `_cas_rewrite`). Mutating it in place would make a
+                # losing attempt's edits visible through `self.get(task_id)`
+                # immediately, even though nothing was ever persisted; only
+                # the CAS success branch below may rebind `self._tasks`.
+                t = copy.copy(t)
                 for key, value in kwargs.items():
                     if key == "status" and value == "done" and t.status != "done":
                         t.done_date = _today()
@@ -303,7 +406,17 @@ class TaskManager:
 
             if new_context != old_context:
                 task = apply(current)
-                self._move_task_between_files(task, old_context, new_context)
+                moved = self._move_task_between_files(task, old_context, new_context)
+                if not moved:
+                    # Task's block is no longer in its source file (an
+                    # external delete raced us) — reconcile like the
+                    # same-context branch does for `found=False` below,
+                    # rather than raising.
+                    self._tasks.pop(task_id, None)
+                    self._last_written_line.pop(task_id, None)
+                    self._save_index()
+                    self._write_dashboard()
+                    return None
                 self._tasks[task_id] = task
             else:
                 path = Path(current.source_file)
@@ -354,11 +467,16 @@ class TaskManager:
                     )
                 except StopIteration:
                     raise _TagAbsentError()
+                # Copy first, same reasoning as `update.apply` — `t` is
+                # `self._tasks[task_id]` itself, and this closure runs fresh
+                # on every CAS retry; only the success branch in
+                # `_cas_rewrite` may rebind `self._tasks`.
+                new_task = copy.copy(t)
                 new_tags = list(t.tags)
                 new_tags[idx] = to_norm
-                t.tags = new_tags
-                t.updated_at = _now_iso()
-                return t
+                new_task.tags = new_tags
+                new_task.updated_at = _now_iso()
+                return new_task
 
             try:
                 found, task = self._cas_rewrite(path, task_id, compute)
@@ -464,7 +582,12 @@ class TaskManager:
         gets one appended, minimally, with every other byte of the line and
         every non-task line untouched) and external-edit detection (a task
         line that no longer matches what the API last wrote gets a fresh
-        `[updated::]` stamp; every other line is left alone).
+        `[updated::]` stamp; every other line is left alone). The write-back
+        (if any) is itself CAS-protected on the file's mtime, bounded to
+        `_CAS_MAX_RETRIES` re-read-and-reparse attempts; on persistent
+        conflict it logs a warning and skips the write for this pass rather
+        than raising — the watcher will fire again for whatever caused the
+        conflict.
         """
         path = Path(file_path)
         # Dashboard.md is auto-generated; never index it as a task source.
@@ -480,24 +603,50 @@ class TaskManager:
                 to_remove = [tid for tid, t in self._tasks.items() if t.source_file == str(path)]
                 for tid in to_remove:
                     del self._tasks[tid]
+                    self._last_written_line.pop(tid, None)
                 if to_remove:
                     self._save_index()
                     self._write_dashboard()
             return
 
         with self._lock:
-            try:
-                lines = path.read_text(encoding="utf-8").splitlines()
-            except Exception as e:
-                logger.warning(f"Could not read {file_path}: {e}")
-                return
+            file_tasks: dict[str, Task] = {}
+            for attempt in range(_CAS_MAX_RETRIES + 1):
+                mtime_before = _mtime_or_none(path)
+                try:
+                    lines, newline, trailing_newline = _read_lines_with_terminator(path)
+                except Exception as e:
+                    logger.warning(f"Could not read {file_path}: {e}")
+                    return
 
-            new_lines, file_tasks, rewrite_needed = self._reparse_lines(lines, str(path), self._tasks)
+                new_lines, file_tasks, rewrite_needed = self._reparse_lines(
+                    lines, str(path), self._tasks
+                )
+                if not rewrite_needed:
+                    break
 
-            if rewrite_needed:
-                atomic_write_lines(path, new_lines)
+                mtime_now = _mtime_or_none(path)
+                if mtime_now == mtime_before:
+                    atomic_write_lines(path, new_lines, newline=newline, trailing_newline=trailing_newline)
+                    break
+                if attempt >= _CAS_MAX_RETRIES:
+                    logger.warning(
+                        f"reindex_file: persistent write conflict on {file_path}; "
+                        "skipping the id/restamp write-back this pass"
+                    )
+                    break
+                # Someone else wrote in between — re-read and re-parse
+                # against the freshest content on the next attempt.
 
-            to_remove = [tid for tid, t in self._tasks.items() if t.source_file == str(path)]
+            # Only tasks NOT present in this parse are gone from this file —
+            # everything `_reparse_lines` just repopulated must survive, or
+            # every reindex would immediately forget the external edit it
+            # was meant to detect (a task restamped this pass would vanish
+            # from the index a moment after being restamped).
+            to_remove = [
+                tid for tid, t in self._tasks.items()
+                if t.source_file == str(path) and tid not in file_tasks
+            ]
             for tid in to_remove:
                 del self._tasks[tid]
                 self._last_written_line.pop(tid, None)
@@ -515,13 +664,13 @@ class TaskManager:
                 if md_file.name == "Dashboard.md" or is_conflict_file(md_file):
                     continue
                 try:
-                    lines = md_file.read_text(encoding="utf-8").splitlines()
+                    lines, newline, trailing_newline = _read_lines_with_terminator(md_file)
                 except Exception as e:
                     logger.warning(f"Could not read {md_file}: {e}")
                     continue
                 new_lines, file_tasks, rewrite_needed = self._reparse_lines(lines, str(md_file), prior)
                 if rewrite_needed:
-                    atomic_write_lines(md_file, new_lines)
+                    atomic_write_lines(md_file, new_lines, newline=newline, trailing_newline=trailing_newline)
                 rebuilt.update(file_tasks)
 
         self._tasks = rebuilt
@@ -548,13 +697,24 @@ class TaskManager:
         stamp. A task id with no prior record at all (first time this
         process has seen it) is taken as-is, no restamp — there is nothing
         to compare against. Every other line — task or not — is copied
-        through byte-for-byte.
+        through byte-for-byte. A checkbox line inside a fenced (``` or ~~~)
+        code block is never a task line (see `_iter_lines_with_fence_state`).
+        A second block in this same file carrying an id already claimed
+        earlier in this parse is treated as if it had no id at all — its
+        stale/duplicated comment is replaced with a freshly minted one,
+        rather than left to fight the first occurrence for the same id on
+        every future parse.
         """
         out_lines: list[str] = []
         file_tasks: dict[str, Task] = {}
         rewrite_needed = False
+        fence = dict(_iter_lines_with_fence_state(lines))
         idx, n = 0, len(lines)
         while idx < n:
+            if fence.get(idx):
+                out_lines.append(lines[idx])
+                idx += 1
+                continue
             block = _match_task_block(lines, idx, file_path)
             if block is None:
                 out_lines.append(lines[idx])
@@ -563,6 +723,11 @@ class TaskManager:
             end, task, had_id = block
             raw_main_line = lines[idx]
             body_lines = lines[idx + 1:end]
+
+            if had_id and task.id in file_tasks:
+                had_id = False
+                task.id = uuid.uuid4().hex[:8]
+                raw_main_line = _ID_RE.sub("", raw_main_line).rstrip()
 
             if had_id:
                 prior_task = prior.get(task.id)
@@ -613,20 +778,38 @@ class TaskManager:
         Returns `(found, task_or_none)`. `found=False` means the task's block
         was not present in the file at all (e.g. externally deleted) — not a
         CAS conflict, so the caller should reconcile rather than retry.
+
+        Before computing the replacement, also checks whether the on-disk
+        block reflects an edit `reindex_file` hasn't absorbed yet — the raw
+        line differs from the last line the API wrote/saw, or the on-disk
+        notes body differs from the in-memory task's. Under the watcher's 2s
+        debounce this is the normal case for an edit that just landed, not a
+        rare race: without this check `compute()` would build its
+        replacement from stale in-memory state and silently overwrite the
+        edit. On either mismatch, absorb it via `reindex_file` and retry
+        (counts toward `_CAS_MAX_RETRIES`) instead of computing against
+        stale state.
         """
         for attempt in range(_CAS_MAX_RETRIES + 1):
             mtime_before = _mtime_or_none(path)
-            lines = _read_lines(path)
+            lines, newline, trailing_newline = _read_lines_with_terminator(path)
             span = _find_task_block_span(lines, task_id)
             if span is None:
                 return False, None
-            result = compute()
             start, end = span
+
+            if self._external_edit_pending(lines, start, task_id):
+                if attempt < _CAS_MAX_RETRIES:
+                    self.reindex_file(str(path))
+                    continue
+                raise TaskConflictError(f"Too many conflicting writes to {path}")
+
+            result = compute()
             new_block = _format_task_block(result) if result is not None else []
             new_lines = lines[:start] + new_block + lines[end:]
             mtime_now = _mtime_or_none(path)
             if mtime_now == mtime_before:
-                atomic_write_lines(path, new_lines)
+                atomic_write_lines(path, new_lines, newline=newline, trailing_newline=trailing_newline)
                 if result is not None:
                     self._tasks[task_id] = result
                     self._last_written_line[task_id] = new_block[0]
@@ -639,18 +822,39 @@ class TaskManager:
             raise TaskConflictError(f"Too many conflicting writes to {path}")
         raise TaskConflictError(f"Too many conflicting writes to {path}")
 
+    def _external_edit_pending(self, lines: list[str], start: int, task_id: str) -> bool:
+        """True if the on-disk block at `lines[start]` carries an edit
+        `_cas_rewrite` hasn't absorbed into `self._tasks` yet: the raw line
+        text no longer matches the last line the API wrote or saw for this
+        id, or the on-disk notes body no longer matches the in-memory
+        task's. Must be called with `self._lock` held."""
+        last_written = self._last_written_line.get(task_id)
+        if last_written is not None and lines[start] != last_written:
+            return True
+        in_memory = self._tasks.get(task_id)
+        if in_memory is not None:
+            on_disk_block = _match_task_block(lines, start)
+            if on_disk_block is not None:
+                _, on_disk_task, _ = on_disk_block
+                if on_disk_task.notes != in_memory.notes:
+                    return True
+        return False
+
     def _cas_insert_at_top(self, path: Path, block: list[str]) -> int:
         """Insert `block` above the first existing task block. Returns its
         1-indexed start line. CAS-protected: re-reads the file and retries
         on a concurrent external write, up to `_CAS_MAX_RETRIES` times."""
         for attempt in range(_CAS_MAX_RETRIES + 1):
             mtime_before = _mtime_or_none(path)
-            content = path.read_text(encoding="utf-8") if path.exists() else ""
-            lines = content.splitlines()
+            lines, newline, trailing_newline = _read_lines_with_terminator(path)
+            fence = dict(_iter_lines_with_fence_state(lines))
 
             first_idx = None
             idx, n = 0, len(lines)
             while idx < n:
+                if fence.get(idx):
+                    idx += 1
+                    continue
                 b = _match_task_block(lines, idx, str(path))
                 if b is not None:
                     first_idx = idx
@@ -666,7 +870,7 @@ class TaskManager:
 
             mtime_now = _mtime_or_none(path)
             if mtime_now == mtime_before:
-                atomic_write_lines(path, new_lines)
+                atomic_write_lines(path, new_lines, newline=newline, trailing_newline=trailing_newline)
                 return insert_at
             if attempt >= _CAS_MAX_RETRIES:
                 raise TaskConflictError(f"Too many conflicting writes to {path}")
@@ -679,8 +883,12 @@ class TaskManager:
         if not path.exists():
             return
         lines = _read_lines(path)
+        fence = dict(_iter_lines_with_fence_state(lines))
         idx, n = 0, len(lines)
         while idx < n:
+            if fence.get(idx):
+                idx += 1
+                continue
             block = _match_task_block(lines, idx, str(path))
             if block is None:
                 idx += 1
@@ -708,21 +916,45 @@ class TaskManager:
             atomic_write_text(file_path, template)
         return file_path
 
-    def _move_task_between_files(self, task: Task, old_context: str, new_context: str):
-        """Remove from old file, append (at top) to new file."""
+    def _move_task_between_files(self, task: Task, old_context: str, new_context: str) -> bool:
+        """Move `task`'s block from its old context file to `new_context`'s.
+
+        Returns False if the task's block is no longer present in the
+        source file (externally deleted) — the caller should reconcile like
+        `update` does for `found=False`, not treat it as a conflict.
+
+        Inserts into the destination BEFORE removing from the source, so a
+        destination-side conflict can never lose the task: if the insert
+        raises, the source is untouched. If the source removal itself then
+        raises (a source-side conflict, after the insert already
+        succeeded), best-effort removes the just-inserted destination block
+        before re-raising, so the task isn't left duplicated in both files.
+        """
         old_path = Path(task.source_file)
-        self._cas_rewrite(old_path, task.id, lambda: None)
-        self._reposition_file(old_path)
+        old_lines = _read_lines(old_path)
+        if _find_task_block_span(old_lines, task.id) is None:
+            return False
 
         new_path = self._get_context_file(new_context)
         block = _format_task_block(task)
         start_line = self._cas_insert_at_top(new_path, block)
+
+        try:
+            self._cas_rewrite(old_path, task.id, lambda: None)
+        except TaskConflictError:
+            try:
+                self._cas_rewrite(new_path, task.id, lambda: None)
+            except TaskConflictError:
+                pass
+            raise
+        self._reposition_file(old_path)
 
         task.source_file = str(new_path)
         task.line_number = start_line
         task.context = new_context
         self._last_written_line[task.id] = block[0]
         self._reposition_file(new_path)
+        return True
 
     def _write_dashboard(self):
         """Regenerate Dashboard.md from current task state.
@@ -896,6 +1128,35 @@ _CHECKBOX_RE = re.compile(r'^- \[(.)\]\s+(?:TODO\s+)?')
 _BODY_LINE_RE = re.compile(r'^\s+>\s?(.*)$')
 _BODY_INDENT = "    "
 
+_FENCE_RE = re.compile(r'^(```|~~~)')
+
+
+def _iter_lines_with_fence_state(lines: list[str]):
+    """Yield `(idx, in_fence)` for every line in `lines`. `in_fence` is True
+    for a line inside — or opening/closing — a ``` or ~~~ fenced code block.
+    A checkbox line inside a fence is documentation/example text, never a
+    real task: every scanner that walks task lines (`_reparse_lines`,
+    `_cas_insert_at_top`, `_find_task_block_span`, `_reposition_file`) skips
+    a line this marks `True` instead of handing it to `_match_task_block`.
+    """
+    in_fence = False
+    marker = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if in_fence:
+            yield idx, True
+            if stripped.startswith(marker):
+                in_fence = False
+                marker = None
+            continue
+        m = _FENCE_RE.match(stripped)
+        if m:
+            marker = m.group(1)
+            in_fence = True
+            yield idx, True
+        else:
+            yield idx, False
+
 
 def _format_task_line(task: Task) -> str:
     """Task → Dataview format markdown line."""
@@ -1031,9 +1292,14 @@ def _match_task_block(
 
 def _find_task_block_span(lines: list[str], task_id: str) -> Optional[tuple[int, int]]:
     """Return the `(start, end)` line span of the block carrying `task_id`'s
-    id comment, or None if not found."""
+    id comment, or None if not found. Skips lines inside a fenced code
+    block — an id comment there is example text, not a real task."""
+    fence = dict(_iter_lines_with_fence_state(lines))
     idx, n = 0, len(lines)
     while idx < n:
+        if fence.get(idx):
+            idx += 1
+            continue
         block = _match_task_block(lines, idx)
         if block is None:
             idx += 1

--- a/api/services/task_watcher.py
+++ b/api/services/task_watcher.py
@@ -16,6 +16,8 @@ from typing import Callable, Optional
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
+from api.services.task_manager import is_conflict_file
+
 logger = logging.getLogger(__name__)
 
 _DEBOUNCE_SECONDS = 2.0
@@ -32,6 +34,8 @@ class _TaskFileHandler(FileSystemEventHandler):
     def _schedule(self, path: str):
         if path.endswith("Dashboard.md"):
             return  # Dashboard is auto-generated; never reindex it as a source
+        if is_conflict_file(Path(path)):
+            return  # Syncthing conflict copy / temp file — never a reindex source
         with self._lock:
             existing = self._pending.pop(path, None)
             if existing:

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** API Gateway
-**Last Updated:** 2026-08-28
+**Last Updated:** 2026-09-03
 
 Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two adjacent catalogs split out for size:
 
@@ -738,12 +738,16 @@ Create a task. Stored as an Obsidian Tasks-compatible markdown checkbox in the v
 {
   "description": "Call dentist",
   "context": "Personal",
+  "status": "todo",
   "priority": "high",
   "due_date": "2025-02-10",
   "tags": ["health"],
-  "reminder_id": "optional-linked-reminder-uuid"
+  "reminder_id": "optional-linked-reminder-uuid",
+  "notes": "Ask about the Tuesday afternoon slot",
+  "fields": {"host": "laptop"}
 }
 ```
+`context`, `status`, `notes`, `fields`, and `reminder_id` are all optional.
 
 ### GET /api/tasks
 
@@ -756,13 +760,21 @@ List/filter tasks.
 - `due_before` (string): YYYY-MM-DD, tasks due before this date
 - `query` (string): Fuzzy text search across task descriptions
 
+### GET /api/tasks/conflicts
+
+List Syncthing conflict copies / in-progress temp files sitting in the tasks
+folder (`name`, `mtime` each) — never indexed as tasks, surfaced so a client
+can prompt the operator to resolve them by hand.
+
 ### GET /api/tasks/{id}
 
 Get a specific task.
 
 ### PUT /api/tasks/{id}
 
-Update a task (description, status, context, priority, due_date, tags).
+Update a task (description, status, context, priority, due_date, tags,
+notes, fields). `fields` merges into the task's operator/unknown fields — a
+string value sets a field, a `null` value removes it.
 
 ### PUT /api/tasks/{id}/complete
 
@@ -771,6 +783,10 @@ Mark a task as done (adds done date automatically).
 ### DELETE /api/tasks/{id}
 
 Delete a task.
+
+All task-mutating endpoints can return `409` if a concurrent external edit
+keeps winning a compare-and-swap race on the underlying file — retry the
+request.
 
 ---
 

--- a/docs/specs/product/task-management.md
+++ b/docs/specs/product/task-management.md
@@ -2,9 +2,9 @@
 
 > **Status:** Complete
 > **Owner:** Task Management
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-09-03
 
-LifeOS provides a task management system fully integrated with Obsidian Tasks plugin. Tasks are stored as markdown checkboxes in your vault and can be managed via chat, API, or Obsidian.
+LifeOS stores tasks as markdown checkboxes in your vault, in a format the Obsidian Tasks plugin can query and display, and manages them via chat, API, or Obsidian. Any checkbox line in `LifeOS/Tasks/*.md` counts as a task — you don't need to type LifeOS's own conventions by hand, and a plain hand-written checklist item is picked up on the next reindex. LifeOS's non-standard statuses (In Progress, Deferred, Blocked, Urgent — see below) render as generic checkboxes in Obsidian until you add them under the Tasks plugin's own "Custom statuses" settings; the plugin doesn't know about them out of the box.
 
 ## Storage Format
 
@@ -15,6 +15,16 @@ LifeOS provides a task management system fully integrated with Obsidian Tasks pl
 Example task line:
 ```
 - [ ] TODO Call dentist [due:: 2025-02-10] [created:: 2025-02-07] #health <!-- id:abc123 -->
+```
+
+A task can also carry a multi-line notes body, stored as indented `> ` lines
+beneath the task line, and operator fields (`host`, `effort`, `model`, `key`,
+or any custom `[key:: value]`) that round-trip through any edit unchanged:
+
+```
+- [ ] TODO Call dentist [due:: 2025-02-10] [created:: 2025-02-07] [host:: laptop] #health <!-- id:abc123 -->
+    > Ask about the Tuesday afternoon slot
+    > Bring insurance card
 ```
 
 ## Custom Statuses
@@ -30,6 +40,11 @@ LifeOS uses checkbox symbols to represent task states:
 | Deferred | `[>]` | Postponed |
 | Blocked | `[?]` | Waiting on dependency |
 | Urgent | `[!]` | High priority |
+
+In Progress, Deferred, Blocked, and Urgent are LifeOS conventions, not
+Obsidian Tasks plugin defaults — add them under the plugin's own settings
+(Tasks → Custom statuses) if you want Obsidian to show and filter on them
+correctly. Todo and Done need no configuration.
 
 ## Creating Tasks
 
@@ -49,11 +64,20 @@ curl -X POST http://localhost:8000/api/tasks \
   -d '{
     "description": "Call dentist",
     "context": "Personal",
+    "status": "blocked",
     "priority": "high",
     "due_date": "2025-02-10",
-    "tags": ["health"]
+    "tags": ["health"],
+    "notes": "Ask about the Tuesday afternoon slot",
+    "fields": {"host": "laptop"}
   }'
 ```
+
+`context`, `status`, `notes`, and `fields` are all optional — omit `context`
+for Inbox, `status` for `todo`. Note: the chat/Telegram assistant's task tool
+always files new tasks in Inbox regardless of what you say, to avoid it
+guessing a wrong context — file directly to a context via the API or MCP
+tools, or move the task afterward.
 
 ### Via MCP Tools
 
@@ -106,9 +130,15 @@ curl -X PUT http://localhost:8000/api/tasks/{id} \
   -H "Content-Type: application/json" \
   -d '{
     "status": "in_progress",
-    "priority": "high"
+    "priority": "high",
+    "notes": "Waiting on the pharmacy callback",
+    "fields": {"host": null}
   }'
 ```
+
+`notes` replaces the notes body outright. `fields` is a merge, not a
+replacement: a string value sets that field, a `null` value removes it, and
+any field you don't mention is left alone.
 
 ### Delete Tasks
 
@@ -130,10 +160,12 @@ Create a task with an associated reminder in one command:
 "add a task to call the dentist and remind me Friday at 3pm"
 ```
 
-The system will:
-1. Create the task
-2. Create a reminder for Friday 3pm
-3. Link them via `reminder_id` field
+This is chat orchestration, not a single API call: the assistant creates the
+task, creates a schedule for Friday 3pm, and links them by passing the
+schedule's id as the task's `reminder_id`. Calling the task and schedule
+APIs directly does the same in two calls — pass `reminder_id` on
+`POST /api/tasks` (see [Scheduler Guide](../../guides/scheduler.md) for
+creating the schedule itself).
 
 ## Obsidian Dashboard
 
@@ -148,29 +180,48 @@ The dashboard includes:
 - Blocked tasks
 - Recently completed tasks
 
-The dashboard uses Obsidian Tasks plugin queries and updates automatically as tasks change in Obsidian. It is created by TaskManager on initialization if it doesn't already exist.
+The dashboard uses Obsidian Tasks plugin queries and regenerates on every
+task change through the API immediately, and within a few seconds of an
+edit made directly in Obsidian (the file watcher debounces external edits
+before reindexing). It is created by TaskManager on initialization if it
+doesn't already exist.
+
+A Syncthing conflict copy or in-progress temp file in `LifeOS/Tasks/` is
+never shown on the dashboard and never indexed as a task — it's surfaced
+instead via `GET /api/tasks/conflicts` so a client can prompt you to resolve
+it by hand.
 
 ## API Reference
 
 | Method | Endpoint | Parameters | Description |
 |--------|----------|------------|-------------|
-| POST | `/api/tasks` | description, context, priority, due_date, tags, reminder_id | Create a task |
+| POST | `/api/tasks` | description, context, status, priority, due_date, tags, reminder_id, notes, fields | Create a task |
 | GET | `/api/tasks` | status, context, tag, due_before, query | List/filter tasks |
+| GET | `/api/tasks/conflicts` | - | List Syncthing conflict/temp files sitting in the tasks folder |
 | GET | `/api/tasks/{id}` | - | Get specific task |
-| PUT | `/api/tasks/{id}` | description, status, context, priority, due_date, tags | Update a task |
+| PUT | `/api/tasks/{id}` | description, status, context, priority, due_date, tags, notes, fields | Update a task |
 | PUT | `/api/tasks/{id}/complete` | - | Mark as done |
 | DELETE | `/api/tasks/{id}` | - | Delete a task |
 
+A task response also includes `updated_at` (an ISO-8601 timestamp with a UTC
+offset, stamped on every create/update/complete/swap-tag) alongside the
+fields above.
+
 ## Technical Details
 
-- Task files are the source of truth (markdown in vault)
+- Task files are the source of truth (markdown in vault); writes are atomic (a reader never sees a partial file)
 - `data/task_index.json` is a query cache rebuilt from markdown
 - Vault file watcher triggers automatic reindexing on changes
+- A task keeps its identity across an external edit that shifts its line number — writes locate it by id, not by a cached position
 - Compatible with Obsidian Tasks plugin for viewing/editing in Obsidian
 - Uses Dataview inline field format for metadata
+
+See [Task Management — Technical](../technical/task-management.md) for how
+id-addressed writes, the notes body, and conflict-file handling actually work.
 
 ## Related Documents
 
 - [API Reference](api-reference.md) -- Task API endpoint contracts
+- [Task Management — Technical](../technical/task-management.md) -- Engineering internals: id-addressed CAS writes, notes body, external-edit detection, conflict files
 - [Scheduler Guide](../../guides/scheduler.md) -- Schedules; the `agent` action writes `#agent` tasks here
 - [Agent Worker](agent-worker.md) -- Tasks tagged `#agent` are picked up by the autonomous worker for hands-free completion

--- a/docs/specs/technical/AGENTS.md
+++ b/docs/specs/technical/AGENTS.md
@@ -13,6 +13,7 @@ This directory contains technical specifications — how the system is built fro
 - `scheduler.md` — Scheduler internals (markdown source of truth + index cache, round-trip, watcher reindex, firing/dispatch)
 - `search-indexing.md` — Hybrid search internals (vector + BM25 fusion, embedding pipeline integration)
 - `security-privacy.md` — Auth, network exposure, data-at-rest, privacy invariants
+- `task-management.md` — Task store internals (id-addressed CAS writes, notes body, external-edit detection, conflict-file handling)
 
 ## Key Principles
 

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-08-21
+> **Last Updated:** 2026-09-03
 
 Codebase organization and module structure for efficient navigation.
 
@@ -111,6 +111,7 @@ Per-backend capabilities (personas, handoff, history ownership, usage capture) a
 
 **Task Management:**
 - `task_manager.py` - Task CRUD, markdown I/O, index persistence, fuzzy query
+- `atomic_write.py` - Shared temp-file + fsync + rename helper for atomic vault/index writes (task files, task index, scheduler store)
 
 **Background Jobs:**
 - `job_queue.py` - SQLite-backed job queue with worker thread (reindex, sync)

--- a/docs/specs/technical/scheduler.md
+++ b/docs/specs/technical/scheduler.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Scheduler
-> **Last Updated:** 2026-05-29
+> **Last Updated:** 2026-09-03
 
 Engineering view of the Scheduler — how a trigger bound to an action is stored,
 reindexed, and fired. For the trigger/action model, line schema, and operator
@@ -78,6 +78,7 @@ short snippet in `last_result` for the dashboard.
 ## Related Documents
 
 ### Specifications
+- [Task Management — Technical](task-management.md) — Task store that mirrors this store's id-addressed block rewrite, `>` body, and merge-forward patterns
 - [Scheduler Guide](../../guides/scheduler.md) — Operator how-to, line schema, trigger/action model (the consumer-facing counterpart to this spec)
 - [API Reference](../product/api-reference.md#scheduler--telegram-endpoints) — `/api/scheduler` contracts
 - [MCP Tools](../product/mcp-tools.md) — `lifeos_schedule_*` tool contracts

--- a/docs/specs/technical/task-management.md
+++ b/docs/specs/technical/task-management.md
@@ -58,6 +58,23 @@ plain `dict[str, str]`) and round-trips through any rewrite untouched,
 because `_format_task_line` re-emits `Task.fields` verbatim in the order it
 holds them (`:898-934`). No parser change is needed to add a new field.
 
+A checkbox line inside a fenced (` ``` ` or `~~~`) code block is never
+parsed as a task, even though `_CHECKBOX_RE` would otherwise match it — a
+line like `- [ ] example` in a documentation snippet is example text, not a
+real task. `_iter_lines_with_fence_state` toggles fence state on any line
+whose stripped text starts with a fence marker; every scanner that walks
+task lines (`_reparse_lines`, `_cas_insert_at_top`, `_find_task_block_span`,
+`_reposition_file`) skips a line it marks as fenced before handing it to
+`_match_task_block`.
+
+**Duplicate ids.** Two lines sharing the same `<!-- id:xxxx -->` comment
+(most often a hand-copied line) are not left to fight over that id forever.
+`_reparse_lines` keeps the first occurrence's id as-is; a later occurrence
+in the same file carrying an id already claimed earlier in the same parse
+is treated exactly like a line with no id comment at all — its
+stale/duplicated comment is replaced with a freshly minted one on that
+pass, and both lines are indexed under distinct ids from then on.
+
 ## Id write-back
 
 A checkbox line with no `<!-- id:xxxx -->` comment gets one minted
@@ -70,6 +87,43 @@ requires `TODO`: on the first reindex after this feature ships, every
 existing hand-written `- [ ]` checklist item in `LifeOS/Tasks/*.md` gets an
 id comment appended, once, and is indexed as a task from then on. That is
 the intended migration, not a bug.
+
+## Input validation
+
+`description`, `notes`, and `fields` are validated by
+`_validate_text_fields` before `create`/`update` do anything else, because
+they're interpolated directly into the checkbox line's text rather than
+going through a serializer that could escape them. Rejected (`ValueError`,
+mapped to HTTP 422 by `api/routes/tasks.py`) rather than silently
+sanitized, since truncating or stripping would save something other than
+what the caller sent:
+
+- A newline (`\n` or `\r`) in `description` or a `fields` value would split
+  the single checkbox line into two.
+- A `]` in `description` or a `fields` value would truncate an inline
+  field's closing bracket and leak the rest of the value into the
+  description (or the next field).
+- An HTML comment opener (`<!--`) anywhere in `description`, a `fields`
+  value, or a `notes` line could forge a new `<!-- id:.. -->`, hijacking
+  another task's id on the next reindex.
+- `notes` lines are allowed to be multi-line — that's their whole point —
+  but not `\r` (would desync the `\n`-joined body from what
+  `Task.notes.split("\n")` expects) or `<!--`.
+- A `fields` key must be a bare word (`^\w+$`), because `_format_task_line`
+  interpolates it directly as `[key:: value]`.
+- A `fields` key may not shadow a reserved key: any inline field with a
+  dedicated `Task` attribute (`due`, `priority`, `created`, `done`,
+  `cancelled`, `updated`) or `id` itself. Accepting one through the
+  free-form `fields` dict would let a caller write a second, conflicting
+  `[key:: value]` onto the line, or forge the id comment outright —
+  `fields={"updated": "SPOOFED"}` would otherwise write two `[updated::]`
+  fields and, after the next reindex re-parses the line, `updated_at` would
+  read back as `"SPOOFED"`.
+
+`status` is validated the same way, against `VALID_STATUSES` — an
+unrecognized status previously wrote a blank checkbox (the symbol lookup
+falls back to `todo`'s `" "`) and round-tripped as the invalid string until
+the next reindex silently flipped it back to `todo`.
 
 ## Id-addressed, compare-and-swap writes
 
@@ -93,11 +147,40 @@ The retry re-invokes the caller's `compute()` closure against the
 just-refreshed `self._tasks[task_id]`, so an `update()` retry re-applies the
 operator's requested changes on top of the latest known state rather than
 blindly overwriting it with stale data — the same "recompute, don't just
-retry the same bytes" discipline CAS requires anywhere.
+retry the same bytes" discipline CAS requires anywhere. `compute()` always
+builds a *new* `Task` from a copy of the current one rather than mutating it
+in place, so a losing attempt's edits are never visible through `get()` —
+`self._tasks[task_id]` is rebound only once a write actually succeeds.
+
+`_cas_rewrite` also checks, before calling `compute()`, whether the on-disk
+block already reflects an edit `reindex_file` hasn't absorbed yet — the raw
+line text no longer matches the last line the API wrote or saw for this id,
+or the on-disk notes body no longer matches the in-memory task's. This is
+the *normal* case for an edit that just landed, not a rare race: the
+watcher's 2s debounce means a `PUT` can easily arrive after an external
+edit has hit disk but before `reindex_file` has run. Without this check,
+`compute()` would build its replacement from the stale in-memory task and
+silently revert the edit — an operator retitling a task and adding a body
+line, followed a moment later by an unrelated `PUT` that only changes
+`priority`, would otherwise lose the retitle and the added line. On a
+mismatch the manager absorbs it via `reindex_file` and retries (counting
+toward `_CAS_MAX_RETRIES`), the same as an mtime conflict.
 
 `self._lock` is a `threading.RLock`, not a plain `Lock`: a CAS retry inside
 a lock-held mutating call re-enters `reindex_file`, which also takes the
 lock. A plain `Lock` would self-deadlock on the very first retry.
+
+**Context-change moves.** `update(..., context=...)` moves a task's block
+between files via `_move_task_between_files`. The destination insert
+happens *before* the source removal: if the destination's CAS insert
+raises, the source is untouched — the task never disappears. If the source
+removal then fails (a conflict there, after the destination insert already
+succeeded), the manager best-effort removes the just-inserted destination
+block before re-raising, rather than leaving the task duplicated in both
+files. If the task's block is no longer present in the source at all (an
+external delete raced the move), the move is treated like any other
+externally-deleted task — reconciled out of the index — rather than raising
+a conflict.
 
 ## Atomic writes
 
@@ -110,6 +193,19 @@ writing directly — only the temp file is, and the swap is one atomic
 rename. `scheduler_store.py` shares this same helper (its own writes had the
 same non-atomic gap; fixing it was a trivial swap with no behavior change,
 verified by the unchanged scheduler test suite).
+
+A task-file rewrite preserves the file's original line terminator (`\r\n`
+vs. `\n`) and whether it ended with a trailing terminator, rather than
+normalizing wholesale to `\n`-joined-plus-trailing-newline. Every call site
+that reads a task file for a possible rewrite (`reindex_file`,
+`rebuild_index`, `_cas_rewrite`, `_cas_insert_at_top`) uses
+`_read_lines_with_terminator`, which reads raw bytes (not `Path.read_text`,
+whose universal-newline translation would silently turn CRLF into LF before
+the terminator could even be inspected) and detects both properties; the
+matching write passes them through as `atomic_write_lines`'s `newline=`/
+`trailing_newline=` keyword arguments. `scheduler_store.py` never calls
+`atomic_write_lines` (it writes whole files via `atomic_write_text`), so
+these defaults don't change its behavior.
 
 ## Notes body
 
@@ -159,9 +255,26 @@ merge-forward already works from the existing JSON-cache-backed
 single running process — after a restart, whatever's on disk simply becomes
 the new baseline for comparison, and the in-memory `Task` always reflects
 the file's actual current content regardless of whether that reset happened.
-The cost of not persisting is purely cosmetic (one skipped `[updated::]`
+The cost of not persisting is usually cosmetic: one skipped `[updated::]`
 restamp immediately after a restart, for a task that was genuinely edited
-while the server was down) — never a correctness gap.
+while the server was down. It is a correctness gap in one specific,
+narrow case — a task's block is inside a fenced code block, or shares a
+duplicate id with another block, at the moment of a restart — where the
+in-memory bookkeeping that would otherwise have resolved it cleanly is
+reset along with everything else in `self._tasks`; the next parse simply
+treats it as a fresh id with no history, same as it would for any other
+process-lifetime-only piece of state. That's an accepted, bounded cost, not
+a claim that no correctness gap exists at all.
+
+`reindex_file`'s own write-back (minting an id, restamping an external
+edit) is itself CAS-protected on the file's mtime, the same discipline as
+`_cas_rewrite`: it re-reads and re-parses (bounded to `_CAS_MAX_RETRIES`
+attempts) if the file changed between its read and its write, rather than
+blindly overwriting whatever landed in between. On persistent conflict it
+logs a warning and skips the write for that pass instead of raising —
+`reindex_file` has no caller to hand a `TaskConflictError` to that would do
+anything useful with it, and the watcher will fire again for whatever
+caused the conflict.
 
 ## Compare-and-swap retry vs. field-level merge
 

--- a/docs/specs/technical/task-management.md
+++ b/docs/specs/technical/task-management.md
@@ -34,15 +34,15 @@ identity or content lives only in the cache except `reminder_id` (see
   an optional indented `> ` notes body directly beneath it, exactly like a
   scheduler entry's `message_content` body
   ([scheduler.md](scheduler.md#source-of-truth--cache)). `_format_task_line`/
-  `_parse_task_line` (`task_manager.py:898`, `:946`) are inverse for a task
+  `_parse_task_line` (`task_manager.py:1224`, `:1272`) are inverse for a task
   written by the API. A hand-authored line need not be — see "Parsing" below.
 - **Cache:** `data/task_index.json` — the full `Task` (dataclass at
-  `task_manager.py:76`), including fields with no markdown representation
-  (`reminder_id`). `rebuild_index` (`:507`) regenerates it from the vault.
+  `task_manager.py:129`), including fields with no markdown representation
+  (`reminder_id`). `rebuild_index` (`:671`) regenerates it from the vault.
 
 ## Parsing
 
-A task line is any `- [.] ...` checkbox line — `_CHECKBOX_RE` (`:892`) does
+A task line is any `- [.] ...` checkbox line — `_CHECKBOX_RE` (`:1188`) does
 **not** require the literal `TODO` keyword. This is deliberate: it lets a
 task typed by hand in Obsidian (`- [ ] Buy milk`) be recognized without the
 operator learning LifeOS's own convention. `_format_task_line` still always
@@ -56,7 +56,7 @@ every other `[key:: value]` — operator fields (`host`, `effort`, `model`,
 `key`) and anything a later feature invents — lands in `Task.fields` (a
 plain `dict[str, str]`) and round-trips through any rewrite untouched,
 because `_format_task_line` re-emits `Task.fields` verbatim in the order it
-holds them (`:898-934`). No parser change is needed to add a new field.
+holds them (`:1224-1258`). No parser change is needed to add a new field.
 
 A checkbox line inside a fenced (` ``` ` or `~~~`) code block is never
 parsed as a task, even though `_CHECKBOX_RE` would otherwise match it — a
@@ -89,7 +89,7 @@ cross-file duplicate for the next full rebuild to resolve.
 
 A checkbox line with no `<!-- id:xxxx -->` comment gets one minted
 (`uuid4().hex[:8]`, same scheme as before) the first time it's parsed. On the
-next reindex, `_reparse_lines` (`:533`) appends that id comment to the raw
+next reindex, `_reparse_lines` (`:713`) appends that id comment to the raw
 line — and changes nothing else about it: no reformatting, no inserted
 `TODO`, no field reordering. Every other line in the file, task or not, is
 copied through byte-for-byte. This matters because the parser no longer
@@ -138,20 +138,20 @@ the next reindex silently flipped it back to `todo`.
 ## Id-addressed, compare-and-swap writes
 
 Every write locates its task's line by id — `_find_task_block_span`
-(`:1030`) scans for the block whose id comment matches, the same mechanism
+(`:1356`) scans for the block whose id comment matches, the same mechanism
 `SchedulerStore._find_block_span` uses. A cached `line_number` is never used
 to address a write; it is refreshed after every write purely as read-side
-bookkeeping (`_reposition_file`, `:673`) so `GET` responses stay accurate.
+bookkeeping (`_reposition_file`, `:917`) so `GET` responses stay accurate.
 This is what lets a `PUT` succeed correctly even when an external edit (via
 Obsidian, delivered by Syncthing) has inserted lines above the task before
 the watcher's 2s debounce catches up.
 
-Each write goes through `_cas_rewrite` (`:597`) or `_cas_insert_at_top`
-(`:640`): read the file's mtime, read and locate the block, compute the new
+Each write goes through `_cas_rewrite` (`:802`) or `_cas_insert_at_top`
+(`:881`): read the file's mtime, read and locate the block, compute the new
 content, then re-check the mtime immediately before writing. A mismatch
 means a concurrent external writer touched the file in between, so the
 manager calls `reindex_file` (absorbing that change into `self._tasks`) and
-retries — up to `_CAS_MAX_RETRIES` (`:61`, currently 3) times — before
+retries — up to `_CAS_MAX_RETRIES` (`:70`, currently 3) times — before
 raising `TaskConflictError`, which `api/routes/tasks.py` maps to HTTP 409.
 The retry re-invokes the caller's `compute()` closure against the
 just-refreshed `self._tasks[task_id]`, so an `update()` retry re-applies the
@@ -221,7 +221,7 @@ these defaults don't change its behavior.
 
 `Task.notes` is a multi-line string stored as `_BODY_INDENT` (four spaces)
 plus `> ` per line, directly beneath the task's checkbox line —
-`_format_task_block` (`:935`) emits it, `_match_task_block` (`:1005`) parses
+`_format_task_block` (`:1261`) emits it, `_match_task_block` (`:1331`) parses
 it back, both mirroring the scheduler entry body pattern exactly
 (`scheduler.md`'s `_format_entry_block`/`_iter_entry_blocks`). Deleting or
 moving a task carries its body with it, because every write operates on the
@@ -304,9 +304,9 @@ for the sibling-line case this issue set out to fix.
 
 Syncthing conflict copies (`*.sync-conflict-YYYYMMDD-HHMMSS...`) and
 in-progress temp files (`.syncthing.*`) are recognized by `is_conflict_file`
-(`:135`) and skipped everywhere: `rebuild_index`'s glob, `reindex_file`
+(`:209`) and skipped everywhere: `rebuild_index`'s glob, `reindex_file`
 (early return, never indexed, never triggers a write), and `TaskWatcher`'s
-event handler. `TaskManager.list_conflicts` (`:435`) surfaces them (name +
+event handler. `TaskManager.list_conflicts` (`:555`) surfaces them (name +
 mtime) via `GET /api/tasks/conflicts`, registered before `GET
 /{task_id}` in `api/routes/tasks.py` so FastAPI doesn't capture `"conflicts"`
 as a task id. Resolving a conflict file is a manual, out-of-band operation

--- a/docs/specs/technical/task-management.md
+++ b/docs/specs/technical/task-management.md
@@ -1,0 +1,220 @@
+# Task Management — Technical
+
+> **Status:** Complete
+> **Owner:** Task Management
+> **Last Updated:** 2026-09-03
+
+Engineering view of the task store — how a task is located, written, and
+reindexed. For the product-facing feature description, statuses, and API
+usage examples, see [product/task-management.md](../product/task-management.md);
+for endpoint contracts see
+[api-reference.md](../product/api-reference.md#task-endpoints). This spec
+does not restate those.
+
+## Modules
+
+| File | Role |
+|------|------|
+| `api/services/task_manager.py` | `Task`, `TaskManager` (CRUD + markdown round-trip + index cache + dashboard), module-level parse/format helpers |
+| `api/services/task_watcher.py` | `TaskWatcher` — watchdog observer that reindexes on external edits |
+| `api/services/atomic_write.py` | `atomic_write_text`/`atomic_write_lines` — shared temp-file-plus-rename helper, also used by `scheduler_store.py` |
+| `api/routes/tasks.py` | `/api/tasks` HTTP surface |
+
+`api/main.py` (lifespan, `api/main.py:185-192`) rebuilds the index from the
+vault on startup, then starts the watcher.
+
+## Source of truth + cache
+
+The vault markdown is authoritative; `data/task_index.json` is a rebuildable
+cache — deleting it just costs one `rebuild_index()` pass. Nothing about task
+identity or content lives only in the cache except `reminder_id` (see
+"Cache-only field merge-forward" below).
+
+- **Source:** `LifeOS/Tasks/{Context}.md` — one checkbox line per task, with
+  an optional indented `> ` notes body directly beneath it, exactly like a
+  scheduler entry's `message_content` body
+  ([scheduler.md](scheduler.md#source-of-truth--cache)). `_format_task_line`/
+  `_parse_task_line` (`task_manager.py:898`, `:946`) are inverse for a task
+  written by the API. A hand-authored line need not be — see "Parsing" below.
+- **Cache:** `data/task_index.json` — the full `Task` (dataclass at
+  `task_manager.py:76`), including fields with no markdown representation
+  (`reminder_id`). `rebuild_index` (`:507`) regenerates it from the vault.
+
+## Parsing
+
+A task line is any `- [.] ...` checkbox line — `_CHECKBOX_RE` (`:892`) does
+**not** require the literal `TODO` keyword. This is deliberate: it lets a
+task typed by hand in Obsidian (`- [ ] Buy milk`) be recognized without the
+operator learning LifeOS's own convention. `_format_task_line` still always
+emits `TODO` on any line it writes, so the Obsidian Tasks dashboard queries
+in `Dashboard.md` (which match on the checkbox status, not the word `TODO`)
+and the existing convention both keep working unchanged.
+
+Inline fields with a dedicated `Task` attribute (`due`, `priority`,
+`created`, `done`, `cancelled`, `updated`) are parsed into that attribute;
+every other `[key:: value]` — operator fields (`host`, `effort`, `model`,
+`key`) and anything a later feature invents — lands in `Task.fields` (a
+plain `dict[str, str]`) and round-trips through any rewrite untouched,
+because `_format_task_line` re-emits `Task.fields` verbatim in the order it
+holds them (`:898-934`). No parser change is needed to add a new field.
+
+## Id write-back
+
+A checkbox line with no `<!-- id:xxxx -->` comment gets one minted
+(`uuid4().hex[:8]`, same scheme as before) the first time it's parsed. On the
+next reindex, `_reparse_lines` (`:533`) appends that id comment to the raw
+line — and changes nothing else about it: no reformatting, no inserted
+`TODO`, no field reordering. Every other line in the file, task or not, is
+copied through byte-for-byte. This matters because the parser no longer
+requires `TODO`: on the first reindex after this feature ships, every
+existing hand-written `- [ ]` checklist item in `LifeOS/Tasks/*.md` gets an
+id comment appended, once, and is indexed as a task from then on. That is
+the intended migration, not a bug.
+
+## Id-addressed, compare-and-swap writes
+
+Every write locates its task's line by id — `_find_task_block_span`
+(`:1030`) scans for the block whose id comment matches, the same mechanism
+`SchedulerStore._find_block_span` uses. A cached `line_number` is never used
+to address a write; it is refreshed after every write purely as read-side
+bookkeeping (`_reposition_file`, `:673`) so `GET` responses stay accurate.
+This is what lets a `PUT` succeed correctly even when an external edit (via
+Obsidian, delivered by Syncthing) has inserted lines above the task before
+the watcher's 2s debounce catches up.
+
+Each write goes through `_cas_rewrite` (`:597`) or `_cas_insert_at_top`
+(`:640`): read the file's mtime, read and locate the block, compute the new
+content, then re-check the mtime immediately before writing. A mismatch
+means a concurrent external writer touched the file in between, so the
+manager calls `reindex_file` (absorbing that change into `self._tasks`) and
+retries — up to `_CAS_MAX_RETRIES` (`:61`, currently 3) times — before
+raising `TaskConflictError`, which `api/routes/tasks.py` maps to HTTP 409.
+The retry re-invokes the caller's `compute()` closure against the
+just-refreshed `self._tasks[task_id]`, so an `update()` retry re-applies the
+operator's requested changes on top of the latest known state rather than
+blindly overwriting it with stale data — the same "recompute, don't just
+retry the same bytes" discipline CAS requires anywhere.
+
+`self._lock` is a `threading.RLock`, not a plain `Lock`: a CAS retry inside
+a lock-held mutating call re-enters `reindex_file`, which also takes the
+lock. A plain `Lock` would self-deadlock on the very first retry.
+
+## Atomic writes
+
+All file writes — task files, `data/task_index.json`, `Dashboard.md`, a
+freshly created context file's template — go through
+`atomic_write.atomic_write_text`/`atomic_write_lines`: write a temp file in
+the same directory, `fsync`, then `os.replace` into place. A reader never
+observes a partial file, because the destination path is never opened for
+writing directly — only the temp file is, and the swap is one atomic
+rename. `scheduler_store.py` shares this same helper (its own writes had the
+same non-atomic gap; fixing it was a trivial swap with no behavior change,
+verified by the unchanged scheduler test suite).
+
+## Notes body
+
+`Task.notes` is a multi-line string stored as `_BODY_INDENT` (four spaces)
+plus `> ` per line, directly beneath the task's checkbox line —
+`_format_task_block` (`:935`) emits it, `_match_task_block` (`:1005`) parses
+it back, both mirroring the scheduler entry body pattern exactly
+(`scheduler.md`'s `_format_entry_block`/`_iter_entry_blocks`). Deleting or
+moving a task carries its body with it, because every write operates on the
+whole block (main line plus body lines), never the main line alone.
+
+## Cache-only field merge-forward
+
+`reminder_id` has no markdown representation — it never appears in a
+`[key:: value]` field, so a plain reindex would silently lose it (the
+markdown, re-parsed, says nothing about it). `_reparse_lines` merges it
+forward from `self._tasks` (the prior in-memory state, itself loaded from
+the JSON cache) by id, the same pattern as `SchedulerStore._merge_prior` for
+`message_content`/`endpoint_config`.
+
+## External-edit detection
+
+Whether a task's line changed externally since the API last wrote it is
+decided by exact-string comparison, not by reformatting the prior `Task` and
+hoping it matches. `TaskManager._last_written_line` (`dict[id, str]`, never
+persisted) holds the literal text last written or observed for each task
+this process's lifetime. `_reparse_lines` compares the current raw line
+against that entry: a mismatch means an external edit — the parsed values
+win (they already do, unconditionally) and the line is rewritten with a
+fresh `[updated::]` stamp, scoped to that one task's line only; a match, or
+no prior entry at all (first time this process has seen the id), leaves the
+line untouched.
+
+Reformatting the prior `Task` instead of storing the exact string was tried
+first and rejected: it broke on any line the API didn't canonically format
+— most notably a line that just had an id minted onto otherwise
+hand-written text (no `TODO`, no `created` field). Reformatting that prior
+`Task` via `_format_task_line` always re-inserts `TODO` and an (empty)
+`created` field, so the comparison found a "difference" on every single
+reindex and rewrote the line every time, defeating idempotency.
+
+**Why no `data/kanban.db` sidecar.** A small sidecar database was one option
+for this bookkeeping — `task_index.json` is rewritten whole on every
+mutation, so it's the wrong place for it — but wasn't needed: `reminder_id`
+merge-forward already works from the existing JSON-cache-backed
+`self._tasks`, and external-edit detection only needs to hold up within a
+single running process — after a restart, whatever's on disk simply becomes
+the new baseline for comparison, and the in-memory `Task` always reflects
+the file's actual current content regardless of whether that reset happened.
+The cost of not persisting is purely cosmetic (one skipped `[updated::]`
+restamp immediately after a restart, for a task that was genuinely edited
+while the server was down) — never a correctness gap.
+
+## Compare-and-swap retry vs. field-level merge
+
+A CAS retry re-applies the caller's requested field changes on top of the
+freshly reindexed task, but it does not attempt a field-level three-way
+merge against a concurrent, unrelated edit to the *same* task (e.g. the
+operator renames a task in Obsidian in the same instant the API is changing
+its due date). The later writer's full requested change wins outright for
+that task — an accepted simplification for a single-user vault, and a
+narrower race window than the previous cached-line-number addressing had
+for the sibling-line case this issue set out to fix.
+
+## Conflict files
+
+Syncthing conflict copies (`*.sync-conflict-YYYYMMDD-HHMMSS...`) and
+in-progress temp files (`.syncthing.*`) are recognized by `is_conflict_file`
+(`:135`) and skipped everywhere: `rebuild_index`'s glob, `reindex_file`
+(early return, never indexed, never triggers a write), and `TaskWatcher`'s
+event handler. `TaskManager.list_conflicts` (`:435`) surfaces them (name +
+mtime) via `GET /api/tasks/conflicts`, registered before `GET
+/{task_id}` in `api/routes/tasks.py` so FastAPI doesn't capture `"conflicts"`
+as a task id. Resolving a conflict file is a manual, out-of-band operation
+(Obsidian, or deleting the losing copy) — nothing here does it automatically.
+
+## Reindex on edit
+
+`TaskWatcher` (`task_watcher.py`) runs a watchdog `Observer` over the tasks
+directory (non-recursive). `_TaskFileHandler` coalesces rapid events per path
+behind a 2s debounce and calls `TaskManager.reindex_file`. `Dashboard.md` and
+conflict/temp files are skipped so regenerating the dashboard, or a Syncthing
+sync artifact landing mid-transfer, never triggers a feedback loop or a spurious
+reindex.
+
+## Privacy Considerations
+
+Task descriptions, notes, and operator fields live entirely in the local
+vault and `data/`; nothing here has an outbound path of its own (see
+[security-privacy.md](security-privacy.md) for the surfaces, like Telegram
+delivery, that do). `data/task_index.json` and the vault markdown carry the
+same content — deleting one and rebuilding from the other never loses or
+duplicates personal data, by construction.
+
+## Related Documents
+
+### Specifications
+- [Task Management — Product](../product/task-management.md) — Feature description, statuses, API usage examples (the consumer-facing counterpart to this spec)
+- [API Reference](../product/api-reference.md#task-endpoints) — `/api/tasks` contracts
+- [Scheduler — Technical](scheduler.md) — The id-addressed block rewrite, notes-style body, and merge-forward patterns this store mirrors
+- [Agent Worker — Product](../product/agent-worker.md#tag-lifecycle) — `POST /{id}/swap-tag` contract this store preserves unchanged
+- [Architecture](architecture.md) — Where the task modules sit in the code structure
+
+### Code References
+- [task_manager.py](../../../api/services/task_manager.py) — Store, round-trip, CAS writes
+- [task_watcher.py](../../../api/services/task_watcher.py) — File watcher
+- [atomic_write.py](../../../api/services/atomic_write.py) — Shared atomic-write helper
+- [tests/test_task_manager.py](../../../tests/test_task_manager.py) · [test_task_watcher.py](../../../tests/test_task_watcher.py) · [test_atomic_write.py](../../../tests/test_atomic_write.py) — Coverage

--- a/docs/specs/technical/task-management.md
+++ b/docs/specs/technical/task-management.md
@@ -75,6 +75,16 @@ is treated exactly like a line with no id comment at all — its
 stale/duplicated comment is replaced with a freshly minted one on that
 pass, and both lines are indexed under distinct ids from then on.
 
+A duplicate that spans two *different* files is resolved only on the next
+full `rebuild_index`, not by a single-file `reindex_file` call: `rebuild_index`
+threads one `seen_ids` set across every file it parses, so a task whose id
+was already claimed by an earlier file in the same rebuild is treated the
+same way as a same-file duplicate. `reindex_file` deliberately does not do
+this — it has no way to distinguish a genuine cross-file duplicate from an
+operator cutting a task line out of one file and pasting it into another,
+so it keeps ids intact on an external cross-file move and leaves any true
+cross-file duplicate for the next full rebuild to resolve.
+
 ## Id write-back
 
 A checkbox line with no `<!-- id:xxxx -->` comment gets one minted
@@ -274,7 +284,10 @@ blindly overwriting whatever landed in between. On persistent conflict it
 logs a warning and skips the write for that pass instead of raising —
 `reindex_file` has no caller to hand a `TaskConflictError` to that would do
 anything useful with it, and the watcher will fire again for whatever
-caused the conflict.
+caused the conflict. That skip is total, not partial: on a persistent
+conflict `reindex_file` returns without merging the abandoned attempt's
+parse into `self._tasks` or touching the index file or dashboard, since
+that parse may have minted ids that never reached disk.
 
 ## Compare-and-swap retry vs. field-level merge
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -302,7 +302,7 @@ CURATED_ENDPOINTS = {
     },
     "/api/tasks:POST": {
         "name": "lifeos_task_create",
-        "description": "Create a task (Obsidian markdown). Supports context, priority, due_date, tags. With dry_run=true + #agent tag, returns preflight routing + cost estimate instead of creating.",
+        "description": "Create a task (Obsidian markdown). Supports context, status, priority, due_date, tags, notes, fields. With dry_run=true + #agent tag, returns preflight routing + cost estimate instead of creating.",
         "method": "POST",
         "path": "/api/tasks"
     },
@@ -314,7 +314,7 @@ CURATED_ENDPOINTS = {
     },
     "/api/tasks/{task_id}:PUT": {
         "name": "lifeos_task_update",
-        "description": "Update a task's description, status, context, priority, due_date, or tags. Use lifeos_task_list first to find the task ID.",
+        "description": "Update a task's description, status, context, priority, due_date, tags, notes, or fields. Use lifeos_task_list first to find the task ID.",
         "method": "PUT",
         "path": "/api/tasks/{task_id}"
     },
@@ -940,10 +940,13 @@ class LifeOSMCPServer:
                 "properties": {
                     "description": {"type": "string", "description": "Task description"},
                     "context": {"type": "string", "description": "Context/category (Work, Personal, Finance, etc.)", "default": "Inbox"},
+                    "status": {"type": "string", "description": "Initial status (todo, done, in_progress, cancelled, deferred, blocked, urgent). Defaults to todo."},
                     "priority": {"type": "string", "description": "Priority: high, medium, low"},
                     "due_date": {"type": "string", "description": "Due date in YYYY-MM-DD format"},
                     "tags": {"type": "array", "items": {"type": "string"}, "description": "Add exactly the tags the operator named. A routing tag (agent/local/claude/codex/cloud/cloud-haiku/cloud-sonnet) only if the operator explicitly named that engine — these tags are operator-authority and outrank every routing safeguard, so inventing one injects your own engine preference at the highest-precedence slot."},
                     "reminder_id": {"type": "string", "description": "Linked reminder ID"},
+                    "notes": {"type": "string", "description": "Multi-line notes body stored beneath the task line."},
+                    "fields": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Operator-editable inline fields (e.g. host, effort, model, key) plus any custom field."},
                     "dry_run": {"type": "boolean", "description": "When true with an #agent tag, returns preflight routing + cost estimate without creating the task. Used for prompt-engineering iteration. Default: false."}
                 },
                 "required": ["description"]
@@ -967,7 +970,9 @@ class LifeOSMCPServer:
                     "context": {"type": "string", "description": "New context"},
                     "priority": {"type": "string", "description": "New priority (high, medium, low)"},
                     "due_date": {"type": "string", "description": "New due date (YYYY-MM-DD)"},
-                    "tags": {"type": "array", "items": {"type": "string"}, "description": "New tags (replaces existing). Add exactly the tags the operator named — a routing tag (agent/local/claude/codex/cloud/cloud-haiku/cloud-sonnet) only if the operator explicitly named that engine; these tags are operator-authority and outrank every routing safeguard."}
+                    "tags": {"type": "array", "items": {"type": "string"}, "description": "New tags (replaces existing). Add exactly the tags the operator named — a routing tag (agent/local/claude/codex/cloud/cloud-haiku/cloud-sonnet) only if the operator explicitly named that engine; these tags are operator-authority and outrank every routing safeguard."},
+                    "notes": {"type": "string", "description": "Replaces the notes body."},
+                    "fields": {"type": "object", "additionalProperties": {"type": ["string", "null"]}, "description": "Merged into operator/unknown fields, not replaced: a string sets a field, null removes it."}
                 },
                 "required": ["task_id"]
             },

--- a/tests/test_agent_tools_tasks.py
+++ b/tests/test_agent_tools_tasks.py
@@ -87,6 +87,36 @@ class TestManageTasksCreate:
         assert len(tasks) == 1
         assert tasks[0].context == "Inbox"
 
+    def test_create_forwards_status_notes_fields(self, tm):
+        """#853: status/notes/fields are threaded through the chat tool too."""
+        _tool_manage_tasks({
+            "action": "create",
+            "description": "Waiting on legal",
+            "status": "blocked",
+            "notes": "chased on Monday",
+            "fields": {"host": "laptop"},
+        })
+        tasks = tm.list_tasks()
+        assert len(tasks) == 1
+        assert tasks[0].status == "blocked"
+        assert tasks[0].notes == "chased on Monday"
+        assert tasks[0].fields == {"host": "laptop"}
+
+
+class TestManageTasksUpdateNotesAndFields:
+    def test_update_notes(self, tm):
+        task = tm.create("Plan launch")
+        _tool_manage_tasks({"action": "update", "task_id": task.id, "notes": "draft outline"})
+        assert tm.get(task.id).notes == "draft outline"
+
+    def test_update_fields_merges_and_removes(self, tm):
+        task = tm.create("Plan launch", fields={"host": "laptop"})
+        _tool_manage_tasks({
+            "action": "update", "task_id": task.id,
+            "fields": {"host": None, "effort": "high"},
+        })
+        assert tm.get(task.id).fields == {"effort": "high"}
+
 
 class TestUnknownAction:
     def test_unknown_action(self, tm):

--- a/tests/test_agent_tools_tasks.py
+++ b/tests/test_agent_tools_tasks.py
@@ -124,6 +124,25 @@ class TestUnknownAction:
         assert out.startswith("Error:")
 
 
+class TestManageTasksCreateBadStatus:
+    """#853 round 1 finding #11: `TaskManager.create` now raises `ValueError`
+    for an unrecognized `status`. Through the chat tool boundary
+    (`execute_tool`, which wraps every handler in try/except and formats an
+    exception as an "Error: ..." string) that must come back as an error
+    string, not an unhandled exception, and nothing should be written."""
+
+    async def test_bad_status_returns_error_string_nothing_written(self, tm):
+        from api.services.agent_tools import execute_tool
+
+        out = await execute_tool("manage_tasks", {
+            "action": "create",
+            "description": "Bad status task",
+            "status": "Done",
+        })
+        assert out.startswith("Error:")
+        assert tm.list_tasks() == []
+
+
 class TestManageTasksFilterDocs:
     """The `manage_tasks` schema is what the orchestrator reads before calling the
     tool, and a bad filter hint fails silently — the call succeeds and returns the

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -4,8 +4,6 @@ Tests for api/services/atomic_write.py
 The shared atomic-write helper used by both task_manager.py and
 scheduler_store.py: temp file in the same directory, fsync, os.replace.
 """
-import builtins
-import unittest.mock as mock
 import pytest
 from pathlib import Path
 
@@ -60,27 +58,30 @@ def test_atomic_write_uses_replace_with_temp_file_in_same_dir(tmp_path, monkeypa
     assert dst == str(target)
 
 
-def test_destination_is_never_opened_directly_for_writing(tmp_path):
-    """A reader opening `target` mid-write must see either the old content
-    in full or the new content in full — never a partial write. Proven here
-    by showing the destination path itself is never opened in a write mode;
-    only a temp file is, and the swap happens via a single os.replace."""
+def test_atomic_write_lines_leaves_destination_unchanged_on_replace_failure(tmp_path, monkeypatch):
+    """Same atomic-semantics proof as
+    `test_failed_replace_cleans_up_temp_file_and_leaves_original` below, for
+    `atomic_write_lines` specifically: if `os.replace` fails mid-write, the
+    destination keeps its old content in full and no temp file survives —
+    never a partial write. (The prior version of this test spied on
+    `builtins.open`, but `os.fdopen` routes through `io.open` regardless of
+    write path, so it passed even against a non-atomic `path.write_text` —
+    it proved nothing about atomicity.)"""
+    import api.services.atomic_write as aw
+
     target = tmp_path / "file.txt"
-    target.write_text("old", encoding="utf-8")
+    target.write_text("old\n", encoding="utf-8")
 
-    opened_for_write = []
-    original_open = builtins.open
+    def boom(src, dst):
+        raise OSError("simulated replace failure")
 
-    def spy_open(file, mode="r", *args, **kwargs):
-        if any(c in mode for c in ("w", "a", "x")):
-            opened_for_write.append(str(file))
-        return original_open(file, mode, *args, **kwargs)
+    monkeypatch.setattr(aw.os, "replace", boom)
 
-    with mock.patch("builtins.open", spy_open):
-        atomic_write_text(target, "new content")
+    with pytest.raises(OSError):
+        atomic_write_lines(target, ["new", "lines"])
 
-    assert str(target) not in opened_for_write
-    assert target.read_text(encoding="utf-8") == "new content"
+    assert target.read_text(encoding="utf-8") == "old\n"
+    assert list(tmp_path.glob(".*.tmp")) == []
 
 
 def test_failed_replace_cleans_up_temp_file_and_leaves_original(tmp_path, monkeypatch):

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,0 +1,101 @@
+"""
+Tests for api/services/atomic_write.py
+
+The shared atomic-write helper used by both task_manager.py and
+scheduler_store.py: temp file in the same directory, fsync, os.replace.
+"""
+import builtins
+import unittest.mock as mock
+import pytest
+from pathlib import Path
+
+from api.services.atomic_write import atomic_write_text, atomic_write_lines
+
+pytestmark = pytest.mark.unit
+
+
+def test_atomic_write_text_creates_file(tmp_path):
+    target = tmp_path / "sub" / "file.txt"
+    atomic_write_text(target, "hello world")
+    assert target.read_text(encoding="utf-8") == "hello world"
+
+
+def test_atomic_write_text_overwrites_existing_content(tmp_path):
+    target = tmp_path / "file.txt"
+    target.write_text("old", encoding="utf-8")
+    atomic_write_text(target, "new")
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_atomic_write_text_no_leftover_temp_file(tmp_path):
+    target = tmp_path / "file.txt"
+    atomic_write_text(target, "content")
+    assert list(tmp_path.glob(".*.tmp")) == []
+
+
+def test_atomic_write_lines_joins_with_trailing_newline(tmp_path):
+    target = tmp_path / "file.txt"
+    atomic_write_lines(target, ["a", "b", "c"])
+    assert target.read_text(encoding="utf-8") == "a\nb\nc\n"
+
+
+def test_atomic_write_uses_replace_with_temp_file_in_same_dir(tmp_path, monkeypatch):
+    import api.services.atomic_write as aw
+
+    calls = []
+    original = aw.os.replace
+
+    def spy(src, dst):
+        calls.append((src, dst))
+        return original(src, dst)
+
+    monkeypatch.setattr(aw.os, "replace", spy)
+
+    target = tmp_path / "file.txt"
+    atomic_write_text(target, "data")
+
+    assert len(calls) == 1
+    src, dst = calls[0]
+    assert Path(src).parent == target.parent
+    assert dst == str(target)
+
+
+def test_destination_is_never_opened_directly_for_writing(tmp_path):
+    """A reader opening `target` mid-write must see either the old content
+    in full or the new content in full — never a partial write. Proven here
+    by showing the destination path itself is never opened in a write mode;
+    only a temp file is, and the swap happens via a single os.replace."""
+    target = tmp_path / "file.txt"
+    target.write_text("old", encoding="utf-8")
+
+    opened_for_write = []
+    original_open = builtins.open
+
+    def spy_open(file, mode="r", *args, **kwargs):
+        if any(c in mode for c in ("w", "a", "x")):
+            opened_for_write.append(str(file))
+        return original_open(file, mode, *args, **kwargs)
+
+    with mock.patch("builtins.open", spy_open):
+        atomic_write_text(target, "new content")
+
+    assert str(target) not in opened_for_write
+    assert target.read_text(encoding="utf-8") == "new content"
+
+
+def test_failed_replace_cleans_up_temp_file_and_leaves_original(tmp_path, monkeypatch):
+    import api.services.atomic_write as aw
+
+    def boom(src, dst):
+        raise OSError("simulated failure")
+
+    monkeypatch.setattr(aw.os, "replace", boom)
+
+    target = tmp_path / "file.txt"
+    target.write_text("original", encoding="utf-8")
+
+    with pytest.raises(OSError):
+        atomic_write_text(target, "new data")
+
+    assert list(tmp_path.glob(".*.tmp")) == []
+    assert target.read_text(encoding="utf-8") == "original"

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -2006,6 +2006,54 @@ class TestMoveTaskConflict:
         final_content = source_path.read_text(encoding="utf-8")
         assert "[priority:: high]" in final_content
 
+    def test_uncontended_move_does_not_reindex_or_extra_write(self, task_manager, monkeypatch):
+        """#853 round 3 finding #1: seeding `self._last_written_line[task.id]`
+        with the destination's just-written line unconditionally, right
+        after the destination insert (rather than only if the source-side
+        removal later raises), made the source removal's
+        `_external_edit_pending` check compare the still-on-disk source
+        line against that destination line. They always mismatch (fresh
+        `updated_at`), so an ordinary, uncontended move triggered a
+        spurious `reindex_file` call and an extra write, burning a CAS
+        retry for no reason. An uncontended move must write exactly twice
+        (once to each file) and never reindex."""
+        task = task_manager.create(
+            "Move me cleanly", context="MoveSrc3", notes="keep this body clean"
+        )
+
+        import api.services.task_manager as tm_mod
+
+        reindex_calls = []
+        monkeypatch.setattr(
+            tm_mod.TaskManager,
+            "reindex_file",
+            lambda self, file_path: reindex_calls.append(file_path),
+        )
+
+        write_calls = []
+        original_atomic_write_lines = tm_mod.atomic_write_lines
+
+        def recording_atomic_write_lines(path, *args, **kwargs):
+            write_calls.append(Path(path))
+            return original_atomic_write_lines(path, *args, **kwargs)
+
+        monkeypatch.setattr(tm_mod, "atomic_write_lines", recording_atomic_write_lines)
+
+        updated = task_manager.update(task.id, context="MoveDest3", priority="high")
+
+        assert reindex_calls == []
+        assert len(write_calls) == 2
+        assert {p.name for p in write_calls} == {"MoveDest3.md", "MoveSrc3.md"}
+
+        dest_content = (task_manager.tasks_dir / "MoveDest3.md").read_text(encoding="utf-8")
+        assert "[priority:: high]" in dest_content
+        assert "Move me cleanly" in dest_content
+
+        source_content = (task_manager.tasks_dir / "MoveSrc3.md").read_text(encoding="utf-8")
+        assert "Move me cleanly" not in source_content
+
+        assert updated.context == "MoveDest3"
+
 
 class TestFieldValidation:
     """#853 round 1 findings #2 and #3: description/notes/fields content

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -5,6 +5,7 @@ Tests task CRUD operations, status transitions, context changes, fuzzy search,
 parse/format round-trip, reindexing, and persistence.
 """
 import json
+import re
 import pytest
 from datetime import date
 from pathlib import Path
@@ -12,12 +13,15 @@ from pathlib import Path
 from api.services.task_manager import (
     Task,
     TaskManager,
+    TaskConflictError,
     STATUS_TO_SYMBOL,
     SYMBOL_TO_STATUS,
     VALID_STATUSES,
     _format_task_line,
+    _format_task_block,
     _parse_task_line,
     _fuzzy_filter,
+    is_conflict_file,
 )
 
 pytestmark = pytest.mark.unit
@@ -799,13 +803,28 @@ class TestParseTaskLine:
 
         assert task is None
 
-    def test_parse_checkbox_without_todo_keyword_returns_none(self):
-        """Test that checkbox without TODO keyword returns None."""
+    def test_parse_checkbox_without_todo_keyword_still_parses(self):
+        """#853: the literal TODO keyword is no longer required to parse a
+        checkbox line as a task — any `- [.] ...` line counts, so a hand-
+        written checklist item gets an id comment written back on reindex
+        instead of being silently ignored forever. (This intentionally
+        replaces the old test_parse_checkbox_without_todo_keyword_returns_none,
+        which pinned the opposite behavior.)"""
         line = "- [ ] Regular checklist item"
 
         task = _parse_task_line(line, "/path/to/Inbox.md", 1)
 
-        assert task is None
+        assert task is not None
+        assert task.description == "Regular checklist item"
+        assert task.status == "todo"
+
+    def test_parse_non_checkbox_line_returns_none(self):
+        """A line that isn't a checkbox at all (heading, blank, prose,
+        non-checkbox bullet) is never mistaken for a task."""
+        assert _parse_task_line("## A heading", "/path/to/Inbox.md", 1) is None
+        assert _parse_task_line("", "/path/to/Inbox.md", 1) is None
+        assert _parse_task_line("- a plain bullet, no checkbox", "/path/to/Inbox.md", 1) is None
+        assert _parse_task_line("Just a sentence.", "/path/to/Inbox.md", 1) is None
 
 
 class TestParseFormatRoundTrip:
@@ -1320,3 +1339,377 @@ class TestListFilterSemanticsMatchDocs:
         # Fixture has 5 tasks, only 2 with due dates.
         assert len(populated_manager.list_tasks(due_before="2099-01-01")) == 2
         assert all(t.due_date is not None for t in populated_manager.list_tasks(due_before="2099-01-01"))
+
+
+# =============================================================================
+# #853 — Task store hardening: id write-back, atomic writes, id-addressed
+# writes, notes body, unknown-field round-trip, cache-field merge-forward,
+# external-edit-wins, CAS retry + conflict, and Syncthing conflict-file skip.
+# =============================================================================
+
+class TestIdWriteBack:
+    """Reindexing mints and writes back a stable id for any hand-authored
+    checkbox line that lacks one, without disturbing anything else."""
+
+    def test_reindex_mints_and_writes_back_id(self, task_manager):
+        file_path = task_manager.tasks_dir / "Handwritten.md"
+        file_path.write_text("- [ ] TODO Buy milk\n", encoding="utf-8")
+
+        task_manager.reindex_file(str(file_path))
+
+        content = file_path.read_text(encoding="utf-8")
+        assert content.startswith("- [ ] TODO Buy milk <!-- id:")
+        m = re.search(r"<!-- id:(\w+) -->", content)
+        assert m
+        minted_id = m.group(1)
+        assert task_manager.get(minted_id).description == "Buy milk"
+
+        # Stable + idempotent on a second reindex.
+        task_manager.reindex_file(str(file_path))
+        assert file_path.read_text(encoding="utf-8") == content
+        assert task_manager.get(minted_id) is not None
+
+    def test_reindex_preserves_mixed_content_byte_for_byte(self, task_manager):
+        lines_in = [
+            "---",
+            "type: tasks",
+            "---",
+            "# Mixed Tasks",
+            "",
+            "Some prose note that isn't a task at all.",
+            "",
+            "- A plain bullet, not a checkbox",
+            "  - nested content under it",
+            "",
+            "- [ ] TODO Buy milk",
+            "- [x] TODO Already has an id <!-- id:existing1 -->",
+            "- [ ] Another hand-written item, no TODO keyword",
+            "",
+            "## Section 2",
+        ]
+        file_path = task_manager.tasks_dir / "Mixed.md"
+        file_path.write_text("\n".join(lines_in) + "\n", encoding="utf-8")
+
+        task_manager.reindex_file(str(file_path))
+
+        lines_out = file_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines_out) == len(lines_in)
+
+        task_line_idx = {10, 11, 12}
+        for i, original in enumerate(lines_in):
+            if i in task_line_idx:
+                continue
+            assert lines_out[i] == original, f"non-task line {i} changed: {lines_out[i]!r}"
+
+        # Already-id'd line: fully untouched.
+        assert lines_out[11] == lines_in[11]
+
+        # Id-less task lines: original text preserved, exactly one id
+        # comment appended.
+        for i in (10, 12):
+            assert lines_out[i].startswith(lines_in[i])
+            suffix = lines_out[i][len(lines_in[i]):]
+            assert re.fullmatch(r" <!-- id:\w+ -->", suffix), f"line {i} suffix: {suffix!r}"
+
+        # Idempotent — a second reindex makes no further change.
+        task_manager.reindex_file(str(file_path))
+        assert file_path.read_text(encoding="utf-8").splitlines() == lines_out
+
+
+class TestIdAddressedWrites:
+    """Writes locate their task by id, not by cached line number, so an
+    external insert above a task doesn't misdirect the next write."""
+
+    def test_update_targets_correct_line_after_external_insert_above(self, task_manager):
+        task_a = task_manager.create("Task A", context="AddressTest")
+        task_manager.create("Task B", context="AddressTest")
+        file_path = task_manager.tasks_dir / "AddressTest.md"
+
+        # Simulate an external edit landing before the watcher reindexes.
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text("New line one\nNew line two\n" + content, encoding="utf-8")
+
+        updated = task_manager.update(task_a.id, description="Task A updated")
+
+        assert updated.description == "Task A updated"
+        final_content = file_path.read_text(encoding="utf-8")
+        assert "New line one" in final_content
+        assert "New line two" in final_content
+        assert re.search(r"- \[ \] TODO Task B \[", final_content), "task B's line was disturbed"
+
+
+class TestNotesBody:
+    def test_create_with_notes_writes_indented_body(self, task_manager):
+        task = task_manager.create("Notes test", context="NotesTest", notes="line one\nline two")
+        content = (task_manager.tasks_dir / "NotesTest.md").read_text(encoding="utf-8")
+        assert "    > line one" in content
+        assert "    > line two" in content
+        assert task_manager.get(task.id).notes == "line one\nline two"
+
+    def test_delete_removes_task_line_and_body(self, task_manager):
+        task = task_manager.create("Delete with notes", context="NotesTest", notes="body line")
+        file_path = task_manager.tasks_dir / "NotesTest.md"
+        assert "body line" in file_path.read_text(encoding="utf-8")
+
+        task_manager.delete(task.id)
+
+        content = file_path.read_text(encoding="utf-8")
+        assert "Delete with notes" not in content
+        assert "body line" not in content
+
+    def test_context_change_moves_notes_body_too(self, task_manager):
+        task = task_manager.create("Move with notes", context="NotesA", notes="keep me")
+        task_manager.update(task.id, context="NotesB")
+
+        old_content = (task_manager.tasks_dir / "NotesA.md").read_text(encoding="utf-8")
+        new_content = (task_manager.tasks_dir / "NotesB.md").read_text(encoding="utf-8")
+        assert "keep me" not in old_content
+        assert "keep me" in new_content
+        assert task_manager.get(task.id).notes == "keep me"
+
+    def test_update_notes_rewrites_body(self, task_manager):
+        task = task_manager.create("Update notes", context="NotesTest", notes="old body")
+        task_manager.update(task.id, notes="new body")
+        content = (task_manager.tasks_dir / "NotesTest.md").read_text(encoding="utf-8")
+        assert "old body" not in content
+        assert "new body" in content
+
+
+class TestUnknownFieldRoundTrip:
+    def test_unknown_field_survives_reindex_and_rewrite(self, task_manager):
+        file_path = task_manager.tasks_dir / "Unknown.md"
+        file_path.write_text(
+            "- [ ] TODO Custom field task [foo:: bar] <!-- id:custom01 -->\n",
+            encoding="utf-8",
+        )
+        task_manager.reindex_file(str(file_path))
+
+        task = task_manager.get("custom01")
+        assert task is not None
+        assert task.fields == {"foo": "bar"}
+
+        # Any API rewrite of the task must not drop the unknown field.
+        task_manager.update("custom01", priority="high")
+        content = file_path.read_text(encoding="utf-8")
+        assert "[foo:: bar]" in content
+        assert task_manager.get("custom01").fields == {"foo": "bar"}
+
+
+class TestOperatorFields:
+    def test_create_with_fields_writes_inline(self, task_manager):
+        task = task_manager.create(
+            "Field test", context="Fields", fields={"host": "laptop", "effort": "high"}
+        )
+        content = (task_manager.tasks_dir / "Fields.md").read_text(encoding="utf-8")
+        assert "[host:: laptop]" in content
+        assert "[effort:: high]" in content
+        assert task.fields == {"host": "laptop", "effort": "high"}
+
+    def test_update_fields_null_removes_field(self, task_manager):
+        task = task_manager.create("Remove field", context="Fields", fields={"host": "laptop"})
+        updated = task_manager.update(task.id, fields={"host": None})
+
+        assert "host" not in updated.fields
+        content = (task_manager.tasks_dir / "Fields.md").read_text(encoding="utf-8")
+        assert "[host::" not in content
+
+    def test_update_fields_merges_not_replaces(self, task_manager):
+        task = task_manager.create("Merge fields", context="Fields", fields={"host": "laptop"})
+        updated = task_manager.update(task.id, fields={"effort": "high"})
+        assert updated.fields == {"host": "laptop", "effort": "high"}
+
+
+class TestMergeForwardCacheFields:
+    def test_reminder_id_survives_reindex_after_external_touch(self, task_manager):
+        task = task_manager.create("Linked task", context="Reminder", reminder_id="rem-123")
+        file_path = task_manager.tasks_dir / "Reminder.md"
+
+        # reminder_id has no markdown representation at all — an unrelated
+        # external touch must not lose it on reindex.
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content + "\n", encoding="utf-8")
+
+        task_manager.reindex_file(str(file_path))
+
+        assert task_manager.get(task.id).reminder_id == "rem-123"
+
+
+class TestExternalEditWins:
+    def test_external_edit_reflected_and_restamped(self, task_manager):
+        task = task_manager.create("Original", context="ExtEdit")
+        file_path = task_manager.tasks_dir / "ExtEdit.md"
+        first_stamp = task_manager.get(task.id).updated_at
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("Original", "Externally renamed"), encoding="utf-8")
+
+        task_manager.reindex_file(str(file_path))
+
+        refreshed = task_manager.get(task.id)
+        assert refreshed.description == "Externally renamed"
+        assert refreshed.updated_at != first_stamp
+        final_content = file_path.read_text(encoding="utf-8")
+        assert f"[updated:: {refreshed.updated_at}]" in final_content
+
+    def test_unrelated_task_untouched_when_only_one_task_edited(self, task_manager):
+        task_a = task_manager.create("Task A", context="ExtEdit2")
+        task_b = task_manager.create("Task B", context="ExtEdit2")
+        file_path = task_manager.tasks_dir / "ExtEdit2.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("Task A", "Task A renamed"), encoding="utf-8")
+
+        b_stamp_before = task_manager.get(task_b.id).updated_at
+
+        task_manager.reindex_file(str(file_path))
+
+        assert task_manager.get(task_a.id).description == "Task A renamed"
+        b_after = task_manager.get(task_b.id)
+        assert b_after.description == "Task B"
+        assert b_after.updated_at == b_stamp_before
+
+
+class TestCasRetryAndConflict:
+    def test_retries_three_times_then_raises_conflict(self, task_manager, monkeypatch):
+        task = task_manager.create("CAS test", context="CasTest")
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        reindex_calls = []
+        original_reindex = task_manager.reindex_file
+
+        def spy_reindex(path):
+            reindex_calls.append(path)
+            return original_reindex(path)
+
+        monkeypatch.setattr(task_manager, "reindex_file", spy_reindex)
+
+        with pytest.raises(TaskConflictError):
+            task_manager.update(task.id, description="new desc")
+
+        assert len(reindex_calls) == 3
+
+    def test_no_retry_needed_in_the_normal_case(self, task_manager):
+        task = task_manager.create("No conflict", context="CasTest2")
+        updated = task_manager.update(task.id, description="updated fine")
+        assert updated.description == "updated fine"
+
+
+class TestConflictFiles:
+    def test_conflict_files_never_indexed(self, task_manager):
+        task_manager.create("Real task", context="ConflictTest")
+        conflict_path = (
+            task_manager.tasks_dir / "ConflictTest.sync-conflict-20260101-120000-ABCDEFG.md"
+        )
+        conflict_path.write_text("- [ ] TODO Ghost task <!-- id:ghost001 -->\n", encoding="utf-8")
+        temp_path = task_manager.tasks_dir / ".syncthing.ConflictTest.md.tmp"
+        temp_path.write_text("- [ ] TODO Temp ghost <!-- id:ghost002 -->\n", encoding="utf-8")
+
+        task_manager.rebuild_index()
+
+        assert task_manager.get("ghost001") is None
+        assert task_manager.get("ghost002") is None
+
+    def test_reindex_file_is_noop_for_conflict_file(self, task_manager):
+        conflict_path = task_manager.tasks_dir / "X.sync-conflict-20260101-120000-ABCDEFG.md"
+        conflict_path.write_text("- [ ] TODO Ghost <!-- id:ghost003 -->\n", encoding="utf-8")
+
+        task_manager.reindex_file(str(conflict_path))
+
+        assert task_manager.get("ghost003") is None
+
+    def test_list_conflicts_reports_name_and_mtime(self, task_manager):
+        conflict_path = task_manager.tasks_dir / "Y.sync-conflict-20260101-120000-ABCDEFG.md"
+        conflict_path.write_text("stub", encoding="utf-8")
+        temp_path = task_manager.tasks_dir / ".syncthing.Y.md.tmp"
+        temp_path.write_text("stub", encoding="utf-8")
+
+        conflicts = task_manager.list_conflicts()
+        names = {c["name"] for c in conflicts}
+        assert conflict_path.name in names
+        assert temp_path.name in names
+        for c in conflicts:
+            assert c["mtime"]
+
+    def test_is_conflict_file_helper(self):
+        assert is_conflict_file(Path("Inbox.sync-conflict-20260101-120000-ABCDEFG.md"))
+        assert is_conflict_file(Path(".syncthing.Inbox.md.tmp"))
+        assert not is_conflict_file(Path("Inbox.md"))
+
+
+class TestUpdatedStamp:
+    def test_create_stamps_updated_with_utc_offset(self, task_manager):
+        task = task_manager.create("Stamped", context="Stamp")
+        assert task.updated_at is not None
+        assert re.search(r"[+-]\d{2}:\d{2}$", task.updated_at)
+        content = (task_manager.tasks_dir / "Stamp.md").read_text(encoding="utf-8")
+        assert f"[updated:: {task.updated_at}]" in content
+
+    def test_update_bumps_updated_stamp(self, task_manager):
+        task = task_manager.create("Stamped2", context="Stamp")
+        updated = task_manager.update(task.id, priority="high")
+        assert updated.updated_at is not None
+        assert re.search(r"[+-]\d{2}:\d{2}$", updated.updated_at)
+
+    def test_complete_stamps_updated(self, task_manager):
+        task = task_manager.create("Stamped3", context="Stamp")
+        completed = task_manager.complete(task.id)
+        assert completed.updated_at is not None
+
+    def test_swap_tag_stamps_updated(self, task_manager):
+        task = task_manager.create("Stamped4", context="Stamp", tags=["agent"])
+        task_manager.swap_tag(task.id, "agent", "agent-running")
+        assert task_manager.get(task.id).updated_at is not None
+
+
+class TestAtomicWriteIntegration:
+    def test_writes_go_through_os_replace(self, task_manager, monkeypatch):
+        import api.services.atomic_write as aw
+
+        calls = []
+        original_replace = aw.os.replace
+
+        def spy_replace(src, dst):
+            calls.append((src, dst))
+            return original_replace(src, dst)
+
+        monkeypatch.setattr(aw.os, "replace", spy_replace)
+
+        task_manager.create("Atomic test", context="Atomic")
+
+        assert len(calls) >= 1
+        for src, dst in calls:
+            assert Path(src).parent == Path(dst).parent
+
+    def test_no_leftover_temp_files_after_write(self, task_manager):
+        task_manager.create("No leftovers", context="Atomic2")
+        assert list(task_manager.tasks_dir.glob(".*.tmp")) == []
+
+
+class TestBlockedStatus:
+    def test_blocked_status_formats_as_question_mark(self, task_manager):
+        task = task_manager.create("Waiting on X", context="StatusTest", status="blocked")
+        assert task.status == "blocked"
+        content = (task_manager.tasks_dir / "StatusTest.md").read_text(encoding="utf-8")
+        assert "- [?] TODO Waiting on X" in content
+
+
+class TestFormatTaskBlock:
+    def test_format_task_block_no_notes_is_single_line(self):
+        task = Task(id="t1", description="No notes", status="todo", context="Inbox", created_date="2025-02-08")
+        assert _format_task_block(task) == [_format_task_line(task)]
+
+    def test_format_task_block_with_notes_appends_indented_lines(self):
+        task = Task(
+            id="t1", description="Has notes", status="todo", context="Inbox",
+            created_date="2025-02-08", notes="line one\nline two",
+        )
+        block = _format_task_block(task)
+        assert block[0] == _format_task_line(task)
+        assert block[1] == "    > line one"
+        assert block[2] == "    > line two"

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1169,6 +1169,35 @@ class TestReindexWriteBackCas:
         assert file_path.read_text(encoding="utf-8") == original_content
         assert any("conflict" in r.message.lower() for r in caplog.records)
 
+    def test_persistent_mismatch_does_not_merge_unwritten_parse_into_index(
+        self, task_manager, monkeypatch
+    ):
+        """#853 round 2 finding #2: on a persistent conflict the write-back
+        is correctly skipped, but `self._tasks` used to be updated anyway
+        from a parse that never reached disk — seeding a "ghost" id (minted
+        while appending a missing id comment) that nothing on disk carries —
+        and every abandoned attempt's `_reparse_lines` mutations to
+        `self._last_written_line` leaked through, not just the final one."""
+        file_path = task_manager.tasks_dir / "ReindexCasGhost.md"
+        original_content = "- [ ] TODO Buy milk\n"
+        file_path.write_text(original_content, encoding="utf-8")
+
+        tasks_before = dict(task_manager._tasks)
+        last_written_before = dict(task_manager._last_written_line)
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        task_manager.reindex_file(str(file_path))  # must not raise
+
+        assert file_path.read_text(encoding="utf-8") == original_content
+        assert task_manager._tasks == tasks_before
+        assert task_manager._last_written_line == last_written_before
+
 
 class TestRebuildIndex:
     """Tests for rebuild_index method."""
@@ -1607,6 +1636,47 @@ class TestDuplicateIds:
         task_manager.reindex_file(str(file_path))
         assert file_path.read_bytes() == before
 
+    def test_cross_file_duplicate_id_resolved_on_rebuild(self, task_manager):
+        """#853 round 2 finding #3: a same-file duplicate id is deduplicated
+        by `_reparse_lines` already, but two DIFFERENT files each carrying
+        `<!-- id:dupe0001 -->` were never deduplicated — `rebuild_index`
+        just let whichever file was parsed last silently win in
+        `self._tasks`, with the losing file's on-disk id now pointing at
+        the wrong task."""
+        inbox_path = task_manager.tasks_dir / "Inbox.md"
+        work_path = task_manager.tasks_dir / "Work.md"
+        inbox_path.write_text("- [ ] TODO Inbox copy <!-- id:dupe0001 -->\n", encoding="utf-8")
+        work_path.write_text("- [ ] TODO Work copy <!-- id:dupe0001 -->\n", encoding="utf-8")
+
+        task_manager.rebuild_index()
+
+        inbox_content = inbox_path.read_text(encoding="utf-8")
+        work_content = work_path.read_text(encoding="utf-8")
+        kept_original = [c for c in (inbox_content, work_content) if "dupe0001" in c]
+        assert len(kept_original) == 1, "exactly one file should keep the original id"
+
+        original = task_manager.get("dupe0001")
+        assert original is not None
+
+        other_content = work_content if "dupe0001" in inbox_content else inbox_content
+        m = re.search(r"<!-- id:(\w+) -->", other_content)
+        assert m
+        fresh_id = m.group(1)
+        assert fresh_id != "dupe0001"
+        fresh = task_manager.get(fresh_id)
+        assert fresh is not None
+        assert fresh.id != original.id
+
+        # Two distinct tasks are indexed, not one clobbering the other.
+        assert {original.description, fresh.description} == {"Inbox copy", "Work copy"}
+
+        # A second rebuild makes no further change — both files byte-identical.
+        inbox_before = inbox_path.read_bytes()
+        work_before = work_path.read_bytes()
+        task_manager.rebuild_index()
+        assert inbox_path.read_bytes() == inbox_before
+        assert work_path.read_bytes() == work_before
+
 
 class TestIdAddressedWrites:
     """Writes locate their task by id, not by cached line number, so an
@@ -1823,6 +1893,30 @@ class TestCasRewriteAbsorbsUnreindexedExternalEdit:
         assert "Retitled before claim" in final_content
         assert "#agent-running" in final_content
 
+    def test_update_preserves_unreindexed_external_body_only_edit(self, task_manager):
+        """#853 round 2 finding #4: `test_update_preserves_unreindexed_
+        external_retitle_and_body` changes the task LINE (a retitle) and the
+        body together, so it stays green even if `_external_edit_pending`'s
+        notes-comparison branch is deleted — the raw-line comparison alone
+        still catches it. This test changes ONLY the body, leaving the task
+        line byte-identical, so it isolates that branch: it fails if the
+        notes comparison is removed."""
+        task = task_manager.create("Body only", context="Absorb3", notes="original body")
+        file_path = task_manager.tasks_dir / "Absorb3.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        content = content.replace(
+            "    > original body", "    > original body\n    > added externally"
+        )
+        file_path.write_text(content, encoding="utf-8")
+
+        updated = task_manager.update(task.id, priority="high")
+
+        assert updated.notes == "original body\nadded externally"
+        final_content = file_path.read_text(encoding="utf-8")
+        assert "added externally" in final_content
+        assert "[priority:: high]" in final_content
+
 
 class TestMoveTaskConflict:
     """#853 round 1 finding #6: a context-change move used to remove the
@@ -1857,6 +1951,60 @@ class TestMoveTaskConflict:
         assert "Move me" not in dest_content
         # Index still points at the source — not left dangling.
         assert task_manager.get(task.id).context == "MoveSrc"
+
+    def test_source_conflict_rollback_leaves_index_pointing_at_intact_source(
+        self, task_manager, monkeypatch
+    ):
+        """#853 round 2 finding #1: when the destination insert succeeds and
+        the SOURCE removal then raises `TaskConflictError`, the best-effort
+        rollback used to run `_external_edit_pending` against a stale
+        (still-the-source) `self._last_written_line`, treat the freshly
+        inserted destination block as an unabsorbed external edit, restamp
+        and absorb it into `self._tasks` via `reindex_file` (context/
+        source_file now pointing at the destination), and then delete that
+        same block from the destination on retry — leaving the index
+        pointing at a file with no block for this id, even though the
+        source file still held the task byte for byte, untouched."""
+        task = task_manager.create("Move me too", context="MoveSrc2", notes="keep this body too")
+        source_path = task_manager.tasks_dir / "MoveSrc2.md"
+        dest_path = task_manager.tasks_dir / "MoveDest2.md"
+        source_content_before = source_path.read_text(encoding="utf-8")
+
+        import api.services.task_manager as tm_mod
+        original_mtime = tm_mod._mtime_or_none
+        state = {"flaky": True, "n": 0}
+
+        def flaky_for_source(path):
+            if state["flaky"] and Path(path) == source_path:
+                state["n"] += 1
+                return state["n"]  # always different -> source CAS never matches
+            return original_mtime(path)
+
+        monkeypatch.setattr(tm_mod, "_mtime_or_none", flaky_for_source)
+
+        with pytest.raises(TaskConflictError):
+            task_manager.update(task.id, context="MoveDest2")
+
+        # Destination has no block for the id — the rollback did its job.
+        dest_content = dest_path.read_text(encoding="utf-8") if dest_path.exists() else ""
+        assert "Move me too" not in dest_content
+        # Source is completely untouched, byte for byte.
+        source_content = source_path.read_text(encoding="utf-8")
+        assert source_content == source_content_before
+        assert "keep this body too" in source_content
+
+        indexed = task_manager.get(task.id)
+        assert indexed is not None
+        assert indexed.source_file.endswith("MoveSrc2.md")
+        assert indexed.context == "MoveSrc2"
+
+        # A subsequent, unmocked update must still succeed against the
+        # (correctly indexed) source file.
+        state["flaky"] = False
+        updated = task_manager.update(task.id, priority="high")
+        assert updated is not None
+        final_content = source_path.read_text(encoding="utf-8")
+        assert "[priority:: high]" in final_content
 
 
 class TestFieldValidation:

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1093,6 +1093,82 @@ class TestReindexFile:
         retrieved = task_manager.get(task.id)
         assert retrieved is None
 
+    def test_external_edit_detection_survives_repeated_reindexes(self, task_manager):
+        """#853 round 1 finding #1: `reindex_file` used to pop
+        `_last_written_line` for every task whose `source_file` matched —
+        exactly the set it had just repopulated — which erased the record
+        `reindex_file` itself needs to detect the NEXT external edit. A
+        second consecutive external edit would then go undetected."""
+        task = task_manager.create("Edit twice", context="RepeatEdit")
+        file_path = task_manager.tasks_dir / "RepeatEdit.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("Edit twice", "First edit"), encoding="utf-8")
+        task_manager.reindex_file(str(file_path))
+        first = task_manager.get(task.id)
+        assert first.description == "First edit"
+        first_stamp = first.updated_at
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("First edit", "Second edit"), encoding="utf-8")
+        task_manager.reindex_file(str(file_path))
+        second = task_manager.get(task.id)
+
+        assert second.description == "Second edit"
+        assert second.updated_at != first_stamp
+        assert f"[updated:: {second.updated_at}]" in file_path.read_text(encoding="utf-8")
+
+
+class TestReindexWriteBackCas:
+    """#853 round 1 finding #14: `reindex_file`'s own write-back (minting an
+    id, restamping an external edit) had no compare-and-swap check against a
+    write landing between its read and its write — a concurrent writer's
+    change could be silently lost."""
+
+    def test_single_mismatch_then_writes_id_back_on_retry(self, task_manager, monkeypatch):
+        file_path = task_manager.tasks_dir / "ReindexCas.md"
+        file_path.write_text("- [ ] TODO Buy milk\n", encoding="utf-8")
+
+        import api.services.task_manager as tm_mod
+        original_mtime = tm_mod._mtime_or_none
+        calls = {"n": 0}
+
+        def mismatch_once_then_real(path):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return 111  # first attempt's mtime_before
+            if calls["n"] == 2:
+                return 222  # first attempt's mtime_now -> forces a mismatch/retry
+            return original_mtime(path)  # every later call: the real, stable value
+
+        monkeypatch.setattr(tm_mod, "_mtime_or_none", mismatch_once_then_real)
+
+        task_manager.reindex_file(str(file_path))
+
+        content = file_path.read_text(encoding="utf-8")
+        assert re.search(r"<!-- id:\w+ -->", content), "id was never written back after the retry"
+
+    def test_persistent_mismatch_skips_write_logs_warning_no_exception(
+        self, task_manager, monkeypatch, caplog
+    ):
+        file_path = task_manager.tasks_dir / "ReindexCasPersistent.md"
+        original_content = "- [ ] TODO Buy milk\n"
+        file_path.write_text(original_content, encoding="utf-8")
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="api.services.task_manager"):
+            task_manager.reindex_file(str(file_path))  # must not raise
+
+        assert file_path.read_text(encoding="utf-8") == original_content
+        assert any("conflict" in r.message.lower() for r in caplog.records)
+
 
 class TestRebuildIndex:
     """Tests for rebuild_index method."""
@@ -1386,13 +1462,21 @@ class TestIdWriteBack:
             "- [ ] Another hand-written item, no TODO keyword",
             "",
             "## Section 2",
+            "",
+            "Example syntax for the docs:",
+            "```markdown",
+            "- [ ] example checkbox inside a fence, not a real task",
+            "```",
+            "",
         ]
         file_path = task_manager.tasks_dir / "Mixed.md"
-        file_path.write_text("\n".join(lines_in) + "\n", encoding="utf-8")
+        original_bytes = ("\n".join(lines_in) + "\n").encode("utf-8")
+        file_path.write_bytes(original_bytes)
 
         task_manager.reindex_file(str(file_path))
 
-        lines_out = file_path.read_text(encoding="utf-8").splitlines()
+        out_bytes = file_path.read_bytes()
+        lines_out = out_bytes.decode("utf-8").splitlines()
         assert len(lines_out) == len(lines_in)
 
         task_line_idx = {10, 11, 12}
@@ -1400,6 +1484,11 @@ class TestIdWriteBack:
             if i in task_line_idx:
                 continue
             assert lines_out[i] == original, f"non-task line {i} changed: {lines_out[i]!r}"
+
+        # The fenced checkbox line (idx 18) is untouched byte-for-byte and
+        # never indexed as a task — #853 round 1 finding #7.
+        assert lines_out[18] == lines_in[18]
+        assert task_manager.list_tasks(query="example checkbox") == []
 
         # Already-id'd line: fully untouched.
         assert lines_out[11] == lines_in[11]
@@ -1411,9 +1500,112 @@ class TestIdWriteBack:
             suffix = lines_out[i][len(lines_in[i]):]
             assert re.fullmatch(r" <!-- id:\w+ -->", suffix), f"line {i} suffix: {suffix!r}"
 
-        # Idempotent — a second reindex makes no further change.
+        # Idempotent — a second reindex makes no further change, down to the
+        # raw bytes (trailing newline / line endings included).
         task_manager.reindex_file(str(file_path))
-        assert file_path.read_text(encoding="utf-8").splitlines() == lines_out
+        assert file_path.read_bytes() == out_bytes
+
+    def test_reindex_preserves_crlf_line_endings(self, task_manager):
+        """#853 round 1 finding #9: a CRLF file must not become LF wholesale
+        when an id gets written back."""
+        file_path = task_manager.tasks_dir / "Crlf.md"
+        original_bytes = b"# CRLF Tasks\r\n\r\n- [ ] TODO Buy milk\r\n"
+        file_path.write_bytes(original_bytes)
+
+        task_manager.reindex_file(str(file_path))
+
+        out_bytes = file_path.read_bytes()
+        assert out_bytes.endswith(b"\r\n")
+        # No bare LF was introduced — every newline is part of a CRLF pair.
+        assert out_bytes.count(b"\n") == out_bytes.count(b"\r\n")
+        lines_out = out_bytes.decode("utf-8").split("\r\n")
+        assert lines_out[0] == "# CRLF Tasks"
+        assert lines_out[1] == ""
+        assert re.fullmatch(r"- \[ \] TODO Buy milk <!-- id:\w+ -->", lines_out[2])
+        assert lines_out[3] == ""  # trailing terminator preserved
+
+    def test_reindex_preserves_missing_trailing_newline(self, task_manager):
+        """#853 round 1 finding #9: a file with no final newline must not
+        gain one just because an id got written back to one of its lines."""
+        file_path = task_manager.tasks_dir / "NoTrailingNewline.md"
+        content = "# No Trailing Newline\n\n- [ ] TODO Buy milk"
+        file_path.write_bytes(content.encode("utf-8"))
+        assert not file_path.read_bytes().endswith(b"\n")
+
+        task_manager.reindex_file(str(file_path))
+
+        out_bytes = file_path.read_bytes()
+        assert not out_bytes.endswith(b"\n")
+        out_text = out_bytes.decode("utf-8")
+        assert out_text.startswith("# No Trailing Newline\n\n- [ ] TODO Buy milk <!-- id:")
+
+
+class TestFencedCodeBlocks:
+    """#853 round 1 finding #7: a checkbox line inside a fenced (``` or
+    ~~~) code block is documentation/example text, never a real task."""
+
+    def test_create_inserts_above_first_real_task_not_inside_fence(self, task_manager):
+        file_path = task_manager.tasks_dir / "FenceInsert.md"
+        file_path.write_text(
+            "# Fence Insert\n\n"
+            "```markdown\n"
+            "- [ ] example, not a real task\n"
+            "```\n\n"
+            "- [ ] TODO Real task <!-- id:realtask1 -->\n",
+            encoding="utf-8",
+        )
+        task_manager.reindex_file(str(file_path))
+
+        task = task_manager.create("New task", context="FenceInsert")
+
+        content = file_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        # The example checkbox inside the fence is unchanged and comes
+        # before the newly created task's line, which comes before "Real
+        # task" — the new task must not land inside the fence.
+        fence_idx = next(i for i, ln in enumerate(lines) if "example, not a real task" in ln)
+        new_task_idx = next(i for i, ln in enumerate(lines) if f"<!-- id:{task.id} -->" in ln)
+        real_task_idx = next(i for i, ln in enumerate(lines) if "realtask1" in ln)
+        assert fence_idx < new_task_idx < real_task_idx
+        assert lines[fence_idx] == "- [ ] example, not a real task"
+        assert task_manager.get("realtask1") is not None
+
+
+class TestDuplicateIds:
+    """#853 round 1 finding #8: two task lines sharing the same id comment
+    (e.g. a hand-copied line) must not fight over it forever."""
+
+    def test_duplicate_id_gets_a_fresh_id_and_both_are_indexed(self, task_manager):
+        file_path = task_manager.tasks_dir / "Dupes.md"
+        file_path.write_text(
+            "- [ ] TODO First copy <!-- id:dupe0001 -->\n"
+            "- [ ] TODO Second copy <!-- id:dupe0001 -->\n",
+            encoding="utf-8",
+        )
+
+        task_manager.reindex_file(str(file_path))
+
+        first = task_manager.get("dupe0001")
+        assert first is not None
+        assert first.description == "First copy"
+
+        content = file_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        second_line = next(ln for ln in lines if "Second copy" in ln)
+        m = re.search(r"<!-- id:(\w+) -->", second_line)
+        assert m
+        second_id = m.group(1)
+        assert second_id != "dupe0001"
+        second = task_manager.get(second_id)
+        assert second is not None
+        assert second.description == "Second copy"
+        # Only one id comment on the rewritten line.
+        assert second_line.count("<!-- id:") == 1
+
+        # A second reindex makes no further change — bytes identical.
+        before = file_path.read_bytes()
+        task_manager.reindex_file(str(file_path))
+        assert file_path.read_bytes() == before
 
 
 class TestIdAddressedWrites:
@@ -1428,14 +1620,22 @@ class TestIdAddressedWrites:
         # Simulate an external edit landing before the watcher reindexes.
         content = file_path.read_text(encoding="utf-8")
         file_path.write_text("New line one\nNew line two\n" + content, encoding="utf-8")
+        before_lines = file_path.read_text(encoding="utf-8").splitlines()
+        task_a_idx = next(i for i, ln in enumerate(before_lines) if f"<!-- id:{task_a.id} -->" in ln)
 
         updated = task_manager.update(task_a.id, description="Task A updated")
 
         assert updated.description == "Task A updated"
-        final_content = file_path.read_text(encoding="utf-8")
-        assert "New line one" in final_content
-        assert "New line two" in final_content
-        assert re.search(r"- \[ \] TODO Task B \[", final_content), "task B's line was disturbed"
+        # #853 round 1 finding #16: every line except task A's own must be
+        # byte-identical before and after — not just spot-checked strings.
+        after_lines = file_path.read_text(encoding="utf-8").splitlines()
+        assert len(after_lines) == len(before_lines)
+        for i, before_line in enumerate(before_lines):
+            if i == task_a_idx:
+                continue
+            assert after_lines[i] == before_line, f"line {i} changed unexpectedly: {after_lines[i]!r}"
+        assert after_lines[task_a_idx] != before_lines[task_a_idx]
+        assert "Task A updated" in after_lines[task_a_idx]
 
 
 class TestNotesBody:
@@ -1449,13 +1649,22 @@ class TestNotesBody:
     def test_delete_removes_task_line_and_body(self, task_manager):
         task = task_manager.create("Delete with notes", context="NotesTest", notes="body line")
         file_path = task_manager.tasks_dir / "NotesTest.md"
+        before_lines = file_path.read_text(encoding="utf-8").splitlines()
         assert "body line" in file_path.read_text(encoding="utf-8")
+
+        task_line_idx = next(i for i, ln in enumerate(before_lines) if f"<!-- id:{task.id} -->" in ln)
+        body_end = task_line_idx + 1
+        while body_end < len(before_lines) and before_lines[body_end].lstrip().startswith(">"):
+            body_end += 1
+        # #853 round 1 finding #16: the remaining file must equal the
+        # fixture minus exactly the task's line and its body lines — not
+        # just "the description string is gone somewhere."
+        expected_lines = before_lines[:task_line_idx] + before_lines[body_end:]
 
         task_manager.delete(task.id)
 
-        content = file_path.read_text(encoding="utf-8")
-        assert "Delete with notes" not in content
-        assert "body line" not in content
+        after_lines = file_path.read_text(encoding="utf-8").splitlines()
+        assert after_lines == expected_lines
 
     def test_context_change_moves_notes_body_too(self, task_manager):
         task = task_manager.create("Move with notes", context="NotesA", notes="keep me")
@@ -1569,6 +1778,178 @@ class TestExternalEditWins:
         assert b_after.updated_at == b_stamp_before
 
 
+class TestCasRewriteAbsorbsUnreindexedExternalEdit:
+    """#853 round 1 finding #5: `_cas_rewrite` used to build its replacement
+    purely from `self._tasks`, so an external edit that had landed on disk
+    but not yet been through `reindex_file` (the normal case under the
+    watcher's 2s debounce, not a rare race) was silently reverted by an
+    unrelated field update."""
+
+    def test_update_preserves_unreindexed_external_retitle_and_body(self, task_manager):
+        task = task_manager.create("Original title", context="Absorb", notes="original body")
+        file_path = task_manager.tasks_dir / "Absorb.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        content = content.replace("Original title", "Externally retitled")
+        content = content.replace(
+            "    > original body", "    > original body\n    > added externally"
+        )
+        file_path.write_text(content, encoding="utf-8")
+
+        updated = task_manager.update(task.id, priority="high")
+
+        assert updated.description == "Externally retitled"
+        assert updated.notes == "original body\nadded externally"
+        assert updated.priority == "high"
+        final_content = file_path.read_text(encoding="utf-8")
+        assert "Externally retitled" in final_content
+        assert "added externally" in final_content
+        assert "[priority:: high]" in final_content
+
+    def test_swap_tag_preserves_unreindexed_external_retitle(self, task_manager):
+        task = task_manager.create("Claim me", context="Absorb2", tags=["agent"])
+        file_path = task_manager.tasks_dir / "Absorb2.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("Claim me", "Retitled before claim"), encoding="utf-8")
+
+        ok = task_manager.swap_tag(task.id, "agent", "agent-running")
+
+        assert ok is True
+        refreshed = task_manager.get(task.id)
+        assert refreshed.description == "Retitled before claim"
+        assert refreshed.tags == ["agent-running"]
+        final_content = file_path.read_text(encoding="utf-8")
+        assert "Retitled before claim" in final_content
+        assert "#agent-running" in final_content
+
+
+class TestMoveTaskConflict:
+    """#853 round 1 finding #6: a context-change move used to remove the
+    block from the source file BEFORE inserting into the destination — if
+    the destination insert then raised, the task was in neither file while
+    the index still pointed at the source."""
+
+    def test_destination_conflict_leaves_task_in_source_only(self, task_manager, monkeypatch):
+        task = task_manager.create("Move me", context="MoveSrc", notes="keep this body")
+        source_path = task_manager.tasks_dir / "MoveSrc.md"
+        dest_path = task_manager.tasks_dir / "MoveDest.md"
+
+        import api.services.task_manager as tm_mod
+        original_mtime = tm_mod._mtime_or_none
+        dest_counter = {"n": 0}
+
+        def flaky_for_dest(path):
+            if Path(path) == dest_path:
+                dest_counter["n"] += 1
+                return dest_counter["n"]  # always different -> destination CAS never matches
+            return original_mtime(path)
+
+        monkeypatch.setattr(tm_mod, "_mtime_or_none", flaky_for_dest)
+
+        with pytest.raises(TaskConflictError):
+            task_manager.update(task.id, context="MoveDest")
+
+        source_content = source_path.read_text(encoding="utf-8")
+        assert "Move me" in source_content
+        assert "keep this body" in source_content
+        dest_content = dest_path.read_text(encoding="utf-8") if dest_path.exists() else ""
+        assert "Move me" not in dest_content
+        # Index still points at the source — not left dangling.
+        assert task_manager.get(task.id).context == "MoveSrc"
+
+
+class TestFieldValidation:
+    """#853 round 1 findings #2 and #3: description/notes/fields content
+    that would corrupt the task line's format, or a `fields` key that
+    shadows a reserved attribute (or the id comment), is rejected with
+    `ValueError` rather than silently corrupting the line or hijacking
+    another task's id."""
+
+    def test_create_rejects_newline_in_description(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Two\nlines", context="Validate")
+        assert task_manager.list_tasks(context="Validate") == []
+
+    def test_create_rejects_bracket_in_description(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Truncate me]", context="Validate")
+
+    def test_create_rejects_html_comment_opener_in_description(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Hijack <!-- id:other -->", context="Validate")
+
+    def test_create_rejects_newline_in_fields_value(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Field newline", context="Validate", fields={"host": "a\nb"})
+
+    def test_create_rejects_bracket_in_fields_value(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Field bracket", context="Validate", fields={"host": "a]b"})
+
+    def test_create_rejects_html_comment_in_fields_value(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create(
+                "Field hijack", context="Validate", fields={"host": "<!-- id:x -->"}
+            )
+
+    def test_create_rejects_spaced_fields_key(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Bad key", context="Validate", fields={"my key": "v"})
+
+    def test_create_rejects_reserved_fields_key(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Spoof updated", context="Validate", fields={"updated": "SPOOFED"})
+
+    def test_create_rejects_id_as_fields_key(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Spoof id", context="Validate", fields={"id": "hijacked"})
+
+    def test_create_rejects_carriage_return_in_notes(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Notes CR", context="Validate", notes="line\rbreak")
+
+    def test_create_rejects_html_comment_in_notes(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Notes hijack", context="Validate", notes="<!-- id:x -->")
+
+    def test_create_allows_multiline_notes(self, task_manager):
+        # Sanity: multi-line notes are the whole point of the field and
+        # must not be rejected by the same newline check used for description.
+        task = task_manager.create("Notes ok", context="Validate", notes="line one\nline two")
+        assert task.notes == "line one\nline two"
+
+    def test_update_rejects_hostile_fields_value(self, task_manager):
+        task = task_manager.create("To update", context="Validate")
+        with pytest.raises(ValueError):
+            task_manager.update(task.id, fields={"host": "bad]value"})
+        assert task_manager.get(task.id).fields == {}
+
+    def test_update_rejects_reserved_fields_key(self, task_manager):
+        task = task_manager.create("To update 2", context="Validate")
+        with pytest.raises(ValueError):
+            task_manager.update(task.id, fields={"priority": "spoofed"})
+        assert "priority" not in task_manager.get(task.id).fields
+
+
+class TestStatusValidation:
+    """#853 round 1 finding #11: `status` was accepted unchecked by the
+    manager — `status="Done"` silently wrote a `[ ]` (unrecognized symbol
+    falls back to a blank checkbox) and round-tripped as `Done` until the
+    next reindex flipped it back to `todo`."""
+
+    def test_create_rejects_unrecognized_status(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Bad status", status="Done")
+        assert task_manager.list_tasks(query="Bad status") == []
+
+    def test_update_rejects_unrecognized_status(self, task_manager):
+        task = task_manager.create("To update", context="StatusValidate")
+        with pytest.raises(ValueError):
+            task_manager.update(task.id, status="Done")
+        assert task_manager.get(task.id).status == "todo"
+
+
 class TestCasRetryAndConflict:
     def test_retries_three_times_then_raises_conflict(self, task_manager, monkeypatch):
         task = task_manager.create("CAS test", context="CasTest")
@@ -1594,10 +1975,85 @@ class TestCasRetryAndConflict:
 
         assert len(reindex_calls) == 3
 
+    def test_update_conflict_leaves_in_memory_task_unchanged(self, task_manager, monkeypatch):
+        """#853 round 1 finding #4: `update.apply()` used to mutate
+        `self._tasks[task_id]` in place via `setattr`, so even a losing CAS
+        attempt's edits were visible through `get()` — the file kept the old
+        description but memory had the new one. `compute()` must build a
+        new `Task` from a copy and `_cas_rewrite` must rebind
+        `self._tasks[task_id]` only on the success branch."""
+        task = task_manager.create("Original description", context="CasTest3")
+        file_path = task_manager.tasks_dir / "CasTest3.md"
+        before_content = file_path.read_text(encoding="utf-8")
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        with pytest.raises(TaskConflictError):
+            task_manager.update(task.id, description="conflicting description")
+
+        assert task_manager.get(task.id).description == "Original description"
+        assert file_path.read_text(encoding="utf-8") == before_content
+
+    def test_swap_tag_conflict_leaves_in_memory_task_unchanged(self, task_manager, monkeypatch):
+        """#853 round 1 finding #4, swap_tag half: same in-place-mutation
+        bug in swap_tag's `compute()` closure — the index would show the new
+        tag while the vault still had the old one."""
+        task = task_manager.create("Swap conflict", context="CasTest4", tags=["agent"])
+        file_path = task_manager.tasks_dir / "CasTest4.md"
+        before_content = file_path.read_text(encoding="utf-8")
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        with pytest.raises(TaskConflictError):
+            task_manager.swap_tag(task.id, "agent", "agent-running")
+
+        assert task_manager.get(task.id).tags == ["agent"]
+        assert file_path.read_text(encoding="utf-8") == before_content
+
     def test_no_retry_needed_in_the_normal_case(self, task_manager):
         task = task_manager.create("No conflict", context="CasTest2")
         updated = task_manager.update(task.id, description="updated fine")
         assert updated.description == "updated fine"
+
+
+class TestCreateCasRetryAndConflict:
+    """#853 round 1 finding #15: `_cas_insert_at_top` (the create path) had
+    no manager-level retry/conflict test — only a mocked-manager route test
+    (`test_create_task_conflict_is_409`)."""
+
+    def test_create_retries_three_times_then_raises_conflict(self, task_manager, monkeypatch):
+        import api.services.task_manager as tm_mod
+
+        call_count = {"n": 0}
+
+        def flaky_mtime(path):
+            call_count["n"] += 1
+            return call_count["n"]  # always different from the previous call
+
+        monkeypatch.setattr(tm_mod, "_mtime_or_none", flaky_mtime)
+
+        with pytest.raises(TaskConflictError):
+            task_manager.create("Conflict test", context="CreateCasTest")
+
+        # `_cas_insert_at_top` calls `_mtime_or_none` twice per attempt
+        # (before + now); `_CAS_MAX_RETRIES` retries means
+        # `_CAS_MAX_RETRIES + 1` attempts.
+        assert call_count["n"] == 2 * (tm_mod._CAS_MAX_RETRIES + 1)
+
+        file_path = task_manager.tasks_dir / "CreateCasTest.md"
+        content = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
+        assert "Conflict test" not in content
+        assert task_manager.list_tasks(query="Conflict test") == []
 
 
 class TestConflictFiles:
@@ -1640,6 +2096,12 @@ class TestConflictFiles:
         assert is_conflict_file(Path("Inbox.sync-conflict-20260101-120000-ABCDEFG.md"))
         assert is_conflict_file(Path(".syncthing.Inbox.md.tmp"))
         assert not is_conflict_file(Path("Inbox.md"))
+
+    def test_is_conflict_file_matches_any_suffix_after_the_marker(self):
+        """#853 round 1 finding #10: the criterion is `*.sync-conflict-*`,
+        not Syncthing's own `-YYYYMMDD-HHMMSS-DEVICEID` timestamp format —
+        match the substring regardless of what follows it."""
+        assert is_conflict_file(Path("Inbox.sync-conflict-foo.md"))
 
 
 class TestUpdatedStamp:
@@ -1685,6 +2147,12 @@ class TestAtomicWriteIntegration:
         assert len(calls) >= 1
         for src, dst in calls:
             assert Path(src).parent == Path(dst).parent
+        # #853 round 1 finding #16: the task markdown file itself must be
+        # among the atomically-written destinations, not just "some file
+        # was written via os.replace" (the index write alone satisfies the
+        # old assertion).
+        task_file = str(task_manager.tasks_dir / "Atomic.md")
+        assert task_file in [dst for _, dst in calls], "task markdown file was never atomically written"
 
     def test_no_leftover_temp_files_after_write(self, task_manager):
         task_manager.create("No leftovers", context="Atomic2")

--- a/tests/test_task_watcher.py
+++ b/tests/test_task_watcher.py
@@ -78,6 +78,22 @@ class TestHandlerScheduling:
         time.sleep(0.2)
         assert calls == []
 
+    def test_skips_sync_conflict_file(self):
+        """#853: a Syncthing conflict copy is never a reindex source."""
+        calls = []
+        handler = _TaskFileHandler(lambda p: calls.append(p))
+        handler.on_modified(_FakeEvent("/x/Tasks/Inbox.sync-conflict-20260101-120000-ABCDEFG.md"))
+        time.sleep(0.2)
+        assert calls == []
+
+    def test_skips_syncthing_temp_file(self):
+        """#853: a Syncthing in-progress temp file is never a reindex source."""
+        calls = []
+        handler = _TaskFileHandler(lambda p: calls.append(p))
+        handler.on_modified(_FakeEvent("/x/Tasks/.syncthing.Inbox.md.tmp"))
+        time.sleep(0.2)
+        assert calls == []
+
     def test_move_event_fires_for_both_paths(self):
         calls = []
         done = threading.Event()

--- a/tests/test_task_watcher.py
+++ b/tests/test_task_watcher.py
@@ -87,10 +87,27 @@ class TestHandlerScheduling:
         assert calls == []
 
     def test_skips_syncthing_temp_file(self):
-        """#853: a Syncthing in-progress temp file is never a reindex source."""
+        """#853: a Syncthing in-progress temp file is never a reindex source.
+
+        This particular path is dropped by `on_modified`'s `.endswith(".md")`
+        check before `is_conflict_file` ever runs — kept as-is because it
+        documents that suffix filter. `test_schedule_skips_syncthing_temp_file_directly`
+        below exercises the `is_conflict_file` guard inside `_schedule` itself.
+        """
         calls = []
         handler = _TaskFileHandler(lambda p: calls.append(p))
         handler.on_modified(_FakeEvent("/x/Tasks/.syncthing.Inbox.md.tmp"))
+        time.sleep(0.2)
+        assert calls == []
+
+    def test_schedule_skips_syncthing_temp_file_directly(self):
+        """Calls `_schedule` directly with a path `on_modified` would never
+        forward (no `.md` suffix), so this actually exercises the
+        `is_conflict_file` guard at `task_watcher.py`'s top of `_schedule` —
+        the previous test above never reaches it."""
+        calls = []
+        handler = _TaskFileHandler(lambda p: calls.append(p))
+        handler._schedule("/x/Tasks/.syncthing.Inbox.md.tmp")
         time.sleep(0.2)
         assert calls == []
 

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -134,6 +134,28 @@ class TestTasksAPI:
         response = client.post("/api/tasks", json={"description": "Pull 1099 from Schwab"})
         assert response.status_code == 409
 
+    def test_create_task_hostile_field_value_is_422(self, client, mock_task_manager):
+        """#853 round 1 finding #2: a `ValueError` from `TaskManager.create`
+        (hostile description/notes/fields content) maps to 422, not an
+        unhandled 500."""
+        mock_task_manager.create.side_effect = ValueError("description must not contain '\\n'")
+        response = client.post("/api/tasks", json={"description": "Pull 1099 from Schwab"})
+        assert response.status_code == 422
+        assert "must not contain" in response.json()["detail"]
+
+    def test_create_task_reserved_field_key_is_422(self, client, mock_task_manager):
+        """#853 round 1 finding #3: a reserved `fields` key (e.g. `updated`)
+        maps to 422."""
+        mock_task_manager.create.side_effect = ValueError(
+            "'updated' is a reserved field and cannot be set via fields"
+        )
+        response = client.post("/api/tasks", json={
+            "description": "Pull 1099 from Schwab",
+            "fields": {"updated": "SPOOFED"},
+        })
+        assert response.status_code == 422
+        assert "reserved" in response.json()["detail"]
+
     # --- DRY RUN (#138) ---
 
     def test_dry_run_with_agent_tag_returns_preflight_preview(self, client, mock_task_manager):
@@ -350,6 +372,14 @@ class TestTasksAPI:
         mock_task_manager.update.side_effect = TaskConflictError("too many conflicting writes")
         response = client.put("/api/tasks/abc12345", json={"priority": "high"})
         assert response.status_code == 409
+
+    def test_update_task_hostile_field_value_is_422(self, client, mock_task_manager):
+        """#853 round 1 finding #2: a `ValueError` from `TaskManager.update`
+        maps to 422, not an unhandled 500."""
+        mock_task_manager.update.side_effect = ValueError("fields['x'] must not contain ']'")
+        response = client.put("/api/tasks/abc12345", json={"fields": {"x": "bad]value"}})
+        assert response.status_code == 422
+        assert "must not contain" in response.json()["detail"]
 
     # --- COMPLETE ---
 

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -57,20 +57,45 @@ class TestTasksAPI:
         data = response.json()
         assert data["description"] == "Pull 1099 from Schwab"
         assert data["id"] == "abc12345"
-        # context comes from the fixture's sample_task; the API itself no
-        # longer accepts a context on create — everything lands in Inbox.
+        # No context in the request -> defaults to Inbox.
         _, kwargs = mock_task_manager.create.call_args
-        assert "context" not in kwargs
+        assert kwargs["context"] == "Inbox"
 
-    def test_create_task_ignores_context_input(self, client, mock_task_manager):
-        """Stray 'context' in the request body is dropped, not forwarded."""
+    def test_create_task_forwards_context(self, client, mock_task_manager):
+        """#853: unlike the chat `manage_tasks` tool (which always lands in
+        Inbox to avoid an LLM guessing a wrong context), the raw HTTP API
+        honors an explicit context on create — a direct API client (the
+        Kanban board) knows exactly where it wants the task filed. This
+        intentionally replaces the old test_create_task_ignores_context_input,
+        which pinned the opposite behavior at this layer."""
         response = client.post("/api/tasks", json={
             "description": "Quick task",
-            "context": "Work",  # silently dropped by Pydantic
+            "context": "Work",
         })
         assert response.status_code == 200
         _, kwargs = mock_task_manager.create.call_args
-        assert "context" not in kwargs
+        assert kwargs["context"] == "Work"
+
+    def test_create_task_forwards_status_notes_fields(self, client, mock_task_manager):
+        response = client.post("/api/tasks", json={
+            "description": "Rich task",
+            "status": "blocked",
+            "notes": "line one\nline two",
+            "fields": {"host": "laptop", "effort": "high"},
+        })
+        assert response.status_code == 200
+        _, kwargs = mock_task_manager.create.call_args
+        assert kwargs["status"] == "blocked"
+        assert kwargs["notes"] == "line one\nline two"
+        assert kwargs["fields"] == {"host": "laptop", "effort": "high"}
+
+    def test_create_task_invalid_status_is_422(self, client, mock_task_manager):
+        response = client.post("/api/tasks", json={
+            "description": "Bad status",
+            "status": "not_a_real_status",
+        })
+        assert response.status_code == 422
+        mock_task_manager.create.assert_not_called()
 
     def test_create_task_minimal(self, client, mock_task_manager):
         response = client.post("/api/tasks", json={
@@ -102,6 +127,12 @@ class TestTasksAPI:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/api/tasks", json={"description": "Pull 1099 from Schwab"})
         assert not (200 <= response.status_code < 300)
+
+    def test_create_task_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.create.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.post("/api/tasks", json={"description": "Pull 1099 from Schwab"})
+        assert response.status_code == 409
 
     # --- DRY RUN (#138) ---
 
@@ -297,6 +328,29 @@ class TestTasksAPI:
         })
         assert response.status_code == 404
 
+    def test_update_task_invalid_status_is_422(self, client, mock_task_manager):
+        response = client.put("/api/tasks/abc12345", json={
+            "status": "not_a_real_status",
+        })
+        assert response.status_code == 422
+        mock_task_manager.update.assert_not_called()
+
+    def test_update_task_forwards_notes_and_fields(self, client, mock_task_manager):
+        response = client.put("/api/tasks/abc12345", json={
+            "notes": "new notes",
+            "fields": {"host": "laptop", "effort": None},
+        })
+        assert response.status_code == 200
+        _, kwargs = mock_task_manager.update.call_args
+        assert kwargs["notes"] == "new notes"
+        assert kwargs["fields"] == {"host": "laptop", "effort": None}
+
+    def test_update_task_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.update.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.put("/api/tasks/abc12345", json={"priority": "high"})
+        assert response.status_code == 409
+
     # --- COMPLETE ---
 
     def test_complete_task(self, client, mock_task_manager):
@@ -308,6 +362,12 @@ class TestTasksAPI:
         mock_task_manager.complete.return_value = None
         response = client.put("/api/tasks/nonexistent/complete")
         assert response.status_code == 404
+
+    def test_complete_task_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.complete.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.put("/api/tasks/abc12345/complete")
+        assert response.status_code == 409
 
     # --- TAGS ---
 
@@ -345,6 +405,12 @@ class TestTasksAPI:
         response = client.delete("/api/tasks/nonexistent")
         assert response.status_code == 404
 
+    def test_delete_task_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.delete.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.delete("/api/tasks/abc12345")
+        assert response.status_code == 409
+
     # --- RESPONSE SHAPE ---
 
     def test_task_response_shape(self, client, mock_task_manager):
@@ -354,10 +420,45 @@ class TestTasksAPI:
         expected_fields = [
             "id", "description", "status", "context", "priority",
             "due_date", "created_date", "done_date", "cancelled_date",
-            "tags", "reminder_id", "source_file", "line_number",
+            "updated_at", "tags", "reminder_id", "notes", "fields",
+            "source_file", "line_number",
         ]
         for f in expected_fields:
             assert f in data, f"Missing field: {f}"
+
+    # --- CONFLICTS ---
+
+    def test_list_conflicts(self, client, mock_task_manager):
+        mock_task_manager.list_conflicts.return_value = [
+            {"name": "Inbox.sync-conflict-20260101-120000-ABCDEFG.md", "mtime": "2026-01-01T12:00:00+00:00"},
+        ]
+        response = client.get("/api/tasks/conflicts")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["conflicts"]) == 1
+        assert data["conflicts"][0]["name"] == "Inbox.sync-conflict-20260101-120000-ABCDEFG.md"
+
+    def test_list_conflicts_empty(self, client, mock_task_manager):
+        mock_task_manager.list_conflicts.return_value = []
+        response = client.get("/api/tasks/conflicts")
+        assert response.status_code == 200
+        assert response.json() == {"conflicts": []}
+
+    def test_conflicts_route_not_captured_by_task_id(self, client, mock_task_manager):
+        """'conflicts' must never be treated as a task id — regression guard
+        for route registration order."""
+        mock_task_manager.list_conflicts.return_value = []
+        response = client.get("/api/tasks/conflicts")
+        assert response.status_code == 200
+        mock_task_manager.get.assert_not_called()
+
+    # --- SWAP-TAG ---
+
+    def test_swap_tag_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.swap_tag.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.post("/api/tasks/abc12345/swap-tag?from=agent&to=agent-running")
+        assert response.status_code == 409
 
 
 class TestListTasksParameterDocs:


### PR DESCRIPTION
## Summary

Brings the vault task store up to the scheduler store's mechanics and adds the fields a Kanban card needs, per #853.

- Writes locate their task by `<!-- id:xxxx -->`, not cached line number — an external edit that inserts lines above a task can no longer misdirect the next write.
- All file writes (task files, `data/task_index.json`, `Dashboard.md`, a fresh context file) go through a new shared `api/services/atomic_write.py` helper: temp file in the same directory, `fsync`, `os.replace`. `scheduler_store.py` was switched to the same helper (its own writes had the same non-atomic gap — a trivial, behavior-identical fix, verified by the unchanged scheduler suite).
- Every write is compare-and-swap protected on the file's mtime: a concurrent external write triggers a reindex + retry, up to 3 times, then `TaskConflictError` -> HTTP 409.
- The parser no longer requires the literal `TODO` keyword — any `- [.] ...` checkbox line counts as a task. A line lacking an id comment gets one minted and written back on reindex, with every other byte of that line (and every other line in the file) left untouched. This is the intended one-time migration for ~150 hand-written checklist items in the real inbox; writer-produced lines keep emitting `TODO`.
- Adds a notes body (indented `> ` lines beneath the task line, mirroring a scheduler entry's body), generic operator/unknown inline fields (`Task.fields`) that round-trip through any rewrite untouched, and a `[updated::]` stamp (ISO-8601 with UTC offset) on every create/update/complete/swap-tag.
- External-edit detection: a task's raw line is compared against the exact text the API last wrote for it (`TaskManager._last_written_line`, in-memory only); a genuine difference means the parsed values win and the line is restamped, scoped to that one task.
- `reminder_id` (the one field with no markdown representation) merges forward across reindex from the in-memory/JSON-cache state, same pattern as the scheduler's `_merge_prior`.
- Syncthing conflict copies (`*.sync-conflict-*`) and temp files (`.syncthing.*`) are never indexed, never trigger a reindex, and are listed via `GET /api/tasks/conflicts` (registered before `/{task_id}`).
- `POST`/`PUT /api/tasks` accept `context`, `status`, `notes`, `fields`; `fields` merges (not replaces) with `null` meaning "remove this field". Chat's `manage_tasks` tool threads `status`/`notes`/`fields` too, but deliberately still ignores `context` on create (unchanged, tested behavior — avoids an LLM guessing a wrong context; the raw API is for direct clients like the board).
- `POST /{id}/swap-tag` semantics are unchanged — verified by the existing (unmodified) agent-worker test suite, which mocks at the HTTP layer.

## Sidecar/state design choice

The issue's technical context allowed a small `data/kanban.db` sidecar for `last_written_line`/tombstones. It wasn't needed: `reminder_id` merge-forward already works from the existing JSON-cache-backed `self._tasks`, and external-edit detection only needs to hold up within one running process — comparing against an in-memory `_last_written_line` map (not persisted) is exactly as correct as a persisted sidecar for every acceptance criterion, and after a restart the cost of not persisting is purely cosmetic (one skipped restamp for a task edited while the server was down), never a correctness gap. Explained in full in `docs/specs/technical/task-management.md`'s "Why no `data/kanban.db` sidecar" section.

An earlier attempt compared the current raw line against a *reformatted* prior `Task` (`_format_task_line(prior)`) instead of the exact string. That broke idempotency on any line the API hadn't canonically written — most concretely, a line that just had an id minted onto otherwise hand-written text (no `TODO`, no `created` field): reformatting always re-inserts `TODO` and an empty `created` field, so the line "differed" and got rewritten on every single reindex. Comparing exact strings fixed it.

## Acceptance criteria → tests

| Criterion | Test(s) |
|---|---|
| PUT before reindex targets the right line; no other line changes | `TestIdAddressedWrites::test_update_targets_correct_line_after_external_insert_above` |
| Writes are atomic (temp + rename); reader never sees a partial file | `test_atomic_write.py` (destination never opened for writing directly, uses `os.replace`), `TestAtomicWriteIntegration` |
| Id-less line gets `<!-- id:.. -->` written back; stable on next reindex | `TestIdWriteBack::test_reindex_mints_and_writes_back_id`, `test_reindex_preserves_mixed_content_byte_for_byte` |
| `notes` round-trips through create/GET | `TestNotesBody::test_create_with_notes_writes_indented_body` |
| DELETE removes task line + body, nothing else | `TestNotesBody::test_delete_removes_task_line_and_body` |
| PUT context moves task + body together | `TestNotesBody::test_context_change_moves_notes_body_too` |
| Every mutation stamps `[updated::]` with a UTC offset | `TestUpdatedStamp` (create/update/complete/swap_tag) |
| Unknown field round-trips through any rewrite | `TestUnknownFieldRoundTrip::test_unknown_field_survives_reindex_and_rewrite` |
| `fields` write on create; `fields: {"k": null}` removes on update | `TestOperatorFields` |
| `reminder_id` survives reindex after external touch | `TestMergeForwardCacheFields::test_reminder_id_survives_reindex_after_external_touch` |
| External edit wins + fresh stamp, scoped to that task | `TestExternalEditWins` (both tests) |
| CAS retries 3x then raises conflict (-> 409) | `TestCasRetryAndConflict::test_retries_three_times_then_raises_conflict`, `test_tasks_api.py`'s `*_conflict_is_409` tests (create/update/complete/delete/swap-tag) |
| Conflict files skipped everywhere; `GET /api/tasks/conflicts` lists them | `TestConflictFiles`, `test_task_watcher.py::test_skips_sync_conflict_file`/`test_skips_syncthing_temp_file`, `test_tasks_api.py::test_list_conflicts*` |
| `status: "blocked"` -> `[?]`; unknown status -> 422 | `TestBlockedStatus`, `test_tasks_api.py::test_create_task_invalid_status_is_422`/`test_update_task_invalid_status_is_422` |
| `context: "Work"` writes to `Work.md` | `TestCreate::test_create_with_context` (existing) + `test_tasks_api.py::test_create_task_forwards_context` |
| Parser doesn't require `TODO`; writer still emits it | `TestParseTaskLine::test_parse_checkbox_without_todo_keyword_still_parses` (replaces the old test pinning the opposite behavior — intentional per #853), `test_parse_non_checkbox_line_returns_none` |
| Existing task/scheduler/agent-worker tests pass unchanged | full focused suite below; agent-worker tests untouched (mock at HTTP layer) |

## Test results

Focused suite (`test_task_manager.py`, `test_task_manager_swap_tag.py`, `test_task_watcher.py`, `test_atomic_write.py`, `test_tasks_api.py`, `test_agent_tools_tasks.py`, `test_mcp_server.py`, `test_scheduler_store.py`, `test_scheduler_watcher.py`): **324 passed**, 0 failed (via `pytest -n auto --dist loadscope`).

Push-gate suite (`scripts/pre-push`, full repo): **unit — 5619 passed, 14 skipped**; **server-free browser — 259 passed, 5975 deselected**. Both green, no environmental failures to report.

## Deliverables

- `docs/specs/technical/task-management.md` (new) — store internals, linked from `docs/specs/technical/AGENTS.md` and the root `AGENTS.md` navigation table.
- `docs/specs/product/task-management.md` — corrected the "fully integrated with Obsidian Tasks plugin" overstatement (custom statuses need Tasks-plugin configuration), the create-context example (now actually accurate — the API genuinely accepts it), the Task-Reminder Linking section (now describes chat orchestration + the direct two-call path), the dashboard-update claim (debounce, not instant), and the API reference table (new params); added a bidirectional link to the new technical spec.
- `docs/specs/product/api-reference.md` — Task Endpoints section updated with the new params and the conflicts endpoint.

## Not completed / decided unilaterally

- Did not add an MCP tool for `GET /api/tasks/conflicts` — out of scope per the issue (board-only surface for now); `CURATED_ENDPOINTS` is a hand-curated whitelist so nothing auto-exposes it.
- Did not thread `context` into the chat `manage_tasks` create action — an existing, deliberately-locked-in test (`test_create_lands_in_inbox_even_if_context_provided`) documents this as intentional to avoid the LLM guessing a wrong context; only the raw HTTP API gained real `context` support on create, per the issue's explicit acceptance criterion.
- Left `api/routes/scheduler.py`'s control-file write (`Scheduler.md`, operator status file) on plain `write_text` — out of scope; only the scheduler *store*'s definition/cache/dashboard writes were switched to the shared atomic helper, matching "fix the scheduler's atomic-write gap in the same helper if trivial."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWVWnyri65hMc3S2u6kRaY
