### PR TITLE
style(web): standardize scrollbar design across all pages

### DIFF
--- a/web/agents.html
+++ b/web/agents.html
@@ -26,6 +26,26 @@
     --completed: #6b7280;
     --failed: #f87171;
   }
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: var(--border);
+    border-radius: 6px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: var(--text-dim);
+  }
   body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     background: var(--bg-primary);

--- a/web/crm.html
+++ b/web/crm.html
@@ -42,6 +42,31 @@
             touch-action: manipulation;
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-muted);
+        }
+
         html, body {
             height: 100%;
             overflow: hidden;
@@ -4634,8 +4659,6 @@
             gap: 1rem;
             overflow-x: auto;
             padding: 0.5rem 0 1rem;
-            scrollbar-width: thin;
-            scrollbar-color: var(--border) transparent;
             margin-bottom: 1.5rem;
         }
 

--- a/web/home.html
+++ b/web/home.html
@@ -28,6 +28,31 @@
             --border: #2a2a3a;
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-secondary);
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: var(--bg-primary);

--- a/web/index.html
+++ b/web/index.html
@@ -45,6 +45,31 @@
             touch-action: manipulation;  /* Disable iOS double-tap delay globally */
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-muted);
+        }
+
         html, body {
             height: 100vh;   /* fallback for browsers without dvh */
             height: 100dvh;  /* track the mobile browser's dynamic chrome (address bar / keyboard) so the composer stays reachable */

--- a/web/journal-trends.html
+++ b/web/journal-trends.html
@@ -24,6 +24,31 @@
             --warn: #a855f7;
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-secondary);
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: var(--bg-primary);

--- a/web/journal.html
+++ b/web/journal.html
@@ -23,6 +23,31 @@
             --border: #2a2a3a;
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-secondary);
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: var(--bg-primary);


### PR DESCRIPTION
## Summary

Replaces the stark white/gray OS-default scrollbars with a thin, themed scrollbar on every page of the web UI, so they read as part of the dark interface instead of standing out against it.

The same block is applied to `index.html` (chat SPA), `crm.html`, `agents.html`, `home.html`, `journal.html`, and `journal-trends.html`:

- **Firefox** — `scrollbar-width: thin` + `scrollbar-color` on a transparent track.
- **WebKit/Blink** — 10px `::-webkit-scrollbar`, transparent track, and a rounded thumb inset with `border: 2px solid transparent` + `background-clip: padding-box` so it reads as a floating pill rather than an edge-to-edge bar.
- Thumb uses each page's existing `--border`, brightening on hover to whichever muted-text token that page already defines (`--text-muted` / `--text-dim` / `--text-secondary`) — no new hardcoded colors, so the treatment tracks each page's palette.

Since the frontend has no shared stylesheet and no build step, the block lives in each page's inline `<style>`, using identical rule structure and ordering across all six files.

Also drops a now-redundant Firefox-only `scrollbar-width`/`scrollbar-color` pair on `.trend-callouts-scroll` in `crm.html`, superseded by the global rule. The deliberate `scrollbar-width: none` rules on the mobile tab strip, hero stats, and heatmap wrapper are left alone — those intentionally hide the scrollbar on horizontal touch-scroll strips, and their class selectors still outrank the new universal rule.

## Test plan

- [x] Pre-push gate: `unit and not slow` (6,124 passed) + `browser and not requires_server` (312 passed).
- [x] CSS well-formedness: one `<style>` block per file, braces balanced in each.
- [ ] Post-deploy: visually confirm the scrollbars on `/chat`, `/crm`, and `/agents`, including hover state and the mobile horizontal strips that should stay hidden.

Note: I was unable to verify visually in-session — the browser tool in this environment cannot reach `localhost:8000` at all (it fails identically on unrelated pages), so this is CSS-reviewed rather than eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSwvRSUsNgwxNxrc4Rh3CF