### PR TITLE
fix(agents): omit model from picker saves until the catalog resolves (#861)

### DIFF
--- a/tests/test_agents_assignment_ui_browser.py
+++ b/tests/test_agents_assignment_ui_browser.py
@@ -175,6 +175,54 @@ def test_shows_what_actually_ran_from_session(page: Page, web_base_url):
     assert "studio" in ran_text
 
 
+def test_effort_change_before_catalog_resolves_does_not_clear_model(page: Page, web_base_url):
+    """#861 regression: changing effort/host before GET /api/agents/models
+    resolves must not send `model: null` and clear a previously saved model
+    field — the model select's options (and thus its value) don't exist yet
+    on the first drawer open of a page load, so `save()` must omit the
+    `model` key entirely until the catalog has populated the select."""
+    pending = []
+
+    def api_handler(route):
+        if "/api/agents/models" in route.request.url:
+            pending.append(route)  # stashed — fulfilled later in the test
+        elif "/api/tasks/" in route.request.url and route.request.method == "PUT":
+            body = json.loads(route.request.post_data or "{}")
+            route.fulfill(status=200, content_type="application/json", body=json.dumps({"id": "t1", **body}))
+        else:
+            route.fulfill(status=200, content_type="application/json", body="{}")
+
+    _load_module(page, web_base_url, api_handler=api_handler)
+    _render(page, {
+        "id": "t8", "title": "Fix the printer", "tags": ["claude"], "assignee": "claude",
+        "fields": {"model": "claude-sonnet-5", "effort": "medium"},
+    })
+
+    # Catalog hasn't resolved yet (its route is stashed) — change effort now.
+    page.locator("[data-field='effort']").select_option("high")
+    calls = page.evaluate("() => window.__lastCalls")
+    assert len(calls) == 1
+    fields = calls[0]["patch"]["fields"]
+    assert fields["effort"] == "high"
+    assert fields["assigned_by"] == "board"
+    assert "model" not in fields  # omitted, not nulled — must not clear the saved model
+
+    # Now let the catalog resolve (fulfill every stashed models route).
+    for route in pending:
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(_MODEL_CATALOG))
+    pending.clear()
+
+    container = page.locator("#test-assignment-container")
+    expect(container.locator("[data-field='model'] option")).to_have_count(3)  # default + 2 claude models
+
+    # Once the catalog is ready, effort changes carry the saved model along.
+    page.locator("[data-field='effort']").select_option("low")
+    calls = page.evaluate("() => window.__lastCalls")
+    assert len(calls) == 2
+    fields2 = calls[1]["patch"]["fields"]
+    assert fields2["model"] == "claude-sonnet-5"
+
+
 def test_put_failure_surfaces_error_without_crashing(page: Page, web_base_url):
     _load_module(page, web_base_url)
     page.evaluate(

--- a/tests/test_agents_board_ui_browser.py
+++ b/tests/test_agents_board_ui_browser.py
@@ -964,6 +964,9 @@ class TestAssignmentPickers:
         task_puts = []
         _open_board(page, agents_base_url, task_puts=task_puts)
         page.locator('[data-card-id="t7"]').click()
+        expect(
+            page.locator(".drawer-assignment [data-field='model'] option")
+        ).to_have_count(3)
         effort_select = page.locator(".drawer-assignment [data-field='effort']")
         expect(effort_select).to_be_visible()
         effort_select.select_option("high")
@@ -979,6 +982,9 @@ class TestAssignmentPickers:
         task_puts = []
         _open_board(page, agents_base_url, task_puts=task_puts)
         page.locator('[data-card-id="t7"]').click()
+        expect(
+            page.locator(".drawer-assignment [data-field='model'] option")
+        ).to_have_count(3)
         host_input = page.locator(".drawer-assignment [data-field='host']")
         expect(host_input).to_be_visible()
         host_input.fill("build-box-2")

--- a/web/agents/assignment.js
+++ b/web/agents/assignment.js
@@ -152,11 +152,13 @@ export function renderAssignmentPickers(container, card, opts = {}) {
   }
   updateVisibility();
 
+  let catalogReady = false;
   function populateModelOptions(catalog) {
     const engine = engineEl.value;
     const models = (catalog.engines && catalog.engines[engine]) || [];
     modelEl.innerHTML = '<option value="">engine default</option>'
       + models.map(m => `<option value="${escapeHtml(m.id)}" ${currentModel === m.id ? 'selected' : ''}>${escapeHtml(m.label || m.id)}</option>`).join('');
+    catalogReady = true;
   }
   loadCatalog().then(populateModelOptions);
 
@@ -176,16 +178,21 @@ export function renderAssignmentPickers(container, card, opts = {}) {
   // `assigned_by: "board"` — that's what keeps preflight's routing
   // corroboration from ever second-guessing a board assignment (see
   // api/services/agent_worker/preflight.py's `_apply_route_corroboration`
-  // and assignment.py's module docstring).
+  // and assignment.py's module docstring). The `model` field is the one
+  // exception: it's omitted (not nulled) until the model catalog has
+  // populated the select. Before that, `modelEl.value` is always '' —
+  // regardless of what the card has saved — so sending `model: null` would
+  // wipe a previously saved model on the very first effort/host change of
+  // a page load, before `GET /api/agents/models` has resolved (#861).
   async function save(extra = {}) {
     const { tags, ...extraFields } = extra;  // `tags` is a top-level PUT key, not a field
     const fields = {
-      model: modelEl.value || null,
       effort: effortEl.value || null,
       host: hostEl.value.trim() || null,
       assigned_by: 'board',
       ...extraFields,
     };
+    if (catalogReady) fields.model = modelEl.value || null;
     const patch = { fields };
     if (tags) patch.tags = tags;
     try {


### PR DESCRIPTION
## Summary
- The assignment drawer's model picker on a Kanban card populates asynchronously once the model catalog (`GET /api/agents/models`) resolves. Changing the effort or host picker before that first fetch completes was sending `model: null` in the save request, silently clearing any model previously saved on the card.
- `save()` now omits the `model` field from the request entirely until the catalog has populated the picker, instead of sending it as `null`.

## Fix
`web/agents/assignment.js`'s `renderAssignmentPickers` now tracks a `catalogReady` flag, set once `populateModelOptions` has written the fetched catalog into the model `<select>`. `save()` only includes a `model` key in the PUT body once `catalogReady` is true; before that, the key is left out of the payload.

Omitting the key is the smallest correct change here, because the fields API is a patch: an omitted key leaves the stored `model` untouched, and nothing the user didn't actually change gets written. The alternative of carrying `card.fields.model` through on every save was rejected — it would re-send a stale snapshot of the card on every effort/host change, which is wrong if something else updated the field in between, and it still writes a field the user didn't touch. Disabling the model/effort/host controls until the catalog resolves was also rejected — it would change the drawer's UX for a bug that's really only about what `save()` sends over the wire.

Out of scope: a saved model that isn't present in the engine's current catalog list (e.g. a model retired from the catalog) is a separate, pre-existing limitation this PR does not address.

## Test
Added `test_effort_change_before_catalog_resolves_does_not_clear_model` to `tests/test_agents_assignment_ui_browser.py`. It stashes the `/api/agents/models` route instead of fulfilling it immediately, renders a card with a saved `model` field, changes the effort picker before the catalog resolves, and asserts the resulting PUT body carries the new effort but no `model` key at all. It then fulfills the stashed catalog route(s), confirms the model `<select>` populates, changes effort again, and asserts that save carries the saved model through once the catalog is ready.

Confirmed the test fails on the unfixed code with `model` present as `None` in the PUT body, then passes after the fix.

Round-1 review follow-up: `tests/test_agents_board_ui_browser.py`'s `test_changing_effort_writes_exactly_one_fields_put` and `test_changing_host_writes_exactly_one_fields_put` now wait for the model catalog to populate (`to_have_count(3)` on the model options, as the sibling model test already did) before changing the control — because the fix omits `model` until the catalog resolves, their exact-dict assertions (`"model": None`) were otherwise race-dependent.

`tests/test_agents_board_ui_browser.py`'s `test_changing_effort_writes_exactly_one_fields_put` and `test_changing_host_writes_exactly_one_fields_put` now wait for the model `<select>` to populate (3 options) before changing the effort/host control, since the fix omits the `model` key from the PUT body until the catalog resolves and the tests' exact-dict assertions otherwise race the catalog fetch.

Command:
```
timeout 900 env HIP_VISIBLE_DEVICES= ROCR_VISIBLE_DEVICES= CUDA_VISIBLE_DEVICES= LIFEOS_AGENT_DEFAULT_ROUTE= /home/nathanramia/.venvs/lifeos/bin/python -m pytest tests/test_agents_assignment_ui_browser.py -q -p no:cacheprovider
```
Result: `8 passed in 3.46s` (7 existing tests + the new regression test).

The pre-push gate also ran the full unit and server-free browser suites on the rebased head: unit `6124 passed, 9 skipped`; browser `312 passed` (and again on the round-1 follow-up commit).

Refs #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWVWnyri65hMc3S2u6kRaY


