### PR TITLE
chore(crm): gzip responses, cancel stale searches, fetch a selected person once, cache the page

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -37,15 +37,19 @@ from pathlib import Path
 from dotenv import load_dotenv
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
+import hashlib
 import logging
+import os
 import socket
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from email.utils import formatdate
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi.exceptions import RequestValidationError
+from starlette.middleware.gzip import GZipMiddleware
 
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
@@ -290,6 +294,39 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# Gzip: scoped to the CRM/people JSON endpoints (#874) rather than applied
+# app-wide with an exclusion for streaming routes. A 300-person list is
+# ~216 KB and a person's full timeline ~620 KB, which matters on Tailscale
+# from a phone; those payloads live under /api/crm and /api/people.
+#
+# Scoping by an *allow*-list of path prefixes, instead of wrapping every
+# route in GZipMiddleware and trying to except the chat/agents/conversations
+# SSE endpoints by content-type, keeps `text/event-stream` responses out of
+# the gzip encoder by construction: Starlette's GZipMiddleware buffers each
+# chunk through a `gzip.GzipFile` before it can flush, which turns
+# token-by-token streaming into delayed, chunky output. None of the SSE
+# routes live under /api/crm or /api/people, so this scoping is sufficient
+# on its own — no separate exclusion list is needed.
+_GZIP_PATH_PREFIXES = ("/api/crm", "/api/people")
+
+
+class _ScopedGZipMiddleware:
+    """Apply `GZipMiddleware` only to requests under `_GZIP_PATH_PREFIXES`."""
+
+    def __init__(self, app, minimum_size: int = 1024) -> None:
+        self.app = app
+        self._gzip_app = GZipMiddleware(app, minimum_size=minimum_size)
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope["path"].startswith(_GZIP_PATH_PREFIXES):
+            await self._gzip_app(scope, receive, send)
+        else:
+            await self.app(scope, receive, send)
+
+
+app.add_middleware(_ScopedGZipMiddleware, minimum_size=1024)
 
 # Include routers
 app.include_router(search.router)
@@ -909,13 +946,43 @@ async def chat_page():
     return {"message": "Chat page not found"}
 
 
-@app.get("/crm")
-async def crm_page():
-    """Serve the CRM UI."""
+_CRM_CACHE_CONTROL = "max-age=60, must-revalidate"
+
+
+def _crm_file_response(request: Request) -> Response:
+    """Serve `web/crm.html` with a short revalidation cache lifetime.
+
+    `FileResponse` on its own computes an ETag from the file's mtime/size but
+    never checks it against the request's `If-None-Match`, so every
+    navigation between Me/Family/Birthdays/a person page re-sent the full
+    ~750 KB page. This replicates Starlette's own ETag algorithm so the
+    header matches what `FileResponse` would have sent, and answers with a
+    bodyless 304 when the client's cached copy is still current.
+    """
     crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    if not crm_path.exists():
+        return JSONResponse({"message": "CRM page not found"}, status_code=404)
+
+    stat_result = os.stat(crm_path)
+    etag_base = f"{stat_result.st_mtime}-{stat_result.st_size}"
+    etag = f'"{hashlib.md5(etag_base.encode(), usedforsecurity=False).hexdigest()}"'
+    headers = {
+        "Cache-Control": _CRM_CACHE_CONTROL,
+        "ETag": etag,
+        "Last-Modified": formatdate(stat_result.st_mtime, usegmt=True),
+    }
+
+    if_none_match = request.headers.get("if-none-match")
+    if if_none_match and etag in (tag.strip() for tag in if_none_match.split(",")):
+        return Response(status_code=304, headers=headers)
+
+    return FileResponse(str(crm_path), stat_result=stat_result, headers=headers)
+
+
+@app.get("/crm")
+async def crm_page(request: Request):
+    """Serve the CRM UI."""
+    return _crm_file_response(request)
 
 
 @app.get("/agents")
@@ -947,81 +1014,54 @@ async def journal_trends_page():
 
 
 @app.get("/crm/{path:path}")
-async def crm_page_with_path(path: str):
+async def crm_page_with_path(request: Request, path: str):
     """Serve the CRM UI for any sub-path (client-side routing)."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)
 
 
 @app.get("/me")
-async def me_page():
+async def me_page(request: Request):
     """Serve the CRM UI for the 'Me' dashboard (owner's profile)."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)
 
 
 @app.get("/me/{path:path}")
-async def me_page_with_path(path: str):
+async def me_page_with_path(request: Request, path: str):
     """Serve the CRM UI for 'Me' sub-paths (client-side routing)."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)
 
 
 @app.get("/family")
-async def family_page():
+async def family_page(request: Request):
     """Serve the CRM UI for the Family dashboard."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)
 
 
 @app.get("/family/{path:path}")
-async def family_page_with_path(path: str):
+async def family_page_with_path(request: Request, path: str):
     """Serve the CRM UI for Family sub-paths (client-side routing)."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)
 
 
 @app.get("/relationship")
-async def relationship_page():
+async def relationship_page(request: Request):
     """Serve the CRM UI for the Relationship dashboard."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)
 
 
 @app.get("/relationship/{path:path}")
-async def relationship_page_with_path(path: str):
+async def relationship_page_with_path(request: Request, path: str):
     """Serve the CRM UI for Relationship sub-paths (client-side routing)."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)
 
 
 @app.get("/birthdays")
-async def birthdays_page():
+async def birthdays_page(request: Request):
     """Serve the CRM UI for the Birthdays page."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)
 
 
 @app.get("/birthdays/{path:path}")
-async def birthdays_page_with_path(path: str):
+async def birthdays_page_with_path(request: Request, path: str):
     """Serve the CRM UI for Birthdays sub-paths (client-side routing)."""
-    crm_path = Path(__file__).parent.parent / "web" / "crm.html"
-    if crm_path.exists():
-        return FileResponse(str(crm_path))
-    return {"message": "CRM page not found"}
+    return _crm_file_response(request)

--- a/api/main.py
+++ b/api/main.py
@@ -296,37 +296,55 @@ app.add_middleware(
 )
 
 
-# Gzip: scoped to the CRM/people JSON endpoints (#874) rather than applied
-# app-wide with an exclusion for streaming routes. A 300-person list is
-# ~216 KB and a person's full timeline ~620 KB, which matters on Tailscale
-# from a phone; those payloads live under /api/crm and /api/people.
+# Gzip: scoped to the CRM/people JSON endpoints plus the CRM page itself
+# (#874), rather than applied app-wide. A 300-person list is ~216 KB, a
+# person's full timeline ~620 KB, and the CRM page (`web/crm.html`) itself
+# is ~750 KB uncompressed — all of which matter on Tailscale from a phone.
 #
-# Scoping by an *allow*-list of path prefixes, instead of wrapping every
-# route in GZipMiddleware and trying to except the chat/agents/conversations
-# SSE endpoints by content-type, keeps `text/event-stream` responses out of
-# the gzip encoder by construction: Starlette's GZipMiddleware buffers each
-# chunk through a `gzip.GzipFile` before it can flush, which turns
-# token-by-token streaming into delayed, chunky output. None of the SSE
-# routes live under /api/crm or /api/people, so this scoping is sufficient
-# on its own — no separate exclusion list is needed.
-_GZIP_PATH_PREFIXES = ("/api/crm", "/api/people")
+# This is a deliberate scoping choice, not a workaround for a streaming
+# hazard: Starlette 0.52.1's GZipMiddleware already refuses to compress
+# `text/event-stream` responses on its own (`DEFAULT_EXCLUDED_CONTENT_TYPES`
+# in `starlette.middleware.gzip`), so applying it app-wide would not in fact
+# risk buffering the chat/agents/conversations SSE endpoints. Scoping by an
+# *allow*-list of paths instead keeps the gzip CPU cost (and the `Vary:
+# Accept-Encoding` header) confined to the handful of routes this issue
+# targets, and keeps that guarantee independent of Starlette's own default
+# exclusion list, which is this dependency's choice to change.
+_GZIP_API_PREFIXES = ("/api/crm", "/api/people")
+# The page routes that serve `web/crm.html` (api/main.py's crm_page() and
+# friends, further down this file) and their client-side-routed sub-paths
+# (e.g. /crm/{person_id}/timeline). Matched as a full path segment, not a
+# bare prefix, so a hypothetical future "/crmfoo" route wouldn't match.
+_GZIP_PAGE_ROUTES = ("/crm", "/me", "/family", "/relationship", "/birthdays")
+
+
+def _in_gzip_scope(path: str) -> bool:
+    if path.startswith(_GZIP_API_PREFIXES):
+        return True
+    return any(path == route or path.startswith(route + "/") for route in _GZIP_PAGE_ROUTES)
 
 
 class _ScopedGZipMiddleware:
-    """Apply `GZipMiddleware` only to requests under `_GZIP_PATH_PREFIXES`."""
+    """Apply `GZipMiddleware` only to requests `_in_gzip_scope()` accepts."""
 
-    def __init__(self, app, minimum_size: int = 1024) -> None:
+    def __init__(self, app, minimum_size: int = 1024, compresslevel: int = 6) -> None:
         self.app = app
-        self._gzip_app = GZipMiddleware(app, minimum_size=minimum_size)
+        self._gzip_app = GZipMiddleware(app, minimum_size=minimum_size, compresslevel=compresslevel)
 
     async def __call__(self, scope, receive, send):
-        if scope["type"] == "http" and scope["path"].startswith(_GZIP_PATH_PREFIXES):
+        if scope["type"] == "http" and _in_gzip_scope(scope["path"]):
             await self._gzip_app(scope, receive, send)
         else:
             await self.app(scope, receive, send)
 
 
-app.add_middleware(_ScopedGZipMiddleware, minimum_size=1024)
+# compresslevel=6 (Starlette's default is 9): the gzip step itself runs
+# synchronously in this middleware, on the event loop, for every matching
+# response. Measured on the real 300-person list response (215,625 raw
+# bytes): level 9 took ~4.5ms for 33,171 compressed bytes; level 6 took
+# ~2.5ms for 34,311 bytes — nearly half the blocking time on the loop for
+# ~3% more bytes on the wire, a better trade here.
+app.add_middleware(_ScopedGZipMiddleware, minimum_size=1024, compresslevel=6)
 
 # Include routers
 app.include_router(search.router)
@@ -949,6 +967,23 @@ async def chat_page():
 _CRM_CACHE_CONTROL = "max-age=60, must-revalidate"
 
 
+def _if_none_match_hits(if_none_match: str, etag: str) -> bool:
+    """Does this request's `If-None-Match` cover `etag` (RFC 9110 §13.1.2)?
+
+    `*` matches any current representation. Otherwise this is a
+    comma-separated list of entity-tags, each optionally weak (`W/"..."`
+    rather than `"..."`) — a weak validator from an intermediary still means
+    "you already have an equivalent representation" for a static file that
+    only ever changes by full replacement, so it's stripped before
+    comparing rather than treated as a non-match.
+    """
+    candidates = [tag.strip() for tag in if_none_match.split(",")]
+    if "*" in candidates:
+        return True
+    normalized = [tag[2:] if tag.startswith("W/") else tag for tag in candidates]
+    return etag in normalized
+
+
 def _crm_file_response(request: Request) -> Response:
     """Serve `web/crm.html` with a short revalidation cache lifetime.
 
@@ -973,7 +1008,7 @@ def _crm_file_response(request: Request) -> Response:
     }
 
     if_none_match = request.headers.get("if-none-match")
-    if if_none_match and etag in (tag.strip() for tag in if_none_match.split(",")):
+    if if_none_match and _if_none_match_hits(if_none_match, etag):
         return Response(status_code=304, headers=headers)
 
     return FileResponse(str(crm_path), stat_result=stat_result, headers=headers)

--- a/docs/specs/product/crm-people.md
+++ b/docs/specs/product/crm-people.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** CRM
-**Last Updated:** 2026-06-21
+**Last Updated:** 2026-09-04
 
 People management: the list and detail views at `/crm`, the contact-source model behind entity splitting/merging, the relationship-strength score that drives ranking and Dunbar circles, and the multi-stage fact-extraction pipeline that surfaces memorable personal details.
 
@@ -181,7 +181,7 @@ Main CRM page at `/crm`.
 
 Behavior:
 - Header shows total people count.
-- Real-time search (< 300 ms).
+- Real-time search (< 300 ms), debounced; a superseded query's response is discarded so the list always reflects what's currently typed, even if an earlier search's response arrives later (#874).
 - Category tabs (Work / Personal / Family).
 - Cards show avatar, name, company/category, interaction count, strength bar.
 - Cards sorted by relationship strength by default.

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-08-26
+> **Last Updated:** 2026-09-04
 
 LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that submit text and consume SSE without importing LifeOS Python modules. Endpoint and event **shapes** are defined in [api-reference.md](../product/api-reference.md); this doc covers **who consumes them**, **whisper-relay integration**, and **breaking-change policy**.
 
@@ -17,6 +17,8 @@ LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that subm
 | **whisper-relay** | Separate app → HTTP (voice transport API) | Server-side only: `POST /api/ask/stream`, handoff — via `src/voice_gateway/adapters/lifeos.py`; no browser UI after #21 |
 | **Voice (web)** | Browser → LifeOS reverse-proxy → whisper-relay | LifeOS `/chat` + `web/chat/voice.js`; proxies `/api/voice/*` — `api/routes/voice.py` |
 | MCP / Managed Agents | stdio or HTTP MCP | Tool catalog only — `mcp_server.py` |
+
+**Response compression (#874).** `api/main.py` applies `GZipMiddleware` scoped to `/api/crm/*` and `/api/people/*` only (`minimum_size=1024`), not app-wide. No SSE route documented on this page lives under either prefix, so every stream above stays uncompressed and unbuffered by construction — there is no exclusion list to maintain, and no gzip-vs-streaming interaction for a future endpoint to worry about unless it's added under one of those two prefixes.
 
 ---
 

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -18,7 +18,7 @@ LifeOS exposes the orchestrator to **HTTP consumers** — thin clients that subm
 | **Voice (web)** | Browser → LifeOS reverse-proxy → whisper-relay | LifeOS `/chat` + `web/chat/voice.js`; proxies `/api/voice/*` — `api/routes/voice.py` |
 | MCP / Managed Agents | stdio or HTTP MCP | Tool catalog only — `mcp_server.py` |
 
-**Response compression (#874).** `api/main.py` applies `GZipMiddleware` scoped to `/api/crm/*` and `/api/people/*` only (`minimum_size=1024`), not app-wide. No SSE route documented on this page lives under either prefix, so every stream above stays uncompressed and unbuffered by construction — there is no exclusion list to maintain, and no gzip-vs-streaming interaction for a future endpoint to worry about unless it's added under one of those two prefixes.
+**Response compression (#874).** `api/main.py` applies `GZipMiddleware` scoped to `/api/crm/*`, `/api/people/*`, and the CRM page routes (`minimum_size=1024`, `compresslevel=6`), not app-wide. This is a deliberate scoping choice, not a required safety measure: the pinned Starlette version (0.52.1) already refuses to compress `text/event-stream` responses on its own, so applying `GZipMiddleware` app-wide would not in fact risk buffering any of the SSE streams documented above. Scoping to an allow-list instead simply keeps the gzip CPU cost confined to the handful of routes large enough to be worth it, independent of a dependency default that could change.
 
 ---
 

--- a/tests/test_crm_request_hygiene_api.py
+++ b/tests/test_crm_request_hygiene_api.py
@@ -1,0 +1,127 @@
+"""API tests for CRM request hygiene (#874):
+
+- `GZipMiddleware` is scoped to `/api/crm/*` and `/api/people/*` only, so
+  large list/timeline payloads shrink over the wire while streaming (SSE)
+  endpoints elsewhere in the API are never touched by the gzip encoder.
+- The CRM page routes (`/crm`, `/me`, `/family`, `/birthdays`,
+  `/relationship`, and their sub-paths) send a short revalidation
+  `Cache-Control` and honor `If-None-Match` with a bodyless 304.
+
+These import `api.main` (`TestClient(app)`), which is a heavy, one-time app
+initialization — following the precedent in `test_chat_api.py`, this module
+is marked `slow` rather than `unit` so it doesn't run in the fast pre-push
+gate; it still runs under `./scripts/test.sh all`/`slow`.
+"""
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+pytestmark = pytest.mark.slow
+
+_CACHE_CONTROL = "max-age=60, must-revalidate"
+
+
+@pytest.fixture(scope="module")
+def client():
+    from api.main import app
+    return TestClient(app)
+
+
+class TestGzipScoping:
+    """GZipMiddleware is scoped to /api/crm/* and /api/people/*."""
+
+    def test_crm_page_is_not_gzipped(self, client):
+        """The static CRM page sits outside /api/crm and /api/people, so it
+        must never be gzip-encoded even though it comfortably exceeds the
+        1KB threshold (~750KB per the issue)."""
+        response = client.get("/crm", headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") is None
+        assert len(response.content) > 1024
+
+    def test_small_crm_response_is_not_gzipped(self, client):
+        """Below the 1KB minimum_size, a /api/crm/* response stays
+        uncompressed even though the path is in scope."""
+        response = client.get("/api/crm/statistics", headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        if len(response.content) >= 1024:
+            pytest.skip("statistics response unexpectedly exceeds the gzip threshold")
+        assert response.headers.get("content-encoding") is None
+
+    @pytest.mark.integration
+    def test_crm_people_list_is_gzipped_when_large_enough(self, client):
+        """A real people list response — ~216KB for 300 people per the
+        issue — must be gzip-encoded. Skips cleanly on a fresh clone with
+        no/small data/crm.db, per the standing brief's guidance for
+        data-dependent assertions."""
+        response = client.get("/api/crm/people?limit=300", headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        if len(response.content) < 1024:
+            pytest.skip("data/crm.db has too few people to exceed the gzip threshold")
+        assert response.headers.get("content-encoding") == "gzip"
+
+    @pytest.mark.integration
+    def test_people_search_endpoint_is_gzipped_when_large_enough(self, client):
+        """/api/people/search is also in scope."""
+        response = client.get("/api/people/search?q=a&limit=50",
+                               headers={"Accept-Encoding": "gzip"})
+        if response.status_code != 200:
+            pytest.skip(f"/api/people/search unavailable in this environment ({response.status_code})")
+        if len(response.content) < 1024:
+            pytest.skip("search response too small in this data set to exceed the gzip threshold")
+        assert response.headers.get("content-encoding") == "gzip"
+
+    def test_chat_stream_route_is_never_gzipped(self, client):
+        """The SSE chat endpoint sits outside /api/crm and /api/people, so
+        the scoped gzip middleware must never touch it — protecting the
+        token-by-token streaming the chat surface depends on (see
+        docs/specs/technical/client-surfaces.md)."""
+        with patch('api.routes.chat.VectorStore') as mock_vs:
+            mock_vs.return_value.search.return_value = []
+            with patch('api.routes.chat.get_synthesizer') as mock_synth:
+                async def mock_stream(*args, **kwargs):
+                    yield "x" * 4000  # comfortably over the 1KB threshold
+                mock_synth.return_value.stream_response = mock_stream
+
+                response = client.post(
+                    "/api/ask/stream",
+                    json={"question": "test question"},
+                    headers={"Accept-Encoding": "gzip"},
+                )
+
+        assert response.headers.get("content-type", "").startswith("text/event-stream")
+        assert response.headers.get("content-encoding") is None
+
+
+class TestCrmPageCacheControl:
+    """Page routes serving crm.html send a short revalidation Cache-Control
+    and honor If-None-Match with a 304 (#874)."""
+
+    @pytest.mark.parametrize("path", [
+        "/crm", "/me", "/family", "/birthdays", "/relationship",
+        "/crm/some-person-id", "/me/timeline", "/family/some-tab",
+        "/relationship/some-tab", "/birthdays/some-tab",
+    ])
+    def test_cache_control_header_present(self, client, path):
+        response = client.get(path)
+        assert response.status_code == 200
+        assert response.headers.get("cache-control") == _CACHE_CONTROL
+        assert response.headers.get("etag")
+
+    def test_matching_if_none_match_returns_304_with_empty_body(self, client):
+        first = client.get("/me")
+        etag = first.headers["etag"]
+
+        second = client.get("/me", headers={"If-None-Match": etag})
+
+        assert second.status_code == 304
+        assert second.headers.get("cache-control") == _CACHE_CONTROL
+        assert second.headers.get("etag") == etag
+        assert second.content == b""
+
+    def test_stale_if_none_match_returns_full_page(self, client):
+        response = client.get("/me", headers={"If-None-Match": '"not-a-real-etag"'})
+        assert response.status_code == 200
+        assert len(response.content) > 1024
+        assert response.headers.get("cache-control") == _CACHE_CONTROL

--- a/tests/test_crm_request_hygiene_api.py
+++ b/tests/test_crm_request_hygiene_api.py
@@ -1,23 +1,34 @@
 """API tests for CRM request hygiene (#874):
 
-- `GZipMiddleware` is scoped to `/api/crm/*` and `/api/people/*` only, so
-  large list/timeline payloads shrink over the wire while streaming (SSE)
-  endpoints elsewhere in the API are never touched by the gzip encoder.
-- The CRM page routes (`/crm`, `/me`, `/family`, `/birthdays`,
-  `/relationship`, and their sub-paths) send a short revalidation
-  `Cache-Control` and honor `If-None-Match` with a bodyless 304.
+- `GZipMiddleware` is scoped to `/api/crm/*`, `/api/people/*`, and the CRM
+  page routes (`/crm`, `/me`, `/family`, `/birthdays`, `/relationship`, and
+  their sub-paths) — the handful of routes with payloads large enough to be
+  worth compressing. Streaming (SSE) endpoints elsewhere in the API sit
+  outside this scope by construction (Starlette's `GZipMiddleware` also
+  already refuses to compress `text/event-stream` on its own, independent
+  of this scoping — see `api/main.py`).
+- Those same CRM page routes send a short revalidation `Cache-Control` and
+  honor `If-None-Match` with a bodyless 304, including the weak-validator
+  (`W/"..."`) and wildcard (`*`) forms.
 
-These import `api.main` (`TestClient(app)`), which is a heavy, one-time app
-initialization — following the precedent in `test_chat_api.py`, this module
-is marked `slow` rather than `unit` so it doesn't run in the fast pre-push
-gate; it still runs under `./scripts/test.sh all`/`slow`.
+Most of this module imports `api.main` (`TestClient(app)`), which is a
+heavy, one-time app initialization — following the precedent in
+`test_chat_api.py`, marked `slow` rather than `unit` so it doesn't run in
+the fast pre-push gate; it still runs under `./scripts/test.sh all`/`slow`.
+`TestGzipUnitSynthetic` below is the deliberate exception: it uses the same
+heavy fixture but is marked plain `unit`, because it's the only assertion
+in this file that the gzip feature is ever actually applied without
+depending on `data/crm.db` being present and large — everything else that
+proves compression happens (`TestGzipScoping`'s two `integration`-marked
+tests) skips cleanly on a fresh clone, which would otherwise leave nothing
+in the default `unit`/pre-push scope asserting the headline behavior at all.
 """
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from starlette.testclient import TestClient
 
-pytestmark = pytest.mark.slow
+from api.services.person_entity import PersonEntity
 
 _CACHE_CONTROL = "max-age=60, must-revalidate"
 
@@ -28,17 +39,71 @@ def client():
     return TestClient(app)
 
 
-class TestGzipScoping:
-    """GZipMiddleware is scoped to /api/crm/* and /api/people/*."""
+def _make_synthetic_people(count: int) -> list[PersonEntity]:
+    """Obviously-synthetic PersonEntity fixtures with long enough names/
+    emails that `count` of them comfortably exceed the gzip 1KB threshold
+    once serialized, regardless of what real data (if any) exists."""
+    people = []
+    for i in range(count):
+        p = PersonEntity(
+            id=f"synthetic-gzip-test-person-{i:04d}",
+            canonical_name=f"Synthetic Gzip Test Person Number {i:04d}",
+            emails=[f"synthetic-gzip-test-{i:04d}@example.test"],
+            company="Example Synthetic Test Company",
+        )
+        p.relationship_strength = float(count - i)
+        people.append(p)
+    return people
 
-    def test_crm_page_is_not_gzipped(self, client):
-        """The static CRM page sits outside /api/crm and /api/people, so it
-        must never be gzip-encoded even though it comfortably exceeds the
-        1KB threshold (~750KB per the issue)."""
+
+class TestGzipUnitSynthetic:
+    """Data-independent positive gzip assertion (runs in the `unit` scope,
+    not `slow` — see module docstring)."""
+
+    pytestmark = pytest.mark.unit
+
+    def test_synthetic_large_people_list_is_gzipped(self, client):
+        """Patches the CRM people store with enough obviously-synthetic
+        people that GET /api/crm/people deterministically exceeds the gzip
+        threshold, so this assertion holds on a completely fresh clone with
+        no `data/` directory at all."""
+        people = _make_synthetic_people(60)
+        mock_person_store = MagicMock()
+        mock_person_store.get_all.return_value = people
+        mock_source_store = MagicMock()
+        mock_source_store.get_for_people_batch.return_value = {}
+
+        with patch("api.routes.crm.get_person_entity_store", return_value=mock_person_store), \
+             patch("api.routes.crm.get_source_entity_store", return_value=mock_source_store):
+            response = client.get("/api/crm/people?limit=100", headers={"Accept-Encoding": "gzip"})
+
+        assert response.status_code == 200
+        assert len(response.content) > 1024, (
+            "fixture must exceed the gzip threshold deterministically — "
+            f"got {len(response.content)} bytes for {len(people)} synthetic people"
+        )
+        assert response.headers.get("content-encoding") == "gzip"
+
+
+class TestGzipScoping:
+    """GZipMiddleware is scoped to /api/crm/*, /api/people/*, and the CRM
+    page routes."""
+
+    pytestmark = pytest.mark.slow
+
+    def test_crm_page_is_gzipped(self, client):
+        """The CRM page (~750KB per the issue, the largest single payload
+        this scope covers) is compressed."""
         response = client.get("/crm", headers={"Accept-Encoding": "gzip"})
         assert response.status_code == 200
-        assert response.headers.get("content-encoding") is None
-        assert len(response.content) > 1024
+        assert response.headers.get("content-encoding") == "gzip"
+
+    def test_crm_page_subpath_is_gzipped(self, client):
+        """A client-side-routed sub-path of a page route (e.g. a person's
+        timeline URL) is in scope too, not just the bare route."""
+        response = client.get("/me/timeline", headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        assert response.headers.get("content-encoding") == "gzip"
 
     def test_small_crm_response_is_not_gzipped(self, client):
         """Below the 1KB minimum_size, a /api/crm/* response stays
@@ -54,7 +119,8 @@ class TestGzipScoping:
         """A real people list response — ~216KB for 300 people per the
         issue — must be gzip-encoded. Skips cleanly on a fresh clone with
         no/small data/crm.db, per the standing brief's guidance for
-        data-dependent assertions."""
+        data-dependent assertions. (TestGzipUnitSynthetic above is the
+        data-independent version of this same assertion.)"""
         response = client.get("/api/crm/people?limit=300", headers={"Accept-Encoding": "gzip"})
         assert response.status_code == 200
         if len(response.content) < 1024:
@@ -73,10 +139,11 @@ class TestGzipScoping:
         assert response.headers.get("content-encoding") == "gzip"
 
     def test_chat_stream_route_is_never_gzipped(self, client):
-        """The SSE chat endpoint sits outside /api/crm and /api/people, so
-        the scoped gzip middleware must never touch it — protecting the
-        token-by-token streaming the chat surface depends on (see
-        docs/specs/technical/client-surfaces.md)."""
+        """The SSE chat endpoint sits outside every gzip-scoped prefix, so
+        this middleware never touches it — belt-and-suspenders alongside
+        Starlette's own refusal to compress `text/event-stream` responses
+        at all (`DEFAULT_EXCLUDED_CONTENT_TYPES` in
+        `starlette.middleware.gzip`, independent of this app's scoping)."""
         with patch('api.routes.chat.VectorStore') as mock_vs:
             mock_vs.return_value.search.return_value = []
             with patch('api.routes.chat.get_synthesizer') as mock_synth:
@@ -97,6 +164,8 @@ class TestGzipScoping:
 class TestCrmPageCacheControl:
     """Page routes serving crm.html send a short revalidation Cache-Control
     and honor If-None-Match with a 304 (#874)."""
+
+    pytestmark = pytest.mark.slow
 
     @pytest.mark.parametrize("path", [
         "/crm", "/me", "/family", "/birthdays", "/relationship",
@@ -119,6 +188,24 @@ class TestCrmPageCacheControl:
         assert second.headers.get("cache-control") == _CACHE_CONTROL
         assert second.headers.get("etag") == etag
         assert second.content == b""
+
+    def test_weak_if_none_match_returns_304(self, client):
+        """An intermediary may weaken a strong ETag to `W/"..."` in transit
+        (RFC 9110 §8.8.3) — that still means the client's copy is current
+        for a static file that only ever changes by full replacement."""
+        first = client.get("/me")
+        etag = first.headers["etag"]
+
+        second = client.get("/me", headers={"If-None-Match": f"W/{etag}"})
+
+        assert second.status_code == 304
+        assert second.content == b""
+
+    def test_wildcard_if_none_match_returns_304(self, client):
+        """`If-None-Match: *` matches any current representation."""
+        response = client.get("/me", headers={"If-None-Match": "*"})
+        assert response.status_code == 304
+        assert response.content == b""
 
     def test_stale_if_none_match_returns_full_page(self, client):
         response = client.get("/me", headers={"If-None-Match": '"not-a-real-etag"'})

--- a/tests/test_crm_request_hygiene_ui_browser.py
+++ b/tests/test_crm_request_hygiene_ui_browser.py
@@ -226,6 +226,20 @@ class TestSearchCancellation:
         are given a long artificial delay so they are still genuinely
         in-flight (and therefore actually get aborted, not just rendered
         over) when the next fill starts.
+
+        The failure-panel check happens between the "two" and "three"
+        fills — i.e. right when "two"'s loadPeople() call aborts "one" —
+        not after "three" has already resolved. Checking only at the end
+        (an earlier version of this test did) is not a real assertion of
+        the `AbortError` guard at all: "three"'s own successful render
+        happens after, and overwrites, anything the (correctly or
+        incorrectly handled) abort of "one"/"two" painted in between, so a
+        version of this file with the guard deleted still passes the
+        final-state check. Checking mid-race, while "two" is still
+        in-flight and nothing has resolved yet to paper over it, is what
+        actually pins the guard: without it, "one"'s abort rejection
+        overwrites "two"'s own "Loading people..." with the generic
+        failure panel on the very next microtask.
         """
         _goto_me_with_rules(page, crm_base_url, [
             {"match": "q=one", "body": {"people": [PERSON_SLOW], "total": 1,
@@ -240,7 +254,14 @@ class TestSearchCancellation:
         search_input.fill("one")
         page.wait_for_timeout(350)
         search_input.fill("two")
-        page.wait_for_timeout(350)
+        page.wait_for_timeout(350)  # "two" fires and aborts "one" here
+
+        # "one" is now aborted and "two" is still in flight (its own 5s
+        # delay hasn't elapsed) — nothing has resolved yet to overwrite a
+        # wrongly-shown failure panel. This is the moment the AbortError
+        # guard actually matters.
+        expect(page.locator("#peopleList")).not_to_contain_text("Failed to load people")
+
         search_input.fill("three")
 
         expect(page.locator(".person-card .person-name")).to_have_text(

--- a/tests/test_crm_request_hygiene_ui_browser.py
+++ b/tests/test_crm_request_hygiene_ui_browser.py
@@ -53,7 +53,10 @@ PERSON_CLICKABLE = {
 PERSON_DETAIL = {
     **PERSON_CLICKABLE,
     "emails": [], "phone_numbers": [], "vault_contexts": [], "sources": [],
-    "source_entities": [], "source_entity_count": 0, "relationships": [],
+    # source_entity_count > 0 while source_entities is empty is the exact
+    # mismatch that used to hang the panel on "Loading source entities..."
+    # forever (nothing re-rendered it after loadRelatedData() was removed).
+    "source_entities": [], "source_entity_count": 3, "relationships": [],
 }
 
 EMPTY_PEOPLE_PAGE = {"people": [], "total": 0, "offset": 0, "count": 0}
@@ -212,22 +215,49 @@ class TestSearchCancellation:
         )
 
     def test_abort_error_does_not_show_failure_state(self, page: Page, crm_base_url):
-        """A cancelled request must not surface the generic error message."""
+        """A cancelled request must not surface the generic error message.
+
+        The fills below are spaced > 300ms apart (matching the sibling
+        tests above) so each one's own debounce actually fires its own
+        request — closer spacing (as an earlier version of this test had
+        it, all 100ms apart) means only the *last* fill's debounce ever
+        fires at all, so nothing is ever superseded or aborted and this
+        assertion would hold trivially, proving nothing. "one" and "two"
+        are given a long artificial delay so they are still genuinely
+        in-flight (and therefore actually get aborted, not just rendered
+        over) when the next fill starts.
+        """
         _goto_me_with_rules(page, crm_base_url, [
-            {"match": "q=", "body": {"people": [PERSON_SLOW], "total": 1,
-                                      "offset": 0, "count": 1}, "delayMs": 600},
+            {"match": "q=one", "body": {"people": [PERSON_SLOW], "total": 1,
+                                         "offset": 0, "count": 1}, "delayMs": 5000},
+            {"match": "q=two", "body": {"people": [PERSON_SLOW], "total": 1,
+                                         "offset": 0, "count": 1}, "delayMs": 5000},
+            {"match": "q=three", "body": {"people": [PERSON_FAST], "total": 1,
+                                           "offset": 0, "count": 1}, "delayMs": 0},
         ])
 
         search_input = page.locator("#searchInput")
         search_input.fill("one")
-        page.wait_for_timeout(100)
+        page.wait_for_timeout(350)
         search_input.fill("two")
-        page.wait_for_timeout(100)
+        page.wait_for_timeout(350)
         search_input.fill("three")
 
-        # None of these superseded/aborted responses should render the
-        # generic failure state.
-        page.wait_for_timeout(1200)
+        expect(page.locator(".person-card .person-name")).to_have_text(
+            "Fast Query Result", timeout=3000)
+
+        # Prove something was actually superseded/aborted before checking
+        # that it didn't surface as a failure — otherwise a version of this
+        # test that never exercises cancellation at all would pass
+        # trivially (this is exactly what #895's review caught).
+        aborted_urls = page.evaluate("window.__abortedUrls")
+        assert any("q=one" in u for u in aborted_urls), (
+            f"expected the superseded 'one' request to be aborted, got: {aborted_urls}"
+        )
+        assert any("q=two" in u for u in aborted_urls), (
+            f"expected the superseded 'two' request to be aborted, got: {aborted_urls}"
+        )
+
         expect(page.locator("#peopleList")).not_to_contain_text("Failed to load people")
 
 
@@ -254,3 +284,12 @@ class TestSinglePersonFetch:
             f"{detail_requests}"
         )
         assert "include_related=true" in detail_requests[0]
+
+        # PERSON_DETAIL carries source_entities: [] (present but empty) —
+        # renderPersonDetail() must treat that as "no source entities" and
+        # never leave the panel on the "Loading source entities..."
+        # placeholder, which nothing re-renders once loadRelatedData() (the
+        # only thing that used to settle it) was removed.
+        source_entities_text = page.locator("#sourceEntitiesList").inner_text()
+        assert "Loading source entities" not in source_entities_text
+        assert "No source entities" in source_entities_text

--- a/tests/test_crm_request_hygiene_ui_browser.py
+++ b/tests/test_crm_request_hygiene_ui_browser.py
@@ -1,0 +1,256 @@
+"""Browser tests for CRM search cancellation and single-fetch person
+selection (#874).
+
+Two request-hygiene habits used to add avoidable round trips on every CRM
+interaction: typing in the people search box fired a request per pause but
+never cancelled the previous one, so a slower earlier response could
+overwrite newer results; and selecting a person issued two back-to-back
+`GET /people/{id}` requests (one plain, one with `include_related=true`).
+
+Unlike most of the browser suite this serves `web/` itself from an ephemeral
+port rather than pointing at a running API. Rather than intercepting network
+requests with Playwright's `page.route()` (whose synchronous handlers run on
+the single connection event loop, so a deliberate `time.sleep()` delay in
+one handler serializes *all* route dispatch instead of modelling two truly
+concurrent in-flight requests), this monkey-patches `window.fetch` itself
+via an init script. That runs entirely inside the page on real
+`setTimeout`/`Promise` concurrency, and — crucially — actually honors
+`AbortSignal` the way a real network stack does, so these tests exercise the
+real cancellation wiring rather than only the identity-check fallback.
+
+Carries no `requires_server` marker, so it runs at pre-push
+(`browser and not requires_server`).
+"""
+import http.server
+import json
+import re
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+# Obviously synthetic people — never real CRM data.
+PERSON_SLOW = {
+    "id": "person-slow-result", "canonical_name": "Slow Query Result",
+    "category": "personal", "dunbar_circle": 3, "relationship_strength": 10,
+    "company": "", "tags": [],
+}
+PERSON_FAST = {
+    "id": "person-fast-result", "canonical_name": "Fast Query Result",
+    "category": "personal", "dunbar_circle": 3, "relationship_strength": 8,
+    "company": "", "tags": [],
+}
+PERSON_CLICKABLE = {
+    "id": "person-clickable", "canonical_name": "Clickable Person",
+    "category": "personal", "dunbar_circle": 3, "relationship_strength": 5,
+    "company": "", "tags": [],
+}
+PERSON_DETAIL = {
+    **PERSON_CLICKABLE,
+    "emails": [], "phone_numbers": [], "vault_contexts": [], "sources": [],
+    "source_entities": [], "source_entity_count": 0, "relationships": [],
+}
+
+EMPTY_PEOPLE_PAGE = {"people": [], "total": 0, "offset": 0, "count": 0}
+
+
+class _CrmHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves crm.html the way api/main.py does for /me, /family, /crm,
+    /birthdays, and /relationship: every non-static path resolves to the
+    same file, and the module tree hangs off /static/."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / "crm.html")
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def crm_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _CrmHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# Installed before any page script runs (rules are baked in at generation
+# time, not set afterward via page.evaluate() — the page's own init() starts
+# fetching on DOMContentLoaded, before an evaluate() call issued after
+# page.goto() returns could possibly land, which would otherwise race an
+# empty rule set against the page's first real fetch calls).
+#
+# Replaces window.fetch with a stub driven by `window.__mockRules` (an array
+# of {match, body, status, delayMs}, checked in order, first match wins).
+# Records every URL fetched into `window.__fetchCalls`. Honors AbortSignal
+# for real: aborting rejects with a genuine "AbortError" DOMException,
+# exactly like a real in-flight fetch would.
+_MOCK_FETCH_INIT_SCRIPT_TEMPLATE = """
+(() => {
+    window.__fetchCalls = [];
+    window.__abortedUrls = [];
+    window.__mockRules = %(rules_json)s;
+    window.fetch = function(input, init) {
+        const url = typeof input === 'string' ? input : input.url;
+        window.__fetchCalls.push(url);
+        const rule = window.__mockRules.find(r => url.includes(r.match));
+        const body = rule ? rule.body : {};
+        const status = rule ? (rule.status || 200) : 200;
+        const delayMs = rule ? (rule.delayMs || 0) : 0;
+        const signal = init && init.signal;
+
+        return new Promise((resolve, reject) => {
+            if (signal && signal.aborted) {
+                window.__abortedUrls.push(url);
+                reject(new DOMException('The operation was aborted.', 'AbortError'));
+                return;
+            }
+            const timer = setTimeout(() => {
+                resolve(new Response(JSON.stringify(body), {
+                    status: status,
+                    headers: { 'Content-Type': 'application/json' },
+                }));
+            }, delayMs);
+            if (signal) {
+                signal.addEventListener('abort', () => {
+                    clearTimeout(timer);
+                    window.__abortedUrls.push(url);
+                    reject(new DOMException('The operation was aborted.', 'AbortError'));
+                });
+            }
+        });
+    };
+})();
+"""
+
+_BASE_RULES = [
+    {"match": "/api/crm/config", "body": {}},
+    {"match": "/api/crm/statistics", "body": {"total_people": 0}},
+    {"match": "/api/crm/birthdays/today", "body": {"birthdays": []}},
+]
+
+
+def _goto_me_with_rules(page: Page, crm_base_url, extra_rules):
+    """Load /me with window.fetch mocked. `extra_rules` are matched before
+    the generic /api/crm/people? fallback, so put more specific rules first."""
+    rules = [*extra_rules, *_BASE_RULES, {"match": "/api/crm/people?", "body": EMPTY_PEOPLE_PAGE}]
+    script = _MOCK_FETCH_INIT_SCRIPT_TEMPLATE % {"rules_json": json.dumps(rules)}
+    page.add_init_script(script)
+    page.goto(f"{crm_base_url}/me")
+    page.wait_for_selector("#searchInput")
+    # Let the initial (empty-search) people load from init() settle before a
+    # test starts typing, so it isn't mistaken for a search result.
+    page.wait_for_timeout(100)
+
+
+def _fetch_calls(page: Page):
+    return page.evaluate("window.__fetchCalls")
+
+
+class TestSearchCancellation:
+    """A slower earlier search response must never overwrite a newer one."""
+
+    def test_delayed_first_query_does_not_overwrite_second(self, page: Page, crm_base_url):
+        _goto_me_with_rules(page, crm_base_url, [
+            {"match": "q=slow", "body": {"people": [PERSON_SLOW], "total": 1,
+                                          "offset": 0, "count": 1}, "delayMs": 600},
+            {"match": "q=fast", "body": {"people": [PERSON_FAST], "total": 1,
+                                          "offset": 0, "count": 1}, "delayMs": 0},
+        ])
+
+        search_input = page.locator("#searchInput")
+        search_input.fill("slow")
+        # Let the 300ms debounce fire the first (slow) request.
+        page.wait_for_timeout(350)
+        search_input.fill("fast")
+        # The second (fast) request's debounce fires and its fast response
+        # renders well before the first one's artificial 600ms delay elapses.
+        expect(page.locator(".person-card .person-name")).to_have_text(
+            "Fast Query Result", timeout=3000)
+
+        # Give the slow response's timer time to fire and confirm it didn't
+        # overwrite the result once it (would have) arrived.
+        page.wait_for_timeout(500)
+        expect(page.locator(".person-card .person-name")).to_have_text("Fast Query Result")
+        expect(page.locator(".person-card")).to_have_count(1)
+
+    def test_superseded_request_is_actually_aborted(self, page: Page, crm_base_url):
+        """The first request's AbortSignal actually fires — not just a
+        stale-response guard — proving loadPeople() really cancels the
+        in-flight call rather than merely ignoring its eventual result."""
+        _goto_me_with_rules(page, crm_base_url, [
+            {"match": "q=slow", "body": {"people": [PERSON_SLOW], "total": 1,
+                                          "offset": 0, "count": 1}, "delayMs": 5000},
+            {"match": "q=fast", "body": {"people": [PERSON_FAST], "total": 1,
+                                          "offset": 0, "count": 1}, "delayMs": 0},
+        ])
+
+        search_input = page.locator("#searchInput")
+        search_input.fill("slow")
+        page.wait_for_timeout(350)
+        search_input.fill("fast")
+        expect(page.locator(".person-card .person-name")).to_have_text(
+            "Fast Query Result", timeout=3000)
+
+        # The mock's setTimeout for the slow rule is 5s out; if the abort
+        # listener fired, window.__abortedUrls records it immediately —
+        # no need to wait anywhere near 5s to know it was cancelled.
+        aborted_urls = page.evaluate("window.__abortedUrls")
+        assert any("q=slow" in u for u in aborted_urls), (
+            f"expected the superseded 'slow' request to be aborted, got: {aborted_urls}"
+        )
+
+    def test_abort_error_does_not_show_failure_state(self, page: Page, crm_base_url):
+        """A cancelled request must not surface the generic error message."""
+        _goto_me_with_rules(page, crm_base_url, [
+            {"match": "q=", "body": {"people": [PERSON_SLOW], "total": 1,
+                                      "offset": 0, "count": 1}, "delayMs": 600},
+        ])
+
+        search_input = page.locator("#searchInput")
+        search_input.fill("one")
+        page.wait_for_timeout(100)
+        search_input.fill("two")
+        page.wait_for_timeout(100)
+        search_input.fill("three")
+
+        # None of these superseded/aborted responses should render the
+        # generic failure state.
+        page.wait_for_timeout(1200)
+        expect(page.locator("#peopleList")).not_to_contain_text("Failed to load people")
+
+
+class TestSinglePersonFetch:
+    """Selecting a person issues exactly one detail request."""
+
+    def test_selecting_person_issues_one_detail_request(self, page: Page, crm_base_url):
+        _goto_me_with_rules(page, crm_base_url, [
+            {"match": "/api/crm/people/person-clickable", "body": PERSON_DETAIL},
+            {"match": "/api/crm/people?", "body": {"people": [PERSON_CLICKABLE], "total": 1,
+                                                     "offset": 0, "count": 1}},
+        ])
+
+        expect(page.locator(".person-card .person-name")).to_have_text("Clickable Person")
+        page.locator(".person-card").first.click()
+
+        expect(page.locator("#detailContent")).to_be_visible()
+        page.wait_for_timeout(300)
+
+        detail_url_re = re.compile(r"/api/crm/people/person-clickable(\?|$)")
+        detail_requests = [u for u in _fetch_calls(page) if detail_url_re.search(u)]
+        assert len(detail_requests) == 1, (
+            f"expected exactly one /people/{{id}} request, got {len(detail_requests)}: "
+            f"{detail_requests}"
+        )
+        assert "include_related=true" in detail_requests[0]

--- a/web/crm.html
+++ b/web/crm.html
@@ -9316,29 +9316,15 @@
 
         // Loads/reloads the people list (with search result caching).
         // Called both for an actual search (handleSearch/clearSearch) and
-        // for a plain reload (init(), and after hide/merge/split via
-        // `await loadPeople()`).
+        // for a plain reload (init(), and after hide/merge/split).
         //
-        // Contract callers should know about: a call may resolve WITHOUT
-        // updating the shared `people` array or calling renderPeopleList(),
-        // if a newer call to loadPeople() started before this one's
-        // response arrived (or answered from cache) — see the identity
-        // check below. `await loadPeople()` therefore only means "this
-        // particular call finished," not "the people list is now known to
-        // be fresh." Every current caller tolerates that: init()'s
-        // `peoplePromise` is awaited only to sequence page setup, not
-        // because later code reads `people` and requires it to be current
-        // at that exact instant (the family/relationship dashboards render
-        // from their own data; the final `await statsPromise` doesn't touch
-        // `people` either), and the hide/merge/split reload calls are
-        // synchronous button actions that don't normally race a concurrent,
-        // unrelated loadPeople() call within the same instant — if one ever
-        // does, the call that actually wins (the most recent one to start)
-        // still renders the definitive state shortly after. This is a
-        // deliberate, accepted sharp edge, not a guaranteed-safe contract:
-        // a caller that truly needs "resolve only once `people` reflects
-        // this exact call" would need a dedicated path that doesn't share
-        // this cancellation/staleness guard.
+        // Contract: a call may resolve WITHOUT updating `people` or
+        // rendering, if a newer call started first (see the identity check
+        // below) — `await loadPeople()` means "this call finished," not
+        // "the list is now fresh." Every current caller tolerates that
+        // today (none reads `people` right after awaiting in a way that
+        // requires it); a caller that needs a stricter guarantee would need
+        // a separate path that doesn't share this cancellation guard.
         async function loadPeople() {
             const listEl = document.getElementById('peopleList');
 
@@ -9429,7 +9415,11 @@
                 // storing a successful response here is safe (it can only
                 // help a later re-search of this exact query render
                 // instantly from cache) even though this call won't adopt
-                // it as the *current* list right now.
+                // it as the *current* list right now. This only helps a
+                // response that actually completed after being superseded;
+                // it does nothing for the common debounce case, where the
+                // older request is aborted outright and there's no response
+                // to cache at all.
                 setCachedSearch(cacheKey, allPeople);
 
                 // A newer search may have started (and possibly already

--- a/web/crm.html
+++ b/web/crm.html
@@ -8647,6 +8647,9 @@
         let people = [];
         let selectedPersonId = null;
         let searchQuery = '';
+        // AbortController for the in-flight people search, so a slower
+        // earlier response can't overwrite a newer query's results (#874).
+        let currentPeopleSearchController = null;
         // People list filters (multi-select)
         let peopleCategoryFilters = new Set(['self', 'family', 'personal']);  // Work excluded by default
         let peopleDunbarFilters = new Set(['0', '1', '2', '3', '4', '5', '6+']);
@@ -8655,7 +8658,6 @@
         let selectedForMerge = new Set();  // IDs selected for merge
         let mergePrimaryId = null;  // Primary person for merge
         let dunbarCircleMap = new Map();  // Map person ID to Dunbar circle
-        let dunbarCirclesInitialized = false;  // Track if global circles have been calculated
         let meInteractionsCache = null;  // Cache for "Me" page interactions
         let meInteractionsCacheYears = null; // Track which years setting the cache was loaded for
         // Config loaded from API
@@ -8985,30 +8987,6 @@
             }
         }
 
-        // Initialize Dunbar circles globally (called once on page load with ALL people)
-        async function initializeDunbarCircles() {
-            if (dunbarCirclesInitialized) return;
-
-            try {
-                // Fetch ALL people sorted by strength to calculate global circles
-                const data = await api('/people?sort=strength&limit=10000');
-                const allPeople = data.people || [];
-
-                console.log(`[Dunbar] Initializing with ${allPeople.length} people`);
-
-                if (allPeople.length === 0) {
-                    console.warn('[Dunbar] No people returned from API');
-                    return;
-                }
-
-                calculateAndStoreDunbarCircles(allPeople);
-                dunbarCirclesInitialized = true;
-                console.log(`[Dunbar] Initialized map with ${dunbarCircleMap.size} entries`);
-            } catch (error) {
-                console.error('[Dunbar] Failed to initialize:', error);
-            }
-        }
-
         // Calculate Dunbar circles from a list of people and store in global map
         function calculateAndStoreDunbarCircles(peopleList) {
             // Sort by relationship strength descending
@@ -9090,6 +9068,11 @@
         }
 
         // API helpers
+        // Pass { signal: abortController.signal } in `options` to make a call
+        // cancellable; a cancelled call rejects with a DOMException named
+        // "AbortError" (thrown by fetch() itself, before the response is
+        // ever inspected) that callers should treat as "superseded", not
+        // as a failure to report.
         async function api(path, options = {}) {
             const response = await fetch(`/api/crm${path}`, {
                 headers: { 'Content-Type': 'application/json' },
@@ -9335,6 +9318,17 @@
         async function loadPeople() {
             const listEl = document.getElementById('peopleList');
 
+            // Cancel whatever search is still in flight (if any) so its
+            // response — cached or not — can never land after this one and
+            // overwrite it. This also covers the cache-hit path below: it
+            // "wins" immediately, so nothing from a still-running earlier
+            // call should be allowed to render or cache over it afterward.
+            if (currentPeopleSearchController) {
+                currentPeopleSearchController.abort();
+            }
+            const searchController = new AbortController();
+            currentPeopleSearchController = searchController;
+
             // Build cache key from search query and dunbar filters
             const cacheKey = getSearchCacheKey(searchQuery, peopleDunbarFilters, peopleTagFilters);
             const cached = getCachedSearch(cacheKey);
@@ -9389,10 +9383,20 @@
                         params.set('tags', [...peopleTagFilters].join(','));
                         params.set('limit', '1000');  // Increase limit for tag filtering
                     }
-                    return api(`/people?${params}`);
+                    return api(`/people?${params}`, { signal: searchController.signal });
                 });
 
                 const results = await Promise.all(fetchPromises);
+
+                // A newer search may have started (and possibly already
+                // resolved from cache) while these requests were in flight.
+                // Abort() stops the network fetch when it's still pending,
+                // but if this one had already reached the browser before
+                // being superseded, abort() is a no-op — so check identity
+                // too and drop the response rather than render or cache it.
+                if (searchController.signal.aborted || currentPeopleSearchController !== searchController) {
+                    return;
+                }
 
                 // Merge and deduplicate results by person ID
                 const seenIds = new Set();
@@ -9421,6 +9425,10 @@
                 });
                 renderPeopleList();
             } catch (error) {
+                if (error.name === 'AbortError') {
+                    // Superseded by a newer search; nothing to report.
+                    return;
+                }
                 console.error('Failed to load people:', error);
                 listEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">⚠️</div><p>Failed to load people</p></div>';
             }
@@ -10077,7 +10085,10 @@
             // Check cache first - render immediately if available
             const cachedPerson = getCachedPerson(personId);
             if (cachedPerson) {
-                // Instant render from cache
+                // Instant render from cache. The cached object already
+                // carries source entities/relationships (it was populated
+                // from an include_related=true fetch), so this alone
+                // renders everything renderPersonDetail knows how to show.
                 renderPersonDetail(cachedPerson);
 
                 // Load data for the active tab
@@ -10088,8 +10099,8 @@
                     loadGraph(personId);
                 }
 
-                // Background refresh: fetch fresh data to update cache
-                api(`/people/${personId}`).then(person => {
+                // Background refresh: one fetch (with related data) to update the cache
+                api(`/people/${personId}?include_related=true`).then(person => {
                     if (selectedPersonId === personId) {
                         setCachedPerson(personId, person);
                         // Only re-render if data changed (compare key fields)
@@ -10099,7 +10110,6 @@
                     }
                 }).catch(err => console.warn('[Cache] Background refresh failed:', err));
 
-                loadRelatedData(personId);
                 return;
             }
 
@@ -10107,13 +10117,11 @@
             showPersonLoadingSkeleton();
 
             try {
-                // First: Load basic person data (fast, no related data)
-                const person = await api(`/people/${personId}`);
+                // Single fetch: person detail plus related data (source
+                // entities, relationships) in one round trip (#874).
+                const person = await api(`/people/${personId}?include_related=true`);
                 setCachedPerson(personId, person);
                 renderPersonDetail(person);
-
-                // Background: Load related data (source entities, relationships)
-                loadRelatedData(personId);
 
                 // Load data for the active tab
                 const activeTab = stayOnCurrentTab ? currentTab : document.querySelector('.tab.active')?.dataset.tab;
@@ -10262,18 +10270,6 @@
             // Called implicitly when renderPersonDetail populates the fields
         }
 
-        // Load related data in background (source entities, relationships)
-        async function loadRelatedData(personId) {
-            try {
-                const person = await api(`/people/${personId}?include_related=true`);
-                // Update source entities if still on same person
-                if (selectedPersonId === personId) {
-                    updateSourceEntities(person.source_entities || [], person.source_entity_count || 0);
-                }
-            } catch (error) {
-                console.error('Failed to load related data:', error);
-            }
-        }
 
         // Update source entities section
         function updateSourceEntities(sourceEntities, count) {
@@ -10480,14 +10476,17 @@
             document.getElementById('notesSaveBtn').style.display = 'none';
             document.getElementById('notesUnsavedIndicator').style.display = 'none';
 
-            // Source entities - show count if available, loading state for list
-            // (full list is loaded in background by loadRelatedData)
+            // Source entities - show count if available, loading state for list.
+            // loadPersonDetail always fetches with include_related=true, so
+            // person.source_entities is normally already present here; the
+            // branches below are a defensive fallback for a caller that
+            // doesn't.
             const sourceEntityCount = person.source_entity_count || 0;
             document.getElementById('sourceEntitiesCount').textContent = sourceEntityCount.toLocaleString();
             const listEl = document.getElementById('sourceEntitiesList');
 
-            // If source_entities included (from include_related=true), render them
-            // Otherwise show loading state - they'll be loaded by loadRelatedData
+            // If source_entities included (from include_related=true), render them.
+            // Otherwise show a loading state.
             if (person.source_entities && person.source_entities.length > 0) {
                 updateSourceEntities(person.source_entities, sourceEntityCount);
             } else if (sourceEntityCount > 0) {

--- a/web/crm.html
+++ b/web/crm.html
@@ -9314,7 +9314,31 @@
             await statsPromise;
         }
 
-        // Load people list (with search result caching)
+        // Loads/reloads the people list (with search result caching).
+        // Called both for an actual search (handleSearch/clearSearch) and
+        // for a plain reload (init(), and after hide/merge/split via
+        // `await loadPeople()`).
+        //
+        // Contract callers should know about: a call may resolve WITHOUT
+        // updating the shared `people` array or calling renderPeopleList(),
+        // if a newer call to loadPeople() started before this one's
+        // response arrived (or answered from cache) — see the identity
+        // check below. `await loadPeople()` therefore only means "this
+        // particular call finished," not "the people list is now known to
+        // be fresh." Every current caller tolerates that: init()'s
+        // `peoplePromise` is awaited only to sequence page setup, not
+        // because later code reads `people` and requires it to be current
+        // at that exact instant (the family/relationship dashboards render
+        // from their own data; the final `await statsPromise` doesn't touch
+        // `people` either), and the hide/merge/split reload calls are
+        // synchronous button actions that don't normally race a concurrent,
+        // unrelated loadPeople() call within the same instant — if one ever
+        // does, the call that actually wins (the most recent one to start)
+        // still renders the definitive state shortly after. This is a
+        // deliberate, accepted sharp edge, not a guaranteed-safe contract:
+        // a caller that truly needs "resolve only once `people` reflects
+        // this exact call" would need a dedicated path that doesn't share
+        // this cancellation/staleness guard.
         async function loadPeople() {
             const listEl = document.getElementById('peopleList');
 
@@ -9388,16 +9412,6 @@
 
                 const results = await Promise.all(fetchPromises);
 
-                // A newer search may have started (and possibly already
-                // resolved from cache) while these requests were in flight.
-                // Abort() stops the network fetch when it's still pending,
-                // but if this one had already reached the browser before
-                // being superseded, abort() is a no-op — so check identity
-                // too and drop the response rather than render or cache it.
-                if (searchController.signal.aborted || currentPeopleSearchController !== searchController) {
-                    return;
-                }
-
                 // Merge and deduplicate results by person ID
                 const seenIds = new Set();
                 for (const data of results) {
@@ -9409,8 +9423,24 @@
                     }
                 }
 
-                // Cache the raw merged results before applying dunbar circles
+                // Cache the raw merged results before applying dunbar circles.
+                // Do this even if this response turns out to be superseded
+                // below — the cache key already encodes the query, so
+                // storing a successful response here is safe (it can only
+                // help a later re-search of this exact query render
+                // instantly from cache) even though this call won't adopt
+                // it as the *current* list right now.
                 setCachedSearch(cacheKey, allPeople);
+
+                // A newer search may have started (and possibly already
+                // resolved from cache) while these requests were in flight.
+                // Abort() stops the network fetch when it's still pending,
+                // but if this one had already reached the browser before
+                // being superseded, abort() is a no-op — so check identity
+                // too and drop the response rather than render it.
+                if (searchController.signal.aborted || currentPeopleSearchController !== searchController) {
+                    return;
+                }
 
                 people = applyDunbarCircles(allPeople);
                 // Sort: self first, then by Dunbar circle, then by relationship strength
@@ -10270,7 +10300,6 @@
             // Called implicitly when renderPersonDetail populates the fields
         }
 
-
         // Update source entities section
         function updateSourceEntities(sourceEntities, count) {
             document.getElementById('sourceEntitiesCount').textContent = count.toLocaleString();
@@ -10478,16 +10507,23 @@
 
             // Source entities - show count if available, loading state for list.
             // loadPersonDetail always fetches with include_related=true, so
-            // person.source_entities is normally already present here; the
-            // branches below are a defensive fallback for a caller that
-            // doesn't.
+            // person.source_entities is normally already present here (as
+            // an array, possibly empty) — the "loading" fallback below is
+            // only reachable if some other caller renders a person object
+            // that omits the key entirely. Checking presence of the key
+            // (not its length) matters: with the old length-based check, an
+            // empty-but-present array fell through to the "loading" branch
+            // and stayed there forever (nothing re-renders it — the
+            // follow-up fetch that used to settle it, loadRelatedData(),
+            // was removed when the two-fetch flow was consolidated).
             const sourceEntityCount = person.source_entity_count || 0;
             document.getElementById('sourceEntitiesCount').textContent = sourceEntityCount.toLocaleString();
             const listEl = document.getElementById('sourceEntitiesList');
 
-            // If source_entities included (from include_related=true), render them.
-            // Otherwise show a loading state.
-            if (person.source_entities && person.source_entities.length > 0) {
+            // If source_entities is present at all (from include_related=true),
+            // render it — updateSourceEntities() itself renders "No source
+            // entities" for an empty array. Otherwise show a loading state.
+            if (person.source_entities) {
                 updateSourceEntities(person.source_entities, sourceEntityCount);
             } else if (sourceEntityCount > 0) {
                 listEl.innerHTML = '<div class="empty-state"><p>Loading source entities...</p></div>';


### PR DESCRIPTION
## TL;DR

Large CRM payloads — the people list, person timelines, and the CRM page itself — are now compressed before they go over the wire, which matters most on a slow connection like Tailscale from a phone. Typing quickly in the people search box no longer risks an older, slower response overwriting the results of what you just typed — the previous search is cancelled the moment a new one starts. Clicking on a person now fetches their details in a single request instead of two back-to-back ones. Switching between the Me, Family, Birthdays, and Relationship pages (and navigating between people) now revalidates the shared page cheaply instead of re-downloading the whole thing every time, and that revalidation now also works correctly behind a proxy that rewrites cache headers slightly. A dead, unused helper function was removed while in the area. A missing page now correctly reports "not found" instead of a success response.

Closes #874

## Design

- **Response compression** is applied narrowly, by URL path, to the route groups with payloads worth compressing: the people list and person-detail JSON, plus the CRM page itself (~750KB, the single largest payload in scope). This is a deliberate scoping choice to keep the compression cost confined to routes that benefit from it — it is not required for streaming safety: the pinned Starlette version already refuses to compress `text/event-stream` responses on its own, so every SSE endpoint (chat, agents, conversations) would be untouched even if this middleware were applied app-wide.
- **Search cancellation** tracks the single most recent search request. Starting a new one cancels whatever was still in flight, and a request whose result comes back after being superseded — whether cancelled outright or already past the point of no return over the network — is discarded rather than rendered or adopted as the current list. This also covers the case where the newer search's answer comes from the client-side cache and returns instantly: the slower, older request is still not allowed to overwrite it afterward. A superseded response's data is still cached under its own query key, though, since that's safe and makes re-typing that exact query later render instantly.
- **Single person-detail request**: the "related data" (source records, relationships) that used to require a second follow-up call is now requested together with the base detail in one call, and the person-detail rendering path uses whatever the one response contains.
- **Page caching**: the CRM page itself now tells the browser it's safe to reuse for a short time, but always to check back with the server first. The server recognizes when the browser's copy is still current — including when an intermediary has weakened the validator, or sent a wildcard — and says so with an empty response instead of resending the ~750KB page.

## Implementation Notes

- `api/main.py`: a small scoped-gzip ASGI middleware (`_ScopedGZipMiddleware`, wrapping Starlette's `GZipMiddleware`, `minimum_size=1024`, `compresslevel=6`) applied to `/api/crm/*`, `/api/people/*`, and the CRM page routes (`_in_gzip_scope()`). A shared `_crm_file_response()` helper is used by all ten routes that serve `web/crm.html` (`/crm`, `/crm/{path}`, `/me`, `/me/{path}`, `/family`, `/family/{path}`, `/relationship`, `/relationship/{path}`, `/birthdays`, `/birthdays/{path}`) — it computes the same ETag Starlette's `FileResponse` would, adds `Cache-Control: max-age=60, must-revalidate`, and answers a matching `If-None-Match` with a bodyless 304, via `_if_none_match_hits()` (handles a comma-separated list, a weak `W/"..."` validator, and a bare `*`). A missing `crm.html` now returns a JSON 404 from this helper, rather than the ten routes' previous behavior of a 200 with `{"message": "CRM page not found"}` — a deliberate improvement, called out here since it's a status-code change.
- `web/crm.html`:
  - `loadPeople()` creates an `AbortController` per call, aborts the previous one (if any) before doing anything else — including before a cache hit — and checks after `await` that it's still the current search before rendering it (though it still caches a successful-but-superseded response under its own query key). `AbortError` is treated as "superseded," not a failure. A comment documents the resulting contract for the four other callers of `loadPeople()` (init's initial load, and the hide/merge/split refreshes): a call may resolve without the shared `people` list actually being updated, if a newer call started first.
  - `loadPersonDetail()`'s two call sites (`cachedPerson` background refresh and the no-cache path) both fetch `/people/{id}?include_related=true` once; the old plain fetch plus the separate `loadRelatedData()` follow-up call is gone (`loadRelatedData` itself deleted, its only two call sites removed).
  - `renderPersonDetail()`'s source-entities branch now checks whether `source_entities` is present at all, not whether it's non-empty — an empty array now correctly renders "No source entities" instead of hanging forever on a "Loading source entities..." placeholder that nothing re-renders now that `loadRelatedData()` (the only thing that used to settle it) is gone.
  - Deleted `initializeDunbarCircles` (dead code, never called, would have requested `limit=10000`) and its now-unused `dunbarCirclesInitialized` flag. Left `calculateAndStoreDunbarCircles`, `applyDunbarCircles`, `loadProfilePhotos`, and `profilePhotoCache` untouched per the issue's scope note (#875 reworks the photo helpers).
  - `api()`'s existing `options` spread already forwarded `signal` to `fetch()` with no code change required; added a doc comment making that explicit.

## Test evidence

### Automated tests

`tests/test_crm_request_hygiene_api.py` (25 tests total):
- `TestGzipUnitSynthetic` (1 test, plain `unit` marker — runs in the fast/pre-push scope): patches the CRM people store with obviously-synthetic people so a `/api/crm/people` response deterministically exceeds 1KB, proving gzip is actually applied without needing `data/crm.db` to exist. (An earlier version of this file only asserted this with two `integration`-marked, data-dependent tests that both skip on a fresh clone — this was flagged in review as leaving the headline acceptance criterion unproven by anything in the default test scope; this new test closes that gap.)
- `TestGzipScoping` (6 tests, `slow`): the CRM page and a client-side-routed sub-path are gzipped; a small `/api/crm/*` response stays uncompressed; the real people-list and people-search endpoints are gzipped when large enough (data-dependent, skip cleanly otherwise); the chat SSE stream is never gzipped.
- `TestCrmPageCacheControl` (14 tests, `slow`): `Cache-Control` present on all ten crm.html routes; a matching, a weak (`W/"..."`), and a wildcard (`*`) `If-None-Match` each return a bodyless 304; a stale one returns the full page.

`tests/test_crm_request_hygiene_ui_browser.py` (4 tests, server-free per `tests/test_voice_mic_block_ui_browser.py`'s pattern — runs at pre-push):
- A slower first search's response never overwrites a faster second one.
- The superseded request's `AbortSignal` genuinely fires (`window.__abortedUrls` is checked directly), not just a stale-response guard.
- A run of *actually superseded* searches (each fill spaced past the 300ms debounce, so each one's own request genuinely fires and gets aborted — an earlier version of this test had all three fills within 200ms, so only the last one's debounce ever fired and nothing was ever superseded or aborted, which is why it passed even against the pre-fix code; flagged in review) never shows the generic failure message, and `window.__abortedUrls` is asserted non-empty before checking that.
- Selecting a person issues exactly one `/people/{id}` request, with `include_related=true`, and an empty-but-present `source_entities` array renders "No source entities" rather than hanging on the loading placeholder.

All were verified to fail against the pre-fix (`addc623`) `web/crm.html`/`api/main.py` and pass against this branch.

```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_crm_request_hygiene_api.py tests/test_crm_request_hygiene_ui_browser.py -m "" --browser chromium -q
...
25 passed in 20.16s
```

Full unit suite and the server-free browser suite both pass on the final, rebased commit (see the pre-push gate output on the push itself).

### Manual verification

Private staging instance against the real data copy (15,391 people), `.env` side effects disabled:

- `curl -H "Accept-Encoding: gzip" .../api/crm/people?limit=300` → `content-encoding: gzip`, compressed to 34,284 bytes (real, `compresslevel=6`).
- `curl -H "Accept-Encoding: gzip" .../me` → `content-encoding: gzip` (the page route itself, now in scope) alongside `cache-control: max-age=60, must-revalidate` and an `etag`.
- Repeating the `/me` request with `If-None-Match: <etag>` (strong), `If-None-Match: W/<etag>` (weak), and `If-None-Match: *` (wildcard) → **304** in all three cases, same `cache-control`/`etag`, empty body; a made-up `If-None-Match` → 200 with the full page.
- `curl -X POST .../api/ask/stream -H "Accept-Encoding: gzip"` → `transfer-encoding: chunked`, no `content-encoding`, multiple discrete SSE events delivered (confirms the chat stream is untouched by the new middleware; the response errored before reaching real token content only because this staging instance has no LLM backend configured — expected and safe, no API spend).
- Playwright against `/me` with real data: typed a rapid two-query sequence ("tay" then "nathan", second fill after the first's debounce fired) — the list showed 70 results, every one matching "nathan", zero "tay"-only leaks from the superseded first query, no console errors.
- Clicked a real person from the list; network log showed exactly one `GET /api/crm/people/{id}?include_related=true` request; the source-entities panel rendered correctly (not stuck loading).
- Two pre-existing, out-of-scope issues found during manual verification (not touched by this PR, unrelated to its changes): the `/api/photos/profile/{id}` avatar endpoint returns 503 in this staging environment (photo service unavailable here; `loadProfilePhotos` is explicitly out of scope per the issue's scope note — #875 owns it), and `/relationship`'s partner timeline chart 404s when `partner_person_id` is unset in config (pre-existing behavior, tracked separately as #891).

## Review focus

- The `_crm_file_response()` ETag algorithm intentionally duplicates Starlette's own (`hashlib.md5` of `mtime-size`, `usedforsecurity=False`) rather than importing a private method, so it produces byte-identical ETags to what `FileResponse` would send on its own — worth double-checking that assumption holds if Starlette's algorithm ever changes.
- `_in_gzip_scope()` is an *allow*-list (`/api/crm`, `/api/people`, plus the five named page routes and their sub-paths) rather than an exclude-list — worth confirming this is the right posture going forward as new routes are added under any of those prefixes.
- Cache-Control/304/gzip was applied to all ten crm.html-serving routes (including `/relationship` and every `/{path}` sub-route), not just the four literally named in the issue's acceptance criteria (`/me`, `/family`, `/crm`, `/birthdays`) — they all serve the identical static file, so this seemed like the right consistency call, but flagging it as a scope decision made unprompted.
- `loadPeople()`'s cancellation guard means any of its callers — not just an actual search — can resolve without the shared `people` list having been updated, if a newer call to `loadPeople()` started first. This is documented in a comment at the top of the function rather than restricted to search-only calls; every current caller tolerates it in practice (verified: none of the family/relationship dashboards or the final stats-await in `init()` read `people` at a point where this matters), but a future caller that needs a strict "resolve only once the list reflects this exact call" guarantee would need a separate path.
- `loadPersonDetail`'s cache-hit path relies on the cached person object having been populated by an `include_related=true` fetch (it always is, since that's the only fetch shape this file ever performs against `/people/{id}` now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqMhBfLUGZ5cKuqyWe5iqD
