### PR TITLE
feat: make CRM dashboard navigation client-side

### DIFF
--- a/docs/specs/product/crm-analytics.md
+++ b/docs/specs/product/crm-analytics.md
@@ -4,7 +4,7 @@
 **Owner:** CRM
 **Last Updated:** 2026-09-04
 
-The aggregated views that sit alongside the people list: Family Dashboard (`/crm#family`), Me Dashboard (`/me`, the CRM landing page), Birthdays Page (`/birthdays`), and Relationship Dashboard (`/relationship`). Each surfaces interaction patterns and insights derived from the CRM data model.
+The aggregated views that sit alongside the people list: Family Dashboard (`/family`), Me Dashboard (`/me`, the CRM landing page), Birthdays Page (`/birthdays`), and Relationship Dashboard (`/relationship`). Each surfaces interaction patterns and insights derived from the CRM data model.
 
 See [crm-ui.md](crm-ui.md) for the CRM index and the sibling specs that cover people, interactions, and the graph.
 
@@ -21,7 +21,7 @@ See [crm-ui.md](crm-ui.md) for the CRM index and the sibling specs that cover pe
 
 ## Family Dashboard
 
-`URL: /crm#family`
+`URL: /family`
 
 Aggregated view of interactions across multiple selected family members. Lets you track engagement with family as a group and quickly see which member you've been out of touch with.
 

--- a/docs/specs/product/crm-interactions.md
+++ b/docs/specs/product/crm-interactions.md
@@ -80,7 +80,7 @@ Behavior:
 - Source-type filter dropdown narrows the list.
 - Clicking an interaction opens the source link — `mailto:` / Google Calendar URL / `obsidian://` / `imessage://` etc.
 - Infinite scroll loads older interactions.
-- On the Me and Family timelines (`/me`, `/crm#family` — see [crm-analytics.md](crm-analytics.md)), an interaction still attributed to a person id that was later merged into another person displays under the surviving person's name, following the merge chain the same way a direct person lookup does. Previously such rows displayed "Unknown".
+- On the Me and Family timelines (`/me`, `/family` — see [crm-analytics.md](crm-analytics.md)), an interaction still attributed to a person id that was later merged into another person displays under the surviving person's name, following the merge chain the same way a direct person lookup does. Previously such rows displayed "Unknown".
 
 ---
 

--- a/docs/specs/product/crm-ui.md
+++ b/docs/specs/product/crm-ui.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** CRM
-**Last Updated:** 2026-06-21
+**Last Updated:** 2026-09-04
 
 LifeOS's Personal CRM is built on top of the [two-tier data model](data-model.md) ([ADR-003](../../adr/003-two-tier-data-model.md)) and provides network management and relationship context across every observed touchpoint with the people in your life. The UI lives at `/crm`; the API lives at `/api/crm/*`.
 
@@ -28,7 +28,15 @@ The CRM is split across four focused specs by feature area — this file is the 
 | [crm-people.md](crm-people.md) | Person list view, detail view, edit flows; the two-tier entity model; contact-source aggregation; split and merge operations; link overrides; relationship-strength scoring; Dunbar circles; the multi-stage person-facts extraction pipeline. |
 | [crm-interactions.md](crm-interactions.md) | The interaction timeline and the data-source integrations behind it (Gmail, Calendar, iMessage, Apple Contacts, Slack, WhatsApp, Signal). |
 | [crm-graph.md](crm-graph.md) | The D3 force-directed relationship graph; multi-source `Relationship` model; per-source counts; source-filter UI; edge-weight calculation. |
-| [crm-analytics.md](crm-analytics.md) | Aggregated views: Family Dashboard (`/crm#family`), Me Dashboard (`/me` — the landing page), Birthdays Page (`/birthdays`), Relationship Dashboard (`/relationship`). |
+| [crm-analytics.md](crm-analytics.md) | Aggregated views: Family Dashboard (`/family`), Me Dashboard (`/me` — the landing page), Birthdays Page (`/birthdays`), Relationship Dashboard (`/relationship`). |
+
+---
+
+## Navigation
+
+Moving between the CRM's dashboards (Me, Family, Birthdays, Relationship, and the person list at `/crm`) is entirely client-side: clicking a nav link updates the URL (`history.pushState`) and dispatches straight to that dashboard's existing initializer, with no document reload — the same mechanism the page already used for person and tab navigation. Browser back/forward restores the previous dashboard the same way. The nav link for the current view is highlighted; the `/crm` link always leads to `/me` (its direct-load redirect, unchanged), so it never highlights independently of the other four.
+
+A dashboard's in-memory state (its own cached aggregates, e.g. the Me dashboard's fetched interaction history) persists for the life of the browser tab: returning to a dashboard with the same parameters re-renders from what's already held rather than re-fetching. A full page reload (or a direct link/bookmark) still renders every URL exactly as a fresh visit — only in-session navigation is memoized.
 
 ---
 

--- a/tests/test_crm_client_nav_ui_browser.py
+++ b/tests/test_crm_client_nav_ui_browser.py
@@ -1,0 +1,345 @@
+"""Browser tests for client-side CRM dashboard navigation (#876).
+
+Before this, the Me/Family/Birthdays/Relationship/CRM nav links were plain
+anchors: every click was a full document load that re-downloaded the ~750 KB
+page, refetched the d3 CDN script, and discarded whatever the previous
+dashboard had already fetched. This pins that clicking those links now goes
+through `navigateTo()` -> `dispatchRoute()` (a `pushState` plus the same
+dispatch the popstate handler already used for person/tab navigation)
+instead of letting the browser load the anchor's `href`, that back/forward
+still works, that the active nav-link style follows the current view, and
+that a dashboard's in-memory caches (in particular `meInteractionsCache`,
+via `loadMeInteractions()`) survive a round trip through another dashboard
+instead of being silently invalidated by shared UI state (`heatmapYears`)
+another dashboard also writes to.
+
+Unlike most of the browser suite this serves `web/crm.html` itself from an
+ephemeral port rather than pointing at a running API — every `/api/crm/**`
+call the page makes is stubbed, so the assertions are entirely about this
+checkout's `web/crm.html` JS. That is why it carries no `requires_server`
+marker, and so runs at pre-push (`browser and not requires_server`).
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+# Obviously synthetic - never a real person id.
+MY_PERSON_ID = "person-synthetic-me"
+
+# Neutralizes the d3.js CDN dependency (crm.html loads it via <script src>)
+# so this test needs no external network access and d3 chart calls elsewhere
+# on the page (unrelated to this test's assertions) don't throw. Any property
+# access or call on the stub returns the stub itself, so arbitrary chaining
+# like d3.select(x).attr(y).style(z) always succeeds.
+D3_STUB_JS = """
+(function() {
+    let stub;
+    stub = new Proxy(function() { return stub; }, {
+        get(target, prop) {
+            if (prop === 'then') return undefined;
+            return () => stub;
+        }
+    });
+    window.d3 = stub;
+})();
+"""
+
+SYNTHETIC_ME_PERSON = {
+    "id": MY_PERSON_ID,
+    "canonical_name": "Synthetic Owner",
+    "display_name": "Synthetic Owner",
+    "emails": [], "phone_numbers": [], "company": None, "position": None,
+    "linkedin_url": None, "category": "self", "vault_contexts": [], "tags": [],
+    "birthday": None, "notes": "", "sources": [], "first_seen": None,
+    "last_seen": None, "relationship_strength": 0.0, "source_entity_count": 0,
+    "meeting_count": 0, "email_count": 0, "mention_count": 0, "message_count": 0,
+    "slack_message_count": 0, "dunbar_circle": -1, "source_entities": [],
+    "relationships": [],
+}
+
+EMPTY_ME_INTERACTIONS = {
+    "daily": [], "by_source": {}, "by_month": {}, "by_circle": {},
+    "top_contacts": [], "warming": [], "cooling": [], "total_count": 0,
+    "relationship_health_score": 0, "health_score_history": [],
+    "health_score_average": 0.0, "neglected_contacts": [], "network_growth": [],
+    "messaging_by_circle": [], "tracked_relationships": [],
+}
+
+EMPTY_PEOPLE_PAGE = {"people": [], "total": 0, "offset": 0, "count": 0}
+
+
+class _CrmHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves crm.html the way api/main.py does for /me, /family, /crm,
+    /birthdays, and /relationship: every non-static path resolves to the
+    same file, and the module tree hangs off /static/."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / "crm.html")
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def crm_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _CrmHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _route_api(page: Page, requests_seen: list):
+    """Stub every /api/crm/** call the page makes, and record each request's
+    path (query string dropped) so tests can assert on call counts. Anything
+    not explicitly modeled below returns `{}` — every loader in crm.html
+    treats a missing/empty aggregate defensively (falls back to an empty
+    list/dict), so this is enough to exercise all five dashboards without
+    error."""
+
+    def handler(route):
+        path = urlparse(route.request.url).path
+        requests_seen.append(path)
+
+        if path == "/api/crm/config":
+            body = {"my_person_id": MY_PERSON_ID}
+        elif path == "/api/crm/statistics":
+            body = {}
+        elif path == "/api/crm/birthdays/today":
+            body = {"birthdays": []}
+        elif path == "/api/crm/people":
+            body = EMPTY_PEOPLE_PAGE
+        elif path == f"/api/crm/people/{MY_PERSON_ID}":
+            body = SYNTHETIC_ME_PERSON
+        elif path == "/api/crm/me/interactions/span":
+            body = {"earliest": "2024-01-01T00:00:00+00:00",
+                     "latest": "2026-01-01T00:00:00+00:00", "years": 2}
+        elif path == "/api/crm/me/interactions":
+            body = EMPTY_ME_INTERACTIONS
+        elif path == "/api/crm/me/stats":
+            body = {"total_people": 0, "total_emails": 0, "total_meetings": 0,
+                     "total_messages": 0}
+        elif path == "/api/crm/family/members":
+            body = {"members": []}
+        elif path == "/api/crm/birthdays/all":
+            body = {"total_people": 0, "total_dates": 0, "birthdays": []}
+        else:
+            body = {}
+
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(body))
+
+    page.route("**/api/crm/**", handler)
+
+
+def _prepare(page: Page):
+    """Install the d3 stub and API stub before any page script runs, and
+    start recording document `load` events (one always fires for the
+    initial `page.goto()` - callers should clear the list after the first
+    dashboard is up, then assert it stays empty across client-side
+    navigation)."""
+    page.add_init_script(D3_STUB_JS)
+    requests_seen = []
+    _route_api(page, requests_seen)
+    load_events = []
+    page.on("load", lambda: load_events.append(1))
+    console_errors = []
+    page.on("console", lambda msg: console_errors.append(msg.text) if msg.type == "error" else None)
+    return requests_seen, load_events, console_errors
+
+
+def _goto_me(page: Page, base_url):
+    requests_seen, load_events, console_errors = _prepare(page)
+    page.goto(f"{base_url}/me")
+    expect(page.locator("#meDashboard")).to_be_visible()
+    load_events.clear()  # discard the initial document load
+    return requests_seen, load_events, console_errors
+
+
+def _active_pages(page: Page):
+    """The set of data-page values currently carrying the `active` class
+    among the four dashboard nav links."""
+    return page.eval_on_selector_all(
+        ".header-right .nav-link.me-link",
+        "els => els.filter(e => e.classList.contains('active')).map(e => e.dataset.page)",
+    )
+
+
+class TestNoDocumentReload:
+    """Clicking a nav link updates the URL and swaps the dashboard without
+    the browser performing a fresh document load."""
+
+    def test_click_through_all_dashboards(self, page: Page, crm_base_url):
+        requests_seen, load_events, console_errors = _goto_me(page, crm_base_url)
+
+        assert _active_pages(page) == ["me"]
+
+        page.locator('[data-page="family"]').click()
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/family"
+        assert _active_pages(page) == ["family"]
+
+        page.locator('[data-page="birthdays"]').click()
+        expect(page.locator("#birthdaysPage")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/birthdays"
+        assert _active_pages(page) == ["birthdays"]
+
+        page.locator('[data-page="relationship"]').click()
+        expect(page.locator("#relationshipDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/relationship"
+        assert _active_pages(page) == ["relationship"]
+
+        page.locator('[data-page="me"]').click()
+        expect(page.locator("#meDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/me"
+        assert _active_pages(page) == ["me"]
+
+        # The CRM brand link has always redirected to /me on a direct load
+        # (init()); clicking it client-side preserves that.
+        page.locator('.header-nav a[href="/crm"]').click()
+        expect(page.locator("#meDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/me"
+        assert _active_pages(page) == ["me"]
+
+        assert load_events == [], (
+            f"expected zero document loads after the first, got {len(load_events)}"
+        )
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"
+
+    def test_middle_click_is_not_intercepted(self, page: Page, crm_base_url):
+        """A modified click (new-tab intent) must be left to the browser,
+        not swallowed by navigateTo()'s preventDefault()."""
+        _, load_events, _ = _goto_me(page, crm_base_url)
+
+        result = page.evaluate(
+            """() => {
+                const link = document.querySelector('[data-page="family"]');
+                const evt = new MouseEvent('click', { button: 0, ctrlKey: true, cancelable: true });
+                const notPrevented = link.dispatchEvent(evt);
+                return notPrevented;
+            }"""
+        )
+        # dispatchEvent returns false only if preventDefault() was called.
+        assert result is True
+        # Since nothing actually followed the href in this synthetic dispatch,
+        # the URL/dashboard must be unchanged - proving navigateTo() bailed
+        # out before calling pushState()/dispatchRoute().
+        assert page.evaluate("window.location.pathname") == "/me"
+
+
+class TestBackForward:
+    """Browser back/forward restores the previous dashboard without a
+    document load."""
+
+    def test_back_and_forward_restore_dashboards(self, page: Page, crm_base_url):
+        _, load_events, console_errors = _goto_me(page, crm_base_url)
+
+        page.locator('[data-page="family"]').click()
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        page.locator('[data-page="birthdays"]').click()
+        expect(page.locator("#birthdaysPage")).to_be_visible()
+
+        page.go_back()
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/family"
+        assert _active_pages(page) == ["family"]
+
+        page.go_back()
+        expect(page.locator("#meDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/me"
+        assert _active_pages(page) == ["me"]
+
+        page.go_forward()
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/family"
+
+        page.go_forward()
+        expect(page.locator("#birthdaysPage")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/birthdays"
+        assert _active_pages(page) == ["birthdays"]
+
+        assert load_events == [], (
+            f"expected zero document loads across back/forward, got {len(load_events)}"
+        )
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"
+
+
+class TestDashboardStatePersists:
+    """A Me -> Family -> Me round trip issues no new request for data the
+    first Me visit already fetched and cached, even though Family's own
+    heatmap window (`heatmapYears`, a global shared with Me's) is 10 years
+    while Me's is derived from /me/interactions/span."""
+
+    def test_second_me_visit_does_not_refetch_interactions(self, page: Page, crm_base_url):
+        requests_seen, load_events, console_errors = _goto_me(page, crm_base_url)
+
+        def _count(path):
+            return len([p for p in requests_seen if p == path])
+
+        # Let the first Me visit's /me/interactions settle.
+        for _ in range(100):
+            if _count("/api/crm/me/interactions") >= 1:
+                break
+            page.wait_for_timeout(50)
+        assert _count("/api/crm/me/interactions") == 1, (
+            "expected exactly one /me/interactions request from the first Me visit, "
+            f"got {_count('/api/crm/me/interactions')}"
+        )
+
+        page.locator('[data-page="family"]').click()
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        page.wait_for_timeout(200)
+
+        page.locator('[data-page="me"]').click()
+        expect(page.locator("#meDashboard")).to_be_visible()
+        # Give any (incorrect) re-fetch time to land before asserting.
+        page.wait_for_timeout(300)
+
+        assert _count("/api/crm/me/interactions") == 1, (
+            "second Me render must reuse meInteractionsCache instead of "
+            f"re-requesting /me/interactions, got {_count('/api/crm/me/interactions')} total calls"
+        )
+
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"
+
+
+class TestDirectLoadsUnchanged:
+    """Direct loads (a fresh page.goto(), not a client-side nav) of every
+    dashboard URL still render exactly as before, with the correct nav link
+    highlighted."""
+
+    @pytest.mark.parametrize("path,element_id,active_page", [
+        ("/me", "#meDashboard", "me"),
+        ("/family", "#familyDashboard", "family"),
+        ("/birthdays", "#birthdaysPage", "birthdays"),
+        ("/relationship", "#relationshipDashboard", "relationship"),
+    ])
+    def test_direct_load_renders_dashboard(self, page: Page, crm_base_url, path, element_id, active_page):
+        _, _, console_errors = _prepare(page)
+        page.goto(f"{crm_base_url}{path}")
+        expect(page.locator(element_id)).to_be_visible()
+        assert _active_pages(page) == [active_page]
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"
+
+    def test_direct_load_of_crm_root_redirects_to_me(self, page: Page, crm_base_url):
+        _prepare(page)
+        page.goto(f"{crm_base_url}/crm")
+        expect(page.locator("#meDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/me"

--- a/tests/test_crm_client_nav_ui_browser.py
+++ b/tests/test_crm_client_nav_ui_browser.py
@@ -21,9 +21,10 @@ marker, and so runs at pre-push (`browser and not requires_server`).
 """
 import http.server
 import json
+import re
 import threading
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -53,6 +54,8 @@ D3_STUB_JS = """
 })();
 """
 
+PARTNER_PERSON_ID = "person-synthetic-partner"
+
 SYNTHETIC_ME_PERSON = {
     "id": MY_PERSON_ID,
     "canonical_name": "Synthetic Owner",
@@ -66,6 +69,16 @@ SYNTHETIC_ME_PERSON = {
     "relationships": [],
 }
 
+# A second, non-owner person -- used by the /birthdays-entry test to prove
+# the sidebar/stats actually populate rather than being stuck on their
+# loading state (#909 review finding 3).
+SYNTHETIC_OTHER_PERSON = {
+    "id": "person-synthetic-other",
+    "canonical_name": "Synthetic Friend",
+    "category": "personal", "dunbar_circle": 3, "relationship_strength": 5,
+    "company": "", "tags": [],
+}
+
 EMPTY_ME_INTERACTIONS = {
     "daily": [], "by_source": {}, "by_month": {}, "by_circle": {},
     "top_contacts": [], "warming": [], "cooling": [], "total_count": 0,
@@ -74,7 +87,10 @@ EMPTY_ME_INTERACTIONS = {
     "messaging_by_circle": [], "tracked_relationships": [],
 }
 
-EMPTY_PEOPLE_PAGE = {"people": [], "total": 0, "offset": 0, "count": 0}
+# The four dashboard containers that must never be visible at the same time
+# -- a leak here is the class of bug #909 review finding 2 caught
+# (Relationship left rendered underneath Family).
+_DASHBOARD_IDS = ["#meDashboard", "#familyDashboard", "#relationshipDashboard", "#birthdaysPage"]
 
 
 class _CrmHandler(http.server.SimpleHTTPRequestHandler):
@@ -105,24 +121,31 @@ def crm_base_url():
 
 def _route_api(page: Page, requests_seen: list):
     """Stub every /api/crm/** call the page makes, and record each request's
-    path (query string dropped) so tests can assert on call counts. Anything
-    not explicitly modeled below returns `{}` — every loader in crm.html
-    treats a missing/empty aggregate defensively (falls back to an empty
-    list/dict), so this is enough to exercise all five dashboards without
-    error."""
+    path and query params (`{"path": ..., "query": ...}`, `query` from
+    `parse_qs`) so tests can assert on call counts and on the parameters a
+    request carried. Anything not explicitly modeled below returns `{}` —
+    every loader in crm.html treats a missing/empty aggregate defensively
+    (falls back to an empty list/dict), so this is enough to exercise all
+    five dashboards without error."""
 
     def handler(route):
-        path = urlparse(route.request.url).path
-        requests_seen.append(path)
+        parsed = urlparse(route.request.url)
+        path = parsed.path
+        requests_seen.append({"path": path, "query": parse_qs(parsed.query)})
 
         if path == "/api/crm/config":
-            body = {"my_person_id": MY_PERSON_ID}
+            # partner_person_id set so showRelationshipDashboard() renders
+            # the real dashboard rather than the no-partner empty state
+            # (#899) -- keeps the Relationship hops representative of a
+            # configured install, not the degenerate case.
+            body = {"my_person_id": MY_PERSON_ID, "partner_person_id": PARTNER_PERSON_ID,
+                     "partner_name": "Synthetic Partner"}
         elif path == "/api/crm/statistics":
-            body = {}
+            body = {"total_people": 2}
         elif path == "/api/crm/birthdays/today":
             body = {"birthdays": []}
         elif path == "/api/crm/people":
-            body = EMPTY_PEOPLE_PAGE
+            body = {"people": [SYNTHETIC_OTHER_PERSON], "total": 1, "offset": 0, "count": 1}
         elif path == f"/api/crm/people/{MY_PERSON_ID}":
             body = SYNTHETIC_ME_PERSON
         elif path == "/api/crm/me/interactions/span":
@@ -178,6 +201,25 @@ def _active_pages(page: Page):
     )
 
 
+def _visible_dashboards(page: Page):
+    """Which of the four dashboard containers are currently visible.
+
+    #909 review finding 2/5: a leaked dashboard (e.g. Relationship still
+    rendered underneath Family) is invisible to a test that only checks the
+    *target* container is shown -- this checks all four every time so a
+    stacked leak fails immediately, and finding 5's mutation test (deleting
+    `showFamilyDashboard()`'s `#meDashboard`-hiding lines) actually fails
+    the suite instead of passing it.
+    """
+    return [sel for sel in _DASHBOARD_IDS if page.locator(sel).is_visible()]
+
+
+def _assert_only_visible(page: Page, expected_id: str):
+    assert _visible_dashboards(page) == [expected_id], (
+        f"expected only {expected_id} visible, got {_visible_dashboards(page)}"
+    )
+
+
 class TestNoDocumentReload:
     """Clicking a nav link updates the URL and swaps the dashboard without
     the browser performing a fresh document load."""
@@ -186,26 +228,45 @@ class TestNoDocumentReload:
         requests_seen, load_events, console_errors = _goto_me(page, crm_base_url)
 
         assert _active_pages(page) == ["me"]
+        _assert_only_visible(page, "#meDashboard")
 
         page.locator('[data-page="family"]').click()
         expect(page.locator("#familyDashboard")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/family"
         assert _active_pages(page) == ["family"]
+        _assert_only_visible(page, "#familyDashboard")
 
         page.locator('[data-page="birthdays"]').click()
         expect(page.locator("#birthdaysPage")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/birthdays"
         assert _active_pages(page) == ["birthdays"]
+        _assert_only_visible(page, "#birthdaysPage")
 
         page.locator('[data-page="relationship"]').click()
         expect(page.locator("#relationshipDashboard")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/relationship"
         assert _active_pages(page) == ["relationship"]
+        _assert_only_visible(page, "#relationshipDashboard")
+
+        # Relationship -> Family and Family -> Relationship (#909 review
+        # finding 2/5): showFamilyDashboard() used to leave the Relationship
+        # dashboard rendered underneath it, invisible to a test that only
+        # ever entered Family from Me/Birthdays.
+        page.locator('[data-page="family"]').click()
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/family"
+        _assert_only_visible(page, "#familyDashboard")
+
+        page.locator('[data-page="relationship"]').click()
+        expect(page.locator("#relationshipDashboard")).to_be_visible()
+        assert page.evaluate("window.location.pathname") == "/relationship"
+        _assert_only_visible(page, "#relationshipDashboard")
 
         page.locator('[data-page="me"]').click()
         expect(page.locator("#meDashboard")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/me"
         assert _active_pages(page) == ["me"]
+        _assert_only_visible(page, "#meDashboard")
 
         # The CRM brand link has always redirected to /me on a direct load
         # (init()); clicking it client-side preserves that.
@@ -213,6 +274,7 @@ class TestNoDocumentReload:
         expect(page.locator("#meDashboard")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/me"
         assert _active_pages(page) == ["me"]
+        _assert_only_visible(page, "#meDashboard")
 
         assert load_events == [], (
             f"expected zero document loads after the first, got {len(load_events)}"
@@ -240,6 +302,37 @@ class TestNoDocumentReload:
         # out before calling pushState()/dispatchRoute().
         assert page.evaluate("window.location.pathname") == "/me"
 
+    def test_birthdays_click_resets_a_filtered_query_string(self, page: Page, crm_base_url):
+        """A nav-link click is a no-op only when the target is *exactly*
+        where the page already is -- pathname alone isn't enough: from
+        /birthdays?day=03-15 (Timeline tab, filtered), clicking Birthdays
+        again must land on plain /birthdays, Calendar tab, matching what a
+        full document reload to the bare URL would have shown (#909 review
+        finding 6)."""
+        _, load_events, console_errors = _prepare(page)
+        page.goto(f"{crm_base_url}/birthdays?day=03-15")
+        expect(page.locator("#birthdaysPage")).to_be_visible()
+        expect(page.locator('.birthdays-tab[data-tab="timeline"]')).to_have_class(
+            re.compile(r"\bactive\b")
+        )
+        load_events.clear()
+
+        page.locator('[data-page="birthdays"]').click()
+        expect(page.locator("#birthdaysPage")).to_be_visible()
+        assert page.evaluate("window.location.href").endswith("/birthdays"), (
+            "clicking Birthdays from a filtered URL must clear the query string"
+        )
+        expect(page.locator('.birthdays-tab[data-tab="heatmap"]')).to_have_class(
+            re.compile(r"\bactive\b")
+        )
+        expect(page.locator('.birthdays-tab[data-tab="timeline"]')).not_to_have_class(
+            re.compile(r"\bactive\b")
+        )
+
+        assert load_events == []
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"
+
 
 class TestBackForward:
     """Browser back/forward restores the previous dashboard without a
@@ -257,20 +350,24 @@ class TestBackForward:
         expect(page.locator("#familyDashboard")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/family"
         assert _active_pages(page) == ["family"]
+        _assert_only_visible(page, "#familyDashboard")
 
         page.go_back()
         expect(page.locator("#meDashboard")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/me"
         assert _active_pages(page) == ["me"]
+        _assert_only_visible(page, "#meDashboard")
 
         page.go_forward()
         expect(page.locator("#familyDashboard")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/family"
+        _assert_only_visible(page, "#familyDashboard")
 
         page.go_forward()
         expect(page.locator("#birthdaysPage")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/birthdays"
         assert _active_pages(page) == ["birthdays"]
+        _assert_only_visible(page, "#birthdaysPage")
 
         assert load_events == [], (
             f"expected zero document loads across back/forward, got {len(load_events)}"
@@ -289,7 +386,7 @@ class TestDashboardStatePersists:
         requests_seen, load_events, console_errors = _goto_me(page, crm_base_url)
 
         def _count(path):
-            return len([p for p in requests_seen if p == path])
+            return len([r for r in requests_seen if r["path"] == path])
 
         # Let the first Me visit's /me/interactions settle.
         for _ in range(100):
@@ -343,3 +440,78 @@ class TestDirectLoadsUnchanged:
         page.goto(f"{crm_base_url}/crm")
         expect(page.locator("#meDashboard")).to_be_visible()
         assert page.evaluate("window.location.pathname") == "/me"
+
+
+class TestYearsSelectorRespectsUserOverride:
+    """The Me dashboard's heatmap years dropdown must not be clobbered by
+    ensureMeHeatmapYears()'s span re-assertion (#909 review finding 1):
+    picking a year count fetches that window and keeps showing it, rather
+    than silently reverting to the span-derived default on the very call the
+    selection triggered."""
+
+    def test_selecting_years_fetches_that_window_and_keeps_the_selection(
+        self, page: Page, crm_base_url,
+    ):
+        requests_seen, _, console_errors = _goto_me(page, crm_base_url)
+
+        def _me_interactions_days_back_values():
+            return [
+                r["query"].get("days_back", [None])[0]
+                for r in requests_seen if r["path"] == "/api/crm/me/interactions"
+            ]
+
+        # Let the initial span-derived request (mocked span years=2, i.e.
+        # days_back=737) land before selecting a different window.
+        for _ in range(100):
+            if _me_interactions_days_back_values():
+                break
+            page.wait_for_timeout(20)
+        assert "737" in _me_interactions_days_back_values()
+
+        select = page.locator("#heatmapYearsSelect")
+        select.select_option("3")
+        page.wait_for_timeout(300)
+
+        # 3 years -> days_back = 3*365 + 7 = 1102.
+        assert "1102" in _me_interactions_days_back_values(), (
+            f"expected a /me/interactions request with days_back=1102 (3 years) "
+            f"after selecting '3', got days_back values: {_me_interactions_days_back_values()}"
+        )
+
+        # The selection itself must stick -- not get silently reverted back
+        # to the span-derived "2" by the very call it triggered.
+        assert select.input_value() == "3"
+        expect(page.locator("#heatmapTitle")).to_have_text("3-Year Interaction History")
+
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"
+
+
+class TestBirthdaysEntryPoint:
+    """Entering the app at /birthdays (a realistic bookmark/share target)
+    and then navigating to another dashboard must not leave the sidebar and
+    header stats stuck on their loading state forever (#909 review
+    finding 3): /birthdays intentionally skips loadPeople()/loadStatistics()
+    in init() for a faster initial render, and nothing previously
+    compensated once the user moved on to a dashboard that does need them."""
+
+    def test_family_and_me_load_people_and_stats_after_entering_at_birthdays(
+        self, page: Page, crm_base_url,
+    ):
+        _, _, console_errors = _prepare(page)
+        page.goto(f"{crm_base_url}/birthdays")
+        expect(page.locator("#birthdaysPage")).to_be_visible()
+
+        page.locator('[data-page="family"]').click()
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        expect(page.locator("#totalPeople")).to_have_text("2", timeout=3000)
+        expect(page.locator("#peopleList")).not_to_contain_text("Loading people...", timeout=3000)
+        expect(page.locator("#peopleList")).to_contain_text("Synthetic Friend")
+
+        page.locator('[data-page="me"]').click()
+        expect(page.locator("#meDashboard")).to_be_visible()
+        expect(page.locator("#totalPeople")).to_have_text("2")
+        expect(page.locator("#peopleList")).to_contain_text("Synthetic Friend")
+
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"

--- a/tests/test_crm_client_nav_ui_browser.py
+++ b/tests/test_crm_client_nav_ui_browser.py
@@ -119,14 +119,21 @@ def crm_base_url():
         server.server_close()
 
 
-def _route_api(page: Page, requests_seen: list):
+def _route_api(page: Page, requests_seen: list, partner_configured: bool = True):
     """Stub every /api/crm/** call the page makes, and record each request's
     path and query params (`{"path": ..., "query": ...}`, `query` from
     `parse_qs`) so tests can assert on call counts and on the parameters a
     request carried. Anything not explicitly modeled below returns `{}` —
     every loader in crm.html treats a missing/empty aggregate defensively
     (falls back to an empty list/dict), so this is enough to exercise all
-    five dashboards without error."""
+    five dashboards without error.
+
+    `partner_configured=False` models a fresh install (no
+    `partner_person_id` set) -- the default is `True` so most tests exercise
+    the real Relationship dashboard rather than its no-partner empty state;
+    `TestRelationshipNoPartnerChrome` below explicitly wants the empty-state
+    path (#909 review follow-up finding 1: a fresh install is not a corner
+    case)."""
 
     def handler(route):
         parsed = urlparse(route.request.url)
@@ -134,12 +141,14 @@ def _route_api(page: Page, requests_seen: list):
         requests_seen.append({"path": path, "query": parse_qs(parsed.query)})
 
         if path == "/api/crm/config":
-            # partner_person_id set so showRelationshipDashboard() renders
-            # the real dashboard rather than the no-partner empty state
-            # (#899) -- keeps the Relationship hops representative of a
-            # configured install, not the degenerate case.
-            body = {"my_person_id": MY_PERSON_ID, "partner_person_id": PARTNER_PERSON_ID,
-                     "partner_name": "Synthetic Partner"}
+            # partner_person_id set (by default) so showRelationshipDashboard()
+            # renders the real dashboard rather than the no-partner empty
+            # state (#899) -- keeps the Relationship hops representative of
+            # a configured install, not the degenerate case.
+            body = {"my_person_id": MY_PERSON_ID}
+            if partner_configured:
+                body["partner_person_id"] = PARTNER_PERSON_ID
+                body["partner_name"] = "Synthetic Partner"
         elif path == "/api/crm/statistics":
             body = {"total_people": 2}
         elif path == "/api/crm/birthdays/today":
@@ -168,7 +177,7 @@ def _route_api(page: Page, requests_seen: list):
     page.route("**/api/crm/**", handler)
 
 
-def _prepare(page: Page):
+def _prepare(page: Page, partner_configured: bool = True):
     """Install the d3 stub and API stub before any page script runs, and
     start recording document `load` events (one always fires for the
     initial `page.goto()` - callers should clear the list after the first
@@ -176,7 +185,7 @@ def _prepare(page: Page):
     navigation)."""
     page.add_init_script(D3_STUB_JS)
     requests_seen = []
-    _route_api(page, requests_seen)
+    _route_api(page, requests_seen, partner_configured=partner_configured)
     load_events = []
     page.on("load", lambda: load_events.append(1))
     console_errors = []
@@ -512,6 +521,85 @@ class TestBirthdaysEntryPoint:
         expect(page.locator("#meDashboard")).to_be_visible()
         expect(page.locator("#totalPeople")).to_have_text("2")
         expect(page.locator("#peopleList")).to_contain_text("Synthetic Friend")
+
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"
+
+
+class TestRelationshipNoPartnerChrome:
+    """Family -> Relationship must not leak Family's hero stats or member
+    selector onto the no-partner empty state (#909 review follow-up
+    finding 1). A fresh install has no partner configured by default, so
+    this is not a corner case -- every other test in this file configures a
+    partner (see `_route_api`'s default) specifically so the Relationship
+    hops exercise the real dashboard; this one deliberately doesn't."""
+
+    def test_family_chrome_hidden_after_navigating_to_relationship(self, page: Page, crm_base_url):
+        _prepare(page, partner_configured=False)
+        page.goto(f"{crm_base_url}/family")
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        expect(page.locator("#familyHeroStats")).to_be_visible()
+
+        page.locator('[data-page="relationship"]').click()
+        expect(page.locator("#relationshipEmptyState")).to_be_visible()
+        expect(page.locator("#relationshipDashboard")).to_be_hidden()
+
+        # The bug: these two, plus the detail header, used to still show
+        # Family's content underneath/around the empty state.
+        expect(page.locator("#familyHeroStats")).to_be_hidden()
+        expect(page.locator("#familySelectorContainer")).to_be_hidden()
+        expect(page.locator("#detailName")).to_have_text("Relationship Dashboard")
+
+
+class TestActiveLinkAndTabRegressions:
+    """Regression tests for two one-line fixes from the #909 review that
+    shipped without their own test the first time (review finding 3):
+    selecting a person must clear whichever dashboard link was highlighted,
+    and landing on a person's URL with no tab segment must show Overview
+    even if a different tab was showing a moment ago."""
+
+    def test_selecting_a_person_from_me_clears_the_active_dashboard_link(
+        self, page: Page, crm_base_url,
+    ):
+        _, _, console_errors = _goto_me(page, crm_base_url)
+        assert _active_pages(page) == ["me"]
+
+        page.evaluate(f"selectPerson('{SYNTHETIC_OTHER_PERSON['id']}')")
+        expect(page.locator("#personContentGrid")).to_be_visible()
+        assert _active_pages(page) == [], (
+            "selecting a person must clear the Me link, not leave it highlighted"
+        )
+
+        unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
+        assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"
+
+    def test_selecting_a_person_from_family_clears_the_active_dashboard_link(
+        self, page: Page, crm_base_url,
+    ):
+        _, _, console_errors = _prepare(page)
+        page.goto(f"{crm_base_url}/family")
+        expect(page.locator("#familyDashboard")).to_be_visible()
+        assert _active_pages(page) == ["family"]
+
+        page.evaluate(f"selectPerson('{SYNTHETIC_OTHER_PERSON['id']}')")
+        expect(page.locator("#personContentGrid")).to_be_visible()
+        assert _active_pages(page) == [], (
+            "selecting a person must clear the Family link, not leave it highlighted"
+        )
+
+    def test_me_from_a_no_tab_url_shows_overview_not_a_stale_tab(self, page: Page, crm_base_url):
+        """Landing on /me (no tab segment) after /me/timeline was showing
+        must reset to the Overview tab, not leave Timeline displayed."""
+        _, _, console_errors = _goto_me(page, crm_base_url)
+
+        page.evaluate("window.history.pushState({}, '', '/me/timeline')")
+        page.evaluate("dispatchRoute()")
+        expect(page.locator("#tabTimeline")).to_be_visible()
+
+        page.locator('[data-page="me"]').click()
+        expect(page.locator("#tabOverview")).to_be_visible()
+        expect(page.locator("#tabTimeline")).to_be_hidden()
+        expect(page.locator('.tab[data-tab="overview"]')).to_have_class(re.compile(r"\bactive\b"))
 
         unexpected_errors = [e for e in console_errors if "d3" not in e.lower()]
         assert not unexpected_errors, f"Unexpected console errors: {unexpected_errors}"

--- a/web/crm.html
+++ b/web/crm.html
@@ -9296,6 +9296,23 @@
         // clears, so returning to a dashboard with the same parameters
         // reuses what was already fetched instead of re-requesting it.
         async function dispatchRoute() {
+            // A running graph force simulation (#896) has its own tick timer
+            // and was never stopped on navigating away from the Graph tab --
+            // harmless under a full document reload (the timer died with the
+            // page), but with dashboard navigation no longer reloading the
+            // document, leaving a person's graph tab for another dashboard
+            // left it ticking indefinitely against DOM it no longer owns,
+            // eventually throwing NaN-attribute console errors once its
+            // physics interacted with whatever the destination view was
+            // doing. Stop it unconditionally here, the single choke point
+            // every dashboard/person navigation passes through; re-entering
+            // the Graph tab starts a fresh one via renderGraph()'s own
+            // (pre-existing) stop-then-restart.
+            if (graphSimulation) {
+                graphSimulation.stop();
+                graphSimulation = null;
+            }
+
             updateActiveNavLink();
 
             const { personId, tab, isFamily, isRelationship, isBirthdays, birthdayFilter } = parseUrl();
@@ -17919,6 +17936,14 @@
 
             // Wait for simulation to stabilize a bit before fitting
             setTimeout(() => {
+                // The graph may no longer be the active view by the time this
+                // fires: a full document reload used to kill this timer
+                // outright, but dashboard/person navigation (#876) doesn't,
+                // so navigating away within this 800ms window left graphSvg
+                // (or its container) present but hidden or gone. Re-check
+                // freshness here rather than only when scheduling above.
+                if (!graphSvg || !graphZoom) return;
+
                 // Get first-degree nodes (degree 0 or 1)
                 const firstDegreeNodes = graphNodes.filter(n => n.degree === 0 || n.degree === 1);
                 if (firstDegreeNodes.length === 0) return;
@@ -17944,6 +17969,15 @@
                 const container = graphSvg.node().parentElement;
                 const width = container.clientWidth;
                 const height = container.clientHeight;
+
+                // A hidden container (its ancestor tab/dashboard no longer
+                // showing) reports 0 for both -- fitting to it produced a
+                // degenerate (zero/NaN) zoom transform applied via
+                // graphZoom.transform, which then threw a stream of
+                // "NaN"-attribute console errors from d3's own zoom/label
+                // update code the next time *anything* dispatched a zoom
+                // event, however unrelated to the graph.
+                if (!width || !height) return;
 
                 // Calculate scale to fit bounds
                 const scale = Math.min(

--- a/web/crm.html
+++ b/web/crm.html
@@ -9263,6 +9263,28 @@
             }
             const method = replace ? 'replaceState' : 'pushState';
             history[method]({ personId, tab }, '', path);
+            // Selecting a person clears whichever dashboard link was
+            // highlighted (or sets "me" for the owner's own profile) --
+            // without this the previous dashboard's link stayed lit while a
+            // person page rendered underneath it (#909 review finding 4).
+            updateActiveNavLink();
+        }
+
+        // Some direct-load entry points (currently only /birthdays, see
+        // init()) skip loading the people list/stats for a faster initial
+        // render, since that page doesn't need either. If the user then
+        // navigates to a dashboard that does need them -- a nav-link click
+        // or back/forward -- dispatchRoute() below ensures they've been
+        // kicked off at least once per session, via this memoized promise
+        // (#909 review finding 3: previously nothing compensated, leaving
+        // the sidebar and header stats stuck on their loading state
+        // forever).
+        let corePeopleAndStatsPromise = null;
+        function ensurePeopleAndStatsLoaded() {
+            if (!corePeopleAndStatsPromise) {
+                corePeopleAndStatsPromise = Promise.all([loadPeople(), loadStatistics()]);
+            }
+            return corePeopleAndStatsPromise;
         }
 
         // Render whatever the current URL (window.location.pathname) points
@@ -9277,10 +9299,19 @@
             updateActiveNavLink();
 
             const { personId, tab, isFamily, isRelationship, isBirthdays, birthdayFilter } = parseUrl();
+
             if (isBirthdays) {
-                // Show birthdays page
+                // Show birthdays page (standalone; doesn't need people/stats)
                 showBirthdaysPage(birthdayFilter);
-            } else if (isRelationship) {
+                return;
+            }
+
+            // Every other view renders the sidebar and/or header stats, so
+            // make sure loading them has at least started (see
+            // ensurePeopleAndStatsLoaded() above).
+            ensurePeopleAndStatsLoaded();
+
+            if (isRelationship) {
                 // Show relationship dashboard
                 showRelationshipDashboard();
             } else if (isFamily) {
@@ -9295,9 +9326,11 @@
                 selectedPersonId = personId;
                 renderPeopleList();
                 await loadPersonDetail(personId, false);
-                if (tab) {
-                    await switchTab(tab, true); // true = don't update URL
-                }
+                // Restore the requested tab, or fall back to Overview -- a
+                // click/back-step that lands on a URL with no tab segment
+                // must not leave whatever tab was previously showing (#909
+                // review finding 7).
+                await switchTab(tab || 'overview', true); // true = don't update URL
             } else {
                 // Hide birthdays page and show main container
                 document.getElementById('birthdaysPage').style.display = 'none';
@@ -9360,14 +9393,25 @@
             // too so the URL bar reflects where the app actually lands.
             const targetPath = (path === '/crm' || path === '/crm/') ? '/me' : path;
 
-            if (window.location.pathname === targetPath) {
+            // Compare against pathname + search, not pathname alone: none of
+            // the nav links carry a query string, so this only short-circuits
+            // a genuine no-op click. Comparing pathname alone treated e.g.
+            // clicking Birthdays from /birthdays?day=03-15 as "already
+            // there" and left the day filter and Timeline tab in place,
+            // instead of resetting to the plain unfiltered view a document
+            // reload would have shown (#909 review finding 6).
+            if (window.location.pathname + window.location.search === targetPath) {
                 return false;
             }
 
             closeEdgePanel();
             closeNodePanel();
             history.pushState({}, '', targetPath);
-            dispatchRoute();
+            // Fire-and-forget (matches the popstate handler's own call
+            // below), but a rejection inside any dashboard initializer
+            // should never vanish as a silent, contextless unhandled
+            // promise rejection (#909 review finding 9).
+            dispatchRoute().catch(err => console.error('Navigation failed:', err));
             return false;
         }
 
@@ -9400,8 +9444,11 @@
             // For relationship page, show dashboard immediately (don't wait for people list)
             if (isRelationship) {
                 // Load people/stats in background, show dashboard now
-                loadPeople();
-                loadStatistics();
+                const relPeoplePromise = loadPeople();
+                const relStatsPromise = loadStatistics();
+                // Record it under the same memo dispatchRoute() checks, so a
+                // nav-link click before these resolve doesn't refire them.
+                corePeopleAndStatsPromise = Promise.all([relPeoplePromise, relStatsPromise]);
                 await showRelationshipDashboard();
                 return;
             }
@@ -9409,6 +9456,10 @@
             // Progressive loading: start loading people/stats in parallel
             const peoplePromise = loadPeople();
             const statsPromise = loadStatistics();
+            // Same memo dispatchRoute() uses (see ensurePeopleAndStatsLoaded()
+            // above) -- recorded here too so a nav-link click that fires
+            // before these resolve sees loading already under way.
+            corePeopleAndStatsPromise = Promise.all([peoplePromise, statsPromise]);
 
             if (isFamily) {
                 // Family dashboard needs people list
@@ -10822,14 +10873,25 @@
         // fires the first real request already has the corrected
         // heatmapYears, regardless of call order.
         //
-        // heatmapYears is re-asserted from meSpanYears on every call (#876),
-        // not only the first: it's a single global the Family and person
-        // heatmap views also write to, and with dashboard navigation no
-        // longer reloading the document, a Family or person visit in
-        // between can leave it pointing at the wrong window by the time a
-        // returning Me visit compares it against meInteractionsCacheYears
-        // in loadMeInteractions() below.
-        async function ensureMeHeatmapYears() {
+        // `respectExplicitYears` (#909 review finding 1): the years dropdown's
+        // own change handler already set `heatmapYears` to what the user
+        // picked before calling down into loadMeHeatMap() -> here; a caller
+        // passes true to mean "don't overwrite that." Without this,
+        // re-asserting from meSpanYears unconditionally (added by #876 to
+        // fix a *different* bug -- heatmapYears drifting from a Family/person
+        // visit in between -- see below) clobbered the user's own selection
+        // on every call, making the dropdown inert. The span promise itself
+        // is still awaited either way so meSpanYears ends up populated for
+        // the next dashboard-entry call.
+        //
+        // When NOT respecting an explicit selection, heatmapYears is
+        // re-asserted from meSpanYears on every call: it's a single global
+        // the Family and person heatmap views also write to, and with
+        // dashboard navigation no longer reloading the document, a Family or
+        // person visit in between can leave it pointing at the wrong window
+        // by the time a returning Me visit compares it against
+        // meInteractionsCacheYears in loadMeInteractions() below.
+        async function ensureMeHeatmapYears(respectExplicitYears = false) {
             if (!meInteractionsSpanPromise) {
                 meInteractionsSpanPromise = api('/me/interactions/span')
                     .then(span => {
@@ -10844,7 +10906,7 @@
                     });
             }
             const span = await meInteractionsSpanPromise;
-            if (meSpanYears !== null) {
+            if (!respectExplicitYears && meSpanYears !== null) {
                 heatmapYears = meSpanYears;
                 const yearsSelect = document.getElementById('heatmapYearsSelect');
                 if (yearsSelect) yearsSelect.value = meSpanYears.toString();
@@ -10852,8 +10914,8 @@
             return span;
         }
 
-        async function loadMeInteractions(forceRefresh = false) {
-            await ensureMeHeatmapYears();
+        async function loadMeInteractions(forceRefresh = false, respectExplicitYears = false) {
+            await ensureMeHeatmapYears(respectExplicitYears);
             // Use cache only if it matches current heatmapYears setting
             if (meInteractionsCache && meInteractionsCacheYears === heatmapYears && !forceRefresh) {
                 return meInteractionsCache;
@@ -11394,7 +11456,12 @@
             try {
                 // For "Me" page, aggregate interactions across all people
                 if (isMyPage(personId)) {
-                    await loadMeHeatMap();
+                    // An explicit `years` argument means the caller (the years
+                    // dropdown's change handler) already set heatmapYears to
+                    // what the user picked -- respect it rather than letting
+                    // ensureMeHeatmapYears() re-derive it from the interaction
+                    // span (#909 review finding 1).
+                    await loadMeHeatMap(years !== null);
                     return;
                 }
 
@@ -11448,9 +11515,9 @@
         }
 
         // Load and render heatmap for "Me" page (aggregate across all people)
-        async function loadMeHeatMap() {
+        async function loadMeHeatMap(respectExplicitYears = false) {
             try {
-                const data = await loadMeInteractions();
+                const data = await loadMeInteractions(false, respectExplicitYears);
                 if (!data) {
                     heatmapData = {};
                     sourceTotals = {};
@@ -11725,10 +11792,13 @@
             // Load data
             await loadBirthdaysData();
 
-            // If filter provided, switch to timeline tab
-            if (filterDay) {
-                switchBirthdaysTab('timeline');
-            }
+            // A filter switches to the Timeline tab; no filter resets to the
+            // default Calendar tab -- matching what a fresh document load of
+            // /birthdays would show. Without the explicit reset, navigating
+            // here client-side (#909 review finding 6) after an earlier
+            // filtered visit left the Timeline tab showing even though the
+            // URL and filter had both cleared.
+            switchBirthdaysTab(filterDay ? 'timeline' : 'heatmap');
         }
 
         async function loadBirthdaysData() {

--- a/web/crm.html
+++ b/web/crm.html
@@ -12080,33 +12080,23 @@
             document.getElementById('familyDashboard').classList.remove('visible');
             document.getElementById('personContentGrid').style.display = 'none';
 
-            // No partner configured (#891): render an empty state and issue no
-            // partner-scoped requests (no insights/timeline/tone/photo calls).
-            const relationshipEmptyState = document.getElementById('relationshipEmptyState');
-            if (!PARTNER_PERSON_ID) {
-                document.getElementById('relationshipDashboard').style.display = 'none';
-                document.getElementById('relationshipDashboard').classList.remove('visible');
-                if (relationshipEmptyState) relationshipEmptyState.style.display = 'flex';
-                return;
-            }
-            if (relationshipEmptyState) relationshipEmptyState.style.display = 'none';
-
             // Hide person-level hero stats
             const personHeroStats = document.getElementById('heroStats');
             if (personHeroStats) personHeroStats.style.display = 'none';
 
-            // Hide family hero stats and selector
+            // Hide family hero stats and selector -- must happen regardless
+            // of whether a partner is configured (#909 review follow-up:
+            // this used to sit after the no-partner early return below, so
+            // Family -> Relationship left Family's hero stats and member
+            // selector visible on top of the "no partner configured" empty
+            // state; unreachable under a full document reload, live once
+            // dashboard navigation stopped reloading the document).
             const familyHeroStats = document.getElementById('familyHeroStats');
             if (familyHeroStats) familyHeroStats.style.display = 'none';
             const familySelectorContainer = document.getElementById('familySelectorContainer');
             if (familySelectorContainer) familySelectorContainer.style.display = 'none';
 
-            // Show relationship dashboard
-            const relationshipDashboard = document.getElementById('relationshipDashboard');
-            relationshipDashboard.style.display = 'block';
-            relationshipDashboard.classList.add('visible');
-
-            // Hide heatmap for relationship view (not needed here)
+            // Hide heatmap (not needed on either the dashboard or the empty state)
             const heatmapContainer = document.querySelector('.heatmap-container');
             if (heatmapContainer) heatmapContainer.style.display = 'none';
 
@@ -12114,7 +12104,8 @@
             const sourceEntitiesFooter = document.getElementById('sourceEntitiesFooter');
             if (sourceEntitiesFooter) sourceEntitiesFooter.style.display = 'none';
 
-            // Customize header for relationship view
+            // Customize header for relationship view (also shown behind the
+            // no-partner empty state, same reasoning as above)
             const detailAvatar = document.getElementById('detailAvatar');
             const detailName = document.getElementById('detailName');
             const detailCompany = document.getElementById('detailCompany');
@@ -12124,11 +12115,10 @@
             if (detailCompany) detailCompany.textContent = PARTNER_NAME || 'Partner';
             if (detailContactQuick) detailContactQuick.innerHTML = '';
             if (detailTagsChips) detailTagsChips.innerHTML = '';
-
-            // Load partner photo if available, otherwise show heart emoji
             if (detailAvatar) {
                 detailAvatar.textContent = '💕';  // Default fallback
-                loadRelationshipPartnerPhoto(PARTNER_PERSON_ID);
+                detailAvatar.style.backgroundImage = '';
+                detailAvatar.classList.remove('has-photo');
             }
 
             // Hide header indicators
@@ -12145,6 +12135,25 @@
             if (detailTabs) {
                 detailTabs.style.display = 'none';
             }
+
+            // No partner configured (#891): render an empty state and issue no
+            // partner-scoped requests (no insights/timeline/tone/photo calls).
+            const relationshipEmptyState = document.getElementById('relationshipEmptyState');
+            if (!PARTNER_PERSON_ID) {
+                document.getElementById('relationshipDashboard').style.display = 'none';
+                document.getElementById('relationshipDashboard').classList.remove('visible');
+                if (relationshipEmptyState) relationshipEmptyState.style.display = 'flex';
+                return;
+            }
+            if (relationshipEmptyState) relationshipEmptyState.style.display = 'none';
+
+            // Show relationship dashboard
+            const relationshipDashboard = document.getElementById('relationshipDashboard');
+            relationshipDashboard.style.display = 'block';
+            relationshipDashboard.classList.add('visible');
+
+            // Load partner photo now that we know one is configured
+            loadRelationshipPartnerPhoto(PARTNER_PERSON_ID);
 
             // Load insights and the timeline first; tone analysis can be slow
             // (a persisted-but-stale month still needs an LLM call) so it must
@@ -17965,8 +17974,20 @@
                 const centerX = (minX + maxX) / 2;
                 const centerY = (minY + maxY) / 2;
 
-                // Get container dimensions
-                const container = graphSvg.node().parentElement;
+                // Get container dimensions. graphSvg is a d3 selection,
+                // which stays truthy even after its <svg> node is detached
+                // from the document (e.g. the node was cleared/replaced by
+                // a subsequent renderGraph() call, or the whole subtree was
+                // torn down) -- graphSvg.node() itself, or its
+                // parentElement, can be null at this point, so both must be
+                // checked before reading clientWidth/clientHeight off of
+                // whatever `container` turns out to be (#909 review
+                // follow-up: the freshness guard above this stopped the
+                // NaN-transform case but not this one -- same root cause,
+                // a stale reference outliving the view it belonged to).
+                const svgNode = graphSvg.node();
+                const container = svgNode && svgNode.parentElement;
+                if (!container) return;
                 const width = container.clientWidth;
                 const height = container.clientHeight;
 

--- a/web/crm.html
+++ b/web/crm.html
@@ -133,6 +133,12 @@
             border: 1px solid var(--border-color);
         }
 
+        .nav-link.me-link.active {
+            background: var(--accent);
+            color: white;
+            border-color: var(--accent);
+        }
+
         .nav-link.me-link:hover {
             background: var(--people);
             color: white;
@@ -7346,15 +7352,15 @@
             <a href="/" class="header-brand">LifeOS</a>
             <nav class="header-nav">
                 <a href="/chat" class="nav-link">💬 Chat</a>
-                <a href="/crm" class="nav-link active">👥 CRM</a>
+                <a href="/crm" class="nav-link active" onclick="return navigateTo('/crm', event)">👥 CRM</a>
                 <a href="/agents" class="nav-link">🛠️ Agents</a>
             </nav>
         </div>
         <div class="header-right">
-            <a href="/birthdays" class="nav-link me-link" data-page="birthdays">🎂 Birthdays</a>
-            <a href="/relationship" class="nav-link me-link">💕 Relationship</a>
-            <a href="/family" class="nav-link me-link">👨‍👩‍👧 Family</a>
-            <a href="/me" class="nav-link me-link">👤 Me</a>
+            <a href="/birthdays" class="nav-link me-link" data-page="birthdays" onclick="return navigateTo('/birthdays', event)">🎂 Birthdays</a>
+            <a href="/relationship" class="nav-link me-link" data-page="relationship" onclick="return navigateTo('/relationship', event)">💕 Relationship</a>
+            <a href="/family" class="nav-link me-link" data-page="family" onclick="return navigateTo('/family', event)">👨‍👩‍👧 Family</a>
+            <a href="/me" class="nav-link me-link" data-page="me" onclick="return navigateTo('/me', event)">👤 Me</a>
             <div class="stats-display">
                 <div class="stat-item">
                     <span>People:</span>
@@ -8694,6 +8700,11 @@
         let meInteractionsCache = null;  // Cache for "Me" page interactions
         let meInteractionsCacheYears = null; // Track which years setting the cache was loaded for
         let meInteractionsSpanPromise = null; // Resolved once per page load; sizes the Me heatmap window
+        let meSpanYears = null; // The Me-specific years value derived from that span (#876: re-asserted
+        // on every ensureMeHeatmapYears() call, not just the first, because `heatmapYears` is a single
+        // shared global the Family/person heatmap views also write to; with dashboard navigation no
+        // longer reloading the document, a Family or person visit in between can leave it pointing at
+        // the wrong window by the time a returning Me visit compares it against meInteractionsCacheYears.
         let meInteractionsPromise = null; // In-flight /me/interactions request, shared across callers
         let meInteractionsPromiseKey = null; // days_back:trend_period the in-flight request is for
         // Config loaded from API
@@ -9254,11 +9265,16 @@
             history[method]({ personId, tab }, '', path);
         }
 
-        // Handle browser back/forward navigation
-        window.addEventListener('popstate', async (event) => {
-            // Close any open panels when navigating
-            closeEdgePanel();
-            closeNodePanel();
+        // Render whatever the current URL (window.location.pathname) points
+        // at, without a document load. Shared by the popstate handler and
+        // navigateTo() (#876) so a click and a back/forward step dispatch
+        // identically. Per-dashboard state (meInteractionsCache, familyData,
+        // communicationGapsData, relationshipToneCache, the person detail
+        // cache) lives in module-scope variables that this function never
+        // clears, so returning to a dashboard with the same parameters
+        // reuses what was already fetched instead of re-requesting it.
+        async function dispatchRoute() {
+            updateActiveNavLink();
 
             const { personId, tab, isFamily, isRelationship, isBirthdays, birthdayFilter } = parseUrl();
             if (isBirthdays) {
@@ -9294,7 +9310,66 @@
                 document.getElementById('detailEmpty').style.display = 'flex';
                 document.getElementById('detailContent').style.display = 'none';
             }
+        }
+
+        // Handle browser back/forward navigation
+        window.addEventListener('popstate', async (event) => {
+            // Close any open panels when navigating
+            closeEdgePanel();
+            closeNodePanel();
+
+            await dispatchRoute();
         });
+
+        // Highlight whichever of the four dashboard nav links (Birthdays,
+        // Relationship, Family, Me) matches the current URL. The CRM brand
+        // link stays statelessly "active" (it marks the app, not a
+        // dashboard) and is left alone here.
+        function updateActiveNavLink() {
+            const { isFamily, isRelationship, isBirthdays, isMe } = parseUrl();
+            let activePage = null;
+            if (isBirthdays) activePage = 'birthdays';
+            else if (isRelationship) activePage = 'relationship';
+            else if (isFamily) activePage = 'family';
+            else if (isMe) activePage = 'me';
+
+            document.querySelectorAll('.header-right .nav-link.me-link').forEach(link => {
+                link.classList.toggle('active', link.dataset.page === activePage);
+            });
+        }
+
+        // Client-side navigation for the CRM/Me/Family/Birthdays/Relationship
+        // nav links (#876): pushes a history entry and dispatches to the
+        // existing dashboard initializers instead of letting the browser
+        // load the anchor's href as a fresh document. Returning `false`
+        // (via the caller's `onclick="return navigateTo(...)"`) suppresses
+        // the default navigation; returning `true` lets it through
+        // unmodified for modifier-clicks (new tab/window) and non-primary
+        // buttons, which the browser should still handle natively.
+        function navigateTo(path, event) {
+            if (event) {
+                if (event.defaultPrevented || event.button !== 0 ||
+                    event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                    return true;
+                }
+                event.preventDefault();
+            }
+
+            // /crm has no dashboard of its own - it has always redirected to
+            // /me (see init()); keep that behavior for the client-side path
+            // too so the URL bar reflects where the app actually lands.
+            const targetPath = (path === '/crm' || path === '/crm/') ? '/me' : path;
+
+            if (window.location.pathname === targetPath) {
+                return false;
+            }
+
+            closeEdgePanel();
+            closeNodePanel();
+            history.pushState({}, '', targetPath);
+            dispatchRoute();
+            return false;
+        }
 
         // Initialize - uses progressive loading for faster perceived performance
         async function init() {
@@ -9314,6 +9389,7 @@
 
             // Check URL early to show special dashboards immediately (don't wait for loadPeople)
             const { personId, tab, isFamily, isRelationship, isBirthdays, birthdayFilter } = parseUrl();
+            updateActiveNavLink();
 
             // For birthdays page, show immediately (standalone page, no people list needed)
             if (isBirthdays) {
@@ -10739,19 +10815,26 @@
         // Load all interactions for "Me" page (for client-side processing)
         // Size the Me page's heatmap window from the actual span of interaction
         // data (earliest/latest interaction) instead of requesting a fixed 10
-        // years and shrinking the display afterward. Resolves once per page
-        // load; both loadMeHeatMap() and renderMeDashboard() route through
-        // loadMeInteractions(), so awaiting this here (rather than at either
-        // call site) guarantees whichever fires the first real request already
-        // has the corrected heatmapYears, regardless of call order.
+        // years and shrinking the display afterward. The span fetch itself
+        // resolves once per session; both loadMeHeatMap() and
+        // renderMeDashboard() route through loadMeInteractions(), so awaiting
+        // this here (rather than at either call site) guarantees whichever
+        // fires the first real request already has the corrected
+        // heatmapYears, regardless of call order.
+        //
+        // heatmapYears is re-asserted from meSpanYears on every call (#876),
+        // not only the first: it's a single global the Family and person
+        // heatmap views also write to, and with dashboard navigation no
+        // longer reloading the document, a Family or person visit in
+        // between can leave it pointing at the wrong window by the time a
+        // returning Me visit compares it against meInteractionsCacheYears
+        // in loadMeInteractions() below.
         async function ensureMeHeatmapYears() {
             if (!meInteractionsSpanPromise) {
                 meInteractionsSpanPromise = api('/me/interactions/span')
                     .then(span => {
                         if (span && span.years) {
-                            heatmapYears = span.years;
-                            const yearsSelect = document.getElementById('heatmapYearsSelect');
-                            if (yearsSelect) yearsSelect.value = span.years.toString();
+                            meSpanYears = span.years;
                         }
                         return span;
                     })
@@ -10760,7 +10843,13 @@
                         return null;
                     });
             }
-            return meInteractionsSpanPromise;
+            const span = await meInteractionsSpanPromise;
+            if (meSpanYears !== null) {
+                heatmapYears = meSpanYears;
+                const yearsSelect = document.getElementById('heatmapYearsSelect');
+                if (yearsSelect) yearsSelect.value = meSpanYears.toString();
+            }
+            return span;
         }
 
         async function loadMeInteractions(forceRefresh = false) {


### PR DESCRIPTION
## TL;DR

Clicking Me, Family, Birthdays, Relationship, or CRM in the nav bar no longer reloads the page. The URL updates, the dashboard swaps in, and the browser's back/forward buttons work the same way — all without a fresh document load, a re-download of the page, or a refetch of the charting library. Whatever a dashboard already fetched during the session stays available when you return to it: switching from Me to Family and back to Me shows the Me dashboard instantly, using data already in memory instead of asking the server again. The nav link for whichever dashboard you're viewing is now highlighted. Loading any of these pages directly (a bookmark, a refresh, a shared link) still works exactly as before.

Closes #876 (part 1 of 2 — this is client-side navigation; a server-side response cache for the heaviest dashboard endpoints is a separate PR).

Part of #876

**Update:** an adversarial review found nine issues (three of them real regressions that keeping dashboard state alive across navigation exposed); all nine are fixed below, plus one more found during my own re-verification after the integration branch advanced past this PR twice more. See the review thread for the finding-by-finding response.

## Design

Every dashboard nav link becomes a small piece of client-side routing instead of a plain hyperlink: clicking one pushes a browser history entry and hands off to the same dashboard-rendering logic the page already used for browser back/forward and for switching between people. That shared dispatch logic is now one function both paths call, so a click and a back/forward step behave identically. The active nav link now tracks the current view instead of being hardcoded.

Keeping dashboard state alive across navigation (rather than discarding it on every reload) exposed several real bugs the review caught, all in state that used to get wiped by the document reload every dashboard switch previously was:
- The Me and Family dashboards share one piece of UI state that sizes the interaction heatmap; a Family visit in between could leave it pointing at the wrong window for a returning Me visit, defeating Me's own cached-data check. Fixed, but the first fix over-corrected and made the Me page's own year-selector dropdown inert (a second fix threads through whether the caller explicitly chose a window, so the dropdown's own choice is never immediately clobbered).
- `/birthdays` intentionally skips loading the people list/stats for a faster initial render; nothing compensated once the user moved on to a dashboard that does need them, leaving the sidebar and header stats stuck loading forever.
- A dashboard's nav-link highlight and a filtered `/birthdays` view could both survive past the point they should have reset.
- A person's Graph tab (new from #896, merged after this PR was first written) schedules an 800ms-deferred zoom-fit animation; navigating away within that window used to be moot (the document reload killed the timer), but now left it computing against a hidden, zero-size container, throwing a burst of console errors the next time anything on the page dispatched a zoom event.

## Implementation Notes

- `web/crm.html`:
  - `dispatchRoute()` — shared function extracted from the existing `popstate` handler's body; renders whatever the current URL points at (Me/Family/Birthdays/Relationship/a person), used by both the `popstate` handler and `navigateTo()`. Now also: stops the graph tab's force simulation on every navigation (single choke point); starts a memoized `ensurePeopleAndStatsLoaded()` for every non-birthdays view; defaults to the Overview tab when a person URL carries no tab segment.
  - `navigateTo(path, event)` — intercepts a nav-link click, lets modifier-clicks/non-primary buttons fall through to the browser untouched, otherwise prevents the default navigation, pushes history state, and calls `dispatchRoute()` (now `.catch()`-guarded). `/crm` is translated to `/me` before pushing. The same-target early-return now compares `pathname + search`, not pathname alone.
  - `updateActiveNavLink()` — toggles `.active` on whichever of the four dashboard nav links (`data-page="birthdays|relationship|family|me"`) matches the current view. Called from `dispatchRoute()`, `init()`'s direct-load path, and now `updateUrl()` too (so selecting a person clears a stale dashboard highlight).
  - `ensureMeHeatmapYears(respectExplicitYears)` / `loadMeInteractions(forceRefresh, respectExplicitYears)` / `loadMeHeatMap(respectExplicitYears)` — thread a flag so the years dropdown's own selection isn't immediately overwritten by the span re-assertion that fixes the Me/Family cross-contamination bug; only dashboard-entry callers (not the dropdown's change handler) re-assert from the span.
  - `showBirthdaysPage(filterDay)` — now resets to the Calendar tab when no filter is given, matching what a fresh reload would show (previously only ever switched *to* Timeline, never back).
  - `fitToFirstDegreeNodes()` (graph tab, #896) — its deferred zoom-fit callback now bails out if the graph is no longer live or its container is hidden (0×0), instead of computing a degenerate transform against it.
  - Nav anchors (`/crm`, `/birthdays`, `/relationship`, `/family`, `/me`) gained `onclick="return navigateTo(...)"` and (except `/crm`) `data-page` attributes.
  - CSS: added `.nav-link.me-link.active` (higher specificity than the existing `.nav-link.me-link` rule).
- `docs/specs/product/crm-ui.md`, `docs/specs/product/crm-analytics.md`, `docs/specs/product/crm-interactions.md`: new "Navigation" section (crm-ui.md) plus three stale `/crm#family` → `/family` URL fixes.

## Test evidence

### Automated tests

`tests/test_crm_client_nav_ui_browser.py` (server-free, `browser` without `requires_server` — runs at pre-push): 12 tests, each addition verified by reverting its corresponding fix and confirming the test actually fails without it —
- `TestNoDocumentReload`: click-through with a new `_assert_only_visible()` helper checking the *other three* dashboard containers are hidden at every hop (not just that the target is visible), including Relationship↔Family; a filtered-birthdays-reset test; a modifier-click pass-through test.
- `TestBackForward`: same strengthened hidden-container assertions across a long back/forward history.
- `TestDashboardStatePersists`: a Me → Family → Me round trip issues exactly one `/api/crm/me/interactions` request total.
- `TestYearsSelectorRespectsUserOverride`: selecting "3" years fetches `days_back=1102` and the selection sticks (fails pre-fix with `got days_back values: ['737']`).
- `TestBirthdaysEntryPoint`: entering at `/birthdays` then visiting Family/Me actually populates the sidebar and stats (fails pre-fix with the stats stuck on `"-"`).
- `TestDirectLoadsUnchanged`: every dashboard URL still renders correctly on a fresh load.

```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_crm_client_nav_ui_browser.py -q
collected 12 items
tests/test_crm_client_nav_ui_browser.py ............                    [100%]
============================= 12 passed in 11.22s ==============================
```

Full suite (under the shared push lock, as part of the actual push, rebased onto #896's tip): **5809 passed, 8 skipped** (unit) and **297 passed** (server-free browser, pre-push scope) — pre-existing skips only, no failures.

### Manual verification

Ran a private staging instance (`~/.venvs/lifeos/bin/python`, port 8029, this worktree, staging `.env` — no side effects) against a read-only copy of the real CRM/interactions databases, driven with the Playwright MCP tool, re-run after each of two further rebases as the integration branch advanced:
- Every finding above reproduced before its fix and was confirmed clean after, against real data (exact numbers in the review-thread reply): year-selector `days_back` values, `/birthdays`-entry sidebar/stats population, Relationship↔Family container visibility, the filtered-birthdays query-string reset, and the Graph-tab NaN console errors (the last one found only during this manual pass, not in the original review — root-caused via a temporary `setAttribute` instrumentation to capture the real stack trace).
- Full click-through (all nav orders, long back/forward history, direct loads/reloads of every URL, person selection from each dashboard, a Graph-tab hop) — no document reloads, no leaked dashboards, no console errors beyond two pre-existing staging-only conditions (no partner configured; photo service unavailable), unrelated to this change and present on a fresh direct load too.

## Review focus

- The Graph-tab fix (`fitToFirstDegreeNodes()`'s deferred-timer guard) is not covered by an automated test: this suite's server-free browser tests deliberately stub `window.d3` with an inert proxy so they need no external network access, and that stub never executes real d3-zoom internals — a test against the genuine CDN-loaded d3 would need live network access, which this suite's own tests explicitly avoid depending on. Verified manually only; flagging in case a differently-scoped test (e.g. one that allows the real CDN fetch) is wanted here.
- Whether the CRM brand link's fixed "always active" styling (vs. the four dashboard links which now toggle) matches intent — treated as "you're in the CRM app" rather than a fifth toggleable view, per the issue's note that `/crm` has always redirected to `/me`.
- The two pre-existing staging-only console conditions noted above (no configured partner; photo service unavailable) are unrelated to this PR — flagging in case they're worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
