### PR TITLE
fix(crm): return a pruned neighborhood from the network graph endpoint

### DIFF
--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -2712,6 +2712,12 @@ def get_network_graph(
         # connection can miss the cut and re-enter as a "second-degree"
         # node, which is misleading and makes the degree filter lie).
         all_direct_candidates: dict[str, Relationship] = {}
+        # The full ranked (and, if category is set, category-filtered) list
+        # of direct candidates first-degree selection drew from - kept so
+        # any part of the deeper-hop budget that goes unspent can be
+        # backfilled from the next-strongest direct candidates instead of
+        # coming back under max_nodes (#896 review round 5, MINOR finding).
+        selection_pool: list[tuple[str, Relationship]] = []
 
         with contextlib.closing(rel_store.open_connection()) as conn:
             if first_degree_limit > 0:
@@ -2838,6 +2844,24 @@ def get_network_graph(
             if node_degrees.get(node_id, 0) > 1:
                 node_degrees[node_id] = 1
                 center_edges[node_id] = rel
+
+        # The deeper-hop tier's reserved share of the budget can't always
+        # be spent (a dense centre may have few or no genuine
+        # friends-of-friends once direct connections are excluded from it
+        # above), so backfill any leftover slots with the next-strongest
+        # direct candidates that missed the first-degree cut - they're
+        # real first-degree people, and every prior version of this
+        # endpoint showed them. Without this, a dense centre's response
+        # came back well under max_nodes even though its own network had
+        # more to show (#896 review round 5, MINOR finding).
+        if len(node_degrees) < max_nodes and len(selection_pool) > first_degree_limit:
+            for canonical_other, rel in selection_pool[first_degree_limit:]:
+                if len(node_degrees) >= max_nodes:
+                    break
+                if canonical_other in node_degrees:
+                    continue
+                node_degrees[canonical_other] = 1
+                center_edges[canonical_other] = rel
     else:
         # Get all people (no center, all are degree 1) - unchanged full-graph path.
         node_degrees = {p.id: 1 for p in all_people_dict.values()}

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -2671,6 +2671,13 @@ def get_network_graph(
         center_person = person_store.get_by_id(center_on)
         if not center_person:
             raise HTTPException(status_code=404, detail=f"Person '{center_on}' not found")
+        # A merged/legacy center id resolves to the surviving canonical
+        # person (get_by_id() above already followed the merge chain to
+        # fetch it) - without this, `all_people_dict` (canonical-keyed)
+        # never has an entry for the raw requested id, so the center
+        # silently drops out of the response even though it "exists"
+        # (#896 review round 3, not-verified note).
+        center_on = center_person.id
 
         # Exclude the CRM owner from 2nd+ degree traversal since they're
         # connected to everyone and would pollute the graph.
@@ -2678,6 +2685,14 @@ def get_network_graph(
 
         node_degrees[center_on] = 0
         frontier: list[str] = []
+        # Ids whose category match was already confirmed during selection
+        # (via compute_person_category, possibly with batched source
+        # entities) - the node-building filter below trusts these instead
+        # of re-checking with a cheaper/different computation, which is
+        # what let a node be selected under one category decision and then
+        # dropped (or kept) under a different one (#896 review round 3
+        # finding 5).
+        category_confirmed_ids: set[str] = set()
 
         # depth == 1 has no deeper tier, so first-degree gets the full
         # remaining budget; depth >= 2 reserves ~25% of max_nodes for
@@ -2687,6 +2702,17 @@ def get_network_graph(
         if max_nodes > 1:
             first_degree_limit = (max_nodes - 1) if depth < 2 else max(1, int(max_nodes * 0.75))
 
+        # Every one of the center's own direct relationships, canonicalised
+        # and de-duped (kept regardless of whether it makes the
+        # first_degree_limit cut) - used both to rank first-degree
+        # candidates and, after selection, to relabel any node that has a
+        # genuine direct center relationship as degree 1 even if it was
+        # only re-discovered through a friend (#896 review round 3
+        # finding 4: capping first-degree selection means a real direct
+        # connection can miss the cut and re-enter as a "second-degree"
+        # node, which is misleading and makes the degree filter lie).
+        all_direct_candidates: dict[str, Relationship] = {}
+
         with contextlib.closing(rel_store.open_connection()) as conn:
             if first_degree_limit > 0:
                 raw_rels = rel_store.get_all_for_person(center_on, conn=conn)
@@ -2694,7 +2720,6 @@ def get_network_graph(
                 # Canonicalise every neighbor id and de-dup, keeping the
                 # higher-weight relationship row when more than one raw row
                 # resolves to the same canonical id (#896 finding 1).
-                candidates: dict[str, Relationship] = {}
                 for rel in raw_rels:
                     other_raw = rel.other_person(center_on)
                     if not other_raw:
@@ -2703,19 +2728,19 @@ def get_network_graph(
                     if other_canonical == center_on:
                         continue  # self-loop after a merge
                     weight = _rendered_edge_weight(rel, center_on, other_canonical, my_person_id, all_people_dict)
-                    existing = candidates.get(other_canonical)
+                    existing = all_direct_candidates.get(other_canonical)
                     if existing is not None:
                         existing_weight = _rendered_edge_weight(
                             existing, center_on, other_canonical, my_person_id, all_people_dict
                         )
                         if weight <= existing_weight:
                             continue
-                    candidates[other_canonical] = rel
+                    all_direct_candidates[other_canonical] = rel
 
                 # Rank by the real rendered edge weight (not a proxy),
                 # deterministic tiebreak by canonical id (#896 finding 5/9).
                 ranked = sorted(
-                    candidates.items(),
+                    all_direct_candidates.items(),
                     key=lambda kv: (
                         -_rendered_edge_weight(kv[1], center_on, kv[0], my_person_id, all_people_dict),
                         kv[0],
@@ -2727,17 +2752,23 @@ def get_network_graph(
                     # candidates, compute categories via one batched
                     # source-entity fetch (same pattern as GET /people),
                     # filter, then take the top first_degree_limit of the
-                    # still-ranked survivors (#896 finding 6).
+                    # still-ranked survivors (#896 finding 6). Every id that
+                    # passes is recorded so the node-building filter below
+                    # trusts this decision instead of re-deriving a
+                    # possibly different one (#896 review round 3 finding 5).
                     window = ranked[:min(len(ranked), 3 * max_nodes)]
                     source_store = get_source_entity_store()
                     cat_sources_by_id = source_store.get_for_people_batch(
                         [cid for cid, _ in window], limit_per_person=_CATEGORY_BATCH_SOURCE_LIMIT
                     )
-                    selection_pool = [
-                        (cid, rel) for cid, rel in window
-                        if (cand_person := all_people_dict.get(cid)) is not None
-                        and compute_person_category(cand_person, cat_sources_by_id.get(cid, [])) == category
-                    ]
+                    selection_pool = []
+                    for cid, rel in window:
+                        cand_person = all_people_dict.get(cid)
+                        if cand_person is None:
+                            continue
+                        if compute_person_category(cand_person, cat_sources_by_id.get(cid, [])) == category:
+                            selection_pool.append((cid, rel))
+                            category_confirmed_ids.add(cid)
                 else:
                     selection_pool = ranked
 
@@ -2779,21 +2810,43 @@ def get_network_graph(
                             cand_person = all_people_dict.get(other_canonical)
                             if cand_person is None or compute_person_category(cand_person, []) != category:
                                 continue
+                            category_confirmed_ids.add(other_canonical)
                         node_degrees[other_canonical] = current_depth
                         next_frontier.append(other_canonical)
                 frontier = next_frontier
+
+        # A node that has a genuine direct relationship to the center is
+        # relabeled degree 1 even if it was only added above via a friend
+        # (#896 review round 3 finding 4) - and gets its guaranteed center
+        # edge, same as any other first-degree node.
+        for node_id, rel in all_direct_candidates.items():
+            if node_degrees.get(node_id, 0) > 1:
+                node_degrees[node_id] = 1
+                center_edges[node_id] = rel
     else:
         # Get all people (no center, all are degree 1) - unchanged full-graph path.
         node_degrees = {p.id: 1 for p in all_people_dict.values()}
 
-    # Filter by category and strength, then build nodes
+    # Filter by category and strength, then build nodes. category_confirmed_ids
+    # is empty for a non-centered (full-graph) request, so every person there
+    # is freshly checked below - same as always for that path.
+    if not center_on:
+        category_confirmed_ids: set[str] = set()
+
     for person_id, degree in node_degrees.items():
         person = all_people_dict.get(person_id)
         if not person:
             continue
 
-        # Apply filters
-        if category and person.category != category:
+        # The exact category this node will be labeled with - also the
+        # single predicate used for the filter below, so a node can never
+        # be selected under one category decision and dropped (or kept)
+        # under a different one (#896 review round 3 finding 5). An id
+        # already confirmed during selection (possibly via a batched,
+        # more-accurate source-entity lookup) is trusted as-is instead of
+        # being re-derived from this cheaper per-node call.
+        computed_category = compute_person_category(person, [])
+        if category and person_id not in category_confirmed_ids and computed_category != category:
             continue
         if person.relationship_strength < min_strength:
             continue
@@ -2803,7 +2856,7 @@ def get_network_graph(
         nodes.append(NetworkNode(
             id=person.id,
             name=person.display_name or person.canonical_name,
-            category=compute_person_category(person, []),
+            category=computed_category,
             strength=person.relationship_strength,
             interaction_count=interaction_count,
             degree=degree,
@@ -2818,13 +2871,18 @@ def get_network_graph(
         # Every edge touching the center is unconditionally included -
         # these are exactly the relationship rows used to select each
         # first-degree node, so this edge is never missing even for a
-        # legacy/merged neighbor id (#896 findings 1 and 2).
-        for neighbor_id, rel in center_edges.items():
-            if neighbor_id not in valid_node_ids:
-                continue  # dropped by the category/min_strength filter above
-            weight = _rendered_edge_weight(rel, center_on, neighbor_id, my_person_id, all_people_dict)
-            pair = (min(center_on, neighbor_id), max(center_on, neighbor_id))
-            edges_by_pair[pair] = _build_network_edge(rel, center_on, neighbor_id, weight)
+        # legacy/merged neighbor id (#896 findings 1 and 2) - UNLESS the
+        # center itself didn't survive the category/min_strength filter
+        # above, in which case it's not in the response at all and an edge
+        # naming it would violate "every edge's endpoints are both present"
+        # (#896 review round 3 finding 3).
+        if center_on in valid_node_ids:
+            for neighbor_id, rel in center_edges.items():
+                if neighbor_id not in valid_node_ids:
+                    continue  # dropped by the category/min_strength filter above
+                weight = _rendered_edge_weight(rel, center_on, neighbor_id, my_person_id, all_people_dict)
+                pair = (min(center_on, neighbor_id), max(center_on, neighbor_id))
+                edges_by_pair[pair] = _build_network_edge(rel, center_on, neighbor_id, weight)
 
         # Fill the remaining edge budget with the strongest non-center
         # edges among the selected nodes (#896 findings 2 and 4).

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -2526,6 +2526,14 @@ def get_network_graph(
     depth: int = Query(default=2, ge=1, le=4, description="Hops from center person"),
     min_strength: float = Query(default=0.0, ge=0.0, le=1.0, description="Minimum relationship strength"),
     category: Optional[str] = Query(default=None, description="Filter by category"),
+    max_nodes: int = Query(
+        default=150, ge=1, le=500,
+        description="Maximum nodes to return for a centered request (ignored with allow_full_graph)",
+    ),
+    max_second_degree_per_node: int = Query(
+        default=10, ge=0, le=50,
+        description="Maximum second-(and deeper-)degree neighbors to add per node at the previous depth",
+    ),
     allow_full_graph: bool = Query(
         default=False,
         description="Required to load full graph without center_on (expensive operation)"
@@ -2537,10 +2545,19 @@ def get_network_graph(
     Returns nodes (people) and edges (relationships) for rendering
     an interactive force-directed network graph.
 
-    If center_on is provided, only returns people within 'depth' hops
-    of the center person. Otherwise, returns all people and relationships.
+    If center_on is provided, this returns a bounded neighborhood: the
+    strongest `max_nodes` connections reachable within `depth` hops, capped
+    at `max_second_degree_per_node` new neighbors per node at each hop
+    beyond the first. Node selection uses indexed per-person queries
+    (RelationshipStore.get_top_neighbors), ranking neighbors by the sum of
+    their shared-interaction count columns as a cheap proxy for strength —
+    the full 500k+-row relationship table is never loaded for a centered
+    request. Edges are then the induced subgraph among the selected nodes
+    (RelationshipStore.get_edges_among), still using the real
+    strength/weight formula on `Relationship`.
 
-    PERFORMANCE: Without center_on, this loads ALL relationships (5000+ edges).
+    Without center_on, this loads ALL relationships (500k+ edges) and all
+    people; `max_nodes`/`max_second_degree_per_node` do not apply.
     Set allow_full_graph=true to explicitly opt-in to this expensive operation.
 
     Each node includes a 'degree' field:
@@ -2566,7 +2583,6 @@ def get_network_graph(
     node_degrees: dict[str, int] = {}
 
     if center_on:
-        # BFS to find people within depth hops of center, tracking degree
         center_person = person_store.get_by_id(center_on)
         if not center_person:
             raise HTTPException(status_code=404, detail=f"Person '{center_on}' not found")
@@ -2576,34 +2592,51 @@ def get_network_graph(
         my_person_id = settings.my_person_id
         is_viewing_self = (center_on == my_person_id)
 
-        # BFS traversal with degree tracking - use batch queries
-        node_degrees[center_on] = 0  # Center is degree 0
-        current_level: set[str] = {center_on}
+        # Center is degree 0. Pick the strongest first-degree neighbors via
+        # the indexed per-person lookup, up to max_nodes total (minus the
+        # center itself) - never the full relationship table.
+        node_degrees[center_on] = 0
+        frontier: list[str] = []
+        if max_nodes > 1:
+            for rel in rel_store.get_top_neighbors(center_on, limit=max_nodes - 1):
+                other_id = rel.other_person(center_on)
+                if other_id and other_id not in node_degrees:
+                    node_degrees[other_id] = 1
+                    frontier.append(other_id)
 
-        for current_depth in range(1, depth + 1):
-            if not current_level:
+        # For depth >= 2, expand each frontier node's strongest neighbors
+        # (up to max_second_degree_per_node each), stopping once max_nodes
+        # is reached.
+        for current_depth in range(2, depth + 1):
+            if not frontier or len(node_degrees) >= max_nodes:
                 break
-            # Batch query for all people at this level
-            level_relationships = rel_store.get_for_people_batch(current_level)
-            next_level: set[str] = set()
-            for person_id in current_level:
-                # Skip "me" as a bridge for 2nd+ degree when not viewing self
-                # This prevents everyone appearing as 2nd-degree through me
-                if not is_viewing_self and current_depth > 1 and person_id == my_person_id:
+            next_frontier: list[str] = []
+            for node_id in frontier:
+                if len(node_degrees) >= max_nodes:
+                    break
+                # Skip "me" as a bridge for 2nd+ degree when not viewing
+                # self - this prevents everyone appearing as 2nd-degree
+                # through me (same rationale as the original BFS).
+                if not is_viewing_self and node_id == my_person_id:
                     continue
-                for rel in level_relationships.get(person_id, []):
-                    other_id = rel.other_person(person_id)
+                if max_second_degree_per_node <= 0:
+                    continue
+                for rel in rel_store.get_top_neighbors(node_id, limit=max_second_degree_per_node):
+                    if len(node_degrees) >= max_nodes:
+                        break
+                    other_id = rel.other_person(node_id)
                     if other_id and other_id not in node_degrees:
-                        next_level.add(other_id)
                         node_degrees[other_id] = current_depth
-            current_level = next_level
+                        next_frontier.append(other_id)
+            frontier = next_frontier
+
+        # Batch lookup only the selected people - never get_all().
+        all_people_dict = person_store.get_by_ids(node_degrees.keys())
     else:
         # Get all people (no center, all are degree 1)
         all_people = person_store.get_all()
         node_degrees = {p.id: 1 for p in all_people}
-
-    # Get all people in one pass (avoid N+1 lookups)
-    all_people_dict = {p.id: p for p in person_store.get_all()}
+        all_people_dict = {p.id: p for p in all_people}
 
     # Filter by category and strength, then build nodes
     for person_id, degree in node_degrees.items():
@@ -2631,8 +2664,12 @@ def get_network_graph(
     # Build a set of valid node IDs after filtering
     valid_node_ids = {n.id for n in nodes}
 
-    # Get all edges in one query instead of per-node queries
-    all_relationships = rel_store.get_all_relationships()
+    # Centered requests get only the induced subgraph among the selected
+    # nodes (indexed); the full-graph opt-in still loads every relationship.
+    if center_on:
+        all_relationships = rel_store.get_edges_among(valid_node_ids)
+    else:
+        all_relationships = rel_store.get_all_relationships()
     seen_edges: set[tuple[str, str]] = set()
 
     # Get owner ID for determining edge weight source

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 import asyncio
 import bisect
+import contextlib
 import json
 import logging
 import sqlite3
@@ -29,7 +30,7 @@ from api.services.source_entity import (
     LINK_STATUS_CONFIRMED,
     LINK_STATUS_REJECTED,
 )
-from api.services.relationship import get_relationship_store
+from api.services.relationship import get_relationship_store, Relationship
 from api.services.relationship_metrics import (
     get_strength_breakdown,
     update_all_strengths,
@@ -2520,6 +2521,51 @@ def get_crm_statistics():
     )
 
 
+def _rendered_edge_weight(
+    rel: Relationship,
+    a_canonical: str,
+    b_canonical: str,
+    my_person_id: str,
+    people_by_id: dict[str, PersonEntity],
+) -> int:
+    """
+    The edge weight exactly as rendered to the client: for an edge that
+    touches the CRM owner, the OTHER person's relationship_strength;
+    otherwise the pair's own `Relationship.pair_strength`.
+
+    `a_canonical`/`b_canonical` must already be canonicalised — a
+    Relationship row's own person_a_id/person_b_id can be a legacy
+    (merged-away) id, and `people_by_id` must be keyed by canonical id (e.g.
+    `PersonEntityStore.get_all()`) or the "other person" lookup silently
+    misses and falls back to pair_strength (#896 review finding 1 — this is
+    the exact bug that made one real edge's weight 90 before vs 96 after).
+    """
+    if a_canonical == my_person_id or b_canonical == my_person_id:
+        other_canonical = b_canonical if a_canonical == my_person_id else a_canonical
+        other_person = people_by_id.get(other_canonical)
+        return int(other_person.relationship_strength) if other_person else rel.pair_strength
+    return rel.pair_strength
+
+
+def _build_network_edge(rel: Relationship, source_id: str, target_id: str, weight: int) -> "NetworkEdge":
+    """Build a NetworkEdge from a Relationship row for already-resolved
+    (canonical) source/target ids and a precomputed weight."""
+    return NetworkEdge(
+        source=source_id,
+        target=target_id,
+        weight=weight,
+        type=rel.relationship_type,
+        shared_events_count=rel.shared_events_count or 0,
+        shared_threads_count=rel.shared_threads_count or 0,
+        shared_messages_count=rel.shared_messages_count or 0,
+        shared_whatsapp_count=rel.shared_whatsapp_count or 0,
+        shared_slack_count=rel.shared_slack_count or 0,
+        shared_phone_calls_count=rel.shared_phone_calls_count or 0,
+        shared_photos_count=rel.shared_photos_count or 0,
+        is_linkedin_connection=rel.is_linkedin_connection,
+    )
+
+
 @router.get("/network", response_model=NetworkGraphResponse)
 def get_network_graph(
     center_on: Optional[str] = Query(default=None, description="Person ID to center the graph on"),
@@ -2534,6 +2580,11 @@ def get_network_graph(
         default=10, ge=0, le=50,
         description="Maximum second-(and deeper-)degree neighbors to add per node at the previous depth",
     ),
+    max_edges: int = Query(
+        default=2000, ge=1, le=20000,
+        description="Target maximum edges for a centered request; every edge touching the centre is "
+                     "always included even if that alone exceeds this (ignored with allow_full_graph)",
+    ),
     allow_full_graph: bool = Query(
         default=False,
         description="Required to load full graph without center_on (expensive operation)"
@@ -2545,20 +2596,42 @@ def get_network_graph(
     Returns nodes (people) and edges (relationships) for rendering
     an interactive force-directed network graph.
 
-    If center_on is provided, this returns a bounded neighborhood: the
-    strongest `max_nodes` connections reachable within `depth` hops, capped
-    at `max_second_degree_per_node` new neighbors per node at each hop
-    beyond the first. Node selection uses indexed per-person queries
-    (RelationshipStore.get_top_neighbors), ranking neighbors by the sum of
-    their shared-interaction count columns as a cheap proxy for strength —
-    the full 500k+-row relationship table is never loaded for a centered
-    request. Edges are then the induced subgraph among the selected nodes
-    (RelationshipStore.get_edges_among), still using the real
-    strength/weight formula on `Relationship`.
+    If center_on is provided, this returns a bounded neighborhood:
+
+    - Node selection: the center (degree 0), then the strongest first-degree
+      connections (degree 1) up to 75% of `max_nodes` when `depth >= 2` (the
+      full `max_nodes - 1` when `depth == 1`, since there is no deeper tier to
+      reserve budget for), ranked by the same value the response renders as
+      edge weight (`_rendered_edge_weight` — the owner's other-person
+      relationship_strength, or pair_strength otherwise), via one indexed
+      query for the center's own relationships. The remaining node budget
+      goes to deeper hops: each first-degree node (processed strongest
+      first) contributes up to `max_second_degree_per_node` of its own
+      strongest neighbors (ranked by a cheaper shared-interaction-count
+      proxy, `RelationshipStore.get_top_neighbors`), until `max_nodes` is
+      reached. The full 500k+-row relationship table is never loaded for a
+      centered request.
+    - Edge selection: every edge connecting the center to a first-degree
+      node is always included (this is what guarantees "every first-degree
+      node has an edge to the center", regardless of `max_edges`). The
+      remaining edge budget (`max_edges` minus those center edges) is filled
+      with the strongest remaining edges among the selected nodes
+      (`RelationshipStore.get_edges_among`), ranked by the same rendered
+      edge weight. Both a merged/legacy id appearing as an endpoint in the
+      raw relationship table, and the id of the CRM owner, are resolved to
+      their canonical id before any of this ranking, lookup, or de-dup.
+    - `category`, if set, is applied during first-degree selection over a
+      window of the 3×`max_nodes` strongest candidates (categories computed
+      via the batched source-entity path, same as `GET /people`), then the
+      top slots are taken from the survivors — best-effort: a category
+      concentrated outside that window is under-represented. Deeper-hop
+      candidates use a cheaper per-person category check with no batched
+      fetch. `min_strength` is applied to already-selected nodes exactly as
+      before (see the docs for a pre-existing scale note).
 
     Without center_on, this loads ALL relationships (500k+ edges) and all
-    people; `max_nodes`/`max_second_degree_per_node` do not apply.
-    Set allow_full_graph=true to explicitly opt-in to this expensive operation.
+    people; none of the caps above apply. Set allow_full_graph=true to
+    explicitly opt-in to this expensive operation.
 
     Each node includes a 'degree' field:
     - 0 = center person
@@ -2578,65 +2651,140 @@ def get_network_graph(
 
     # Build the graph
     nodes: list[NetworkNode] = []
-    edges: list[NetworkEdge] = []
-    # Map person_id -> degree (distance from center)
+    # Map person_id -> degree (distance from center); center_edges maps a
+    # first-degree canonical id to the exact Relationship row that selected
+    # it, so the center-to-first-degree edges never depend on get_edges_among
+    # re-finding them by id (#896 review finding 1).
     node_degrees: dict[str, int] = {}
+    center_edges: dict[str, Relationship] = {}
+
+    # #880: cached and cheap. Also serves as the canonical-id-keyed strength
+    # lookup used to rank first-degree candidates by the real rendered edge
+    # weight (finding 5), and as the final node-building/edge-weight lookup
+    # (already canonical-keyed, so no separate batch-by-id call is needed —
+    # finding 1's third consequence was exactly a requested-id-keyed dict).
+    all_people_dict = {p.id: p for p in person_store.get_all()}
+
+    my_person_id = person_store.get_canonical_id(settings.my_person_id)
 
     if center_on:
         center_person = person_store.get_by_id(center_on)
         if not center_person:
             raise HTTPException(status_code=404, detail=f"Person '{center_on}' not found")
 
-        # Get the CRM owner's ID - exclude from 2nd+ degree traversal
-        # since they're connected to everyone and would pollute the graph
-        my_person_id = settings.my_person_id
+        # Exclude the CRM owner from 2nd+ degree traversal since they're
+        # connected to everyone and would pollute the graph.
         is_viewing_self = (center_on == my_person_id)
 
-        # Center is degree 0. Pick the strongest first-degree neighbors via
-        # the indexed per-person lookup, up to max_nodes total (minus the
-        # center itself) - never the full relationship table.
         node_degrees[center_on] = 0
         frontier: list[str] = []
-        if max_nodes > 1:
-            for rel in rel_store.get_top_neighbors(center_on, limit=max_nodes - 1):
-                other_id = rel.other_person(center_on)
-                if other_id and other_id not in node_degrees:
-                    node_degrees[other_id] = 1
-                    frontier.append(other_id)
 
-        # For depth >= 2, expand each frontier node's strongest neighbors
-        # (up to max_second_degree_per_node each), stopping once max_nodes
-        # is reached.
-        for current_depth in range(2, depth + 1):
-            if not frontier or len(node_degrees) >= max_nodes:
-                break
-            next_frontier: list[str] = []
-            for node_id in frontier:
-                if len(node_degrees) >= max_nodes:
+        # depth == 1 has no deeper tier, so first-degree gets the full
+        # remaining budget; depth >= 2 reserves ~25% of max_nodes for
+        # second-(and deeper-)degree hops instead of consuming the whole
+        # budget on first-degree alone (#896 review finding 3).
+        first_degree_limit = 0
+        if max_nodes > 1:
+            first_degree_limit = (max_nodes - 1) if depth < 2 else max(1, int(max_nodes * 0.75))
+
+        with contextlib.closing(rel_store.open_connection()) as conn:
+            if first_degree_limit > 0:
+                raw_rels = rel_store.get_all_for_person(center_on, conn=conn)
+
+                # Canonicalise every neighbor id and de-dup, keeping the
+                # higher-weight relationship row when more than one raw row
+                # resolves to the same canonical id (#896 finding 1).
+                candidates: dict[str, Relationship] = {}
+                for rel in raw_rels:
+                    other_raw = rel.other_person(center_on)
+                    if not other_raw:
+                        continue
+                    other_canonical = person_store.get_canonical_id(other_raw)
+                    if other_canonical == center_on:
+                        continue  # self-loop after a merge
+                    weight = _rendered_edge_weight(rel, center_on, other_canonical, my_person_id, all_people_dict)
+                    existing = candidates.get(other_canonical)
+                    if existing is not None:
+                        existing_weight = _rendered_edge_weight(
+                            existing, center_on, other_canonical, my_person_id, all_people_dict
+                        )
+                        if weight <= existing_weight:
+                            continue
+                    candidates[other_canonical] = rel
+
+                # Rank by the real rendered edge weight (not a proxy),
+                # deterministic tiebreak by canonical id (#896 finding 5/9).
+                ranked = sorted(
+                    candidates.items(),
+                    key=lambda kv: (
+                        -_rendered_edge_weight(kv[1], center_on, kv[0], my_person_id, all_people_dict),
+                        kv[0],
+                    ),
+                )
+
+                if category:
+                    # Best-effort: consider a window of the strongest
+                    # candidates, compute categories via one batched
+                    # source-entity fetch (same pattern as GET /people),
+                    # filter, then take the top first_degree_limit of the
+                    # still-ranked survivors (#896 finding 6).
+                    window = ranked[:min(len(ranked), 3 * max_nodes)]
+                    source_store = get_source_entity_store()
+                    cat_sources_by_id = source_store.get_for_people_batch(
+                        [cid for cid, _ in window], limit_per_person=_CATEGORY_BATCH_SOURCE_LIMIT
+                    )
+                    selection_pool = [
+                        (cid, rel) for cid, rel in window
+                        if (cand_person := all_people_dict.get(cid)) is not None
+                        and compute_person_category(cand_person, cat_sources_by_id.get(cid, [])) == category
+                    ]
+                else:
+                    selection_pool = ranked
+
+                for canonical_other, rel in selection_pool[:first_degree_limit]:
+                    node_degrees[canonical_other] = 1
+                    frontier.append(canonical_other)
+                    center_edges[canonical_other] = rel
+
+            # For depth >= 2, expand each frontier node's strongest
+            # neighbors (up to max_second_degree_per_node each, in
+            # first-degree strength order) into the budget left after the
+            # first-degree tier above.
+            for current_depth in range(2, depth + 1):
+                if not frontier or len(node_degrees) >= max_nodes:
                     break
-                # Skip "me" as a bridge for 2nd+ degree when not viewing
-                # self - this prevents everyone appearing as 2nd-degree
-                # through me (same rationale as the original BFS).
-                if not is_viewing_self and node_id == my_person_id:
-                    continue
-                if max_second_degree_per_node <= 0:
-                    continue
-                for rel in rel_store.get_top_neighbors(node_id, limit=max_second_degree_per_node):
+                next_frontier: list[str] = []
+                for node_id in frontier:
                     if len(node_degrees) >= max_nodes:
                         break
-                    other_id = rel.other_person(node_id)
-                    if other_id and other_id not in node_degrees:
-                        node_degrees[other_id] = current_depth
-                        next_frontier.append(other_id)
-            frontier = next_frontier
-
-        # Batch lookup only the selected people - never get_all().
-        all_people_dict = person_store.get_by_ids(node_degrees.keys())
+                    # Skip "me" as a bridge for 2nd+ degree when not viewing
+                    # self - this prevents everyone appearing as 2nd-degree
+                    # through me (same rationale as the original BFS).
+                    if not is_viewing_self and node_id == my_person_id:
+                        continue
+                    if max_second_degree_per_node <= 0:
+                        continue
+                    for rel in rel_store.get_top_neighbors(node_id, limit=max_second_degree_per_node, conn=conn):
+                        if len(node_degrees) >= max_nodes:
+                            break
+                        other_raw = rel.other_person(node_id)
+                        if not other_raw:
+                            continue
+                        other_canonical = person_store.get_canonical_id(other_raw)
+                        if other_canonical in node_degrees:
+                            continue
+                        if category:
+                            # Cheap best-effort check (no batched
+                            # source-entity fetch per intermediate node).
+                            cand_person = all_people_dict.get(other_canonical)
+                            if cand_person is None or compute_person_category(cand_person, []) != category:
+                                continue
+                        node_degrees[other_canonical] = current_depth
+                        next_frontier.append(other_canonical)
+                frontier = next_frontier
     else:
-        # Get all people (no center, all are degree 1)
-        all_people = person_store.get_all()
-        node_degrees = {p.id: 1 for p in all_people}
-        all_people_dict = {p.id: p for p in all_people}
+        # Get all people (no center, all are degree 1) - unchanged full-graph path.
+        node_degrees = {p.id: 1 for p in all_people_dict.values()}
 
     # Filter by category and strength, then build nodes
     for person_id, degree in node_degrees.items():
@@ -2664,54 +2812,51 @@ def get_network_graph(
     # Build a set of valid node IDs after filtering
     valid_node_ids = {n.id for n in nodes}
 
-    # Centered requests get only the induced subgraph among the selected
-    # nodes (indexed); the full-graph opt-in still loads every relationship.
+    edges_by_pair: dict[tuple[str, str], NetworkEdge] = {}
+
     if center_on:
-        all_relationships = rel_store.get_edges_among(valid_node_ids)
+        # Every edge touching the center is unconditionally included -
+        # these are exactly the relationship rows used to select each
+        # first-degree node, so this edge is never missing even for a
+        # legacy/merged neighbor id (#896 findings 1 and 2).
+        for neighbor_id, rel in center_edges.items():
+            if neighbor_id not in valid_node_ids:
+                continue  # dropped by the category/min_strength filter above
+            weight = _rendered_edge_weight(rel, center_on, neighbor_id, my_person_id, all_people_dict)
+            pair = (min(center_on, neighbor_id), max(center_on, neighbor_id))
+            edges_by_pair[pair] = _build_network_edge(rel, center_on, neighbor_id, weight)
+
+        # Fill the remaining edge budget with the strongest non-center
+        # edges among the selected nodes (#896 findings 2 and 4).
+        remaining_budget = max_edges - len(edges_by_pair)
+        if remaining_budget > 0 and len(valid_node_ids) > 1:
+            scored: list[tuple[int, tuple[str, str], Relationship, str, str]] = []
+            for rel in rel_store.get_edges_among(valid_node_ids):
+                a_canonical = person_store.get_canonical_id(rel.person_a_id)
+                b_canonical = person_store.get_canonical_id(rel.person_b_id)
+                if a_canonical not in valid_node_ids or b_canonical not in valid_node_ids:
+                    continue
+                pair = (min(a_canonical, b_canonical), max(a_canonical, b_canonical))
+                if pair in edges_by_pair:
+                    continue
+                weight = _rendered_edge_weight(rel, a_canonical, b_canonical, my_person_id, all_people_dict)
+                scored.append((weight, pair, rel, a_canonical, b_canonical))
+            # Strongest first, deterministic tiebreak by pair.
+            scored.sort(key=lambda t: (-t[0], t[1]))
+            for weight, pair, rel, a_canonical, b_canonical in scored[:remaining_budget]:
+                edges_by_pair[pair] = _build_network_edge(rel, a_canonical, b_canonical, weight)
     else:
-        all_relationships = rel_store.get_all_relationships()
-    seen_edges: set[tuple[str, str]] = set()
+        # allow_full_graph path: unchanged behavior, no max_edges cap.
+        for rel in rel_store.get_all_relationships():
+            if rel.person_a_id not in valid_node_ids or rel.person_b_id not in valid_node_ids:
+                continue
+            pair = (min(rel.person_a_id, rel.person_b_id), max(rel.person_a_id, rel.person_b_id))
+            if pair in edges_by_pair:
+                continue
+            weight = _rendered_edge_weight(rel, rel.person_a_id, rel.person_b_id, my_person_id, all_people_dict)
+            edges_by_pair[pair] = _build_network_edge(rel, rel.person_a_id, rel.person_b_id, weight)
 
-    # Get owner ID for determining edge weight source
-    my_person_id = settings.my_person_id
-
-    for rel in all_relationships:
-        # Both people must be in valid nodes
-        if rel.person_a_id not in valid_node_ids or rel.person_b_id not in valid_node_ids:
-            continue
-
-        # Create consistent edge key (smaller ID first)
-        edge_key = (min(rel.person_a_id, rel.person_b_id), max(rel.person_a_id, rel.person_b_id))
-        if edge_key in seen_edges:
-            continue
-        seen_edges.add(edge_key)
-
-        # Determine edge weight:
-        # - For edges involving the owner: use the other person's relationship_strength
-        # - For edges between two other people: use pair_strength
-        if rel.person_a_id == my_person_id or rel.person_b_id == my_person_id:
-            # Owner edge - use the other person's relationship_strength
-            other_id = rel.person_b_id if rel.person_a_id == my_person_id else rel.person_a_id
-            other_person = all_people_dict.get(other_id)
-            weight = int(other_person.relationship_strength) if other_person else rel.pair_strength
-        else:
-            # Non-owner edge - use pair_strength
-            weight = rel.pair_strength
-
-        edges.append(NetworkEdge(
-            source=rel.person_a_id,
-            target=rel.person_b_id,
-            weight=weight,
-            type=rel.relationship_type,
-            shared_events_count=rel.shared_events_count or 0,
-            shared_threads_count=rel.shared_threads_count or 0,
-            shared_messages_count=rel.shared_messages_count or 0,
-            shared_whatsapp_count=rel.shared_whatsapp_count or 0,
-            shared_slack_count=rel.shared_slack_count or 0,
-            shared_phone_calls_count=rel.shared_phone_calls_count or 0,
-            shared_photos_count=rel.shared_photos_count or 0,
-            is_linkedin_connection=rel.is_linkedin_connection,
-        ))
+    edges = list(edges_by_pair.values())
 
     elapsed = (time.time() - start_time) * 1000
     logger.info(f"network_graph(center={center_on}, depth={depth}) took {elapsed:.1f}ms ({len(nodes)} nodes, {len(edges)} edges)")

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -2804,6 +2804,18 @@ def get_network_graph(
                         other_canonical = person_store.get_canonical_id(other_raw)
                         if other_canonical in node_degrees:
                             continue
+                        if other_canonical in all_direct_candidates:
+                            # A genuine direct connection of the center
+                            # isn't a friend-of-friend - skip it here so the
+                            # budget reserved for deeper hops goes to actual
+                            # second-degree people instead of being spent
+                            # (and then immediately relabeled back to
+                            # degree 1 below) on centre connections that
+                            # merely missed the first-degree cut (#896
+                            # review round 4, MAJOR finding: this reclaimed
+                            # the whole reserved budget for dense centres,
+                            # collapsing the second-degree tier again).
+                            continue
                         if category:
                             # Cheap best-effort check (no batched
                             # source-entity fetch per intermediate node).
@@ -2818,7 +2830,10 @@ def get_network_graph(
         # A node that has a genuine direct relationship to the center is
         # relabeled degree 1 even if it was only added above via a friend
         # (#896 review round 3 finding 4) - and gets its guaranteed center
-        # edge, same as any other first-degree node.
+        # edge, same as any other first-degree node. The skip above means
+        # this shouldn't fire in practice any more (a direct candidate is
+        # never added as a deeper-hop node in the first place), but it's
+        # kept as a correctness backstop rather than relied upon.
         for node_id, rel in all_direct_candidates.items():
             if node_degrees.get(node_id, 0) > 1:
                 node_degrees[node_id] = 1

--- a/api/services/relationship.py
+++ b/api/services/relationship.py
@@ -786,6 +786,96 @@ class RelationshipStore:
         finally:
             conn.close()
 
+    def get_top_neighbors(self, person_id: str, limit: int) -> list["Relationship"]:
+        """
+        Get a person's strongest relationships without scanning the full table.
+
+        Uses the person_a_id/person_b_id indexes (WHERE ... OR ...) to fetch
+        only rows involving person_id, then orders that small set by the sum
+        of the shared-interaction count columns as a cheap proxy for
+        relationship strength. This is NOT the same as `Relationship.pair_strength`
+        / `edge_weight` (which factor in recency and diversity too) — it's a
+        server-side ranking heuristic for picking which neighbors to include
+        in a bounded graph; the real strength formula is still used for the
+        edges actually returned.
+
+        Args:
+            person_id: Canonical person ID
+            limit: Maximum relationships to return (strongest first)
+
+        Returns:
+            List of relationships, strongest (by the count-sum proxy) first
+        """
+        if limit <= 0:
+            return []
+
+        conn = self._get_connection()
+        try:
+            cursor = conn.execute("""
+                SELECT *,
+                    (shared_events_count + shared_threads_count + shared_messages_count +
+                     shared_whatsapp_count + shared_slack_count + shared_phone_calls_count +
+                     shared_photos_count) AS _rank_score
+                FROM relationships
+                WHERE person_a_id = ? OR person_b_id = ?
+                ORDER BY _rank_score DESC
+                LIMIT ?
+            """, (person_id, person_id, limit))
+            # Drop the trailing _rank_score column before handing the row to
+            # from_row(), which indexes columns positionally.
+            return [Relationship.from_row(row[:-1]) for row in cursor.fetchall()]
+        finally:
+            conn.close()
+
+    def get_edges_among(self, person_ids) -> list["Relationship"]:
+        """
+        Get the induced subgraph among a set of person IDs: every relationship
+        where BOTH endpoints are in person_ids.
+
+        Runs one indexed IN (...) query per chunk of ids against each of
+        person_a_id and person_b_id (chunking to stay under SQLite's
+        bound-parameter limit for large id sets), confirms in Python that
+        both endpoints of each returned row are actually in the requested
+        set (a row matching on one indexed column isn't guaranteed to match
+        on the other), and dedups by unordered pair.
+
+        Args:
+            person_ids: IDs to restrict the subgraph to
+
+        Returns:
+            Deduplicated list of relationships, each unordered pair once
+        """
+        ids_set = set(person_ids)
+        if not ids_set:
+            return []
+
+        ids_list = list(ids_set)
+        chunk_size = 500  # comfortably under SQLite's older 999-variable limit
+        conn = self._get_connection()
+        try:
+            seen: set[tuple[str, str]] = set()
+            results: list[Relationship] = []
+            for column in ("person_a_id", "person_b_id"):
+                for i in range(0, len(ids_list), chunk_size):
+                    chunk = ids_list[i:i + chunk_size]
+                    placeholders = ",".join("?" * len(chunk))
+                    cursor = conn.execute(
+                        f"SELECT * FROM relationships WHERE {column} IN ({placeholders})",
+                        chunk,
+                    )
+                    for row in cursor.fetchall():
+                        rel = Relationship.from_row(row)
+                        if rel.person_a_id not in ids_set or rel.person_b_id not in ids_set:
+                            continue
+                        key = (rel.person_a_id, rel.person_b_id)
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        results.append(rel)
+            return results
+        finally:
+            conn.close()
+
     def get_all_relationships(self, limit: Optional[int] = None) -> list["Relationship"]:
         """
         Get all relationships.

--- a/api/services/relationship.py
+++ b/api/services/relationship.py
@@ -786,22 +786,77 @@ class RelationshipStore:
         finally:
             conn.close()
 
-    def get_top_neighbors(self, person_id: str, limit: int) -> list["Relationship"]:
+    def open_connection(self) -> sqlite3.Connection:
+        """
+        Open a new connection for a caller that will make several
+        RelationshipStore calls in one pass (e.g. selecting a bounded graph
+        neighborhood: one `get_all_for_person()` plus one `get_top_neighbors()`
+        per intermediate node) and wants to share a single connection instead
+        of paying a connect/close cost on every call (#896 review finding 11).
+
+        Pass the returned connection as `conn` to `get_all_for_person()` /
+        `get_top_neighbors()`; the caller owns it and must close it (e.g. via
+        `with contextlib.closing(store.open_connection()) as conn:`).
+        """
+        return self._get_connection()
+
+    def get_all_for_person(
+        self, person_id: str, conn: Optional[sqlite3.Connection] = None
+    ) -> list["Relationship"]:
+        """
+        Get every relationship row where person_id appears as either
+        endpoint, unordered and unlimited.
+
+        Uses the person_a_id/person_b_id indexes (WHERE ... OR ...), never
+        scans the full table. Callers that need a ranking rank/filter the
+        result themselves (see `get_top_neighbors()` for the count-sum-proxy
+        case, or `api/routes/crm.py`'s network endpoint for ranking by the
+        real rendered edge weight).
+
+        Args:
+            person_id: Canonical person ID
+            conn: Optional already-open connection to reuse (see
+                `open_connection()`); a fresh one is opened and closed if
+                omitted.
+
+        Returns:
+            List of relationships involving person_id, in no particular order
+        """
+        owns_conn = conn is None
+        if owns_conn:
+            conn = self._get_connection()
+        try:
+            cursor = conn.execute(
+                "SELECT * FROM relationships WHERE person_a_id = ? OR person_b_id = ?",
+                (person_id, person_id),
+            )
+            return [Relationship.from_row(row) for row in cursor.fetchall()]
+        finally:
+            if owns_conn:
+                conn.close()
+
+    def get_top_neighbors(
+        self, person_id: str, limit: int, conn: Optional[sqlite3.Connection] = None
+    ) -> list["Relationship"]:
         """
         Get a person's strongest relationships without scanning the full table.
 
-        Uses the person_a_id/person_b_id indexes (WHERE ... OR ...) to fetch
-        only rows involving person_id, then orders that small set by the sum
-        of the shared-interaction count columns as a cheap proxy for
-        relationship strength. This is NOT the same as `Relationship.pair_strength`
-        / `edge_weight` (which factor in recency and diversity too) — it's a
-        server-side ranking heuristic for picking which neighbors to include
-        in a bounded graph; the real strength formula is still used for the
-        edges actually returned.
+        Fetches every relationship touching person_id via `get_all_for_person()`
+        (indexed, not a full-table scan) and ranks that small set in Python by
+        the sum of the shared-interaction count columns as a cheap proxy for
+        relationship strength, with the relationship id as a deterministic
+        tiebreak (#896 review finding 9). This proxy is NOT the same as
+        `Relationship.pair_strength` / `edge_weight` (which factor in recency
+        and diversity too) — it's a server-side ranking heuristic for picking
+        which neighbors to include in a bounded graph; the real strength
+        formula is still used for the edges actually returned.
 
         Args:
             person_id: Canonical person ID
             limit: Maximum relationships to return (strongest first)
+            conn: Optional already-open connection to reuse (see
+                `open_connection()`); a fresh one is opened and closed if
+                omitted.
 
         Returns:
             List of relationships, strongest (by the count-sum proxy) first
@@ -809,38 +864,34 @@ class RelationshipStore:
         if limit <= 0:
             return []
 
-        conn = self._get_connection()
-        try:
-            cursor = conn.execute("""
-                SELECT *,
-                    (shared_events_count + shared_threads_count + shared_messages_count +
-                     shared_whatsapp_count + shared_slack_count + shared_phone_calls_count +
-                     shared_photos_count) AS _rank_score
-                FROM relationships
-                WHERE person_a_id = ? OR person_b_id = ?
-                ORDER BY _rank_score DESC
-                LIMIT ?
-            """, (person_id, person_id, limit))
-            # Drop the trailing _rank_score column before handing the row to
-            # from_row(), which indexes columns positionally.
-            return [Relationship.from_row(row[:-1]) for row in cursor.fetchall()]
-        finally:
-            conn.close()
+        rels = self.get_all_for_person(person_id, conn=conn)
+        rels.sort(key=lambda r: (-r.total_shared_interactions, r.id))
+        return rels[:limit]
 
-    def get_edges_among(self, person_ids) -> list["Relationship"]:
+    def get_edges_among(
+        self, person_ids, conn: Optional[sqlite3.Connection] = None
+    ) -> list["Relationship"]:
         """
         Get the induced subgraph among a set of person IDs: every relationship
         where BOTH endpoints are in person_ids.
 
-        Runs one indexed IN (...) query per chunk of ids against each of
-        person_a_id and person_b_id (chunking to stay under SQLite's
-        bound-parameter limit for large id sets), confirms in Python that
-        both endpoints of each returned row are actually in the requested
-        set (a row matching on one indexed column isn't guaranteed to match
-        on the other), and dedups by unordered pair.
+        Loads person_ids into a temp table and joins it against `relationships`
+        twice (once per endpoint column). This avoids the two-pass
+        `person_a_id IN (...)` / `person_b_id IN (...)` approach's blowup when
+        one of the ids has many relationships overall (e.g. the CRM owner in a
+        150-node selection still has thousands of total relationships, most
+        of which don't have their OTHER endpoint in the set) — measured on
+        the real dataset, that approach fetched and Python-filtered ~48k rows
+        for a 150-node owner-centered request; this join returns only the
+        ~2.4k that actually match, in about a third of the time. Avoids
+        SQLite's bound-parameter limit entirely (no `IN (...)` list at all),
+        so there's no chunking to reason about regardless of person_ids' size.
 
         Args:
             person_ids: IDs to restrict the subgraph to
+            conn: Optional already-open connection to reuse (see
+                `open_connection()`); a fresh one is opened and closed if
+                omitted.
 
         Returns:
             Deduplicated list of relationships, each unordered pair once
@@ -849,32 +900,35 @@ class RelationshipStore:
         if not ids_set:
             return []
 
-        ids_list = list(ids_set)
-        chunk_size = 500  # comfortably under SQLite's older 999-variable limit
-        conn = self._get_connection()
+        owns_conn = conn is None
+        if owns_conn:
+            conn = self._get_connection()
         try:
+            conn.execute("CREATE TEMP TABLE IF NOT EXISTS _network_edge_ids (id TEXT PRIMARY KEY)")
+            conn.execute("DELETE FROM _network_edge_ids")
+            conn.executemany(
+                "INSERT OR IGNORE INTO _network_edge_ids (id) VALUES (?)",
+                [(pid,) for pid in ids_set],
+            )
+            cursor = conn.execute("""
+                SELECT r.* FROM relationships r
+                JOIN _network_edge_ids a ON r.person_a_id = a.id
+                JOIN _network_edge_ids b ON r.person_b_id = b.id
+            """)
             seen: set[tuple[str, str]] = set()
             results: list[Relationship] = []
-            for column in ("person_a_id", "person_b_id"):
-                for i in range(0, len(ids_list), chunk_size):
-                    chunk = ids_list[i:i + chunk_size]
-                    placeholders = ",".join("?" * len(chunk))
-                    cursor = conn.execute(
-                        f"SELECT * FROM relationships WHERE {column} IN ({placeholders})",
-                        chunk,
-                    )
-                    for row in cursor.fetchall():
-                        rel = Relationship.from_row(row)
-                        if rel.person_a_id not in ids_set or rel.person_b_id not in ids_set:
-                            continue
-                        key = (rel.person_a_id, rel.person_b_id)
-                        if key in seen:
-                            continue
-                        seen.add(key)
-                        results.append(rel)
+            for row in cursor.fetchall():
+                rel = Relationship.from_row(row)
+                key = (rel.person_a_id, rel.person_b_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                results.append(rel)
             return results
         finally:
-            conn.close()
+            conn.execute("DROP TABLE IF EXISTS _network_edge_ids")
+            if owns_conn:
+                conn.close()
 
     def get_all_relationships(self, limit: Optional[int] = None) -> list["Relationship"]:
         """

--- a/api/services/relationship.py
+++ b/api/services/relationship.py
@@ -8,6 +8,7 @@ Relationships are discovered by analyzing shared contexts:
 - Co-mentions in notes
 """
 import sqlite3
+import contextlib
 import json
 import threading
 import uuid
@@ -27,6 +28,19 @@ TYPE_COWORKER = "coworker"
 TYPE_FRIEND = "friend"
 TYPE_FAMILY = "family"
 TYPE_INFERRED = "inferred"  # Discovered through shared contexts
+
+# Explicit column list matching Relationship.from_row()'s expected positional
+# order (see its "Row order" comment). Named rather than `SELECT *` so a
+# query using it doesn't silently depend on the table's physical column
+# order, and doesn't couple to a query adding its own extra columns
+# (#896 review finding 10 / round 3 blocker 2).
+_RELATIONSHIP_COLUMNS = (
+    "id, person_a_id, person_b_id, relationship_type, shared_contexts, "
+    "shared_events_count, shared_threads_count, first_seen_together, "
+    "last_seen_together, created_at, updated_at, shared_messages_count, "
+    "shared_whatsapp_count, shared_slack_count, is_linkedin_connection, "
+    "shared_phone_calls_count, shared_photos_count"
+)
 
 
 @dataclass
@@ -841,15 +855,33 @@ class RelationshipStore:
         """
         Get a person's strongest relationships without scanning the full table.
 
-        Fetches every relationship touching person_id via `get_all_for_person()`
-        (indexed, not a full-table scan) and ranks that small set in Python by
-        the sum of the shared-interaction count columns as a cheap proxy for
-        relationship strength, with the relationship id as a deterministic
-        tiebreak (#896 review finding 9). This proxy is NOT the same as
-        `Relationship.pair_strength` / `edge_weight` (which factor in recency
-        and diversity too) — it's a server-side ranking heuristic for picking
-        which neighbors to include in a bounded graph; the real strength
-        formula is still used for the edges actually returned.
+        Ranks and limits in SQL: an indexed WHERE (person_a_id/person_b_id)
+        narrows to this person's own rows, `ORDER BY <shared-interaction
+        count sum> DESC, id LIMIT ?` picks the top `limit` with a
+        deterministic tiebreak, and only those rows are ever hydrated into
+        `Relationship` objects. This proxy is NOT the same as
+        `Relationship.pair_strength` / `edge_weight` (which factor in
+        recency and diversity too) — it's a server-side ranking heuristic
+        for picking which neighbors to include in a bounded graph; the real
+        strength formula is still used for the edges actually returned.
+
+        An earlier version of this method fetched every relationship for
+        person_id via `get_all_for_person()` and ranked/limited in Python.
+        That fixed the tiebreak and removed a positional-`SELECT *`-plus-
+        computed-column coupling, but turned a bounded fetch into an
+        unbounded one on the hottest path in the network-graph endpoint's
+        selection loop: for a person with hundreds of relationships of
+        their own (a first-degree node during second-degree expansion,
+        not just the center), every one of those rows was hydrated just to
+        keep the top handful. Measured (#896 review round 3): 48
+        `get_top_neighbors` calls for one request pulled ~39,600
+        `Relationship.from_row()` constructions total, at ~9µs each
+        (JSON-decoding `shared_contexts` plus four `fromisoformat` calls) —
+        0.356s of a 0.549s request. Ranking and limiting in SQL again (with
+        an explicit column list, never `SELECT *`, so there's still no
+        positional coupling to a computed or reordered column) keeps both
+        of that version's fixes while hydrating only the rows actually
+        returned.
 
         Args:
             person_id: Canonical person ID
@@ -864,9 +896,25 @@ class RelationshipStore:
         if limit <= 0:
             return []
 
-        rels = self.get_all_for_person(person_id, conn=conn)
-        rels.sort(key=lambda r: (-r.total_shared_interactions, r.id))
-        return rels[:limit]
+        owns_conn = conn is None
+        if owns_conn:
+            conn = self._get_connection()
+        try:
+            cursor = conn.execute(f"""
+                SELECT {_RELATIONSHIP_COLUMNS}
+                FROM relationships
+                WHERE person_a_id = ? OR person_b_id = ?
+                ORDER BY (
+                    shared_events_count + shared_threads_count + shared_messages_count +
+                    shared_whatsapp_count + shared_slack_count + shared_phone_calls_count +
+                    shared_photos_count
+                ) DESC, id
+                LIMIT ?
+            """, (person_id, person_id, limit))
+            return [Relationship.from_row(row) for row in cursor.fetchall()]
+        finally:
+            if owns_conn:
+                conn.close()
 
     def get_edges_among(
         self, person_ids, conn: Optional[sqlite3.Connection] = None
@@ -926,7 +974,11 @@ class RelationshipStore:
                 results.append(rel)
             return results
         finally:
-            conn.execute("DROP TABLE IF EXISTS _network_edge_ids")
+            # If the connection is already in a bad state, letting this
+            # raise would mask whatever exception got us into `finally` in
+            # the first place (#896 review round 3 finding 6).
+            with contextlib.suppress(sqlite3.Error):
+                conn.execute("DROP TABLE IF EXISTS _network_edge_ids")
             if owns_conn:
                 conn.close()
 

--- a/docs/specs/product/api-crm.md
+++ b/docs/specs/product/api-crm.md
@@ -234,13 +234,19 @@ Merge two person records. Combines all interactions, relationships, and source e
 
 ### GET /api/crm/network
 
-Network graph data (nodes + edges).
+Network graph data (nodes + edges). With `center_on`, this is a bounded
+neighborhood — the strongest connections within `depth` hops, capped by
+`max_nodes` and `max_second_degree_per_node` — not the full relationship
+table (see [crm-graph.md § Bounded Neighborhood](crm-graph.md#bounded-neighborhood)).
 
 **Query parameters:**
-- `center_on` (string): Person ID to center on
-- `depth` (int): Graph depth
-- `min_strength` (float): Minimum edge strength
+- `center_on` (string): Person ID to center on. Required unless `allow_full_graph=true`.
+- `depth` (int, 1–4, default 2): Graph depth
+- `min_strength` (float, 0.0–1.0, default 0.0): Minimum node relationship strength
 - `category` (string): Filter by category
+- `max_nodes` (int, 1–500, default 150): Total nodes in the response, including the center
+- `max_second_degree_per_node` (int, 0–50, default 10): Second-(and deeper-)degree neighbors added per node at the previous depth
+- `allow_full_graph` (bool, default false): Opt-in to load every person and relationship (no `center_on`); ignores the two caps above
 
 **Response includes edge source breakdown:**
 - `shared_events_count`

--- a/docs/specs/product/api-crm.md
+++ b/docs/specs/product/api-crm.md
@@ -236,17 +236,19 @@ Merge two person records. Combines all interactions, relationships, and source e
 
 Network graph data (nodes + edges). With `center_on`, this is a bounded
 neighborhood — the strongest connections within `depth` hops, capped by
-`max_nodes` and `max_second_degree_per_node` — not the full relationship
-table (see [crm-graph.md § Bounded Neighborhood](crm-graph.md#bounded-neighborhood)).
+`max_nodes`, `max_second_degree_per_node`, and `max_edges` — not the full
+relationship table (see
+[crm-graph.md § Bounded Neighborhood](crm-graph.md#bounded-neighborhood)).
 
 **Query parameters:**
 - `center_on` (string): Person ID to center on. Required unless `allow_full_graph=true`.
 - `depth` (int, 1–4, default 2): Graph depth
-- `min_strength` (float, 0.0–1.0, default 0.0): Minimum node relationship strength
-- `category` (string): Filter by category
+- `min_strength` (float, 0.0–1.0, default 0.0): Minimum node relationship strength. Currently a no-op regardless of value — validated to 0.0–1.0 while `relationship_strength` is 0–100.
+- `category` (string): Filter by category. Best-effort for a centered request — see the docs linked above.
 - `max_nodes` (int, 1–500, default 150): Total nodes in the response, including the center
 - `max_second_degree_per_node` (int, 0–50, default 10): Second-(and deeper-)degree neighbors added per node at the previous depth
-- `allow_full_graph` (bool, default false): Opt-in to load every person and relationship (no `center_on`); ignores the two caps above
+- `max_edges` (int, 1–20000, default 2000): Target maximum edges; every edge touching the center is always included even if that alone exceeds this
+- `allow_full_graph` (bool, default false): Opt-in to load every person and relationship (no `center_on`); ignores the three caps above
 
 **Response includes edge source breakdown:**
 - `shared_events_count`

--- a/docs/specs/product/crm-graph.md
+++ b/docs/specs/product/crm-graph.md
@@ -175,6 +175,14 @@ The Graph tab sends only `center_on` and `depth`, leaving the caps above at
 their server defaults so a future default change reaches the tab without a
 frontend edit.
 
+`allow_full_graph=true` combined with `category` now filters every person by
+the same dynamically-computed category the response displays for them
+(`compute_person_category(person, [])`), rather than their raw stored
+`category` field — more self-consistent than before (a person's displayed
+category and whether a category filter kept them can no longer disagree),
+and the only externally-visible change to the full-graph path from this
+issue's otherwise-untouched behavior.
+
 **Graph enhancements:**
 
 - **Fullscreen mode** — toggle expands the graph to the viewport (mobile + desktop).

--- a/docs/specs/product/crm-graph.md
+++ b/docs/specs/product/crm-graph.md
@@ -83,32 +83,63 @@ D3-based force-directed graph that renders the selected person's network.
 - Clicking a node navigates to that person; hovering shows a tooltip with name and company.
 - Toggle the labels and reset-zoom controls in the toolbar.
 - Re-renders when the person selection changes.
-- Renders in well under a second regardless of how large the underlying contact
-  graph is, because the server returns a bounded neighborhood rather than the
-  full relationship set (see Bounded Neighborhood below); the client-side
-  strength slider then further narrows that bounded set to the ~25 first-degree
-  nodes the graph is designed to display at once.
+- Renders in roughly half a second on the real dataset regardless of how
+  large the underlying contact graph is, because the server returns a
+  bounded neighborhood rather than the full relationship set (see Bounded
+  Neighborhood below); the client-side strength slider then further narrows
+  that bounded set to the ~25 first-degree nodes the graph is designed to
+  display at once.
 
 ### Bounded Neighborhood
 
 `GET /api/crm/network?center_on=<id>` (used by the Graph tab) never loads
-every relationship. Instead it selects:
+every relationship. Node selection:
 
-1. The center person (degree 0).
-2. Up to `max_nodes - 1` of the center's strongest first-degree connections
-   (default `max_nodes=150`), ranked by an indexed per-person query.
-3. For `depth=2` (the Graph tab's default), up to
-   `max_second_degree_per_node` (default `10`) of each first-degree node's
-   own strongest connections, added in first-degree strength order until
-   `max_nodes` is reached.
+1. The center person (degree 0). If the center is hidden, it (and anything
+   reachable only through it) is dropped from the response the same way a
+   hidden person is dropped anywhere else in the CRM — the response can end
+   up with zero nodes if the hidden person also has no real relationships,
+   but that isn't guaranteed for every hidden person.
+2. The center's strongest first-degree connections (degree 1) — up to
+   `max_nodes - 1` when `depth=1`, or up to 75% of `max_nodes` when
+   `depth >= 2` (see the next point for why). Ranked by the same value the
+   response renders as edge weight: for an edge to the CRM owner, the other
+   person's `relationship_strength`; otherwise the pair's own
+   `pair_strength`. This ranking uses one indexed query for the center's own
+   relationships, not the full relationship table.
+3. For `depth=2` (the Graph tab's default), the *remaining* node budget goes
+   to deeper hops: each first-degree node, processed strongest first,
+   contributes up to `max_second_degree_per_node` (default `10`) of its own
+   strongest connections, ranked by a cheaper sum-of-shared-interaction-counts
+   proxy, until `max_nodes` is reached. First-degree selection reserving
+   ~25% of the budget for this tier (rather than consuming the whole budget
+   itself) is what makes second-degree nodes actually appear for a
+   well-connected center.
 
-Edges returned are the induced subgraph among exactly the selected nodes —
-every edge's endpoints are both present in the response, the center is
-always present, and every first-degree node has an edge to the center.
-"Strongest" for node *selection* is the sum of the relationship's
-shared-interaction counts (a cheap ranking proxy); the edge weight and
-strength values in the response are unchanged — computed the same way they
-always were.
+A relationship row referencing a legacy (merged-away) person id is resolved
+to its canonical id before any of this ranking or de-duplication, so a
+stale id in the underlying data can't produce a duplicate node or a
+first-degree node with no edge back to the center.
+
+Edge selection: every edge connecting the center to a first-degree node is
+always included, regardless of `max_edges` — this is what guarantees every
+first-degree node has an edge to the center. The remaining edge budget
+(`max_edges` minus those center edges) is filled with the strongest
+remaining edges among the selected nodes, by the same rendered edge weight.
+Without this cap, the induced subgraph among a well-connected center's
+neighbors is close to complete (up to `max_nodes` choose 2 edges) — capping
+it means the strength slider's bottom end may show fewer inter-node edges
+than an uncapped response would have.
+
+`category`, if set, is applied during first-degree selection over a window
+of the 3×`max_nodes` strongest candidates (categories computed via the same
+batched source-entity lookup `GET /people` uses), then the top slots are
+taken from the survivors — best-effort: a category concentrated outside
+that window is under-represented in the result. Deeper-hop candidates use a
+cheaper per-person category check with no batched fetch. `min_strength` is
+applied to already-selected nodes exactly as it always was — note it's
+currently a no-op in practice regardless of value, since it's validated to
+0.0–1.0 while `relationship_strength` is on a 0–100 scale.
 
 Query parameters:
 
@@ -116,11 +147,12 @@ Query parameters:
 |---|---|---|---|
 | `max_nodes` | 1–500 | 150 | Total nodes in the response, including the center |
 | `max_second_degree_per_node` | 0–50 | 10 | Second-(and deeper-)degree neighbors added per node at the previous depth |
-| `allow_full_graph` | bool | false | Opt-in to load every person and relationship (no `center_on`); ignores the two caps above |
+| `max_edges` | 1–20000 | 2000 | Target maximum edges; every edge touching the center is always included even if that alone exceeds this |
+| `allow_full_graph` | bool | false | Opt-in to load every person and relationship (no `center_on`); ignores the three caps above |
 
-The Graph tab always passes `max_nodes` and `max_second_degree_per_node`
-explicitly at their defaults, so the bounded contract is visible in the
-request rather than implicit.
+The Graph tab sends only `center_on` and `depth`, leaving the caps above at
+their server defaults so a future default change reaches the tab without a
+frontend edit.
 
 **Graph enhancements:**
 

--- a/docs/specs/product/crm-graph.md
+++ b/docs/specs/product/crm-graph.md
@@ -155,6 +155,14 @@ applied to already-selected nodes exactly as it always was — note it's
 currently a no-op in practice regardless of value, since it's validated to
 0.0–1.0 while `relationship_strength` is on a 0–100 scale.
 
+A well-connected center often has few or no genuine friends-of-friends left
+to fill the deeper-hop tier once its own direct connections are excluded
+from that tier (point 3 above) — so any of that tier's budget that goes
+unspent is backfilled from the center's next-strongest direct candidates
+that missed the first-degree cut. They're real first-degree people (see the
+relabeling note above), so a dense center's response still reaches
+`max_nodes` rather than coming back short.
+
 The Graph tab's own auto-selected strength-slider threshold
 (`calculateOptimalEdgeThreshold`) never picks a threshold that would hide
 every first-degree node, and returns 0 outright when every first-degree

--- a/docs/specs/product/crm-graph.md
+++ b/docs/specs/product/crm-graph.md
@@ -95,11 +95,15 @@ D3-based force-directed graph that renders the selected person's network.
 `GET /api/crm/network?center_on=<id>` (used by the Graph tab) never loads
 every relationship. Node selection:
 
-1. The center person (degree 0). If the center is hidden, it (and anything
-   reachable only through it) is dropped from the response the same way a
-   hidden person is dropped anywhere else in the CRM — the response can end
-   up with zero nodes if the hidden person also has no real relationships,
-   but that isn't guaranteed for every hidden person.
+1. The center person (degree 0), resolved to its canonical id first — a
+   merged/legacy `center_on` id still resolves to the surviving person.
+   The center is always present in the response *unless it is hidden*, in
+   which case it (and anything reachable only through it) is dropped the
+   same way a hidden person is dropped anywhere else in the CRM — the
+   response can end up with zero nodes if the hidden person also has no
+   real relationships, but that isn't guaranteed for every hidden person.
+   If the center is filtered out this way, edges naming it are omitted too
+   (see Edge selection below).
 2. The center's strongest first-degree connections (degree 1) — up to
    `max_nodes - 1` when `depth=1`, or up to 75% of `max_nodes` when
    `depth >= 2` (see the next point for why). Ranked by the same value the
@@ -114,7 +118,11 @@ every relationship. Node selection:
    proxy, until `max_nodes` is reached. First-degree selection reserving
    ~25% of the budget for this tier (rather than consuming the whole budget
    itself) is what makes second-degree nodes actually appear for a
-   well-connected center.
+   well-connected center. A node that has a genuine direct relationship to
+   the center but missed the first-degree cut, and is then re-discovered
+   through a friend, is relabeled `degree: 1` (and given its own center
+   edge) rather than being shown as second-degree — `degree` always means
+   "has a direct edge to the center," not "was found in the first pass."
 
 A relationship row referencing a legacy (merged-away) person id is resolved
 to its canonical id before any of this ranking or de-duplication, so a
@@ -123,23 +131,36 @@ first-degree node with no edge back to the center.
 
 Edge selection: every edge connecting the center to a first-degree node is
 always included, regardless of `max_edges` — this is what guarantees every
-first-degree node has an edge to the center. The remaining edge budget
-(`max_edges` minus those center edges) is filled with the strongest
-remaining edges among the selected nodes, by the same rendered edge weight.
-Without this cap, the induced subgraph among a well-connected center's
-neighbors is close to complete (up to `max_nodes` choose 2 edges) — capping
-it means the strength slider's bottom end may show fewer inter-node edges
-than an uncapped response would have.
+first-degree node has an edge to the center — except when the center itself
+was dropped by the `category`/`min_strength` filters below, in which case no
+center edges are emitted (there is no center node left for them to connect
+to). The remaining edge budget (`max_edges` minus those center edges) is
+filled with the strongest remaining edges among the selected nodes, by the
+same rendered edge weight. Without this cap, the induced subgraph among a
+well-connected center's neighbors is close to complete (up to `max_nodes`
+choose 2 edges) — capping it means the strength slider's bottom end may
+show fewer inter-node edges than an uncapped response would have.
 
 `category`, if set, is applied during first-degree selection over a window
 of the 3×`max_nodes` strongest candidates (categories computed via the same
 batched source-entity lookup `GET /people` uses), then the top slots are
 taken from the survivors — best-effort: a category concentrated outside
 that window is under-represented in the result. Deeper-hop candidates use a
-cheaper per-person category check with no batched fetch. `min_strength` is
+cheaper per-person category check with no batched fetch. Every node's
+`category` field, and whether it survives this filter, both come from the
+same computation for that node (either the batched one during selection, or
+the cheap one otherwise) — an id is never selected under one category
+decision and then dropped, or kept, under a different one. `min_strength` is
 applied to already-selected nodes exactly as it always was — note it's
 currently a no-op in practice regardless of value, since it's validated to
 0.0–1.0 while `relationship_strength` is on a 0–100 scale.
+
+The Graph tab's own auto-selected strength-slider threshold
+(`calculateOptimalEdgeThreshold`) never picks a threshold that would hide
+every first-degree node, and returns 0 outright when every first-degree
+edge shares one weight (there's no discriminating threshold to pick in that
+case) — without this, bounding the edge set could put a real person's
+graph in a state where it rendered nothing at all on first load.
 
 Query parameters:
 

--- a/docs/specs/product/crm-graph.md
+++ b/docs/specs/product/crm-graph.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** CRM
-**Last Updated:** 2026-05-27
+**Last Updated:** 2026-09-04
 
 The D3 force-directed graph at `/crm` plus the multi-source `Relationship` model that backs it. Covers connection discovery, edge-weight calculation, source-filter UI, and the graph rendering itself.
 
@@ -83,7 +83,44 @@ D3-based force-directed graph that renders the selected person's network.
 - Clicking a node navigates to that person; hovering shows a tooltip with name and company.
 - Toggle the labels and reset-zoom controls in the toolbar.
 - Re-renders when the person selection changes.
-- Renders < 2s for ~30 nodes.
+- Renders in well under a second regardless of how large the underlying contact
+  graph is, because the server returns a bounded neighborhood rather than the
+  full relationship set (see Bounded Neighborhood below); the client-side
+  strength slider then further narrows that bounded set to the ~25 first-degree
+  nodes the graph is designed to display at once.
+
+### Bounded Neighborhood
+
+`GET /api/crm/network?center_on=<id>` (used by the Graph tab) never loads
+every relationship. Instead it selects:
+
+1. The center person (degree 0).
+2. Up to `max_nodes - 1` of the center's strongest first-degree connections
+   (default `max_nodes=150`), ranked by an indexed per-person query.
+3. For `depth=2` (the Graph tab's default), up to
+   `max_second_degree_per_node` (default `10`) of each first-degree node's
+   own strongest connections, added in first-degree strength order until
+   `max_nodes` is reached.
+
+Edges returned are the induced subgraph among exactly the selected nodes —
+every edge's endpoints are both present in the response, the center is
+always present, and every first-degree node has an edge to the center.
+"Strongest" for node *selection* is the sum of the relationship's
+shared-interaction counts (a cheap ranking proxy); the edge weight and
+strength values in the response are unchanged — computed the same way they
+always were.
+
+Query parameters:
+
+| Parameter | Range | Default | Meaning |
+|---|---|---|---|
+| `max_nodes` | 1–500 | 150 | Total nodes in the response, including the center |
+| `max_second_degree_per_node` | 0–50 | 10 | Second-(and deeper-)degree neighbors added per node at the previous depth |
+| `allow_full_graph` | bool | false | Opt-in to load every person and relationship (no `center_on`); ignores the two caps above |
+
+The Graph tab always passes `max_nodes` and `max_second_degree_per_node`
+explicitly at their defaults, so the bounded contract is visible in the
+request rather than implicit.
 
 **Graph enhancements:**
 
@@ -170,7 +207,7 @@ class RelationshipDetailResponse(BaseModel):
     weight: int = 0
 ```
 
-The network endpoint (`/api/crm/people/{id}/network`) includes the same breakdown per edge so the graph can filter and re-weight client-side.
+The network endpoint (`GET /api/crm/network?center_on={id}`) includes the same breakdown per edge so the graph can filter and re-weight client-side.
 
 ---
 

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -396,6 +396,145 @@ class TestNetworkGraph:
         assert response.status_code == 200
 
 
+class TestNetworkGraphPruning:
+    """Tests for the bounded/pruned centered neighborhood (#870)."""
+
+    def test_max_nodes_validation(self, client, sample_person_id):
+        """max_nodes outside 1..500 is rejected.
+
+        api/main.py's app-wide RequestValidationError handler converts
+        FastAPI's default 422 to 400 for all endpoints.
+        """
+        for value in (0, 501):
+            response = client.get(
+                f"/api/crm/network?center_on={sample_person_id}&max_nodes={value}"
+            )
+            assert response.status_code == 400
+
+    def test_max_second_degree_per_node_validation(self, client, sample_person_id):
+        """max_second_degree_per_node outside 0..50 is rejected (see above:
+        validation errors surface as 400, not 422, app-wide)."""
+        for value in (-1, 51):
+            response = client.get(
+                f"/api/crm/network?center_on={sample_person_id}"
+                f"&max_second_degree_per_node={value}"
+            )
+            assert response.status_code == 400
+
+    def test_response_never_exceeds_max_nodes(self, client, sample_person_id):
+        """The returned node count never exceeds max_nodes."""
+        response = client.get(
+            f"/api/crm/network?center_on={sample_person_id}&depth=2"
+            f"&max_nodes=20&max_second_degree_per_node=5"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["nodes"]) <= 20
+
+    def test_first_degree_nodes_are_strongest(self, client, sample_person_id):
+        """When a center has more first-degree connections than fit, the
+        returned first-degree nodes are the strongest ones."""
+        from api.services.relationship import get_relationship_store
+
+        rel_store = get_relationship_store()
+        top = rel_store.get_top_neighbors(sample_person_id, limit=3)
+        if len(top) < 3:
+            pytest.skip("Person has fewer than 3 relationships; can't test ordering")
+        expected_ids = {rel.other_person(sample_person_id) for rel in top}
+
+        response = client.get(
+            f"/api/crm/network?center_on={sample_person_id}&depth=1&max_nodes=4"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        returned_first_degree = {n["id"] for n in data["nodes"] if n["degree"] == 1}
+        assert returned_first_degree == expected_ids
+
+    def test_edge_closure_invariants(self, client, sample_person_id):
+        """Center present; every edge's endpoints are both in the node set;
+        every first-degree node has an edge to the center."""
+        response = client.get(
+            f"/api/crm/network?center_on={sample_person_id}&depth=2"
+            f"&max_nodes=50&max_second_degree_per_node=5"
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        node_ids = {n["id"] for n in data["nodes"]}
+        assert sample_person_id in node_ids
+
+        edge_pairs = set()
+        for edge in data["edges"]:
+            assert edge["source"] in node_ids
+            assert edge["target"] in node_ids
+            edge_pairs.add(frozenset((edge["source"], edge["target"])))
+
+        first_degree_ids = {n["id"] for n in data["nodes"] if n["degree"] == 1}
+        for fid in first_degree_ids:
+            assert frozenset((sample_person_id, fid)) in edge_pairs
+
+    def test_centered_request_never_loads_all_relationships(
+        self, client, sample_person_id, monkeypatch
+    ):
+        """A centered request must use the indexed neighbor/edge queries,
+        never RelationshipStore.get_all_relationships() (the 5+ second,
+        546k-row scan this issue exists to avoid)."""
+        from api.services.relationship import RelationshipStore
+
+        def _must_not_be_called(self, limit=None):
+            raise AssertionError(
+                "get_all_relationships() must not be called for a centered request"
+            )
+
+        monkeypatch.setattr(RelationshipStore, "get_all_relationships", _must_not_be_called)
+
+        response = client.get(f"/api/crm/network?center_on={sample_person_id}&depth=2")
+        assert response.status_code == 200
+
+    def test_allow_full_graph_still_calls_get_all_relationships(self, monkeypatch):
+        """The opt-in full-graph path is untouched: it still loads everything."""
+        from fastapi.testclient import TestClient
+        from api.services.relationship import RelationshipStore
+
+        calls = []
+        original = RelationshipStore.get_all_relationships
+
+        def _tracked(self, limit=None):
+            calls.append(1)
+            return original(self, limit=limit)
+
+        monkeypatch.setattr(RelationshipStore, "get_all_relationships", _tracked)
+
+        from api.main import app
+        response = TestClient(app).get("/api/crm/network?allow_full_graph=true")
+        assert response.status_code == 200
+        assert calls, "allow_full_graph=true should still call get_all_relationships()"
+
+
+class TestNetworkGraphLatency:
+    """Latency regression test for #870 - skips cleanly on a small/fresh dataset."""
+
+    def test_centered_depth2_under_500ms(self, client, sample_person_id):
+        """A centered depth=2 request completes in well under 500ms on the
+        production-sized dataset (the pre-#870 endpoint took 10+ seconds)."""
+        import time
+        from api.services.relationship import get_relationship_store
+
+        rel_store = get_relationship_store()
+        if rel_store.count() < 10000:
+            pytest.skip(
+                "Relationship table is too small to be a meaningful latency "
+                "check (not the production dataset)"
+            )
+
+        start = time.monotonic()
+        response = client.get(f"/api/crm/network?center_on={sample_person_id}&depth=2")
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert response.status_code == 200
+        assert elapsed_ms < 500, f"network graph took {elapsed_ms:.1f}ms (limit 500ms)"
+
+
 class TestRelationshipDetail:
     """Tests for relationship detail endpoint."""
 

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -451,6 +451,23 @@ class TestNetworkGraphPruning:
         data = response.json()
         assert len(data["nodes"]) <= 20
 
+    def test_response_reaches_max_nodes_for_a_well_connected_centre(self, client, sample_person_id):
+        """A centre with enough direct connections to fill the whole budget
+        on its own must actually get max_nodes back, not come back short
+        because the reserved second-degree share went unspent (#896 review
+        round 5, MINOR finding: backfill any leftover deeper-hop budget
+        from the next-strongest direct candidates)."""
+        from api.services.relationship import get_relationship_store
+
+        rel_store = get_relationship_store()
+        if len(rel_store.get_all_for_person(sample_person_id)) < 150:
+            pytest.skip("Person has fewer than 150 relationships; can't test the full-budget case")
+
+        response = client.get(f"/api/crm/network?center_on={sample_person_id}&depth=2")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["nodes"]) == 150
+
     def test_first_degree_nodes_are_the_true_top_n_by_rendered_weight(self, client, sample_person_id):
         """When a center has more first-degree connections than fit, the
         kept set equals the TRUE top-N by rendered edge weight — computed

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -421,6 +421,26 @@ class TestNetworkGraphPruning:
             )
             assert response.status_code == 400
 
+    def test_max_edges_validation(self, client, sample_person_id):
+        """max_edges outside 1..20000 is rejected (#896 review finding 2/4)."""
+        for value in (0, 20001):
+            response = client.get(
+                f"/api/crm/network?center_on={sample_person_id}&max_edges={value}"
+            )
+            assert response.status_code == 400
+
+    def test_edges_bounded_by_max_edges(self, client, sample_person_id):
+        """The edge count stays near max_edges — allowing for the fact that
+        every centre-touching edge is always included even if there are
+        more first-degree nodes than max_edges (#896 review finding 2/4)."""
+        response = client.get(
+            f"/api/crm/network?center_on={sample_person_id}&depth=2&max_edges=50"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        first_degree_count = sum(1 for n in data["nodes"] if n["degree"] == 1)
+        assert len(data["edges"]) <= max(50, first_degree_count)
+
     def test_response_never_exceeds_max_nodes(self, client, sample_person_id):
         """The returned node count never exceeds max_nodes."""
         response = client.get(
@@ -431,24 +451,59 @@ class TestNetworkGraphPruning:
         data = response.json()
         assert len(data["nodes"]) <= 20
 
-    def test_first_degree_nodes_are_strongest(self, client, sample_person_id):
+    def test_first_degree_nodes_are_the_true_top_n_by_rendered_weight(self, client, sample_person_id):
         """When a center has more first-degree connections than fit, the
-        returned first-degree nodes are the strongest ones."""
+        kept set equals the TRUE top-N by rendered edge weight — computed
+        independently here from every one of the center's relationship
+        rows, not by calling the endpoint's own ranking helper (#896 review
+        finding 5: the old version of this test compared against
+        RelationshipStore.get_top_neighbors(), the very function the
+        endpoint used to rank candidates, so it could not fail on a wrong
+        ranking). Skips cleanly without the real dataset."""
         from api.services.relationship import get_relationship_store
+        from api.services.person_entity import get_person_entity_store
+        from api.routes.crm import _rendered_edge_weight
+        from config.settings import settings
 
         rel_store = get_relationship_store()
-        top = rel_store.get_top_neighbors(sample_person_id, limit=3)
-        if len(top) < 3:
-            pytest.skip("Person has fewer than 3 relationships; can't test ordering")
-        expected_ids = {rel.other_person(sample_person_id) for rel in top}
+        person_store = get_person_entity_store()
+
+        raw_rels = rel_store.get_all_for_person(sample_person_id)
+        if len(raw_rels) < 5:
+            pytest.skip("Person has fewer than 5 relationships; can't test top-N ordering meaningfully")
+
+        all_people_dict = {p.id: p for p in person_store.get_all()}
+        my_person_id = person_store.get_canonical_id(settings.my_person_id)
+
+        # Independently compute the true top-N (canonicalised, de-duped,
+        # ranked by the exact rendered-weight formula) the same way a
+        # correct implementation must.
+        candidates: dict[str, float] = {}
+        for rel in raw_rels:
+            other_raw = rel.other_person(sample_person_id)
+            if not other_raw:
+                continue
+            other_canonical = person_store.get_canonical_id(other_raw)
+            if other_canonical == sample_person_id:
+                continue
+            weight = _rendered_edge_weight(
+                rel, sample_person_id, other_canonical, my_person_id, all_people_dict
+            )
+            if other_canonical not in candidates or weight > candidates[other_canonical]:
+                candidates[other_canonical] = weight
+
+        n = 5
+        expected_top_n = {
+            cid for cid, _ in sorted(candidates.items(), key=lambda kv: (-kv[1], kv[0]))[:n]
+        }
 
         response = client.get(
-            f"/api/crm/network?center_on={sample_person_id}&depth=1&max_nodes=4"
+            f"/api/crm/network?center_on={sample_person_id}&depth=1&max_nodes={n + 1}"
         )
         assert response.status_code == 200
         data = response.json()
-        returned_first_degree = {n["id"] for n in data["nodes"] if n["degree"] == 1}
-        assert returned_first_degree == expected_ids
+        returned_first_degree = {n_["id"] for n_ in data["nodes"] if n_["degree"] == 1}
+        assert returned_first_degree == expected_top_n
 
     def test_edge_closure_invariants(self, client, sample_person_id):
         """Center present; every edge's endpoints are both in the node set;
@@ -491,22 +546,22 @@ class TestNetworkGraphPruning:
         response = client.get(f"/api/crm/network?center_on={sample_person_id}&depth=2")
         assert response.status_code == 200
 
-    def test_allow_full_graph_still_calls_get_all_relationships(self, monkeypatch):
-        """The opt-in full-graph path is untouched: it still loads everything."""
-        from fastapi.testclient import TestClient
+    def test_allow_full_graph_still_calls_get_all_relationships(self, client, monkeypatch):
+        """The opt-in full-graph path is untouched: it still calls
+        get_all_relationships(). Stubbed to return [] instead of calling the
+        original so this runs in milliseconds rather than materializing the
+        full ~546k-edge graph in memory (#896 review finding 8)."""
         from api.services.relationship import RelationshipStore
 
         calls = []
-        original = RelationshipStore.get_all_relationships
 
-        def _tracked(self, limit=None):
+        def _stub(self, limit=None):
             calls.append(1)
-            return original(self, limit=limit)
+            return []
 
-        monkeypatch.setattr(RelationshipStore, "get_all_relationships", _tracked)
+        monkeypatch.setattr(RelationshipStore, "get_all_relationships", _stub)
 
-        from api.main import app
-        response = TestClient(app).get("/api/crm/network?allow_full_graph=true")
+        response = client.get("/api/crm/network?allow_full_graph=true")
         assert response.status_code == 200
         assert calls, "allow_full_graph=true should still call get_all_relationships()"
 

--- a/tests/test_crm_graph_flat_weight_ui_browser.py
+++ b/tests/test_crm_graph_flat_weight_ui_browser.py
@@ -152,3 +152,153 @@ def test_calculate_optimal_edge_threshold_flat_weight_returns_zero(page: Page, c
         }
     """)
     assert varied_threshold > 0
+
+
+# 200 first-degree weights, evenly spread across 9-35 (integers, so some
+# repeat) -- with this many candidates spread this way, the OLD
+# first-degree-only threshold search settles on percent=85 (verified by
+# simulating the algorithm directly), which maps to threshold 9+90*0.85=
+# 85.5 against the full 9-99 range used elsewhere -- excluding every one
+# of these edges (max is 35). The 27-edges-in-a-row fixture used earlier
+# in this file settles on a much lower percent and doesn't reproduce the
+# bug; this distribution is what actually triggers it, matching the
+# reviewer's real-data report (#896 review round 4, MINOR finding 3).
+_DIVERGING_FIRST_DEGREE_WEIGHTS = [round(9 + (35 - 9) * i / 199) for i in range(200)]
+
+
+def _diverging_weight_range_fixture():
+    """First-degree edges span 9-35 (200 of them, see above), but a
+    second-degree edge in the same response goes up to 99.
+    calculateOptimalEdgeThreshold() used to compute its weight range from
+    first-degree edges only, so the percent it chose could still exclude
+    every first-degree edge once applyGraphFilters() applied that same
+    percent against the FULL edge range."""
+    nodes = [{
+        "id": CENTER_ID, "name": "Center", "category": "personal",
+        "strength": 50, "interaction_count": 10, "degree": 0,
+    }]
+    edges = []
+    for i, weight in enumerate(_DIVERGING_FIRST_DEGREE_WEIGHTS):
+        node_id = f"n{i}"
+        nodes.append({
+            "id": node_id, "name": f"Person {i}", "category": "personal",
+            "strength": 50, "interaction_count": 5, "degree": 1,
+        })
+        edges.append({
+            "source": CENTER_ID, "target": node_id, "weight": weight,
+            "type": "inferred",
+            "shared_events_count": 1, "shared_threads_count": 0, "shared_messages_count": 0,
+            "shared_whatsapp_count": 0, "shared_slack_count": 0, "shared_phone_calls_count": 0,
+            "shared_photos_count": 0, "is_linkedin_connection": False,
+        })
+    # A second-degree node connected to a first-degree one by a much
+    # stronger edge - widens the FULL weight range to 99 without adding
+    # any first-degree edge above 35.
+    nodes.append({
+        "id": "second0", "name": "Second", "category": "personal",
+        "strength": 50, "interaction_count": 5, "degree": 2,
+    })
+    edges.append({
+        "source": "n0", "target": "second0", "weight": 99, "type": "inferred",
+        "shared_events_count": 1, "shared_threads_count": 0, "shared_messages_count": 0,
+        "shared_whatsapp_count": 0, "shared_slack_count": 0, "shared_phone_calls_count": 0,
+        "shared_photos_count": 0, "is_linkedin_connection": False,
+    })
+    return {"nodes": nodes, "edges": edges}
+
+
+def test_diverging_weight_ranges_still_renders_first_degree_nodes(page: Page, crm_base_url):
+    """First-degree edges (9-35) and the full edge set (9-99) diverge -
+    the auto-selected threshold must still leave first-degree nodes
+    visible on load, not just the centre."""
+    fixture = _diverging_weight_range_fixture()
+
+    def handler(route):
+        if "/api/crm/network" in route.request.url:
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps(fixture))
+        else:
+            route.fulfill(status=200, content_type="application/json", body="{}")
+
+    page.route("**/api/**", handler)
+    page.goto(f"{crm_base_url}/crm/{CENTER_ID}/graph")
+    page.wait_for_selector("#graphContainer")
+
+    page.evaluate("(id) => window.loadGraph(id)", CENTER_ID)
+    page.wait_for_timeout(300)
+
+    circle_count = page.locator("#graphContainer svg circle").count()
+    assert circle_count > 1, "expected first-degree nodes to render, not just the centre"
+
+
+def test_calculate_optimal_edge_threshold_uses_full_range_not_first_degree_only(page: Page, crm_base_url):
+    """The percent calculateOptimalEdgeThreshold() picks must remain valid
+    once applied against the SAME full-edge weight range
+    applyGraphFilters() actually uses - not a narrower first-degree-only
+    range computed internally and then discarded."""
+    page.goto(f"{crm_base_url}/crm/{CENTER_ID}/graph")
+    page.wait_for_function("typeof window.calculateOptimalEdgeThreshold === 'function'")
+
+    result = page.evaluate("""
+        (firstDegreeWeights) => {
+            const links = firstDegreeWeights.map((weight, i) => (
+                { source: 'center', target: 'n' + i, weight }
+            ));
+            links.push({ source: 'n0', target: 'second0', weight: 99 });
+
+            const percent = window.calculateOptimalEdgeThreshold([], links, 'center', 25);
+
+            // Reproduce applyGraphFilters()'s own threshold formula against
+            // the FULL edge set (matching getGraphWeightStats()) to check
+            // the chosen percent is actually usable.
+            const weights = links.map(l => l.weight);
+            const maxWeight = weights.reduce((a, b) => Math.max(a, b), 1);
+            const minWeight = weights.reduce((a, b) => Math.min(a, b), Infinity);
+            const weightRange = Math.max(1, maxWeight - minWeight);
+            const threshold = minWeight + weightRange * (percent / 100);
+
+            const firstDegreeEdges = links.filter(l => l.source === 'center' || l.target === 'center');
+            const visibleCount = firstDegreeEdges.filter(l => l.weight >= threshold).length;
+
+            return { percent, visibleCount };
+        }
+    """, _DIVERGING_FIRST_DEGREE_WEIGHTS)
+
+    assert result["visibleCount"] > 0, (
+        f"threshold derived from percent={result['percent']} excludes every first-degree edge"
+    )
+
+
+def test_apply_graph_filters_falls_back_when_manual_slider_would_blank_the_tab(page: Page, crm_base_url):
+    """Even if some future case still lets a bad percent through,
+    applyGraphFilters() itself must not render zero first-degree nodes -
+    dragging the slider to a percent that would exclude every first-degree
+    edge (100%, against the diverging 9-99 full range) must fall back to
+    showing everything instead."""
+    fixture = _diverging_weight_range_fixture()
+
+    def handler(route):
+        if "/api/crm/network" in route.request.url:
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps(fixture))
+        else:
+            route.fulfill(status=200, content_type="application/json", body="{}")
+
+    page.route("**/api/**", handler)
+    page.goto(f"{crm_base_url}/crm/{CENTER_ID}/graph")
+    page.wait_for_selector("#graphContainer")
+
+    page.evaluate("(id) => window.loadGraph(id)", CENTER_ID)
+    page.wait_for_timeout(300)
+
+    page.evaluate("""
+        () => {
+            const slider = document.getElementById('edgeStrengthSlider');
+            slider.value = 100;
+            slider.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+    """)
+    page.wait_for_timeout(300)
+
+    circle_count = page.locator("#graphContainer svg circle").count()
+    assert circle_count > 1, "applyGraphFilters() did not fall back to threshold 0"

--- a/tests/test_crm_graph_flat_weight_ui_browser.py
+++ b/tests/test_crm_graph_flat_weight_ui_browser.py
@@ -1,0 +1,154 @@
+"""Server-free browser test for the Graph tab's threshold auto-selection
+(#896 review round 3, blocker 1).
+
+`calculateOptimalEdgeThreshold()` used to pick a threshold that hid every
+first-degree node whenever every first-degree edge shared exactly one
+weight: forcing a minimum weightRange of 1 when maxWeight == minWeight made
+even the first non-zero sweep step (5%) exclude every edge. Bounding the
+returned edge set (#870/#896) made every returned edge cluster into a
+narrower set of weight values, so this pre-existing bug started firing for
+a real, common shape of response instead of a rare one -- a real person's
+Graph tab loaded and immediately showed "No connections match current
+filters" with zero user interaction.
+
+Unlike the rest of the browser suite this serves `web/` itself from an
+ephemeral port rather than pointing at a running API, because the
+assertion is about the JS in *this* checkout and every API call the page
+makes is intercepted anyway. That is why it carries no `requires_server`
+marker, and so runs at pre-push (`browser and not requires_server`). Keep
+it that way -- reaching for a live server here would silently drop this
+regression from the push gate.
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+CENTER_ID = "flat-weight-center"
+
+
+class _CrmHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the CRM SPA the way api/main.py does: any /crm/* path returns
+    crm.html; everything else falls through to web/ as static files."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path == "/" or path.startswith("/crm"):
+            return str(WEB_DIR / "crm.html")
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def crm_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _CrmHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _flat_weight_network_fixture(node_count=149):
+    """A `GET /api/crm/network` response shaped like the real one that
+    triggered this bug: more first-degree nodes than the ~25-node display
+    target, every one of them connected by an edge of the exact same
+    weight (a common case once the network-graph endpoint bounds edges to
+    the strongest N by weight -- ties at the boundary are common)."""
+    nodes = [{
+        "id": CENTER_ID, "name": "Center", "category": "personal",
+        "strength": 50, "interaction_count": 10, "degree": 0,
+    }]
+    edges = []
+    for i in range(node_count):
+        node_id = f"n{i}"
+        nodes.append({
+            "id": node_id, "name": f"Person {i}", "category": "personal",
+            "strength": 50, "interaction_count": 5, "degree": 1,
+        })
+        edges.append({
+            "source": CENTER_ID, "target": node_id, "weight": 9, "type": "inferred",
+            "shared_events_count": 1, "shared_threads_count": 0, "shared_messages_count": 0,
+            "shared_whatsapp_count": 0, "shared_slack_count": 0, "shared_phone_calls_count": 0,
+            "shared_photos_count": 0, "is_linkedin_connection": False,
+        })
+    return {"nodes": nodes, "edges": edges}
+
+
+def test_flat_weight_graph_still_renders_nodes(page: Page, crm_base_url):
+    """When every first-degree edge shares one weight, the auto-selected
+    threshold must not hide every node."""
+    fixture = _flat_weight_network_fixture()
+
+    def handler(route):
+        if "/api/crm/network" in route.request.url:
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps(fixture))
+        else:
+            route.fulfill(status=200, content_type="application/json", body="{}")
+
+    page.route("**/api/**", handler)
+    page.goto(f"{crm_base_url}/crm/{CENTER_ID}/graph")
+    page.wait_for_selector("#graphContainer")
+
+    # Drive the graph tab's real loading path directly (this test is only
+    # about calculateOptimalEdgeThreshold()'s interaction with the fixture
+    # above; it doesn't exercise the rest of the SPA's bootstrap -
+    # config/people-list/stats - which init() would otherwise need stubbed
+    # in full to complete without errors).
+    page.evaluate("(id) => window.loadGraph(id)", CENTER_ID)
+    page.wait_for_timeout(300)
+
+    circle_count = page.locator("#graphContainer svg circle").count()
+    empty_state_visible = page.locator("#graphContainer .empty-state").count() > 0
+
+    assert circle_count > 0, (
+        "Graph tab rendered zero nodes for a flat-weight response "
+        f"(empty-state shown: {empty_state_visible})"
+    )
+    # The center plus at least a handful of first-degree nodes - not just
+    # the bare minimum of one circle.
+    assert circle_count >= 10
+
+
+def test_calculate_optimal_edge_threshold_flat_weight_returns_zero(page: Page, crm_base_url):
+    """Direct unit-style check on the function itself, independent of the
+    rendering pipeline: a flat-weight edge set (more first-degree nodes
+    than the target) must resolve to threshold 0, not a percent that
+    excludes every edge."""
+    page.goto(f"{crm_base_url}/crm/{CENTER_ID}/graph")
+    page.wait_for_function("typeof window.calculateOptimalEdgeThreshold === 'function'")
+
+    threshold = page.evaluate("""
+        () => {
+            const links = [];
+            for (let i = 0; i < 149; i++) {
+                links.push({ source: 'center', target: 'n' + i, weight: 9 });
+            }
+            return window.calculateOptimalEdgeThreshold([], links, 'center', 25);
+        }
+    """)
+
+    assert threshold == 0
+
+    # Sanity: a varied weight distribution over the same shape still picks
+    # a non-trivial threshold - the fix isn't just "always return 0".
+    varied_threshold = page.evaluate("""
+        () => {
+            const links = [];
+            for (let i = 0; i < 149; i++) {
+                links.push({ source: 'center', target: 'n' + i, weight: i % 100 });
+            }
+            return window.calculateOptimalEdgeThreshold([], links, 'center', 25);
+        }
+    """)
+    assert varied_threshold > 0

--- a/tests/test_crm_graph_flat_weight_ui_browser.py
+++ b/tests/test_crm_graph_flat_weight_ui_browser.py
@@ -289,7 +289,12 @@ def test_apply_graph_filters_falls_back_when_manual_slider_would_blank_the_tab(p
     page.wait_for_selector("#graphContainer")
 
     page.evaluate("(id) => window.loadGraph(id)", CENTER_ID)
-    page.wait_for_timeout(300)
+    # updateEdgeVisibility debounces applyGraphFilters() by 500ms, so the
+    # slider-input handler below doesn't actually run applyGraphFilters()
+    # until ~500ms after the dispatched event - 300ms was too short and
+    # read the pre-change render, silently not exercising the fallback at
+    # all (#896 review round 5 nit). 1200ms gives comfortable margin.
+    page.wait_for_timeout(1200)
 
     page.evaluate("""
         () => {
@@ -298,7 +303,7 @@ def test_apply_graph_filters_falls_back_when_manual_slider_would_blank_the_tab(p
             slider.dispatchEvent(new Event('input', { bubbles: true }));
         }
     """)
-    page.wait_for_timeout(300)
+    page.wait_for_timeout(1200)
 
     circle_count = page.locator("#graphContainer svg circle").count()
     assert circle_count > 1, "applyGraphFilters() did not fall back to threshold 0"

--- a/tests/test_crm_network_graph_selection.py
+++ b/tests/test_crm_network_graph_selection.py
@@ -75,7 +75,17 @@ class _FakeRelationshipStore:
         )
 
 
-def _call_network_graph(person_store, rel_store, **overrides):
+class _FakeSourceEntityStore:
+    """Stands in for SourceEntityStore's batched category lookup."""
+
+    def __init__(self, sources_by_id: dict | None = None):
+        self._sources_by_id = sources_by_id or {}
+
+    def get_for_people_batch(self, canonical_person_ids, limit_per_person=50):
+        return {cid: self._sources_by_id.get(cid, []) for cid in canonical_person_ids}
+
+
+def _call_network_graph(person_store, rel_store, source_store=None, **overrides):
     """Call get_network_graph() directly with patched stores and sensible
     defaults for the query params it would otherwise get from FastAPI's
     Query(...) declarations."""
@@ -89,7 +99,8 @@ def _call_network_graph(person_store, rel_store, **overrides):
     kwargs.update(overrides)
 
     with patch("api.routes.crm.get_person_entity_store", return_value=person_store), \
-            patch("api.routes.crm.get_relationship_store", return_value=rel_store):
+            patch("api.routes.crm.get_relationship_store", return_value=rel_store), \
+            patch("api.routes.crm.get_source_entity_store", return_value=source_store or _FakeSourceEntityStore()):
         return get_network_graph(**kwargs)
 
 
@@ -342,3 +353,125 @@ class TestMaxEdgesAlwaysIncludesCentreEdges:
         edge_pairs = {frozenset((e.source, e.target)) for e in result.edges}
         assert frozenset(("a", "c")) in edge_pairs  # the stronger one
         assert frozenset(("a", "b")) not in edge_pairs  # the weaker one, dropped
+
+
+class TestCentreEdgeSkippedWhenCentreFiltered:
+    """#896 review round 3, MAJOR finding 3: emitting centre edges
+    unconditionally after only checking the OTHER endpoint broke edge
+    closure whenever the centre itself didn't survive the category/
+    min_strength filter."""
+
+    def test_no_edge_names_the_filtered_out_centre(self, monkeypatch):
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        # Centre has no work signal at all -> categorised "personal" and
+        # will be filtered out by category="work" below. The first-degree
+        # candidate has a "work" signal (slack) so it survives selection.
+        center = PersonEntity(id="center", canonical_name="Center")
+        first = PersonEntity(id="first", canonical_name="First", sources=["slack"])
+
+        center_rels = [Relationship(person_a_id="center", person_b_id="first", shared_events_count=5)]
+
+        person_store = _FakePersonStore(people_by_id={"center": center, "first": first})
+        rel_store = _FakeRelationshipStore(center_rels=center_rels)
+
+        result = _call_network_graph(
+            person_store, rel_store, depth=1, max_nodes=150, category="work",
+        )
+
+        node_ids = {n.id for n in result.nodes}
+        assert "center" not in node_ids  # filtered out, as intended
+        assert "first" in node_ids
+
+        for edge in result.edges:
+            assert edge.source in node_ids
+            assert edge.target in node_ids
+        assert not any("center" in (e.source, e.target) for e in result.edges)
+
+
+class TestDegreeRelabeling:
+    """#896 review round 3, MINOR finding 4: a node with a genuine direct
+    relationship to the centre must be labeled degree 1 (and get its centre
+    edge) even if the first-degree budget cut it and it was only
+    re-discovered through a friend -- `degree` must mean "has a direct edge
+    to the centre," not "was found in the first selection pass."""
+
+    def test_direct_neighbor_that_missed_the_cut_is_relabeled_degree_one(self, monkeypatch):
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        people = {"center": PersonEntity(id="center", canonical_name="Center")}
+        center_rels = []
+        # 8 genuine direct candidates; max_nodes=10 with depth>=2 caps
+        # first-degree at 75% = 7, so the weakest ("missed") gets excluded
+        # from the first pass despite having a real edge to the centre.
+        for i in range(8):
+            pid = f"first{i}" if i < 7 else "missed"
+            people[pid] = PersonEntity(id=pid, canonical_name=pid)
+            # Descending strength: first0 strongest, "missed" weakest.
+            center_rels.append(Relationship(
+                person_a_id="center", person_b_id=pid, shared_events_count=20 - i,
+            ))
+
+        # first0 (the strongest, definitely selected) is also directly
+        # connected to "missed" - this is how "missed" gets re-discovered
+        # as a second-degree candidate.
+        friend_rel = Relationship(person_a_id="first0", person_b_id="missed", shared_events_count=3)
+
+        person_store = _FakePersonStore(people_by_id=people)
+        rel_store = _FakeRelationshipStore(
+            center_rels=center_rels,
+            neighbor_rels_by_id={"first0": [friend_rel]},
+        )
+
+        result = _call_network_graph(
+            person_store, rel_store, depth=2, max_nodes=10, max_second_degree_per_node=5,
+        )
+
+        missed_node = next(n for n in result.nodes if n.id == "missed")
+        assert missed_node.degree == 1
+
+        edge_pairs = {frozenset((e.source, e.target)) for e in result.edges}
+        assert frozenset(("center", "missed")) in edge_pairs
+
+
+class TestCategoryPredicateConsistency:
+    """#896 review round 3, MINOR finding 5: selection used
+    compute_person_category() with batched source entities, while the
+    node-building filter re-checked with a different (raw attribute)
+    predicate -- a candidate could be selected under one decision and then
+    dropped under another. Fixed by having the node-building filter trust
+    an id already confirmed during selection instead of re-deriving a
+    possibly different answer."""
+
+    def test_candidate_confirmed_via_batched_sources_is_not_dropped_by_the_cheap_check(self, monkeypatch):
+        from api.services.source_entity import SourceEntity
+
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        # No email/sources signal of its own -- compute_person_category(p, [])
+        # (the cheap check) would call this "personal." Only the batched
+        # source-entity fetch (a Slack source entity) reveals "work."
+        candidate = PersonEntity(id="candidate", canonical_name="Candidate")
+        center = PersonEntity(id="center", canonical_name="Center")
+
+        center_rels = [Relationship(person_a_id="center", person_b_id="candidate", shared_events_count=5)]
+
+        person_store = _FakePersonStore(people_by_id={"center": center, "candidate": candidate})
+        rel_store = _FakeRelationshipStore(center_rels=center_rels)
+        source_store = _FakeSourceEntityStore(
+            sources_by_id={"candidate": [SourceEntity(source_type="slack")]}
+        )
+
+        # Sanity: the cheap and batched computations really do disagree for
+        # this fixture, or the test proves nothing.
+        from api.services.person_entity import compute_person_category
+        assert compute_person_category(candidate, []) != "work"
+        assert compute_person_category(candidate, [SourceEntity(source_type="slack")]) == "work"
+
+        result = _call_network_graph(
+            person_store, rel_store, source_store=source_store,
+            depth=1, max_nodes=150, category="work",
+        )
+
+        node_ids = {n.id for n in result.nodes}
+        assert "candidate" in node_ids

--- a/tests/test_crm_network_graph_selection.py
+++ b/tests/test_crm_network_graph_selection.py
@@ -248,7 +248,22 @@ class TestSecondDegreeTier:
         first-degree cut (re-discovered through a friend, then promoted
         back to degree 1 by the finding-4 relabelling), leaving nothing
         for genuine friends-of-friends on a dense centre. Fixed by skipping
-        ids already in all_direct_candidates during deeper-hop expansion."""
+        ids already in all_direct_candidates during deeper-hop expansion.
+
+        `max_second_degree_per_node=1` here is deliberate (#896 review round
+        5 nit): with a larger limit, a genuine friend can slip in on the
+        same first-degree node's turn even without the skip, since that
+        node's own budget covers both candidates - the earlier version of
+        this test passed regardless of whether the skip existed. With
+        limit=1, only ONE second-degree slot is even fetched per
+        first-degree node, so which one it is matters: the first 5
+        first-degree nodes here only know a "missed" direct candidate, and
+        the last 2 only know a genuine friend. Without the skip, the first
+        5 nodes' "missed" additions (later relabeled to degree 1, but only
+        after they've already occupied the reserved budget during
+        traversal) exhaust the 2-slot reserved budget before the 2
+        friend-only nodes are ever reached - so this only passes when the
+        skip is actually skipping."""
         monkeypatch.setattr(settings, "my_person_id", "nobody")
 
         people = {"center": PersonEntity(id="center", canonical_name="Center")}
@@ -263,17 +278,22 @@ class TestSecondDegreeTier:
                 person_a_id="center", person_b_id=pid, shared_events_count=30 - i,
             ))
 
-        # Each selected first-degree node also knows one of the "missed"
-        # direct candidates (the old bug's re-entry path) AND one genuine
-        # friend-of-friend who has no relationship with the centre at all.
+        # first0..first4 each know only ONE of the "missed" direct
+        # candidates (the old bug's re-entry path) - no genuine friend at
+        # all. first5/first6 each know only ONE genuine friend-of-friend
+        # who has no relationship with the centre at all.
         neighbor_rels_by_id = {}
-        for i in range(7):
+        for i in range(5):
             first_id = f"first{i}"
-            missed_id = f"missed{i % 5}"
+            missed_id = f"missed{i}"
+            neighbor_rels_by_id[first_id] = [
+                Relationship(person_a_id=first_id, person_b_id=missed_id, shared_events_count=10),
+            ]
+        for i in range(5, 7):
+            first_id = f"first{i}"
             friend_id = f"genuine_friend{i}"
             people[friend_id] = PersonEntity(id=friend_id, canonical_name=friend_id)
             neighbor_rels_by_id[first_id] = [
-                Relationship(person_a_id=first_id, person_b_id=missed_id, shared_events_count=10),
                 Relationship(person_a_id=first_id, person_b_id=friend_id, shared_events_count=9),
             ]
 
@@ -281,7 +301,7 @@ class TestSecondDegreeTier:
         rel_store = _FakeRelationshipStore(center_rels=center_rels, neighbor_rels_by_id=neighbor_rels_by_id)
 
         result = _call_network_graph(
-            person_store, rel_store, depth=2, max_nodes=10, max_second_degree_per_node=5,
+            person_store, rel_store, depth=2, max_nodes=10, max_second_degree_per_node=1,
         )
 
         degree2_ids = {n.id for n in result.nodes if n.degree == 2}
@@ -440,29 +460,41 @@ class TestCentreEdgeSkippedWhenCentreFiltered:
 
 
 class TestDegreeRelabeling:
-    """#896 review round 3, MINOR finding 4, as refined by round 4: `degree`
-    must mean "has a direct edge to the centre." Round 3 achieved this by
-    relabelling a direct connection that missed the first-degree cut back
-    to degree 1 if a friend happened to re-introduce it as "second-degree" -
-    but round 4 found that re-entry path was reclaiming the whole budget
-    reserved for genuine friends-of-friends on a dense centre. The deeper-hop
-    expansion now skips any id that's already a known direct connection of
-    the centre (see TestSecondDegreeTier's dense-centre test), so a missed
-    direct connection is no longer re-discoverable at all - it's simply
-    absent from a budget-constrained response, exactly like any other
-    candidate that didn't make the cut. `all_direct_candidates` is kept in
-    `api/routes/crm.py` as a relabelling backstop that should no longer be
-    reachable in practice; this test locks down the now-correct behavior
-    (absence, not relabelling) for the exact scenario round 3's test used."""
+    """#896 review round 3, MINOR finding 4, refined by rounds 4 and 5:
+    `degree` must mean "has a direct edge to the centre."
 
-    def test_direct_neighbor_that_missed_the_cut_is_simply_absent(self, monkeypatch):
+    Round 3 achieved this by relabelling a direct connection that missed
+    the first-degree cut back to degree 1 if a friend happened to
+    re-introduce it as "second-degree" - but round 4 found that re-entry
+    path was reclaiming the whole budget reserved for genuine
+    friends-of-friends on a dense centre, so deeper-hop expansion was
+    changed to skip any id already known to be a direct connection of the
+    centre (see TestSecondDegreeTier's dense-centre test) instead of
+    relying on relabelling to clean it up afterward.
+
+    Round 5 found that skip alone made a missed-cut direct connection
+    disappear from the response entirely whenever the reserved tier didn't
+    have a genuine friend-of-friend to spend its budget on - a real
+    first-degree person, shown by every prior version of this endpoint,
+    now simply absent even though there was room for them. The fix
+    backfills any leftover budget from the next-strongest direct
+    candidates (ranked, category-filtered the same way first-degree
+    selection was) instead of leaving those slots unused. `all_direct_candidates`'s
+    relabelling loop is kept in `api/routes/crm.py` as a backstop that
+    should no longer be reachable in practice; this test locks down the
+    backfill as the mechanism that brings a missed-cut direct connection
+    back, with degree 1 and its own centre edge - not a "second-degree"
+    relabel."""
+
+    def test_direct_neighbor_that_missed_the_cut_is_backfilled_as_degree_one(self, monkeypatch):
         monkeypatch.setattr(settings, "my_person_id", "nobody")
 
         people = {"center": PersonEntity(id="center", canonical_name="Center")}
         center_rels = []
         # 8 genuine direct candidates; max_nodes=10 with depth>=2 caps
         # first-degree at 75% = 7, so the weakest ("missed") gets excluded
-        # from the first pass despite having a real edge to the centre.
+        # from the first pass despite having a real edge to the centre -
+        # leaving 2 of the 10 slots unused (8 selected so far: centre + 7).
         for i in range(8):
             pid = f"first{i}" if i < 7 else "missed"
             people[pid] = PersonEntity(id=pid, canonical_name=pid)
@@ -471,26 +503,44 @@ class TestDegreeRelabeling:
                 person_a_id="center", person_b_id=pid, shared_events_count=20 - i,
             ))
 
-        # first0 (the strongest, definitely selected) is also directly
-        # connected to "missed" - this is the round-3 re-entry path, which
-        # must now be skipped rather than followed.
-        friend_rel = Relationship(person_a_id="first0", person_b_id="missed", shared_events_count=3)
-
         person_store = _FakePersonStore(people_by_id=people)
-        rel_store = _FakeRelationshipStore(
-            center_rels=center_rels,
-            neighbor_rels_by_id={"first0": [friend_rel]},
-        )
+        rel_store = _FakeRelationshipStore(center_rels=center_rels)
 
         result = _call_network_graph(
             person_store, rel_store, depth=2, max_nodes=10, max_second_degree_per_node=5,
         )
 
-        node_ids = {n.id for n in result.nodes}
-        assert "missed" not in node_ids
+        missed_node = next(n for n in result.nodes if n.id == "missed")
+        assert missed_node.degree == 1
 
         edge_pairs = {frozenset((e.source, e.target)) for e in result.edges}
-        assert frozenset(("center", "missed")) not in edge_pairs
+        assert frozenset(("center", "missed")) in edge_pairs
+
+    def test_backfill_does_not_exceed_max_nodes(self, monkeypatch):
+        """The backfill must still respect the overall cap - it fills
+        leftover slots, it doesn't add an unbounded number of extras."""
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        people = {"center": PersonEntity(id="center", canonical_name="Center")}
+        center_rels = []
+        # 20 direct candidates for a budget of only 10 (centre + 9) - no
+        # room for backfill at all; every remaining candidate must stay
+        # excluded.
+        for i in range(20):
+            pid = f"cand{i}"
+            people[pid] = PersonEntity(id=pid, canonical_name=pid)
+            center_rels.append(Relationship(
+                person_a_id="center", person_b_id=pid, shared_events_count=20 - i,
+            ))
+
+        person_store = _FakePersonStore(people_by_id=people)
+        rel_store = _FakeRelationshipStore(center_rels=center_rels)
+
+        result = _call_network_graph(
+            person_store, rel_store, depth=2, max_nodes=10, max_second_degree_per_node=5,
+        )
+
+        assert len(result.nodes) == 10
 
 
 class TestCategoryPredicateConsistency:

--- a/tests/test_crm_network_graph_selection.py
+++ b/tests/test_crm_network_graph_selection.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for GET /api/crm/network's centered-neighborhood selection logic
+(api/routes/crm.py::get_network_graph), using hand-built fixtures and
+patched stores rather than a running server or real data (#896 adversarial
+review of #870/PR #896).
+
+These call the route handler function directly (bypassing HTTP), following
+the pattern established in test_crm_people_list_batching.py for #880.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from api.services.person_entity import PersonEntity
+from api.services.relationship import Relationship
+from config.settings import settings
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeConn:
+    """Stands in for a sqlite3.Connection - closeable, otherwise unused."""
+
+    def close(self):
+        pass
+
+    def execute(self, *args, **kwargs):
+        raise AssertionError("fake connection should not be queried directly")
+
+
+class _FakePersonStore:
+    """Stands in for PersonEntityStore: a fixed people-by-canonical-id map
+    plus a legacy-id -> canonical-id merge map, matching the real
+    get_canonical_id()/get_by_id()/get_all() contracts the endpoint uses."""
+
+    def __init__(self, people_by_id: dict, merged_ids: dict | None = None):
+        self._people_by_id = people_by_id
+        self._merged_ids = merged_ids or {}
+
+    def get_canonical_id(self, person_id: str) -> str:
+        return self._merged_ids.get(person_id, person_id)
+
+    def get_by_id(self, person_id: str):
+        return self._people_by_id.get(self.get_canonical_id(person_id))
+
+    def get_all(self, include_hidden: bool = False, include_merged: bool = False):
+        return list(self._people_by_id.values())
+
+
+class _FakeRelationshipStore:
+    """Stands in for RelationshipStore for the centered-selection path:
+    a fixed set of the centre's own relationships, plus a per-node map for
+    the second-degree expansion's get_top_neighbors() calls."""
+
+    def __init__(self, center_rels=None, neighbor_rels_by_id=None, edges_among=None):
+        self._center_rels = center_rels or []
+        self._neighbor_rels_by_id = neighbor_rels_by_id or {}
+        self._edges_among = edges_among or []
+
+    def open_connection(self):
+        return _FakeConn()
+
+    def get_all_for_person(self, person_id, conn=None):
+        return list(self._center_rels)
+
+    def get_top_neighbors(self, person_id, limit, conn=None):
+        return list(self._neighbor_rels_by_id.get(person_id, []))[:limit]
+
+    def get_edges_among(self, person_ids):
+        return list(self._edges_among)
+
+    def get_all_relationships(self, limit=None):
+        raise AssertionError(
+            "get_all_relationships() must not be called for a centered request"
+        )
+
+
+def _call_network_graph(person_store, rel_store, **overrides):
+    """Call get_network_graph() directly with patched stores and sensible
+    defaults for the query params it would otherwise get from FastAPI's
+    Query(...) declarations."""
+    from api.routes.crm import get_network_graph
+
+    kwargs = dict(
+        center_on="center", depth=2, min_strength=0.0, category=None,
+        max_nodes=150, max_second_degree_per_node=10, max_edges=2000,
+        allow_full_graph=False,
+    )
+    kwargs.update(overrides)
+
+    with patch("api.routes.crm.get_person_entity_store", return_value=person_store), \
+            patch("api.routes.crm.get_relationship_store", return_value=rel_store):
+        return get_network_graph(**kwargs)
+
+
+class TestLegacyIdNeighbor:
+    """#896 review finding 1: a relationship row whose neighbor endpoint is
+    a merged-away (legacy) id must not produce a duplicate node id, must
+    still connect to the centre, and must compute the same edge weight as
+    the pre-#870 formula would for the same real-world pair."""
+
+    def test_unique_node_and_centre_edge_for_non_owner_pair(self, monkeypatch):
+        monkeypatch.setattr(settings, "my_person_id", "owner-not-in-graph")
+
+        center = PersonEntity(id="center", canonical_name="Center")
+        neighbor = PersonEntity(id="canonical-neighbor", canonical_name="Neighbor")
+
+        # The stored relationship row references the LEGACY id, not the
+        # canonical one - simulating an incompletely-migrated old merge.
+        legacy_rel = Relationship(
+            person_a_id="center", person_b_id="legacy-neighbor-id",
+            shared_events_count=3,
+        )
+
+        person_store = _FakePersonStore(
+            people_by_id={"center": center, "canonical-neighbor": neighbor},
+            merged_ids={"legacy-neighbor-id": "canonical-neighbor"},
+        )
+        rel_store = _FakeRelationshipStore(center_rels=[legacy_rel])
+
+        result = _call_network_graph(person_store, rel_store, depth=1)
+
+        node_ids = [n.id for n in result.nodes]
+        assert len(node_ids) == len(set(node_ids)), "duplicate node id"
+        assert "canonical-neighbor" in node_ids
+        assert "legacy-neighbor-id" not in node_ids
+
+        edge_pairs = {frozenset((e.source, e.target)) for e in result.edges}
+        assert frozenset(("center", "canonical-neighbor")) in edge_pairs
+
+        # Neither side is the owner, so the OLD formula (and the fixed one)
+        # both use pair_strength here - this pins that the edge is present
+        # and correctly weighted, not silently dropped.
+        matching = [e for e in result.edges
+                    if frozenset((e.source, e.target)) == frozenset(("center", "canonical-neighbor"))]
+        assert len(matching) == 1
+        assert matching[0].weight == legacy_rel.pair_strength
+
+    def test_owner_edge_weight_uses_canonical_relationship_strength(self, monkeypatch):
+        """The specific numeric bug from the review: looking up the OTHER
+        person by their legacy id in a canonical-keyed people dict misses
+        and silently falls back to pair_strength instead of their real
+        relationship_strength."""
+        monkeypatch.setattr(settings, "my_person_id", "owner-id")
+
+        owner = PersonEntity(id="owner-id", canonical_name="Owner")
+        neighbor = PersonEntity(id="canonical-neighbor", canonical_name="Neighbor")
+        neighbor.relationship_strength = 77.0
+
+        legacy_rel = Relationship(
+            person_a_id="owner-id", person_b_id="legacy-neighbor-id",
+            shared_events_count=1,
+        )
+        # Sanity: the fixture must actually distinguish the two formulas.
+        assert int(neighbor.relationship_strength) != legacy_rel.pair_strength
+
+        person_store = _FakePersonStore(
+            people_by_id={"owner-id": owner, "canonical-neighbor": neighbor},
+            merged_ids={"legacy-neighbor-id": "canonical-neighbor"},
+        )
+        rel_store = _FakeRelationshipStore(center_rels=[legacy_rel])
+
+        result = _call_network_graph(person_store, rel_store, center_on="owner-id", depth=1)
+
+        edge = next(
+            e for e in result.edges
+            if frozenset((e.source, e.target)) == frozenset(("owner-id", "canonical-neighbor"))
+        )
+        assert edge.weight == int(neighbor.relationship_strength)
+
+
+class TestSecondDegreeTier:
+    """#896 review finding 3: depth>=2 must still surface second-degree
+    nodes for a well-connected centre, instead of first-degree selection
+    silently consuming the whole max_nodes budget."""
+
+    def test_second_degree_nodes_appear_for_well_connected_centre(self, monkeypatch):
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        people = {"center": PersonEntity(id="center", canonical_name="Center")}
+        center_rels = []
+        neighbor_rels_by_id = {}
+        for i in range(7):
+            first_id = f"first{i}"
+            second_id = f"second{i}"
+            people[first_id] = PersonEntity(id=first_id, canonical_name=first_id)
+            people[second_id] = PersonEntity(id=second_id, canonical_name=second_id)
+            center_rels.append(Relationship(
+                person_a_id="center", person_b_id=first_id, shared_events_count=10 - i,
+            ))
+            neighbor_rels_by_id[first_id] = [Relationship(
+                person_a_id=first_id, person_b_id=second_id, shared_events_count=5,
+            )]
+
+        person_store = _FakePersonStore(people_by_id=people)
+        rel_store = _FakeRelationshipStore(center_rels=center_rels, neighbor_rels_by_id=neighbor_rels_by_id)
+
+        result = _call_network_graph(
+            person_store, rel_store, depth=2, max_nodes=10, max_second_degree_per_node=5,
+        )
+
+        degrees_present = {n.degree for n in result.nodes}
+        assert 2 in degrees_present, "expected at least one second-degree node"
+        assert len(result.nodes) <= 10
+
+        first_degree_count = sum(1 for n in result.nodes if n.degree == 1)
+        # 75% of max_nodes=10 -> 7, so first-degree must not consume all 9
+        # non-centre slots the old code would have given it.
+        assert first_degree_count <= 7
+
+    def test_depth_one_uses_full_budget_for_first_degree(self, monkeypatch):
+        """depth=1 has no deeper tier, so it should NOT apply the 75% split
+        -- first-degree gets the full remaining budget, matching pre-#896
+        behavior for a one-hop request."""
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        people = {"center": PersonEntity(id="center", canonical_name="Center")}
+        center_rels = []
+        for i in range(9):
+            first_id = f"first{i}"
+            people[first_id] = PersonEntity(id=first_id, canonical_name=first_id)
+            center_rels.append(Relationship(
+                person_a_id="center", person_b_id=first_id, shared_events_count=10 - i,
+            ))
+
+        person_store = _FakePersonStore(people_by_id=people)
+        rel_store = _FakeRelationshipStore(center_rels=center_rels)
+
+        result = _call_network_graph(person_store, rel_store, depth=1, max_nodes=10)
+
+        first_degree_count = sum(1 for n in result.nodes if n.degree == 1)
+        assert first_degree_count == 9  # all 9 candidates fit max_nodes-1
+
+
+class TestFirstDegreeRankedByRenderedWeight:
+    """#896 review finding 5: replaces the old circular test (which compared
+    the endpoint's output against get_top_neighbors, the very function it
+    used to rank candidates, so it could not fail on a wrong ranking).
+    Uses a hand-built fixture with a KNOWN correct order by the real
+    rendered edge weight, deliberately opposite the shared-count-sum proxy's
+    order, so a proxy-based implementation would fail this test."""
+
+    def test_ranks_by_pair_strength_not_shared_count_sum(self, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
+        monkeypatch.setattr(settings, "my_person_id", "nobody")  # pair_strength branch
+
+        now = datetime.now(timezone.utc)
+        # "bulk": huge raw shared-count sum (wins under the old proxy) but
+        # old and single-source -> LOW pair_strength.
+        bulk = Relationship(
+            person_a_id="center", person_b_id="bulk",
+            shared_slack_count=50, last_seen_together=now - timedelta(days=250),
+        )
+        # "recent": small raw count sum (loses under the old proxy) but
+        # very recent and multi-source -> HIGH pair_strength.
+        recent = Relationship(
+            person_a_id="center", person_b_id="recent",
+            shared_events_count=3, shared_phone_calls_count=3, last_seen_together=now,
+        )
+        # Sanity: the fixture actually inverts the two rankings, or this
+        # test would pass regardless of which one the code uses.
+        assert bulk.total_shared_interactions > recent.total_shared_interactions
+        assert recent.pair_strength > bulk.pair_strength
+
+        person_store = _FakePersonStore(people_by_id={
+            "center": PersonEntity(id="center", canonical_name="Center"),
+            "bulk": PersonEntity(id="bulk", canonical_name="Bulk"),
+            "recent": PersonEntity(id="recent", canonical_name="Recent"),
+        })
+        rel_store = _FakeRelationshipStore(center_rels=[bulk, recent])
+
+        # max_nodes=2 -> first_degree_limit = max_nodes-1 = 1 (depth=1), so
+        # only the true strongest by rendered weight survives.
+        result = _call_network_graph(
+            person_store, rel_store, depth=1, max_nodes=2, max_second_degree_per_node=0,
+        )
+
+        first_degree_ids = [n.id for n in result.nodes if n.degree == 1]
+        assert first_degree_ids == ["recent"]
+
+
+class TestMaxEdgesAlwaysIncludesCentreEdges:
+    """#896 review findings 2 and 4: max_edges bounds the TOTAL edges
+    returned, but every edge touching the centre is unconditionally
+    included even if that alone exceeds max_edges."""
+
+    def test_centre_edges_survive_a_tiny_max_edges(self, monkeypatch):
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        people = {"center": PersonEntity(id="center", canonical_name="Center")}
+        center_rels = []
+        for i in range(5):
+            first_id = f"first{i}"
+            people[first_id] = PersonEntity(id=first_id, canonical_name=first_id)
+            center_rels.append(Relationship(person_a_id="center", person_b_id=first_id, shared_events_count=1))
+
+        person_store = _FakePersonStore(people_by_id=people)
+        rel_store = _FakeRelationshipStore(center_rels=center_rels)
+
+        result = _call_network_graph(
+            person_store, rel_store, depth=1, max_nodes=150, max_edges=2,
+        )
+
+        # All 5 centre edges present despite max_edges=2.
+        assert len(result.edges) == 5
+        edge_pairs = {frozenset((e.source, e.target)) for e in result.edges}
+        for i in range(5):
+            assert frozenset(("center", f"first{i}")) in edge_pairs
+
+    def test_remaining_budget_fills_with_strongest_non_centre_edges(self, monkeypatch):
+        """Once every centre edge is included, the leftover max_edges budget
+        goes to the strongest remaining edges among the selected nodes, not
+        an arbitrary subset."""
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        people = {
+            "center": PersonEntity(id="center", canonical_name="Center"),
+            "a": PersonEntity(id="a", canonical_name="A"),
+            "b": PersonEntity(id="b", canonical_name="B"),
+            "c": PersonEntity(id="c", canonical_name="C"),
+        }
+        center_rels = [
+            Relationship(person_a_id="center", person_b_id="a", shared_events_count=1),
+            Relationship(person_a_id="center", person_b_id="b", shared_events_count=1),
+            Relationship(person_a_id="center", person_b_id="c", shared_events_count=1),
+        ]
+        # Two non-centre edges among a/b/c, different strengths.
+        weak = Relationship(person_a_id="a", person_b_id="b", shared_events_count=1)
+        strong = Relationship(person_a_id="a", person_b_id="c", shared_events_count=50)
+        assert strong.pair_strength > weak.pair_strength
+
+        person_store = _FakePersonStore(people_by_id=people)
+        rel_store = _FakeRelationshipStore(center_rels=center_rels, edges_among=[weak, strong])
+
+        # 3 centre edges + budget for exactly 1 more non-centre edge.
+        result = _call_network_graph(
+            person_store, rel_store, depth=1, max_nodes=150, max_edges=4,
+        )
+
+        assert len(result.edges) == 4
+        edge_pairs = {frozenset((e.source, e.target)) for e in result.edges}
+        assert frozenset(("a", "c")) in edge_pairs  # the stronger one
+        assert frozenset(("a", "b")) not in edge_pairs  # the weaker one, dropped

--- a/tests/test_crm_network_graph_selection.py
+++ b/tests/test_crm_network_graph_selection.py
@@ -242,6 +242,56 @@ class TestSecondDegreeTier:
         first_degree_count = sum(1 for n in result.nodes if n.degree == 1)
         assert first_degree_count == 9  # all 9 candidates fit max_nodes-1
 
+    def test_dense_centre_still_returns_genuine_second_degree_nodes(self, monkeypatch):
+        """#896 review round 4, MAJOR finding: the reserved second-degree
+        budget was being reclaimed by direct connections that missed the
+        first-degree cut (re-discovered through a friend, then promoted
+        back to degree 1 by the finding-4 relabelling), leaving nothing
+        for genuine friends-of-friends on a dense centre. Fixed by skipping
+        ids already in all_direct_candidates during deeper-hop expansion."""
+        monkeypatch.setattr(settings, "my_person_id", "nobody")
+
+        people = {"center": PersonEntity(id="center", canonical_name="Center")}
+        center_rels = []
+        # 12 genuine direct candidates - max_nodes=10 with depth>=2 caps
+        # first-degree at 7 (75%), so 5 of them ("missed0".."missed4")
+        # are real direct connections that just didn't rank high enough.
+        for i in range(12):
+            pid = f"first{i}" if i < 7 else f"missed{i - 7}"
+            people[pid] = PersonEntity(id=pid, canonical_name=pid)
+            center_rels.append(Relationship(
+                person_a_id="center", person_b_id=pid, shared_events_count=30 - i,
+            ))
+
+        # Each selected first-degree node also knows one of the "missed"
+        # direct candidates (the old bug's re-entry path) AND one genuine
+        # friend-of-friend who has no relationship with the centre at all.
+        neighbor_rels_by_id = {}
+        for i in range(7):
+            first_id = f"first{i}"
+            missed_id = f"missed{i % 5}"
+            friend_id = f"genuine_friend{i}"
+            people[friend_id] = PersonEntity(id=friend_id, canonical_name=friend_id)
+            neighbor_rels_by_id[first_id] = [
+                Relationship(person_a_id=first_id, person_b_id=missed_id, shared_events_count=10),
+                Relationship(person_a_id=first_id, person_b_id=friend_id, shared_events_count=9),
+            ]
+
+        person_store = _FakePersonStore(people_by_id=people)
+        rel_store = _FakeRelationshipStore(center_rels=center_rels, neighbor_rels_by_id=neighbor_rels_by_id)
+
+        result = _call_network_graph(
+            person_store, rel_store, depth=2, max_nodes=10, max_second_degree_per_node=5,
+        )
+
+        degree2_ids = {n.id for n in result.nodes if n.degree == 2}
+        assert degree2_ids, "expected at least one genuine second-degree node"
+        assert not any(nid.startswith("missed") for nid in degree2_ids), (
+            "a direct connection that missed the first-degree cut must never "
+            "be labeled degree 2"
+        )
+        assert any(nid.startswith("genuine_friend") for nid in degree2_ids)
+
 
 class TestFirstDegreeRankedByRenderedWeight:
     """#896 review finding 5: replaces the old circular test (which compared
@@ -390,13 +440,22 @@ class TestCentreEdgeSkippedWhenCentreFiltered:
 
 
 class TestDegreeRelabeling:
-    """#896 review round 3, MINOR finding 4: a node with a genuine direct
-    relationship to the centre must be labeled degree 1 (and get its centre
-    edge) even if the first-degree budget cut it and it was only
-    re-discovered through a friend -- `degree` must mean "has a direct edge
-    to the centre," not "was found in the first selection pass."""
+    """#896 review round 3, MINOR finding 4, as refined by round 4: `degree`
+    must mean "has a direct edge to the centre." Round 3 achieved this by
+    relabelling a direct connection that missed the first-degree cut back
+    to degree 1 if a friend happened to re-introduce it as "second-degree" -
+    but round 4 found that re-entry path was reclaiming the whole budget
+    reserved for genuine friends-of-friends on a dense centre. The deeper-hop
+    expansion now skips any id that's already a known direct connection of
+    the centre (see TestSecondDegreeTier's dense-centre test), so a missed
+    direct connection is no longer re-discoverable at all - it's simply
+    absent from a budget-constrained response, exactly like any other
+    candidate that didn't make the cut. `all_direct_candidates` is kept in
+    `api/routes/crm.py` as a relabelling backstop that should no longer be
+    reachable in practice; this test locks down the now-correct behavior
+    (absence, not relabelling) for the exact scenario round 3's test used."""
 
-    def test_direct_neighbor_that_missed_the_cut_is_relabeled_degree_one(self, monkeypatch):
+    def test_direct_neighbor_that_missed_the_cut_is_simply_absent(self, monkeypatch):
         monkeypatch.setattr(settings, "my_person_id", "nobody")
 
         people = {"center": PersonEntity(id="center", canonical_name="Center")}
@@ -413,8 +472,8 @@ class TestDegreeRelabeling:
             ))
 
         # first0 (the strongest, definitely selected) is also directly
-        # connected to "missed" - this is how "missed" gets re-discovered
-        # as a second-degree candidate.
+        # connected to "missed" - this is the round-3 re-entry path, which
+        # must now be skipped rather than followed.
         friend_rel = Relationship(person_a_id="first0", person_b_id="missed", shared_events_count=3)
 
         person_store = _FakePersonStore(people_by_id=people)
@@ -427,11 +486,11 @@ class TestDegreeRelabeling:
             person_store, rel_store, depth=2, max_nodes=10, max_second_degree_per_node=5,
         )
 
-        missed_node = next(n for n in result.nodes if n.id == "missed")
-        assert missed_node.degree == 1
+        node_ids = {n.id for n in result.nodes}
+        assert "missed" not in node_ids
 
         edge_pairs = {frozenset((e.source, e.target)) for e in result.edges}
-        assert frozenset(("center", "missed")) in edge_pairs
+        assert frozenset(("center", "missed")) not in edge_pairs
 
 
 class TestCategoryPredicateConsistency:

--- a/tests/test_person_entity.py
+++ b/tests/test_person_entity.py
@@ -459,67 +459,6 @@ class TestPersonEntityStore:
         result = temp_store.delete("fake-id")
         assert result is False
 
-    def test_get_by_ids_batch(self, temp_store):
-        """get_by_ids() returns a dict keyed by the requested ids (#870)."""
-        e1 = PersonEntity(canonical_name="Person One", emails=["one@test.com"])
-        e2 = PersonEntity(canonical_name="Person Two", emails=["two@test.com"])
-        temp_store.add(e1)
-        temp_store.add(e2)
-
-        result = temp_store.get_by_ids([e1.id, e2.id])
-
-        assert set(result.keys()) == {e1.id, e2.id}
-        assert result[e1.id].canonical_name == "Person One"
-        assert result[e2.id].canonical_name == "Person Two"
-
-    def test_get_by_ids_omits_missing(self, temp_store):
-        """An id with no matching entity is simply absent from the result."""
-        e1 = PersonEntity(canonical_name="Exists", emails=["exists@test.com"])
-        temp_store.add(e1)
-
-        result = temp_store.get_by_ids([e1.id, "does-not-exist"])
-
-        assert set(result.keys()) == {e1.id}
-
-    def test_get_by_ids_empty_input(self, temp_store):
-        """An empty id list returns an empty dict without querying."""
-        assert temp_store.get_by_ids([]) == {}
-
-    def test_get_by_ids_excludes_hidden_by_default(self, temp_store):
-        """Hidden entities are omitted unless include_hidden=True."""
-        entity = PersonEntity(canonical_name="Hidden Person", emails=["hidden@test.com"])
-        temp_store.add(entity)
-        temp_store.hide_person(entity.id, reason="test")
-
-        assert temp_store.get_by_ids([entity.id]) == {}
-        result = temp_store.get_by_ids([entity.id], include_hidden=True)
-        assert entity.id in result
-
-    def test_get_by_ids_follows_merge_chain(self, temp_store):
-        """A requested id that was merged into another resolves to the survivor."""
-        primary = PersonEntity(canonical_name="Primary", emails=["primary@test.com"])
-        temp_store.add(primary)
-        # Simulate a completed merge: the secondary id no longer has a row,
-        # but the merge map points it at the surviving primary.
-        temp_store._merged_ids["secondary-id"] = primary.id
-
-        result = temp_store.get_by_ids(["secondary-id"])
-
-        assert result["secondary-id"].id == primary.id
-
-    def test_get_by_ids_chunks_beyond_sqlite_variable_limit(self, temp_store):
-        """Correct results when the id list is larger than SQLite's default
-        999-variable limit, forcing the method to chunk its IN (...) queries."""
-        ids = []
-        for i in range(1200):
-            entity = PersonEntity(canonical_name=f"Person {i}", emails=[f"p{i}@test.com"])
-            temp_store.add(entity)
-            ids.append(entity.id)
-
-        result = temp_store.get_by_ids(ids)
-
-        assert set(result.keys()) == set(ids)
-
     def test_persistence(self, tmp_path):
         """Test that entities persist across store instances."""
         db_path = str(tmp_path / "test_persist.db")

--- a/tests/test_person_entity.py
+++ b/tests/test_person_entity.py
@@ -459,6 +459,67 @@ class TestPersonEntityStore:
         result = temp_store.delete("fake-id")
         assert result is False
 
+    def test_get_by_ids_batch(self, temp_store):
+        """get_by_ids() returns a dict keyed by the requested ids (#870)."""
+        e1 = PersonEntity(canonical_name="Person One", emails=["one@test.com"])
+        e2 = PersonEntity(canonical_name="Person Two", emails=["two@test.com"])
+        temp_store.add(e1)
+        temp_store.add(e2)
+
+        result = temp_store.get_by_ids([e1.id, e2.id])
+
+        assert set(result.keys()) == {e1.id, e2.id}
+        assert result[e1.id].canonical_name == "Person One"
+        assert result[e2.id].canonical_name == "Person Two"
+
+    def test_get_by_ids_omits_missing(self, temp_store):
+        """An id with no matching entity is simply absent from the result."""
+        e1 = PersonEntity(canonical_name="Exists", emails=["exists@test.com"])
+        temp_store.add(e1)
+
+        result = temp_store.get_by_ids([e1.id, "does-not-exist"])
+
+        assert set(result.keys()) == {e1.id}
+
+    def test_get_by_ids_empty_input(self, temp_store):
+        """An empty id list returns an empty dict without querying."""
+        assert temp_store.get_by_ids([]) == {}
+
+    def test_get_by_ids_excludes_hidden_by_default(self, temp_store):
+        """Hidden entities are omitted unless include_hidden=True."""
+        entity = PersonEntity(canonical_name="Hidden Person", emails=["hidden@test.com"])
+        temp_store.add(entity)
+        temp_store.hide_person(entity.id, reason="test")
+
+        assert temp_store.get_by_ids([entity.id]) == {}
+        result = temp_store.get_by_ids([entity.id], include_hidden=True)
+        assert entity.id in result
+
+    def test_get_by_ids_follows_merge_chain(self, temp_store):
+        """A requested id that was merged into another resolves to the survivor."""
+        primary = PersonEntity(canonical_name="Primary", emails=["primary@test.com"])
+        temp_store.add(primary)
+        # Simulate a completed merge: the secondary id no longer has a row,
+        # but the merge map points it at the surviving primary.
+        temp_store._merged_ids["secondary-id"] = primary.id
+
+        result = temp_store.get_by_ids(["secondary-id"])
+
+        assert result["secondary-id"].id == primary.id
+
+    def test_get_by_ids_chunks_beyond_sqlite_variable_limit(self, temp_store):
+        """Correct results when the id list is larger than SQLite's default
+        999-variable limit, forcing the method to chunk its IN (...) queries."""
+        ids = []
+        for i in range(1200):
+            entity = PersonEntity(canonical_name=f"Person {i}", emails=[f"p{i}@test.com"])
+            temp_store.add(entity)
+            ids.append(entity.id)
+
+        result = temp_store.get_by_ids(ids)
+
+        assert set(result.keys()) == set(ids)
+
     def test_persistence(self, tmp_path):
         """Test that entities persist across store instances."""
         db_path = str(tmp_path / "test_persist.db")

--- a/tests/test_relationship.py
+++ b/tests/test_relationship.py
@@ -366,6 +366,63 @@ class TestGetTopNeighbors:
         """A person with no relationships returns an empty list."""
         assert store.get_top_neighbors("lonely", limit=10) == []
 
+    def test_tied_scores_break_deterministically_by_id(self, store):
+        """Two relationships tied on the count-sum proxy resolve to a stable
+        order (by relationship id), not whatever order SQLite happens to
+        return (#896 review finding 9)."""
+        r1 = store.add(Relationship(person_a_id="center", person_b_id="tied1", shared_events_count=5))
+        r2 = store.add(Relationship(person_a_id="center", person_b_id="tied2", shared_events_count=5))
+        expected_order = sorted([r1.id, r2.id])
+
+        # Repeat a few times - a non-deterministic tiebreak would be free to
+        # vary across calls even against the same data.
+        for _ in range(3):
+            neighbors = store.get_top_neighbors("center", limit=10)
+            assert [r.id for r in neighbors] == expected_order
+
+    def test_shares_a_passed_in_connection(self, store):
+        """A caller-supplied `conn` is used (and left open) instead of the
+        store opening and closing its own (#896 review finding 11)."""
+        store.add(Relationship(person_a_id="center", person_b_id="other", shared_events_count=1))
+
+        conn = store.open_connection()
+        try:
+            neighbors = store.get_top_neighbors("center", limit=10, conn=conn)
+            assert len(neighbors) == 1
+            # Connection must still be usable - the store did not close it.
+            conn.execute("SELECT 1")
+        finally:
+            conn.close()
+
+
+class TestGetAllForPerson:
+    """Tests for RelationshipStore.get_all_for_person() (#896 review finding 5/10)."""
+
+    def test_returns_every_relationship_for_person_unordered(self, store):
+        """All relationships touching person_id come back, regardless of
+        which side of the row they're stored on."""
+        store.add(Relationship(person_a_id="center", person_b_id="a", shared_events_count=1))
+        store.add(Relationship(person_a_id="b", person_b_id="center", shared_events_count=2))
+        store.add(Relationship(person_a_id="x", person_b_id="y", shared_events_count=99))  # unrelated
+
+        rels = store.get_all_for_person("center")
+
+        others = {r.other_person("center") for r in rels}
+        assert others == {"a", "b"}
+
+    def test_no_relationships_returns_empty(self, store):
+        assert store.get_all_for_person("lonely") == []
+
+    def test_shares_a_passed_in_connection(self, store):
+        store.add(Relationship(person_a_id="center", person_b_id="other"))
+        conn = store.open_connection()
+        try:
+            rels = store.get_all_for_person("center", conn=conn)
+            assert len(rels) == 1
+            conn.execute("SELECT 1")  # still usable
+        finally:
+            conn.close()
+
 
 class TestGetEdgesAmong:
     """Tests for RelationshipStore.get_edges_among() (#870)."""
@@ -395,9 +452,12 @@ class TestGetEdgesAmong:
 
         assert len(edges) == 1
 
-    def test_chunks_beyond_sqlite_variable_limit(self, store):
+    def test_correct_with_more_ids_than_sqlite_variable_limit(self, store):
         """Correct results when the id set is larger than SQLite's default
-        999-variable limit, forcing the method to chunk its IN (...) queries."""
+        999-variable limit. The temp-table join this method uses (#896
+        review finding 4) has no `IN (...)` list at all, so there's no
+        chunking to reason about -- this just pins that a large id set
+        still works."""
         num_people = 1200
         ids = [f"person{i}" for i in range(num_people)]
 
@@ -417,3 +477,32 @@ class TestGetEdgesAmong:
             a, b = sorted([ids[i], ids[i + 1]])
             assert (a, b) in pairs
         assert not any("outsider" in pair for pair in pairs)
+
+    def test_shares_a_passed_in_connection(self, store):
+        """A caller-supplied `conn` is used (and left open) instead of the
+        store opening and closing its own (#896 review finding 11)."""
+        store.add(Relationship(person_a_id="a", person_b_id="b"))
+
+        conn = store.open_connection()
+        try:
+            edges = store.get_edges_among({"a", "b"}, conn=conn)
+            assert len(edges) == 1
+            conn.execute("SELECT 1")  # still usable
+        finally:
+            conn.close()
+
+    def test_two_calls_on_same_connection_do_not_collide(self, store):
+        """The temp table used internally is cleared/dropped between calls,
+        so reusing one connection for consecutive calls (as the network
+        endpoint does across its selection pass) doesn't leak stale rows."""
+        store.add(Relationship(person_a_id="a", person_b_id="b"))
+        store.add(Relationship(person_a_id="c", person_b_id="d"))
+
+        conn = store.open_connection()
+        try:
+            first = store.get_edges_among({"a", "b"}, conn=conn)
+            second = store.get_edges_among({"c", "d"}, conn=conn)
+            assert {(r.person_a_id, r.person_b_id) for r in first} == {("a", "b")}
+            assert {(r.person_a_id, r.person_b_id) for r in second} == {("c", "d")}
+        finally:
+            conn.close()

--- a/tests/test_relationship.py
+++ b/tests/test_relationship.py
@@ -315,3 +315,105 @@ class TestRelationshipStore:
         assert stats["by_type"][TYPE_COWORKER] == 1
         assert stats["by_type"][TYPE_FRIEND] == 1
         assert stats["avg_shared_interactions"] > 0
+
+
+class TestGetTopNeighbors:
+    """Tests for RelationshipStore.get_top_neighbors() (#870)."""
+
+    def test_orders_by_summed_shared_counts_desc(self, store):
+        """Strongest neighbor (highest summed shared counts) comes first."""
+        store.add(Relationship(person_a_id="center", person_b_id="weak", shared_events_count=1))
+        store.add(Relationship(person_a_id="center", person_b_id="strong", shared_events_count=20))
+        store.add(Relationship(person_a_id="center", person_b_id="medium", shared_messages_count=5))
+
+        neighbors = store.get_top_neighbors("center", limit=10)
+
+        assert [r.other_person("center") for r in neighbors] == ["strong", "medium", "weak"]
+
+    def test_works_regardless_of_person_a_or_b_position(self, store):
+        """A neighbor stored as person_a_id or person_b_id is found either way."""
+        # "center" ends up as person_a_id or person_b_id depending on
+        # lexicographic order - both must be found.
+        store.add(Relationship(person_a_id="aaa_center", person_b_id="zzz_other", shared_events_count=3))
+        store.add(Relationship(person_a_id="000_other", person_b_id="aaa_center", shared_events_count=7))
+
+        neighbors = store.get_top_neighbors("aaa_center", limit=10)
+
+        others = {r.other_person("aaa_center") for r in neighbors}
+        assert others == {"zzz_other", "000_other"}
+
+    def test_respects_limit(self, store):
+        """Only the top `limit` neighbors are returned."""
+        for i in range(5):
+            store.add(Relationship(
+                person_a_id="center", person_b_id=f"p{i}", shared_events_count=i + 1,
+            ))
+
+        neighbors = store.get_top_neighbors("center", limit=2)
+
+        assert len(neighbors) == 2
+        # Highest shared_events_count values are p4 (5) then p3 (4).
+        assert {r.other_person("center") for r in neighbors} == {"p4", "p3"}
+
+    def test_limit_zero_returns_empty(self, store):
+        """limit=0 (or negative) returns no rows without querying."""
+        store.add(Relationship(person_a_id="center", person_b_id="other", shared_events_count=1))
+
+        assert store.get_top_neighbors("center", limit=0) == []
+        assert store.get_top_neighbors("center", limit=-1) == []
+
+    def test_no_relationships_returns_empty(self, store):
+        """A person with no relationships returns an empty list."""
+        assert store.get_top_neighbors("lonely", limit=10) == []
+
+
+class TestGetEdgesAmong:
+    """Tests for RelationshipStore.get_edges_among() (#870)."""
+
+    def test_returns_only_edges_with_both_endpoints_in_set(self, store):
+        """An edge is included only when both its endpoints are in the set."""
+        store.add(Relationship(person_a_id="a", person_b_id="b"))  # both in set
+        store.add(Relationship(person_a_id="a", person_b_id="outside"))  # one in set
+        store.add(Relationship(person_a_id="outside1", person_b_id="outside2"))  # none in set
+
+        edges = store.get_edges_among({"a", "b"})
+
+        pairs = {(r.person_a_id, r.person_b_id) for r in edges}
+        assert pairs == {("a", "b")}
+
+    def test_empty_input_returns_empty(self, store):
+        """An empty id set returns no edges without querying."""
+        store.add(Relationship(person_a_id="a", person_b_id="b"))
+        assert store.get_edges_among(set()) == []
+
+    def test_dedupes_by_unordered_pair(self, store):
+        """Each unordered pair appears at most once even though the method
+        queries both person_a_id and person_b_id."""
+        store.add(Relationship(person_a_id="a", person_b_id="b"))
+
+        edges = store.get_edges_among({"a", "b"})
+
+        assert len(edges) == 1
+
+    def test_chunks_beyond_sqlite_variable_limit(self, store):
+        """Correct results when the id set is larger than SQLite's default
+        999-variable limit, forcing the method to chunk its IN (...) queries."""
+        num_people = 1200
+        ids = [f"person{i}" for i in range(num_people)]
+
+        # Chain them: person0-person1, person1-person2, ... so there are
+        # num_people - 1 edges, every one of which has both endpoints in `ids`.
+        for i in range(num_people - 1):
+            store.add(Relationship(person_a_id=ids[i], person_b_id=ids[i + 1]))
+
+        # Also add an edge to someone outside the set - must be excluded.
+        store.add(Relationship(person_a_id=ids[0], person_b_id="outsider"))
+
+        edges = store.get_edges_among(ids)
+
+        assert len(edges) == num_people - 1
+        pairs = {(r.person_a_id, r.person_b_id) for r in edges}
+        for i in range(num_people - 1):
+            a, b = sorted([ids[i], ids[i + 1]])
+            assert (a, b) in pairs
+        assert not any("outsider" in pair for pair in pairs)

--- a/tests/test_relationship.py
+++ b/tests/test_relationship.py
@@ -394,6 +394,32 @@ class TestGetTopNeighbors:
         finally:
             conn.close()
 
+    def test_only_hydrates_up_to_limit_relationships(self, store, monkeypatch):
+        """The ranking and LIMIT happen in SQL, so from_row() is called at
+        most `limit` times -- not once per relationship touching the
+        person. An earlier version of this method fetched every
+        relationship for the person via get_all_for_person() and ranked in
+        Python, which fixed the tiebreak but turned a bounded fetch into an
+        unbounded one on the network-graph endpoint's hottest path (#896
+        review round 3, BLOCKER 2: measured at ~39,600 Relationship
+        constructions for one real request, ~0.356s of a 0.549s response)."""
+        for i in range(50):
+            store.add(Relationship(person_a_id="center", person_b_id=f"p{i}", shared_events_count=i))
+
+        original_from_row = Relationship.from_row.__func__
+        calls = []
+
+        def _counting_from_row(cls, row):
+            calls.append(1)
+            return original_from_row(cls, row)
+
+        monkeypatch.setattr(Relationship, "from_row", classmethod(_counting_from_row))
+
+        neighbors = store.get_top_neighbors("center", limit=5)
+
+        assert len(neighbors) == 5
+        assert len(calls) == 5, f"expected exactly 5 Relationship.from_row() calls, got {len(calls)}"
+
 
 class TestGetAllForPerson:
     """Tests for RelationshipStore.get_all_for_person() (#896 review finding 5/10)."""

--- a/web/crm.html
+++ b/web/crm.html
@@ -16891,6 +16891,14 @@
             const weights = firstDegreeEdges.map(l => l.weight);
             const maxWeight = weights.reduce((a, b) => Math.max(a, b), 1);
             const minWeight = weights.reduce((a, b) => Math.min(a, b), Infinity);
+
+            // Every first-degree edge shares one weight - there's no
+            // discriminating threshold to pick, and forcing a minimum
+            // weightRange of 1 below would make even a 5% step exclude
+            // every edge (weight >= minWeight + 0.05), blanking the whole
+            // tab (#896 review round 3 finding 1).
+            if (maxWeight === minWeight) return 0;
+
             const weightRange = Math.max(1, maxWeight - minWeight);
 
             // Count first-degree nodes (excluding center)
@@ -16921,6 +16929,12 @@
                 });
 
                 const nodeCount = visibleNodes.size;
+
+                // Never pick a threshold that hides every first-degree
+                // node - being closer to the target count is worthless if
+                // the tab ends up blank (#896 review round 3 finding 1).
+                if (nodeCount === 0) break;
+
                 const diff = Math.abs(nodeCount - targetNodeCount);
 
                 if (diff < bestDiff) {

--- a/web/crm.html
+++ b/web/crm.html
@@ -16951,10 +16951,10 @@
 
             try {
                 // Use the network endpoint with depth=2 for second-degree connections.
-                // max_nodes/max_second_degree_per_node are passed explicitly at their
-                // server-side defaults so the bounded neighborhood contract is visible
-                // here rather than implicit (#870).
-                const data = await api(`/network?center_on=${personId}&depth=2&max_nodes=150&max_second_degree_per_node=10`);
+                // Only depth/center_on are sent - max_nodes/max_second_degree_per_node/
+                // max_edges are left to the server's own defaults so a future default
+                // change reaches the tab without a frontend edit (#896 review finding 12).
+                const data = await api(`/network?center_on=${personId}&depth=2`);
 
                 if (!data.nodes || data.nodes.length === 0) {
                     container.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🔗</div><p>No connections to visualize</p></div>';

--- a/web/crm.html
+++ b/web/crm.html
@@ -16887,16 +16887,23 @@
 
             if (firstDegreeEdges.length === 0) return 0;
 
-            // Get weights of first-degree edges
-            const weights = firstDegreeEdges.map(l => l.weight);
+            // Weight range comes from ALL links (matching getGraphWeightStats(),
+            // which is what applyGraphFilters() actually turns a percent back
+            // into a threshold with), not just the first-degree ones. Picking a
+            // percent against a narrower first-degree-only range and then
+            // applying it against the full range is how a real response (e.g.
+            // first-degree weights 9-35 but other edges up to 99) could still
+            // pick a percent that excludes every first-degree edge once
+            // applied (#896 review round 4, MINOR finding 3).
+            const weights = links.map(l => l.weight);
             const maxWeight = weights.reduce((a, b) => Math.max(a, b), 1);
             const minWeight = weights.reduce((a, b) => Math.min(a, b), Infinity);
 
-            // Every first-degree edge shares one weight - there's no
-            // discriminating threshold to pick, and forcing a minimum
-            // weightRange of 1 below would make even a 5% step exclude
-            // every edge (weight >= minWeight + 0.05), blanking the whole
-            // tab (#896 review round 3 finding 1).
+            // Every edge shares one weight - there's no discriminating
+            // threshold to pick, and forcing a minimum weightRange of 1 below
+            // would make even a 5% step exclude every edge (weight >=
+            // minWeight + 0.05), blanking the whole tab (#896 review round 3
+            // finding 1).
             if (maxWeight === minWeight) return 0;
 
             const weightRange = Math.max(1, maxWeight - minWeight);
@@ -18222,8 +18229,29 @@
                 // Get memoized weight stats from FULL dataset (avoids recalculating on every filter change)
                 const weightStats = getGraphWeightStats();
                 const { maxWeight, minWeight, weightRange } = weightStats;
-                const threshold = minWeight + (weightRange * (thresholdPercent / 100));
+                let threshold = minWeight + (weightRange * (thresholdPercent / 100));
                 const secondThreshold = minWeight + (weightRange * (secondThresholdPercent / 100));
+
+                // Safety net, independent of calculateOptimalEdgeThreshold()'s
+                // own correctness: if the threshold this slider position maps
+                // to would exclude every first-degree edge (e.g. the slider
+                // was dragged manually, or the first-degree and full weight
+                // ranges still diverge for some case not accounted for), fall
+                // back to showing everything rather than rendering a blank
+                // tab (#896 review round 4, MINOR finding 3).
+                const firstDegreeEdgesAll = graphLinksAll.filter(l => {
+                    if (!l) return false;
+                    const isFirstDegree = l.source === graphCenterId || l.target === graphCenterId;
+                    return isFirstDegree && edgeHasSelectedSource(l, selectedSources);
+                });
+                if (firstDegreeEdgesAll.length > 0 && !firstDegreeEdgesAll.some(l => l.weight >= threshold)) {
+                    threshold = minWeight;
+                    if (slider) {
+                        slider.value = 0;
+                        const sliderLabel = document.getElementById('edgeStrengthValue');
+                        if (sliderLabel) sliderLabel.textContent = '0%';
+                    }
+                }
 
                 // Build node lookup by ID from ORIGINAL data
                 const nodeById = {};

--- a/web/crm.html
+++ b/web/crm.html
@@ -16950,8 +16950,11 @@
             container.innerHTML = '<div class="loading">Loading graph...</div>';
 
             try {
-                // Use the network endpoint with depth=2 for second-degree connections
-                const data = await api(`/network?center_on=${personId}&depth=2`);
+                // Use the network endpoint with depth=2 for second-degree connections.
+                // max_nodes/max_second_degree_per_node are passed explicitly at their
+                // server-side defaults so the bounded neighborhood contract is visible
+                // here rather than implicit (#870).
+                const data = await api(`/network?center_on=${personId}&depth=2&max_nodes=150&max_second_degree_per_node=10`);
 
                 if (!data.nodes || data.nodes.length === 0) {
                     container.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🔗</div><p>No connections to visualize</p></div>';


### PR DESCRIPTION
## TL;DR

Opening a person's Graph tab used to take 10+ seconds and download up to 166MB of JSON, because the server loaded every one of the 546,000+ relationship rows in the database on every request and filtered them in Python — even though the graph only ever shows about 25-150 people at once. The endpoint now looks up just the strongest connections around the person being viewed, using indexed queries, and returns only those. On the real dataset this cuts the request to a fraction of a second under normal load and the payload to under 1MB, with no visible change to how the graph looks or behaves. Three adversarial review rounds found real correctness and performance problems in earlier versions of this change (including a version that could render a real person's Graph tab completely blank on load, and one that silently stopped returning second-degree connections again); all are fixed and locked down with regression tests. The fourth review round approved with minor nits, all addressed below.

Closes #870

## Design

- The network-graph endpoint, when centered on a person, selects a bounded neighborhood instead of loading the full relationship table: the center person, the strongest first-degree connections up to a node cap, and (for the default two-hop view) a bounded number of each first-degree connection's own strongest connections — with roughly a quarter of the node budget reserved for that second tier so it doesn't get crowded out by a well-connected center. That reserved budget only ever goes to genuine friends-of-friends — a direct connection of the center that missed the first-degree cut is never counted against it.
- First-degree candidates are ranked by the exact same value the response renders as edge weight (not a cheaper proxy), so "strongest" in the response matches what a person would see if they inspected every edge by hand. Deeper-hop candidates use a cheaper shared-interaction-count proxy, ranked and limited in SQL so the cost stays bounded regardless of how many relationships an intermediate person has.
- Every id coming out of the raw relationship table — including the center's own id — is resolved to its canonical (current, non-merged) person id before it's used for ranking, de-duplication, or lookup.
- A `max_edges` parameter (default 2000) bounds the response's edge count: every edge connecting the center to a first-degree person is always included (unless the center itself didn't survive a category/strength filter), and the remaining budget goes to the strongest other edges among the selected people.
- `degree` always means "has a direct edge to the center" — a person who has one is never mislabeled as a friend-of-a-friend.
- `category`, when set, uses one consistent categorization decision for both selecting candidates and building the final response, so a person is never selected under one answer and dropped under another. This also applies to the opt-in full-graph mode: `allow_full_graph=true` combined with `category` now filters everyone by the same dynamically-computed category the response displays for them, rather than their raw stored category field — more self-consistent than before, and the one externally-visible behavior change to that otherwise-untouched path.
- The Graph tab's own client-side auto-threshold logic no longer picks a threshold that hides every node — neither when the returned edges happen to share one weight, nor when the first-degree and full edge weight ranges diverge enough that a percent chosen against one excludes everything once applied against the other. A second, independent safety net falls back to showing everything if a computed threshold would still leave nothing visible.
- The full-graph, non-centered mode (`allow_full_graph=true`) is otherwise untouched — it still loads everything, as before, and remains opt-in.
- The Graph tab's request states only what it needs (`center_on`, `depth`); every cap is left at the server's default.

## Implementation Notes

- `api/services/relationship.py`:
  - `RelationshipStore.get_all_for_person(person_id, conn=None)` — every relationship row touching a person, indexed, unordered/unlimited; used for the center's own candidate set, which needs every row to rank by the real edge-weight formula.
  - `RelationshipStore.get_top_neighbors(person_id, limit, conn=None)` — ranks and limits in SQL (explicit column list via `_RELATIONSHIP_COLUMNS`, `ORDER BY <shared-interaction count sum> DESC, id LIMIT ?`), so only the rows actually returned are ever hydrated into `Relationship` objects, with a deterministic tiebreak and no dependence on the table's physical column order.
  - `RelationshipStore.get_edges_among(person_ids, conn=None)` — joins through a temp table instead of two `person_a_id`/`person_b_id IN (...)` scans, which for a well-connected center previously fetched tens of thousands of irrelevant rows; cleanup is wrapped in `contextlib.suppress(sqlite3.Error)` so it can't mask a real exception.
  - `RelationshipStore.open_connection()` — lets a caller share one connection across a whole selection pass instead of opening one per query.
- `api/routes/crm.py`:
  - `get_network_graph()`: `center_on` is canonicalized immediately after the initial lookup. First-degree candidates come from one `get_all_for_person(center_on)` call, canonicalized and de-duped, ranked by `_rendered_edge_weight()` (the exact formula the response uses for edge weight), capped at 75% of `max_nodes` when `depth >= 2`. The center-to-first-degree edges are built directly from those same relationship rows. Deeper-hop expansion skips any id already known to be a direct connection of the center, so the reserved second-degree budget goes to genuine friends-of-friends; a small relabeling pass is kept as a correctness backstop (should be unreachable in the normal case now). `category` filtering uses one shared decision (`category_confirmed_ids`) for both selection and the final node filter, and this same computed-category predicate is what the non-centered/full-graph path's filter now uses too. Center-touching edges are only emitted when the center itself is present in the final node set.
  - `_rendered_edge_weight()` / `_build_network_edge()`: extracted helpers shared between ranking and edge construction.
- `web/crm.html`:
  - `loadGraph()` sends only `center_on` and `depth`.
  - `calculateOptimalEdgeThreshold()` returns 0 when every first-degree edge shares one weight, never accepts a percent that leaves zero first-degree nodes visible, and computes its weight range from the full edge set (matching what `applyGraphFilters()`/`getGraphWeightStats()` actually use) rather than a first-degree-only range that could diverge from it.
  - `applyGraphFilters()` falls back to threshold 0 if the threshold it's about to apply would exclude every first-degree edge — a second line of defense independent of the auto-threshold calculation above.
- `docs/specs/product/crm-graph.md`: describes the 75/25 depth split (and that the reserved tier is protected from direct-connection reclaim), `max_edges`'s always-include-center-edges behavior (and the filtered-center exception), the category best-effort window and its single-predicate guarantee (centered and full-graph paths both), the corrected latency claim, and the hidden/merged-center cases precisely.
- `docs/specs/product/api-crm.md`: documents `max_nodes`, `max_second_degree_per_node`, and `max_edges` with their ranges/defaults, and notes the pre-existing `min_strength` scale issue (left alone, as directed).

## Test evidence

### Automated tests

```
HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_relationship.py tests/test_person_entity.py tests/test_crm_network_graph_selection.py tests/test_crm_graph_flat_weight_ui_browser.py -q
============================= test session starts ==============================
collected 92 items
tests/test_relationship.py ...................................            [ 38%]
tests/test_person_entity.py .........................................    [ 82%]
tests/test_crm_network_graph_selection.py ...........                    [ 94%]
tests/test_crm_graph_flat_weight_ui_browser.py .....                     [100%]
============================= 92 passed in ~21-28s ==============================
```

```
HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_crm_api.py -q -k Network
============================= test session starts ==============================
collected 53 items / 40 deselected / 13 selected
tests/test_crm_api.py .............                                      [100%]
====================== 13 passed, 40 deselected ================================
```

Coverage by concern:
- **Store correctness** (`tests/test_relationship.py`): `get_top_neighbors` ordering/limit/tiebreak/shared-connection, including a regression test counting `Relationship.from_row()` calls to prove it never hydrates more than `limit` rows; `get_all_for_person` and `get_edges_among` (temp-table join) correctness, including 1,200 synthetic ids and no state leak across two calls on one connection.
- **Handler selection logic, hand-built fixtures, no real data needed** (`tests/test_crm_network_graph_selection.py`, calling the route handler directly with patched stores):
  - `TestLegacyIdNeighbor` — unique node, guaranteed center edge, correct weight for a legacy-id neighbor.
  - `TestSecondDegreeTier` — a well-connected synthetic center gets both tiers at `depth=2`, the full budget at `depth=1`, **and** (new) a dense-centre test asserting genuine friends-of-friends still surface as degree-2 nodes even when several direct connections miss the first-degree cut and are reachable through the same first-degree nodes.
  - `TestFirstDegreeRankedByRenderedWeight` — a fixture where the shared-count-sum proxy and the real weight deliberately disagree; the endpoint follows the real weight.
  - `TestMaxEdgesAlwaysIncludesCentreEdges` — center edges always survive a tiny `max_edges`; the remaining budget goes to the strongest non-center edge.
  - `TestCentreEdgeSkippedWhenCentreFiltered` — a category filter that excludes the center leaves no edge naming it.
  - `TestDegreeRelabeling` — updated this round: a direct neighbor that misses the first-degree cut and would previously have been re-discovered through a friend is now simply absent from the response, not relabeled — the re-entry path itself is what's now skipped.
  - `TestCategoryPredicateConsistency` — a candidate confirmed "work" only via batched source entities is not dropped by a cheaper re-check.
- **API-level, real staging data, skip cleanly without it** (`tests/test_crm_api.py::TestNetworkGraphPruning` / `TestNetworkGraphLatency`): cap validation, node/edge caps respected, edge-closure invariants, `get_all_relationships()` never called for a centered request (and still called, via a stub, for the opt-in full-graph path), the true-top-N-by-rendered-weight check against independently-recomputed real data, and the depth=2 latency check.
- **Server-free browser tests** (`tests/test_crm_graph_flat_weight_ui_browser.py`): a flat-weight fixture (149 first-degree edges, all one weight) confirmed failing against the pre-round-3 `calculateOptimalEdgeThreshold` and passing against the fix; a diverging-range fixture (200 first-degree edges spread 9-35, one second-degree edge at 99 — reproducing the round-4 reviewer's real-data shape) confirmed failing against the pre-round-4 JS (percent=85 chosen against the narrow range → threshold 85.5 against the full range → 0 visible) and passing against the fix, plus a direct check of `applyGraphFilters()`'s own fallback when the slider is manually dragged to a percent that would otherwise blank the tab.

### Manual verification

In-process measurements (`TestClient`, no HTTP/network overhead) on the real staging dataset:

| Request | Before #870 | After round 1 | After round 2 | After round 3 | After round 4 |
|---|---|---|---|---|---|
| owner, depth=2 | 12.0-17.4s, up to 166MB | ~1.45-1.68s | 272-470ms | 222-470ms | unchanged (round 4 touched selection/frontend logic, not the hot path) |
| a 564-relationship test center, depth=2 | — | — | 1.1-1.4s (structural regression) | 222-375ms | unchanged |

This machine is shared with several sibling implementer/review agents also running full test suites concurrently this session; `uptime` load average ranged from ~4 to over 30 during this work.

**Degree-2 histogram, mid-strength centre, `depth=2`, real data:** `{0: 1, 1: 149}` at the round-3 head (the round-4 bug — the reserved budget was being reclaimed) → **`{0: 1, 1: 112, 2: 37}`** after this round's fix, matching round 3's own numbers again.

**Browser verification (mandatory, Playwright against staging with real data)**, repeated after each rebase (five total; integration branch advanced under sibling PRs #880/#887/#893/#895/#897/#898/#900/#903): the owner's and a mid-strength non-owner's Graph tabs render with 0 console errors attributable to the graph code (one unrelated pre-existing `503` from `/api/photos/profile/{id}` — no Immich configured in staging) at every rebase. This round: confirmed the mid-strength centre's second-degree nodes visibly render again when the degree filter/second-degree slider are used (2 degree-2 circles appeared), and re-confirmed no blank-tab regression on load for both centres.

**Not added:** a full-D3-rendering server-free test beyond the flat-weight/diverging-range fixtures above. The rest of the graph's D3 rendering pipeline is untouched by this PR; these tests specifically target the client-side threshold logic this PR's own changes made newly relevant. Broader D3 rendering coverage is a larger, separate undertaking (`web/crm.html`'s graph code depends on D3 v7 from an external CDN with no vendored copy).

### Existing test suite

Pre-push gate (full unit suite + server-free browser tests) on the final pushed commit (`19db1d9`): **5740 passed, 8 skipped, 0 failed** (unit); **269 passed** (browser).

Along the way, this branch's rebases onto the advancing `feat/crm-performance` integration branch inherited (and, once, briefly conflicted with) sibling PRs' own changes to shared files (`api/services/person_entity.py`'s `get_by_ids` from #897 collided textually with an identically-named, differently-shaped method this PR had added and later removed — resolved by keeping #897's version, which is what the rest of the codebase now uses) and a pre-existing #880/#893 test failure, already fixed upstream before this branch needed it. No test in this PR's own scope was ever weakened, skipped, or deleted without being replaced by a stronger version; `TestDegreeRelabeling`'s single test was updated in place this round to assert the new, correct behavior (see above) rather than removed.

## Review focus

- `_rendered_edge_weight()`'s canonicalization of both relationship-row endpoints (`api/routes/crm.py`) — the fix for round 1's blocker; the numeric example in that review is worth re-checking against the current code.
- The 75%/25% first-degree/second-degree split and the "skip known direct connections during deeper-hop expansion" fix (`api/routes/crm.py`, `first_degree_limit` / the `if other_canonical in all_direct_candidates` check) — fixed ratios and a skip-list rather than a single unified selection; flag if this should be restructured.
- `RelationshipStore.get_top_neighbors`'s SQL-side `ORDER BY` expression — computes the shared-interaction sum inline rather than via a stored/indexed column, so it's not itself index-accelerated; bounded by the indexed `WHERE` clause narrowing to one person's rows first, but worth confirming that's sufficient headroom for the highest-degree people in this dataset.
- The category best-effort window (3×`max_nodes`) and the `category_confirmed_ids` trust mechanism (`api/routes/crm.py`) — flag if a category concentrated further down the ranked list, or a category check disagreement for a non-confirmed id, needs different handling.
- Whether the `min_strength` 0-1-vs-0-100 scale issue (documented, left alone, pre-existing) should get its own follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqMhBfLUGZ5cKuqyWe5iqD
