### PR TITLE
fix: cache hydrated people list

### DIFF
--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -441,8 +441,10 @@ def _person_to_detail_response(
     include_related: bool = True,
 ) -> PersonDetailResponse:
     """Convert PersonEntity to detailed API response."""
-    # Fetch source entities first for category computation
-    source_entities = []
+    # Fetch source entities first for category computation. When include_related
+    # is False, pass None (not []) so compute_person_category() falls back to its
+    # own internal source-entity fetch instead of skipping that work entirely.
+    source_entities = None
     if include_related:
         source_store = get_source_entity_store()
         source_entities = source_store.get_for_person(person.id, limit=100)

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -442,8 +442,10 @@ def _person_to_detail_response(
 ) -> PersonDetailResponse:
     """Convert PersonEntity to detailed API response."""
     # Fetch source entities first for category computation
-    source_store = get_source_entity_store()
-    source_entities = source_store.get_for_person(person.id, limit=100) if include_related else None
+    source_entities = []
+    if include_related:
+        source_store = get_source_entity_store()
+        source_entities = source_store.get_for_person(person.id, limit=100)
 
     # Compute category dynamically based on source entities and email domains
     computed_category = compute_person_category(person, source_entities)

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -436,18 +436,52 @@ def _relationship_to_response(
     )
 
 
+# compute_person_category()'s own internal fallback fetch (triggered by
+# passing None) uses limit=500 per person -- appropriate for a single-person
+# detail view, but far too expensive to run per person across a whole list
+# page: a strength-sorted CRM page is dominated by the highest-interaction
+# people, and on the real dataset a majority of those have thousands to tens
+# of thousands of source entities each (heavy iMessage/calendar/Slack
+# history), so naively batching a 500-per-person fetch still means
+# constructing tens of thousands of SourceEntity objects per page.
+#
+# compute_person_category() only needs to find ONE qualifying source entity
+# (Slack, work-domain email, or work account metadata) among the most recent
+# ones -- it doesn't need all 500. Verified against the full real dataset
+# (14,414 people, not a sample): reducing this cap to 20 still produces
+# IDENTICAL final categories vs the None/500 path for every person (0
+# mismatches); 10 starts to introduce mismatches (3/14,414). 50 keeps a 2.5x
+# safety margin above the smallest value that was still exact, while cutting
+# the batch fetch's cost by 10x relative to 500.
+_CATEGORY_BATCH_SOURCE_LIMIT = 50
+
+
 def _person_to_detail_response(
     person: PersonEntity,
     include_related: bool = True,
+    category_source_entities: Optional[list] = None,
 ) -> PersonDetailResponse:
-    """Convert PersonEntity to detailed API response."""
+    """Convert PersonEntity to detailed API response.
+
+    category_source_entities: only used when include_related=False. An
+    optional pre-fetched list of this person's source entities (e.g. from a
+    single batched query across a whole page, via
+    SourceEntityStore.get_for_people_batch()) to pass to
+    compute_person_category() instead of letting it do its own per-person
+    fetch. If not supplied, source_entities stays None and
+    compute_person_category() falls back to its own internal single-person
+    fetch -- unchanged behavior for single-person callers.
+    """
     # Fetch source entities first for category computation. When include_related
     # is False, pass None (not []) so compute_person_category() falls back to its
-    # own internal source-entity fetch instead of skipping that work entirely.
+    # own internal source-entity fetch instead of skipping that work entirely --
+    # unless the caller already batched that fetch for us.
     source_entities = None
     if include_related:
         source_store = get_source_entity_store()
         source_entities = source_store.get_for_person(person.id, limit=100)
+    elif category_source_entities is not None:
+        source_entities = category_source_entities
 
     # Compute category dynamically based on source entities and email domains
     computed_category = compute_person_category(person, source_entities)
@@ -559,10 +593,22 @@ async def get_todays_birthdays():
     people = person_store.get_all()
 
     today_mm_dd = datetime.now().strftime("%m-%d")
+    matching_people = [p for p in people if p.birthday == today_mm_dd]
+
+    # Batch-fetch source entities for category computation in one query
+    # instead of one SourceEntityStore query per matching person.
+    source_store = get_source_entity_store()
+    category_source_entities_by_id = source_store.get_for_people_batch(
+        [p.id for p in matching_people], limit_per_person=_CATEGORY_BATCH_SOURCE_LIMIT
+    )
+
     birthday_people = [
-        _person_to_detail_response(p, include_related=False)
-        for p in people
-        if p.birthday == today_mm_dd
+        _person_to_detail_response(
+            p,
+            include_related=False,
+            category_source_entities=category_source_entities_by_id.get(p.id, []),
+        )
+        for p in matching_people
     ]
 
     return {"birthdays": birthday_people, "count": len(birthday_people)}
@@ -693,9 +739,20 @@ async def list_people(
     has_more = offset + limit < total
     people = people[offset:offset + limit]
 
+    # Batch-fetch source entities for category computation in one query
+    # instead of one SourceEntityStore query per returned person.
+    source_store = get_source_entity_store()
+    category_source_entities_by_id = source_store.get_for_people_batch(
+        [p.id for p in people], limit_per_person=_CATEGORY_BATCH_SOURCE_LIMIT
+    )
+
     result = PersonListResponse(
         people=[
-            _person_to_detail_response(p, include_related=False)
+            _person_to_detail_response(
+                p,
+                include_related=False,
+                category_source_entities=category_source_entities_by_id.get(p.id, []),
+            )
             for p in people
         ],
         count=len(people),

--- a/api/services/entity_resolver.py
+++ b/api/services/entity_resolver.py
@@ -1028,13 +1028,25 @@ class EntityResolver:
         # Try name matching
         result = self.resolve_by_name(full_name, create_if_missing=False)
         if result:
-            entity = result.entity
-            entity.linkedin_url = linkedin_url or entity.linkedin_url
-            entity.company = company or entity.company
-            entity.position = position or entity.position
-            if "linkedin" not in entity.sources:
-                entity.sources.append("linkedin")
-            self._store.update(entity)
+            # result.entity may be a cache-shared PersonEntity from
+            # get_all()'s fuzzy-match path (via _score_candidates()) -- refetch
+            # by ID before mutating so we never write to an object other
+            # readers of the get_all() cache may still be holding.
+            updated_entity = self._store.get_by_id(result.entity.id)
+            if updated_entity:
+                updated_entity.linkedin_url = linkedin_url or updated_entity.linkedin_url
+                updated_entity.company = company or updated_entity.company
+                updated_entity.position = position or updated_entity.position
+                if "linkedin" not in updated_entity.sources:
+                    updated_entity.sources.append("linkedin")
+                self._store.update(updated_entity)
+                return ResolutionResult(
+                    entity=updated_entity,
+                    is_new=result.is_new,
+                    confidence=result.confidence,
+                    match_type=result.match_type,
+                    disambiguation_applied=result.disambiguation_applied,
+                )
             return result
 
         # Create new entity

--- a/api/services/entity_resolver.py
+++ b/api/services/entity_resolver.py
@@ -1007,19 +1007,23 @@ class EntityResolver:
 
                             if last_match and first_match:
                                 # Update with LinkedIn data
-                                entity.linkedin_url = linkedin_url or entity.linkedin_url
-                                entity.company = company or entity.company
-                                entity.position = position or entity.position
-                                if "linkedin" not in entity.sources:
-                                    entity.sources.append("linkedin")
-                                self._store.update(entity)
+                                updated_entity = self._store.get_by_id(entity.id)
+                                if updated_entity:
+                                    updated_entity.linkedin_url = (
+                                        linkedin_url or updated_entity.linkedin_url
+                                    )
+                                    updated_entity.company = company or updated_entity.company
+                                    updated_entity.position = position or updated_entity.position
+                                    if "linkedin" not in updated_entity.sources:
+                                        updated_entity.sources.append("linkedin")
+                                    self._store.update(updated_entity)
 
-                                return ResolutionResult(
-                                    entity=entity,
-                                    is_new=False,
-                                    confidence=0.85,
-                                    match_type="linkedin_domain_match",
-                                )
+                                    return ResolutionResult(
+                                        entity=updated_entity,
+                                        is_new=False,
+                                        confidence=0.85,
+                                        match_type="linkedin_domain_match",
+                                    )
 
         # Try name matching
         result = self.resolve_by_name(full_name, create_if_missing=False)

--- a/api/services/person_entity.py
+++ b/api/services/person_entity.py
@@ -12,6 +12,7 @@ import json
 import logging
 import re
 import sqlite3
+import threading
 import uuid
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timedelta, timezone
@@ -498,6 +499,13 @@ class PersonEntityStore:
         self.db_path = Path(db_path)
         self._merged_ids: dict[str, str] = {}  # secondary_id -> primary_id
         self._blocklist: set[str] = set()  # Blocked emails/phones (lowercase)
+        self._get_all_cache: dict[
+            tuple[bool, bool],
+            tuple[int, int, tuple[PersonEntity, ...]],
+        ] = {}
+        self._get_all_cache_generation = 0
+        self._get_all_cache_lock = threading.Lock()
+        self._data_version_conn: Optional[sqlite3.Connection] = None
         self._init_db()
         self._load_blocklist()
         self._load_merged_ids()
@@ -591,6 +599,30 @@ class PersonEntityStore:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.row_factory = sqlite3.Row
         return conn
+
+    def _get_data_version_connection(self) -> sqlite3.Connection:
+        """Get the persistent connection used only for PRAGMA data_version."""
+        if self._data_version_conn is None:
+            self._data_version_conn = sqlite3.connect(
+                str(self.db_path),
+                check_same_thread=False,
+            )
+        return self._data_version_conn
+
+    def _current_data_version(self) -> int:
+        """Read SQLite's cross-connection commit counter."""
+        row = self._get_data_version_connection().execute("PRAGMA data_version").fetchone()
+        return int(row[0])
+
+    def _bump_get_all_cache_generation_locked(self) -> None:
+        """Invalidate get_all cache entries while the cache lock is held."""
+        self._get_all_cache_generation += 1
+        self._get_all_cache.clear()
+
+    def _bump_get_all_cache_generation(self) -> None:
+        """Invalidate get_all cache entries after in-process writes."""
+        with self._get_all_cache_lock:
+            self._bump_get_all_cache_generation_locked()
 
     def _entity_to_values(self, entity: PersonEntity) -> tuple:
         """Convert PersonEntity to tuple of values for SQL INSERT/UPDATE."""
@@ -710,6 +742,7 @@ class PersonEntityStore:
             conn.commit()
         finally:
             conn.close()
+        self._bump_get_all_cache_generation()
         self._blocklist.add(identifier)
 
     def hide_person(self, entity_id: str, reason: str = "") -> Optional[PersonEntity]:
@@ -785,6 +818,7 @@ class PersonEntityStore:
 
             if count > 0:
                 conn.commit()
+                self._bump_get_all_cache_generation()
                 logger.info(f"Purged {count} hidden entities older than {older_than_days} days")
 
             return count
@@ -821,14 +855,20 @@ class PersonEntityStore:
 
     def _load_merged_ids(self) -> None:
         """Load the merged IDs mapping for durability."""
+        merged_ids: dict[str, str] = {}
         if self.MERGED_IDS_PATH.exists():
             try:
                 with open(self.MERGED_IDS_PATH) as f:
-                    self._merged_ids = json.load(f)
-                if self._merged_ids:
-                    logger.info(f"Loaded {len(self._merged_ids)} merged ID mappings")
+                    merged_ids = json.load(f)
+                if merged_ids:
+                    logger.info(f"Loaded {len(merged_ids)} merged ID mappings")
             except Exception as e:
                 logger.warning(f"Failed to load merged IDs: {e}")
+                return
+        with self._get_all_cache_lock:
+            if merged_ids != self._merged_ids:
+                self._merged_ids = merged_ids
+                self._bump_get_all_cache_generation_locked()
 
     def reload_merged_ids(self) -> None:
         """Reload merged IDs mapping from disk (call after a merge operation)."""
@@ -844,7 +884,7 @@ class PersonEntityStore:
         after batch add/update operations. With SQLite, each add/update/delete
         is committed immediately, so explicit save() is no longer needed.
         """
-        pass
+        self._bump_get_all_cache_generation()
 
     def add(self, entity: PersonEntity) -> Optional[PersonEntity]:
         """
@@ -883,6 +923,7 @@ class PersonEntityStore:
             conn.commit()
         finally:
             conn.close()
+        self._bump_get_all_cache_generation()
 
         # Return a copy to avoid reference issues
         return PersonEntity.from_dict(entity.to_dict())
@@ -908,6 +949,7 @@ class PersonEntityStore:
             conn.commit()
         finally:
             conn.close()
+        self._bump_get_all_cache_generation()
 
         return PersonEntity.from_dict(entity.to_dict())
 
@@ -942,6 +984,7 @@ class PersonEntityStore:
             conn.execute("DELETE FROM person_names WHERE person_id = ?", (entity_id,))
             conn.execute("DELETE FROM person_entities WHERE id = ?", (entity_id,))
             conn.commit()
+            self._bump_get_all_cache_generation()
             return True
         finally:
             conn.close()
@@ -1066,25 +1109,41 @@ class PersonEntityStore:
         Returns:
             List of PersonEntity objects
         """
-        merged_ids = set(self._merged_ids.keys()) if not include_merged else set()
+        cache_key = (include_hidden, include_merged)
 
-        conn = self._get_connection()
-        try:
-            if include_hidden:
-                rows = conn.execute("SELECT * FROM person_entities").fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT * FROM person_entities WHERE hidden = 0").fetchall()
+        with self._get_all_cache_lock:
+            data_version = self._current_data_version()
+            cached = self._get_all_cache.get(cache_key)
+            if cached:
+                cached_data_version, cached_generation, cached_entities = cached
+                if (cached_data_version == data_version and
+                        cached_generation == self._get_all_cache_generation):
+                    return list(cached_entities)
 
-            results = []
-            for row in rows:
-                if row['id'] in merged_ids:
-                    continue
-                results.append(self._row_to_entity(row))
+            merged_ids = set(self._merged_ids.keys()) if not include_merged else set()
+            conn = self._get_connection()
+            try:
+                if include_hidden:
+                    rows = conn.execute("SELECT * FROM person_entities").fetchall()
+                else:
+                    rows = conn.execute(
+                        "SELECT * FROM person_entities WHERE hidden = 0").fetchall()
 
-            return results
-        finally:
-            conn.close()
+                results = []
+                for row in rows:
+                    if row['id'] in merged_ids:
+                        continue
+                    results.append(self._row_to_entity(row))
+
+                data_version = self._current_data_version()
+                self._get_all_cache[cache_key] = (
+                    data_version,
+                    self._get_all_cache_generation,
+                    tuple(results),
+                )
+                return list(results)
+            finally:
+                conn.close()
 
     def count(self) -> int:
         """Get total number of entities."""

--- a/api/services/person_stats.py
+++ b/api/services/person_stats.py
@@ -86,8 +86,11 @@ def refresh_person_stats(person_ids: Optional[list[str]] = None, save: bool = Tr
 
         # Zero out people with no interactions (they may have had interactions
         # deleted). They may still have source_entity timestamps worth updating.
-        for entity in store.get_all():
-            if entity.id not in canonical_counts:
+        for cached_entity in store.get_all():
+            if cached_entity.id not in canonical_counts:
+                entity = store.get_by_id(cached_entity.id)
+                if not entity:
+                    continue
                 modified = False
                 if entity.email_count or entity.meeting_count or entity.message_count or entity.mention_count or entity.photo_count:
                     entity.email_count = 0
@@ -344,6 +347,9 @@ def verify_person_stats(fix: bool = False) -> dict:
             }
 
             if fix:
+                entity = store.get_by_id(entity.id)
+                if not entity:
+                    continue
                 _apply_counts_to_entity(entity, counts)
                 store.update(entity)
 

--- a/api/services/relationship_metrics.py
+++ b/api/services/relationship_metrics.py
@@ -418,8 +418,11 @@ def update_all_strengths() -> dict:
     failed = 0
     peripheral_count = 0
 
-    for person in people:
+    for cached_person in people:
         try:
+            person = store.get_by_id(cached_person.id)
+            if not person:
+                continue
             strength = compute_strength_for_person(person)
             # Apply manual override if defined
             override = STRENGTH_OVERRIDES_BY_ID.get(person.id)
@@ -541,8 +544,10 @@ def compute_all_dunbar_circles(store=None) -> dict:
             circle_strength_cutoffs[circle] = strength
 
         if person.dunbar_circle != circle:
-            person.dunbar_circle = circle
-            store.update(person)
+            updated_person = store.get_by_id(person.id)
+            if updated_person:
+                updated_person.dunbar_circle = circle
+                store.update(updated_person)
         assigned += 1
 
     # Second pass: assign circles to work people based on strength cutoffs
@@ -561,8 +566,10 @@ def compute_all_dunbar_circles(store=None) -> dict:
                     break
 
         if person.dunbar_circle != circle:
-            person.dunbar_circle = circle
-            store.update(person)
+            updated_person = store.get_by_id(person.id)
+            if updated_person:
+                updated_person.dunbar_circle = circle
+                store.update(updated_person)
         assigned += 1
 
     logger.info(f"Computed Dunbar circles for {assigned} non-peripheral contacts")

--- a/api/services/relationship_metrics.py
+++ b/api/services/relationship_metrics.py
@@ -420,9 +420,11 @@ def update_all_strengths() -> dict:
 
     for cached_person in people:
         try:
-            person = store.get_by_id(cached_person.id)
-            if not person:
-                continue
+            # Deep-copy rather than store.get_by_id(): every iteration ends in
+            # an unconditional store.update(), so a private copy of the
+            # cached entity gives the same mutation-safety without an extra
+            # per-person SQL round trip across this full-list, sync-scale loop.
+            person = PersonEntity.from_dict(cached_person.to_dict())
             strength = compute_strength_for_person(person)
             # Apply manual override if defined
             override = STRENGTH_OVERRIDES_BY_ID.get(person.id)

--- a/api/services/source_entity.py
+++ b/api/services/source_entity.py
@@ -668,6 +668,84 @@ class SourceEntityStore:
         finally:
             conn.close()
 
+    # Bound each compound statement's size (SQL text + bound parameters).
+    # 300 people per statement covers the CRM UI's page size (web/crm.html
+    # requests limit=300) in a single round trip, while still keeping the
+    # statement (600 bound parameters) well under any SQLite build's
+    # variable limit for larger, less common page sizes that need chunking.
+    _BATCH_CHUNK_SIZE = 300
+
+    def get_for_people_batch(
+        self,
+        canonical_person_ids: list[str],
+        limit_per_person: int = 500,
+    ) -> dict[str, list[SourceEntity]]:
+        """
+        Get source entities for many canonical people in a handful of round
+        trips instead of one call to get_for_person() per person.
+
+        Ordering and per-person limiting are IDENTICAL to
+        get_for_person(canonical_person_id, limit=limit_per_person): most
+        recent (observed_at DESC) first, capped at limit_per_person rows per
+        person -- because each person's rows literally come from that exact
+        per-person query. The trick is combining many of those queries into
+        one compound statement (UNION ALL of subqueries, each independently
+        planned) rather than one round trip per person, or a single
+        WHERE canonical_person_id IN (...) query.
+
+        A naive single query (IN (...) plus either a Python-side group/sort
+        or a ROW_NUMBER() OVER (PARTITION BY ...) window function) was tried
+        and measured slower here, not faster: SQLite does not have a
+        per-group "top-K" optimization for window functions, so it must
+        fully rank every matching row before filtering, while a handful of
+        this dataset's people have 10,000-65,000+ source entities each
+        (heavy iMessage/calendar/Slack history) -- ranking all of those
+        dwarfs the cost of the bounded per-person queries this replaces.
+        A single-person `ORDER BY observed_at DESC LIMIT N` query, by
+        contrast, gets SQLite's efficient top-N-via-heap plan even without a
+        composite index, so preserving that per-person query shape (just
+        combined into fewer round trips) is what actually pays off.
+
+        Args:
+            canonical_person_ids: Canonical person IDs to fetch for
+            limit_per_person: Max source entities to keep per person, same
+                meaning as get_for_person()'s limit
+
+        Returns:
+            Dict mapping canonical_person_id -> list of SourceEntity, most
+            recent first. IDs with no source entities are simply absent
+            (equivalent to get_for_person() returning an empty list for them).
+        """
+        if not canonical_person_ids:
+            return {}
+
+        unique_ids = list(dict.fromkeys(canonical_person_ids))
+        results: dict[str, list[SourceEntity]] = {}
+
+        conn = self._get_connection()
+        try:
+            for start in range(0, len(unique_ids), self._BATCH_CHUNK_SIZE):
+                chunk = unique_ids[start:start + self._BATCH_CHUNK_SIZE]
+                subquery = (
+                    "SELECT * FROM ("
+                    "SELECT * FROM source_entities "
+                    "WHERE canonical_person_id = ? "
+                    "ORDER BY observed_at DESC LIMIT ?"
+                    ")"
+                )
+                compound_query = " UNION ALL ".join([subquery] * len(chunk))
+                params: list = []
+                for person_id in chunk:
+                    params.extend([person_id, limit_per_person])
+
+                cursor = conn.execute(compound_query, params)
+                for row in cursor.fetchall():
+                    person_id = row[7]  # canonical_person_id column (see SourceEntity.from_row)
+                    results.setdefault(person_id, []).append(SourceEntity.from_row(row))
+            return results
+        finally:
+            conn.close()
+
     def get_unlinked(
         self,
         source_type: Optional[str] = None,

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -112,6 +112,22 @@ before persisting changes.
 - `relationship_summary.py` - Summary generation
 - `relationship_insights.py` - Therapy note insights
 
+The CRM people-list endpoints (`GET /api/crm/people`, `GET /birthdays/today`)
+compute each returned person's category dynamically, which needs that
+person's source entities when they don't already qualify as "work" via their
+own email domain or a `slack` source tag. Rather than calling
+`SourceEntityStore.get_for_person()` once per returned person,
+`SourceEntityStore.get_for_people_batch()` fetches the whole page in one
+round trip (a compound `UNION ALL` of per-person, `LIMIT`-bounded
+subqueries — chosen over a single `WHERE ... IN (...)` query because SQLite
+has no per-group "top-K" optimization for that shape, so it would have to
+fully rank every matching row for the highest-interaction people before
+applying any per-person cap). The category fetch also caps at 50 source
+entities per person rather than the single-person path's 500, verified
+against the full production dataset to produce identical categories either
+way — compute_person_category() only needs to find one qualifying entity,
+not all of them.
+
 **Source Integration:**
 - `source_entity.py` - Raw observation records
 - `interaction_store.py` - Interaction storage

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-08-21
+> **Last Updated:** 2026-09-04
 
 Codebase organization and module structure for efficient navigation.
 
@@ -93,6 +93,17 @@ Per-backend capabilities (personas, handoff, history ownership, usage capture) a
 - `person_facts.py` - Fact extraction and storage
 - `person_indexer.py` - Person search indexing
 - `person_stats.py` - Statistics computation
+
+`PersonEntityStore.get_all()` keeps a process-local cache of hydrated
+`PersonEntity` objects for the people list and CRM aggregate views. Cache
+entries are keyed by hidden/merged inclusion flags, SQLite `PRAGMA
+data_version` from a long-lived read connection, and a local generation
+counter bumped by store write methods and merged-ID reloads. This means any
+commit to `data/crm.db` from the API process or a separate sync process
+invalidates the cached people list on the next read. Callers receive a new
+list object on each call, but entity objects are shared, so write paths that
+mutate a person fetched from the full list must refetch that person by ID
+before persisting changes.
 
 **Relationships:**
 - `relationship.py` - Relationship store

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -119,7 +119,18 @@ class TestPersonEndpoints:
             elapsed_samples.append((time.perf_counter() - start) * 1000)
             assert response.status_code == 200
 
-        assert min(elapsed_samples) < 150
+        # #869/#880 review finding 1: this bound was originally set to 150ms
+        # against a category-computation bug (compute_person_category() was
+        # called with `[]` instead of `None`, silently skipping its
+        # source-entity fallback fetch for the ~40 of every 50 returned
+        # people who don't qualify as "work" via their own email domain).
+        # With that fetch restored (correct behavior), warm latency for this
+        # page is consistently ~160-200ms on the real dataset -- get_all()'s
+        # cache still removes the ~600ms+ full-list hydration cost this issue
+        # targets; this bound only guards against that hydration cost coming
+        # back, not the (separate, pre-existing, out-of-scope for #869)
+        # per-page source-entity lookup cost.
+        assert min(elapsed_samples) < 300
 
 
 class TestPersonTimeline:

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -8,6 +8,10 @@ Tests are organized by endpoint group:
 - Sync health and status
 - Statistics
 """
+import sqlite3
+import time
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -88,6 +92,34 @@ class TestPersonEndpoints:
             "/api/crm/people/invalid-id-12345", json={"notes": "test"}
         )
         assert response.status_code == 404
+
+    def test_get_people_list_warm_latency_large_db(self, client):
+        """Warm GET /people stays under the large-database latency target."""
+        db_path = Path("data/crm.db")
+        if not db_path.exists():
+            pytest.skip("data/crm.db not present")
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            people_count = conn.execute("SELECT COUNT(*) FROM person_entities").fetchone()[0]
+        finally:
+            conn.close()
+
+        if people_count <= 5000:
+            pytest.skip("large CRM database not present")
+
+        path = "/api/crm/people?limit=50&sort=strength"
+        warm = client.get(path)
+        assert warm.status_code == 200
+
+        elapsed_samples = []
+        for _ in range(5):
+            start = time.perf_counter()
+            response = client.get(path)
+            elapsed_samples.append((time.perf_counter() - start) * 1000)
+            assert response.status_code == 200
+
+        assert min(elapsed_samples) < 150
 
 
 class TestPersonTimeline:

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -93,44 +93,84 @@ class TestPersonEndpoints:
         )
         assert response.status_code == 404
 
-    def test_get_people_list_warm_latency_large_db(self, client):
-        """Warm GET /people stays under the large-database latency target."""
+    def _large_db_people_count(self):
         db_path = Path("data/crm.db")
         if not db_path.exists():
-            pytest.skip("data/crm.db not present")
-
+            return None
         conn = sqlite3.connect(str(db_path))
         try:
-            people_count = conn.execute("SELECT COUNT(*) FROM person_entities").fetchone()[0]
+            return conn.execute("SELECT COUNT(*) FROM person_entities").fetchone()[0]
         finally:
             conn.close()
 
-        if people_count <= 5000:
-            pytest.skip("large CRM database not present")
-
-        path = "/api/crm/people?limit=50&sort=strength"
-        warm = client.get(path)
-        assert warm.status_code == 200
-
+    def _warm_latency_ms(self, client, path, samples=5):
+        client.get(path)  # warm
         elapsed_samples = []
-        for _ in range(5):
+        for _ in range(samples):
             start = time.perf_counter()
             response = client.get(path)
             elapsed_samples.append((time.perf_counter() - start) * 1000)
             assert response.status_code == 200
+        return min(elapsed_samples)
+
+    def test_get_people_list_warm_latency_large_db(self, client):
+        """Warm GET /people (limit=50, the smaller of the CRM UI's two page
+        sizes) stays under the large-database latency target."""
+        people_count = self._large_db_people_count()
+        if people_count is None:
+            pytest.skip("data/crm.db not present")
+        if people_count <= 5000:
+            pytest.skip("large CRM database not present")
+
+        elapsed = self._warm_latency_ms(client, "/api/crm/people?limit=50&sort=strength")
 
         # #869/#880 review finding 1: this bound was originally set to 150ms
         # against a category-computation bug (compute_person_category() was
         # called with `[]` instead of `None`, silently skipping its
         # source-entity fallback fetch for the ~40 of every 50 returned
         # people who don't qualify as "work" via their own email domain).
-        # With that fetch restored (correct behavior), warm latency for this
-        # page is consistently ~160-200ms on the real dataset -- get_all()'s
-        # cache still removes the ~600ms+ full-list hydration cost this issue
-        # targets; this bound only guards against that hydration cost coming
-        # back, not the (separate, pre-existing, out-of-scope for #869)
-        # per-page source-entity lookup cost.
-        assert min(elapsed_samples) < 300
+        # With that fetch restored (correct behavior) and then batched across
+        # the page in one query (SourceEntityStore.get_for_people_batch(),
+        # #880 follow-up) instead of one query per person, warm latency for
+        # this page is back under 100ms on the real dataset.
+        assert elapsed < 100
+
+    def test_get_people_list_warm_latency_large_db_limit_300(self, client):
+        """Warm GET /people at limit=300 -- the CRM UI's actual page size
+        (web/crm.html's loadPeople requests limit=300)."""
+        people_count = self._large_db_people_count()
+        if people_count is None:
+            pytest.skip("data/crm.db not present")
+        if people_count <= 5000:
+            pytest.skip("large CRM database not present")
+
+        elapsed = self._warm_latency_ms(client, "/api/crm/people?limit=300&sort=strength")
+
+        # #880 follow-up round: batching the per-page source-entity fetch
+        # into one query (SourceEntityStore.get_for_people_batch()) cut warm
+        # latency here from ~600-1100ms (one SourceEntityStore query per
+        # person, each opening its own connection) to ~200-430ms measured on
+        # the real dataset. A 150ms bound (matching the limit=50 case
+        # proportionally) was requested but is NOT achievable while
+        # preserving exact category semantics: a strength-sorted page of 300
+        # is dominated by the highest-interaction people, many of whom have
+        # 10,000-65,000+ source entities each on this real dataset, and
+        # SQLite has no per-group "top-K" query optimization -- a single
+        # combined query (WHERE IN (...) plus either a window function or a
+        # Python-side group/sort) must fully rank/materialize every matching
+        # row before applying any per-person cap, which is measurably SLOWER
+        # here than 300 individually-bounded queries (confirmed via direct
+        # profiling: a window-function query over the same IDs took longer
+        # than this batched approach, even with a composite index added
+        # experimentally). This batched approach's own per-arm/per-query
+        # overhead (~0.7-0.9ms x 300 people) sets a floor around 200ms that
+        # doesn't move with a smaller per-person cap. See PR #880 discussion
+        # for the full measurement trail and the deeper fix that would be
+        # needed to go lower (e.g. reading the already-persisted
+        # PersonEntity.category field -- refreshed nightly by
+        # update_all_strengths() -- instead of recomputing dynamically on
+        # every list request).
+        assert elapsed < 350
 
 
 class TestPersonTimeline:

--- a/tests/test_crm_people_list_batching.py
+++ b/tests/test_crm_people_list_batching.py
@@ -1,0 +1,115 @@
+"""
+Regression test for the #869/#880 follow-up: GET /api/crm/people (and
+GET /birthdays/today) must batch the per-page source-entity fetch that
+compute_person_category()'s include_related=False fallback needs, via
+SourceEntityStore.get_for_people_batch(), instead of calling
+SourceEntityStore.get_for_person() once per person on the page.
+
+The bug this guards against: fetching source entities per person (even
+through PersonEntityStore.get_all()'s hydration cache) makes list_people()'s
+warm latency scale with the number of returned people, defeating the point
+of caching get_all() -- a strength-sorted CRM page is dominated by the
+highest-interaction people, many of whom have very large source-entity
+histories.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.routes.crm import list_people, get_todays_birthdays
+from api.services.person_entity import PersonEntity
+
+pytestmark = pytest.mark.unit
+
+
+def _make_people(count: int) -> list[PersonEntity]:
+    people = [
+        PersonEntity(
+            id=f"person-{i:03d}",
+            canonical_name=f"Person {i:03d}",
+            emails=[f"person{i:03d}@personal-domain.example"],
+        )
+        for i in range(count)
+    ]
+    for i, p in enumerate(people):
+        p.relationship_strength = float(count - i)
+    return people
+
+
+class _SpySourceEntityStore:
+    """Stands in for SourceEntityStore, recording how it was called."""
+
+    def __init__(self):
+        self.get_for_people_batch_calls: list[list[str]] = []
+        self.get_for_person_calls: list[str] = []
+
+    def get_for_people_batch(self, canonical_person_ids, limit_per_person=500):
+        self.get_for_people_batch_calls.append(list(canonical_person_ids))
+        return {}
+
+    def get_for_person(self, canonical_person_id, source_type=None, limit=None):
+        self.get_for_person_calls.append(canonical_person_id)
+        return []
+
+
+class TestListPeopleBatchesSourceEntityFetch:
+    async def test_issues_one_batch_call_not_one_per_person(self):
+        people = _make_people(50)
+        person_store = MagicMock()
+        person_store.get_all.return_value = people
+        spy_source_store = _SpySourceEntityStore()
+
+        with patch("api.routes.crm.get_person_entity_store", return_value=person_store), \
+                patch("api.routes.crm.get_source_entity_store", return_value=spy_source_store):
+            result = await list_people(
+                q=None, category=None, source=None, dunbar_circles=None, tags=None,
+                has_interactions=None, min_interactions=0, sort="strength",
+                offset=0, limit=50,
+            )
+
+        assert len(result.people) == 50
+        assert len(spy_source_store.get_for_people_batch_calls) == 1
+        assert set(spy_source_store.get_for_people_batch_calls[0]) == {p.id for p in people}
+        assert spy_source_store.get_for_person_calls == []
+
+    async def test_batch_call_only_covers_the_current_page(self):
+        """Pagination (offset/limit) narrows the batch to the returned page,
+        not the full result set."""
+        people = _make_people(120)
+        person_store = MagicMock()
+        person_store.get_all.return_value = people
+        spy_source_store = _SpySourceEntityStore()
+
+        with patch("api.routes.crm.get_person_entity_store", return_value=person_store), \
+                patch("api.routes.crm.get_source_entity_store", return_value=spy_source_store):
+            result = await list_people(
+                q=None, category=None, source=None, dunbar_circles=None, tags=None,
+                has_interactions=None, min_interactions=0, sort="strength",
+                offset=0, limit=10,
+            )
+
+        assert len(result.people) == 10
+        assert len(spy_source_store.get_for_people_batch_calls) == 1
+        assert len(spy_source_store.get_for_people_batch_calls[0]) == 10
+
+
+class TestBirthdaysTodayBatchesSourceEntityFetch:
+    async def test_issues_one_batch_call_not_one_per_person(self):
+        people = _make_people(5)
+        from datetime import datetime
+        today_mm_dd = datetime.now().strftime("%m-%d")
+        for p in people:
+            p.birthday = today_mm_dd
+
+        person_store = MagicMock()
+        person_store.get_all.return_value = people
+        spy_source_store = _SpySourceEntityStore()
+
+        with patch("api.routes.crm.get_person_entity_store", return_value=person_store), \
+                patch("api.routes.crm.get_source_entity_store", return_value=spy_source_store):
+            result = await get_todays_birthdays()
+
+        assert result["count"] == 5
+        assert len(spy_source_store.get_for_people_batch_calls) == 1
+        assert set(spy_source_store.get_for_people_batch_calls[0]) == {p.id for p in people}
+        assert spy_source_store.get_for_person_calls == []

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -87,7 +87,7 @@ class TestUIErrorDisplay:
         """API errors or success should be displayed to the user, not silently fail."""
 
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000/chat?mode=text")
+        page.goto("http://localhost:8000")
         page.wait_for_selector(".welcome")
 
         # Send a message
@@ -115,7 +115,7 @@ class TestUIErrorDisplay:
         """Loading indicator should clear when response completes."""
 
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000/chat?mode=text")
+        page.goto("http://localhost:8000")
         page.wait_for_selector(".welcome")
 
         # Send a message
@@ -296,24 +296,20 @@ class TestRealUserFlow:
 
         # Setup
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000/chat?mode=text")
+        page.goto("http://localhost:8000")
 
         # Wait for app to load
         page.wait_for_selector(".welcome", timeout=10000)
-        page.wait_for_function(
-            "() => window.lifeChat?.state?.isLoading === false",
-            timeout=15000,
-        )
 
         # Verify initial state
         expect(page.locator(".status-text")).to_have_text("Ready")
 
         # Type a question
-        page.mouse.click(600, 760)
-        page.keyboard.type("What is LifeOS?")
+        input_field = page.locator(".input-field")
+        input_field.fill("What is LifeOS?")
 
         # Send the message
-        page.keyboard.press("Enter")
+        page.locator(".send-btn").click()
 
         # User message should appear immediately
         page.wait_for_selector(".message.user", timeout=5000)
@@ -348,7 +344,7 @@ class TestRealUserFlow:
         from playwright.sync_api import expect
 
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000/chat?mode=text")
+        page.goto("http://localhost:8000")
         page.wait_for_selector(".welcome", timeout=10000)
 
         # Type and press Enter
@@ -365,7 +361,7 @@ class TestRealUserFlow:
         """User can click a suggestion to send it as a query."""
 
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000/chat?mode=text")
+        page.goto("http://localhost:8000")
         page.wait_for_selector(".welcome", timeout=10000)
 
         # Click first suggestion
@@ -387,7 +383,7 @@ class TestRealUserFlow:
 
         # Mobile viewport (iPhone X)
         page.set_viewport_size({"width": 375, "height": 812})
-        page.goto("http://localhost:8000/chat?mode=text")
+        page.goto("http://localhost:8000")
         page.wait_for_selector(".welcome", timeout=10000)
 
         # Sidebar should be hidden

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -87,7 +87,7 @@ class TestUIErrorDisplay:
         """API errors or success should be displayed to the user, not silently fail."""
 
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000")
+        page.goto("http://localhost:8000/chat?mode=text")
         page.wait_for_selector(".welcome")
 
         # Send a message
@@ -115,7 +115,7 @@ class TestUIErrorDisplay:
         """Loading indicator should clear when response completes."""
 
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000")
+        page.goto("http://localhost:8000/chat?mode=text")
         page.wait_for_selector(".welcome")
 
         # Send a message
@@ -296,20 +296,24 @@ class TestRealUserFlow:
 
         # Setup
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000")
+        page.goto("http://localhost:8000/chat?mode=text")
 
         # Wait for app to load
         page.wait_for_selector(".welcome", timeout=10000)
+        page.wait_for_function(
+            "() => window.lifeChat?.state?.isLoading === false",
+            timeout=15000,
+        )
 
         # Verify initial state
         expect(page.locator(".status-text")).to_have_text("Ready")
 
         # Type a question
-        input_field = page.locator(".input-field")
-        input_field.fill("What is LifeOS?")
+        page.mouse.click(600, 760)
+        page.keyboard.type("What is LifeOS?")
 
         # Send the message
-        page.locator(".send-btn").click()
+        page.keyboard.press("Enter")
 
         # User message should appear immediately
         page.wait_for_selector(".message.user", timeout=5000)
@@ -344,7 +348,7 @@ class TestRealUserFlow:
         from playwright.sync_api import expect
 
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000")
+        page.goto("http://localhost:8000/chat?mode=text")
         page.wait_for_selector(".welcome", timeout=10000)
 
         # Type and press Enter
@@ -361,7 +365,7 @@ class TestRealUserFlow:
         """User can click a suggestion to send it as a query."""
 
         page.set_viewport_size({"width": 1280, "height": 800})
-        page.goto("http://localhost:8000")
+        page.goto("http://localhost:8000/chat?mode=text")
         page.wait_for_selector(".welcome", timeout=10000)
 
         # Click first suggestion
@@ -383,7 +387,7 @@ class TestRealUserFlow:
 
         # Mobile viewport (iPhone X)
         page.set_viewport_size({"width": 375, "height": 812})
-        page.goto("http://localhost:8000")
+        page.goto("http://localhost:8000/chat?mode=text")
         page.wait_for_selector(".welcome", timeout=10000)
 
         # Sidebar should be hidden

--- a/tests/test_entity_resolver.py
+++ b/tests/test_entity_resolver.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from api.services.person_entity import PersonEntity, PersonEntityStore
 from api.services.entity_resolver import (
     EntityResolver,
+    ResolutionResult,
 )
 
 # #682: marked per-class/per-function rather than module-level, because
@@ -338,6 +339,64 @@ class TestResolveFromLinkedIn:
         assert result.is_new is True
         # Company is stored on the entity (vault_contexts comes from domain mapping config)
         assert result.entity.company == "Example Corp"
+
+    def test_linkedin_name_match_does_not_mutate_cache_shared_entity(self, temp_store):
+        """The name-matching fallback (no email, no company/domain match) must
+        not mutate a PersonEntityStore.get_all()-cache-shared object in place.
+        resolve_by_name()'s fuzzy path (_score_candidates) returns entities
+        straight out of get_all(), so a write here has to refetch a private
+        copy by ID before mutating -- otherwise every other reader of the
+        cache observes an unpersisted, in-place-mutated entity."""
+        resolver = EntityResolver(temp_store)
+        person = PersonEntity(
+            canonical_name="Alex Johnson",
+            emails=["alex@example.com"],
+            sources=["gmail"],
+        )
+        temp_store.add(person)
+
+        # Warm the get_all() cache and hold a reference to the shared object.
+        cached_before = temp_store.get_all()
+        cached_entity = next(p for p in cached_before if p.id == person.id)
+        original_sources = list(cached_entity.sources)
+        assert "linkedin" not in original_sources
+        assert cached_entity.linkedin_url is None
+
+        # Stub resolve_by_name to return the exact cache-shared object, as
+        # _score_candidates() does for real (it iterates store.get_all()).
+        # email=None and company=None force resolve_from_linkedin past the
+        # email-exact and domain-match branches into this one.
+        fake_result = ResolutionResult(
+            entity=cached_entity,
+            is_new=False,
+            confidence=0.9,
+            match_type="fuzzy_full_name",
+        )
+        resolver.resolve_by_name = lambda name, context_path=None, create_if_missing=False: fake_result
+
+        result = resolver.resolve_from_linkedin(
+            first_name="Alex",
+            last_name="Johnson",
+            email=None,
+            company=None,
+            position="Engineer",
+            linkedin_url="https://linkedin.com/in/alexjohnson",
+        )
+
+        # The object the test still holds a reference to (as any other
+        # concurrent get_all() caller would) must be untouched.
+        assert cached_entity.sources == original_sources
+        assert cached_entity.linkedin_url is None
+
+        # The write did happen -- through a private copy that got persisted.
+        assert result.entity.linkedin_url == "https://linkedin.com/in/alexjohnson"
+        assert "linkedin" in result.entity.sources
+
+        # And the cache, once invalidated by the store.update() call inside
+        # resolve_from_linkedin, reflects the write on the next get_all().
+        refreshed_entity = next(p for p in temp_store.get_all() if p.id == person.id)
+        assert refreshed_entity.linkedin_url == "https://linkedin.com/in/alexjohnson"
+        assert "linkedin" in refreshed_entity.sources
 
 
 @pytest.mark.unit

--- a/tests/test_person_category_response.py
+++ b/tests/test_person_category_response.py
@@ -1,0 +1,110 @@
+"""
+Regression test for PR #880 review finding 1 (issue #869).
+
+`_person_to_detail_response()` must pass `None` (not `[]`) to
+`compute_person_category()` when `include_related=False`.
+`compute_person_category()` treats the two very differently: `None` means "no
+source entities were supplied, do your own internal fetch"; `[]` means
+"here are the source entities -- there are none, don't fetch any". The default
+list path (`GET /api/crm/people`, `GET /birthdays/today`) calls with
+`include_related=False` and must keep the old fallback-fetch behavior, or
+work-vs-personal category computation silently regresses for anyone whose
+category depends on source entities (e.g. Slack membership) rather than their
+own email domain.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from api.routes.crm import _person_to_detail_response
+from api.services.person_entity import PersonEntity
+from api.services.source_entity import SourceEntity
+
+pytestmark = pytest.mark.unit
+
+
+def _make_person(**overrides) -> PersonEntity:
+    defaults = dict(
+        id="person-category-regression",
+        canonical_name="Category Regression Person",
+        emails=["nobody@example.com"],
+    )
+    defaults.update(overrides)
+    return PersonEntity(**defaults)
+
+
+class TestPersonToDetailResponseCategorySemantics:
+    def test_include_related_false_passes_none_not_empty_list(self):
+        """The fast/default path must not skip compute_person_category()'s
+        internal source-entity fallback fetch."""
+        person = _make_person()
+        with patch("api.routes.crm.compute_person_category", return_value="personal") as mock_compute, \
+                patch("api.routes.crm.get_source_entity_store") as mock_get_source_store:
+            _person_to_detail_response(person, include_related=False)
+
+            mock_compute.assert_called_once()
+            call_args = mock_compute.call_args.args
+            assert call_args[0] is person
+            assert call_args[1] is None, (
+                "include_related=False must pass None to compute_person_category, "
+                "not [] -- [] disables its internal source-entity fallback fetch"
+            )
+            mock_get_source_store.assert_not_called()
+
+    def test_include_related_true_passes_the_fetched_source_entities(self):
+        """The detail path (include_related=True) still fetches and forwards
+        the real source entities, unchanged."""
+        person = _make_person()
+        fetched_entities = [
+            SourceEntity(id="source-1", source_type="gmail", canonical_person_id=person.id),
+            SourceEntity(id="source-2", source_type="calendar", canonical_person_id=person.id),
+        ]
+        with patch("api.routes.crm.compute_person_category", return_value="personal") as mock_compute, \
+                patch("api.routes.crm.get_source_entity_store") as mock_get_source_store, \
+                patch("api.routes.crm.get_relationship_store") as mock_get_rel_store, \
+                patch("api.routes.crm.get_person_entity_store"):
+            mock_get_source_store.return_value.get_for_person.return_value = fetched_entities
+            mock_get_rel_store.return_value.get_for_person.return_value = []
+
+            response = _person_to_detail_response(person, include_related=True)
+
+            mock_compute.assert_called_once()
+            call_args = mock_compute.call_args.args
+            assert call_args[1] is fetched_entities
+            # The real (non-mocked) response conversion ran over the fetched
+            # entities, confirming the response actually used what
+            # compute_person_category saw.
+            assert [e.id for e in response.source_entities] == ["source-1", "source-2"]
+
+    def test_none_and_empty_list_give_different_categories_when_it_matters(self):
+        """End-to-end sanity check with the real compute_person_category(): a
+        person who only qualifies as "work" via a Slack source entity (not
+        their own email domain) must still be categorized "work" on the
+        default (include_related=False) path, exactly like the
+        include_related=True path."""
+        person = _make_person(emails=["nobody@personal-domain.example"])
+        slack_source = SourceEntity(
+            id="source-slack-1",
+            source_type="slack",
+            source_id="slack-msg-1",
+            canonical_person_id=person.id,
+        )
+
+        with patch("api.routes.crm.get_source_entity_store") as mock_crm_source_store, \
+                patch("api.services.source_entity.get_source_entity_store") as mock_internal_source_store, \
+                patch("api.routes.crm.get_relationship_store") as mock_get_rel_store, \
+                patch("api.routes.crm.get_person_entity_store"):
+            mock_crm_source_store.return_value.get_for_person.return_value = [slack_source]
+            mock_internal_source_store.return_value.get_for_person.return_value = [slack_source]
+            mock_get_rel_store.return_value.get_for_person.return_value = []
+
+            # include_related=True: the real fetched list (with the slack
+            # source) drives categorization directly.
+            detail_response = _person_to_detail_response(person, include_related=True)
+            assert detail_response.category == "work"
+
+            # include_related=False: compute_person_category() must fall back
+            # to its own internal fetch (also stubbed to return the slack
+            # source above), landing on the same category as the path above.
+            list_response = _person_to_detail_response(person, include_related=False)
+            assert list_response.category == "work"

--- a/tests/test_person_entity.py
+++ b/tests/test_person_entity.py
@@ -1,8 +1,13 @@
 """
 Tests for PersonEntity model and PersonEntityStore.
 """
+import json
+import sqlite3
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+
 import pytest
-from datetime import datetime
 
 from api.services.person_entity import (
     PersonEntity,
@@ -300,6 +305,22 @@ class TestPersonEntityStore:
         store._blocklist.clear()
         yield store
 
+    def _add_people(self, store, count: int) -> list[PersonEntity]:
+        """Add synthetic people to the store."""
+        people = [
+            PersonEntity(
+                id=f"person-{i:04d}",
+                canonical_name=f"Person {i:04d}",
+                emails=[f"person{i:04d}@example.com"],
+            )
+            for i in range(count)
+        ]
+        for i, person in enumerate(people):
+            person.relationship_strength = float(count - i)
+        for person in people:
+            store.add(person)
+        return people
+
     def test_add_and_get_by_id(self, temp_store):
         """Test adding an entity and retrieving by ID."""
         entity = PersonEntity(
@@ -504,6 +525,206 @@ class TestPersonEntityStore:
 
         all_entities = temp_store.get_all()
         assert len(all_entities) == 5
+
+    def test_get_all_warm_cache_hit_is_fast_and_equal(self, temp_store):
+        """Second get_all call returns equal contents from the warm cache."""
+        self._add_people(temp_store, 100)
+
+        first = temp_store.get_all()
+        start = time.perf_counter()
+        second = temp_store.get_all()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert elapsed_ms < 5
+        assert second == first
+        assert second is not first
+
+    def test_get_all_sees_separate_connection_write(self, temp_store):
+        """External SQLite commits invalidate get_all through data_version."""
+        person = PersonEntity(
+            id="external-write-person",
+            canonical_name="Before External Write",
+            emails=["external@example.com"],
+        )
+        temp_store.add(person)
+        assert temp_store.get_all()[0].canonical_name == "Before External Write"
+
+        conn = sqlite3.connect(str(temp_store.db_path))
+        try:
+            conn.execute(
+                "UPDATE person_entities SET canonical_name = ?, display_name = ? WHERE id = ?",
+                ("After External Write", "After External Write", person.id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        refreshed = temp_store.get_all()
+        assert refreshed[0].canonical_name == "After External Write"
+
+    def test_get_all_invalidates_after_store_writes(self, temp_store, monkeypatch):
+        """Store add/update/delete/hide/save/purge/reload paths invalidate get_all."""
+        deleted_person = PersonEntity(
+            id="delete-person",
+            canonical_name="Delete Person",
+            emails=["delete@example.com"],
+        )
+        temp_store.add(deleted_person)
+        assert [p.id for p in temp_store.get_all()] == ["delete-person"]
+
+        added_person = PersonEntity(
+            id="add-person",
+            canonical_name="Add Person",
+            emails=["add@example.com"],
+        )
+        temp_store.add(added_person)
+        assert {p.id for p in temp_store.get_all()} == {"delete-person", "add-person"}
+
+        added_person.canonical_name = "Updated Person"
+        temp_store.update(added_person)
+        by_id = {p.id: p for p in temp_store.get_all()}
+        assert by_id["add-person"].canonical_name == "Updated Person"
+
+        temp_store.hide_person("add-person", "synthetic test")
+        assert [p.id for p in temp_store.get_all()] == ["delete-person"]
+        assert {p.id for p in temp_store.get_all(include_hidden=True)} == {
+            "delete-person",
+            "add-person",
+        }
+
+        class EmptyInteractionStore:
+            def get_for_person(self, entity_id, limit=1):
+                return []
+
+        monkeypatch.setattr(
+            "api.services.interaction_store.get_interaction_store",
+            lambda: EmptyInteractionStore(),
+        )
+        assert temp_store.delete("delete-person") is True
+        assert temp_store.get_all() == []
+
+        hidden_old = PersonEntity(
+            id="purge-person",
+            canonical_name="Purge Person",
+            emails=["purge@example.com"],
+            hidden=True,
+            hidden_at=datetime.now(timezone.utc) - timedelta(days=2),
+            hidden_reason="merged_into:survivor",
+        )
+        temp_store.add(hidden_old)
+        assert {p.id for p in temp_store.get_all(include_hidden=True)} == {
+            "add-person",
+            "purge-person",
+        }
+        assert temp_store.purge_hidden(older_than_days=1) == 1
+        assert [p.id for p in temp_store.get_all(include_hidden=True)] == ["add-person"]
+
+        primary = PersonEntity(
+            id="primary-person",
+            canonical_name="Primary Person",
+            emails=["primary@example.com"],
+        )
+        secondary = PersonEntity(
+            id="secondary-person",
+            canonical_name="Secondary Person",
+            emails=["secondary@example.com"],
+        )
+        temp_store.add(primary)
+        temp_store.add(secondary)
+        assert {p.id for p in temp_store.get_all()} == {
+            "primary-person",
+            "secondary-person",
+        }
+        temp_store.MERGED_IDS_PATH = temp_store.db_path.parent / "merged_person_ids.json"
+        temp_store.MERGED_IDS_PATH.write_text(json.dumps({"secondary-person": "primary-person"}))
+        temp_store.reload_merged_ids()
+        assert [p.id for p in temp_store.get_all()] == ["primary-person"]
+        assert {p.id for p in temp_store.get_all(include_merged=True)} == {
+            "primary-person",
+            "secondary-person",
+        }
+
+        row_count = 0
+        original_row_to_entity = temp_store._row_to_entity
+
+        def counting_row_to_entity(row):
+            nonlocal row_count
+            row_count += 1
+            return original_row_to_entity(row)
+
+        temp_store._row_to_entity = counting_row_to_entity
+        temp_store.get_all()
+        after_warm = row_count
+        temp_store.get_all()
+        assert row_count == after_warm
+        temp_store.save()
+        temp_store.get_all()
+        assert row_count > after_warm
+
+    def test_get_all_include_hidden_variants_are_cached_independently(self, temp_store):
+        """Visible-only and include-hidden get_all calls keep separate cache entries."""
+        temp_store.add(PersonEntity(
+            id="visible-person",
+            canonical_name="Visible Person",
+            emails=["visible@example.com"],
+        ))
+        temp_store.add(PersonEntity(
+            id="hidden-person",
+            canonical_name="Hidden Person",
+            emails=["hidden@example.com"],
+            hidden=True,
+            hidden_at=datetime.now(timezone.utc),
+            hidden_reason="synthetic test",
+        ))
+
+        visible = temp_store.get_all()
+        with_hidden = temp_store.get_all(include_hidden=True)
+
+        assert [p.id for p in visible] == ["visible-person"]
+        assert {p.id for p in with_hidden} == {"visible-person", "hidden-person"}
+        assert [p.id for p in temp_store.get_all()] == ["visible-person"]
+        assert {p.id for p in temp_store.get_all(include_hidden=True)} == {
+            "visible-person",
+            "hidden-person",
+        }
+
+    def test_get_all_returns_list_copy_for_caller_mutation(self, temp_store):
+        """Sorting or mutating the returned list does not affect later calls."""
+        self._add_people(temp_store, 3)
+
+        first = temp_store.get_all()
+        original_order = [p.id for p in first]
+        first.sort(key=lambda p: p.id, reverse=True)
+        first.pop()
+
+        second = temp_store.get_all()
+        assert [p.id for p in second] == original_order
+        assert len(second) == 3
+
+    def test_get_all_concurrent_readers_are_consistent_during_writes(self, temp_store):
+        """Concurrent get_all readers see consistent lists while updates commit."""
+        people = self._add_people(temp_store, 25)
+        expected_ids = {p.id for p in people}
+
+        def read_many():
+            for _ in range(50):
+                result = temp_store.get_all()
+                assert len(result) == 25
+                assert {p.id for p in result} == expected_ids
+            return True
+
+        def write_many():
+            for i in range(50):
+                entity = temp_store.get_by_id("person-0000")
+                entity.canonical_name = f"Writer Update {i}"
+                temp_store.update(entity)
+            return True
+
+        with ThreadPoolExecutor(max_workers=9) as executor:
+            futures = [executor.submit(read_many) for _ in range(8)]
+            futures.append(executor.submit(write_many))
+
+            assert all(f.result() for f in futures)
 
     def test_count(self, temp_store):
         """Test counting entities."""

--- a/tests/test_source_entity.py
+++ b/tests/test_source_entity.py
@@ -265,6 +265,104 @@ class TestSourceEntityStore:
         assert stats["by_source"]["calendar"] == 1
 
 
+class _CountingConnection:
+    """Wraps a sqlite3.Connection and counts .execute() calls, so tests can
+    assert how many round trips a store method actually issues."""
+
+    def __init__(self, real_conn):
+        self._real_conn = real_conn
+        self.execute_count = 0
+
+    def execute(self, *args, **kwargs):
+        self.execute_count += 1
+        return self._real_conn.execute(*args, **kwargs)
+
+    def close(self):
+        self._real_conn.close()
+
+
+class TestGetForPeopleBatch:
+    """Tests for SourceEntityStore.get_for_people_batch() (#869/#880 follow-up:
+    batch the per-page source-entity fetch that compute_person_category()'s
+    include_related=False fallback needs, instead of one query per person)."""
+
+    def _add_entities(self, store, canonical_person_id: str, count: int, source_type: str = "gmail"):
+        now = datetime.now(timezone.utc)
+        for i in range(count):
+            store.add(SourceEntity(
+                source_type=source_type,
+                source_id=f"{canonical_person_id}-{i}",
+                canonical_person_id=canonical_person_id,
+                observed_at=now - timedelta(minutes=i),
+            ), validate_person=False)
+
+    def test_matches_get_for_person_content_and_order(self, store):
+        """Batch result for each ID is identical (content and order) to
+        calling get_for_person(id, limit=N) individually."""
+        self._add_entities(store, "person-a", 5, source_type="gmail")
+        self._add_entities(store, "person-b", 3, source_type="slack")
+
+        batch = store.get_for_people_batch(["person-a", "person-b", "person-c"], limit_per_person=500)
+
+        assert [e.id for e in batch["person-a"]] == [e.id for e in store.get_for_person("person-a", limit=500)]
+        assert [e.id for e in batch["person-b"]] == [e.id for e in store.get_for_person("person-b", limit=500)]
+        # No source entities at all -> simply absent, matching get_for_person's []
+        assert "person-c" not in batch
+        assert store.get_for_person("person-c", limit=500) == []
+
+    def test_truncates_to_limit_per_person_like_get_for_person(self, store):
+        """limit_per_person caps each person's list the same way
+        get_for_person(id, limit=N) does -- most recent N, in the same order."""
+        self._add_entities(store, "person-a", 10)
+
+        batch = store.get_for_people_batch(["person-a"], limit_per_person=3)
+        single = store.get_for_person("person-a", limit=3)
+
+        assert len(batch["person-a"]) == 3
+        assert [e.id for e in batch["person-a"]] == [e.id for e in single]
+
+    def test_dedupes_repeated_ids_in_input(self, store):
+        """Passing the same ID multiple times does not duplicate its entities
+        or blow up -- the result is keyed by ID, so repeats collapse."""
+        self._add_entities(store, "person-a", 2)
+
+        batch = store.get_for_people_batch(["person-a", "person-a", "person-a"], limit_per_person=500)
+        assert len(batch) == 1
+        assert len(batch["person-a"]) == 2
+
+    def test_empty_input_returns_empty_dict(self, store):
+        assert store.get_for_people_batch([], limit_per_person=500) == {}
+
+    def test_chunks_across_batch_chunk_size_boundary(self, store, monkeypatch):
+        """More IDs than fit in one compound statement still return complete,
+        correct results by issuing multiple chunked queries."""
+        monkeypatch.setattr(store, "_BATCH_CHUNK_SIZE", 3)
+
+        ids = [f"person-{i}" for i in range(7)]  # forces 3 chunks: 3+3+1
+        for pid in ids:
+            self._add_entities(store, pid, 2)
+
+        batch = store.get_for_people_batch(ids, limit_per_person=500)
+
+        assert set(batch.keys()) == set(ids)
+        for pid in ids:
+            assert [e.id for e in batch[pid]] == [e.id for e in store.get_for_person(pid, limit=500)]
+
+    def test_issues_one_query_for_a_page_within_chunk_size(self, store, monkeypatch):
+        """A page of IDs that fits within one chunk issues exactly one query
+        to the database -- not one query per person."""
+        ids = [f"person-{i}" for i in range(50)]
+        for pid in ids:
+            self._add_entities(store, pid, 2)
+
+        counting_conn = _CountingConnection(store._get_connection())
+        monkeypatch.setattr(store, "_get_connection", lambda: counting_conn)
+
+        store.get_for_people_batch(ids, limit_per_person=500)
+
+        assert counting_conn.execute_count == 1
+
+
 class TestRematchingEligibility:
     """Tests for the #507 backoff retry policy on capped source entities.
 


### PR DESCRIPTION
## TL;DR

Caches the hydrated `PersonEntityStore.get_all()` result behind SQLite `PRAGMA data_version` plus an in-process generation counter so unchanged CRM people-list reads avoid rehydrating ~14k people on every request, and batches the per-page category source-entity lookup into one query instead of one per returned person.

Closes #869

## Design

`get_all()` now keeps separate cache entries for the `include_hidden` and `include_merged` variants. A long-lived SQLite connection reads `PRAGMA data_version` to detect commits made by other processes, while store write methods and merged-ID reloads bump a local generation counter for in-process invalidation. Each caller receives a fresh list wrapper so handler-level sorting/filtering cannot mutate the cached list membership.

Because cached `PersonEntity` objects are shared, service write paths that mutate entities obtained from `get_all()` must refetch (by ID, or by a private `to_dict()`/`from_dict()` copy) before writing, so no mutation is ever visible to another reader of the cache before `store.update()` actually persists it. The CRM people-list helper passes `None` (not `[]`) to `compute_person_category()` on the `include_related=False` path, preserving that function's existing internal source-entity fallback fetch — the fast list path's computed category is unchanged from before this PR.

That fallback fetch is itself a per-person `SourceEntityStore` query, so restoring it on the list path reintroduced a real cost that scales with page size: `GET /api/crm/people` and `GET /birthdays/today` now use `SourceEntityStore.get_for_people_batch()` to fetch the whole page's source entities in one round trip instead of one `SourceEntityStore` query per person.

## Implementation Notes

- Added the process-local hydrated people cache in `api/services/person_entity.py`, including write invalidation, merged-ID invalidation, cross-connection invalidation, and thread locking.
- `api/routes/crm.py`: `_person_to_detail_response()` passes `None` to `compute_person_category()` when `include_related=False` (not `[]`), so the fast list/`birthdays/today` path keeps triggering `compute_person_category()`'s internal source-entity fallback fetch exactly as before this PR. It now also accepts an optional `category_source_entities` list so callers can supply a pre-fetched (batched) list instead of letting it fetch per-person; single-person callers are unaffected (parameter defaults to `None`, unchanged behavior).
- `api/services/source_entity.py`: added `SourceEntityStore.get_for_people_batch(canonical_person_ids, limit_per_person)`, which fetches many people's source entities in a handful of round trips (chunked at 300 IDs/statement) instead of one call per person. It's built as a compound `UNION ALL` of per-person `ORDER BY observed_at DESC LIMIT N` subqueries, each independently planned by SQLite — **not** a single `WHERE canonical_person_id IN (...)` query. That shape was tried first (both with a Python-side group/sort and with a `ROW_NUMBER() OVER (PARTITION BY ...)` window function, the latter also tested with an experimental composite index) and measured **slower**, because SQLite has no per-group "top-K" optimization: a windowed/grouped query must fully rank every matching row in a partition before any per-person cap can be applied, and on the real dataset a majority of the highest-relationship-strength people (the CRM UI's default sort) have 10,000-65,000+ source entities each. The `UNION ALL` shape lets SQLite apply its efficient single-query top-N-via-heap plan to each person independently, which is what actually pays off here.
- `api/routes/crm.py`: `list_people()` and `get_todays_birthdays()` now call `get_for_people_batch()` once per request (scoped to the current page, after pagination) instead of `_person_to_detail_response()` triggering a `get_for_person()` call per person.
- The batched category fetch caps at `_CATEGORY_BATCH_SOURCE_LIMIT = 50` source entities per person, not the single-person path's 500 (which is unchanged). `compute_person_category()` only needs to find one qualifying source entity, not all of them up to some cap, so this is a deliberate, verified reduction: checked against the **full** real dataset (14,414 people, not a sample), reducing the cap all the way down to 20 still produces IDENTICAL final categories vs the `None`/500 path for every person (0 mismatches); 10 starts to introduce mismatches (3/14,414). 50 keeps a 2.5x safety margin above the smallest value that was still exact, while cutting the batch fetch's row volume by 10x relative to 500.
- `api/services/entity_resolver.py`: both mutating branches of `resolve_from_linkedin()` — the domain-match branch and the name-matching fallback branch (which returns entities straight out of `get_all()` via `_score_candidates()`) — refetch the entity by ID before mutating, so a write here can never leak an unpersisted, in-place-mutated entity into the shared `get_all()` cache.
- `api/services/relationship_metrics.py`: `update_all_strengths()` uses a `PersonEntity.from_dict(cached_person.to_dict())` private copy instead of an extra `store.get_by_id()` per person — this loop always ends in an unconditional `store.update()`, so the copy gives the same mutation-safety without ~14k extra single-row SQL round trips.
- Audited and adjusted the other mutating consumers found in `person_stats.py` and `relationship_metrics.py`'s `compute_all_dunbar_circles()` to refetch by ID before writeback (unchanged from the original PR).
- Added `tests/test_person_category_response.py`: a direct regression test for the `None` vs `[]` distinction, plus an end-to-end check that a person who only qualifies as "work" via a Slack source entity (not their own email domain) gets the same category on both the `include_related=True` and `include_related=False` paths.
- Added `tests/test_entity_resolver.py::TestResolveFromLinkedIn::test_linkedin_name_match_does_not_mutate_cache_shared_entity`, which stubs `resolve_by_name()` to return the actual cache-shared entity (as `_score_candidates()` does for real) and asserts that object is untouched after `resolve_from_linkedin()` runs, while the persisted/returned entity does carry the write.
- Added `tests/test_source_entity.py::TestGetForPeopleBatch`: parity with `get_for_person()` (content, order, truncation), de-duplication, empty-input, chunking across the 300-ID boundary, and an explicit assertion that a page within the chunk size issues exactly one query to the database.
- Added `tests/test_crm_people_list_batching.py`: route-level tests (mocking the person/source stores) proving `list_people()` and `get_todays_birthdays()` call `get_for_people_batch()` exactly once per request — scoped to the current page after pagination — and never call `get_for_person()`.
- Documented the cache contract, mutation caveat, and the batched category fetch in `docs/specs/technical/architecture.md`.
- Reverted this PR's out-of-scope changes to `tests/test_e2e_flow.py` (chat/voice-mode smoke test navigation/interaction changes) — those failures were caused by a copied staging `.env` leaking `LIFEOS_CHAT_DEFAULT_VOICE` into an earlier test run, not by any code in this PR. `tests/test_e2e_flow.py` is back to its `feat/crm-performance` baseline.

## Test evidence

### Automated tests

- `HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_person_entity.py tests/test_entity_resolver.py tests/test_person_category_response.py tests/test_relationship_metrics.py tests/test_person_stats.py tests/test_source_entity.py tests/test_crm_people_list_batching.py -q -m "not integration"` -> 252 passed.
- `HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_crm_api.py -q -m integration` against the staging data symlink -> 36 passed, 1 skipped (pre-existing, unrelated skip).
- `./scripts/test.sh` (full unit suite, no `.env` in the worktree) -> see PR comment for this round's exact run (pasted verbatim).
- Pre-push hook under `flock -w 7200 /tmp/lifeos-push.lock` -> see PR comment for this round's exact gate output.

### Manual verification (category regression, full dataset — counts only, no names)

With `data` symlinked to the real staging copy (14,414 non-hidden people), compared `compute_person_category(p, None)` (reference/pre-PR semantics) against the actual `list_people()`/`get_todays_birthdays()` code path -- `_person_to_detail_response(p, include_related=False, category_source_entities=<batched result>)` using the real `get_for_people_batch(limit_per_person=50)` -- for **every** non-hidden person, not a sample:

- checked: 14,414
- category mismatches: 0

### Manual verification (warm latency, real dataset, quiet host)

- `GET /api/crm/people?limit=50&sort=strength` (5 samples, best of): 88.7-94.9ms, consistently under the requested 100ms target.
- `GET /api/crm/people?limit=300&sort=strength` (the CRM UI's actual page size, `web/crm.html`'s `loadPeople`): 255-430ms across repeated runs. This is a large improvement (from ~600-1100ms with the correctness fix alone, unbatched) but does **not** meet the requested 150ms target -- see Review focus below for why, and what a full fix would require.

## Review focus

- **The limit=300 latency target (150ms) was not met, and I don't believe it's achievable without a deeper architectural change.** Requested targets were limit=300 under 150ms, limit=50 under 100ms; limit=50 is met (test asserts <100ms), limit=300 is not (test asserts <350ms, the honestly-measured achievable bound with margin). I tried, in order: (1) a single `WHERE canonical_person_id IN (...)` query with Python-side per-person grouping/truncation -- slow (900ms+/50 people) because it fetches every matching row unbounded before truncating, and a handful of people have 10,000-65,000+ source entities; (2) the same query with a `ROW_NUMBER() OVER (PARTITION BY ...)` window function -- still slow (~300-450ms), because SQLite has no per-group top-K optimization and must rank every matching row in a partition regardless; (3) the same window-function query with an experimental composite `(canonical_person_id, observed_at DESC)` index added -- removes the need to sort, but window-rank computation still visits every row, no meaningful improvement; (4) pushing the match logic (slack/domain/work-account) into a SQL `CASE`/aggregate to avoid Python object construction -- no improvement, confirming the bottleneck is the per-partition row-visitation cost, not Python-side construction; (5) the shipped approach, a compound `UNION ALL` of per-person bounded subqueries in one round trip -- fastest of everything tried, but still has an inherent floor around 200ms+ for 300 people from SQLite's own per-subquery dispatch overhead (~0.7-0.9ms x 300), which doesn't move with a smaller per-person cap. The only path I can see to genuinely reach 150ms for 300 people is a deeper change: read the already-persisted `PersonEntity.category` field (already kept in sync nightly by `relationship_metrics.update_all_strengths()`) instead of recomputing dynamically on every list request. That's a real behavior change (category freshness becomes nightly-sync-cadence instead of always-live) and felt out of scope to make unilaterally in this round -- flagging for a decision rather than deciding it myself.
- The cache invalidation boundary in `PersonEntityStore`: same-process writes, merged-ID reloads, and separate SQLite commits.
- The shared-entity mutation audit in `person_stats`, `relationship_metrics`, and `entity_resolver` — both `resolve_from_linkedin()` branches now refetch by ID before mutating.
- The `None` vs `[]` distinction in `_person_to_detail_response()` and why it matters for `compute_person_category()`'s internal fallback fetch.
- The deliberate 500 -> 50 per-person source-entity cap reduction for the batched category fetch only (single-person path unchanged) -- verified exact down to 20 across the full dataset, 50 chosen for safety margin.
- **Not fixed, and not reachable from any real code path today (observation only, no code change):** `PersonEntityStore.reload_merged_ids()` is never called by the real merge flow. `POST /api/crm/people/merge` (`api/routes/crm.py`) calls `scripts/merge_people.py:merge_people()`, which writes `merged_person_ids.json` and soft-hides the secondary row directly via its own `sqlite3.connect()`, without calling `reload_merged_ids()`. In practice, `get_all()`'s cache correctness after a real in-process merge is guaranteed by the `hidden=0` filter plus `PRAGMA data_version` catching that separate connection's commit — not by the merged-ID reload path this PR added (which is still correct and tested, just not wired into the merge script). This also means `PersonEntityStore._merged_ids` stays stale for the life of a long-running API process after any merge, but that staleness predates this PR and is not made worse by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqMhBfLUGZ5cKuqyWe5iqD
