### PR TITLE
chore(git): push over HTTPS so the pre-push gate cannot outlive GitHub's SSH idle limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Audience:** All AI coding agents (Claude Code, Cursor, Copilot, etc.)
 > **Status:** Complete
-> **Last Updated:** 2026-08-19
+> **Last Updated:** 2026-09-04
 
 LifeOS is a self-hosted personal AI assistant with two halves:
 
@@ -270,6 +270,7 @@ Quick-reference guardrails for all contributors. These complement the Developmen
 - **Browser tests:** the web SPA is served at `/chat` (not `/`); `test.sh browser` covers only `test_ui_browser.py`, `test_e2e_flow.py`, and `test_voice_mic_block_ui_browser.py` — run new browser test files directly with pytest.
 - **What the pre-push hook skips:** a docs-only push and a deletion-only push skip the suites; everything else runs them in full. The docs-only judgement is `test.sh`'s `decide_plan`, called by the hook rather than reimplemented — so dependency manifests (`requirements*.txt`, `constraints*.txt`) still run tests despite the `.txt` extension. The hook never runs a narrowed subset: a prior failure changes test *order* (`--ff`), never which tests are selected.
 - **Server-free browser tests:** most browser tests point at a running `lifeos-api` and carry `requires_server` on top of `browser`. A browser test that serves `web/` itself on an ephemeral port and stubs every `/api/` call (see `tests/test_voice_mic_block_ui_browser.py`) omits that marker, so `browser and not requires_server` selects it. The pre-push hook runs that set alongside `unit and not slow` — it's the only gate that catches a `web/` JS regression before it reaches main, so prefer the self-contained pattern for new frontend tests.
+- **Push over HTTPS, not SSH:** `./scripts/setup-hooks.sh` points `origin`'s push URL at HTTPS (fetch stays SSH) because GitHub closes an idle SSH session after ~6 minutes while this ~9-minute gate is still running, which otherwise fails the push even after every test passed. If you push over SSH anyway, `scripts/pre-push` prints a one-line warning naming the HTTPS URL and keeps going.
 
 ---
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,7 +1,7 @@
 # Installation Guide
 
 > **Status:** Complete
-> **Last Updated:** 2026-08-28
+> **Last Updated:** 2026-09-04
 > **Audience:** New users
 
 > **Quick start**: If you have Claude Code, run it in the project root and point it at
@@ -109,7 +109,10 @@ runs — it's the unattended-operations layer, and it's Linux-only today.
 ```bash
 git clone https://github.com/yourusername/LifeOS.git
 cd LifeOS
+./scripts/setup-hooks.sh
 ```
+
+`setup-hooks.sh` wires up the tracked git hooks and repoints `origin`'s *push* URL at HTTPS (fetches stay SSH), because GitHub closes an idle SSH session after ~6 minutes and the pre-push test gate runs for ~9, which otherwise fails a passing push. It also checks that `gh`'s credential helper is configured for HTTPS pushes and tells you to run `gh auth setup-git` if not, without failing setup.
 
 ---
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -23,6 +23,30 @@ cd "$PROJECT_ROOT"
 # git call below (and inside pytest) resolves via cwd.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR
 
+# git invokes pre-push as `pre-push <remote name> <remote url>`. An SSH push
+# URL holds a connection open for this whole gate (~9 min), and GitHub closes
+# an idle SSH session after ~6 min -- so a push over SSH can fail with
+# "Connection closed by remote host" even after every test passed (#886).
+# Warn once with the HTTPS equivalent and keep going; never fail the push
+# over this. `./scripts/setup-hooks.sh` configures the HTTPS push URL so this
+# should not normally fire.
+REMOTE_PUSH_URL="${2:-}"
+case "$REMOTE_PUSH_URL" in
+    git@*:*)
+        _rest="${REMOTE_PUSH_URL#git@}"
+        _host="${_rest%%:*}"
+        _path="${_rest#*:}"
+        echo "Warning: pushing over SSH ($REMOTE_PUSH_URL) can outlive GitHub's ~6-minute idle limit during this gate. Prefer: https://${_host}/${_path}"
+        unset _rest _host _path
+        ;;
+    ssh://*)
+        _rest="${REMOTE_PUSH_URL#ssh://}"
+        _rest="${_rest#*@}"
+        echo "Warning: pushing over SSH ($REMOTE_PUSH_URL) can outlive GitHub's ~6-minute idle limit during this gate. Prefer: https://${_rest}"
+        unset _rest
+        ;;
+esac
+
 # Detect what's being pushed so we can skip tests on docs-only pushes.
 # git feeds pre-push hooks lines of "local_ref local_sha remote_ref remote_sha" on stdin.
 CHANGED_FILES=""

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# LifeOS Git Hooks Setup
+#
+# Configures this clone's git plumbing so the tracked hooks run and pushes
+# don't hang:
+#
+#   1. `core.hooksPath = scripts` -- git runs the tracked scripts/pre-push,
+#      scripts/pre-commit, scripts/post-commit directly. No copying into
+#      .git/hooks (a copy there is never executed).
+#   2. A separate HTTPS push URL on `origin`, derived from its SSH fetch URL.
+#      The pre-push gate takes ~9 minutes; GitHub closes an idle SSH session
+#      after ~6, so an SSH push can fail with "Connection closed by remote
+#      host" even after every test passed (#886). Fetches stay SSH; only the
+#      push URL changes. Idempotent -- a non-GitHub or already-HTTPS origin
+#      is left alone.
+#   3. A check that the `gh` credential helper is wired up for HTTPS pushes,
+#      since that's what makes step 2 work without a password prompt.
+#
+# Usage: ./scripts/setup-hooks.sh
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+echo "Configuring git hooks..."
+git config core.hooksPath scripts
+echo "  core.hooksPath = scripts"
+
+FETCH_URL="$(git remote get-url origin 2>/dev/null || true)"
+if [ -z "$FETCH_URL" ]; then
+    echo "No 'origin' remote found -- skipping push transport setup."
+    exit 0
+fi
+
+# Derive https://github.com/<owner>/<repo>.git from an SSH GitHub fetch URL
+# (git@github.com:<owner>/<repo>.git). Leave everything else alone: an
+# https:// origin already avoids the idle-SSH problem, and a non-GitHub
+# remote isn't something we can safely rewrite.
+case "$FETCH_URL" in
+    git@github.com:*)
+        REPO_PATH="${FETCH_URL#git@github.com:}"
+        HTTPS_URL="https://github.com/${REPO_PATH}"
+        CURRENT_PUSH_URL="$(git remote get-url --push origin 2>/dev/null || true)"
+        if [ "$CURRENT_PUSH_URL" = "$HTTPS_URL" ]; then
+            echo "Push URL already set to $HTTPS_URL"
+        else
+            git remote set-url --push origin "$HTTPS_URL"
+            echo "Set push URL to $HTTPS_URL (fetch stays $FETCH_URL)"
+        fi
+        ;;
+    https://github.com/*)
+        echo "origin already uses HTTPS ($FETCH_URL) -- leaving push URL alone."
+        ;;
+    *)
+        echo "origin is not a github.com SSH remote ($FETCH_URL) -- leaving push URL alone."
+        ;;
+esac
+
+# The HTTPS push above relies on gh's own credential helper. Point at the
+# fix rather than failing setup if it isn't configured yet.
+if ! git config --get-all 'credential.https://github.com.helper' 2>/dev/null | grep -q "gh auth git-credential"; then
+    echo ""
+    echo "NOTE: the 'gh' credential helper for github.com is not configured."
+    echo "  HTTPS pushes will prompt for a password/token until you run:"
+    echo "    gh auth setup-git"
+fi
+
+echo "Done."

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -1,0 +1,79 @@
+"""
+Tests for the `scripts/pre-push` SSH push-URL warning (#886).
+
+The hook is invoked by git as `pre-push <remote name> <remote url>`. GitHub
+closes an idle SSH session after ~6 minutes, and the gate's test run takes
+~9, so an SSH push URL can fail with "Connection closed by remote host" even
+after every test passed. The hook prints one warning line naming the HTTPS
+equivalent when `$2` is an SSH URL, and stays silent for an HTTPS one.
+
+Exercised in plan-only mode (mirrors tests/test_prepush_gate.py) with a
+deletion-only ref on stdin, so the hook takes its fastest exit path and never
+shells out to the real test suite or scripts/test.sh.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "scripts" / "pre-push"
+
+
+def _run(remote_url: str) -> str:
+    env = {
+        **os.environ,
+        "LIFEOS_PREPUSH_PLAN_ONLY": "1",
+        "LIFEOS_PREPUSH_CHANGED_FILES": "",
+        "LIFEOS_PREPUSH_HAVE_CONTENT": "0",
+    }
+    result = subprocess.run(
+        ["bash", str(HOOK), "origin", remote_url],
+        capture_output=True, text=True, env=env, cwd=str(REPO),
+        stdin=subprocess.DEVNULL,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    return result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "remote_url,expected_https",
+    [
+        ("git@github.com:nbramia/LifeOS.git", "https://github.com/nbramia/LifeOS.git"),
+        ("ssh://git@github.com/nbramia/LifeOS.git", "https://github.com/nbramia/LifeOS.git"),
+    ],
+    ids=["scp_like", "ssh_url"],
+)
+def test_ssh_push_url_warns_once_with_https_equivalent(remote_url, expected_https):
+    out = _run(remote_url)
+    warning_lines = [line for line in out.splitlines() if line.startswith("Warning:")]
+    assert len(warning_lines) == 1, f"expected exactly one warning line, got: {out!r}"
+    assert remote_url in warning_lines[0]
+    assert expected_https in warning_lines[0]
+
+
+@pytest.mark.unit
+def test_https_push_url_is_silent():
+    out = _run("https://github.com/nbramia/LifeOS.git")
+    assert "Warning:" not in out
+
+
+@pytest.mark.unit
+def test_no_remote_url_is_silent():
+    """A bare positional-args call (e.g. some other hook invocation style)
+    must not crash on an unset $2."""
+    env = {
+        **os.environ,
+        "LIFEOS_PREPUSH_PLAN_ONLY": "1",
+        "LIFEOS_PREPUSH_CHANGED_FILES": "",
+        "LIFEOS_PREPUSH_HAVE_CONTENT": "0",
+    }
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        capture_output=True, text=True, env=env, cwd=str(REPO),
+        stdin=subprocess.DEVNULL,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "Warning:" not in result.stdout


### PR DESCRIPTION
## TL;DR

Pushes now go out over HTTPS instead of SSH, so a passing test gate can no longer be undone by GitHub silently dropping the connection. A new setup script wires this up on a fresh clone, and the push hook now warns (without blocking) if it ever sees an SSH push URL anyway.

Closes #886

## Design

- `scripts/setup-hooks.sh` (new): a one-time, idempotent setup step for a clone. Sets `core.hooksPath` to `scripts` so the tracked hooks (`pre-commit`, `pre-push`, `post-commit`) run without being copied into `.git/hooks`. Then, if `origin`'s fetch URL is an SSH GitHub remote (`git@github.com:owner/repo.git`), it points `origin`'s *push* URL at the HTTPS equivalent while leaving fetch on SSH — an already-HTTPS or non-GitHub origin is left untouched. Finally it checks whether the `gh` credential helper is registered for `https://github.com` and, if not, prints instructions to run `gh auth setup-git` without failing the rest of setup.
- `scripts/pre-push` (hook): now reads its `$2` argument (the remote URL git invokes it with) and, if it looks like an SSH URL (`git@host:...` or `ssh://...`), prints one warning line naming the HTTPS equivalent and continues running the gate as normal. Silent for an HTTPS URL. This is a safety net for anyone who pushes without having run the setup script, or pushes to a URL directly.

## Implementation Notes

- `scripts/setup-hooks.sh`: new script, `git config core.hooksPath scripts`, then a `case` on `git remote get-url origin` (`git@github.com:*` → rewrite push URL via `git remote set-url --push origin <https>`; `https://github.com/*` → no-op; anything else → no-op), then a `git config --get-all 'credential.https://github.com.helper'` check for `gh auth git-credential`.
- `scripts/pre-push`: added a block right after the existing `unset GIT_DIR ...` line that inspects `${2:-}` and, on an SSH-shaped URL, derives the HTTPS equivalent (`git@host:path` → `https://host/path`; `ssh://[user@]host/path` → `https://host/path`) and echoes a single `Warning: ...` line. No change to what runs afterward — same docs-only/deletion-only classification, same unit + browser suites.
- `tests/test_pre_push_hook.py` (new): invokes `scripts/pre-push` via `subprocess` in the existing `LIFEOS_PREPUSH_PLAN_ONLY=1` plan-only mode (same pattern as `tests/test_prepush_gate.py`) with a deletion-only ref on stdin, so it exercises the warning logic without ever shelling out to the real test suite. Covers: `git@github.com:...` warns, `ssh://git@github.com/...` warns, `https://github.com/...` is silent, and no `$2` at all is silent (doesn't crash on an unset positional arg).
- `AGENTS.md` § Testing: two-sentence note on why `origin`'s push URL is HTTPS and what the hook does if it isn't.
- `docs/guides/installation.md`: Step 1 now runs `./scripts/setup-hooks.sh` right after cloning, with a two-sentence explanation of what it configures and why.

## Test evidence

### Automated tests

```
HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_pre_push_hook.py tests/test_prepush_gate.py -q
```
```
collected 17 items

tests/test_pre_push_hook.py ....                                         [ 23%]
tests/test_prepush_gate.py .............                                 [100%]

============================== 17 passed in 2.84s ==============================
```

Full suite (`./scripts/test.sh`, no `.env` present in the worktree):
```
========== 5608 passed, 9 skipped, 1181 warnings in 198.67s (0:03:18) ==========
```

The pre-push gate itself ran the same suite plus the server-free browser tests on push and passed:
```
Running unit tests... passed (========== 5608 passed, 9 skipped, 1181 warnings in 163.17s (0:02:43) ==========)
Running server-free browser tests... passed (=============== 259 passed, 5961 deselected in 170.11s (0:02:50) ===============)
```

### Manual verification

Ran `scripts/setup-hooks.sh` against temp git repos (isolated `HOME`, no real credentials touched) covering: SSH GitHub origin with no `gh` credential helper configured (sets `core.hooksPath`, rewrites push URL to HTTPS, prints the `gh auth setup-git` note); running it a second time is a no-op message ("Push URL already set to ..."); an already-HTTPS origin (left alone); a non-GitHub SSH origin (`git@gitlab.com:...`, left alone); and an SSH GitHub origin with the `gh` credential helper present (no note printed). All five matched the acceptance criteria.

Ran `scripts/pre-push` directly (plan-only mode, deletion-only stdin) with `$2` set to `git@github.com:nbramia/LifeOS.git`, `ssh://git@github.com/nbramia/LifeOS.git`, and `https://github.com/nbramia/LifeOS.git` — the first two each printed exactly one `Warning: ...` line naming `https://github.com/nbramia/LifeOS.git`; the third printed nothing.

Pushed this branch itself over HTTPS under the shared `/tmp/lifeos-push.lock`, exactly as the standing brief for this milestone specifies — the gate ran to completion and the push succeeded, which is the real-world case #886 exists to fix.

## Review focus

- `scripts/setup-hooks.sh` is a brand-new script — there was no pre-existing "setup script that installs hooks" in the repo (`grep -rn "core.hooksPath" scripts/` only turned up the explanatory comment in `scripts/pre-push`; `core.hooksPath` itself is set by hand in the shared clone's `.git/config`, not by any tracked script). I judged the cleanest fix was a small dedicated script that both installs the hook path and does the push-URL/credential-helper work described in the issue, run once after cloning (Step 1 of installation.md). Worth double-checking that placement matches what was intended rather than, say, folding it into an existing setup script.
- The SSH→HTTPS URL derivation in both `scripts/pre-push` and `scripts/setup-hooks.sh` is GitHub-shaped (`git@host:owner/repo.git`, `ssh://[user@]host/...`); it isn't validated against exotic SSH remote forms (custom ports, `ssh://git@host:2222/owner/repo.git`) since the issue and this repo only ever use `github.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqMhBfLUGZ5cKuqyWe5iqD
