### PR TITLE
fix(people): bound people search results and batch the recency lookup

### DIFF
--- a/api/routes/people.py
+++ b/api/routes/people.py
@@ -47,6 +47,7 @@ class SearchResponse(BaseModel):
     people: list[PersonResponse]
     count: int
     query: str
+    total: Optional[int] = None
 
 
 class StatisticsResponse(BaseModel):
@@ -92,7 +93,11 @@ class InteractionsResponse(BaseModel):
     formatted_history: str = ""
 
 
-def _entity_to_response(entity, include_channels: bool = True) -> PersonResponse:
+def _entity_to_response(
+    entity,
+    include_channels: bool = True,
+    precomputed_recency: Optional[dict[str, datetime]] = None,
+) -> PersonResponse:
     """
     Convert PersonEntity to API response.
 
@@ -100,6 +105,11 @@ def _entity_to_response(entity, include_channels: bool = True) -> PersonResponse
         entity: PersonEntity to convert
         include_channels: If True, fetch active_channels from InteractionStore.
                          Set to False for bulk operations to improve performance.
+        precomputed_recency: If given, use this source_type -> last-interaction
+                         datetime map instead of querying InteractionStore for
+                         this entity. Lets callers batch the recency lookup for
+                         a whole page of results with one query instead of one
+                         per person. Ignored when include_channels is False.
     """
     # Basic fields from entity
     response = PersonResponse(
@@ -135,8 +145,11 @@ def _entity_to_response(entity, include_channels: bool = True) -> PersonResponse
     # Fetch active channels if requested (uses new get_last_interaction_by_source)
     if include_channels and entity.id:
         try:
-            interaction_store = get_interaction_store()
-            recency_by_source = interaction_store.get_last_interaction_by_source(entity.id)
+            if precomputed_recency is not None:
+                recency_by_source = precomputed_recency
+            else:
+                interaction_store = get_interaction_store()
+                recency_by_source = interaction_store.get_last_interaction_by_source(entity.id)
 
             now = datetime.now(timezone.utc)
             active = []
@@ -157,36 +170,56 @@ def _entity_to_response(entity, include_channels: bool = True) -> PersonResponse
 @router.get("/search", response_model=SearchResponse)
 def search_people(
     q: str = Query(..., description="Search query for name or email"),
+    limit: int = Query(default=20, ge=1, le=200, description="Max results to return"),
 ):
-    """Search for people by name or email."""
+    """
+    Search for people by name, email, alias, or display name.
+
+    Matching runs in SQL (PersonEntityStore.search, an indexed LIKE scan)
+    instead of loading every person into Python and substring-scanning them.
+    A generous internal candidate cap (`limit * 5`, minimum 200) is fetched
+    from the store so the existing relevance ordering -- exact canonical-name
+    match first, then most recent `last_seen` -- is preserved within the
+    returned page for the common cases (a full name, a rare token, a partial
+    email). Note: for a query with more than `candidate_cap` total matches
+    (e.g. a single common letter), an exact match with an old `last_seen` that
+    falls outside the store's candidate window could be excluded even though
+    a full scan would have surfaced it first -- this only matters for
+    pathologically broad queries, not realistic search terms.
+    """
     store = get_person_entity_store()
-    all_entities = store.get_all()
-
-    # Search by name, email, or aliases
     query_lower = q.lower()
-    results = []
-    for entity in all_entities:
-        if query_lower in entity.canonical_name.lower():
-            results.append(entity)
-        elif any(query_lower in email.lower() for email in entity.emails):
-            results.append(entity)
-        elif any(query_lower in alias.lower() for alias in entity.aliases):
-            results.append(entity)
-        elif entity.display_name and query_lower in entity.display_name.lower():
-            results.append(entity)
 
-    # Sort by relevance (exact matches first, then by last_seen)
-    results.sort(
+    candidate_cap = max(limit * 5, 200)
+    candidates = store.search(q, limit=candidate_cap)
+
+    # Sort by relevance (exact matches first, then by last_seen) -- same
+    # ordering the old full-scan implementation used.
+    candidates.sort(
         key=lambda e: (
             e.canonical_name.lower() != query_lower,  # Exact match first
             -(e.last_seen.timestamp() if e.last_seen else 0)  # Recent first
         )
     )
+    results = candidates[:limit]
+
+    # Batch the recency-by-source lookup for the whole page in one query
+    # instead of one per person (the old N+1 cost).
+    interaction_store = get_interaction_store()
+    recency_map = interaction_store.get_last_interaction_by_source_batch(
+        [e.id for e in results if e.id]
+    )
+
+    total = store.count_search(q)
 
     return SearchResponse(
-        people=[_entity_to_response(e) for e in results],
+        people=[
+            _entity_to_response(e, precomputed_recency=recency_map.get(e.id))
+            for e in results
+        ],
         count=len(results),
         query=q,
+        total=total,
     )
 
 
@@ -222,24 +255,11 @@ def list_people(
 ):
     """List all people, optionally filtered by category."""
     store = get_person_entity_store()
-    all_entities = store.get_all()
-
-    # Filter by category if specified
-    if category:
-        all_entities = [e for e in all_entities if e.category == category]
-
-    # Sort by last_seen (most recent first)
-    all_entities.sort(
-        key=lambda e: e.last_seen or datetime.min.replace(tzinfo=timezone.utc),
-        reverse=True
-    )
-
-    # Limit results
-    all_entities = all_entities[:limit]
+    entities = store.list_recent(limit=limit, category=category)
 
     return SearchResponse(
-        people=[_entity_to_response(e) for e in all_entities],
-        count=len(all_entities),
+        people=[_entity_to_response(e) for e in entities],
+        count=len(entities),
         query="*",
     )
 

--- a/api/routes/people.py
+++ b/api/routes/people.py
@@ -180,18 +180,36 @@ def search_people(
     A generous internal candidate cap (`limit * 5`, minimum 200) is fetched
     from the store so the existing relevance ordering -- exact canonical-name
     match first, then most recent `last_seen` -- is preserved within the
-    returned page for the common cases (a full name, a rare token, a partial
-    email). Note: for a query with more than `candidate_cap` total matches
-    (e.g. a single common letter), an exact match with an old `last_seen` that
-    falls outside the store's candidate window could be excluded even though
-    a full scan would have surfaced it first -- this only matters for
-    pathologically broad queries, not realistic search terms.
+    returned page. For a query with more than `candidate_cap` total matches,
+    the *canonical-name* exact match could otherwise fall outside that
+    window (it's ranked by recency like everything else while the store
+    fetches candidates), so it's looked up separately via the store's
+    indexed `person_names` table (`get_by_name`, an O(1) lookup) and spliced
+    into the candidate set when it isn't already present -- restoring "your
+    own exact name always finds you" for single-token names with thousands
+    of substring matches, at the cost of one extra indexed lookup per
+    request.
     """
     store = get_person_entity_store()
     query_lower = q.lower()
 
     candidate_cap = max(limit * 5, 200)
     candidates = store.search(q, limit=candidate_cap)
+
+    # Guarantee the exact canonical-name match is always a candidate, even
+    # when it doesn't fall within the store's recency-ordered candidate
+    # window (see docstring). `get_by_name` is an indexed exact lookup on
+    # person_names, not a substring scan, so this is cheap regardless of how
+    # many people match `q` as a substring.
+    candidate_ids = {e.id for e in candidates if e.id}
+    exact_owner = store.get_by_name(q)
+    if (
+        exact_owner is not None
+        and exact_owner.id not in candidate_ids
+        and not exact_owner.hidden
+        and exact_owner.canonical_name.lower() == query_lower
+    ):
+        candidates.append(exact_owner)
 
     # Sort by relevance (exact matches first, then by last_seen) -- same
     # ordering the old full-scan implementation used.
@@ -204,7 +222,13 @@ def search_people(
     results = candidates[:limit]
 
     # Batch the recency-by-source lookup for the whole page in one query
-    # instead of one per person (the old N+1 cost).
+    # instead of one per person (the old N+1 cost). A person absent from the
+    # batch result genuinely has no interactions -- get_last_interaction_by_
+    # source_batch() documents that IDs with none are simply absent, so this
+    # must be `{}` (a real "no recency data" answer), not `None`, or
+    # _entity_to_response falls back to its own per-person query for every
+    # such person and the N+1 cost this batching exists to remove comes right
+    # back.
     interaction_store = get_interaction_store()
     recency_map = interaction_store.get_last_interaction_by_source_batch(
         [e.id for e in results if e.id]
@@ -214,7 +238,7 @@ def search_people(
 
     return SearchResponse(
         people=[
-            _entity_to_response(e, precomputed_recency=recency_map.get(e.id))
+            _entity_to_response(e, precomputed_recency=recency_map.get(e.id, {}))
             for e in results
         ],
         count=len(results),
@@ -257,8 +281,19 @@ def list_people(
     store = get_person_entity_store()
     entities = store.list_recent(limit=limit, category=category)
 
+    # Same batched recency lookup as search_people() -- without it this
+    # became the endpoint with the N+1 (one interaction-store query per
+    # returned person, up to `limit`=500).
+    interaction_store = get_interaction_store()
+    recency_map = interaction_store.get_last_interaction_by_source_batch(
+        [e.id for e in entities if e.id]
+    )
+
     return SearchResponse(
-        people=[_entity_to_response(e) for e in entities],
+        people=[
+            _entity_to_response(e, precomputed_recency=recency_map.get(e.id, {}))
+            for e in entities
+        ],
         count=len(entities),
         query="*",
     )

--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -35,6 +35,16 @@ VALID_SOURCE_TYPES = frozenset({
     "whatsapp", "contacts", "phone", "photos", "slack",
 })
 
+# Chunk size for any SQL IN/NOT IN clause built from a caller-supplied list
+# of ids. SQLite's default SQLITE_MAX_VARIABLE_NUMBER has been 32766 since
+# 3.32.0 (999 was the default before that, and some builds raise it further
+# still -- this one measures 250,000). 900 has no relationship to any of
+# those numbers; it's a deliberately conservative, portable chunk size that
+# stays safely under all of them without detecting the compiled-in limit at
+# runtime. Mirrored in api/services/person_entity.py's PersonEntityStore
+# (kept as a separate constant there -- no shared import for one number).
+SQL_IN_CLAUSE_CHUNK_SIZE = 900
+
 # Reasonable timestamp bounds
 _MIN_TIMESTAMP = datetime(2000, 1, 1, tzinfo=timezone.utc)
 _MAX_FUTURE_DAYS = 90  # Calendar events can be up to ~30 days out; allow margin
@@ -984,9 +994,9 @@ class InteractionStore:
         Batched version of get_last_interaction_by_source() for many people.
 
         Runs one `GROUP BY person_id, source_type` query per chunk of ids
-        (chunked at 900 to stay under SQLite's default 999 bound-parameter
-        limit) instead of one query per person, so callers that need this
-        for a page of search/list results don't pay an N+1 cost.
+        instead of one query per person, so callers that need this for a
+        page of search/list results don't pay an N+1 cost. See
+        SQL_IN_CLAUSE_CHUNK_SIZE for why the chunk size is 900.
 
         Args:
             person_ids: PersonEntity IDs to fetch recency for.
@@ -999,15 +1009,14 @@ class InteractionStore:
         if not person_ids:
             return {}
 
-        # De-dupe while preserving determinism; chunk to stay under SQLite's
-        # default limit on bound parameters (999).
+        # De-dupe while preserving determinism, then chunk the IN clause.
         unique_ids = list(dict.fromkeys(person_ids))
         result: dict[str, dict[str, datetime]] = {}
         now = datetime.now(timezone.utc).isoformat()
 
         conn = self._get_connection()
         try:
-            chunk_size = 900
+            chunk_size = SQL_IN_CLAUSE_CHUNK_SIZE
             for i in range(0, len(unique_ids), chunk_size):
                 chunk = unique_ids[i:i + chunk_size]
                 placeholders = ",".join("?" * len(chunk))

--- a/api/services/interaction_store.py
+++ b/api/services/interaction_store.py
@@ -977,6 +977,61 @@ class InteractionStore:
         finally:
             conn.close()
 
+    def get_last_interaction_by_source_batch(
+        self, person_ids: list[str]
+    ) -> dict[str, dict[str, datetime]]:
+        """
+        Batched version of get_last_interaction_by_source() for many people.
+
+        Runs one `GROUP BY person_id, source_type` query per chunk of ids
+        (chunked at 900 to stay under SQLite's default 999 bound-parameter
+        limit) instead of one query per person, so callers that need this
+        for a page of search/list results don't pay an N+1 cost.
+
+        Args:
+            person_ids: PersonEntity IDs to fetch recency for.
+
+        Returns:
+            Dict mapping person_id to the same per-source dict that
+            get_last_interaction_by_source() would return for that person.
+            IDs with no interactions are simply absent.
+        """
+        if not person_ids:
+            return {}
+
+        # De-dupe while preserving determinism; chunk to stay under SQLite's
+        # default limit on bound parameters (999).
+        unique_ids = list(dict.fromkeys(person_ids))
+        result: dict[str, dict[str, datetime]] = {}
+        now = datetime.now(timezone.utc).isoformat()
+
+        conn = self._get_connection()
+        try:
+            chunk_size = 900
+            for i in range(0, len(unique_ids), chunk_size):
+                chunk = unique_ids[i:i + chunk_size]
+                placeholders = ",".join("?" * len(chunk))
+                cursor = conn.execute(
+                    f"""
+                    SELECT person_id, source_type, MAX(timestamp) as last_ts
+                    FROM interactions
+                    WHERE person_id IN ({placeholders}) AND timestamp <= ?
+                    GROUP BY person_id, source_type
+                    """,
+                    chunk + [now],
+                )
+                for row in cursor.fetchall():
+                    person_id = row[0]
+                    source_type = row[1]
+                    ts_str = row[2]
+                    if not ts_str:
+                        continue
+                    dt = _make_aware(datetime.fromisoformat(ts_str.replace("Z", "+00:00")))
+                    result.setdefault(person_id, {})[source_type] = dt
+            return result
+        finally:
+            conn.close()
+
     def get_first_interaction_dates(self, min_interactions: int = 1) -> dict[str, datetime]:
         """
         Get the earliest interaction timestamp for each person.

--- a/api/services/person_entity.py
+++ b/api/services/person_entity.py
@@ -27,6 +27,16 @@ from api.utils.datetime_utils import make_aware as _make_aware
 logger = logging.getLogger(__name__)
 
 
+def _escape_like_pattern(text: str) -> str:
+    """Escape SQL LIKE wildcards (`%`, `_`) and the escape character itself.
+
+    Without this, a literal `%` or `_` typed into a search box (e.g. an
+    email local part containing `_`) is interpreted as a wildcard instead of
+    a literal character. Pair with `ESCAPE '\\'` in the LIKE clause.
+    """
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 @dataclass
 class PersonEntity:
     """
@@ -1063,6 +1073,16 @@ class PersonEntityStore:
         """
         Search entities by name, email, or alias.
 
+        `%` and `_` in `query` are escaped so they match literally rather
+        than as SQL LIKE wildcards.
+
+        Known limitation (pre-existing, not introduced by the LIKE-based
+        matching added in #872): `emails` and `aliases` are stored as JSON
+        text, so a non-ASCII character inside one of those lists is stored
+        as a `\\uXXXX` escape sequence and a LIKE against the raw column
+        cannot match the literal character a caller types. `canonical_name`
+        and `display_name` are plain text columns and are unaffected.
+
         Args:
             query: Search string
             limit: Maximum results to return
@@ -1074,13 +1094,13 @@ class PersonEntityStore:
         """
         query_lower = query.lower()
         merged_ids = set(self._merged_ids.keys()) if not include_merged else set()
-        pattern = f"%{query_lower}%"
+        pattern = f"%{_escape_like_pattern(query_lower)}%"
 
         conn = self._get_connection()
         try:
             conditions = [
-                "(LOWER(canonical_name) LIKE ? OR LOWER(display_name) LIKE ? "
-                "OR LOWER(emails) LIKE ? OR LOWER(aliases) LIKE ?)"
+                "(LOWER(canonical_name) LIKE ? ESCAPE '\\' OR LOWER(display_name) LIKE ? ESCAPE '\\' "
+                "OR LOWER(emails) LIKE ? ESCAPE '\\' OR LOWER(aliases) LIKE ? ESCAPE '\\')"
             ]
             params: list = [pattern, pattern, pattern, pattern]
 
@@ -1105,37 +1125,47 @@ class PersonEntityStore:
         finally:
             conn.close()
 
-    def count_search(self, query: str, include_hidden: bool = False) -> int:
+    def count_search(self, query: str, include_hidden: bool = False,
+                      include_merged: bool = False) -> int:
         """
         Count entities matching the same predicate as search().
 
         Cheap `COUNT(*)` companion to search() for callers that want a
         "how many matched in total" figure without paginating through every
-        row. Note this does not exclude already-merged duplicate rows (search()
-        filters those out in Python after fetching) -- that set is normally
-        tiny relative to total matches, and re-checking it here would cost the
-        same full-table work count_search exists to avoid.
+        row. Excludes already-merged duplicate rows the same way search()
+        does, via `id NOT IN (...)` over the (small, currently in the low
+        hundreds) set of merged ids -- comfortably under SQLite's default
+        999-bound-parameter limit, and cheap relative to the LIKE scan this
+        query already has to do.
 
         Args:
             query: Search string, same matching as search()
             include_hidden: If True, include hidden entities (default: False)
+            include_merged: If True, include entities that were merged into
+                others (default: False)
 
         Returns:
             Number of matching rows.
         """
         query_lower = query.lower()
-        pattern = f"%{query_lower}%"
+        pattern = f"%{_escape_like_pattern(query_lower)}%"
+        merged_ids = list(self._merged_ids.keys()) if not include_merged else []
 
         conn = self._get_connection()
         try:
             conditions = [
-                "(LOWER(canonical_name) LIKE ? OR LOWER(display_name) LIKE ? "
-                "OR LOWER(emails) LIKE ? OR LOWER(aliases) LIKE ?)"
+                "(LOWER(canonical_name) LIKE ? ESCAPE '\\' OR LOWER(display_name) LIKE ? ESCAPE '\\' "
+                "OR LOWER(emails) LIKE ? ESCAPE '\\' OR LOWER(aliases) LIKE ? ESCAPE '\\')"
             ]
             params: list = [pattern, pattern, pattern, pattern]
 
             if not include_hidden:
                 conditions.append("hidden = 0")
+
+            if merged_ids:
+                placeholders = ",".join("?" * len(merged_ids))
+                conditions.append(f"id NOT IN ({placeholders})")
+                params.extend(merged_ids)
 
             where = " AND ".join(conditions)
             row = conn.execute(

--- a/api/services/person_entity.py
+++ b/api/services/person_entity.py
@@ -26,6 +26,16 @@ from api.utils.datetime_utils import make_aware as _make_aware
 
 logger = logging.getLogger(__name__)
 
+# Chunk size for any SQL IN/NOT IN clause built from a caller-supplied list
+# of ids. SQLite's default SQLITE_MAX_VARIABLE_NUMBER has been 32766 since
+# 3.32.0 (999 was the default before that, and some builds raise it further
+# still -- this one measures 250,000). 900 has no relationship to any of
+# those numbers; it's a deliberately conservative, portable chunk size that
+# stays safely under all of them without detecting the compiled-in limit at
+# runtime. Mirrored in api/services/interaction_store.py's InteractionStore
+# (kept as a separate constant there -- no shared import for one number).
+SQL_IN_CLAUSE_CHUNK_SIZE = 900
+
 
 def _escape_like_pattern(text: str) -> str:
     """Escape SQL LIKE wildcards (`%`, `_`) and the escape character itself.
@@ -1133,9 +1143,9 @@ class PersonEntityStore:
         Cheap `COUNT(*)` companion to search() for callers that want a
         "how many matched in total" figure without paginating through every
         row. Excludes already-merged duplicate rows the same way search()
-        does, via `id NOT IN (...)` over the (small, currently in the low
-        hundreds) set of merged ids -- comfortably under SQLite's default
-        999-bound-parameter limit, and cheap relative to the LIKE scan this
+        does, via one `id NOT IN (...)` clause per SQL_IN_CLAUSE_CHUNK_SIZE
+        chunk of merged ids (currently in the low hundreds, so this is a
+        single chunk in practice) -- cheap relative to the LIKE scan this
         query already has to do.
 
         Args:
@@ -1162,10 +1172,15 @@ class PersonEntityStore:
             if not include_hidden:
                 conditions.append("hidden = 0")
 
-            if merged_ids:
-                placeholders = ",".join("?" * len(merged_ids))
+            # One NOT IN clause per chunk (ANDed together) rather than a
+            # single unbounded one, matching InteractionStore's batch-query
+            # chunking so a future spike in merged people can't turn this
+            # into "too many SQL variables".
+            for i in range(0, len(merged_ids), SQL_IN_CLAUSE_CHUNK_SIZE):
+                chunk = merged_ids[i:i + SQL_IN_CLAUSE_CHUNK_SIZE]
+                placeholders = ",".join("?" * len(chunk))
                 conditions.append(f"id NOT IN ({placeholders})")
-                params.extend(merged_ids)
+                params.extend(chunk)
 
             where = " AND ".join(conditions)
             row = conn.execute(

--- a/api/services/person_entity.py
+++ b/api/services/person_entity.py
@@ -1105,6 +1105,100 @@ class PersonEntityStore:
         finally:
             conn.close()
 
+    def count_search(self, query: str, include_hidden: bool = False) -> int:
+        """
+        Count entities matching the same predicate as search().
+
+        Cheap `COUNT(*)` companion to search() for callers that want a
+        "how many matched in total" figure without paginating through every
+        row. Note this does not exclude already-merged duplicate rows (search()
+        filters those out in Python after fetching) -- that set is normally
+        tiny relative to total matches, and re-checking it here would cost the
+        same full-table work count_search exists to avoid.
+
+        Args:
+            query: Search string, same matching as search()
+            include_hidden: If True, include hidden entities (default: False)
+
+        Returns:
+            Number of matching rows.
+        """
+        query_lower = query.lower()
+        pattern = f"%{query_lower}%"
+
+        conn = self._get_connection()
+        try:
+            conditions = [
+                "(LOWER(canonical_name) LIKE ? OR LOWER(display_name) LIKE ? "
+                "OR LOWER(emails) LIKE ? OR LOWER(aliases) LIKE ?)"
+            ]
+            params: list = [pattern, pattern, pattern, pattern]
+
+            if not include_hidden:
+                conditions.append("hidden = 0")
+
+            where = " AND ".join(conditions)
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM person_entities WHERE {where}", params
+            ).fetchone()
+            return row[0] if row else 0
+        finally:
+            conn.close()
+
+    def list_recent(self, limit: int = 50, category: Optional[str] = None,
+                     include_hidden: bool = False,
+                     include_merged: bool = False) -> list[PersonEntity]:
+        """
+        List entities ordered by last_seen DESC, most recent first, in SQL.
+
+        This is the bounded counterpart to get_all() for callers (like
+        GET /api/people/list) that only need the top N by recency: it applies
+        ORDER BY / LIMIT and the category filter in SQL instead of loading
+        every entity into Python and sorting there.
+
+        Args:
+            limit: Maximum results to return
+            category: If given, filter to this category in SQL
+            include_hidden: If True, include hidden entities (default: False)
+            include_merged: If True, include entities that were merged into
+                others (default: False)
+
+        Returns:
+            List of PersonEntity objects, most recently seen first.
+        """
+        merged_ids = set(self._merged_ids.keys()) if not include_merged else set()
+
+        conn = self._get_connection()
+        try:
+            conditions = []
+            params: list = []
+
+            if not include_hidden:
+                conditions.append("hidden = 0")
+            if category:
+                conditions.append("category = ?")
+                params.append(category)
+
+            where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+            # Over-fetch a little when we need to filter out merged rows in
+            # Python, so the final page still has `limit` rows when possible.
+            fetch_limit = limit + len(merged_ids) if merged_ids else limit
+            sql = (f"SELECT * FROM person_entities {where} "
+                   f"ORDER BY last_seen DESC LIMIT ?")
+            rows = conn.execute(sql, params + [fetch_limit]).fetchall()
+
+            results = []
+            for row in rows:
+                if row['id'] in merged_ids:
+                    continue
+                results.append(self._row_to_entity(row))
+                if len(results) >= limit:
+                    break
+
+            return results
+        finally:
+            conn.close()
+
     def get_all(self, include_hidden: bool = False,
                 include_merged: bool = False) -> list[PersonEntity]:
         """

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** API Gateway
-**Last Updated:** 2026-08-28
+**Last Updated:** 2026-09-04
 
 Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two adjacent catalogs split out for size:
 
@@ -685,7 +685,24 @@ Get a specific person by name.
 
 ### GET /api/people/search
 
-Search people by name or email.
+Search people by name, email, alias, or display name. Matches sort exact
+canonical-name matches first, then most recently seen.
+
+**Query Parameters:**
+- `q` (string, required): Search text
+- `limit` (integer, optional, default 20, max 200): Max results to return
+
+**Response:** adds a `total` field (count of all matching people, not just
+the returned page) alongside the existing `people`/`count`/`query` fields.
+
+### GET /api/people/list
+
+List people ordered by most recently seen first, optionally filtered by
+category.
+
+**Query Parameters:**
+- `limit` (integer, optional, default 50, max 500): Max results to return
+- `category` (string, optional): Filter to this category
 
 ---
 

--- a/docs/specs/product/mcp-tools.md
+++ b/docs/specs/product/mcp-tools.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** API Gateway
-> **Last Updated:** 2026-08-19
+> **Last Updated:** 2026-09-04
 
 MCP (Model Context Protocol) server that exposes LifeOS capabilities to AI assistants like Claude Code.
 
@@ -323,6 +323,7 @@ Search for people in your network.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | q | string | Yes | Name or email to search |
+| limit | integer | No | Max results (default: 10, max: 50) |
 
 ### lifeos_memories_create
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1418,11 +1418,13 @@ class LifeOSMCPServer:
                 return "No people found."
             shown = people[:10]
             # Use the API's total match count when available (falling back to
-            # the page size for older/mocked responses that lack it) so a
-            # broad query still signals "there are many more matches, narrow
-            # your query" instead of silently looking like an exhaustive
-            # result set of 10.
-            total = data.get("total", len(people))
+            # the page size for older/mocked responses that lack it, or that
+            # carry an explicit `"total": null` -- SearchResponse.total is
+            # Optional, so a sibling endpoint's response could serialize it
+            # that way) so a broad query still signals "there are many more
+            # matches, narrow your query" instead of silently looking like an
+            # exhaustive result set of 10.
+            total = data.get("total") or len(people)
             if total > len(shown):
                 text = f"Found {total} people (showing {len(shown)}):\n\n"
             else:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -374,7 +374,28 @@ class LifeOSMCPServer:
         except Exception:  # pragma: no cover — keep server bootable without agent worker
             self._result_cache = None
         self._load_openapi_spec()
+        self._cap_people_search_limit()
         self._register_inter_agent_tools()
+
+    def _cap_people_search_limit(self) -> None:
+        """Advertise a smaller `limit` default/max for lifeos_people_search
+        than the API itself allows (default 20, max 200).
+
+        The formatter only ever displays the first 10 results regardless of
+        how many the API returns, so keeping the LLM-facing default at 10 and
+        the max at 50 keeps typical tool-call context small; a caller can
+        still ask for the API's full range directly against the HTTP API if
+        it genuinely needs more. Runs after tool build so it applies whether
+        the schema came from the live OpenAPI spec or the offline fallback.
+        """
+        for tool in self.tools:
+            if tool.get("name") != "lifeos_people_search":
+                continue
+            limit_prop = tool.get("inputSchema", {}).get("properties", {}).get("limit")
+            if limit_prop is not None:
+                limit_prop["default"] = 10
+                limit_prop["maximum"] = 50
+            break
 
     def _register_inter_agent_tools(self) -> None:
         """Expose the `lifeos_agent_*` family to remote agents over MCP.
@@ -674,7 +695,8 @@ class LifeOSMCPServer:
             "lifeos_people_search": {
                 "type": "object",
                 "properties": {
-                    "q": {"type": "string", "description": "Name or email to search"}
+                    "q": {"type": "string", "description": "Name or email to search"},
+                    "limit": {"type": "integer", "description": "Max results (default: 10)", "default": 10, "maximum": 50}
                 },
                 "required": ["q"]
             },
@@ -1176,6 +1198,16 @@ class LifeOSMCPServer:
         # managed agents pass it explicitly per the system prompt.
         if tool_name.startswith("lifeos_agent_"):
             return self._handle_inter_agent(tool_name, dict(arguments))
+
+        # lifeos_people_search defaults to a smaller page than the API's own
+        # default (20) so the formatter's existing top-10 display stays
+        # stable when the caller doesn't specify a limit. Applied before the
+        # cache key is captured below so two calls that omit `limit` share a
+        # cache entry with each other (and with an explicit limit=10 call)
+        # instead of the injected default making every no-limit call look
+        # like a fresh, uncached request.
+        if tool_name == "lifeos_people_search":
+            arguments.setdefault("limit", 10)
 
         # Cache check for read-only tools when the caller is session-aware.
         cache_key_args = arguments

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1416,8 +1416,18 @@ class LifeOSMCPServer:
             people = data.get("people", data.get("results", []))
             if not people:
                 return "No people found."
-            text = f"Found {len(people)} people:\n\n"
-            for p in people[:10]:
+            shown = people[:10]
+            # Use the API's total match count when available (falling back to
+            # the page size for older/mocked responses that lack it) so a
+            # broad query still signals "there are many more matches, narrow
+            # your query" instead of silently looking like an exhaustive
+            # result set of 10.
+            total = data.get("total", len(people))
+            if total > len(shown):
+                text = f"Found {total} people (showing {len(shown)}):\n\n"
+            else:
+                text = f"Found {total} people:\n\n"
+            for p in shown:
                 name = p.get("name", p.get("canonical_name", "Unknown"))
                 text += f"- **{name}**"
                 if email := p.get("email"):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -467,6 +467,98 @@ def test_call_api_skips_cache_when_session_id_missing():
 
 
 # ---------------------------------------------------------------------------
+# lifeos_people_search limit (#872)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_people_search_defaults_limit_to_ten_when_absent():
+    """Omitting `limit` must still send limit=10 to the API, so the tool's
+    behavior (and the formatter's existing top-10 display) stays unchanged
+    for callers that don't know about the new param."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    server = module.LifeOSMCPServer()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"people": [], "count": 0, "query": "ada"}
+    fake_response.raise_for_status = MagicMock()
+    fake.get.return_value = fake_response
+    server.client = fake
+
+    server._call_api("lifeos_people_search", {"q": "ada"})
+
+    assert fake.get.call_count == 1
+    _, kwargs = fake.get.call_args
+    assert kwargs["params"]["limit"] == 10
+
+
+@pytest.mark.unit
+def test_people_search_passes_through_an_explicit_limit():
+    """An explicit `limit` from the caller must reach the API unchanged."""
+    import importlib.util
+    from unittest.mock import MagicMock
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    server = module.LifeOSMCPServer()
+    fake = MagicMock()
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"people": [], "count": 0, "query": "ada"}
+    fake_response.raise_for_status = MagicMock()
+    fake.get.return_value = fake_response
+    server.client = fake
+
+    server._call_api("lifeos_people_search", {"q": "ada", "limit": 30})
+
+    assert fake.get.call_count == 1
+    _, kwargs = fake.get.call_args
+    assert kwargs["params"]["limit"] == 30
+
+
+@pytest.mark.unit
+def test_people_search_tool_schema_advertises_limit_default_and_cap(openapi_spec, monkeypatch):
+    """The published schema documents the smaller MCP-facing default (10)
+    and max (50) even though the API itself defaults to 20 with a 200 cap.
+
+    Builds the server against the in-process OpenAPI spec (this checkout's
+    code), not whatever's live on localhost:8000 — a running server may
+    still be on pre-#872 code and wouldn't have the `limit` param yet.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    class _FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return openapi_spec
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def get(self, *a, **k):
+            return _FakeResp()
+
+    monkeypatch.setattr(module.httpx, "Client", _FakeClient)
+    server = module.LifeOSMCPServer()
+    tool = next(t for t in server.tools if t["name"] == "lifeos_people_search")
+    limit_prop = tool["inputSchema"]["properties"]["limit"]
+    assert limit_prop["default"] == 10
+    assert limit_prop["maximum"] == 50
+
+
+# ---------------------------------------------------------------------------
 # Investments snapshot tool (#447)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -558,6 +558,64 @@ def test_people_search_tool_schema_advertises_limit_default_and_cap(openapi_spec
     assert limit_prop["maximum"] == 50
 
 
+def _synthetic_people(n):
+    return [
+        {
+            "canonical_name": f"Person {i}",
+            "entity_id": f"id{i}",
+            "relationship_strength": 10,
+            "days_since_contact": 5,
+            "active_channels": [],
+        }
+        for i in range(n)
+    ]
+
+
+@pytest.mark.unit
+def test_people_search_formatter_header_reports_total_not_page_size():
+    """#872 review finding 3: with `limit` now bounding the page, the header
+    must report the true match count (`total`), not just how many rows are
+    in this page -- otherwise a broad query silently looks exhaustive and
+    the caller loses the "there are many more, narrow your query" signal.
+    The ten person blocks themselves must stay byte-identical either way."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    server = module.LifeOSMCPServer()
+
+    people = _synthetic_people(10)
+    small_query_data = {"people": people, "count": 10, "query": "a", "total": 10}
+    broad_query_data = {"people": people, "count": 10, "query": "a", "total": 253}
+
+    small_out = server._format_response("lifeos_people_search", small_query_data)
+    broad_out = server._format_response("lifeos_people_search", broad_query_data)
+
+    assert "Found 10 people:" in small_out
+    assert "Found 253 people (showing 10):" in broad_out
+
+    small_body = small_out.split("\n\n", 1)[1]
+    broad_body = broad_out.split("\n\n", 1)[1]
+    assert small_body == broad_body, "person blocks must be identical regardless of the header"
+
+
+@pytest.mark.unit
+def test_people_search_formatter_falls_back_to_page_size_without_total():
+    """A response with no `total` field must not crash and should fall back
+    to the page size, matching the pre-#872 header exactly."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    server = module.LifeOSMCPServer()
+
+    people = _synthetic_people(1)
+    out = server._format_response(
+        "lifeos_people_search", {"people": people, "count": 1, "query": "solo"}
+    )
+    assert "Found 1 people:" in out
+
+
 # ---------------------------------------------------------------------------
 # Investments snapshot tool (#447)
 # ---------------------------------------------------------------------------

--- a/tests/test_people.py
+++ b/tests/test_people.py
@@ -578,10 +578,19 @@ class TestPersonEntityStoreSearchHelpers:
         assert len(store.list_recent(limit=2)) == 2
 
 
+@pytest.mark.slow
 @pytest.mark.integration
 class TestSearchPeopleLatency:
     """#872: GET /api/people/search must stay fast against the production
-    dataset. Skips cleanly on a fresh clone with no data/crm.db."""
+    dataset. Skips cleanly on a fresh clone with no data/crm.db.
+
+    Also marked `slow` (alongside `integration`, matching the pattern in
+    test_query_router.py/test_summarizer.py) purely so the module-level
+    `unit` mark on this file doesn't sweep it into the pre-push hook's
+    `-m "unit and not slow"` gate: a hard wall-clock bound is unreliable
+    there, where pytest-xdist runs ~16 workers in parallel on the same
+    host and contends with this test's own timing.
+    """
 
     def _person_count(self):
         import sqlite3
@@ -608,9 +617,16 @@ class TestSearchPeopleLatency:
         client = TestClient(app)
         client.get("/api/people/search", params={"q": "a"})  # warm
 
-        start = time.perf_counter()
-        resp = client.get("/api/people/search", params={"q": "a"})
-        elapsed_ms = (time.perf_counter() - start) * 1000
+        # Best of several samples (same approach as test_crm_api.py's
+        # _warm_latency_ms) rather than a single call: this host runs many
+        # concurrent agent sessions, and one unlucky sample sharing a CPU
+        # quantum with unrelated work isn't a real regression.
+        samples = []
+        for _ in range(5):
+            start = time.perf_counter()
+            resp = client.get("/api/people/search", params={"q": "a"})
+            samples.append((time.perf_counter() - start) * 1000)
+            assert resp.status_code == 200
+        elapsed_ms = min(samples)
 
-        assert resp.status_code == 200
-        assert elapsed_ms < 200, f"?q=a took {elapsed_ms:.1f}ms, expected under 200ms"
+        assert elapsed_ms < 200, f"?q=a took {elapsed_ms:.1f}ms (best of 5), expected under 200ms"

--- a/tests/test_people.py
+++ b/tests/test_people.py
@@ -9,13 +9,11 @@ P1.4 Acceptance Criteria:
 - "What do I know about Alex" returns relevant context
 - Excludes self-references (configured user name)
 """
-import pytest
-
-# Most tests in this file are fast unit tests
-pytestmark = pytest.mark.unit
 import tempfile
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from api.services.people import (
     PeopleRegistry,
@@ -23,6 +21,9 @@ from api.services.people import (
     resolve_person_name,
     PEOPLE_DICTIONARY,
 )
+
+# Most tests in this file are fast unit tests
+pytestmark = pytest.mark.unit
 
 
 class TestPeopleExtraction:
@@ -287,3 +288,329 @@ Taking Alice to the park. Jane is making dinner.
             assert len(results) >= 1
 
             indexer.stop()
+
+
+# ---------------------------------------------------------------------------
+# #872: bound GET /api/people/search results and batch the recency lookup.
+#
+# These tests build isolated PersonEntityStore/InteractionStore instances
+# (temp SQLite files, no dependency on data/crm.db) and monkeypatch the
+# getters api.routes.people imports, so they run as fast unit tests on a
+# fresh clone. A separate integration-marked latency test at the bottom
+# exercises the real dataset when present.
+# ---------------------------------------------------------------------------
+
+def _make_person(**kwargs):
+    from api.services.person_entity import PersonEntity
+    defaults = dict(canonical_name="", emails=[], last_seen=None)
+    defaults.update(kwargs)
+    return PersonEntity(**defaults)
+
+
+class TestSearchPeopleEndpoint:
+    """GET /api/people/search — limit validation and preserved ordering."""
+
+    @pytest.fixture
+    def stores(self, tmp_path, monkeypatch):
+        from api.services.person_entity import PersonEntityStore
+        from api.services.interaction_store import InteractionStore
+        import api.routes.people as people_routes
+
+        person_store = PersonEntityStore(db_path=str(tmp_path / "people.db"))
+        interaction_store = InteractionStore(
+            db_path=str(tmp_path / "interactions.db"), strict=False
+        )
+
+        now = datetime.now(timezone.utc)
+        # Exact canonical-name match, but the oldest last_seen of the three —
+        # must still sort first (exact match beats recency).
+        exact_old = _make_person(
+            id="exact-old",
+            canonical_name="Ada Test",
+            emails=["ada.test@example.com"],
+            last_seen=now - timedelta(days=400),
+        )
+        # Substring match on canonical_name, more recent than the exact match.
+        partial_recent = _make_person(
+            id="partial-recent",
+            canonical_name="Ada Testerson",
+            emails=["ada.testerson@example.com"],
+            last_seen=now - timedelta(days=1),
+        )
+        # Substring match via email only.
+        email_match = _make_person(
+            id="email-match",
+            canonical_name="Someone Else",
+            emails=["contains.ada.test@example.com"],
+            last_seen=now - timedelta(days=2),
+        )
+        # Does not match "ada test" anywhere.
+        non_match = _make_person(
+            id="non-match",
+            canonical_name="Bob Nomatch",
+            emails=["bob@example.com"],
+            last_seen=now,
+        )
+        for entity in (exact_old, partial_recent, email_match, non_match):
+            person_store.add(entity)
+
+        monkeypatch.setattr(people_routes, "get_person_entity_store", lambda: person_store)
+        monkeypatch.setattr(people_routes, "get_interaction_store", lambda: interaction_store)
+        return person_store, interaction_store
+
+    @pytest.fixture
+    def client(self, stores):
+        from fastapi.testclient import TestClient
+        from api.main import app
+        return TestClient(app)
+
+    def test_limit_zero_is_rejected(self, client):
+        # This app's global RequestValidationError handler (api/main.py)
+        # converts all validation errors to 400, not FastAPI's default 422.
+        resp = client.get("/api/people/search", params={"q": "ada", "limit": 0})
+        assert resp.status_code == 400
+
+    def test_limit_over_max_is_rejected(self, client):
+        resp = client.get("/api/people/search", params={"q": "ada", "limit": 201})
+        assert resp.status_code == 400
+
+    def test_limit_boundaries_are_accepted(self, client):
+        assert client.get("/api/people/search", params={"q": "ada", "limit": 1}).status_code == 200
+        assert client.get("/api/people/search", params={"q": "ada", "limit": 200}).status_code == 200
+
+    def test_default_limit_is_20(self, client):
+        resp = client.get("/api/people/search", params={"q": "ada"})
+        assert resp.status_code == 200
+        # Only 3 of the 4 synthetic entities match "ada" at all, well under
+        # the default of 20, so this just confirms the default didn't clamp
+        # unexpectedly low (e.g. to something like 1 or 5).
+        assert resp.json()["count"] == 3
+
+    def test_exact_match_sorts_first_even_when_older(self, client):
+        resp = client.get("/api/people/search", params={"q": "Ada Test", "limit": 20})
+        assert resp.status_code == 200
+        data = resp.json()
+        names = [p["canonical_name"] for p in data["people"]]
+        assert names[0] == "Ada Test", "exact canonical-name match must sort first"
+        assert "Bob Nomatch" not in names
+
+    def test_non_exact_matches_sort_by_recency(self, client):
+        resp = client.get("/api/people/search", params={"q": "ada.test", "limit": 20})
+        assert resp.status_code == 200
+        names = [p["canonical_name"] for p in resp.json()["people"]]
+        # None of these are an exact canonical-name match for "ada.test", so
+        # order falls back to most-recent last_seen first.
+        assert names.index("Ada Testerson") < names.index("Someone Else")
+
+    def test_total_reflects_full_match_count_not_page_size(self, client):
+        resp = client.get("/api/people/search", params={"q": "ada", "limit": 1})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["total"] == 3
+
+    def test_recency_lookup_is_batched_once(self, client, stores, monkeypatch):
+        """The N+1 per-person recency query must become exactly one batched
+        call for the whole page, no matter how many results are returned."""
+        _, interaction_store = stores
+        calls = []
+        original = interaction_store.get_last_interaction_by_source_batch
+
+        def spy(person_ids):
+            calls.append(list(person_ids))
+            return original(person_ids)
+
+        monkeypatch.setattr(interaction_store, "get_last_interaction_by_source_batch", spy)
+
+        resp = client.get("/api/people/search", params={"q": "ada", "limit": 20})
+        assert resp.status_code == 200
+        assert len(calls) == 1, "expected exactly one batched recency call"
+        returned_ids = {p["entity_id"] for p in resp.json()["people"]}
+        assert set(calls[0]) == returned_ids
+
+
+class TestListPeopleEndpoint:
+    """GET /api/people/list — SQL-side ordering and category filter."""
+
+    @pytest.fixture
+    def stores(self, tmp_path, monkeypatch):
+        from api.services.person_entity import PersonEntityStore
+        import api.routes.people as people_routes
+
+        person_store = PersonEntityStore(db_path=str(tmp_path / "people.db"))
+
+        now = datetime.now(timezone.utc)
+        oldest = _make_person(
+            id="oldest", canonical_name="Carol Old", category="work",
+            last_seen=now - timedelta(days=10),
+        )
+        middle = _make_person(
+            id="middle", canonical_name="Dave Mid", category="personal",
+            last_seen=now - timedelta(days=5),
+        )
+        newest = _make_person(
+            id="newest", canonical_name="Erin New", category="work",
+            last_seen=now,
+        )
+        for entity in (oldest, middle, newest):
+            person_store.add(entity)
+
+        monkeypatch.setattr(people_routes, "get_person_entity_store", lambda: person_store)
+        return person_store
+
+    @pytest.fixture
+    def client(self, stores):
+        from fastapi.testclient import TestClient
+        from api.main import app
+        return TestClient(app)
+
+    def test_orders_most_recent_first(self, client):
+        resp = client.get("/api/people/list", params={"limit": 10})
+        assert resp.status_code == 200
+        names = [p["canonical_name"] for p in resp.json()["people"]]
+        assert names == ["Erin New", "Dave Mid", "Carol Old"]
+
+    def test_category_filter_applied_in_sql(self, client):
+        resp = client.get("/api/people/list", params={"limit": 10, "category": "work"})
+        assert resp.status_code == 200
+        names = {p["canonical_name"] for p in resp.json()["people"]}
+        assert names == {"Erin New", "Carol Old"}
+
+    def test_limit_truncates(self, client):
+        resp = client.get("/api/people/list", params={"limit": 1})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["people"][0]["canonical_name"] == "Erin New"
+
+
+class TestInteractionStoreBatchRecency:
+    """InteractionStore.get_last_interaction_by_source_batch (#872)."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        from api.services.interaction_store import InteractionStore
+        return InteractionStore(db_path=str(tmp_path / "interactions.db"), strict=False)
+
+    def _insert_raw(self, store, person_id, source_type, days_ago, iid=None):
+        import uuid
+        conn = store._get_connection()
+        ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+        try:
+            conn.execute(
+                "INSERT INTO interactions (id, person_id, timestamp, source_type, title) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (iid or str(uuid.uuid4()), person_id, ts, source_type, "test"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_empty_input_returns_empty_dict(self, store):
+        assert store.get_last_interaction_by_source_batch([]) == {}
+
+    def test_matches_per_person_single_lookup(self, store):
+        self._insert_raw(store, "p1", "gmail", days_ago=1)
+        self._insert_raw(store, "p1", "gmail", days_ago=5)  # older gmail, should be superseded
+        self._insert_raw(store, "p1", "imessage", days_ago=2)
+        self._insert_raw(store, "p2", "slack", days_ago=3)
+
+        batch = store.get_last_interaction_by_source_batch(["p1", "p2"])
+        single_p1 = store.get_last_interaction_by_source("p1")
+        single_p2 = store.get_last_interaction_by_source("p2")
+
+        assert batch["p1"] == single_p1
+        assert batch["p2"] == single_p2
+        assert set(batch["p1"].keys()) == {"gmail", "imessage"}
+
+    def test_person_with_no_interactions_is_absent(self, store):
+        self._insert_raw(store, "p1", "gmail", days_ago=1)
+        batch = store.get_last_interaction_by_source_batch(["p1", "no-such-person"])
+        assert "no-such-person" not in batch
+
+    def test_chunks_over_900_ids(self, store):
+        """More than SQLite's ~999 bound-parameter limit must not error."""
+        self._insert_raw(store, "p-5", "gmail", days_ago=1)
+        many_ids = [f"p-{i}" for i in range(1500)]
+        batch = store.get_last_interaction_by_source_batch(many_ids)
+        assert batch["p-5"]["gmail"]
+
+
+class TestPersonEntityStoreSearchHelpers:
+    """PersonEntityStore.count_search / list_recent (#872)."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        from api.services.person_entity import PersonEntityStore
+        return PersonEntityStore(db_path=str(tmp_path / "people.db"))
+
+    def test_count_search_matches_number_of_search_results_below_limit(self, store):
+        for i in range(5):
+            store.add(_make_person(
+                id=f"p{i}", canonical_name=f"Ada Match {i}", emails=[],
+                last_seen=datetime.now(timezone.utc),
+            ))
+        store.add(_make_person(id="other", canonical_name="No Hit", emails=[]))
+
+        assert store.count_search("ada") == 5
+        # A limit smaller than the true count still reports the full total.
+        assert len(store.search("ada", limit=2)) == 2
+
+    def test_list_recent_orders_and_filters_by_category(self, store):
+        now = datetime.now(timezone.utc)
+        store.add(_make_person(id="a", canonical_name="A", category="work",
+                                last_seen=now - timedelta(days=1)))
+        store.add(_make_person(id="b", canonical_name="B", category="family",
+                                last_seen=now))
+        store.add(_make_person(id="c", canonical_name="C", category="work",
+                                last_seen=now - timedelta(days=2)))
+
+        all_recent = store.list_recent(limit=10)
+        assert [e.canonical_name for e in all_recent] == ["B", "A", "C"]
+
+        work_only = store.list_recent(limit=10, category="work")
+        assert [e.canonical_name for e in work_only] == ["A", "C"]
+
+    def test_list_recent_respects_limit(self, store):
+        for i in range(3):
+            store.add(_make_person(id=f"p{i}", canonical_name=f"Person {i}",
+                                    last_seen=datetime.now(timezone.utc) - timedelta(days=i)))
+        assert len(store.list_recent(limit=2)) == 2
+
+
+@pytest.mark.integration
+class TestSearchPeopleLatency:
+    """#872: GET /api/people/search must stay fast against the production
+    dataset. Skips cleanly on a fresh clone with no data/crm.db."""
+
+    def _person_count(self):
+        import sqlite3
+        db_path = Path("data/crm.db")
+        if not db_path.exists():
+            return None
+        conn = sqlite3.connect(str(db_path))
+        try:
+            return conn.execute("SELECT COUNT(*) FROM person_entities").fetchone()[0]
+        finally:
+            conn.close()
+
+    def test_broad_query_under_200ms(self):
+        import time
+        from fastapi.testclient import TestClient
+        from api.main import app
+
+        count = self._person_count()
+        if count is None:
+            pytest.skip("data/crm.db not present")
+        if count < 100:
+            pytest.skip("too few people in database for a meaningful latency check")
+
+        client = TestClient(app)
+        client.get("/api/people/search", params={"q": "a"})  # warm
+
+        start = time.perf_counter()
+        resp = client.get("/api/people/search", params={"q": "a"})
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert resp.status_code == 200
+        assert elapsed_ms < 200, f"?q=a took {elapsed_ms:.1f}ms, expected under 200ms"

--- a/tests/test_people.py
+++ b/tests/test_people.py
@@ -748,6 +748,25 @@ class TestPersonEntityStoreSearchHelpers:
         # A limit smaller than the true count still reports the full total.
         assert len(store.search("ada", limit=2)) == 2
 
+    def test_count_search_excludes_merged_people(self, store):
+        """#872 review nit 1: count_search()'s merged-row exclusion had no
+        test -- mutating it away (`merged_ids = []`) let the whole suite
+        keep passing. Simulate a merge the same way a real merge operation's
+        durable record (merged_person_ids.json) would represent it: a
+        secondary id mapped to the primary it was merged into."""
+        now = datetime.now(timezone.utc)
+        store.add(_make_person(id="primary", canonical_name="Ada Merged Primary",
+                                emails=[], last_seen=now))
+        store.add(_make_person(id="secondary", canonical_name="Ada Merged Secondary",
+                                emails=[], last_seen=now))
+        assert store.count_search("ada merged") == 2
+
+        store._merged_ids = {"secondary": "primary"}
+
+        assert store.count_search("ada merged") == 1
+        # include_merged=True restores the pre-merge count, same as search().
+        assert store.count_search("ada merged", include_merged=True) == 2
+
     def test_list_recent_orders_and_filters_by_category(self, store):
         now = datetime.now(timezone.utc)
         store.add(_make_person(id="a", canonical_name="A", category="work",

--- a/tests/test_people.py
+++ b/tests/test_people.py
@@ -354,9 +354,33 @@ class TestSearchPeopleEndpoint:
         for entity in (exact_old, partial_recent, email_match, non_match):
             person_store.add(entity)
 
+        # One of the four has a real interaction; the other three have none
+        # at all -- exercising both branches of the batched-recency fix
+        # (#872 review finding 1): "absent from the batch map" must mean
+        # "no interactions", not "go run a per-person fallback query".
+        self._insert_raw_interaction(interaction_store, "partial-recent", "gmail", days_ago=1)
+
         monkeypatch.setattr(people_routes, "get_person_entity_store", lambda: person_store)
         monkeypatch.setattr(people_routes, "get_interaction_store", lambda: interaction_store)
         return person_store, interaction_store
+
+    @staticmethod
+    def _insert_raw_interaction(interaction_store, person_id, source_type, days_ago):
+        """Insert an interaction row directly, bypassing InteractionStore.add()
+        (which resolves person_id against the global PersonEntityStore
+        singleton, not this test's isolated one)."""
+        import uuid
+        conn = interaction_store._get_connection()
+        ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+        try:
+            conn.execute(
+                "INSERT INTO interactions (id, person_id, timestamp, source_type, title) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), person_id, ts, source_type, "test"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
 
     @pytest.fixture
     def client(self, stores):
@@ -411,22 +435,154 @@ class TestSearchPeopleEndpoint:
 
     def test_recency_lookup_is_batched_once(self, client, stores, monkeypatch):
         """The N+1 per-person recency query must become exactly one batched
-        call for the whole page, no matter how many results are returned."""
+        call for the whole page, no matter how many results are returned --
+        and the per-person fallback (get_last_interaction_by_source) must
+        never run, including for the three people in this fixture with zero
+        interactions (#872 review finding 1: an id absent from the batch
+        result means "no interactions", not "go run the fallback query")."""
         _, interaction_store = stores
-        calls = []
-        original = interaction_store.get_last_interaction_by_source_batch
+        batch_calls = []
+        original_batch = interaction_store.get_last_interaction_by_source_batch
 
-        def spy(person_ids):
-            calls.append(list(person_ids))
-            return original(person_ids)
+        def batch_spy(person_ids):
+            batch_calls.append(list(person_ids))
+            return original_batch(person_ids)
 
-        monkeypatch.setattr(interaction_store, "get_last_interaction_by_source_batch", spy)
+        per_person_calls = []
+
+        def per_person_spy(person_id):
+            per_person_calls.append(person_id)
+            return {}
+
+        monkeypatch.setattr(interaction_store, "get_last_interaction_by_source_batch", batch_spy)
+        monkeypatch.setattr(interaction_store, "get_last_interaction_by_source", per_person_spy)
 
         resp = client.get("/api/people/search", params={"q": "ada", "limit": 20})
         assert resp.status_code == 200
-        assert len(calls) == 1, "expected exactly one batched recency call"
-        returned_ids = {p["entity_id"] for p in resp.json()["people"]}
-        assert set(calls[0]) == returned_ids
+        data = resp.json()
+
+        assert len(batch_calls) == 1, "expected exactly one batched recency call"
+        returned_ids = {p["entity_id"] for p in data["people"]}
+        assert set(batch_calls[0]) == returned_ids
+        assert per_person_calls == [], (
+            f"the per-person fallback must never run once results are batched, "
+            f"but it ran for: {per_person_calls}"
+        )
+
+        # The fixture's zero-interaction people must still report "no active
+        # channels" correctly, not silently omit the field or error.
+        by_id = {p["entity_id"]: p for p in data["people"]}
+        assert by_id["exact-old"]["active_channels"] == []
+        assert by_id["partial-recent"]["active_channels"] == ["gmail"]
+
+
+class TestExactMatchOutsideCandidateWindow:
+    """#872 review finding 2: a query with far more matches than the
+    internal candidate cap (`limit * 5`, minimum 200) must still surface the
+    exact canonical-name match. The store's candidate window is ordered by
+    recency, so the exact match -- the single oldest of hundreds of
+    substring matches here -- would otherwise be excluded from the window
+    entirely and never returned at all, not just reordered."""
+
+    @pytest.fixture
+    def client(self, tmp_path, monkeypatch):
+        from api.services.person_entity import PersonEntityStore
+        from api.services.interaction_store import InteractionStore
+        import api.routes.people as people_routes
+        from fastapi.testclient import TestClient
+        from api.main import app
+
+        person_store = PersonEntityStore(db_path=str(tmp_path / "people.db"))
+        interaction_store = InteractionStore(
+            db_path=str(tmp_path / "interactions.db"), strict=False
+        )
+
+        now = datetime.now(timezone.utc)
+        # 205 filler people, all matching the substring "widget" and all
+        # more recently seen than the exact match below -- comfortably more
+        # than the 200-row candidate window a default query uses.
+        for i in range(205):
+            person_store.add(_make_person(
+                id=f"filler-{i}",
+                canonical_name=f"Widget Owner {i}",
+                last_seen=now - timedelta(seconds=i),
+            ))
+        # The exact canonical-name match for query "widget" -- the oldest
+        # last_seen of anyone matching, so a plain recency-ordered candidate
+        # fetch excludes it from the top 200 entirely.
+        person_store.add(_make_person(
+            id="exact-widget",
+            canonical_name="Widget",
+            last_seen=now - timedelta(days=3650),
+        ))
+
+        monkeypatch.setattr(people_routes, "get_person_entity_store", lambda: person_store)
+        monkeypatch.setattr(people_routes, "get_interaction_store", lambda: interaction_store)
+        return TestClient(app)
+
+    def test_exact_match_still_returned_first(self, client):
+        resp = client.get("/api/people/search", params={"q": "widget", "limit": 20})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["people"][0]["canonical_name"] == "Widget"
+        assert data["total"] == 206
+
+    def test_exact_match_included_at_mcp_default_limit_too(self, client):
+        """MCP's default limit=10 hits the same >=200 candidate cap (the
+        formula is `max(limit * 5, 200)`), so the splice must still apply."""
+        resp = client.get("/api/people/search", params={"q": "widget", "limit": 10})
+        assert resp.status_code == 200
+        names = [p["canonical_name"] for p in resp.json()["people"]]
+        assert names[0] == "Widget"
+
+
+class TestSearchPeopleLikeEscaping:
+    """#872 review finding 5: `%` and `_` in a search query must match
+    literally, not act as SQL LIKE wildcards, now that matching runs in SQL
+    instead of a Python substring scan."""
+
+    @pytest.fixture
+    def client(self, tmp_path, monkeypatch):
+        from api.services.person_entity import PersonEntityStore
+        from api.services.interaction_store import InteractionStore
+        import api.routes.people as people_routes
+        from fastapi.testclient import TestClient
+        from api.main import app
+
+        person_store = PersonEntityStore(db_path=str(tmp_path / "people.db"))
+        interaction_store = InteractionStore(
+            db_path=str(tmp_path / "interactions.db"), strict=False
+        )
+
+        now = datetime.now(timezone.utc)
+        # A literal "_" in the name, plus a distractor with an arbitrary
+        # character in the same position -- an unescaped "_" (SQL LIKE's
+        # single-character wildcard) would incorrectly match both.
+        person_store.add(_make_person(id="underscore-literal", canonical_name="Foo_Bar", last_seen=now))
+        person_store.add(_make_person(id="underscore-distractor", canonical_name="FooXBar", last_seen=now))
+        # A literal "%" in the name, plus a distractor with extra characters
+        # in the same position -- an unescaped "%" (SQL LIKE's multi-character
+        # wildcard) would incorrectly match both.
+        person_store.add(_make_person(id="percent-literal", canonical_name="100%Club", last_seen=now))
+        person_store.add(_make_person(id="percent-distractor", canonical_name="100XYZClub", last_seen=now))
+
+        monkeypatch.setattr(people_routes, "get_person_entity_store", lambda: person_store)
+        monkeypatch.setattr(people_routes, "get_interaction_store", lambda: interaction_store)
+        return TestClient(app)
+
+    def test_underscore_matches_literally(self, client):
+        resp = client.get("/api/people/search", params={"q": "foo_bar", "limit": 20})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert {p["entity_id"] for p in data["people"]} == {"underscore-literal"}
+        assert data["total"] == 1
+
+    def test_percent_matches_literally(self, client):
+        resp = client.get("/api/people/search", params={"q": "100%club", "limit": 20})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert {p["entity_id"] for p in data["people"]} == {"percent-literal"}
+        assert data["total"] == 1
 
 
 class TestListPeopleEndpoint:
@@ -435,9 +591,13 @@ class TestListPeopleEndpoint:
     @pytest.fixture
     def stores(self, tmp_path, monkeypatch):
         from api.services.person_entity import PersonEntityStore
+        from api.services.interaction_store import InteractionStore
         import api.routes.people as people_routes
 
         person_store = PersonEntityStore(db_path=str(tmp_path / "people.db"))
+        interaction_store = InteractionStore(
+            db_path=str(tmp_path / "interactions.db"), strict=False
+        )
 
         now = datetime.now(timezone.utc)
         oldest = _make_person(
@@ -456,7 +616,8 @@ class TestListPeopleEndpoint:
             person_store.add(entity)
 
         monkeypatch.setattr(people_routes, "get_person_entity_store", lambda: person_store)
-        return person_store
+        monkeypatch.setattr(people_routes, "get_interaction_store", lambda: interaction_store)
+        return person_store, interaction_store
 
     @pytest.fixture
     def client(self, stores):
@@ -482,6 +643,37 @@ class TestListPeopleEndpoint:
         data = resp.json()
         assert data["count"] == 1
         assert data["people"][0]["canonical_name"] == "Erin New"
+
+    def test_recency_lookup_is_batched_once(self, client, stores, monkeypatch):
+        """#872 review finding 6: /api/people/list must use the same batched
+        recency lookup as /api/people/search instead of one query per
+        returned person."""
+        _, interaction_store = stores
+        batch_calls = []
+        original_batch = interaction_store.get_last_interaction_by_source_batch
+
+        def batch_spy(person_ids):
+            batch_calls.append(list(person_ids))
+            return original_batch(person_ids)
+
+        per_person_calls = []
+
+        def per_person_spy(person_id):
+            per_person_calls.append(person_id)
+            return {}
+
+        monkeypatch.setattr(interaction_store, "get_last_interaction_by_source_batch", batch_spy)
+        monkeypatch.setattr(interaction_store, "get_last_interaction_by_source", per_person_spy)
+
+        resp = client.get("/api/people/list", params={"limit": 10})
+        assert resp.status_code == 200
+        returned_ids = {p["entity_id"] for p in resp.json()["people"]}
+
+        assert len(batch_calls) == 1, "expected exactly one batched recency call"
+        assert set(batch_calls[0]) == returned_ids
+        assert per_person_calls == [], (
+            f"the per-person fallback must never run, but it ran for: {per_person_calls}"
+        )
 
 
 class TestInteractionStoreBatchRecency:


### PR DESCRIPTION
## TL;DR

Searching your people directory for a common letter used to scan every person in the database and take about 2.6 seconds, returning nearly 6 MB of data. It now returns a bounded page of results (20 by default, up to 200) in well under a fifth of a second, in the same order as before (best name match first — including your own exact name even on a very broad query — then most recently contacted). Listing people is now fetched directly in already-sorted order instead of loading everyone and sorting in memory, and no longer runs one extra lookup per person either. The Claude/MCP "find a person" tool asks for 10 results by default, same as its display always showed, and its "Found N people" summary still reports the true match count even though it now only fetches 10.

Closes #872

## Design

- `GET /api/people/search` now takes an optional `limit` (1-200, default 20). Matching runs against the person store's indexed name/email/alias search instead of loading every person into the API process and substring-scanning them in Python. A query typed with `%` or `_` in it (e.g. an email fragment containing an underscore) matches those characters literally rather than as SQL wildcards.
- The "who did I last talk to and on what channel" lookup, which previously ran once per matched person (an N+1 query pattern), now runs once per search request covering every returned person — including people with zero interactions, who correctly get "no active channels" instead of triggering a redundant per-person lookup.
- Your own exact name always finds you: even on a query so broad it matches hundreds of people, the person whose name matches exactly is looked up separately (a cheap indexed lookup, not a scan) and guaranteed to be included and ranked first, matching the pre-existing behavior.
- `GET /api/people/list` now asks the database directly for "most recently seen, in this category, top N" instead of loading everyone and sorting in the API process, and shares the same one-query recency lookup as search.
- The MCP `lifeos_people_search` tool (used by Claude Code, chat, and the agent worker to resolve a person before acting) now asks for 10 results by default — matching what it already displayed — instead of asking for everything and discarding all but the first 10. Its "Found N people" summary still reports the true total match count (with a "(showing 10)" note when there are more), not just the page size, so a broad query doesn't silently look exhaustive. This schema addition was approved by the operator up front, recorded on issue #872 (2026-09-04).

## Implementation Notes

- `api/routes/people.py`: `search_people` (`GET /search`) calls `PersonEntityStore.search()` with a generous internal candidate cap (`limit * 5`, minimum 200) instead of `get_all()`, then does one `PersonEntityStore.get_by_name(q)` call and splices the result into the candidate set if it's a genuine canonical-name exact match not already present (restoring "own name always found" for queries broader than the candidate window), re-sorts with the same relevance rule as before (exact canonical-name match first, then most recent `last_seen`), and slices to `limit`. `list_people` (`GET /list`) calls `PersonEntityStore.list_recent()` instead of `get_all()` + Python sort/filter/slice. `_entity_to_response()` gained an optional `precomputed_recency` argument; both handlers batch-fetch a recency map for the whole page and pass `recency_map.get(e.id, {})` (never `None`, so an id truly absent from the batch result — no interactions — can't be mistaken for "not precomputed" and trigger a redundant per-person query). `SearchResponse` gained an optional `total` field (full match count via `PersonEntityStore.count_search()`); `count` still reflects the returned page size.
- `api/services/person_entity.py`: added `PersonEntityStore.count_search(query, include_hidden=False, include_merged=False)` (a `COUNT(*)` with the same predicate as `search()`, excluding already-merged rows via `id NOT IN (...)` the same way `search()`'s Python-side filter does) and `PersonEntityStore.list_recent(limit, category=None, include_hidden=False, include_merged=False)` (`ORDER BY last_seen DESC LIMIT ?` in SQL with the category filter also in SQL, over-fetching by the count of globally merged IDs so filtering already-merged rows out in Python still leaves a full page). A new module-level `_escape_like_pattern()` escapes `\`, `%`, and `_` before building the LIKE pattern, paired with `ESCAPE '\'` on all four LIKE clauses in `search()` and `count_search()`, so a literal `%`/`_` in a query matches literally instead of acting as a SQL wildcard.
- `api/services/interaction_store.py`: added `InteractionStore.get_last_interaction_by_source_batch(person_ids)`, one `GROUP BY person_id, source_type` query per 900-id chunk (SQLite's default bound-parameter limit is 999), returning the same per-person shape `get_last_interaction_by_source()` already returned (an id with no interactions is simply absent from the result).
- `mcp_server.py`: `lifeos_people_search`'s static fallback schema and `_call_api()`'s default-injection both add `limit` (defaults to 10 when the caller omits it, before the per-session result-cache key is captured so an omitted-limit call and an explicit `limit=10` call share a cache entry). A new `_cap_people_search_limit()` runs after tool build and clamps the advertised `default`/`maximum` on `limit` to 10/50 (below the API's own 20/200) whether the schema came from the live OpenAPI spec or the offline fallback. The formatter's header now reads `total` (falling back to the page size when absent) with a "(showing N)" suffix when there are more matches than shown, instead of always reporting the page size.
- `docs/specs/product/api-reference.md`, `docs/specs/product/mcp-tools.md`: documented the new `limit`/`total` fields and `GET /api/people/list` (previously undocumented).

## Test evidence

### Automated tests

`tests/test_people.py`: limit validation (0 and 201 rejected — this app's global validation-error handler returns 400, not FastAPI's default 422), exact-match-before-recency ordering with a synthetic fixture, `total` vs `count` on a truncated page, the batched recency call count (monkeypatched, asserts exactly one call covering exactly the returned ids, *and* that the per-person fallback method is never called even for people with zero interactions — `TestSearchPeopleEndpoint::test_recency_lookup_is_batched_once`), a dedicated `TestExactMatchOutsideCandidateWindow` (206 synthetic people, exact match is the single oldest and falls outside the 200-row candidate window, asserted still returned first at both `limit=20` and `limit=10`), a dedicated `TestSearchPeopleLikeEscaping` (literal `_`/`%` in a query against a distractor entity that would incorrectly match if the wildcard were left unescaped), `list` ordering, category filtering, and the same batched-recency assertion as search, `InteractionStore.get_last_interaction_by_source_batch` (matches the per-person method's output, empty input, absent person, and >900-id chunking), `PersonEntityStore.count_search`/`list_recent`, and an integration-marked latency test.

```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_people.py tests/test_mcp_server.py -q -m "not requires_server"
tests/test_people.py .s....s.....s...........................            [ 47%]
tests/test_mcp_server.py .............................................   [100%]
82 passed, 3 skipped, 7 deselected in 43.08s
```

`tests/test_mcp_server.py`: default `limit=10` reaches the API when the caller omits it, an explicit `limit` passes through unchanged, the published tool schema advertises `default: 10, maximum: 50` (built against this checkout's in-process OpenAPI spec, not whatever's live on :8000), and the formatter's header reports the true `total` with byte-identical person blocks regardless of page size (`test_people_search_formatter_header_reports_total_not_page_size`, `test_people_search_formatter_falls_back_to_page_size_without_total`).

Full pre-push gate (unit suite + server-free browser tests), from the actual push of the final commit (rebased onto `feat/crm-performance`'s current tip, 0045238/#900):

```
Running unit tests... passed (5637 passed, 8 skipped, 1181 warnings in 327.15s)
Running server-free browser tests... passed (259 passed, 5990 deselected in 174.55s)
```

### Manual verification

Against the staging data symlink (`data/crm.db`, 15,391 people, 14,414 after hidden/merge filtering), compared the old full-scan implementation (run inline from this checkout, not a separate git revision) against the new implementation for 5 queries — a full name, a first name, a partial email fragment, a rare/no-match token, and a single common letter:

```
full_name:        top20_identical=True  (1/1 matches, both old and new)
first_name:       top20_identical=True  (20/20 overlap)
partial_email:    top20_identical=True  (1/1 matches)
rare_token:       top20_identical=True  (0/0 — no matches either way)
single_letter_a:  top20_identical=True  (20/20 overlap); old_total=12981 vs new count_search=13032*
```

\* At the time of this measurement `count_search()` didn't yet exclude merged rows (finding 4); after the fix it excludes them the same way `search()` does, so this gap is now closed rather than merely documented.

Latency, same dataset, in-process `TestClient` (no network hop), best of 5 warm calls:

```
old (simulated: get_all() + Python substring scan + one InteractionStore
     query per match, i.e. the exact pre-#872 code path):
  ?q=a:   2170.2ms  (12,981 matches)
  ?q=nat:   50.5ms  (238 matches, matching logic only, no serialization)

new (actual endpoint, includes JSON serialization):
  ?q=a:    124.2ms min / 148.6ms avg  (page of 20)
  ?q=nat:   27.6ms min /  31.3ms avg  (page of 20)
  /list?limit=50: 62.9ms min / 68.0ms avg
```

No frontend files reference `/api/people/search` or `/api/people/list` (grepped `web/`), so no browser verification was needed for this PR.

## Review focus

- **Validation status code**: the issue's acceptance criteria say `limit` outside 1-200 "shall return a validation error," which I read as satisfied by this app's existing global handler returning **400** (not FastAPI's default 422) for every `RequestValidationError` — pre-existing app-wide behavior (`api/main.py`), not something this PR changes. Tests assert 400.
- **Known limitation, not fixed**: `emails`/`aliases` are stored as JSON text, so a non-ASCII character inside one of those lists is stored as a `\uXXXX` escape sequence that a LIKE against the raw column can't match against the literal character a caller types. `canonical_name`/`display_name` are plain text columns and are unaffected. This is pre-existing `PersonEntityStore.search()` behavior that this PR's move from a Python scan to SQL LIKE now exposes on the endpoint (an adversarial review found 4 such values in the staging dataset); documented in `search()`'s docstring rather than fixed, since fixing it would mean either decoding JSON per-row (defeating the point of an indexed scan) or a schema change, both out of this issue's scope.
- **Exact-match splice is a single extra indexed lookup, not a second scan**: `get_by_name()` is a primary-key lookup on `person_names`, so the fix in finding 2 below adds a constant, small cost per search request regardless of how many people match the query as a substring.
- Sibling #873 (crm.py/crm.html) untouched, as instructed.

### Addressed from adversarial review (see PR comments for the full per-finding response)

1. **[BLOCKER]** A person absent from the batched recency result (genuinely zero interactions) was passed as `None` rather than `{}`, so `_entity_to_response()` treated it as "not precomputed" and ran the per-person fallback query anyway — silently reintroducing the N+1 this PR exists to remove. Fixed: `recency_map.get(e.id, {})`.
2. **[MAJOR]** A query with more matches than the internal candidate cap could drop the exact canonical-name match entirely, not just reorder it, when it fell outside the store's recency-ordered candidate window. Fixed via a cheap indexed `get_by_name()` lookup spliced into the candidate set.
3. **[MAJOR]** The MCP formatter's header reported the page size instead of the true match count once `limit` bounded the page. Fixed: reports `total`, with a "(showing N)" note when it's larger than the page.
4. **[MINOR]** `count_search()`'s merged-row overcount is now excluded via SQL (`id NOT IN (...)`) rather than approximated.
5. **[MINOR]** `%`/`_` in a query are now escaped so they match literally instead of as SQL LIKE wildcards; the non-ASCII JSON-column gap above is the accepted, documented remainder.
6. **[MINOR]** `GET /api/people/list` now uses the same batched recency lookup as search instead of one query per returned person.
7. No code change needed — the MCP schema change was approved by the operator up front (see Design section above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
