### PR TITLE
test(agents): stabilize test_board_frame_moves_a_card_with_no_navigation (#862)

### DIFF
--- a/tests/test_agents_board_ui_browser.py
+++ b/tests/test_agents_board_ui_browser.py
@@ -528,14 +528,22 @@ class TestLiveUpdates:
     comment. These deliver a real "event: board" frame on a reconnect."""
 
     def test_board_frame_moves_a_card_with_no_navigation(self, page: Page, agents_base_url):
+        """#862: withhold the frame behind `stream_gate` (see the sibling
+        drawer tests below) so the "still in unassigned" assertion can't
+        lose a race with the stub's `retry: 20` reconnect on a slow first
+        paint — previously flaky (measured 6/30 and 3/30 in #860's
+        verification) because that frame could already have landed by the
+        time the first assertion polled."""
+        stream_gate = threading.Event()
         moved_board = copy.deepcopy(_board_fixture())
         _move_card_in_state(moved_board, "t1", "in_progress")
         frame = f"event: board\ndata: {json.dumps(moved_board)}\n\n"
 
-        _open_board(page, agents_base_url, board_stream_frames=[frame])
+        _open_board(page, agents_base_url, board_stream_frames=[frame], stream_gate=stream_gate)
         expect(page.locator('.board-lane[data-lane="unassigned"] [data-card-id="t1"]')).to_be_visible()
 
         url_before = page.url
+        stream_gate.set()
         expect(page.locator('.board-lane[data-lane="in_progress"] [data-card-id="t1"]')).to_be_visible(timeout=8000)
         expect(page.locator('.board-lane[data-lane="unassigned"] [data-card-id="t1"]')).to_have_count(0)
         assert page.url == url_before  # no page reload/navigation happened


### PR DESCRIPTION
## Summary

`test_board_frame_moves_a_card_with_no_navigation` was flaky by construction: it asserted `t1` was still in the `unassigned` lane right after page load, while the SSE stub's `retry: 20` reconnect could deliver the "card moved" frame ~20ms later. On a slow first paint the frame won the race and the pre-move assertion failed.

Measured during PR #860's verification (same pytest environment, only `web/` swapped): base `3507b36` failed 6/30 runs; head `91bb01a` failed 3/30. The flake predates #860 and is unrelated to it.

## Fix

Gate the stub's `/board/stream` connection behind a `threading.Event` — the same `stream_gate` pattern the sibling deferred-frame tests in this file (`test_drawer_notes_survive_a_board_frame_while_typing_and_flushes_on_blur`, `test_deferred_frame_flushes_when_focus_leaves_drawer_without_an_edit`) already use. The pre-move "still in unassigned" assertion now runs while the gate is closed, so no frame can possibly have arrived yet; only then does the test call `stream_gate.set()` and assert the move. Test-only change — no production code touched, and no existing assertion was weakened.

Closes #862

## Test plan

- [x] `tests/test_agents_board_ui_browser.py::TestLiveUpdates::test_board_frame_moves_a_card_with_no_navigation` run 5x consecutively: `REPEAT RESULT: pass=5 fail=0 of 5`
- [x] Pre-push gate (unit + server-free browser suites) passed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWVWnyri65hMc3S2u6kRaY
