### PR TITLE
fix(crm): run CRM and people handlers off the event loop

### DIFF
--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+import asyncio
 import json
 import logging
 import sqlite3
@@ -532,7 +533,7 @@ def _get_partner_name() -> str:
 
 
 @router.get("/config", response_model=CRMConfigResponse)
-async def get_crm_config():
+def get_crm_config():
     """
     Get CRM configuration values for frontend.
 
@@ -549,7 +550,7 @@ async def get_crm_config():
 
 
 @router.get("/birthdays/today")
-async def get_todays_birthdays():
+def get_todays_birthdays():
     """Get all people with birthdays today."""
     person_store = get_person_entity_store()
     people = person_store.get_all()
@@ -565,7 +566,7 @@ async def get_todays_birthdays():
 
 
 @router.get("/birthdays/all")
-async def get_all_birthdays():
+def get_all_birthdays():
     """Get all people with birthdays, grouped by date."""
     person_store = get_person_entity_store()
     people = person_store.get_all()
@@ -593,7 +594,7 @@ async def get_all_birthdays():
 
 
 @router.get("/people", response_model=PersonListResponse)
-async def list_people(
+def list_people(
     q: Optional[str] = Query(default=None, description="Search query"),
     category: Optional[str] = Query(default=None, description="Filter by category"),
     source: Optional[str] = Query(default=None, description="Filter by source"),
@@ -707,7 +708,7 @@ async def list_people(
 
 
 @router.get("/people/{person_id}", response_model=PersonDetailResponse)
-async def get_person(
+def get_person(
     person_id: str,
     include_related: bool = Query(default=False, description="Include source entities and relationships"),
     refresh_strength: bool = Query(default=False, description="Recompute relationship strength (slower)"),
@@ -746,7 +747,7 @@ async def get_person(
 
 
 @router.patch("/people/{person_id}", response_model=PersonDetailResponse)
-async def update_person(person_id: str, request: PersonUpdateRequest):
+def update_person(person_id: str, request: PersonUpdateRequest):
     """
     Update a person's notes, tags, or category.
     """
@@ -807,7 +808,7 @@ class PersonMergeResponse(BaseModel):
 
 
 @router.post("/people/merge", response_model=PersonMergeResponse)
-async def merge_people(request: PersonMergeRequest):
+def merge_people(request: PersonMergeRequest):
     """
     Merge multiple people into a single record.
 
@@ -1064,7 +1065,7 @@ class ContactSource(BaseModel):
 
 
 @router.get("/people/{person_id}/contact-sources")
-async def get_person_contact_sources(person_id: str):
+def get_person_contact_sources(person_id: str):
     """
     Get aggregated contact sources linked to a person.
 
@@ -1190,7 +1191,7 @@ async def get_person_contact_sources(person_id: str):
 
 
 @router.get("/people/{person_id}/source-entities")
-async def get_person_source_entities(
+def get_person_source_entities(
     person_id: str,
     limit: int = Query(default=500, ge=1, le=5000, description="Max source entities to return"),
     offset: int = Query(default=0, ge=0, description="Offset for pagination"),
@@ -1277,7 +1278,7 @@ async def get_person_source_entities(
 
 
 @router.post("/people/split", response_model=PersonSplitResponse)
-async def split_person(request: PersonSplitRequest):
+def split_person(request: PersonSplitRequest):
     """
     Split source entities from one person to another.
 
@@ -1552,7 +1553,7 @@ async def split_person(request: PersonSplitRequest):
 
 
 @router.get("/people/{person_id}/timeline", response_model=TimelineResponse)
-async def get_person_timeline(
+def get_person_timeline(
     person_id: str,
     source_type: Optional[str] = Query(
         default=None,
@@ -1634,7 +1635,7 @@ SOURCE_BADGES = {
 
 
 @router.get("/people/{person_id}/timeline/aggregated", response_model=AggregatedTimelineResponse)
-async def get_person_timeline_aggregated(
+def get_person_timeline_aggregated(
     person_id: str,
     source_type: Optional[str] = Query(
         default=None,
@@ -1798,7 +1799,7 @@ async def get_person_timeline_aggregated(
 
 
 @router.get("/people/{person_id}/connections", response_model=ConnectionsResponse)
-async def get_person_connections(
+def get_person_connections(
     person_id: str,
     relationship_type: Optional[str] = Query(default=None, description="Filter by type"),
     limit: int = Query(default=50, ge=1, le=200, description="Max results"),
@@ -1866,7 +1867,7 @@ async def get_person_connections(
 
 
 @router.get("/people/{person_id}/strength", response_model=dict)
-async def get_person_strength_breakdown(person_id: str):
+def get_person_strength_breakdown(person_id: str):
     """
     Get detailed breakdown of relationship strength components.
 
@@ -1905,7 +1906,7 @@ def _fact_to_response(fact: PersonFact) -> PersonFactResponse:
 
 
 @router.get("/people/{person_id}/facts", response_model=PersonFactsResponse)
-async def get_person_facts(person_id: str):
+def get_person_facts(person_id: str):
     """
     Get all facts about a person.
 
@@ -1966,14 +1967,15 @@ async def extract_person_facts(person_id: str, model: Optional[str] = None):
     elif model == "haiku":
         model = PersonFactExtractor.MODEL_HAIKU
     person_store = get_person_entity_store()
-    person = person_store.get_by_id(person_id)
+    person = await asyncio.to_thread(person_store.get_by_id, person_id)
 
     if not person:
         raise HTTPException(status_code=404, detail=f"Person '{person_id}' not found")
 
     # Get ALL interactions for the person (extractor will sample strategically)
     interaction_store = get_interaction_store()
-    interactions = interaction_store.get_for_person(
+    interactions = await asyncio.to_thread(
+        interaction_store.get_for_person,
         person_id,
         days_back=3650,  # Look back 10 years for full history
         limit=100000,  # No practical limit - let extractor sample
@@ -2020,7 +2022,7 @@ async def extract_person_facts(person_id: str, model: Optional[str] = None):
 
 
 @router.put("/people/{person_id}/facts/{fact_id}", response_model=PersonFactResponse)
-async def update_person_fact(person_id: str, fact_id: str, request: FactUpdateRequest):
+def update_person_fact(person_id: str, fact_id: str, request: FactUpdateRequest):
     """
     Update a fact's value or metadata.
     """
@@ -2051,7 +2053,7 @@ async def update_person_fact(person_id: str, fact_id: str, request: FactUpdateRe
 
 
 @router.delete("/people/{person_id}/facts/{fact_id}")
-async def delete_person_fact(person_id: str, fact_id: str):
+def delete_person_fact(person_id: str, fact_id: str):
     """
     Delete a fact.
     """
@@ -2070,7 +2072,7 @@ async def delete_person_fact(person_id: str, fact_id: str):
 
 
 @router.post("/people/{person_id}/facts/{fact_id}/confirm")
-async def confirm_person_fact(person_id: str, fact_id: str):
+def confirm_person_fact(person_id: str, fact_id: str):
     """
     Mark a fact as confirmed by user.
 
@@ -2091,7 +2093,7 @@ async def confirm_person_fact(person_id: str, fact_id: str):
 
 
 @router.post("/people/{person_id}/hide")
-async def hide_person(person_id: str, request: HidePersonRequest):
+def hide_person(person_id: str, request: HidePersonRequest):
     """
     Hide a person (soft delete) and blocklist their identifiers.
 
@@ -2132,7 +2134,7 @@ async def hide_person(person_id: str, request: HidePersonRequest):
 
 
 @router.get("/discover", response_model=DiscoverResponse)
-async def discover_connections(
+def discover_connections(
     person_id: Optional[str] = Query(default=None, description="Person to find suggestions for"),
     limit: int = Query(default=10, ge=1, le=50, description="Max suggestions"),
 ):
@@ -2234,14 +2236,15 @@ async def import_source_data(
 
     if source_type == "whatsapp":
         from api.services.whatsapp_import import import_whatsapp_export
-        stats = import_whatsapp_export(
+        stats = await asyncio.to_thread(
+            import_whatsapp_export,
             content_str,
             file.filename or "chat.txt",
             source_store,
         )
     else:  # signal
         from api.services.signal_import import import_signal_export
-        stats = import_signal_export(content_str, source_store)
+        stats = await asyncio.to_thread(import_signal_export, content_str, source_store)
 
     return {
         "status": "completed",
@@ -2252,7 +2255,7 @@ async def import_source_data(
 
 
 @router.post("/sources/{source_type}/sync")
-async def sync_source(source_type: str):
+def sync_source(source_type: str):
     """
     Trigger a sync for a specific data source.
     """
@@ -2273,7 +2276,7 @@ async def sync_source(source_type: str):
 
 
 @router.post("/relationships/discover")
-async def trigger_relationship_discovery():
+def trigger_relationship_discovery():
     """
     Trigger relationship discovery across all sources.
 
@@ -2294,7 +2297,7 @@ async def trigger_relationship_discovery():
 
 
 @router.post("/strengths/update")
-async def update_relationship_strengths():
+def update_relationship_strengths():
     """
     Update relationship strength scores for all people.
     """
@@ -2306,7 +2309,7 @@ async def update_relationship_strengths():
 
 
 @router.get("/statistics", response_model=StatisticsResponse)
-async def get_crm_statistics():
+def get_crm_statistics():
     """
     Get comprehensive CRM statistics.
     """
@@ -2335,7 +2338,7 @@ async def get_crm_statistics():
 
 
 @router.get("/network", response_model=NetworkGraphResponse)
-async def get_network_graph(
+def get_network_graph(
     center_on: Optional[str] = Query(default=None, description="Person ID to center the graph on"),
     depth: int = Query(default=2, ge=1, le=4, description="Hops from center person"),
     min_strength: float = Query(default=0.0, ge=0.0, le=1.0, description="Minimum relationship strength"),
@@ -2521,7 +2524,7 @@ class RelationshipDetailResponse(BaseModel):
 
 
 @router.get("/relationship/{person_a_id}/{person_b_id}", response_model=RelationshipDetailResponse)
-async def get_relationship_details(person_a_id: str, person_b_id: str):
+def get_relationship_details(person_a_id: str, person_b_id: str):
     """
     Get detailed information about the relationship between two people.
 
@@ -2608,7 +2611,7 @@ async def get_relationship_details(person_a_id: str, person_b_id: str):
 # =======================
 
 @router.get("/slack/status")
-async def get_slack_status():
+def get_slack_status():
     """
     Get Slack integration status.
 
@@ -2627,7 +2630,7 @@ async def get_slack_status():
 
 
 @router.get("/slack/oauth/start")
-async def start_slack_oauth(state: Optional[str] = None):
+def start_slack_oauth(state: Optional[str] = None):
     """
     Start Slack OAuth flow.
 
@@ -2646,7 +2649,7 @@ async def start_slack_oauth(state: Optional[str] = None):
 
 
 @router.get("/slack/callback")
-async def slack_oauth_callback(code: str, state: Optional[str] = None):
+def slack_oauth_callback(code: str, state: Optional[str] = None):
     """
     Handle Slack OAuth callback.
 
@@ -2670,7 +2673,7 @@ async def slack_oauth_callback(code: str, state: Optional[str] = None):
 
 
 @router.post("/slack/sync")
-async def sync_slack_users_endpoint(workspace_id: str = "default"):
+def sync_slack_users_endpoint(workspace_id: str = "default"):
     """
     Sync Slack users to the CRM.
 
@@ -2703,7 +2706,7 @@ async def sync_slack_users_endpoint(workspace_id: str = "default"):
 
 
 @router.delete("/slack/disconnect")
-async def disconnect_slack(workspace_id: str = "default"):
+def disconnect_slack(workspace_id: str = "default"):
     """
     Disconnect a Slack workspace.
 
@@ -2724,7 +2727,7 @@ async def disconnect_slack(workspace_id: str = "default"):
 # ==================================
 
 @router.get("/contacts/status")
-async def get_contacts_status():
+def get_contacts_status():
     """
     Get Apple Contacts integration status.
 
@@ -2741,7 +2744,7 @@ async def get_contacts_status():
 
 
 @router.post("/contacts/sync")
-async def sync_contacts_endpoint():
+def sync_contacts_endpoint():
     """
     Sync Apple Contacts to the CRM.
 
@@ -2936,7 +2939,7 @@ class FamilyInteractionsResponse(BaseModel):
 
 
 @router.get("/me/stats", response_model=MeStatsResponse)
-async def get_me_stats():
+def get_me_stats():
     """
     Get aggregate statistics for the owner's personal dashboard.
 
@@ -2963,7 +2966,7 @@ async def get_me_stats():
 
 
 @router.get("/me/timeline", response_model=TimelineResponse)
-async def get_me_timeline(
+def get_me_timeline(
     source_type: Optional[str] = Query(
         default=None,
         description="Filter by source type. Supports comma-separated values for compound "
@@ -3046,7 +3049,7 @@ async def get_me_timeline(
 
 
 @router.get("/me/interactions", response_model=MeInteractionsResponse)
-async def get_me_interactions(
+def get_me_interactions(
     days_back: int = Query(default=365, ge=1, le=3660, description="Days of history (up to 10 years)"),
     trend_period: str = Query(default="quarter", description="Trend comparison period: week, month, quarter, year"),
     health_period: str = Query(default="quarter", description="Health score history period: month, quarter, year"),
@@ -3605,7 +3608,7 @@ async def get_me_interactions(
 
 
 @router.get("/family/members", response_model=FamilyMembersResponse)
-async def get_family_members():
+def get_family_members():
     """
     Get all family members for the multi-select dropdown and visualizations.
 
@@ -3701,7 +3704,7 @@ async def get_family_members():
 
 
 @router.get("/family/stats", response_model=FamilyStatsResponse)
-async def get_family_stats(
+def get_family_stats(
     person_ids: str = Query(
         ...,
         description="Comma-separated list of person IDs to get lifetime stats for"
@@ -3740,7 +3743,7 @@ async def get_family_stats(
 
 
 @router.get("/family/timeline", response_model=TimelineResponse)
-async def get_family_timeline(
+def get_family_timeline(
     person_ids: str = Query(
         ...,
         description="Comma-separated list of person IDs to include in timeline"
@@ -3822,7 +3825,7 @@ async def get_family_timeline(
 
 
 @router.get("/family/interactions", response_model=FamilyInteractionsResponse)
-async def get_family_interactions(
+def get_family_interactions(
     person_ids: str = Query(
         ...,
         description="Comma-separated list of person IDs to aggregate"
@@ -4067,7 +4070,7 @@ class CommunicationGapsResponse(BaseModel):
 
 
 @router.get("/family/communication-gaps", response_model=CommunicationGapsResponse)
-async def get_family_communication_gaps(
+def get_family_communication_gaps(
     person_ids: str = Query(
         ...,
         description="Comma-separated list of person IDs"
@@ -4188,7 +4191,7 @@ class ChannelMixResponse(BaseModel):
 
 
 @router.get("/family/channel-mix", response_model=ChannelMixResponse)
-async def get_family_channel_mix(
+def get_family_channel_mix(
     person_ids: str = Query(
         ...,
         description="Comma-separated list of person IDs"
@@ -4276,7 +4279,7 @@ class SyncErrorResponse(BaseModel):
 
 
 @router.get("/sync/health", response_model=list[SyncHealthResponse])
-async def get_all_sync_health():
+def get_all_sync_health():
     """
     Get health status for all sync sources.
 
@@ -4303,7 +4306,7 @@ async def get_all_sync_health():
 
 
 @router.get("/sync/health/summary", response_model=SyncHealthSummaryResponse)
-async def get_sync_health_summary():
+def get_sync_health_summary():
     """
     Get summary of sync health across all sources.
 
@@ -4318,7 +4321,7 @@ async def get_sync_health_summary():
 
 
 @router.get("/sync/health/{source}", response_model=SyncHealthResponse)
-async def get_source_sync_health(source: str):
+def get_source_sync_health(source: str):
     """
     Get health status for a specific sync source.
     """
@@ -4345,7 +4348,7 @@ async def get_source_sync_health(source: str):
 
 
 @router.get("/sync/errors", response_model=list[SyncErrorResponse])
-async def get_sync_errors(
+def get_sync_errors(
     source: Optional[str] = Query(default=None, description="Filter by source"),
     limit: int = Query(default=50, ge=1, le=200, description="Max results"),
 ):
@@ -4372,7 +4375,7 @@ async def get_sync_errors(
 
 
 @router.get("/sync/stale", response_model=list[SyncHealthResponse])
-async def get_stale_syncs():
+def get_stale_syncs():
     """
     Get list of syncs that are stale (>24 hours old).
 
@@ -4425,7 +4428,7 @@ class ReviewQueueResponse(BaseModel):
 
 
 @router.get("/review-queue", response_model=ReviewQueueResponse)
-async def get_review_queue(
+def get_review_queue(
     min_confidence: float = Query(default=0.0, ge=0.0, le=1.0, description="Minimum confidence"),
     max_confidence: float = Query(default=0.85, ge=0.0, le=1.0, description="Maximum confidence"),
     link_method: Optional[str] = Query(default=None, description="Filter by resolution method (e.g. email_exact, name_fuzzy)"),
@@ -4490,7 +4493,7 @@ async def get_review_queue(
 
 
 @router.post("/review-queue/{entity_id}/confirm")
-async def confirm_review_item(entity_id: str):
+def confirm_review_item(entity_id: str):
     """
     Confirm a low-confidence match as correct.
 
@@ -4517,7 +4520,7 @@ async def confirm_review_item(entity_id: str):
 
 
 @router.post("/review-queue/{entity_id}/reject")
-async def reject_review_item(entity_id: str, request: LinkConfirmRequest):
+def reject_review_item(entity_id: str, request: LinkConfirmRequest):
     """
     Reject a low-confidence match.
 
@@ -4585,7 +4588,7 @@ async def reject_review_item(entity_id: str, request: LinkConfirmRequest):
 
 
 @router.get("/data-health")
-async def get_data_health():
+def get_data_health():
     """
     Get comprehensive data health statistics.
 
@@ -4724,9 +4727,9 @@ async def get_data_health():
 
 
 @router.get("/data-health/summary")
-async def get_data_health_summary():
+def get_data_health_summary():
     """Get a brief summary of data health for the UI header."""
-    health = await get_data_health()
+    health = get_data_health()
 
     return {
         "total_interactions": sum(
@@ -4758,7 +4761,7 @@ class LinkOverrideResponse(BaseModel):
 
 
 @router.get("/link-overrides")
-async def get_link_overrides(person_id: Optional[str] = Query(default=None)):
+def get_link_overrides(person_id: Optional[str] = Query(default=None)):
     """
     Get all link override rules.
 
@@ -4805,7 +4808,7 @@ async def get_link_overrides(person_id: Optional[str] = Query(default=None)):
 
 
 @router.delete("/link-overrides/{override_id}")
-async def delete_link_override(override_id: str):
+def delete_link_override(override_id: str):
     """Delete a link override rule."""
     from api.services.link_override import get_link_override_store
 
@@ -4898,7 +4901,7 @@ class ToneAnalysisDetailedResponse(BaseModel):
 
 
 @router.get("/relationship/insights", response_model=RelationshipInsightsResponse)
-async def get_relationship_insights(person_id: Optional[str] = None):
+def get_relationship_insights(person_id: Optional[str] = None):
     """
     Get all relationship insights for the configured partner.
 
@@ -4939,7 +4942,7 @@ async def get_relationship_insights(person_id: Optional[str] = None):
 
 
 @router.post("/relationship/insights/generate", response_model=RelationshipInsightsResponse)
-async def generate_relationship_insights(
+def generate_relationship_insights(
     person_id: Optional[str] = None,
     category: Optional[str] = None
 ):
@@ -4995,7 +4998,7 @@ async def generate_relationship_insights(
 
 
 @router.post("/relationship/insights/{insight_id}/confirm")
-async def confirm_relationship_insight(insight_id: str):
+def confirm_relationship_insight(insight_id: str):
     """
     Mark an insight as confirmed.
 
@@ -5013,7 +5016,7 @@ async def confirm_relationship_insight(insight_id: str):
 
 
 @router.delete("/relationship/insights/{insight_id}")
-async def delete_relationship_insight(insight_id: str):
+def delete_relationship_insight(insight_id: str):
     """
     Delete/dismiss an insight.
     """
@@ -5029,7 +5032,7 @@ async def delete_relationship_insight(insight_id: str):
 
 
 @router.post("/relationship/tone-analysis", response_model=ToneAnalysisResponse)
-async def analyze_relationship_tone(person_id: Optional[str] = None, months: int = 12):
+def analyze_relationship_tone(person_id: Optional[str] = None, months: int = 12):
     """
     Analyze tone/sentiment in iMessage conversations over time.
 
@@ -5174,7 +5177,7 @@ MESSAGES:
 
 
 @router.post("/relationship/tone-analysis-detailed", response_model=ToneAnalysisDetailedResponse)
-async def analyze_relationship_tone_detailed(person_id: Optional[str] = None, months: int = 12):
+def analyze_relationship_tone_detailed(person_id: Optional[str] = None, months: int = 12):
     """
     Analyze tone/sentiment separately for the user and their partner in iMessage conversations.
 

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import logging
 import sqlite3
+import threading
 import time
 
 from fastapi import APIRouter, HTTPException, Query, UploadFile, File
@@ -47,6 +48,22 @@ from api.services.person_facts import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/crm", tags=["crm"])
+
+# Serializes the mutating handlers below (merge, split, hide, review-queue
+# confirm/reject, and the sync-trigger POSTs — plus photos.py's own sync
+# trigger, which imports this lock).  #868 converted these from `async def`
+# with no `await` to plain `def`, which restores fairness by dispatching
+# them to the worker threadpool instead of running them start-to-finish
+# inline on the event loop — but that inline run was also, incidentally,
+# every mutating handler's only serialization against every other request.
+# Off the loop, two of these can now genuinely interleave; several
+# (`merge_people` in particular, via `scripts/merge_people.py`'s single
+# global intent log and merged-id read-modify-write) are not safe under
+# that interleaving. This is a single coarse lock rather than one per
+# handler because they can mutate overlapping state (a merge and a split
+# both touch person_store); a single-user host pays essentially nothing for
+# serializing writes that used to be serialized anyway.
+_mutation_lock = threading.Lock()
 
 # Work email domain for category detection (loaded from settings)
 WORK_EMAIL_DOMAIN = settings.work_email_domain if hasattr(settings, 'work_email_domain') and settings.work_email_domain else "example.com"
@@ -824,58 +841,59 @@ def merge_people(request: PersonMergeRequest):
     The merge is durable - merged IDs are tracked so entity resolution
     won't recreate duplicates from future syncs.
     """
-    import sys
-    from pathlib import Path
-    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-    from scripts.merge_people import merge_people as do_merge
+    with _mutation_lock:
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+        from scripts.merge_people import merge_people as do_merge
 
-    person_store = get_person_entity_store()
-    _source_store = get_source_entity_store()  # noqa: F841
+        person_store = get_person_entity_store()
+        _source_store = get_source_entity_store()  # noqa: F841
 
-    # Validate primary exists
-    primary = person_store.get_by_id(request.primary_id)
-    if not primary:
-        raise HTTPException(status_code=404, detail=f"Primary person '{request.primary_id}' not found")
+        # Validate primary exists
+        primary = person_store.get_by_id(request.primary_id)
+        if not primary:
+            raise HTTPException(status_code=404, detail=f"Primary person '{request.primary_id}' not found")
 
-    # Validate all secondaries exist
-    for sec_id in request.secondary_ids:
-        secondary = person_store.get_by_id(sec_id)
-        if not secondary:
-            raise HTTPException(status_code=404, detail=f"Secondary person '{sec_id}' not found")
-        if sec_id == request.primary_id:
-            raise HTTPException(status_code=400, detail="Cannot merge a person into itself")
+        # Validate all secondaries exist
+        for sec_id in request.secondary_ids:
+            secondary = person_store.get_by_id(sec_id)
+            if not secondary:
+                raise HTTPException(status_code=404, detail=f"Secondary person '{sec_id}' not found")
+            if sec_id == request.primary_id:
+                raise HTTPException(status_code=400, detail="Cannot merge a person into itself")
 
-    # Perform merges
-    total_stats = {
-        'interactions_updated': 0,
-        'source_entities_updated': 0,
-        'facts_cleared': 0,
-        'emails_merged': 0,
-        'phones_merged': 0,
-        'aliases_added': 0,
-        'tags_merged': 0,
-        'notes_merged': 0,
-    }
+        # Perform merges
+        total_stats = {
+            'interactions_updated': 0,
+            'source_entities_updated': 0,
+            'facts_cleared': 0,
+            'emails_merged': 0,
+            'phones_merged': 0,
+            'aliases_added': 0,
+            'tags_merged': 0,
+            'notes_merged': 0,
+        }
 
-    merged_ids = []
-    for sec_id in request.secondary_ids:
-        try:
-            stats = do_merge(request.primary_id, sec_id, dry_run=False)
-            merged_ids.append(sec_id)
-            for key in total_stats:
-                total_stats[key] += stats.get(key, 0)
-        except Exception as e:
-            logger.error(f"Failed to merge {sec_id} into {request.primary_id}: {e}")
-            raise HTTPException(status_code=500, detail=f"Merge failed for {sec_id}: {str(e)}")
+        merged_ids = []
+        for sec_id in request.secondary_ids:
+            try:
+                stats = do_merge(request.primary_id, sec_id, dry_run=False)
+                merged_ids.append(sec_id)
+                for key in total_stats:
+                    total_stats[key] += stats.get(key, 0)
+            except Exception as e:
+                logger.error(f"Failed to merge {sec_id} into {request.primary_id}: {e}")
+                raise HTTPException(status_code=500, detail=f"Merge failed for {sec_id}: {str(e)}")
 
-    logger.info(f"Merged {len(merged_ids)} people into {request.primary_id}: {merged_ids}")
+        logger.info(f"Merged {len(merged_ids)} people into {request.primary_id}: {merged_ids}")
 
-    return PersonMergeResponse(
-        status="completed",
-        primary_id=request.primary_id,
-        merged_ids=merged_ids,
-        stats=total_stats,
-    )
+        return PersonMergeResponse(
+            status="completed",
+            primary_id=request.primary_id,
+            merged_ids=merged_ids,
+            stats=total_stats,
+        )
 
 
 # ============================================================================
@@ -1297,259 +1315,260 @@ def split_person(request: PersonSplitRequest):
 
     If to_person_id is None, a new person is created with new_person_name.
     """
-    import uuid
-    from pathlib import Path
-    from datetime import datetime, timezone
+    with _mutation_lock:
+        import uuid
+        from pathlib import Path
+        from datetime import datetime, timezone
 
-    from api.services.link_override import get_link_override_store, LinkOverride
+        from api.services.link_override import get_link_override_store, LinkOverride
 
-    person_store = get_person_entity_store()
-    _source_store = get_source_entity_store()  # noqa: F841
+        person_store = get_person_entity_store()
+        _source_store = get_source_entity_store()  # noqa: F841
 
-    # Validate from_person exists
-    from_person = person_store.get_by_id(request.from_person_id)
-    if not from_person:
-        raise HTTPException(status_code=404, detail=f"From person '{request.from_person_id}' not found")
+        # Validate from_person exists
+        from_person = person_store.get_by_id(request.from_person_id)
+        if not from_person:
+            raise HTTPException(status_code=404, detail=f"From person '{request.from_person_id}' not found")
 
-    # Get or create to_person
-    if request.to_person_id:
-        to_person = person_store.get_by_id(request.to_person_id)
-        if not to_person:
-            raise HTTPException(status_code=404, detail=f"To person '{request.to_person_id}' not found")
-    else:
-        if not request.new_person_name:
-            raise HTTPException(status_code=400, detail="new_person_name required when to_person_id is not provided")
+        # Get or create to_person
+        if request.to_person_id:
+            to_person = person_store.get_by_id(request.to_person_id)
+            if not to_person:
+                raise HTTPException(status_code=404, detail=f"To person '{request.to_person_id}' not found")
+        else:
+            if not request.new_person_name:
+                raise HTTPException(status_code=400, detail="new_person_name required when to_person_id is not provided")
 
-        to_person = PersonEntity(
-            id=str(uuid.uuid4()),
-            canonical_name=request.new_person_name,
-            sources=[],
-            first_seen=datetime.now(timezone.utc),
-            last_seen=datetime.now(timezone.utc),
-        )
-        person_store.add(to_person)
+            to_person = PersonEntity(
+                id=str(uuid.uuid4()),
+                canonical_name=request.new_person_name,
+                sources=[],
+                first_seen=datetime.now(timezone.utc),
+                last_seen=datetime.now(timezone.utc),
+            )
+            person_store.add(to_person)
+            person_store.save()
+            logger.info(f"Created new person for split: {to_person.canonical_name} ({to_person.id})")
+
+            # Verify the person was saved correctly
+            verify_person = person_store.get_by_id(to_person.id)
+            if not verify_person:
+                logger.error(f"CRITICAL: Person {to_person.id} was not saved correctly after split creation!")
+                raise HTTPException(status_code=500, detail="Failed to save new person during split")
+
+        # Get source entity details for override creation
+        crm_db = Path(__file__).parent.parent.parent / "data" / "crm.db"
+        conn = sqlite3.connect(crm_db)
+        conn.row_factory = sqlite3.Row
+
+        placeholders = ','.join('?' * len(request.source_entity_ids))
+        cursor = conn.execute(f"""
+            SELECT id, source_type, source_id, observed_name, observed_email, observed_phone
+            FROM source_entities
+            WHERE id IN ({placeholders})
+            AND canonical_person_id = ?
+        """, request.source_entity_ids + [request.from_person_id])
+
+        source_entity_details = [dict(row) for row in cursor]
+
+        if len(source_entity_details) != len(request.source_entity_ids):
+            found_ids = {se['id'] for se in source_entity_details}
+            missing = set(request.source_entity_ids) - found_ids
+            raise HTTPException(
+                status_code=400,
+                detail=f"Some source entities not found or not linked to from_person: {missing}"
+            )
+
+        # Move source entities
+        cursor = conn.execute(f"""
+            UPDATE source_entities
+            SET canonical_person_id = ?, linked_at = ?, link_status = 'confirmed'
+            WHERE id IN ({placeholders})
+        """, [to_person.id, datetime.now(timezone.utc).isoformat()] + request.source_entity_ids)
+        source_entities_moved = cursor.rowcount
+        conn.commit()
+
+        # Move interactions - get source_types from the source entities
+        _source_types = list({se['source_type'] for se in source_entity_details})  # noqa: F841
+        source_ids = [se['source_id'] for se in source_entity_details if se['source_id']]
+
+        interactions_moved = 0
+        if source_ids:
+            int_db = Path(__file__).parent.parent.parent / "data" / "interactions.db"
+            int_conn = sqlite3.connect(int_db)
+
+            id_placeholders = ','.join('?' * len(source_ids))
+            cursor = int_conn.execute(f"""
+                UPDATE interactions
+                SET person_id = ?
+                WHERE person_id = ?
+                AND source_id IN ({id_placeholders})
+            """, [to_person.id, request.from_person_id] + source_ids)
+            interactions_moved = cursor.rowcount
+            int_conn.commit()
+            int_conn.close()
+
+        # Update source lists on both persons
+        cursor = conn.execute("""
+            SELECT DISTINCT source_type FROM source_entities
+            WHERE canonical_person_id = ?
+        """, (from_person.id,))
+        from_person.sources = [row[0] for row in cursor]
+
+        cursor = conn.execute("""
+            SELECT DISTINCT source_type FROM source_entities
+            WHERE canonical_person_id = ?
+        """, (to_person.id,))
+        to_person.sources = [row[0] for row in cursor]
+
+        # Update phone_numbers and emails based on remaining source entities
+        # Get phones/emails that were moved
+        moved_phones = {se.get('observed_phone') for se in source_entity_details if se.get('observed_phone')}
+        moved_emails = {se.get('observed_email', '').lower() for se in source_entity_details if se.get('observed_email')}
+
+        # Add moved phones/emails to to_person
+        for phone in moved_phones:
+            if phone and phone not in to_person.phone_numbers:
+                to_person.phone_numbers.append(phone)
+                if not to_person.phone_primary:
+                    to_person.phone_primary = phone
+        for email in moved_emails:
+            if email and not to_person.has_email(email):
+                to_person.emails.append(email)
+
+        # Remove phones from from_person that no longer have source entities
+        cursor = conn.execute("""
+            SELECT DISTINCT observed_phone FROM source_entities
+            WHERE canonical_person_id = ? AND observed_phone IS NOT NULL
+        """, (from_person.id,))
+        remaining_phones = {row[0] for row in cursor}
+        from_person.phone_numbers = [p for p in from_person.phone_numbers if p in remaining_phones]
+        if from_person.phone_primary and from_person.phone_primary not in remaining_phones:
+            from_person.phone_primary = from_person.phone_numbers[0] if from_person.phone_numbers else None
+
+        # Remove emails from from_person that no longer have source entities
+        cursor = conn.execute("""
+            SELECT DISTINCT LOWER(observed_email) FROM source_entities
+            WHERE canonical_person_id = ? AND observed_email IS NOT NULL
+        """, (from_person.id,))
+        remaining_emails = {row[0] for row in cursor}
+        from_person.emails = [e for e in from_person.emails if e.lower() in remaining_emails]
+
+        person_store.update(from_person)
+        person_store.update(to_person)
         person_store.save()
-        logger.info(f"Created new person for split: {to_person.canonical_name} ({to_person.id})")
 
-        # Verify the person was saved correctly
-        verify_person = person_store.get_by_id(to_person.id)
-        if not verify_person:
-            logger.error(f"CRITICAL: Person {to_person.id} was not saved correctly after split creation!")
-            raise HTTPException(status_code=500, detail="Failed to save new person during split")
+        conn.close()
 
-    # Get source entity details for override creation
-    crm_db = Path(__file__).parent.parent.parent / "data" / "crm.db"
-    conn = sqlite3.connect(crm_db)
-    conn.row_factory = sqlite3.Row
+        # Create link overrides for durability
+        overrides_created = 0
+        if request.create_overrides:
+            override_store = get_link_override_store()
 
-    placeholders = ','.join('?' * len(request.source_entity_ids))
-    cursor = conn.execute(f"""
-        SELECT id, source_type, source_id, observed_name, observed_email, observed_phone
-        FROM source_entities
-        WHERE id IN ({placeholders})
-        AND canonical_person_id = ?
-    """, request.source_entity_ids + [request.from_person_id])
+            # Group by name pattern + source_type
+            patterns = {}
+            for se in source_entity_details:
+                name = se.get('observed_name', '')
+                source_type = se.get('source_type', '')
+                source_id = se.get('source_id', '')
 
-    source_entity_details = [dict(row) for row in cursor]
+                if not name:
+                    continue
 
-    if len(source_entity_details) != len(request.source_entity_ids):
-        found_ids = {se['id'] for se in source_entity_details}
-        missing = set(request.source_entity_ids) - found_ids
-        raise HTTPException(
-            status_code=400,
-            detail=f"Some source entities not found or not linked to from_person: {missing}"
-        )
+                key = (name.lower(), source_type)
+                if key not in patterns:
+                    patterns[key] = {'name': name, 'source_type': source_type, 'contexts': set()}
 
-    # Move source entities
-    cursor = conn.execute(f"""
-        UPDATE source_entities
-        SET canonical_person_id = ?, linked_at = ?, link_status = 'confirmed'
-        WHERE id IN ({placeholders})
-    """, [to_person.id, datetime.now(timezone.utc).isoformat()] + request.source_entity_ids)
-    source_entities_moved = cursor.rowcount
-    conn.commit()
+                # Extract context patterns from source_id
+                if source_type in ('vault', 'granola') and source_id:
+                    _work = settings.current_work_path.rstrip('/')
+                    if _work in source_id:
+                        patterns[key]['contexts'].add(f'{_work}/')
+                    elif 'Work/' in source_id:
+                        patterns[key]['contexts'].add('Work/')
 
-    # Move interactions - get source_types from the source entities
-    _source_types = list({se['source_type'] for se in source_entity_details})  # noqa: F841
-    source_ids = [se['source_id'] for se in source_entity_details if se['source_id']]
-
-    interactions_moved = 0
-    if source_ids:
-        int_db = Path(__file__).parent.parent.parent / "data" / "interactions.db"
-        int_conn = sqlite3.connect(int_db)
-
-        id_placeholders = ','.join('?' * len(source_ids))
-        cursor = int_conn.execute(f"""
-            UPDATE interactions
-            SET person_id = ?
-            WHERE person_id = ?
-            AND source_id IN ({id_placeholders})
-        """, [to_person.id, request.from_person_id] + source_ids)
-        interactions_moved = cursor.rowcount
-        int_conn.commit()
-        int_conn.close()
-
-    # Update source lists on both persons
-    cursor = conn.execute("""
-        SELECT DISTINCT source_type FROM source_entities
-        WHERE canonical_person_id = ?
-    """, (from_person.id,))
-    from_person.sources = [row[0] for row in cursor]
-
-    cursor = conn.execute("""
-        SELECT DISTINCT source_type FROM source_entities
-        WHERE canonical_person_id = ?
-    """, (to_person.id,))
-    to_person.sources = [row[0] for row in cursor]
-
-    # Update phone_numbers and emails based on remaining source entities
-    # Get phones/emails that were moved
-    moved_phones = {se.get('observed_phone') for se in source_entity_details if se.get('observed_phone')}
-    moved_emails = {se.get('observed_email', '').lower() for se in source_entity_details if se.get('observed_email')}
-
-    # Add moved phones/emails to to_person
-    for phone in moved_phones:
-        if phone and phone not in to_person.phone_numbers:
-            to_person.phone_numbers.append(phone)
-            if not to_person.phone_primary:
-                to_person.phone_primary = phone
-    for email in moved_emails:
-        if email and not to_person.has_email(email):
-            to_person.emails.append(email)
-
-    # Remove phones from from_person that no longer have source entities
-    cursor = conn.execute("""
-        SELECT DISTINCT observed_phone FROM source_entities
-        WHERE canonical_person_id = ? AND observed_phone IS NOT NULL
-    """, (from_person.id,))
-    remaining_phones = {row[0] for row in cursor}
-    from_person.phone_numbers = [p for p in from_person.phone_numbers if p in remaining_phones]
-    if from_person.phone_primary and from_person.phone_primary not in remaining_phones:
-        from_person.phone_primary = from_person.phone_numbers[0] if from_person.phone_numbers else None
-
-    # Remove emails from from_person that no longer have source entities
-    cursor = conn.execute("""
-        SELECT DISTINCT LOWER(observed_email) FROM source_entities
-        WHERE canonical_person_id = ? AND observed_email IS NOT NULL
-    """, (from_person.id,))
-    remaining_emails = {row[0] for row in cursor}
-    from_person.emails = [e for e in from_person.emails if e.lower() in remaining_emails]
-
-    person_store.update(from_person)
-    person_store.update(to_person)
-    person_store.save()
-
-    conn.close()
-
-    # Create link overrides for durability
-    overrides_created = 0
-    if request.create_overrides:
-        override_store = get_link_override_store()
-
-        # Group by name pattern + source_type
-        patterns = {}
-        for se in source_entity_details:
-            name = se.get('observed_name', '')
-            source_type = se.get('source_type', '')
-            source_id = se.get('source_id', '')
-
-            if not name:
-                continue
-
-            key = (name.lower(), source_type)
-            if key not in patterns:
-                patterns[key] = {'name': name, 'source_type': source_type, 'contexts': set()}
-
-            # Extract context patterns from source_id
-            if source_type in ('vault', 'granola') and source_id:
-                _work = settings.current_work_path.rstrip('/')
-                if _work in source_id:
-                    patterns[key]['contexts'].add(f'{_work}/')
-                elif 'Work/' in source_id:
-                    patterns[key]['contexts'].add('Work/')
-
-        for (name_lower, source_type), pattern in patterns.items():
-            if pattern['contexts']:
-                for context in pattern['contexts']:
+            for (name_lower, source_type), pattern in patterns.items():
+                if pattern['contexts']:
+                    for context in pattern['contexts']:
+                        override = LinkOverride(
+                            id=str(uuid.uuid4()),
+                            name_pattern=pattern['name'],
+                            source_type=source_type,
+                            context_pattern=context,
+                            preferred_person_id=to_person.id,
+                            rejected_person_id=from_person.id,
+                            reason=f"Split via UI from {from_person.canonical_name}",
+                        )
+                        override_store.add(override)
+                        overrides_created += 1
+                else:
                     override = LinkOverride(
                         id=str(uuid.uuid4()),
                         name_pattern=pattern['name'],
                         source_type=source_type,
-                        context_pattern=context,
+                        context_pattern=None,
                         preferred_person_id=to_person.id,
                         rejected_person_id=from_person.id,
                         reason=f"Split via UI from {from_person.canonical_name}",
                     )
                     override_store.add(override)
                     overrides_created += 1
-            else:
-                override = LinkOverride(
-                    id=str(uuid.uuid4()),
-                    name_pattern=pattern['name'],
-                    source_type=source_type,
-                    context_pattern=None,
-                    preferred_person_id=to_person.id,
-                    rejected_person_id=from_person.id,
-                    reason=f"Split via UI from {from_person.canonical_name}",
-                )
-                override_store.add(override)
-                overrides_created += 1
 
-    # Recalculate stats and relationships for both persons
-    # (Consistent with merge behavior - recalculate after moving data)
-    logger.info("Recalculating stats and relationships...")
+        # Recalculate stats and relationships for both persons
+        # (Consistent with merge behavior - recalculate after moving data)
+        logger.info("Recalculating stats and relationships...")
 
-    int_db = Path(__file__).parent.parent.parent / "data" / "interactions.db"
-    int_conn_stats = sqlite3.connect(int_db)
+        int_db = Path(__file__).parent.parent.parent / "data" / "interactions.db"
+        int_conn_stats = sqlite3.connect(int_db)
 
-    # Recalculate stats for both persons
-    from_stats = _recalculate_person_stats(from_person.id, int_conn_stats, person_store)
-    to_stats = _recalculate_person_stats(to_person.id, int_conn_stats, person_store)
+        # Recalculate stats for both persons
+        from_stats = _recalculate_person_stats(from_person.id, int_conn_stats, person_store)
+        to_stats = _recalculate_person_stats(to_person.id, int_conn_stats, person_store)
 
-    if from_stats:
-        logger.info(f"  {from_person.canonical_name} stats: {from_stats['old']} -> {from_stats['new']}")
-    if to_stats:
-        logger.info(f"  {to_person.canonical_name} stats: {to_stats['old']} -> {to_stats['new']}")
+        if from_stats:
+            logger.info(f"  {from_person.canonical_name} stats: {from_stats['old']} -> {from_stats['new']}")
+        if to_stats:
+            logger.info(f"  {to_person.canonical_name} stats: {to_stats['old']} -> {to_stats['new']}")
 
-    # Recalculate relationships with my_person_id
-    my_person_id = settings.my_person_id
-    if my_person_id:
-        from_rel = _recalculate_relationship_with_me(from_person.id, my_person_id, int_conn_stats)
-        to_rel = _recalculate_relationship_with_me(to_person.id, my_person_id, int_conn_stats)
+        # Recalculate relationships with my_person_id
+        my_person_id = settings.my_person_id
+        if my_person_id:
+            from_rel = _recalculate_relationship_with_me(from_person.id, my_person_id, int_conn_stats)
+            to_rel = _recalculate_relationship_with_me(to_person.id, my_person_id, int_conn_stats)
 
-        if from_rel.get('action') != 'none':
-            logger.info(f"  {from_person.canonical_name} relationship: {from_rel}")
-        if to_rel.get('action') != 'none':
-            logger.info(f"  {to_person.canonical_name} relationship: {to_rel}")
+            if from_rel.get('action') != 'none':
+                logger.info(f"  {from_person.canonical_name} relationship: {from_rel}")
+            if to_rel.get('action') != 'none':
+                logger.info(f"  {to_person.canonical_name} relationship: {to_rel}")
 
-    int_conn_stats.close()
+        int_conn_stats.close()
 
-    # Recalculate relationship strength for both persons
-    # (also updates is_peripheral_contact; dunbar_circle requires full recalc)
-    from_strength = update_strength_for_person(from_person.id)
-    if from_strength is not None:
-        logger.info(f"  {from_person.canonical_name} strength: {from_strength}")
+        # Recalculate relationship strength for both persons
+        # (also updates is_peripheral_contact; dunbar_circle requires full recalc)
+        from_strength = update_strength_for_person(from_person.id)
+        if from_strength is not None:
+            logger.info(f"  {from_person.canonical_name} strength: {from_strength}")
 
-    to_strength = update_strength_for_person(to_person.id)
-    if to_strength is not None:
-        logger.info(f"  {to_person.canonical_name} strength: {to_strength}")
+        to_strength = update_strength_for_person(to_person.id)
+        if to_strength is not None:
+            logger.info(f"  {to_person.canonical_name} strength: {to_strength}")
 
-    person_store.save()
+        person_store.save()
 
-    logger.info(
-        f"Split {source_entities_moved} source entities from {from_person.canonical_name} "
-        f"to {to_person.canonical_name}, {interactions_moved} interactions, "
-        f"{overrides_created} overrides created"
-    )
+        logger.info(
+            f"Split {source_entities_moved} source entities from {from_person.canonical_name} "
+            f"to {to_person.canonical_name}, {interactions_moved} interactions, "
+            f"{overrides_created} overrides created"
+        )
 
-    return PersonSplitResponse(
-        status="completed",
-        from_person_id=request.from_person_id,
-        to_person_id=to_person.id,
-        source_entities_moved=source_entities_moved,
-        interactions_moved=interactions_moved,
-        overrides_created=overrides_created,
-    )
+        return PersonSplitResponse(
+            status="completed",
+            from_person_id=request.from_person_id,
+            to_person_id=to_person.id,
+            source_entities_moved=source_entities_moved,
+            interactions_moved=interactions_moved,
+            overrides_created=overrides_created,
+        )
 
 
 @router.get("/people/{person_id}/timeline", response_model=TimelineResponse)
@@ -1966,20 +1985,27 @@ async def extract_person_facts(person_id: str, model: Optional[str] = None):
         model = PersonFactExtractor.MODEL_SONNET
     elif model == "haiku":
         model = PersonFactExtractor.MODEL_HAIKU
-    person_store = get_person_entity_store()
-    person = await asyncio.to_thread(person_store.get_by_id, person_id)
+    # get_person_entity_store()/get_interaction_store() themselves run
+    # inside the thread hop, not just the calls made on their result: on a
+    # cold singleton they run _init_db() etc, which is exactly the blocking
+    # work this handler must keep off the event loop.
+    def _fetch_person():
+        return get_person_entity_store().get_by_id(person_id)
+
+    person = await asyncio.to_thread(_fetch_person)
 
     if not person:
         raise HTTPException(status_code=404, detail=f"Person '{person_id}' not found")
 
     # Get ALL interactions for the person (extractor will sample strategically)
-    interaction_store = get_interaction_store()
-    interactions = await asyncio.to_thread(
-        interaction_store.get_for_person,
-        person_id,
-        days_back=3650,  # Look back 10 years for full history
-        limit=100000,  # No practical limit - let extractor sample
-    )
+    def _fetch_interactions():
+        return get_interaction_store().get_for_person(
+            person_id,
+            days_back=3650,  # Look back 10 years for full history
+            limit=100000,  # No practical limit - let extractor sample
+        )
+
+    interactions = await asyncio.to_thread(_fetch_interactions)
 
     if not interactions:
         return FactExtractionResponse(
@@ -2003,7 +2029,7 @@ async def extract_person_facts(person_id: str, model: Optional[str] = None):
 
     # Extract facts (use async version for proper event loop handling)
     try:
-        extractor = get_person_fact_extractor()
+        extractor = await asyncio.to_thread(get_person_fact_extractor)
         extracted_facts = await extractor.extract_facts_async(
             person_id=person_id,
             person_name=person.canonical_name,
@@ -2106,31 +2132,32 @@ def hide_person(person_id: str, request: HidePersonRequest):
     The person is not deleted, just hidden. Hidden people won't appear
     in search results or the people list.
     """
-    person_store = get_person_entity_store()
-    person = person_store.get_by_id(person_id)
+    with _mutation_lock:
+        person_store = get_person_entity_store()
+        person = person_store.get_by_id(person_id)
 
-    if not person:
-        raise HTTPException(status_code=404, detail=f"Person '{person_id}' not found")
+        if not person:
+            raise HTTPException(status_code=404, detail=f"Person '{person_id}' not found")
 
-    # Check if already hidden
-    if person.hidden:
+        # Check if already hidden
+        if person.hidden:
+            return {
+                "status": "already_hidden",
+                "person_id": person_id,
+                "hidden_at": person.hidden_at.isoformat() if person.hidden_at else None,
+            }
+
+        # Hide the person
+        hidden = person_store.hide_person(person_id, request.reason)
+
         return {
-            "status": "already_hidden",
+            "status": "hidden",
             "person_id": person_id,
-            "hidden_at": person.hidden_at.isoformat() if person.hidden_at else None,
+            "name": hidden.canonical_name,
+            "emails_blocked": len(hidden.emails),
+            "phones_blocked": len(hidden.phone_numbers),
+            "reason": request.reason,
         }
-
-    # Hide the person
-    hidden = person_store.hide_person(person_id, request.reason)
-
-    return {
-        "status": "hidden",
-        "person_id": person_id,
-        "name": hidden.canonical_name,
-        "emails_blocked": len(hidden.emails),
-        "phones_blocked": len(hidden.phone_numbers),
-        "reason": request.reason,
-    }
 
 
 @router.get("/discover", response_model=DiscoverResponse)
@@ -2232,7 +2259,11 @@ async def import_source_data(
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Failed to decode file: {e}")
 
-    source_store = get_source_entity_store()
+    # get_source_entity_store() itself runs inside the thread hop, not just
+    # the calls made on its result: on a cold singleton it runs _init_db()
+    # etc, which is exactly the blocking work this handler must keep off
+    # the event loop.
+    source_store = await asyncio.to_thread(get_source_entity_store)
 
     if source_type == "whatsapp":
         from api.services.whatsapp_import import import_whatsapp_export
@@ -2259,20 +2290,21 @@ def sync_source(source_type: str):
     """
     Trigger a sync for a specific data source.
     """
-    # WhatsApp has no standalone nightly sync of its own (issue #784) — its
-    # data is imported as part of the combined apple_import step, so a
-    # WhatsApp entry here belongs at the same (currently stub, see TODO
-    # below) parity level as gmail/imessage/linkedin, not below it.
-    valid_sources = {"gmail", "calendar", "slack", "contacts", "imessage", "linkedin", "vault", "whatsapp"}
-    if source_type not in valid_sources:
-        raise HTTPException(status_code=400, detail=f"Invalid source type: {source_type}")
+    with _mutation_lock:
+        # WhatsApp has no standalone nightly sync of its own (issue #784) — its
+        # data is imported as part of the combined apple_import step, so a
+        # WhatsApp entry here belongs at the same (currently stub, see TODO
+        # below) parity level as gmail/imessage/linkedin, not below it.
+        valid_sources = {"gmail", "calendar", "slack", "contacts", "imessage", "linkedin", "vault", "whatsapp"}
+        if source_type not in valid_sources:
+            raise HTTPException(status_code=400, detail=f"Invalid source type: {source_type}")
 
-    # TODO: Implement actual sync triggers
-    return {
-        "status": "queued",
-        "source_type": source_type,
-        "message": "Sync queued for processing",
-    }
+        # TODO: Implement actual sync triggers
+        return {
+            "status": "queued",
+            "source_type": source_type,
+            "message": "Sync queued for processing",
+        }
 
 
 @router.post("/relationships/discover")
@@ -2284,16 +2316,17 @@ def trigger_relationship_discovery():
     to discover connections between people.
     Automatically recalculates relationship strengths after discovery.
     """
-    results = run_full_discovery()
+    with _mutation_lock:
+        results = run_full_discovery()
 
-    # Automatically recalculate relationship strengths after discovery
-    strength_results = update_all_strengths()
-    results["strengths_updated"] = strength_results.get("updated", 0)
+        # Automatically recalculate relationship strengths after discovery
+        strength_results = update_all_strengths()
+        results["strengths_updated"] = strength_results.get("updated", 0)
 
-    return {
-        "status": "completed",
-        "discovered": results,
-    }
+        return {
+            "status": "completed",
+            "discovered": results,
+        }
 
 
 @router.post("/strengths/update")
@@ -2301,11 +2334,12 @@ def update_relationship_strengths():
     """
     Update relationship strength scores for all people.
     """
-    results = update_all_strengths()
-    return {
-        "status": "completed",
-        "results": results,
-    }
+    with _mutation_lock:
+        results = update_all_strengths()
+        return {
+            "status": "completed",
+            "results": results,
+        }
 
 
 @router.get("/statistics", response_model=StatisticsResponse)
@@ -2679,30 +2713,31 @@ def sync_slack_users_endpoint(workspace_id: str = "default"):
 
     Creates SourceEntity records for all users in the workspace.
     """
-    from api.services.slack_integration import (
-        get_slack_client,
-        sync_slack_users,
-        SlackAPIError,
-    )
-
-    client = get_slack_client()
-    if not client.is_connected(workspace_id):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Not connected to Slack workspace {workspace_id}. Complete OAuth first.",
+    with _mutation_lock:
+        from api.services.slack_integration import (
+            get_slack_client,
+            sync_slack_users,
+            SlackAPIError,
         )
 
-    source_store = get_source_entity_store()
+        client = get_slack_client()
+        if not client.is_connected(workspace_id):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Not connected to Slack workspace {workspace_id}. Complete OAuth first.",
+            )
 
-    try:
-        stats = sync_slack_users(client, source_store, workspace_id)
-        return {
-            "status": "completed",
-            "workspace_id": workspace_id,
-            "stats": stats,
-        }
-    except SlackAPIError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        source_store = get_source_entity_store()
+
+        try:
+            stats = sync_slack_users(client, source_store, workspace_id)
+            return {
+                "status": "completed",
+                "workspace_id": workspace_id,
+                "stats": stats,
+            }
+        except SlackAPIError as e:
+            raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.delete("/slack/disconnect")
@@ -2751,29 +2786,30 @@ def sync_contacts_endpoint():
     Creates SourceEntity records for all contacts.
     Requires macOS and Contacts permission.
     """
-    from api.services.apple_contacts import get_contacts_reader, sync_apple_contacts
+    with _mutation_lock:
+        from api.services.apple_contacts import get_contacts_reader, sync_apple_contacts
 
-    reader = get_contacts_reader()
-    if not reader.is_available:
-        raise HTTPException(
-            status_code=400,
-            detail="Apple Contacts not available. Requires macOS and pyobjc-framework-Contacts.",
-        )
+        reader = get_contacts_reader()
+        if not reader.is_available:
+            raise HTTPException(
+                status_code=400,
+                detail="Apple Contacts not available. Requires macOS and pyobjc-framework-Contacts.",
+            )
 
-    auth_status = reader.check_authorization()
-    if auth_status != "authorized":
-        raise HTTPException(
-            status_code=403,
-            detail=f"Contacts access not authorized: {auth_status}. Grant permission in System Preferences.",
-        )
+        auth_status = reader.check_authorization()
+        if auth_status != "authorized":
+            raise HTTPException(
+                status_code=403,
+                detail=f"Contacts access not authorized: {auth_status}. Grant permission in System Preferences.",
+            )
 
-    source_store = get_source_entity_store()
-    stats = sync_apple_contacts(source_store, reader)
+        source_store = get_source_entity_store()
+        stats = sync_apple_contacts(source_store, reader)
 
-    return {
-        "status": "completed",
-        "stats": stats,
-    }
+        return {
+            "status": "completed",
+            "stats": stats,
+        }
 
 
 # =============================
@@ -4499,24 +4535,25 @@ def confirm_review_item(entity_id: str):
 
     Updates the link confidence to 1.0 and status to confirmed.
     """
-    source_store = get_source_entity_store()
-    entity = source_store.get_by_id(entity_id)
+    with _mutation_lock:
+        source_store = get_source_entity_store()
+        entity = source_store.get_by_id(entity_id)
 
-    if not entity:
-        raise HTTPException(status_code=404, detail=f"Source entity '{entity_id}' not found")
+        if not entity:
+            raise HTTPException(status_code=404, detail=f"Source entity '{entity_id}' not found")
 
-    if not entity.canonical_person_id:
-        raise HTTPException(status_code=400, detail="Source entity is not linked to any person")
+        if not entity.canonical_person_id:
+            raise HTTPException(status_code=400, detail="Source entity is not linked to any person")
 
-    # Update to confirmed status
-    source_store.link_to_person(
-        entity_id,
-        entity.canonical_person_id,
-        confidence=1.0,
-        status=LINK_STATUS_CONFIRMED,
-    )
+        # Update to confirmed status
+        source_store.link_to_person(
+            entity_id,
+            entity.canonical_person_id,
+            confidence=1.0,
+            status=LINK_STATUS_CONFIRMED,
+        )
 
-    return {"status": "confirmed", "entity_id": entity_id}
+        return {"status": "confirmed", "entity_id": entity_id}
 
 
 @router.post("/review-queue/{entity_id}/reject")
@@ -4526,60 +4563,61 @@ def reject_review_item(entity_id: str, request: LinkConfirmRequest):
 
     Optionally creates a new person from the source entity.
     """
-    source_store = get_source_entity_store()
-    person_store = get_person_entity_store()
-    entity = source_store.get_by_id(entity_id)
+    with _mutation_lock:
+        source_store = get_source_entity_store()
+        person_store = get_person_entity_store()
+        entity = source_store.get_by_id(entity_id)
 
-    if not entity:
-        raise HTTPException(status_code=404, detail=f"Source entity '{entity_id}' not found")
+        if not entity:
+            raise HTTPException(status_code=404, detail=f"Source entity '{entity_id}' not found")
 
-    new_person_id = None
+        new_person_id = None
 
-    if request.create_new_person:
-        if not request.new_person_name:
-            name = entity.observed_name or entity.observed_email or "Unknown"
+        if request.create_new_person:
+            if not request.new_person_name:
+                name = entity.observed_name or entity.observed_email or "Unknown"
+            else:
+                name = request.new_person_name
+
+            # Create new person
+            new_person = PersonEntity(
+                canonical_name=name,
+                display_name=name,
+                emails=[entity.observed_email] if entity.observed_email else [],
+                phone_numbers=[entity.observed_phone] if entity.observed_phone else [],
+                sources=[entity.source_type],
+                first_seen=entity.observed_at,
+                last_seen=entity.observed_at,
+                source_entity_count=1,
+            )
+            person_store.add(new_person)
+            person_store.save()
+
+            # Verify the person was saved correctly
+            verify_person = person_store.get_by_id(new_person.id)
+            if not verify_person:
+                logger.error(f"CRITICAL: Person {new_person.id} was not saved correctly after reject creation!")
+                raise HTTPException(status_code=500, detail="Failed to save new person during reject")
+
+            # Link to new person
+            source_store.link_to_person(
+                entity_id,
+                new_person.id,
+                confidence=1.0,
+                status=LINK_STATUS_CONFIRMED,
+            )
+            new_person_id = new_person.id
         else:
-            name = request.new_person_name
+            # Mark as rejected
+            entity.link_status = LINK_STATUS_REJECTED
+            entity.canonical_person_id = None
+            source_store.update(entity)
 
-        # Create new person
-        new_person = PersonEntity(
-            canonical_name=name,
-            display_name=name,
-            emails=[entity.observed_email] if entity.observed_email else [],
-            phone_numbers=[entity.observed_phone] if entity.observed_phone else [],
-            sources=[entity.source_type],
-            first_seen=entity.observed_at,
-            last_seen=entity.observed_at,
-            source_entity_count=1,
-        )
-        person_store.add(new_person)
-        person_store.save()
-
-        # Verify the person was saved correctly
-        verify_person = person_store.get_by_id(new_person.id)
-        if not verify_person:
-            logger.error(f"CRITICAL: Person {new_person.id} was not saved correctly after reject creation!")
-            raise HTTPException(status_code=500, detail="Failed to save new person during reject")
-
-        # Link to new person
-        source_store.link_to_person(
-            entity_id,
-            new_person.id,
-            confidence=1.0,
-            status=LINK_STATUS_CONFIRMED,
-        )
-        new_person_id = new_person.id
-    else:
-        # Mark as rejected
-        entity.link_status = LINK_STATUS_REJECTED
-        entity.canonical_person_id = None
-        source_store.update(entity)
-
-    return {
-        "status": "rejected",
-        "entity_id": entity_id,
-        "new_person_id": new_person_id,
-    }
+        return {
+            "status": "rejected",
+            "entity_id": entity_id,
+            "new_person_id": new_person_id,
+        }
 
 
 # ============================================================================

--- a/api/routes/people.py
+++ b/api/routes/people.py
@@ -155,7 +155,7 @@ def _entity_to_response(entity, include_channels: bool = True) -> PersonResponse
 
 
 @router.get("/search", response_model=SearchResponse)
-async def search_people(
+def search_people(
     q: str = Query(..., description="Search query for name or email"),
 ):
     """Search for people by name or email."""
@@ -191,7 +191,7 @@ async def search_people(
 
 
 @router.get("/person/{name}", response_model=PersonResponse)
-async def get_person(name: str):
+def get_person(name: str):
     """Get a specific person by name."""
     resolver = get_entity_resolver()
     result = resolver.resolve(name=name)
@@ -203,7 +203,7 @@ async def get_person(name: str):
 
 
 @router.get("/statistics", response_model=StatisticsResponse)
-async def get_statistics():
+def get_statistics():
     """Get statistics about aggregated people."""
     store = get_person_entity_store()
     stats = store.get_statistics()
@@ -216,7 +216,7 @@ async def get_statistics():
 
 
 @router.get("/list", response_model=SearchResponse)
-async def list_people(
+def list_people(
     limit: int = Query(default=50, ge=1, le=500, description="Max results"),
     category: Optional[str] = Query(default=None, description="Filter by category"),
 ):
@@ -245,7 +245,7 @@ async def list_people(
 
 
 @router.post("/resolve", response_model=EntityResolveResponse)
-async def resolve_entity(request: EntityResolveRequest) -> EntityResolveResponse:
+def resolve_entity(request: EntityResolveRequest) -> EntityResolveResponse:
     """
     **PRIMARY TOOL for finding someone's email, full name, and contact info from a nickname or partial name.**
 
@@ -283,7 +283,7 @@ async def resolve_entity(request: EntityResolveRequest) -> EntityResolveResponse
 
 
 @router.get("/entity/{entity_id}", response_model=PersonResponse)
-async def get_entity(entity_id: str):
+def get_entity(entity_id: str):
     """Get a specific entity by ID."""
     store = get_person_entity_store()
     entity = store.get_by_id(entity_id)
@@ -295,7 +295,7 @@ async def get_entity(entity_id: str):
 
 
 @router.get("/entity/{entity_id}/interactions", response_model=InteractionsResponse)
-async def get_entity_interactions(
+def get_entity_interactions(
     entity_id: str,
     days_back: int = Query(default=90, ge=1, le=365, description="Days to look back"),
     limit: int = Query(default=50, ge=1, le=200, description="Max interactions"),
@@ -338,38 +338,38 @@ async def get_entity_interactions(
 
 # Legacy v2 endpoints (redirect to main endpoints for backward compatibility)
 @router.post("/v2/resolve", response_model=EntityResolveResponse, include_in_schema=False)
-async def resolve_entity_v2(request: EntityResolveRequest) -> EntityResolveResponse:
+def resolve_entity_v2(request: EntityResolveRequest) -> EntityResolveResponse:
     """Legacy v2 endpoint - redirects to main resolve endpoint."""
-    return await resolve_entity(request)
+    return resolve_entity(request)
 
 
 @router.get("/v2/entities", response_model=SearchResponse, include_in_schema=False)
-async def list_entities_v2(
+def list_entities_v2(
     limit: int = Query(default=50, ge=1, le=500),
     category: Optional[str] = Query(default=None),
 ):
     """Legacy v2 endpoint - redirects to main list endpoint."""
-    return await list_people(limit=limit, category=category)
+    return list_people(limit=limit, category=category)
 
 
 @router.get("/v2/entity/{entity_id}", response_model=PersonResponse, include_in_schema=False)
-async def get_entity_v2(entity_id: str):
+def get_entity_v2(entity_id: str):
     """Legacy v2 endpoint - redirects to main entity endpoint."""
-    return await get_entity(entity_id)
+    return get_entity(entity_id)
 
 
 @router.get("/v2/entity/{entity_id}/interactions", response_model=InteractionsResponse, include_in_schema=False)
-async def get_entity_interactions_v2(
+def get_entity_interactions_v2(
     entity_id: str,
     days_back: int = Query(default=90, ge=1, le=365),
     limit: int = Query(default=50, ge=1, le=200),
 ):
     """Legacy v2 endpoint - redirects to main interactions endpoint."""
-    return await get_entity_interactions(entity_id, days_back=days_back, limit=limit)
+    return get_entity_interactions(entity_id, days_back=days_back, limit=limit)
 
 
 @router.get("/v2/statistics", include_in_schema=False)
-async def get_v2_statistics():
+def get_v2_statistics():
     """Legacy v2 endpoint - redirects to main statistics."""
     store = get_person_entity_store()
     interaction_store = get_interaction_store()

--- a/api/routes/photos.py
+++ b/api/routes/photos.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
+from api.routes.crm import _mutation_lock
 from config.settings import settings
 
 router = APIRouter(prefix="/api/photos", tags=["photos"])
@@ -271,39 +272,40 @@ def trigger_photo_sync(
     Creates SourceEntity and Interaction records for matched people
     in Photos face recognition data.
     """
-    _check_photos_enabled()
+    with _mutation_lock:
+        _check_photos_enabled()
 
-    from api.services.apple_photos_sync import sync_apple_photos
+        from api.services.apple_photos_sync import sync_apple_photos
 
-    try:
-        # For now, always do full sync (incremental requires tracking state)
-        stats = sync_apple_photos(since=None)
+        try:
+            # For now, always do full sync (incremental requires tracking state)
+            stats = sync_apple_photos(since=None)
 
-        return SyncResponse(
-            success=True,
-            stats=stats,
-            message=f"Synced {stats.get('person_matches', 0)} people, "
-                    f"created {stats.get('interactions_created', 0)} interactions"
-        )
-    except Exception as e:
-        # A plain JSONResponse, not a SyncResponse, so a top-level "error"
-        # key can ride alongside the existing fields instead of being
-        # filtered out by response_model validation. #609 made this legible
-        # (top-level "error" key); #614 decided a total failure must also
-        # be non-2xx, since a consumer that only checks HTTP status
-        # (`raise_for_status()`) should get correct behavior without
-        # knowing about the body convention. 500 because this is an
-        # unhandled exception, not a classified upstream/dependency
-        # failure. The "error" key stays as additive defense —
-        # `mcp_server.py: dispatch()` and the agent worker's ToolRegistry
-        # already flag any tool result as an error generically whenever the
-        # body carries a top-level "error" key.
-        return JSONResponse(status_code=500, content={
-            "success": False,
-            "stats": {"error": str(e)},
-            "message": f"Sync failed: {e}",
-            "error": str(e),
-        })
+            return SyncResponse(
+                success=True,
+                stats=stats,
+                message=f"Synced {stats.get('person_matches', 0)} people, "
+                        f"created {stats.get('interactions_created', 0)} interactions"
+            )
+        except Exception as e:
+            # A plain JSONResponse, not a SyncResponse, so a top-level "error"
+            # key can ride alongside the existing fields instead of being
+            # filtered out by response_model validation. #609 made this legible
+            # (top-level "error" key); #614 decided a total failure must also
+            # be non-2xx, since a consumer that only checks HTTP status
+            # (`raise_for_status()`) should get correct behavior without
+            # knowing about the body convention. 500 because this is an
+            # unhandled exception, not a classified upstream/dependency
+            # failure. The "error" key stays as additive defense —
+            # `mcp_server.py: dispatch()` and the agent worker's ToolRegistry
+            # already flag any tool result as an error generically whenever the
+            # body carries a top-level "error" key.
+            return JSONResponse(status_code=500, content={
+                "success": False,
+                "stats": {"error": str(e)},
+                "message": f"Sync failed: {e}",
+                "error": str(e),
+            })
 
 
 def _get_thumbnail_path(uuid: str) -> Path | None:

--- a/api/routes/photos.py
+++ b/api/routes/photos.py
@@ -76,7 +76,7 @@ def _check_photos_enabled():
 
 
 @router.get("/stats", response_model=PhotosStatsResponse)
-async def get_photos_stats():
+def get_photos_stats():
     """
     Get statistics about the Photos library.
 
@@ -115,7 +115,7 @@ async def get_photos_stats():
 
 
 @router.get("/people", response_model=list[PhotosPersonResponse])
-async def list_photos_people(
+def list_photos_people(
     linked_only: bool = Query(
         default=True,
         description="Only return people linked to Apple Contacts"
@@ -162,7 +162,7 @@ async def list_photos_people(
 
 
 @router.get("/person/{person_id}", response_model=PhotosForPersonResponse)
-async def get_photos_for_person(
+def get_photos_for_person(
     person_id: str,
     date: Optional[str] = Query(None, description="Filter by date (YYYY-MM-DD)"),
     limit: int = Query(default=50, ge=1, le=200),
@@ -214,7 +214,7 @@ async def get_photos_for_person(
 
 
 @router.get("/shared/{person_a_id}/{person_b_id}", response_model=CoAppearanceResponse)
-async def get_shared_photos(
+def get_shared_photos(
     person_a_id: str,
     person_b_id: str,
     limit: int = Query(default=20, ge=1, le=100),
@@ -259,7 +259,7 @@ async def get_shared_photos(
 
 
 @router.post("/sync", response_model=SyncResponse)
-async def trigger_photo_sync(
+def trigger_photo_sync(
     incremental: bool = Query(
         default=True,
         description="If true, only sync new photos since last sync"
@@ -355,7 +355,7 @@ def _get_thumbnail_path(uuid: str) -> Path | None:
 
 
 @router.get("/thumbnail/{uuid}")
-async def get_photo_thumbnail(uuid: str):
+def get_photo_thumbnail(uuid: str):
     """
     Get a thumbnail for a photo by UUID.
 
@@ -407,7 +407,7 @@ async def get_photo_thumbnail(uuid: str):
 
 
 @router.get("/profile/{person_id}")
-async def get_profile_photo(person_id: str):
+def get_profile_photo(person_id: str):
     """
     Get a profile photo thumbnail for a person.
 
@@ -481,7 +481,7 @@ def _get_photo_file_path(uuid: str) -> Path | None:
 
 
 @router.get("/open/{uuid}")
-async def open_photo_in_app(uuid: str):
+def open_photo_in_app(uuid: str):
     """
     Open a specific photo in the Photos app or Preview.
 

--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -5,6 +5,7 @@ Stores lightweight interaction records with links to sources.
 Each interaction represents a single touchpoint (email, meeting, note mention).
 """
 import sqlite3
+import threading
 import uuid
 import logging
 from dataclasses import dataclass, field, asdict
@@ -1466,6 +1467,11 @@ class InteractionStore:
 
 # Singleton instance
 _interaction_store: Optional[InteractionStore] = None
+# #868 moved CRM/people/photos handlers off the event loop and onto worker
+# threads, so two first-requests after a restart can now race this
+# check-and-set. Double-checked locking: the lock is only taken while
+# _interaction_store is still None, so it costs nothing once constructed.
+_interaction_store_lock = threading.Lock()
 
 
 def get_interaction_store(db_path: Optional[str] = None) -> InteractionStore:
@@ -1480,7 +1486,9 @@ def get_interaction_store(db_path: Optional[str] = None) -> InteractionStore:
     """
     global _interaction_store
     if _interaction_store is None:
-        _interaction_store = InteractionStore(db_path)
+        with _interaction_store_lock:
+            if _interaction_store is None:
+                _interaction_store = InteractionStore(db_path)
     return _interaction_store
 
 

--- a/api/services/person_entity.py
+++ b/api/services/person_entity.py
@@ -12,6 +12,7 @@ import json
 import logging
 import re
 import sqlite3
+import threading
 import uuid
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timedelta, timezone
@@ -1150,6 +1151,11 @@ class PersonEntityStore:
 
 # Singleton instance
 _entity_store: Optional[PersonEntityStore] = None
+# #868 moved CRM/people/photos handlers off the event loop and onto worker
+# threads, so two first-requests after a restart can now race this
+# check-and-set. Double-checked locking: the lock is only taken while
+# _entity_store is still None, so it costs nothing once constructed.
+_entity_store_lock = threading.Lock()
 
 
 def get_person_entity_store(db_path: str = None) -> PersonEntityStore:
@@ -1164,7 +1170,9 @@ def get_person_entity_store(db_path: str = None) -> PersonEntityStore:
     """
     global _entity_store
     if _entity_store is None:
-        _entity_store = PersonEntityStore(db_path)
+        with _entity_store_lock:
+            if _entity_store is None:
+                _entity_store = PersonEntityStore(db_path)
     return _entity_store
 
 

--- a/api/services/person_facts.py
+++ b/api/services/person_facts.py
@@ -23,6 +23,7 @@ import logging
 import random
 import re
 import sqlite3
+import threading
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -1732,13 +1733,20 @@ Interactions:
 # Singleton instances
 _fact_store: Optional[PersonFactStore] = None
 _fact_extractor: Optional[PersonFactExtractor] = None
+# #868 moved CRM/people/photos handlers off the event loop and onto worker
+# threads, so two first-requests after a restart can now race this
+# check-and-set. Double-checked locking: the lock is only taken while
+# _fact_store is still None, so it costs nothing once constructed.
+_fact_store_lock = threading.Lock()
 
 
 def get_person_fact_store(db_path: Optional[str] = None) -> PersonFactStore:
     """Get or create the singleton PersonFactStore."""
     global _fact_store
     if _fact_store is None:
-        _fact_store = PersonFactStore(db_path)
+        with _fact_store_lock:
+            if _fact_store is None:
+                _fact_store = PersonFactStore(db_path)
     return _fact_store
 
 

--- a/api/services/relationship.py
+++ b/api/services/relationship.py
@@ -9,6 +9,7 @@ Relationships are discovered by analyzing shared contexts:
 """
 import sqlite3
 import json
+import threading
 import uuid
 import logging
 from dataclasses import dataclass, field, asdict
@@ -844,6 +845,11 @@ class RelationshipStore:
 
 # Singleton instance
 _relationship_store: Optional[RelationshipStore] = None
+# #868 moved CRM/people/photos handlers off the event loop and onto worker
+# threads, so two first-requests after a restart can now race this
+# check-and-set. Double-checked locking: the lock is only taken while
+# _relationship_store is still None, so it costs nothing once constructed.
+_relationship_store_lock = threading.Lock()
 
 
 def get_relationship_store(db_path: Optional[str] = None) -> RelationshipStore:
@@ -858,5 +864,7 @@ def get_relationship_store(db_path: Optional[str] = None) -> RelationshipStore:
     """
     global _relationship_store
     if _relationship_store is None:
-        _relationship_store = RelationshipStore(db_path)
+        with _relationship_store_lock:
+            if _relationship_store is None:
+                _relationship_store = RelationshipStore(db_path)
     return _relationship_store

--- a/api/services/source_entity.py
+++ b/api/services/source_entity.py
@@ -10,6 +10,7 @@ their linkage to canonical person records with confidence scores.
 """
 import sqlite3
 import json
+import threading
 import uuid
 import logging
 from dataclasses import dataclass, field, asdict
@@ -1280,6 +1281,11 @@ class SourceEntityStore:
 
 # Singleton instance
 _source_entity_store: Optional[SourceEntityStore] = None
+# #868 moved CRM/people/photos handlers off the event loop and onto worker
+# threads, so two first-requests after a restart can now race this
+# check-and-set. Double-checked locking: the lock is only taken while
+# _source_entity_store is still None, so it costs nothing once constructed.
+_source_entity_store_lock = threading.Lock()
 
 
 def get_source_entity_store(db_path: Optional[str] = None) -> SourceEntityStore:
@@ -1294,7 +1300,9 @@ def get_source_entity_store(db_path: Optional[str] = None) -> SourceEntityStore:
     """
     global _source_entity_store
     if _source_entity_store is None:
-        _source_entity_store = SourceEntityStore(db_path)
+        with _source_entity_store_lock:
+            if _source_entity_store is None:
+                _source_entity_store = SourceEntityStore(db_path)
     return _source_entity_store
 
 

--- a/docs/specs/standards/python-conventions.md
+++ b/docs/specs/standards/python-conventions.md
@@ -1,7 +1,7 @@
 # Python Conventions
 
 > **Status:** Complete
-> **Last Updated:** 2026-08-26
+> **Last Updated:** 2026-09-04
 > **Audience:** All developers and AI agents
 
 Coding conventions extracted from the LifeOS codebase. Match these patterns when writing new code.
@@ -67,7 +67,7 @@ from config.settings import settings
 
 ## Route Handler Pattern
 
-Routes are thin async functions on an `APIRouter`. They delegate to a service singleton and return Pydantic models or dicts.
+Routes are thin functions on an `APIRouter`. They delegate to a service singleton and return Pydantic models or dicts.
 
 ```python
 # api/routes/tasks.py
@@ -91,6 +91,7 @@ Key patterns:
 - Request/response Pydantic models are defined at the top of the route file.
 - 404s use `raise HTTPException(status_code=404, detail="...")`.
 - No try/except in routes -- services handle errors internally.
+- `async def` only if the handler's own body actually `await`s something; otherwise plain `def` (#868). LifeOS runs a single uvicorn event loop shared by every client surface, so a coroutine handler with no `await` still runs inline on that loop instead of FastAPI's worker threadpool -- one slow handler then blocks everyone else's requests. A handler that keeps `async def` pushes its blocking store/LLM calls onto a thread with `await asyncio.to_thread(...)` rather than calling them inline. See `api/routes/crm.py`, `api/routes/people.py`, `api/routes/photos.py` for the current worked example.
 
 ## Service / Store Pattern
 

--- a/docs/specs/standards/python-conventions.md
+++ b/docs/specs/standards/python-conventions.md
@@ -70,11 +70,13 @@ from config.settings import settings
 Routes are thin functions on an `APIRouter`. They delegate to a service singleton and return Pydantic models or dicts.
 
 ```python
-# api/routes/tasks.py
+# Generic shape, modeled on api/routes/tasks.py's list_tasks -- see the
+# `async def` vs. `def` bullet below for which form a new handler like this
+# one should actually use.
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
 @router.get("", response_model=TaskListResponse)
-async def list_tasks(
+def list_tasks(
     status: Optional[str] = None,
     context: Optional[str] = None,
 ):
@@ -91,7 +93,7 @@ Key patterns:
 - Request/response Pydantic models are defined at the top of the route file.
 - 404s use `raise HTTPException(status_code=404, detail="...")`.
 - No try/except in routes -- services handle errors internally.
-- `async def` only if the handler's own body actually `await`s something; otherwise plain `def` (#868). LifeOS runs a single uvicorn event loop shared by every client surface, so a coroutine handler with no `await` still runs inline on that loop instead of FastAPI's worker threadpool -- one slow handler then blocks everyone else's requests. A handler that keeps `async def` pushes its blocking store/LLM calls onto a thread with `await asyncio.to_thread(...)` rather than calling them inline. See `api/routes/crm.py`, `api/routes/people.py`, `api/routes/photos.py` for the current worked example.
+- `async def` only if the handler's own body actually `await`s something; otherwise plain `def` (#868). LifeOS runs a single uvicorn event loop shared by every client surface, so a coroutine handler with no `await` still runs inline on that loop instead of FastAPI's worker threadpool -- one slow handler then blocks everyone else's requests. A handler that keeps `async def` pushes its blocking store/LLM calls onto a thread with `await asyncio.to_thread(...)` rather than calling them inline. Applied and enforced (`tests/test_route_handlers_sync.py`) for `api/routes/crm.py`, `api/routes/people.py`, and `api/routes/photos.py` as of #868 -- the rest of `api/routes/` has not been converted yet, so `async def` with no `await` elsewhere is pre-existing, not an exception to this rule.
 
 ## Service / Store Pattern
 

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-08-21
+> **Last Updated:** 2026-09-04
 
 Codebase organization and module structure for efficient navigation.
 
@@ -274,6 +274,24 @@ async def endpoint_handler(
 
     return ResponseModel(...)
 ```
+
+**`def` vs. `async def` (#868).** LifeOS runs one uvicorn process with a
+single event loop; every client surface (chat, Telegram, voice, MCP, the
+agent worker, and the CRM/people UI) shares it. A handler declared `async
+def` with nothing to `await` still runs inline on that loop, so its
+synchronous DB/CPU work blocks every other in-flight request until it
+returns. A handler declared plain `def` is dispatched by FastAPI to the
+worker threadpool (via Starlette's `run_in_threadpool`, anyio's default
+capacity of 40) automatically, which restores fairness between requests.
+The CRM, people, and photos routers (`api/routes/crm.py`, `api/routes/people.py`,
+`api/routes/photos.py`) follow this rule: a handler is `async def` only if
+its own body actually awaits something (an LLM call, `await file.read()`);
+otherwise it is `def`. A handler that keeps `async def` pushes its blocking
+store or LLM calls onto a thread explicitly with `await asyncio.to_thread(...)`
+(e.g. `api/routes/investments.py`, `api/routes/crm.py`'s fact-extraction and
+source-import endpoints) rather than doing them inline. This is a fairness
+fix, not a throughput one — CPU-bound work still holds the GIL while it
+runs; per-endpoint throughput is tracked separately (issues #869-#874).
 
 ### Service Store Pattern
 

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -259,7 +259,7 @@ from api.routes.crm_models import (
 
 ```python
 @router.get("/endpoint", response_model=ResponseModel)
-async def endpoint_handler(
+def endpoint_handler(
     param: str = Query(..., description="Required parameter"),
     optional: int = Query(default=10, ge=1, le=100),
 ):
@@ -284,14 +284,28 @@ returns. A handler declared plain `def` is dispatched by FastAPI to the
 worker threadpool (via Starlette's `run_in_threadpool`, anyio's default
 capacity of 40) automatically, which restores fairness between requests.
 The CRM, people, and photos routers (`api/routes/crm.py`, `api/routes/people.py`,
-`api/routes/photos.py`) follow this rule: a handler is `async def` only if
-its own body actually awaits something (an LLM call, `await file.read()`);
-otherwise it is `def`. A handler that keeps `async def` pushes its blocking
-store or LLM calls onto a thread explicitly with `await asyncio.to_thread(...)`
-(e.g. `api/routes/investments.py`, `api/routes/crm.py`'s fact-extraction and
-source-import endpoints) rather than doing them inline. This is a fairness
-fix, not a throughput one — CPU-bound work still holds the GIL while it
-runs; per-endpoint throughput is tracked separately (issues #869-#874).
+`api/routes/photos.py`) follow this rule as of #868: a handler is `async def`
+only if its own body actually awaits something (an LLM call, `await
+file.read()`); otherwise it is `def`. A handler that keeps `async def`
+pushes its blocking store or LLM calls onto a thread explicitly with `await
+asyncio.to_thread(...)` (e.g. `api/routes/investments.py`, `api/routes/crm.py`'s
+fact-extraction and source-import endpoints) rather than doing them inline.
+This is a fairness fix, not a throughput one — CPU-bound work still holds
+the GIL while it runs; per-endpoint throughput is tracked separately
+(issues #869-#874). **Scope:** this is the rule for these three routers
+specifically, enforced by `tests/test_route_handlers_sync.py`; the rest of
+`api/routes/` still has `async def` handlers with no `await` that #868 did
+not touch — converting them is a separate, unstarted effort, not a silent
+exception to the rule above.
+Moving these handlers off the loop also removed the implicit serialization
+an inline `async def` gave every request against every other one. Handlers
+that mutate shared on-disk state (`merge_people`, `split_person`,
+`hide_person`, the review-queue confirm/reject endpoints, and the
+sync-trigger POSTs) now hold a module-level `threading.Lock`
+(`api/routes/crm.py`'s `_mutation_lock`) across their bodies to restore
+that serialization explicitly, since two of them interleaving could
+otherwise corrupt shared bookkeeping (e.g. `scripts/merge_people.py`'s
+merge-intent log).
 
 ### Service Store Pattern
 

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -46,8 +46,7 @@ class TestMeStatsEndpoint:
         store.get_all.return_value = people
         return store
 
-    @pytest.mark.asyncio
-    async def test_returns_aggregate_stats(self, mock_person_store):
+    def test_returns_aggregate_stats(self, mock_person_store):
         """Stats endpoint should return totals across all people."""
         from api.routes.crm import get_me_stats
 
@@ -60,8 +59,7 @@ class TestMeStatsEndpoint:
         assert result.total_meetings == 35  # 20 + 10 + 5
         assert result.total_messages == 800  # 500 + 200 + 100
 
-    @pytest.mark.asyncio
-    async def test_handles_empty_database(self):
+    def test_handles_empty_database(self):
         """Stats endpoint should handle empty database gracefully."""
         from api.routes.crm import get_me_stats
 
@@ -141,8 +139,7 @@ class TestMeInteractionsEndpoint:
 
         return person_store, interaction_store
 
-    @pytest.mark.asyncio
-    async def test_returns_aggregated_data(self, mock_stores):
+    def test_returns_aggregated_data(self, mock_stores):
         """Interactions endpoint should return aggregated data for dashboard."""
         from api.routes.crm import get_me_interactions
 
@@ -167,8 +164,7 @@ class TestMeInteractionsEndpoint:
         # Check source breakdown
         assert 'imessage' in result.by_source
 
-    @pytest.mark.asyncio
-    async def test_excludes_self_interactions(self, mock_stores):
+    def test_excludes_self_interactions(self, mock_stores):
         """Interactions should not include self-interactions (via get_all_in_range exclude)."""
         from api.routes.crm import get_me_interactions
 
@@ -183,8 +179,7 @@ class TestMeInteractionsEndpoint:
         call_args = interaction_store.get_all_in_range.call_args
         assert MY_PERSON_ID in call_args.kwargs.get('exclude_person_ids', [])
 
-    @pytest.mark.asyncio
-    async def test_filters_by_date_range(self):
+    def test_filters_by_date_range(self):
         """Date filtering is done by get_all_in_range method."""
         from api.routes.crm import get_me_interactions
 

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -53,7 +53,7 @@ class TestMeStatsEndpoint:
 
         with patch('api.routes.crm.get_person_entity_store', return_value=mock_person_store):
             with patch('api.routes.crm.get_interaction_store'):
-                result = await get_me_stats()
+                result = get_me_stats()
 
         assert result.total_people == 3
         assert result.total_emails == 175  # 100 + 50 + 25
@@ -70,7 +70,7 @@ class TestMeStatsEndpoint:
 
         with patch('api.routes.crm.get_person_entity_store', return_value=mock_store):
             with patch('api.routes.crm.get_interaction_store'):
-                result = await get_me_stats()
+                result = get_me_stats()
 
         assert result.total_people == 0
         assert result.total_emails == 0
@@ -150,7 +150,7 @@ class TestMeInteractionsEndpoint:
 
         with patch('api.routes.crm.get_person_entity_store', return_value=person_store):
             with patch('api.routes.crm.get_interaction_store', return_value=interaction_store):
-                result = await get_me_interactions(days_back=30)
+                result = get_me_interactions(days_back=30)
 
         # Should have total count
         assert result.total_count == 2
@@ -176,7 +176,7 @@ class TestMeInteractionsEndpoint:
 
         with patch('api.routes.crm.get_person_entity_store', return_value=person_store):
             with patch('api.routes.crm.get_interaction_store', return_value=interaction_store):
-                await get_me_interactions(days_back=365)
+                get_me_interactions(days_back=365)
 
         # Verify get_all_in_range was called with exclude_person_ids
         interaction_store.get_all_in_range.assert_called_once()
@@ -217,7 +217,7 @@ class TestMeInteractionsEndpoint:
 
         with patch('api.routes.crm.get_person_entity_store', return_value=person_store):
             with patch('api.routes.crm.get_interaction_store', return_value=interaction_store):
-                result = await get_me_interactions(days_back=30)
+                result = get_me_interactions(days_back=30)
 
         assert result.total_count == 1
         assert len(result.daily) == 1  # Should have one day with data

--- a/tests/test_route_handlers_concurrency.py
+++ b/tests/test_route_handlers_concurrency.py
@@ -7,40 +7,86 @@ so FastAPI ran it inline on the single event loop instead of dispatching it
 to the worker threadpool. A slow request (a full people-list scan, a
 relationship tone analysis) then blocked every other request on the process
 until it finished — measured on production as a 3 ms request taking 3.4 s
-behind four people-list calls, or 14 s behind a tone analysis.
+behind four people-list calls, or 14.1 s behind a tone analysis. The issue's
+acceptance criteria give both scenarios an explicit bound: `GET
+/api/crm/config` must complete in under 100 ms while either is in flight.
 
-This starts the real app with `TestClient` as a context manager, which (per
-Starlette) keeps one shared portal/event loop alive for the client's
-lifetime — the same single-event-loop model the production server uses,
-unlike a bare `client.get()` call outside a `with` block, which gets its own
-throwaway loop per request and would never reproduce the bug. It then fires
-several concurrent slow requests and asserts a trivial one finishes quickly
-while they're in flight.
+This builds a router-only app (`FastAPI()` + `include_router(crm_router)`)
+rather than the real `api.main.app`, and enters `TestClient` as a context
+manager against *that* — a bare `client.get()` outside a `with` block gets
+its own throwaway event loop per request and would never reproduce the bug,
+but the real app's lifespan starts Telegram listeners, the scheduler, the
+job-queue worker, and file watchers, and writes Dashboard files into the
+configured vault — side effects a "unit" test must not have, and ones that
+would collide with an already-running production server's own listeners on
+a real deployment. A router-only app keeps the one thing the bug actually
+needs (a single shared event loop dispatching `def` handlers to the
+threadpool) without booting anything else.
 
-The slow request is made deterministic by monkeypatching the person store's
-`get_all()` (what `GET /api/crm/people` calls) to sleep and return an empty
-list, so this does not depend on `data/crm.db` existing or having any
-particular size.
+Both slow requests are made deterministic by monkeypatching a store method
+to sleep and return an empty result, so this does not depend on `data/`
+existing or having any particular size:
+- people-list scenario: `person_entity_store.get_all()` (what `GET
+  /api/crm/people` calls).
+- tone-analysis scenario: `interaction_store.get_for_person()` (the first
+  blocking call in `analyze_relationship_tone_detailed`).
 """
 import time
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+from api.routes.crm import router as crm_router
 
 pytestmark = pytest.mark.unit
 
 SLEEP_SECONDS = 1.5
-# Generous compared to the issue's <100ms production target: this asserts
-# the fast request is NOT serialized behind the slow ones (which would push
-# it past SLEEP_SECONDS), not that it hits the production latency bound on
-# potentially loaded CI hardware.
-FAST_REQUEST_BOUND_SECONDS = 0.75
+# The issue's own acceptance bound. Measured non-flaky even under deliberate
+# full-CPU saturation (idle: low-single-digit ms; 32 busy-loops on a 32-core
+# box: still under 10ms) — a 100x margin under contention, so 100ms asserts
+# the criterion instead of just approximating it.
+FAST_REQUEST_BOUND_SECONDS = 0.1
 
 
-@pytest.fixture
-def app_client(monkeypatch):
-    from api.main import app
+def _router_only_app() -> FastAPI:
+    """A minimal app carrying only the CRM router — no lifespan, no other
+    routers, no side effects. Enough to reproduce the event-loop-sharing bug
+    without starting Telegram/scheduler/job-queue/watchers."""
+    app = FastAPI()
+    app.include_router(crm_router)
+    return app
+
+
+def _assert_fast_request_not_blocked(client, *, slow_request):
+    """Fire 4 concurrent slow requests via `slow_request(client)`, then
+    assert `GET /api/crm/config` completes well under the slow requests'
+    sleep while they're in flight."""
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        slow_futures = [pool.submit(slow_request, client) for _ in range(4)]
+        # Give the slow requests time to actually start running.
+        time.sleep(0.2)
+
+        start = time.time()
+        fast_response = client.get("/api/crm/config")
+        elapsed = time.time() - start
+
+        for future in slow_futures:
+            slow_response = future.result(timeout=SLEEP_SECONDS + 5)
+            assert slow_response.status_code == 200
+
+    assert fast_response.status_code == 200
+    assert elapsed < FAST_REQUEST_BOUND_SECONDS, (
+        f"GET /api/crm/config took {elapsed:.3f}s with slow requests in "
+        f"flight (bound {FAST_REQUEST_BOUND_SECONDS}s) — it looks like a "
+        "handler is running inline on the event loop again"
+    )
+
+
+def test_fast_config_request_not_blocked_by_concurrent_slow_people_list(monkeypatch):
+    """Acceptance criterion 1: 4 concurrent `GET /api/crm/people?limit=300`
+    in flight must not push `GET /api/crm/config` past 100ms."""
     from api.services.person_entity import get_person_entity_store
 
     store = get_person_entity_store()
@@ -54,30 +100,30 @@ def app_client(monkeypatch):
 
     monkeypatch.setattr(store, "get_all", slow_get_all)
 
-    with TestClient(app) as client:
-        yield client
+    with TestClient(_router_only_app()) as client:
+        _assert_fast_request_not_blocked(
+            client,
+            slow_request=lambda c: c.get("/api/crm/people?limit=300"),
+        )
 
 
-def test_fast_config_request_not_blocked_by_concurrent_slow_people_list(app_client):
-    with ThreadPoolExecutor(max_workers=4) as pool:
-        slow_futures = [
-            pool.submit(app_client.get, "/api/crm/people?limit=300")
-            for _ in range(4)
-        ]
-        # Give the slow requests time to actually start running.
-        time.sleep(0.2)
+def test_fast_config_request_not_blocked_by_concurrent_tone_analysis(monkeypatch):
+    """Acceptance criterion 2: a `POST /api/crm/relationship/tone-analysis-detailed`
+    in flight must not push `GET /api/crm/config` past 100ms."""
+    from api.services.interaction_store import get_interaction_store
 
-        start = time.time()
-        fast_response = app_client.get("/api/crm/config")
-        elapsed = time.time() - start
+    interaction_store = get_interaction_store()
 
-        for future in slow_futures:
-            slow_response = future.result(timeout=SLEEP_SECONDS + 5)
-            assert slow_response.status_code == 200
+    def slow_get_for_person(*args, **kwargs):
+        # Sleep only, same reasoning as above — tone analysis's first
+        # blocking call is interaction_store.get_for_person().
+        time.sleep(SLEEP_SECONDS)
+        return []
 
-    assert fast_response.status_code == 200
-    assert elapsed < FAST_REQUEST_BOUND_SECONDS, (
-        f"GET /api/crm/config took {elapsed:.2f}s with 4 slow people-list "
-        f"requests in flight (bound {FAST_REQUEST_BOUND_SECONDS}s) — it "
-        "looks like a handler is running inline on the event loop again"
-    )
+    monkeypatch.setattr(interaction_store, "get_for_person", slow_get_for_person)
+
+    with TestClient(_router_only_app()) as client:
+        _assert_fast_request_not_blocked(
+            client,
+            slow_request=lambda c: c.post("/api/crm/relationship/tone-analysis-detailed"),
+        )

--- a/tests/test_route_handlers_concurrency.py
+++ b/tests/test_route_handlers_concurrency.py
@@ -1,0 +1,83 @@
+"""
+Concurrency regression: a slow CRM request must not stall an unrelated fast
+one (#868).
+
+Before this fix, every CRM/people handler ran `async def` with no `await`,
+so FastAPI ran it inline on the single event loop instead of dispatching it
+to the worker threadpool. A slow request (a full people-list scan, a
+relationship tone analysis) then blocked every other request on the process
+until it finished — measured on production as a 3 ms request taking 3.4 s
+behind four people-list calls, or 14 s behind a tone analysis.
+
+This starts the real app with `TestClient` as a context manager, which (per
+Starlette) keeps one shared portal/event loop alive for the client's
+lifetime — the same single-event-loop model the production server uses,
+unlike a bare `client.get()` call outside a `with` block, which gets its own
+throwaway loop per request and would never reproduce the bug. It then fires
+several concurrent slow requests and asserts a trivial one finishes quickly
+while they're in flight.
+
+The slow request is made deterministic by monkeypatching the person store's
+`get_all()` (what `GET /api/crm/people` calls) to sleep and return an empty
+list, so this does not depend on `data/crm.db` existing or having any
+particular size.
+"""
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+SLEEP_SECONDS = 1.5
+# Generous compared to the issue's <100ms production target: this asserts
+# the fast request is NOT serialized behind the slow ones (which would push
+# it past SLEEP_SECONDS), not that it hits the production latency bound on
+# potentially loaded CI hardware.
+FAST_REQUEST_BOUND_SECONDS = 0.75
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    from api.main import app
+    from api.services.person_entity import get_person_entity_store
+
+    store = get_person_entity_store()
+
+    def slow_get_all(*args, **kwargs):
+        # Sleep only — deliberately does not fall through to the real
+        # get_all(), so this test's timing is independent of how much data
+        # (if any) data/crm.db holds.
+        time.sleep(SLEEP_SECONDS)
+        return []
+
+    monkeypatch.setattr(store, "get_all", slow_get_all)
+
+    with TestClient(app) as client:
+        yield client
+
+
+def test_fast_config_request_not_blocked_by_concurrent_slow_people_list(app_client):
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        slow_futures = [
+            pool.submit(app_client.get, "/api/crm/people?limit=300")
+            for _ in range(4)
+        ]
+        # Give the slow requests time to actually start running.
+        time.sleep(0.2)
+
+        start = time.time()
+        fast_response = app_client.get("/api/crm/config")
+        elapsed = time.time() - start
+
+        for future in slow_futures:
+            slow_response = future.result(timeout=SLEEP_SECONDS + 5)
+            assert slow_response.status_code == 200
+
+    assert fast_response.status_code == 200
+    assert elapsed < FAST_REQUEST_BOUND_SECONDS, (
+        f"GET /api/crm/config took {elapsed:.2f}s with 4 slow people-list "
+        f"requests in flight (bound {FAST_REQUEST_BOUND_SECONDS}s) — it "
+        "looks like a handler is running inline on the event loop again"
+    )

--- a/tests/test_route_handlers_mutation_lock.py
+++ b/tests/test_route_handlers_mutation_lock.py
@@ -1,0 +1,91 @@
+"""
+Concurrent merges must serialize (#868 review finding 3).
+
+Converting the CRM/people/photos handlers from `async def` with no `await`
+to plain `def` (#868) restored fairness by dispatching them to the worker
+threadpool instead of running them start-to-finish inline on the event
+loop — but that inline run was also, incidentally, every mutating
+handler's only serialization against every other request. `merge_people`
+delegates to `scripts/merge_people.merge_people`, which keeps a single
+global merge-intent log and does a read-modify-write of the merged-ids
+file; two concurrent merges interleaving there can corrupt that
+bookkeeping. `api/routes/crm.py` now holds `_mutation_lock` (a module-level
+`threading.Lock`) across `merge_people` and the other write handlers named
+in the review (split, hide, review-queue confirm/reject, the sync-trigger
+POSTs) to restore that serialization explicitly.
+
+This test proves the lock actually works: it patches the merge function
+`merge_people` calls (`scripts.merge_people.merge_people`, imported locally
+inside the handler on every call) with a fake that records whether it was
+ever entered while another call was still inside it, fires two concurrent
+`POST /api/crm/people/merge` requests, and asserts no overlap was ever
+observed.
+"""
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.crm import router as crm_router
+
+pytestmark = pytest.mark.unit
+
+
+def _router_only_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(crm_router)
+    return app
+
+
+def test_concurrent_merges_serialize(monkeypatch):
+    fake_person_store = MagicMock()
+    fake_person_store.get_by_id.return_value = MagicMock()  # any id "exists"
+    monkeypatch.setattr(
+        "api.routes.crm.get_person_entity_store", lambda: fake_person_store
+    )
+    monkeypatch.setattr(
+        "api.routes.crm.get_source_entity_store", lambda: MagicMock()
+    )
+
+    currently_running = threading.Event()
+    overlap_detected = threading.Event()
+
+    def fake_do_merge(primary_id, secondary_id, dry_run=False):
+        if currently_running.is_set():
+            overlap_detected.set()
+        currently_running.set()
+        try:
+            # Long enough that a second, unserialized call would overlap
+            # this one; short enough to keep the test fast.
+            time.sleep(0.2)
+        finally:
+            currently_running.clear()
+        return {}
+
+    monkeypatch.setattr(
+        "scripts.merge_people.merge_people", fake_do_merge
+    )
+
+    def do_request(client, n):
+        return client.post(
+            "/api/crm/people/merge",
+            json={"primary_id": "primary", "secondary_ids": [f"secondary-{n}"]},
+        )
+
+    with TestClient(_router_only_app()) as client:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(do_request, client, n) for n in range(2)]
+            responses = [f.result(timeout=10) for f in futures]
+
+    for response in responses:
+        assert response.status_code == 200, response.text
+
+    assert not overlap_detected.is_set(), (
+        "two concurrent merge requests ran scripts.merge_people.merge_people "
+        "at the same time — _mutation_lock in api/routes/crm.py is not "
+        "serializing them"
+    )

--- a/tests/test_route_handlers_no_shared_connections.py
+++ b/tests/test_route_handlers_no_shared_connections.py
@@ -1,0 +1,116 @@
+"""
+Static guard: no store reachable from the CRM/people/photos routers caches
+a SQLite connection across calls, or opens one with `check_same_thread=False`
+(#868 review finding 9).
+
+Acceptance criterion 6 for #868 is that these routers' stores keep opening a
+fresh `sqlite3.connect()` per call rather than sharing one across threads —
+that is what makes dispatching their handlers to worker threads safe at all.
+This was verified by inspection at review time rather than tested; this
+guard locks the invariant in going forward.
+
+A cached connection would show up as an instance attribute assigned the
+result of `sqlite3.connect(...)` (e.g. `self._conn = sqlite3.connect(...)`
+in `__init__` or anywhere else) — the opposite of the established pattern
+(`api/services/imessage.py`, `docs/specs/standards/python-conventions.md`
+§ Database Access Pattern) of opening and closing a connection within each
+method. `check_same_thread=False` is SQLite's own opt-out of the safety
+check that would otherwise raise if a connection built on one thread were
+used from another; needing it at all would mean a connection is being
+shared across threads, which these stores must never do now that their
+callers run on the worker threadpool.
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Every store module reachable from api/routes/crm.py, api/routes/people.py,
+# and api/routes/photos.py (verified by grepping their imports at review
+# time -- see the PR's review response for the exact call graph).
+STORE_MODULES = [
+    "api/services/person_entity.py",
+    "api/services/interaction_store.py",
+    "api/services/source_entity.py",
+    "api/services/relationship.py",
+    "api/services/person_facts.py",
+    "api/services/relationship_insights.py",
+    "api/services/apple_photos.py",
+]
+
+
+def _sqlite_connect_calls(tree):
+    """Yield every ast.Call node that is a `sqlite3.connect(...)` call."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_sqlite_connect = (
+            isinstance(func, ast.Attribute)
+            and func.attr == "connect"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "sqlite3"
+        )
+        if is_sqlite_connect:
+            yield node
+
+
+def _has_check_same_thread_false(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg == "check_same_thread" and isinstance(kw.value, ast.Constant) and kw.value.value is False:
+            return True
+    return False
+
+
+def _caches_connection_on_self(tree) -> bool:
+    """True if any `self.<attr> = sqlite3.connect(...)` assignment exists
+    anywhere in the module -- the anti-pattern this guard forbids."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        value = node.value
+        is_sqlite_connect_call = (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Attribute)
+            and value.func.attr == "connect"
+            and isinstance(value.func.value, ast.Name)
+            and value.func.value.id == "sqlite3"
+        )
+        if not is_sqlite_connect_call:
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+            ):
+                return True
+    return False
+
+
+@pytest.mark.parametrize("relative_path", STORE_MODULES)
+def test_store_does_not_share_a_connection_across_calls(relative_path):
+    path = REPO_ROOT / relative_path
+    source = path.read_text()
+    tree = ast.parse(source, filename=str(path))
+
+    unsafe_connects = [
+        call for call in _sqlite_connect_calls(tree) if _has_check_same_thread_false(call)
+    ]
+    assert not unsafe_connects, (
+        f"{relative_path} opens a sqlite3 connection with "
+        "check_same_thread=False -- that only makes sense for a connection "
+        "shared across threads, which these routers' stores must not do "
+        "now that their handlers run on the worker threadpool"
+    )
+
+    assert not _caches_connection_on_self(tree), (
+        f"{relative_path} assigns a sqlite3.connect(...) result to a "
+        "'self.*' attribute -- stores reachable from the CRM/people/photos "
+        "routers must open a fresh connection per call, not cache one "
+        "across calls/threads"
+    )

--- a/tests/test_route_handlers_sync.py
+++ b/tests/test_route_handlers_sync.py
@@ -12,10 +12,23 @@ automatically; an `async def` handler with nothing to await gets none of
 that and instead runs inline on the loop.
 
 This walks the CRM, people, and photos routers and fails if any handler is a
-coroutine function whose own source contains no `await` — the exact
-regression this issue fixes.
+coroutine function whose own body contains no `await`/`async for`/`async
+with` — the exact regression this issue fixes. This scope is deliberate:
+the same convention applies project-wide (see
+docs/specs/standards/python-conventions.md), but an AST scan of the rest of
+`api/routes/` at review time found 95 more `async def` handlers with no
+`await` across 23 other modules — converting those is out of scope for
+#868, so this guard, like the docs it enforces, is scoped to the three
+routers this issue actually changed.
+
+The check is AST-based rather than a substring search on the source text:
+`"await" not in source` would pass vacuously for a handler whose docstring
+or a comment merely mentions the word "await" without a real await
+anywhere in the body.
 """
+import ast
 import inspect
+import textwrap
 
 import pytest
 
@@ -39,6 +52,43 @@ def _handlers(router):
     return handlers
 
 
+class _AsyncConstructFinder(ast.NodeVisitor):
+    """Finds `await`/`async for`/`async with` in a function's own body,
+    without descending into any nested function/lambda — an inner
+    function's own await doesn't make the outer one truly async."""
+
+    def __init__(self):
+        self.found = False
+
+    def visit_Await(self, node):
+        self.found = True
+
+    def visit_AsyncFor(self, node):
+        self.found = True
+
+    def visit_AsyncWith(self, node):
+        self.found = True
+
+    def visit_FunctionDef(self, node):
+        pass  # don't descend into nested defs
+
+    def visit_AsyncFunctionDef(self, node):
+        pass
+
+    def visit_Lambda(self, node):
+        pass
+
+
+def _has_own_async_construct(fn) -> bool:
+    """True if `fn`'s own body (not any nested def) contains an `await`,
+    `async for`, or `async with`."""
+    source = textwrap.dedent(inspect.getsource(fn))
+    func_node = ast.parse(source).body[0]
+    finder = _AsyncConstructFinder()
+    finder.generic_visit(func_node)  # visits func_node's children, not func_node itself
+    return finder.found
+
+
 ROUTERS = [
     ("crm", crm_router),
     ("people", people_router),
@@ -49,18 +99,18 @@ ROUTERS = [
 @pytest.mark.parametrize("router_name,router", ROUTERS)
 def test_async_handlers_all_contain_an_await(router_name, router):
     """
-    Every `async def` handler in these routers must contain an `await` in
-    its own body. A coroutine function with no `await` runs synchronously on
-    the event loop anyway (getting none of asyncio's concurrency) while also
-    blocking every other request on the process — strictly worse than a
-    plain `def`, which FastAPI dispatches to the threadpool automatically.
+    Every `async def` handler in these routers must contain a real
+    `await`/`async for`/`async with` in its own body. A coroutine function
+    with none of those runs synchronously on the event loop anyway (getting
+    none of asyncio's concurrency) while also blocking every other request
+    on the process — strictly worse than a plain `def`, which FastAPI
+    dispatches to the threadpool automatically.
     """
     violations = []
     for path, endpoint in _handlers(router):
         if not inspect.iscoroutinefunction(endpoint):
             continue
-        source = inspect.getsource(endpoint)
-        if "await" not in source:
+        if not _has_own_async_construct(endpoint):
             violations.append(f"{endpoint.__name__} ({path})")
 
     assert not violations, (

--- a/tests/test_route_handlers_sync.py
+++ b/tests/test_route_handlers_sync.py
@@ -1,0 +1,86 @@
+"""
+Static guard: CRM, people, and photos route handlers run off the event loop
+when they can (#868).
+
+Every request to these routers used to run as `async def` even when its body
+did no async work at all, so FastAPI dispatched it straight onto the single
+event loop instead of the worker threadpool. One slow handler (a full
+people-list scan, a relationship tone analysis) then blocked every other
+request on the process — chat, Telegram, voice, MCP, and other CRM tabs —
+until it finished. A plain `def` handler is dispatched to the threadpool
+automatically; an `async def` handler with nothing to await gets none of
+that and instead runs inline on the loop.
+
+This walks the CRM, people, and photos routers and fails if any handler is a
+coroutine function whose own source contains no `await` — the exact
+regression this issue fixes.
+"""
+import inspect
+
+import pytest
+
+from api.routes.crm import router as crm_router
+from api.routes.people import router as people_router
+from api.routes.photos import router as photos_router
+
+pytestmark = pytest.mark.unit
+
+
+def _handlers(router):
+    """Return (path, endpoint) pairs for a router's routes, deduplicated."""
+    seen = set()
+    handlers = []
+    for route in router.routes:
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None or endpoint in seen:
+            continue
+        seen.add(endpoint)
+        handlers.append((route.path, endpoint))
+    return handlers
+
+
+ROUTERS = [
+    ("crm", crm_router),
+    ("people", people_router),
+    ("photos", photos_router),
+]
+
+
+@pytest.mark.parametrize("router_name,router", ROUTERS)
+def test_async_handlers_all_contain_an_await(router_name, router):
+    """
+    Every `async def` handler in these routers must contain an `await` in
+    its own body. A coroutine function with no `await` runs synchronously on
+    the event loop anyway (getting none of asyncio's concurrency) while also
+    blocking every other request on the process — strictly worse than a
+    plain `def`, which FastAPI dispatches to the threadpool automatically.
+    """
+    violations = []
+    for path, endpoint in _handlers(router):
+        if not inspect.iscoroutinefunction(endpoint):
+            continue
+        source = inspect.getsource(endpoint)
+        if "await" not in source:
+            violations.append(f"{endpoint.__name__} ({path})")
+
+    assert not violations, (
+        f"{router_name} router: async def handlers with no await "
+        f"(should be plain def): {', '.join(violations)}"
+    )
+
+
+def test_at_least_one_handler_remains_async_per_await_router():
+    """
+    Sanity check on the test itself: crm and people each keep at least one
+    genuinely async handler (fact extraction / source import in crm.py; the
+    legacy v2 wrappers folded into their sync targets in people.py leave no
+    async handler there, which is expected). This guards against the
+    parametrized test above passing vacuously if `_handlers` ever stopped
+    finding routes.
+    """
+    crm_handlers = _handlers(crm_router)
+    assert crm_handlers, "expected to find CRM route handlers"
+    assert any(inspect.iscoroutinefunction(fn) for _, fn in crm_handlers), (
+        "expected at least one genuinely async handler in api/routes/crm.py "
+        "(e.g. fact extraction, which awaits an LLM call)"
+    )


### PR DESCRIPTION
## TL;DR

Opening the CRM used to freeze the rest of LifeOS. A single slow CRM request (a big people list, a relationship tone analysis) blocked chat, Telegram, voice, MCP, and every other CRM tab until it finished — a 3 ms request could take several seconds, or worse, behind it. CRM, people, and photo requests now run off the shared request-handling thread whenever they don't need it, so slow and fast requests no longer queue behind each other. No endpoint's response changed; only how requests are scheduled changed.

Closes #868

## Design

CRM, people, and photo requests are handled by the API's single shared process. A request handler declared to do asynchronous work stays on that process's own scheduling loop even when it does nothing asynchronous — so a handler that scans thousands of records or waits on the local LLM held that loop hostage, and every other request (including ones from a completely different feature) queued behind it.

Handlers with no asynchronous work of their own are now declared as ordinary synchronous handlers, which the framework automatically runs on a worker thread instead of the shared loop. The handful of handlers that do have real asynchronous work (extracting facts via the LLM, importing an uploaded WhatsApp/Signal export, reading an uploaded file) keep their asynchronous form, and their blocking database work — including constructing the underlying data-store objects themselves, not just calling into them — is explicitly pushed onto a worker thread too, so they no longer block the loop either. This restores fairness between concurrent requests; it does not make any individual endpoint faster (that's the scope of the sibling issues #869-#874).

Moving these handlers onto worker threads also removed a mutex they got for free by running start-to-finish on the loop: two requests that write shared on-disk state (a merge, a split, a hide, a review-queue decision, a sync trigger) could previously never interleave. They now hold an explicit lock across their bodies so a concurrent pair still can't. Two more implicit-serialization holes were closed the same way: the lazy singleton getters for the data stores these routers use, and the getter calls inside the two handlers that stayed `async`.

## Implementation Notes

- `api/routes/crm.py`: converted 60 of 62 `async def` handlers with no `await` to plain `def` (matches the issue's count of 59 handlers with none, plus `get_data_health_summary`, whose only `await` was a call to `get_data_health()` — itself converted, so the call site and its caller both dropped `async`). The 2 remaining `async def` handlers keep their real awaits: `extract_person_facts` (LLM call via `extract_facts_async`) and `import_source_data` (`await file.read()`); both push their blocking store/parsing calls, and the store/extractor getter calls themselves, through `asyncio.to_thread` rather than running them inline before/after the await.
- `api/routes/people.py`: converted all 12 `async def` handlers to `def`, including the 4 legacy `/v2/*` wrappers, whose only `await` was calling the (now sync) primary handlers directly — those call sites dropped `await` too.
- `api/routes/photos.py`: converted all 8 `async def` handlers (none had an `await`) to `def`. These back the CRM's profile/thumbnail/shared-photo requests.
- **`_mutation_lock`** (new module-level `threading.Lock` in `api/routes/crm.py`): held across the full body of every handler that mutates shared on-disk state — `merge_people`, `split_person`, `hide_person`, `confirm_review_item`, `reject_review_item`, `sync_source`, `trigger_relationship_discovery`, `update_relationship_strengths`, `sync_slack_users_endpoint`, `sync_contacts_endpoint` — plus `api/routes/photos.py`'s `trigger_photo_sync`, which imports the same lock. Restores the serialization these handlers got for free when they ran inline on the event loop; without it, two concurrent merges could corrupt `scripts/merge_people.py`'s single global merge-intent log and its merged-id read-modify-write.
- Lazy singleton getters (`get_person_entity_store`, `get_interaction_store`, `get_source_entity_store`, `get_relationship_store`, `get_person_fact_store`) now use double-checked locking (`threading.Lock`, one per module) around their `if _x is None: _x = X()` construction, so two first-requests after a restart can't race and double-construct a store.
- `tests/test_me_page.py`: five tests called `get_me_stats`/`get_me_interactions` directly with `await` under `@pytest.mark.asyncio`; updated the call sites to plain calls and dropped the marker/`async` now that those handlers are synchronous. This is the exact "handler calls another handler directly" case the issue flagged, just in test code instead of route code.
- New `tests/test_route_handlers_sync.py`: walks the CRM, people, and photos routers and fails if any `async def` handler's own body contains no `await`/`async for`/`async with` (an AST check, not a substring search — a docstring or comment that merely mentions "await" can't pass it vacuously). Scoped, by design and by the doc wording it enforces, to these three routers; the rest of `api/routes/` has ~95 unconverted `async def`-with-no-`await` handlers that are pre-existing and out of scope for #868.
- New `tests/test_route_handlers_concurrency.py`: builds a router-only app (`FastAPI()` + `include_router(crm_router)`, no lifespan) and enters `TestClient` as a context manager against it — keeping one shared event loop for the client's lifetime reproduces the production single-loop model without booting Telegram/scheduler/job-queue/watchers or writing to a configured vault. Two scenarios, both asserting the issue's actual acceptance bound (`GET /api/crm/config` under 100ms): (1) `person_entity_store.get_all()` patched to sleep, 4 concurrent `GET /api/crm/people?limit=300` in flight; (2) `interaction_store.get_for_person()` patched to sleep, a `POST /api/crm/relationship/tone-analysis-detailed` in flight. Verified both fail against the pre-fix code and pass after.
- New `tests/test_route_handlers_mutation_lock.py`: patches `scripts.merge_people.merge_people` to record whether it was ever re-entered while another call was inside it, fires two concurrent `POST /api/crm/people/merge` requests, and asserts no overlap. Verified it fails with the lock removed and passes with it in place.
- New `tests/test_route_handlers_no_shared_connections.py`: an AST-based static guard over the 7 store modules reachable from these routers (`person_entity`, `interaction_store`, `source_entity`, `relationship`, `person_facts`, `relationship_insights`, `apple_photos`) — fails if any opens a SQLite connection with `check_same_thread=False` or assigns one to a `self.*` attribute (the anti-pattern of caching a connection across calls/threads, instead of the established open-fresh-per-call pattern).
- `docs/specs/technical/architecture.md` and `docs/specs/standards/python-conventions.md`: added a current-state note on the `def` vs. `async def` convention this issue establishes, explicit that it's scoped to these three routers, and a sentence on why mutating handlers now need an explicit lock. Fixed both docs' canonical route-handler-pattern code snippets, which had shown `async def` with no `await` immediately above the new rule.

## Test evidence

### Automated tests

```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest \
    tests/test_crm_api.py tests/test_people.py tests/test_people_e2e.py tests/test_photos_sync_api.py \
    tests/test_merge_people.py tests/test_split_person.py tests/test_crm_ui_requirements.py \
    tests/test_me_page.py tests/test_route_handlers_sync.py tests/test_route_handlers_concurrency.py \
    tests/test_route_handlers_mutation_lock.py tests/test_route_handlers_no_shared_connections.py -q
...
114 passed, 4 skipped, 1 failed in ...
```
The one failure, `test_me_page.py::TestMyPersonIdConstant::test_my_person_id_is_valid_uuid`, is pre-existing and environment-dependent (needs a real configured `settings.my_person_id`; empty in a clean checkout) — the reviewer independently confirmed this and it is unrelated to this change.

Full unit suite, run clean (no `.env` in the worktree, no concurrent host load this time):
```
$ ./scripts/test.sh unit
========== 5585 passed, 8 skipped, 1181 warnings in 276.77s (0:04:36) ==========
```

### Manual verification

Static guard against the pre-fix code (confirms the new tests actually catch the regression):
```
$ git stash push -- api/routes/crm.py api/routes/people.py api/routes/photos.py
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_route_handlers_concurrency.py tests/test_route_handlers_sync.py -v
...
FAILED tests/test_route_handlers_concurrency.py::test_fast_config_request_not_blocked_by_concurrent_slow_people_list
FAILED tests/test_route_handlers_concurrency.py::test_fast_config_request_not_blocked_by_concurrent_tone_analysis
FAILED tests/test_route_handlers_sync.py::test_async_handlers_all_contain_an_await[crm-router0] - ... 59 handlers listed
FAILED tests/test_route_handlers_sync.py::test_async_handlers_all_contain_an_await[people-router1] - ... 8 handlers listed
FAILED tests/test_route_handlers_sync.py::test_async_handlers_all_contain_an_await[photos-router2] - ... 8 handlers listed
$ git stash pop
```

Mutation-lock guard against the lock removed (confirms `test_concurrent_merges_serialize` actually catches the regression):
```
AssertionError: two concurrent merge requests ran scripts.merge_people.merge_people at the same
time — _mutation_lock in api/routes/crm.py is not serializing them
```

Controlled byte-identical check — same frozen staging data, pre-fix code on :8012 vs. post-fix code on :8011, diffing `GET /api/crm/people?limit=20`, `/api/crm/people/{id}`, `/timeline`, `/connections`, `/facts`, `/api/crm/statistics`, `/api/crm/birthdays/all`:
```
people: byte_identical=True struct_identical=True
person: byte_identical=True struct_identical=True
timeline: byte_identical=True struct_identical=True
connections: byte_identical=True struct_identical=True
facts: byte_identical=True struct_identical=True
statistics: byte_identical=True struct_identical=True
birthdays: byte_identical=True struct_identical=True

ALL IDENTICAL
```
This isolates the code change from data drift. A separate diff between the fixed staging instance and live production (`:8000`) showed only `relationship_strength` values and category counts differing — expected, since production continued receiving real syncs and strength recalculations between when the staging copy was taken and when this check ran; JSON shape and every other field matched. (The reviewer independently ran a broader 40-endpoint byte-identity check plus an OpenAPI-schema hash comparison and found the same: fully identical.)

Real-world concurrency demonstration (real staging data, no monkeypatch — 4 concurrent `GET /api/crm/people?limit=10000` in flight, each individually ~6.2s):
```
Pre-fix  (:8012): GET /api/crm/config took 24.947s
Post-fix (:8011): GET /api/crm/config took 0.030s
```

`extract_person_facts`'s and `import_source_data`'s new `to_thread`-wrapped getter paths were smoke-tested directly (no LLM/upload infra needed for this): a 404 lookup through `extract_person_facts` and a full synthetic-WhatsApp-content run through `import_source_data` both completed correctly with the getters now running inside the thread hop.

## Review focus

- `api/routes/crm.py`'s `_mutation_lock` scope — it's one coarse lock across all the mutating handlers named above (including `photos.py`'s sync trigger) rather than one per handler, on the reasoning that several of them can touch overlapping state (a merge and a split both touch `person_store`) and a single-user host pays essentially nothing for serializing writes that used to be serialized anyway. Flag if a finer-grained (or differently-scoped) lock would be preferable.
- `api/routes/crm.py`'s `get_data_health_summary` / `get_data_health` pair and `import_source_data` / `extract_person_facts` — these are the handlers where the mechanical "drop `async`" rule needed a second pass (a caller's own `await` disappearing once its callee went sync, blocking calls that needed an explicit `asyncio.to_thread`, and now the getter calls themselves moved into that hop too).
- The static "no shared connection" guard (`tests/test_route_handlers_no_shared_connections.py`) hardcodes the 7 store modules these routers currently reach; if a new store gets added to the call graph, this list needs a manual update — there's no automated reachability check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
