### PR TITLE
fix(crm): show profile photos in the people list without probing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -54,7 +54,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, investments, jobs, perf, agents, vault, fitness, voice, agent_proxy, hermes_proxy, journal, journal_trends, journal_ingest
-from api.services.log_redaction import configure_telegram_log_redaction
+from api.services.log_redaction import configure_telegram_log_redaction, install_query_string_redaction_filter
 from api.services.route_timing import RouteTimingMiddleware
 from config.settings import settings
 
@@ -67,6 +67,12 @@ from config.settings import settings
 # API embeds the bot token in the URL) from ever logging at INFO here (#519).
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 configure_telegram_log_redaction()
+# #904: uvicorn's own access logger writes every request's raw query string
+# to logs/server.log regardless of what a route handler logs -- this is the
+# only process that runs an HTTP server, so it's the only place this needs
+# installing (see install_query_string_redaction_filter()'s docstring for
+# why this must run at import time, not inside a route or startup event).
+install_query_string_redaction_filter()
 
 logger = logging.getLogger(__name__)
 

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -634,6 +634,14 @@ class CRMConfigResponse(BaseModel):
     partner_person_id: str = ""
     partner_name: str = ""
     family_default_selected_ids: list[str] = []
+    # Whether Apple Photos is configured at all (settings.photos_enabled is
+    # just Path.exists() on the library's database file -- cheap, unlike
+    # GET /api/photos/stats, which runs several full-library aggregate
+    # queries when Photos *is* configured). The client uses this to decide
+    # whether to request avatar/profile photos at all, so a Photos-less
+    # install never issues a request that would otherwise 503 (#875, #907
+    # review finding 2).
+    photos_enabled: bool = False
 
 
 def _load_family_default_selected_ids() -> list[str]:
@@ -677,6 +685,7 @@ def get_crm_config():
         partner_person_id=PARTNER_PERSON_ID,
         partner_name=_get_partner_name(),
         family_default_selected_ids=_load_family_default_selected_ids(),
+        photos_enabled=settings.photos_enabled,
     )
 
 

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -269,6 +269,9 @@ class PersonDetailResponse(BaseModel):
     slack_message_count: int = 0  # Actual Slack messages (not daily summaries)
     # Pre-computed Dunbar circle (0-6 for meaningful, 7 for peripheral)
     dunbar_circle: Optional[int] = None
+    # True when photo_count > 0, so the client knows to request an avatar
+    # instead of rendering initials -- no per-person probe needed.
+    has_profile_photo: bool = False
     # Related data
     source_entities: list[SourceEntityResponse] = []
     relationships: list[RelationshipResponse] = []
@@ -605,6 +608,7 @@ def _person_to_detail_response(
         message_count=person.message_count,
         slack_message_count=person.slack_message_count,
         dunbar_circle=person.dunbar_circle,
+        has_profile_photo=person.photo_count > 0,
     )
 
     if include_related:
@@ -851,8 +855,11 @@ def list_people(
         has_more=has_more,
     )
 
+    # #904: never log the raw search text or other filter values here -- the
+    # CRM search box's contents (names, partial emails) are personal data.
+    # Counts and timing only.
     elapsed = (time.time() - start_time) * 1000
-    logger.info(f"list_people(q={q}, category={category}, limit={limit}) took {elapsed:.1f}ms ({total} total, {len(people)} returned)")
+    logger.info(f"list_people took {elapsed:.1f}ms (limit={limit}, {total} total, {len(people)} returned)")
 
     return result
 

--- a/api/routes/photos.py
+++ b/api/routes/photos.py
@@ -7,8 +7,8 @@ and syncing to LifeOS CRM.
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query, Request
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
 from api.routes.crm import _mutation_lock
@@ -408,15 +408,23 @@ def get_photo_thumbnail(uuid: str):
     )
 
 
-@router.api_route("/profile/{person_id}", methods=["GET", "HEAD"])
-def get_profile_photo(person_id: str, request: Request):
+@router.get("/profile/{person_id}")
+@router.head("/profile/{person_id}", include_in_schema=False)
+def get_profile_photo(person_id: str):
     """
     Get a profile photo thumbnail for a person.
 
     Returns the most recent photo of the person that has a thumbnail available.
-    Use this for avatars/profile pictures in the UI. Also accepts HEAD, returning
-    the same status and headers with no body, so clients can check availability
-    without downloading the image.
+    Use this for avatars/profile pictures in the UI. Also accepts HEAD --
+    stacking a `@router.head` registration on the same function (rather than
+    branching on the request method ourselves) lets Starlette's `FileResponse`
+    handle it natively, which gives a `HEAD` response the exact same headers
+    (`etag`, `last-modified`, `content-length`, `accept-ranges`) a `GET` would
+    carry, just without the body -- a hand-rolled `HEAD` branch returning a
+    bare `Response` could not match that (#907 review finding 3). It also
+    avoids FastAPI's "duplicate operation ID" warning that a single
+    `@router.api_route(methods=["GET", "HEAD"])` registration triggers
+    (finding 5), since GET and HEAD are now separate routes.
     """
     _check_photos_enabled()
 
@@ -439,12 +447,6 @@ def get_profile_photo(person_id: str, request: Request):
                 media_type = "image/jpeg"
                 if suffix == ".png":
                     media_type = "image/png"
-
-                if request.method == "HEAD":
-                    return Response(
-                        media_type=media_type,
-                        headers={"Cache-Control": "public, max-age=3600"}  # Cache for 1 hour
-                    )
 
                 return FileResponse(
                     thumb_path,

--- a/api/routes/photos.py
+++ b/api/routes/photos.py
@@ -7,8 +7,8 @@ and syncing to LifeOS CRM.
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import FileResponse, JSONResponse, Response
 from pydantic import BaseModel
 
 from api.routes.crm import _mutation_lock
@@ -408,13 +408,15 @@ def get_photo_thumbnail(uuid: str):
     )
 
 
-@router.get("/profile/{person_id}")
-def get_profile_photo(person_id: str):
+@router.api_route("/profile/{person_id}", methods=["GET", "HEAD"])
+def get_profile_photo(person_id: str, request: Request):
     """
     Get a profile photo thumbnail for a person.
 
     Returns the most recent photo of the person that has a thumbnail available.
-    Use this for avatars/profile pictures in the UI.
+    Use this for avatars/profile pictures in the UI. Also accepts HEAD, returning
+    the same status and headers with no body, so clients can check availability
+    without downloading the image.
     """
     _check_photos_enabled()
 
@@ -438,16 +440,24 @@ def get_profile_photo(person_id: str):
                 if suffix == ".png":
                     media_type = "image/png"
 
+                if request.method == "HEAD":
+                    return Response(
+                        media_type=media_type,
+                        headers={"Cache-Control": "public, max-age=3600"}  # Cache for 1 hour
+                    )
+
                 return FileResponse(
                     thumb_path,
                     media_type=media_type,
                     headers={"Cache-Control": "public, max-age=3600"}  # Cache for 1 hour
                 )
 
-    # No photo available
+    # No photo available. Cache the miss too, so repeated list renders for
+    # people without a photo don't re-request it every time.
     raise HTTPException(
         status_code=404,
-        detail=f"No profile photo available for person {person_id}"
+        detail=f"No profile photo available for person {person_id}",
+        headers={"Cache-Control": "public, max-age=3600"},
     )
 
 

--- a/api/services/log_redaction.py
+++ b/api/services/log_redaction.py
@@ -1,4 +1,4 @@
-"""Redaction of Telegram bot tokens from log records (#519).
+"""Redaction of secrets and personal data from log records (#519, #904).
 
 The Telegram Bot API embeds the bot token directly in the request path
 (``https://api.telegram.org/bot<digits>:<secret>/<method>``). ``httpx``'s
@@ -22,6 +22,18 @@ Call ``configure_telegram_log_redaction()`` once per process, after the
 process's own root logging setup (``logging.basicConfig`` or equivalent) has
 run — it needs at least one handler already attached to root for the filter
 to have something to attach to.
+
+A third, unrelated filter lives here too for the same reason: uvicorn's own
+access logger (``uvicorn.access``) writes the full request line — path *and*
+query string — for every request, at INFO, regardless of what any route
+handler logs. `#904 <https://github.com/nbramia/LifeOS/issues/904>`_ fixed
+the CRM people-list handler's own log line, but the raw text typed into the
+CRM search box (``GET /api/crm/people?q=<text>``) still reached
+``logs/server.log`` this way — a gap the handler-level fix structurally
+cannot close, since it only ever sees the parsed query parameter, never the
+access logger's own line. ``RequestQueryStringRedactionFilter`` /
+``install_query_string_redaction_filter()`` strip everything from the first
+``?`` onward in that line, for every route, not just this one.
 """
 from __future__ import annotations
 
@@ -95,3 +107,60 @@ def configure_telegram_log_redaction() -> None:
     least one handler)."""
     silence_noisy_http_loggers()
     install_telegram_redaction_filter()
+
+
+# Matches the query string (and the `?` that introduces it) in a request
+# line, e.g. "GET /api/crm/people?q=alex&limit=5 HTTP/1.1" -- everything from
+# `?` up to the next whitespace (the URL itself never contains a literal,
+# unencoded space or `?`).
+QUERY_STRING_PATTERN = re.compile(r"\?\S*")
+
+REDACTED_QUERY_STRING = "?<redacted>"
+
+
+class RequestQueryStringRedactionFilter(logging.Filter):
+    """Strips the query string from uvicorn's access-log request line.
+
+    uvicorn's access logger (``uvicorn.access``) logs the full request line
+    -- including the raw query string -- for every request, independent of
+    anything a route handler itself logs. That's how `q=<search text>` from
+    the CRM people list's search box (personal data: names, partial emails)
+    reaches `logs/server.log` even after the handler's own log line (#904)
+    stops naming it. Never drops a record, only redacts in place.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            # Don't let a malformed record (bad % args, etc.) break logging.
+            return True
+
+        if "?" in message:
+            record.msg = QUERY_STRING_PATTERN.sub(REDACTED_QUERY_STRING, message, count=1)
+            record.args = ()
+
+        return True
+
+
+def install_query_string_redaction_filter() -> None:
+    """Install `RequestQueryStringRedactionFilter` directly on the
+    `uvicorn.access` logger. Idempotent.
+
+    Not attached via the root logger's handlers (the pattern the Telegram
+    filter above uses): uvicorn's default logging config gives
+    `uvicorn.access` `propagate=False` and its own dedicated handler, so a
+    record logged there never reaches root's handlers at all -- the filter
+    has to sit on the logger itself to see it.
+
+    Call this after `uvicorn.access` has already been configured (uvicorn's
+    own `Config.configure_logging()` runs `logging.config.dictConfig()`,
+    which resets that logger's filters). In the normal startup path
+    (`uvicorn.run("api.main:app", ...)`, as `scripts/server.sh` uses), that
+    dictConfig call happens during `Config.__init__`, strictly before the
+    app string is imported and this module's own `uvicorn.access` logger's
+    filters would be reset -- so this is safe to call at import time here.
+    """
+    access_logger = logging.getLogger("uvicorn.access")
+    if not any(isinstance(f, RequestQueryStringRedactionFilter) for f in access_logger.filters):
+        access_logger.addFilter(RequestQueryStringRedactionFilter())

--- a/api/services/log_redaction.py
+++ b/api/services/log_redaction.py
@@ -127,9 +127,36 @@ class RequestQueryStringRedactionFilter(logging.Filter):
     the CRM people list's search box (personal data: names, partial emails)
     reaches `logs/server.log` even after the handler's own log line (#904)
     stops naming it. Never drops a record, only redacts in place.
+
+    #907 review round 2: ``uvicorn.logging.AccessFormatter.formatMessage``
+    does not call ``record.getMessage()`` at all -- it unconditionally
+    unpacks ``record.args`` as a 5-tuple
+    (``client_addr, method, full_path, http_version, status_code``) and
+    rebuilds the request line from those fields. An earlier version of this
+    filter rewrote ``record.msg`` to the redacted line and cleared
+    ``record.args`` to make ``getMessage()`` return the safe string -- which
+    is exactly right for a *generic* ``logging.Formatter``, but broke
+    uvicorn's formatter: unpacking ``()`` into five names raises
+    ``ValueError: not enough values to unpack``, and that exception, not an
+    access line, is what actually reached ``logs/server.log`` (as a 79-line
+    "Logging error" traceback per request). The fix has to redact
+    ``args[2]`` (the piece the formatter actually reads) in place and leave
+    the 5-tuple shape intact. The ``record.msg``-based rewrite is kept only
+    as a fallback for a record that isn't shaped like uvicorn's own
+    access-log call.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if isinstance(args, tuple) and len(args) == 5 and isinstance(args[2], str) and "?" in args[2]:
+            path, _, _query = args[2].partition("?")
+            record.args = (args[0], args[1], path + REDACTED_QUERY_STRING, args[3], args[4])
+            return True
+
+        # Fallback: a record not shaped like uvicorn's access-log call (that
+        # call always hits the branch above). Kept belt-and-braces for any
+        # other caller of this filter, formatted the ordinary way via
+        # record.getMessage()/record.msg.
         try:
             message = record.getMessage()
         except Exception:

--- a/docs/specs/product/api-crm.md
+++ b/docs/specs/product/api-crm.md
@@ -45,6 +45,8 @@ List/search people with filters.
 - `limit` (int): Results per page (default: 50)
 - `offset` (int): Pagination offset
 
+Each returned person carries `has_profile_photo` (bool, from `photo_count > 0`) alongside the usual fields, so a client can request `GET /api/photos/profile/{id}` only for people flagged true instead of probing everyone (#875). `GET /api/crm/people/{id}` carries the same field for consistency.
+
 ### GET /api/crm/people/{id}
 
 Get person detail with source entities.

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -742,7 +742,7 @@ Get a thumbnail image for a photo by UUID. Returns the image file from the Photo
 
 ### GET /api/photos/profile/{person_id}
 
-Get a profile photo thumbnail for a person. Returns the most recent available photo thumbnail for use as an avatar.
+Get a profile photo thumbnail for a person. Returns the most recent available photo thumbnail for use as an avatar. Also accepts `HEAD` (same status as `GET`, no body), so a client can check availability without downloading the image. Both the `200` and `404` responses carry `Cache-Control: public, max-age=3600`, so a client that already knows a person has no reachable photo doesn't need to ask again within the hour.
 
 ### GET /api/photos/open/{uuid}
 

--- a/docs/specs/product/crm-people.md
+++ b/docs/specs/product/crm-people.md
@@ -184,6 +184,7 @@ Behavior:
 - Real-time search (< 300 ms), debounced; a superseded query's response is discarded so the list always reflects what's currently typed, even if an earlier search's response arrives later (#874).
 - Category tabs (Work / Personal / Family).
 - Cards show avatar, name, company/category, interaction count, strength bar.
+- A card's avatar shows the person's profile photo only when the list response flags them as having one (`has_profile_photo`); nothing else is ever probed. The image loads lazily and falls back to initials with no error if the photo turns out to be unavailable (#875).
 - Cards sorted by relationship strength by default.
 - Infinite scroll loads more people.
 - Mobile-responsive layout.

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -23,11 +23,11 @@ api/
 │   ├── calendar.py            # Calendar integration
 │   ├── chat.py                # Streaming chat with agentic pipeline
 │   ├── conversations.py       # Conversation history
-│   ├── crm.py                 # CRM endpoints (~5,100 LOC)
-│   ├── crm_models/            # CRM Pydantic models and helpers
+│   ├── crm.py                 # CRM endpoints + models (~5,100 LOC) -- see below
+│   ├── crm_models/            # NOT wired into the app -- see "CRM Models Package"
 │   │   ├── __init__.py        # Re-exports models and utils
-│   │   ├── models.py          # All Pydantic models (~600 LOC)
-│   │   └── _utils.py          # Shared helper functions
+│   │   ├── models.py          # Unused parallel Pydantic models (~600 LOC)
+│   │   └── _utils.py          # is_family_member() is kept in sync by a test
 │   ├── _proxy.py              # Shared reverse-proxy router factory (agent/hermes)
 │   ├── agent_proxy.py         # Agent text-backend reverse proxy
 │   ├── hermes_proxy.py        # Hermes text-backend reverse proxy + persona envelope
@@ -201,39 +201,29 @@ db_path = get_crm_db_path()  # Returns "data/crm.db"
 
 ## CRM Models Package (api/routes/crm_models/)
 
-The CRM models package consolidates Pydantic models and utilities for the CRM API.
+**Not currently wired into the running API.** The Pydantic models the CRM API
+actually serves — `PersonDetailResponse` (including `has_profile_photo`,
+added in #875), `PersonListResponse`, `TimelineItem`, and the rest — are
+defined directly inside `api/routes/crm.py`, alongside the route handlers
+that use them; `api/main.py` mounts only `crm.router`. `crm_models/` is a
+separate, parallel module tree (`models.py`, `_utils.py`, `__init__.py`)
+that predates or anticipated a split of `crm.py` into smaller files but was
+never finished wiring up — nothing in `api/main.py` or `api/routes/crm.py`
+imports from it.
 
-### Importing Models
+It isn't dead code, though: `api.routes.crm_models._utils.is_family_member`
+is a second, independent implementation of the family-matching logic that
+`api.services.person_entity._is_family_member` also implements for the live
+path, and `tests/test_family_matching.py` exercises both directly so the two
+can't silently drift apart. Anyone touching family-matching rules needs to
+update both. If `crm_models/` is ever finished and wired up (or removed),
+that test and this note both need to move with it.
+
+### Importing the family-matching utility
 
 ```python
-from api.routes.crm_models import (
-    PersonDetailResponse,
-    TimelineItem,
-    NetworkGraphResponse,
-)
+from api.routes.crm_models._utils import is_family_member
 ```
-
-### Importing Utilities
-
-```python
-from api.routes.crm_models import (
-    compute_person_category,
-    person_to_detail_response,
-    MY_PERSON_ID,
-)
-```
-
-### Models Reference
-
-| Category | Models |
-|----------|--------|
-| Person | PersonDetailResponse, PersonListResponse, PersonUpdateRequest, PersonMergeRequest, PersonSplitRequest |
-| Timeline | TimelineItem, TimelineResponse, AggregatedTimelineResponse |
-| Relationships | RelationshipResponse, RelationshipDetailResponse, ConnectionResponse |
-| Network | NetworkNode, NetworkEdge, NetworkGraphResponse |
-| Facts | PersonFactResponse, PersonFactsResponse, FactExtractionResponse |
-| Dashboard | MeStatsResponse, MeInteractionsResponse, FamilyInteractionsResponse |
-| Health | SyncHealthResponse, ReviewQueueResponse |
 
 ---
 
@@ -271,12 +261,13 @@ from api.routes import (
 
 ### CRM Models
 
+`api/routes/crm.py` defines and uses its own response models directly — they
+aren't re-exported for other modules to import. The one thing from
+`api/routes/crm_models/` that another module does import (see [CRM Models
+Package](#crm-models-package-apiroutescrm_models) above):
+
 ```python
-from api.routes.crm_models import (
-    PersonDetailResponse, TimelineItem, NetworkGraphResponse,
-    compute_person_category, person_to_detail_response,
-    MY_PERSON_ID, FAMILY_EXACT_NAMES,
-)
+from api.routes.crm_models._utils import is_family_member
 ```
 
 ---

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -47,16 +47,22 @@ class TestCRMConfig:
         `photos_enabled=settings.photos_enabled` from get_crm_config()
         left every other test in this repo green, because
         CRMConfigResponse.photos_enabled defaults to False and this host
-        has no Photos library configured (settings.photos_enabled is also
-        False here) -- the mutation and the real answer coincided. This
-        pins the False case against the actual settings value; the next
-        test below forces the True case so the field can't be silently
-        hardcoded to False and still pass both."""
-        from config.settings import settings
+        (at authoring time) had no Photos library configured -- the
+        mutation and the real answer coincided. Forces False explicitly
+        (rather than asserting against whatever settings.photos_enabled
+        happens to be on the machine running the suite, e.g. a Mac with a
+        real Photos library configured) so this pins the False case
+        unconditionally; the next test below forces the True case, so the
+        field can't be silently hardcoded to one value and still pass
+        both."""
+        from unittest.mock import patch, PropertyMock
+        from config.settings import Settings
 
-        response = client.get("/api/crm/config")
+        with patch.object(Settings, "photos_enabled", new_callable=PropertyMock, return_value=False):
+            response = client.get("/api/crm/config")
+
         assert response.status_code == 200
-        assert response.json()["photos_enabled"] == settings.photos_enabled is False
+        assert response.json()["photos_enabled"] is False
 
     def test_photos_enabled_reflects_settings_when_true(self, client):
         from unittest.mock import patch, PropertyMock

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -37,6 +37,38 @@ def sample_person_id(client):
     pytest.skip("No people in database to test")
 
 
+class TestCRMConfig:
+    """Tests for GET /api/crm/config."""
+
+    def test_photos_enabled_reflects_settings_when_false(self, client):
+        """#907 review round 2, finding 2: the server side of #875's
+        photos_enabled field (web/crm.html's loadCRMConfig() reads it to
+        decide whether to ever request an avatar) had no test -- deleting
+        `photos_enabled=settings.photos_enabled` from get_crm_config()
+        left every other test in this repo green, because
+        CRMConfigResponse.photos_enabled defaults to False and this host
+        has no Photos library configured (settings.photos_enabled is also
+        False here) -- the mutation and the real answer coincided. This
+        pins the False case against the actual settings value; the next
+        test below forces the True case so the field can't be silently
+        hardcoded to False and still pass both."""
+        from config.settings import settings
+
+        response = client.get("/api/crm/config")
+        assert response.status_code == 200
+        assert response.json()["photos_enabled"] == settings.photos_enabled is False
+
+    def test_photos_enabled_reflects_settings_when_true(self, client):
+        from unittest.mock import patch, PropertyMock
+        from config.settings import Settings
+
+        with patch.object(Settings, "photos_enabled", new_callable=PropertyMock, return_value=True):
+            response = client.get("/api/crm/config")
+
+        assert response.status_code == 200
+        assert response.json()["photos_enabled"] is True
+
+
 class TestPersonEndpoints:
     """Tests for /api/crm/people endpoints."""
 

--- a/tests/test_crm_api.py
+++ b/tests/test_crm_api.py
@@ -8,6 +8,7 @@ Tests are organized by endpoint group:
 - Sync health and status
 - Statistics
 """
+import logging
 import sqlite3
 import time
 from pathlib import Path
@@ -48,6 +49,43 @@ class TestPersonEndpoints:
         assert "total" in data
         assert "offset" in data
         assert "count" in data
+
+    def test_get_people_list_has_profile_photo_field(self, client):
+        """#875: every row must carry `has_profile_photo` as a plain bool, so
+        the client can decide whether to request an avatar without probing
+        each person first."""
+        response = client.get("/api/crm/people?limit=50")
+        assert response.status_code == 200
+        people = response.json()["people"]
+        if not people:
+            pytest.skip("No people in database to test")
+        for person in people:
+            assert "has_profile_photo" in person
+            assert isinstance(person["has_profile_photo"], bool)
+
+    def test_person_detail_has_profile_photo_matches_list(self, client):
+        """#875: the detail endpoint must agree with the list endpoint for
+        the same person -- both derive `has_profile_photo` from
+        `person.photo_count` via the same `_person_to_detail_response`
+        helper, so a divergence here would mean one path stopped setting it."""
+        response = client.get("/api/crm/people?limit=20")
+        people = response.json()["people"]
+        if not people:
+            pytest.skip("No people in database to test")
+        for person in people[:10]:
+            detail = client.get(f"/api/crm/people/{person['id']}")
+            assert detail.status_code == 200
+            assert detail.json()["has_profile_photo"] == person["has_profile_photo"]
+
+    def test_list_people_never_logs_the_search_query(self, client, caplog):
+        """#904: the search box's contents are personal data (names, partial
+        emails) -- the list handler's own log line must carry counts and
+        timing only, never the raw `q` (or other filter values)."""
+        distinctive_query = "zzz-synthetic-search-marker-not-a-real-name-9f3c"
+        with caplog.at_level(logging.INFO, logger="api.routes.crm"):
+            response = client.get(f"/api/crm/people?q={distinctive_query}&limit=5")
+        assert response.status_code == 200
+        assert distinctive_query not in caplog.text
 
     def test_get_people_with_search(self, client):
         """GET /people with search query works."""

--- a/tests/test_crm_avatar_photos_ui_browser.py
+++ b/tests/test_crm_avatar_photos_ui_browser.py
@@ -1,0 +1,233 @@
+"""Browser tests for people-list avatars (#875).
+
+The list's avatar loader used to probe every rendered row with `HEAD`, a
+method the photo route rejected with 405, so every avatar was permanently
+marked "no photo" and the loader was never even called after render. The fix
+threads `has_profile_photo` through the list response and renders a real
+`<img>` only for flagged people — no probing loop, no per-person fetch.
+
+Unlike most of the browser suite this serves `web/` itself from an ephemeral
+port rather than pointing at a running API, and — because an avatar loads via
+a plain `<img src>` rather than `fetch()` — intercepts requests with
+Playwright's `page.route()` (which covers image loads) instead of the
+`window.fetch` monkey-patch `test_crm_request_hygiene_ui_browser.py` uses for
+its abort-timing tests; nothing here needs real concurrency, just to observe
+which URLs the browser actually requests. Carries no `requires_server`
+marker, so it runs at pre-push (`browser and not requires_server`).
+
+A note on "no console errors": Chromium logs "Failed to load resource: ...
+404" to the DevTools console for *any* request (image, fetch, XHR) that
+completes with a non-2xx status, regardless of whether the page's JS handles
+it — confirmed empirically here, including through `page.route()` mocks. That
+browser-level notice cannot be suppressed by application code short of never
+making the request in the first place, so the "photo not found" case here
+(PERSON_MISSING_THUMB) does trigger it. `_app_console_errors()` filters that
+one known, unavoidable browser notice out and asserts nothing else was
+logged, which is the meaningful signal: no *application* error (an uncaught
+exception, or our own code logging one) resulted from a missing thumbnail.
+`page.on("pageerror")` (uncaught JS exceptions) is checked directly with no
+filtering, matching the rest of this suite's convention.
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+# Obviously synthetic people — never real CRM data.
+PERSON_HAS_PHOTO = {
+    "id": "person-has-photo", "canonical_name": "Has Photo Person",
+    "category": "personal", "dunbar_circle": 3, "relationship_strength": 10,
+    "company": "", "tags": [], "has_profile_photo": True,
+}
+PERSON_MISSING_THUMB = {
+    "id": "person-missing-thumb", "canonical_name": "Missing Thumb Person",
+    "category": "personal", "dunbar_circle": 3, "relationship_strength": 8,
+    "company": "", "tags": [], "has_profile_photo": True,
+}
+PERSON_NO_PHOTO = {
+    "id": "person-no-photo", "canonical_name": "No Photo Person",
+    "category": "personal", "dunbar_circle": 3, "relationship_strength": 5,
+    "company": "", "tags": [], "has_profile_photo": False,
+}
+
+# A real, decodable 2x2 JPEG (generated once with Pillow at authoring
+# time -- Pillow itself is not a test-time dependency, these are just
+# static bytes). Content doesn't matter, but it must actually decode so
+# the <img> fires onload rather than onerror -- a hand-rolled/truncated
+# JPEG here previously made the "has-photo" assertion flaky: the
+# request succeeded (200) but the browser's image decoder silently
+# failed and fired onerror, with no console error to flag it (a decode
+# failure on a 2xx response is silent to the console).
+FAKE_JPEG_BYTES = b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a\x1f\x1e\x1d\x1a\x1c\x1c $.\' ",#\x1c\x1c(7),01444\x1f\'9=82<.342\xff\xdb\x00C\x01\t\t\t\x0c\x0b\x0c\x18\r\r\x182!\x1c!22222222222222222222222222222222222222222222222222\xff\xc0\x00\x11\x08\x00\x02\x00\x02\x03\x01"\x00\x02\x11\x01\x03\x11\x01\xff\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\xff\xc4\x00\xb5\x10\x00\x02\x01\x03\x03\x02\x04\x03\x05\x05\x04\x04\x00\x00\x01}\x01\x02\x03\x00\x04\x11\x05\x12!1A\x06\x13Qa\x07"q\x142\x81\x91\xa1\x08#B\xb1\xc1\x15R\xd1\xf0$3br\x82\t\n\x16\x17\x18\x19\x1a%&\'()*456789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz\x83\x84\x85\x86\x87\x88\x89\x8a\x92\x93\x94\x95\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xff\xc4\x00\x1f\x01\x00\x03\x01\x01\x01\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\xff\xc4\x00\xb5\x11\x00\x02\x01\x02\x04\x04\x03\x04\x07\x05\x04\x04\x00\x01\x02w\x00\x01\x02\x03\x11\x04\x05!1\x06\x12AQ\x07aq\x13"2\x81\x08\x14B\x91\xa1\xb1\xc1\t#3R\xf0\x15br\xd1\n\x16$4\xe1%\xf1\x17\x18\x19\x1a&\'()*56789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x92\x93\x94\x95\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xff\xda\x00\x0c\x03\x01\x00\x02\x11\x03\x11\x00?\x00\xb1E\x14Wa\xc8\x7f\xff\xd9'
+
+
+class _CrmHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves crm.html the way api/main.py does for /me, /family, /crm,
+    /birthdays, and /relationship: every non-static path resolves to the
+    same file, and the module tree hangs off /static/."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / "crm.html")
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def crm_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _CrmHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _open_me_with_stubs(page: Page, crm_base_url, *, people, photos_enabled=True):
+    """Loads /me with every `/api/**` call stubbed: the people list, the
+    boilerplate config/stats/birthdays calls init() also fires, the
+    photos-enabled check (`loadPhotosEnabled`), and the profile photo route
+    itself (200 for PERSON_HAS_PHOTO, 404 for PERSON_MISSING_THUMB, and it
+    must never be requested at all for PERSON_NO_PHOTO).
+
+    Returns (photo_requests, photo_methods, console_errors, page_errors):
+    the URLs and HTTP methods of every `/api/photos/profile/*` request the
+    page actually issued, so a caller can assert both "which people" and
+    "never HEAD" from the same load."""
+    photo_requests = []
+    photo_methods = []
+
+    def handler(route):
+        url = route.request.url
+        if "/api/photos/profile/" in url:
+            photo_requests.append(url)
+            photo_methods.append(route.request.method)
+            if "person-has-photo" in url:
+                route.fulfill(status=200, content_type="image/jpeg", body=FAKE_JPEG_BYTES)
+            else:
+                route.fulfill(status=404, content_type="application/json",
+                              body=json.dumps({"detail": "not found"}))
+            return
+        if "/api/photos/stats" in url:
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps({"photos_enabled": photos_enabled}))
+            return
+        if "/api/crm/people?" in url or url.rstrip("/").endswith("/api/crm/people"):
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps({"people": people, "total": len(people),
+                                            "offset": 0, "count": len(people)}))
+            return
+        if "/api/crm/config" in url:
+            route.fulfill(status=200, content_type="application/json", body="{}")
+            return
+        if "/api/crm/statistics" in url:
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps({"total_people": len(people)}))
+            return
+        if "/api/crm/birthdays/today" in url:
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps({"birthdays": []}))
+            return
+        # Anything else this page might request on load: empty success.
+        route.fulfill(status=200, content_type="application/json", body="{}")
+
+    page.route("**/api/**", handler)
+
+    console_errors = []
+    page_errors = []
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+
+    page.goto(f"{crm_base_url}/me")
+    page.wait_for_selector("#searchInput")
+    expect(page.locator(".person-card")).to_have_count(len(people))
+    # Let onload/onerror settle for the flagged people's <img> elements.
+    page.wait_for_timeout(300)
+
+    return photo_requests, photo_methods, console_errors, page_errors
+
+
+def _app_console_errors(console_errors):
+    """Filters out Chromium's unavoidable "Failed to load resource" notice
+    for a non-2xx response (see module docstring) so what's left is
+    application-level noise only."""
+    return [e for e in console_errors if "Failed to load resource" not in e]
+
+
+def _avatar(page: Page, person_id: str):
+    return page.locator(f'.person-avatar[data-person-id="{person_id}"]')
+
+
+class TestAvatarRendering:
+    """Only flagged people get a photo request; never a HEAD probe; a
+    missing thumbnail falls back to initials without an application error."""
+
+    def test_exactly_two_photo_requests_for_flagged_people(self, page: Page, crm_base_url):
+        photo_requests, photo_methods, console_errors, page_errors = _open_me_with_stubs(
+            page, crm_base_url,
+            people=[PERSON_HAS_PHOTO, PERSON_MISSING_THUMB, PERSON_NO_PHOTO],
+        )
+
+        assert len(photo_requests) == 2, f"expected exactly 2 photo requests, got: {photo_requests}"
+        assert any("person-has-photo" in u for u in photo_requests)
+        assert any("person-missing-thumb" in u for u in photo_requests)
+        assert not any("person-no-photo" in u for u in photo_requests)
+
+        assert page_errors == []
+        assert _app_console_errors(console_errors) == []
+
+    def test_no_head_requests_are_ever_issued(self, page: Page, crm_base_url):
+        _photo_requests, photo_methods, _console_errors, _page_errors = _open_me_with_stubs(
+            page, crm_base_url, people=[PERSON_HAS_PHOTO, PERSON_NO_PHOTO],
+        )
+        assert photo_methods, "expected at least one photo request"
+        assert all(m == "GET" for m in photo_methods), f"expected only GET, got: {photo_methods}"
+
+    def test_avatar_classes_reflect_photo_availability(self, page: Page, crm_base_url):
+        _open_me_with_stubs(
+            page, crm_base_url,
+            people=[PERSON_HAS_PHOTO, PERSON_MISSING_THUMB, PERSON_NO_PHOTO],
+        )
+
+        expect(_avatar(page, "person-has-photo")).to_have_class("person-avatar has-photo")
+        expect(_avatar(page, "person-has-photo").locator("img")).to_have_count(1)
+
+        # The 404 flips the optimistic has-photo render back to no-photo and
+        # removes the broken <img>, leaving initials visible.
+        expect(_avatar(page, "person-missing-thumb")).to_have_class("person-avatar no-photo")
+        expect(_avatar(page, "person-missing-thumb").locator("img")).to_have_count(0)
+        assert _avatar(page, "person-missing-thumb").inner_text().strip() != ""
+
+        expect(_avatar(page, "person-no-photo")).to_have_class("person-avatar no-photo")
+        expect(_avatar(page, "person-no-photo").locator("img")).to_have_count(0)
+
+
+class TestPhotosDisabled:
+    """When Photos isn't configured at all, the list must not request any
+    avatar image, even for people the list flags as having one."""
+
+    def test_photos_disabled_issues_zero_photo_requests(self, page: Page, crm_base_url):
+        photo_requests, _photo_methods, console_errors, page_errors = _open_me_with_stubs(
+            page, crm_base_url,
+            people=[PERSON_HAS_PHOTO, PERSON_MISSING_THUMB, PERSON_NO_PHOTO],
+            photos_enabled=False,
+        )
+
+        assert photo_requests == []
+        assert page_errors == []
+        assert _app_console_errors(console_errors) == []
+
+        for person in (PERSON_HAS_PHOTO, PERSON_MISSING_THUMB, PERSON_NO_PHOTO):
+            expect(_avatar(page, person["id"])).to_have_class("person-avatar no-photo")
+            expect(_avatar(page, person["id"]).locator("img")).to_have_count(0)

--- a/tests/test_crm_avatar_photos_ui_browser.py
+++ b/tests/test_crm_avatar_photos_ui_browser.py
@@ -94,12 +94,24 @@ def crm_base_url():
         server.server_close()
 
 
-def _open_me_with_stubs(page: Page, crm_base_url, *, people, photos_enabled=True):
+def _open_me_with_stubs(page: Page, crm_base_url, *, people, photos_enabled=True,
+                         photo_status_for=None):
     """Loads /me with every `/api/**` call stubbed: the people list, the
-    boilerplate config/stats/birthdays calls init() also fires, the
-    photos-enabled check (`loadPhotosEnabled`), and the profile photo route
-    itself (200 for PERSON_HAS_PHOTO, 404 for PERSON_MISSING_THUMB, and it
-    must never be requested at all for PERSON_NO_PHOTO).
+    boilerplate config/statistics/birthdays calls init() also fires, and the
+    profile photo route itself.
+
+    `photos_enabled` is served from `/api/crm/config` (#907 review finding
+    2: this used to be its own round trip to `/api/photos/stats`, which is
+    not cheap when Photos *is* configured and blocked every page's first
+    render; `photos_enabled` now piggybacks on the config request `init()`
+    already awaits, and there is no separate `/api/photos/stats` call to
+    stub any more).
+
+    `photo_status_for(url) -> int | None` picks the status for a photo
+    request; the default (None) fulfills `person-has-photo` with 200 and
+    everything else with 404, matching the original 3-person fixture. A
+    caller with many flagged people (see `TestLazyLoading`) can override it
+    to fulfill every request with 200 instead.
 
     Returns (photo_requests, photo_methods, console_errors, page_errors):
     the URLs and HTTP methods of every `/api/photos/profile/*` request the
@@ -108,20 +120,22 @@ def _open_me_with_stubs(page: Page, crm_base_url, *, people, photos_enabled=True
     photo_requests = []
     photo_methods = []
 
+    def _default_photo_status(url):
+        return 200 if "person-has-photo" in url else 404
+
+    status_for = photo_status_for or _default_photo_status
+
     def handler(route):
         url = route.request.url
         if "/api/photos/profile/" in url:
             photo_requests.append(url)
             photo_methods.append(route.request.method)
-            if "person-has-photo" in url:
+            status = status_for(url)
+            if status == 200:
                 route.fulfill(status=200, content_type="image/jpeg", body=FAKE_JPEG_BYTES)
             else:
-                route.fulfill(status=404, content_type="application/json",
+                route.fulfill(status=status, content_type="application/json",
                               body=json.dumps({"detail": "not found"}))
-            return
-        if "/api/photos/stats" in url:
-            route.fulfill(status=200, content_type="application/json",
-                          body=json.dumps({"photos_enabled": photos_enabled}))
             return
         if "/api/crm/people?" in url or url.rstrip("/").endswith("/api/crm/people"):
             route.fulfill(status=200, content_type="application/json",
@@ -129,7 +143,8 @@ def _open_me_with_stubs(page: Page, crm_base_url, *, people, photos_enabled=True
                                             "offset": 0, "count": len(people)}))
             return
         if "/api/crm/config" in url:
-            route.fulfill(status=200, content_type="application/json", body="{}")
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps({"photos_enabled": photos_enabled}))
             return
         if "/api/crm/statistics" in url:
             route.fulfill(status=200, content_type="application/json",
@@ -202,6 +217,9 @@ class TestAvatarRendering:
 
         expect(_avatar(page, "person-has-photo")).to_have_class("person-avatar has-photo")
         expect(_avatar(page, "person-has-photo").locator("img")).to_have_count(1)
+        # AC 6 ("images load lazily"): mutation-checked -- deleting
+        # loading="lazy" from renderAvatarPhotoImg() must fail this.
+        expect(_avatar(page, "person-has-photo").locator("img")).to_have_attribute("loading", "lazy")
 
         # The 404 flips the optimistic has-photo render back to no-photo and
         # removes the broken <img>, leaving initials visible.
@@ -231,3 +249,39 @@ class TestPhotosDisabled:
         for person in (PERSON_HAS_PHOTO, PERSON_MISSING_THUMB, PERSON_NO_PHOTO):
             expect(_avatar(page, person["id"])).to_have_class("person-avatar no-photo")
             expect(_avatar(page, person["id"]).locator("img")).to_have_count(0)
+
+
+class TestLazyLoadingAtScale:
+    """AC 6: rendering 300 flagged people must not fire 300 image requests
+    on first paint -- `loading="lazy"` is supposed to defer the ones outside
+    (or well past) the viewport until scrolled into view. This is the
+    mutation-check the `has-photo` test's single `to_have_attribute` can't
+    provide on its own: deleting `loading="lazy"` leaves that assertion's
+    target element correct in isolation, but only this test actually proves
+    the browser behaves differently because of it -- with the attribute
+    removed, all 300 requests fire immediately instead of a small fraction."""
+
+    def test_300_flagged_rows_request_far_fewer_images_at_first_paint(
+        self, page: Page, crm_base_url
+    ):
+        people = [
+            {
+                "id": f"person-{i}", "canonical_name": f"Person {i}",
+                "category": "personal", "dunbar_circle": 3,
+                "relationship_strength": 300 - i,
+                "company": "", "tags": [], "has_profile_photo": True,
+            }
+            for i in range(300)
+        ]
+
+        photo_requests, _photo_methods, _console_errors, _page_errors = _open_me_with_stubs(
+            page, crm_base_url, people=people,
+            photo_status_for=lambda _url: 200,
+        )
+
+        assert len(people) == 300
+        assert 0 < len(photo_requests) < len(people) / 2, (
+            f"expected well under {len(people)} image requests at first paint "
+            f"(loading=\"lazy\" should defer most off-screen rows), got "
+            f"{len(photo_requests)}"
+        )

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -103,6 +103,101 @@ class TestTelegramTokenRedactionFilter:
         assert result is True
 
 
+class TestRequestQueryStringRedactionFilter:
+    """#904: uvicorn's own access logger (`uvicorn.access`) logs the full
+    request line -- path and query string -- for every request at INFO,
+    independent of anything a route handler logs. That's how the CRM people
+    list's raw search text (`?q=<text>`) reached `logs/server.log` even
+    after the handler's own log line stopped naming it."""
+
+    def setup_method(self, method):
+        self._access_logger = logging.getLogger("uvicorn.access")
+        self._filters_before = list(self._access_logger.filters)
+
+    def teardown_method(self, method):
+        self._access_logger.filters = self._filters_before
+
+    @staticmethod
+    def _uvicorn_access_record(path_with_query: str) -> logging.LogRecord:
+        """Builds a LogRecord the way uvicorn's h11 protocol implementation
+        actually logs one: `access_logger.info('%s - "%s %s HTTP/%s" %d',
+        client_addr, method, path_with_query_string, http_version, status)`
+        -- msg is the raw format string, args carry the query string, not a
+        pre-formatted message."""
+        return logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=("127.0.0.1:54644", "GET", path_with_query, "1.1", 200),
+            exc_info=None,
+        )
+
+    def test_redacts_query_string_from_access_log_line(self):
+        from api.services.log_redaction import (
+            RequestQueryStringRedactionFilter,
+            REDACTED_QUERY_STRING,
+        )
+
+        marker = "ZZQMARKER7788"
+        record = self._uvicorn_access_record(
+            f"/api/crm/people?q={marker}&sort=strength&limit=5"
+        )
+        result = RequestQueryStringRedactionFilter().filter(record)
+
+        assert result is True  # never drops the record
+        message = record.getMessage()
+        assert marker not in message
+        assert REDACTED_QUERY_STRING in message
+        # The rest of the request line is still useful for diagnostics.
+        assert "GET /api/crm/people?<redacted> HTTP/1.1" in message
+        assert "200" in message
+
+    def test_leaves_query_string_free_requests_untouched(self):
+        from api.services.log_redaction import RequestQueryStringRedactionFilter
+
+        record = self._uvicorn_access_record("/health")
+        RequestQueryStringRedactionFilter().filter(record)
+        assert record.getMessage() == '127.0.0.1:54644 - "GET /health HTTP/1.1" 200'
+
+    def test_does_not_raise_on_bad_percent_args(self):
+        from api.services.log_redaction import RequestQueryStringRedactionFilter
+
+        record = logging.LogRecord(
+            name="uvicorn.access", level=logging.INFO, pathname=__file__, lineno=1,
+            msg="%s %s", args=("only one",), exc_info=None,
+        )
+        result = RequestQueryStringRedactionFilter().filter(record)
+        assert result is True
+
+    def test_install_attaches_filter_to_uvicorn_access_logger(self):
+        from api.services.log_redaction import (
+            install_query_string_redaction_filter,
+            RequestQueryStringRedactionFilter,
+        )
+
+        install_query_string_redaction_filter()
+        assert any(
+            isinstance(f, RequestQueryStringRedactionFilter)
+            for f in self._access_logger.filters
+        )
+
+    def test_install_is_idempotent(self):
+        from api.services.log_redaction import (
+            install_query_string_redaction_filter,
+            RequestQueryStringRedactionFilter,
+        )
+
+        install_query_string_redaction_filter()
+        install_query_string_redaction_filter()
+        count = sum(
+            1 for f in self._access_logger.filters
+            if isinstance(f, RequestQueryStringRedactionFilter)
+        )
+        assert count == 1
+
+
 class TestConfigureTelegramLogRedaction:
     def setup_method(self, method):
         self._root = logging.getLogger()

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -154,6 +154,46 @@ class TestRequestQueryStringRedactionFilter:
         assert "GET /api/crm/people?<redacted> HTTP/1.1" in message
         assert "200" in message
 
+    def test_redacted_record_survives_uvicorns_actual_access_formatter(self):
+        """#907 review round 2 (BLOCKER): uvicorn.logging.AccessFormatter
+        does not call record.getMessage() at all -- it unconditionally
+        unpacks record.args as a 5-tuple and rebuilds the request line from
+        those fields. An earlier version of this filter rewrote record.msg
+        and cleared record.args to (), which made getMessage() look correct
+        (the test above) while silently breaking that unpack: formatting
+        the record for real raised `ValueError: not enough values to
+        unpack`, which is what production's uvicorn.access logger actually
+        emitted -- a 79-line traceback per request with a query string,
+        not an access line. This test would have caught it; the one above
+        could not, because it never involves the real formatter."""
+        from uvicorn.logging import AccessFormatter
+        from api.services.log_redaction import (
+            RequestQueryStringRedactionFilter,
+            REDACTED_QUERY_STRING,
+        )
+
+        marker = "ZZQMARKER7788"
+        record = self._uvicorn_access_record(
+            f"/api/crm/people?q={marker}&sort=strength&limit=5"
+        )
+        RequestQueryStringRedactionFilter().filter(record)
+
+        # The 5-tuple shape AccessFormatter.formatMessage() unpacks must
+        # survive -- this is the regression guard for the fix itself.
+        assert isinstance(record.args, tuple) and len(record.args) == 5
+
+        # uvicorn's actual default access-log format string (config.py's
+        # LOGGING_CONFIG["formatters"]["access"]["fmt"]).
+        fmt = '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+        formatter = AccessFormatter(fmt, use_colors=False)
+
+        formatted = formatter.format(record)  # must not raise
+
+        assert marker not in formatted
+        assert REDACTED_QUERY_STRING in formatted
+        assert "GET /api/crm/people?<redacted> HTTP/1.1" in formatted
+        assert "200" in formatted
+
     def test_leaves_query_string_free_requests_untouched(self):
         from api.services.log_redaction import RequestQueryStringRedactionFilter
 

--- a/tests/test_photos_profile_api.py
+++ b/tests/test_photos_profile_api.py
@@ -1,0 +1,119 @@
+"""
+Tests for the profile photo endpoint (GET/HEAD /api/photos/profile/{person_id}).
+
+#875: the CRM people list needs to know, and then fetch, which people have a
+usable avatar without probing every row with a request method the route
+didn't accept. These tests pin the route-level contract that makes that
+possible: HEAD behaves like GET (status, no body), and both 200 and 404
+responses carry a cache header the client can rely on to avoid repeat
+requests.
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch, PropertyMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from api.main import app
+    return TestClient(app)
+
+
+@pytest.fixture
+def photos_enabled():
+    """The route gates on `settings.photos_enabled`, a property derived from
+    whether the Photos library file exists on disk -- force it on so the
+    handler itself (not just the disabled short-circuit) gets exercised."""
+    from config.settings import Settings
+    with patch.object(
+        Settings, "photos_enabled", new_callable=PropertyMock, return_value=True
+    ):
+        yield
+
+
+def _fake_photo_interaction(source_id="FAKE-UUID-0001"):
+    from api.services.interaction_store import Interaction
+    return Interaction(
+        id="interaction-1",
+        person_id="person-1",
+        timestamp=datetime.now(timezone.utc),
+        source_type="photos",
+        title="synthetic test photo",
+        source_id=source_id,
+    )
+
+
+class TestProfilePhotoDisabled:
+    """Photos not configured at all: the route's short-circuit runs before
+    HEAD/GET are distinguished, so both must carry the same status."""
+
+    def test_head_matches_get_status_and_has_no_body(self, client):
+        get_resp = client.get("/api/photos/profile/some-person")
+        head_resp = client.request("HEAD", "/api/photos/profile/some-person")
+
+        assert head_resp.status_code == get_resp.status_code == 503
+        assert head_resp.content == b""
+
+
+class TestProfilePhotoAvailable:
+    """A person with a photo interaction whose thumbnail file exists."""
+
+    def test_get_returns_image_body(self, client, photos_enabled, tmp_path):
+        thumb = tmp_path / "thumb.jpeg"
+        thumb.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
+
+        with patch("api.services.interaction_store.get_interaction_store") as mock_store, \
+             patch("api.routes.photos._get_thumbnail_path", return_value=thumb):
+            mock_store.return_value.get_for_person.return_value = [_fake_photo_interaction()]
+            response = client.get("/api/photos/profile/person-1")
+
+        assert response.status_code == 200
+        assert response.content == b"\xff\xd8\xff\xe0fake-jpeg-bytes"
+        assert response.headers["content-type"] == "image/jpeg"
+
+    def test_head_returns_200_with_no_body_and_matching_cache_header(self, client, photos_enabled, tmp_path):
+        """#875: HEAD used to 405 on this route (GET-only), which is why the
+        list's avatar loader was permanently marking everyone as no-photo."""
+        thumb = tmp_path / "thumb.jpeg"
+        thumb.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
+
+        with patch("api.services.interaction_store.get_interaction_store") as mock_store, \
+             patch("api.routes.photos._get_thumbnail_path", return_value=thumb):
+            mock_store.return_value.get_for_person.return_value = [_fake_photo_interaction()]
+            head_resp = client.request("HEAD", "/api/photos/profile/person-1")
+            get_resp = client.get("/api/photos/profile/person-1")
+
+        assert head_resp.status_code == 200
+        assert head_resp.content == b""
+        assert head_resp.headers.get("cache-control") == get_resp.headers.get("cache-control")
+        assert "max-age=3600" in head_resp.headers.get("cache-control", "")
+
+
+class TestProfilePhotoMissing:
+    """Photos enabled, but no reachable thumbnail for this person -- either
+    no photo interactions at all, or none with a thumbnail on disk."""
+
+    def test_get_404_carries_cache_control_of_at_least_one_hour(self, client, photos_enabled):
+        with patch("api.services.interaction_store.get_interaction_store") as mock_store:
+            mock_store.return_value.get_for_person.return_value = []
+            response = client.get("/api/photos/profile/person-without-photo")
+
+        assert response.status_code == 404
+        cache_control = response.headers.get("cache-control", "")
+        assert "max-age=" in cache_control
+        max_age = int(cache_control.split("max-age=")[1].split(",")[0].strip())
+        assert max_age >= 3600
+
+    def test_head_404_matches_get_with_no_body(self, client, photos_enabled):
+        with patch("api.services.interaction_store.get_interaction_store") as mock_store:
+            mock_store.return_value.get_for_person.return_value = []
+            head_resp = client.request("HEAD", "/api/photos/profile/person-without-photo")
+            get_resp = client.get("/api/photos/profile/person-without-photo")
+
+        assert head_resp.status_code == get_resp.status_code == 404
+        assert head_resp.content == b""
+        assert head_resp.headers.get("cache-control") == get_resp.headers.get("cache-control")

--- a/tests/test_photos_profile_api.py
+++ b/tests/test_photos_profile_api.py
@@ -75,9 +75,20 @@ class TestProfilePhotoAvailable:
         assert response.content == b"\xff\xd8\xff\xe0fake-jpeg-bytes"
         assert response.headers["content-type"] == "image/jpeg"
 
-    def test_head_returns_200_with_no_body_and_matching_cache_header(self, client, photos_enabled, tmp_path):
+    def test_head_returns_200_with_no_body_and_full_header_parity_with_get(
+        self, client, photos_enabled, tmp_path
+    ):
         """#875: HEAD used to 405 on this route (GET-only), which is why the
-        list's avatar loader was permanently marking everyone as no-photo."""
+        list's avatar loader was permanently marking everyone as no-photo.
+
+        #907 review finding 3: a hand-rolled `if request.method == "HEAD"`
+        branch returning a bare `Response` matched status and `cache-control`
+        but dropped `etag`, `last-modified`, `accept-ranges`, and the real
+        `content-length` -- a client using HEAD to revalidate a cached avatar
+        couldn't. The route now stacks `@router.get`/`@router.head` on the
+        same function so Starlette's `FileResponse` handles HEAD natively
+        (RFC 9110 SS9.3.2: HEAD's header fields must match what GET would
+        send), so this asserts full header equality, not just cache-control."""
         thumb = tmp_path / "thumb.jpeg"
         thumb.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
 
@@ -87,10 +98,22 @@ class TestProfilePhotoAvailable:
             head_resp = client.request("HEAD", "/api/photos/profile/person-1")
             get_resp = client.get("/api/photos/profile/person-1")
 
-        assert head_resp.status_code == 200
+        assert head_resp.status_code == get_resp.status_code == 200
         assert head_resp.content == b""
-        assert head_resp.headers.get("cache-control") == get_resp.headers.get("cache-control")
+        assert get_resp.content  # GET actually carries the body
+
+        # Headers that must be identical between HEAD and GET (date/server
+        # excluded -- not part of this route's contract, and legitimately
+        # timing-dependent).
+        for header in ("content-length", "content-type", "cache-control", "etag", "last-modified"):
+            assert header in get_resp.headers, f"GET response missing {header!r}"
+            assert head_resp.headers.get(header) == get_resp.headers.get(header), (
+                f"{header!r} differs: HEAD={head_resp.headers.get(header)!r} "
+                f"GET={get_resp.headers.get(header)!r}"
+            )
         assert "max-age=3600" in head_resp.headers.get("cache-control", "")
+        # content-length reflects the real file size, not the (empty) HEAD body.
+        assert int(head_resp.headers["content-length"]) == len(get_resp.content)
 
 
 class TestProfilePhotoMissing:

--- a/web/crm.html
+++ b/web/crm.html
@@ -549,6 +549,8 @@
         }
 
         .person-avatar {
+            position: relative;
+            overflow: hidden;
             width: 40px;
             height: 40px;
             background: linear-gradient(135deg, var(--people) 0%, var(--people-hover) 100%);
@@ -565,6 +567,14 @@
         }
         .person-avatar.has-photo {
             color: transparent;
+        }
+        .person-avatar .avatar-photo-img {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            border-radius: 50%;
         }
 
         .person-info {
@@ -9273,8 +9283,10 @@
                 return;
             }
 
-            // Load CRM config first (needed for myPersonId)
-            await loadCRMConfig();
+            // Load CRM config first (needed for myPersonId). Resolve whether
+            // Photos is configured at all in parallel, before the people list
+            // can render its first avatar (see loadPhotosEnabled).
+            await Promise.all([loadCRMConfig(), loadPhotosEnabled()]);
 
             // Check for birthdays today (non-blocking)
             checkAndShowBirthdayToast();
@@ -9524,7 +9536,7 @@
                      onclick="selectPerson('${person.id}')">
                     <div class="person-checkbox ${selectedForMerge.has(person.id) ? 'checked' : ''}"
                          onclick="event.stopPropagation(); toggleMergeSelection('${person.id}')"></div>
-                    <div class="person-avatar" data-person-id="${person.id}" style="${getAvatarStyle(person.category)}">${getInitials(person.canonical_name)}</div>
+                    <div class="person-avatar ${avatarPhotoClass(person)}" data-person-id="${person.id}" style="${getAvatarStyle(person.category)}">${getInitials(person.canonical_name)}${renderAvatarPhotoImg(person)}</div>
                     <div class="person-info">
                         <div class="person-name">${escapeHtml(person.canonical_name)}</div>
                         <div class="person-company">${escapeHtml(person.company || '')}</div>
@@ -13366,47 +13378,67 @@
             return name.split(' ').map(n => n[0]).join('').substring(0, 2).toUpperCase();
         }
 
-        // Cache for profile photo availability
+        // Cache for profile photo availability, keyed by person id. Populated
+        // as list avatars resolve (see renderAvatarPhotoImg/handleAvatarPhotoError
+        // below) and reused by the detail-header and relationship-page loaders.
         const profilePhotoCache = new Map();
 
-        // Load profile photos for visible avatars
-        async function loadProfilePhotos() {
-            const avatars = document.querySelectorAll('.person-avatar[data-person-id]');
-            for (const avatar of avatars) {
-                const personId = avatar.dataset.personId;
-                if (!personId) continue;
+        // Whether the Photos integration is configured server-side at all
+        // (settings.photos_enabled). Resolved once in init() before the people
+        // list first renders (see loadPhotosEnabled), so an install without
+        // Photos configured issues zero photo requests instead of letting every
+        // flagged person's <img> fail with a 503. Defaults to false (no
+        // requests) until resolved.
+        let photosEnabled = false;
 
-                // Skip if already processed
-                if (avatar.classList.contains('has-photo') || avatar.classList.contains('no-photo')) continue;
-
-                // Check cache first
-                if (profilePhotoCache.has(personId)) {
-                    const hasPhoto = profilePhotoCache.get(personId);
-                    if (hasPhoto) {
-                        avatar.style.backgroundImage = `url(/api/photos/profile/${personId})`;
-                        avatar.classList.add('has-photo');
-                    } else {
-                        avatar.classList.add('no-photo');
-                    }
-                    continue;
-                }
-
-                // Try to load the photo
-                try {
-                    const response = await fetch(`/api/photos/profile/${personId}`, { method: 'HEAD' });
-                    if (response.ok) {
-                        avatar.style.backgroundImage = `url(/api/photos/profile/${personId})`;
-                        avatar.classList.add('has-photo');
-                        profilePhotoCache.set(personId, true);
-                    } else {
-                        avatar.classList.add('no-photo');
-                        profilePhotoCache.set(personId, false);
-                    }
-                } catch {
-                    avatar.classList.add('no-photo');
-                    profilePhotoCache.set(personId, false);
-                }
+        async function loadPhotosEnabled() {
+            try {
+                const response = await fetch('/api/photos/stats');
+                const data = await response.json();
+                photosEnabled = !!data.photos_enabled;
+            } catch {
+                photosEnabled = false;
             }
+        }
+
+        // Returns the <img> markup for a person-list avatar, or '' when no photo
+        // request should be issued at all. Renders only for people the list
+        // response flagged via has_profile_photo -- never a HEAD probe, never a
+        // loop over every rendered row. `loading="lazy"` defers the actual
+        // network request until the row nears the viewport, so a 300-row list
+        // does not fire hundreds of image loads on render. A person already
+        // known (from an earlier render this session) to have no reachable
+        // thumbnail is skipped entirely so a repeat render can't re-trigger the
+        // same failed request.
+        function renderAvatarPhotoImg(person) {
+            if (!photosEnabled) return '';
+            if (!person.has_profile_photo) return '';
+            if (profilePhotoCache.get(person.id) === false) return '';
+            return `<img class="avatar-photo-img" data-person-id="${person.id}" loading="lazy" alt=""
+                        src="/api/photos/profile/${person.id}"
+                        onload="profilePhotoCache.set('${person.id}', true)"
+                        onerror="handleAvatarPhotoError(this, '${person.id}')">`;
+        }
+
+        // Fallback when a flagged person's thumbnail can't actually be loaded
+        // (e.g. the photo record exists but the file is missing on disk).
+        // Removes the broken <img> so the initials underneath show through,
+        // and remembers the miss so later renders don't retry it.
+        function handleAvatarPhotoError(img, personId) {
+            profilePhotoCache.set(personId, false);
+            const avatar = img.closest('.person-avatar');
+            if (avatar) {
+                avatar.classList.remove('has-photo');
+                avatar.classList.add('no-photo');
+            }
+            img.remove();
+        }
+
+        // Class for a person-list avatar: 'has-photo' when the list flagged the
+        // person and no earlier render already proved the thumbnail unreachable;
+        // 'no-photo' otherwise (plain initials, no photo request at all).
+        function avatarPhotoClass(person) {
+            return renderAvatarPhotoImg(person) ? 'has-photo' : 'no-photo';
         }
 
         // Load profile photo for detail avatar

--- a/web/crm.html
+++ b/web/crm.html
@@ -565,6 +565,19 @@
             background-size: cover;
             background-position: center;
         }
+        /* Inert here in practice: getAvatarStyle() sets an inline `color`
+           on every .person-avatar, and an inline style always wins over
+           this class rule, so a still-loading (optimistically has-photo)
+           avatar keeps showing its initials in full color rather than
+           hiding them -- which is what we want, since it means a slow or
+           never-resolving photo request degrades to visible initials
+           instead of a blank circle. The .avatar-photo-img overlay below
+           is what actually hides the initials, by visually covering them
+           once the image loads. `has-photo`/`no-photo` mostly serve as a
+           JS/test state marker on .person-avatar; this rule is kept
+           because it's harmless and genuinely does apply to other avatars
+           sharing this class pattern without an inline color (e.g.
+           .detail-avatar.has-photo, a separate rule, does hide its text). */
         .person-avatar.has-photo {
             color: transparent;
         }
@@ -9005,6 +9018,14 @@
                     FAMILY_DEFAULT_SELECTED_IDS = config.family_default_selected_ids;
                     console.log('[Config] Loaded family_default_selected_ids:', FAMILY_DEFAULT_SELECTED_IDS.length, 'IDs');
                 }
+                // #907 review finding 2: this used to be its own round trip
+                // to GET /api/photos/stats, which -- when Photos *is*
+                // configured -- runs several full-library aggregate queries
+                // and blocked every page's first render on it. `config`'s
+                // `photos_enabled` is just a Path.exists() check server-side
+                // and this request is already awaited before the list ever
+                // renders, so no extra request is needed.
+                photosEnabled = !!config.photos_enabled;
             } catch (error) {
                 console.warn('[Config] Failed to load CRM config:', error);
             }
@@ -9283,10 +9304,10 @@
                 return;
             }
 
-            // Load CRM config first (needed for myPersonId). Resolve whether
-            // Photos is configured at all in parallel, before the people list
-            // can render its first avatar (see loadPhotosEnabled).
-            await Promise.all([loadCRMConfig(), loadPhotosEnabled()]);
+            // Load CRM config first (needed for myPersonId, and for
+            // photosEnabled -- see loadCRMConfig -- before the people list
+            // can render its first avatar).
+            await loadCRMConfig();
 
             // Check for birthdays today (non-blocking)
             checkAndShowBirthdayToast();
@@ -9531,12 +9552,17 @@
                 return;
             }
 
-            listEl.innerHTML = filteredPeople.map(person => `
+            listEl.innerHTML = filteredPeople.map(person => {
+                // Computed once and reused for both the class name and the
+                // markup itself, rather than calling renderAvatarPhotoImg()
+                // twice per row for the same answer.
+                const avatarImg = renderAvatarPhotoImg(person);
+                return `
                 <div class="person-card ${person.id === selectedPersonId ? 'selected' : ''}"
                      onclick="selectPerson('${person.id}')">
                     <div class="person-checkbox ${selectedForMerge.has(person.id) ? 'checked' : ''}"
                          onclick="event.stopPropagation(); toggleMergeSelection('${person.id}')"></div>
-                    <div class="person-avatar ${avatarPhotoClass(person)}" data-person-id="${person.id}" style="${getAvatarStyle(person.category)}">${getInitials(person.canonical_name)}${renderAvatarPhotoImg(person)}</div>
+                    <div class="person-avatar ${avatarImg ? 'has-photo' : 'no-photo'}" data-person-id="${person.id}" style="${getAvatarStyle(person.category)}">${getInitials(person.canonical_name)}${avatarImg}</div>
                     <div class="person-info">
                         <div class="person-name">${escapeHtml(person.canonical_name)}</div>
                         <div class="person-company">${escapeHtml(person.company || '')}</div>
@@ -9546,7 +9572,8 @@
                         <div class="person-strength-bar" style="width: ${person.relationship_strength || 0}%"></div>
                     </div>
                 </div>
-            `).join('');
+            `;
+            }).join('');
 
             updateMergeToolbar();
         }
@@ -13384,22 +13411,17 @@
         const profilePhotoCache = new Map();
 
         // Whether the Photos integration is configured server-side at all
-        // (settings.photos_enabled). Resolved once in init() before the people
-        // list first renders (see loadPhotosEnabled), so an install without
-        // Photos configured issues zero photo requests instead of letting every
-        // flagged person's <img> fail with a 503. Defaults to false (no
-        // requests) until resolved.
+        // (settings.photos_enabled, cheap: a Path.exists() check). Set from
+        // GET /api/crm/config's `photos_enabled` field in loadCRMConfig(),
+        // which init() already awaits before the people list first renders --
+        // no separate request (see #907 review finding 2: this used to be
+        // its own round trip to GET /api/photos/stats, which runs several
+        // full-library aggregate queries when Photos *is* configured and
+        // blocked every page's first render on it). Defaults to false (no
+        // requests) until loadCRMConfig() resolves, so an install without
+        // Photos configured issues zero photo requests instead of letting
+        // every flagged person's <img> fail with a 503.
         let photosEnabled = false;
-
-        async function loadPhotosEnabled() {
-            try {
-                const response = await fetch('/api/photos/stats');
-                const data = await response.json();
-                photosEnabled = !!data.photos_enabled;
-            } catch {
-                photosEnabled = false;
-            }
-        }
 
         // Returns the <img> markup for a person-list avatar, or '' when no photo
         // request should be issued at all. Renders only for people the list
@@ -13434,13 +13456,6 @@
             img.remove();
         }
 
-        // Class for a person-list avatar: 'has-photo' when the list flagged the
-        // person and no earlier render already proved the thumbnail unreachable;
-        // 'no-photo' otherwise (plain initials, no photo request at all).
-        function avatarPhotoClass(person) {
-            return renderAvatarPhotoImg(person) ? 'has-photo' : 'no-photo';
-        }
-
         // Load profile photo for detail avatar
         async function loadDetailProfilePhoto(personId) {
             const avatar = document.getElementById('detailAvatar');
@@ -13448,6 +13463,16 @@
 
             // Reset classes
             avatar.classList.remove('has-photo', 'no-photo');
+
+            // #907 review finding 7: without this, an install with Photos
+            // not configured issued a photo request (and got a 503, logged
+            // to the console) every time a person was selected -- the list
+            // half of #875 already avoids this, this loader didn't.
+            if (!photosEnabled) {
+                avatar.style.backgroundImage = '';
+                avatar.classList.add('no-photo');
+                return;
+            }
 
             // Check cache first
             if (profilePhotoCache.has(personId)) {
@@ -13482,6 +13507,12 @@
         async function loadRelationshipPartnerPhoto(personId) {
             const avatar = document.getElementById('detailAvatar');
             if (!avatar || !personId) return;
+
+            // #907 review finding 7: see loadDetailProfilePhoto -- without
+            // this, a Photos-less install issued a photo request (503) every
+            // time the relationship dashboard loaded. Leave the default
+            // emoji in place, same as the "no photo" outcome below.
+            if (!photosEnabled) return;
 
             // Check cache first
             if (profilePhotoCache.has(personId)) {


### PR DESCRIPTION
## TL;DR

Profile photos now show up in the CRM people list for the people who actually have one, without probing every visible row first. Opening the list no longer sends any avatar requests for people without a photo, a person whose photo turns out to be missing quietly falls back to their initials, and an install with Photos turned off sends no avatar requests at all — anywhere in the CRM, including the person detail header and the relationship dashboard, not just the list. Separately, the server no longer writes what someone typed into the people-search box to its logs, including the copy of that text uvicorn's own access log used to write independently of anything the app logged.

Closes #875
Closes #904

## Design

- The people-list response now tells the client, per person, whether they have a usable profile photo (`has_profile_photo`), computed from the existing photo count the person record already carries. The same field is present on the single-person detail response for consistency.
- Whether Photos is configured at all (`photos_enabled`) rides on `GET /api/crm/config`, a call the client already makes before its first render — no separate request. The client checks this before ever requesting an avatar, anywhere in the CRM (list, person detail header, relationship dashboard).
- The client renders a real photo only for people flagged that way, loaded lazily so a large list doesn't fire a burst of image loads on render. No probing request of any kind is issued for anyone else.
- If a flagged person's photo can't actually be loaded (the record exists but the thumbnail file is missing), the avatar quietly falls back to initials and remembers not to try again for the rest of the session.
- The avatar photo route answers a `HEAD` request exactly the way a browser expects one to behave: the same headers a `GET` would carry (cache validators included), just without the body. Both a found and a not-found response are cacheable for an hour, so repeat renders don't need to ask again.
- The people-list handler's server log line reports counts and timing only — never the search text a person typed or any filter value. So does uvicorn's own access-log line for every request, not just this one.

## Implementation Notes

- `api/routes/crm.py`: `PersonDetailResponse.has_profile_photo`, set in `_person_to_detail_response()` from `person.photo_count > 0`. `CRMConfigResponse.photos_enabled`, set in `get_crm_config()` from `settings.photos_enabled` (a cheap `Path.exists()`). `list_people()`'s INFO log line no longer includes `q` or `category` (#904).
- `api/routes/photos.py`: `get_profile_photo()` (`/api/photos/profile/{person_id}`) now stacks `@router.get(...)` and `@router.head(..., include_in_schema=False)` on the same function, so Starlette's `FileResponse` handles `HEAD` natively — full header parity with `GET` (`etag`, `last-modified`, `accept-ranges`, real `content-length`), and no duplicate-operation-id warning. The "no photo" `404` carries `Cache-Control: public, max-age=3600`.
- `api/services/log_redaction.py`: new `RequestQueryStringRedactionFilter`, installed directly on the `uvicorn.access` logger from `api/main.py` at import time. uvicorn's access logger writes the full request line (path *and* query string) at INFO independent of anything a route handler logs, and has `propagate=False` with its own dedicated handler — so a root-handler filter (the pattern the existing Telegram-token filter uses) can't see it; it has to sit on the logger itself. Installing it at `api/main.py` import time is safe because uvicorn's own logging `dictConfig()` call (inside `Config.__init__`) runs *before* the app string gets imported in the `scripts/server.sh` startup path (`uvicorn.run("api.main:app", ...)`) — confirmed empirically, see the module's docstring. **The filter redacts `record.args[2]` in place, keeping the 5-tuple shape intact** — `uvicorn.logging.AccessFormatter.formatMessage` unconditionally unpacks `record.args` as `(client_addr, method, full_path, http_version, status_code)` and never reads `record.msg`/`getMessage()` at all, so an earlier version of this filter (which rewrote `record.msg` and cleared `record.args`) broke that unpack and turned every query-string request into a 79-line "Logging error" traceback instead of an access line. A `record.msg`-based rewrite is kept only as a fallback for a record that isn't shaped like uvicorn's own access-log call.
- `web/crm.html`:
  - `renderPeopleList()` computes `renderAvatarPhotoImg(person)` once per row and reuses it for both the `has-photo`/`no-photo` class and the markup itself.
  - `renderAvatarPhotoImg()` renders a `loading="lazy"` `<img>` only when `photosEnabled && person.has_profile_photo` and the person isn't already known (via `profilePhotoCache`) to have no reachable thumbnail.
  - `handleAvatarPhotoError()` is the `onerror` handler: removes the broken `<img>`, flips the avatar to the `no-photo` class, and caches the miss.
  - `photosEnabled` is set in `loadCRMConfig()` from `GET /api/crm/config`'s `photos_enabled` field — `init()` already awaits this before the people list's first render, so no separate request is needed.
  - `loadDetailProfilePhoto()` and `loadRelationshipPartnerPhoto()` (the person-detail header and relationship-dashboard photo loaders) now check `photosEnabled` too, so a Photos-less install doesn't 503 on every person selection or every relationship-dashboard load.
  - The old `loadProfilePhotos()` (a post-render probing loop that `HEAD`-checked every avatar and was never actually called) and the now-redundant `avatarPhotoClass()` helper are removed; `profilePhotoCache` is kept and still shared with the detail-header/relationship-page photo loaders.
  - CSS: `.person-avatar` is a positioning context (`position: relative; overflow: hidden`) for `.avatar-photo-img`, an absolutely-positioned, `object-fit: cover` image that visually covers the initials once it loads. The pre-existing `.person-avatar.has-photo { color: transparent }` rule is inert on list rows specifically (an inline `color` from `getAvatarStyle()` always wins) — documented in place; it's what makes a still-loading avatar degrade to visible initials instead of a blank circle, and it does apply where nothing sets an inline color (e.g. `.detail-avatar.has-photo`).
- `docs/specs/technical/architecture.md`: corrected — `PersonDetailResponse` and the other models the API actually serves live in `api/routes/crm.py`, not `api/routes/crm_models/`, which is a separate module tree not wired into the running app. It isn't dead code, though: `is_family_member()` there is a second implementation of family-matching logic that `tests/test_family_matching.py` keeps in sync with the real one in `api/services/person_entity.py`.

## Test evidence

### Automated tests

```
HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest \
  tests/test_photos_profile_api.py tests/test_crm_avatar_photos_ui_browser.py \
  tests/test_crm_request_hygiene_ui_browser.py tests/test_log_redaction.py tests/test_family_matching.py -q
```
```
42 passed
```

```
HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_crm_api.py -q -k "photos_enabled or has_profile_photo or never_logs"
```
```
5 passed
```
This file's own latency-threshold tests (`test_get_people_list_warm_latency_large_db{,_limit_300}`, `test_me_interactions_3657_days_under_1200ms`, `test_me_interactions_span_under_50ms` — the first's own docstring already documents it as host-load-sensitive) intermittently exceed their fixed-ms thresholds on this shared, multi-agent host; how many fail on a given run tracks how loaded the host is at that moment (observed 101ms-1865ms against 50-1200ms bounds across this PR's review rounds, worsening as more concurrent agent activity piled up). Confirmed pre-existing and unrelated by reproducing the identical failures on `origin/feat/crm-performance` with this branch's diff removed. Not touched.

Full unit suite, run under the shared push lock per host-load policy (final round):
```
flock -w 7200 /tmp/lifeos-push.lock ./scripts/test.sh
5723 passed, 8 skipped, 1181 warnings in 405.27s
```
(Only the pre-existing `voice_proxy` duplicate-operation-id warning remains — this PR's own duplicate warning is gone after finding 3+5's fix.)

Full pre-push gate (unit suite + server-free browser suite), run automatically by `git push` under the shared lock, on the final rebase (`feat/crm-performance` @ `86527c5`):
```
Running unit tests... passed (5772 passed, 8 skipped, 1182 warnings in 261.60s)
Running server-free browser tests... passed (280 passed, 6156 deselected in 199.38s)
```

Acceptance criteria, from #875 and #904:

| # | Criterion | Test | Result |
|---|---|---|---|
| 1 | `GET /api/crm/people` includes `has_profile_photo: bool`, true iff `photo_count > 0` | `test_get_people_list_has_profile_photo_field`, `test_person_detail_has_profile_photo_matches_list` (`tests/test_crm_api.py`) | Pass |
| 2 | The client requests a photo only for `has_profile_photo` people, never `HEAD` | `test_exactly_two_photo_requests_for_flagged_people`, `test_no_head_requests_are_ever_issued` (`tests/test_crm_avatar_photos_ui_browser.py`) | Pass |
| 3 | `HEAD /api/photos/profile/{id}` returns the same status as `GET`, no body, full header parity | `test_head_returns_200_with_no_body_and_full_header_parity_with_get`, `TestProfilePhotoDisabled`, `TestProfilePhotoMissing` (`tests/test_photos_profile_api.py`) | Pass |
| 4 | `GET`'s `Cache-Control` allows ≥ 1 hour caching on both `200` and `404` | `test_get_returns_image_body`, `test_get_404_carries_cache_control_of_at_least_one_hour` (`tests/test_photos_profile_api.py`) | Pass |
| 5 | A missing thumbnail falls back to initials with no application error | `test_avatar_classes_reflect_photo_availability` (`tests/test_crm_avatar_photos_ui_browser.py`) — see Review focus on what "no console error" means here | Pass |
| 6 | 300 rows don't block the main thread on photo loading (lazy) | `expect(img).to_have_attribute("loading", "lazy")` and `test_300_flagged_rows_request_far_fewer_images_at_first_paint` (`tests/test_crm_avatar_photos_ui_browser.py`) — mutation-tested: deleting `loading="lazy"` fails both (300/300 requests instead of ~50/300) | Pass |
| 7 | Photos disabled → initials everywhere, zero photo requests, everywhere in the CRM | `test_photos_disabled_issues_zero_photo_requests` (list); manually re-verified on staging for the list, person detail header, and relationship dashboard | Pass |
| 904-1 | No log record (handler or access log) contains the raw `q` text | `test_list_people_never_logs_the_search_query` (handler; `tests/test_crm_api.py`); `test_redacts_query_string_from_access_log_line`, `test_redacted_record_survives_uvicorns_actual_access_formatter` (access log, run through the *real* `uvicorn.logging.AccessFormatter`; `tests/test_log_redaction.py`) | Pass |
| 904-2 | Reproduced end to end against the exact production log configuration, without breaking the access log itself | See Manual verification | Pass |
| config | `GET /api/crm/config`'s `photos_enabled` matches `settings.photos_enabled` | `test_photos_enabled_reflects_settings_when_false`, `test_photos_enabled_reflects_settings_when_true` (`tests/test_crm_api.py`) | Pass |

### Manual verification

Private staging instance on port 8026, launched from this worktree against a read-only copy of the production databases (photos library absent, matching the standing brief's staging setup), rebuilt after each rebase and after the args-based redaction fix.

- **#904 end to end**, matching the exact configuration `scripts/server.sh` uses (`uvicorn.run("api.main:app", host=..., port=..., log_level="info", ...)`, the app loaded by string so `api/main.py`'s module-level filter installation runs after uvicorn's own logging `dictConfig()`): sent `?q=ZZQMARKER7788&sort=strength&limit=5`, then `grep`'d the log file for both the marker and `"Logging error"` — **both zero occurrences** — and confirmed a normal, correctly-formatted access line was emitted: `INFO:     127.0.0.1:... - "GET /api/crm/people?<redacted> HTTP/1.1" 200 OK`. Also sent a query-string-free request (`/health`, `/api/crm/config`) and confirmed those log completely untouched. (An earlier round's version of this same check only grepped for the marker's *absence*, which a broken filter also produces — as the 79-line traceback it emits instead of an access line happens to echo the redacted message in its `Message:` field. Now checks for the absence of `"Logging error"` too, and for a normal-shaped access line.)
- `curl` against the running staging instance confirmed the photo route fix end to end with real data: `GET` on a person with a photo interaction → `200 image/jpeg` with `Cache-Control: public, max-age=3600`; `HEAD` on the same id → `200`, empty body, same header; `GET`/`HEAD` on a person without one → `404` with the same `Cache-Control`.
- Playwright against `/me` (219 real people, photos disabled in this staging install, in an isolated tab): 0 console errors, initials rendered for everyone, and **zero `/api/photos/*` requests of any kind**. Search and person selection both still worked with 0 console errors.
- Selected a real flagged person (`has_profile_photo: true`) on `/me`: the detail header issued **zero** photo requests (previously it would 503 and log a console error every time, per finding 7) — 0 console errors. Timeline and Graph tabs for that person: 0 console errors, 0 photo requests.
- `/family`, `/birthdays`: 0 console errors. `/relationship`: 0 console errors too now — a sibling PR (#899) fixed the no-partner-configured case this staging install was hitting, previously reported here as 2 pre-existing, unrelated errors; confirmed the relationship dashboard also issues 0 photo requests.
- To verify a photo actually renders end to end, pointed a second staging run at a temporary Photos-library stand-in (real `Photos.sqlite` file presence, one real, decodable synthetic JPEG placed in `resources/derivatives/`) for a real person id already flagged `has_profile_photo: true`. `GET`/`HEAD` on that person's photo route both returned `200` with the real image bytes and full header parity. `GET /api/crm/config`'s `photos_enabled` came back `true` directly from this fixture; with that, the flagged person's avatar rendered the real photo (`class="person-avatar has-photo"`, an `<img>` with `naturalWidth: 2`), and a different flagged person whose file didn't exist fell back cleanly to `class="person-avatar no-photo"` with visible initials and no `<img>` left in the DOM.

**On `photo_count` lag** (raised in review): `photo_count` is refreshed synchronously at the end of each Apple Photos sync run (`apple_photos_sync.py` calls `refresh_person_stats()` for exactly the people who gained photo interactions in that run) — not by a separate, possibly-delayed nightly job — so it goes stale only for the same window any other interaction-derived count would, between sync runs, not an extra lag beyond that.

## Review findings addressed (round 2)

All eight findings from the first adversarial review are fixed on this branch; see Implementation Notes above for where. Summary:

1. **[BLOCKER]** uvicorn's access logger was still writing the raw query string independent of the handler fix — added `RequestQueryStringRedactionFilter`.
2. **[MAJOR]** `photos_enabled` moved to the already-cheap, already-awaited `/api/crm/config`; the blocking `/api/photos/stats` round trip is gone.
3. **[MAJOR]** The hand-rolled `HEAD` branch is gone; stacked `@router.get`/`@router.head` gives Starlette-native header parity.
4. **[MAJOR]** AC 6 now has a direct `loading="lazy"` assertion plus a 300-row scale test, both mutation-tested.
5. **[MINOR]** Same fix as 3 also removes this PR's duplicate-operation-id warning.
6. **[MINOR]** `docs/specs/technical/architecture.md` corrected; the "dead code" claim below is retracted.
7. **[MINOR]** `loadDetailProfilePhoto`/`loadRelationshipPartnerPhoto` now guard on `photosEnabled`; re-verified in Playwright.
8. **[NIT]** CSS comment corrected; redundant `renderAvatarPhotoImg()` call removed.

## Review findings addressed (round 3 — verification pass)

1. **[BLOCKER]** The round-2 redaction fix broke uvicorn's access log for every request with a query string: `uvicorn.logging.AccessFormatter.formatMessage` never reads `record.msg`/`getMessage()` — it unconditionally unpacks `record.args` as a 5-tuple `(client_addr, method, full_path, http_version, status_code)`. Clearing `record.args` to make `getMessage()` return the redacted line (correct for a *generic* `logging.Formatter`, wrong for this one) raised `ValueError: not enough values to unpack` inside the formatter — a 79-line traceback per request in place of an access line, worse than the leak it replaced. Fixed by redacting `args[2]` in place and keeping the 5-tuple shape; `record.msg` is now touched only as a fallback for a record that isn't shaped like uvicorn's own access-log call. New test runs a record through the *real* `uvicorn.logging.AccessFormatter` and asserts it doesn't raise and the marker is absent — mutation-tested against the old filter, which fails it. Re-verified end to end exactly as production runs (`log_level="info"`): both the marker and `"Logging error"` are absent from the log, and a normal access line is emitted.
2. **[MINOR]** Added tests pinning `GET /api/crm/config`'s `photos_enabled` against `settings.photos_enabled`, forcing both the `False` (this host's real state) and `True` cases so the field can't be silently hardcoded to its Pydantic default and still pass.

## Review focus

- **What "no console error" means for a missing thumbnail (AC 5).** Confirmed empirically (including through Playwright's `page.route()` mocks) that Chromium logs "Failed to load resource: ... 404" to the DevTools console for *any* request — image, `fetch()`, or otherwise — that completes with a non-2xx status, regardless of whether the page's JS handles it. That notice cannot be suppressed by application code short of never making the request, so `test_crm_avatar_photos_ui_browser.py` filters that one specific, unavoidable browser-level notice out of its console-error assertions (see `_app_console_errors()` and the module docstring there) and checks for zero *application* errors (uncaught exceptions via `page.on("pageerror")`, and anything else logged) instead. Still a judgment call worth a second look.
- ~~`api/routes/crm_models/` is unused dead code~~ — **retracted.** It has a live test dependency (`tests/test_family_matching.py`); see finding 6 and the corrected doc.
- Latency-test flakiness on this shared host (see Test evidence) has been present and worsening across all three review rounds due to increasing concurrent host load; still pre-existing and unrelated, reconfirmed each round against `origin/feat/crm-performance` without this branch's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

