### PR TITLE
chore(crm): remove tone_analysis_results rows when a person is merged or deleted

### DIFF
--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -1017,6 +1017,7 @@ def merge_people(request: PersonMergeRequest):
             'interactions_updated': 0,
             'source_entities_updated': 0,
             'facts_cleared': 0,
+            'tone_rows_cleared': 0,
             'emails_merged': 0,
             'phones_merged': 0,
             'aliases_added': 0,

--- a/api/services/tone_analysis_store.py
+++ b/api/services/tone_analysis_store.py
@@ -16,14 +16,19 @@ shape). `interaction_count` is the number of interactions that went into
 computing the result -- the caller uses it, together with `updated_at`, to
 decide whether a stored month is still fresh.
 
-Known gap (#899 review finding 8): nothing currently deletes a person's
-rows here on merge or delete -- `scripts/merge_people.py` and
-`scripts/cleanup_orphaned_records.py` cover `person_facts`,
-`relationships`, `link_overrides`, and `source_entities`, but not this
-table, so a merged/deleted person's tone rows orphan indefinitely. A prior
-`delete_for_person()` method existed for this but had no caller and was
-removed per AGENTS.md Simplicity; wiring cleanup into one of those scripts
-is a reasonable follow-up rather than in-scope work here.
+Rows for a merged-away or deleted person don't orphan (#910): when two
+people are merged, `scripts/merge_people.py` deletes the absorbed
+person's rows here in the same crm.db transaction it clears
+`person_facts` in -- deliberately *not* re-keyed onto the survivor (a
+re-keyed row could collide with a `period_key` the survivor already has,
+since the primary key here is `(person_id, period_key)`) and deliberately
+leaving the survivor's own rows untouched (unlike `person_facts`, a
+survivor's stale row self-heals via the ordinary interaction-count
+freshness check in `api/routes/crm.py`'s
+`analyze_relationship_tone_detailed` the next time tone analysis runs for
+it, so there's nothing here that needs forcing). `scripts/cleanup_orphaned_records.py`
+separately reports and removes any row whose person id no longer exists
+at all, guarded for installs where this table hasn't been created yet.
 """
 import json
 import logging

--- a/scripts/cleanup_orphaned_records.py
+++ b/scripts/cleanup_orphaned_records.py
@@ -83,6 +83,34 @@ def cleanup_orphaned_records(dry_run: bool = True) -> dict:
         print(f"  Deleted: {cursor.rowcount}")
         stats['deleted_facts'] = cursor.rowcount
 
+    # 2b. Count orphaned tone_analysis_results (#910). Unlike the other
+    # tables here, this one is created lazily by ToneAnalysisStore on its
+    # first use (api/services/tone_analysis_store.py), so it may not exist
+    # yet on an install where tone analysis has never run -- guarded,
+    # unlike the always-present tables above.
+    tone_table_exists = cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='tone_analysis_results'"
+    ).fetchone()
+    if tone_table_exists:
+        cursor.execute("""
+            SELECT COUNT(*) FROM tone_analysis_results t
+            WHERE NOT EXISTS (SELECT 1 FROM valid_person_ids v WHERE v.id = t.person_id)
+        """)
+        orphan_tone_rows = cursor.fetchone()[0]
+        print(f"Orphaned tone_analysis_results: {orphan_tone_rows}")
+        stats['orphan_tone_rows'] = orphan_tone_rows
+
+        if not dry_run and orphan_tone_rows > 0:
+            cursor.execute("""
+                DELETE FROM tone_analysis_results
+                WHERE NOT EXISTS (SELECT 1 FROM valid_person_ids v WHERE v.id = tone_analysis_results.person_id)
+            """)
+            print(f"  Deleted: {cursor.rowcount}")
+            stats['deleted_tone_rows'] = cursor.rowcount
+    else:
+        print("Orphaned tone_analysis_results: table not present, skipping")
+        stats['orphan_tone_rows'] = 0
+
     # 3. Count orphaned link_overrides
     cursor.execute("""
         SELECT COUNT(*) FROM link_overrides o

--- a/scripts/merge_people.py
+++ b/scripts/merge_people.py
@@ -270,6 +270,7 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
         'interactions_updated': 0,
         'source_entities_updated': 0,
         'facts_cleared': 0,
+        'tone_rows_cleared': 0,
         'emails_merged': 0,
         'phones_merged': 0,
         'aliases_added': 0,
@@ -408,6 +409,11 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
             (canonical_primary_id, canonical_secondary_id)
         ).fetchone()[0]
         logger.info(f"4. {stats['facts_cleared']} facts to clear")
+        stats['tone_rows_cleared'] = crm_conn.execute(
+            "SELECT COUNT(*) FROM tone_analysis_results WHERE person_id = ?",
+            (canonical_secondary_id,)
+        ).fetchone()[0]
+        logger.info(f"   {stats['tone_rows_cleared']} tone analysis rows to clear")
 
         # 4. Count relationships
         from api.services.relationship import get_relationship_store
@@ -435,6 +441,7 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
         logger.info(f"Interactions: {stats['interactions_updated']}")
         logger.info(f"Source entities: {stats['source_entities_updated']}")
         logger.info(f"Facts: {stats['facts_cleared']}")
+        logger.info(f"Tone analysis rows: {stats['tone_rows_cleared']}")
         logger.info(f"Relationships: {stats['relationships_updated']} transfer, {stats['relationships_merged']} merge, {stats['relationships_deleted']} delete")
         logger.info(f"Emails: +{stats['emails_merged']}, Phones: +{stats['phones_merged']}, Aliases: +{stats['aliases_added']}")
         logger.info("\nDRY RUN - no changes made. Use --execute to apply.")
@@ -525,6 +532,37 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
                 (canonical_primary_id, canonical_secondary_id)
             )
         logger.info(f"   Facts cleared: {stats['facts_cleared']}")
+
+        # 4b-2. Remove tone analysis results for the absorbed person only
+        # (#910). Unlike facts (cleared for *both* ids, above), the
+        # primary's own tone_analysis_results rows are deliberately left
+        # alone: each row's freshness is already keyed to a stored
+        # interaction_count compared against the person's *current*
+        # interaction count (api/routes/crm.py's analyze_relationship_tone_detailed).
+        # Step 3 above just repointed the secondary's interactions to the
+        # primary, so any month where that changes the primary's count
+        # self-heals the next time tone analysis runs for the primary --
+        # it recomputes using the now-complete, merged interaction history
+        # rather than needing this script to know that. The secondary's
+        # own rows have no such self-healing (the id they're keyed to is
+        # about to stop existing), so those are the ones that must be
+        # deleted here to avoid orphaning -- not re-keyed onto the primary,
+        # since a re-keyed row could collide with a period_key the primary
+        # already has (the table's primary key is (person_id, period_key)),
+        # and simply deleting it lets the primary's next tone-analysis
+        # request compute a fresh score from the merged data instead of
+        # carrying forward a score computed from only half of it.
+        cursor = crm_conn.execute(
+            "SELECT COUNT(*) FROM tone_analysis_results WHERE person_id = ?",
+            (canonical_secondary_id,)
+        )
+        stats['tone_rows_cleared'] = cursor.fetchone()[0]
+        if stats['tone_rows_cleared'] > 0:
+            crm_conn.execute(
+                "DELETE FROM tone_analysis_results WHERE person_id = ?",
+                (canonical_secondary_id,)
+            )
+        logger.info(f"   Tone analysis rows cleared: {stats['tone_rows_cleared']}")
 
         # 4c. Merge relationships (raw SQL within same transaction)
         stats['relationships_updated'] = 0
@@ -713,6 +751,7 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
     logger.info(f"Interactions updated: {stats['interactions_updated']}")
     logger.info(f"Source entities updated: {stats['source_entities_updated']}")
     logger.info(f"Facts cleared: {stats['facts_cleared']} (will regenerate)")
+    logger.info(f"Tone analysis rows cleared: {stats['tone_rows_cleared']}")
     logger.info(f"Relationships: {stats['relationships_updated']} transferred, {stats['relationships_merged']} merged, {stats['relationships_deleted']} deleted")
     logger.info(f"Emails merged: {stats['emails_merged']}")
     logger.info(f"Phones merged: {stats['phones_merged']}")

--- a/scripts/merge_people.py
+++ b/scripts/merge_people.py
@@ -127,6 +127,20 @@ def clear_merge_log():
         MERGE_LOG_FILE.unlink()
 
 
+def _tone_analysis_results_table_exists(conn: sqlite3.Connection) -> bool:
+    """True if crm.db has a tone_analysis_results table.
+
+    Unlike the other tables merge_people touches, this one is created
+    lazily by ToneAnalysisStore on its first use
+    (api/services/tone_analysis_store.py) rather than always being
+    present, so a crm.db where tone analysis has never run doesn't have it
+    yet (#910).
+    """
+    return conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='tone_analysis_results'"
+    ).fetchone() is not None
+
+
 def get_canonical_person_id(person_id: str) -> str:
     """
     Get the canonical (primary) person ID, following merge chain if needed.
@@ -409,10 +423,12 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
             (canonical_primary_id, canonical_secondary_id)
         ).fetchone()[0]
         logger.info(f"4. {stats['facts_cleared']} facts to clear")
-        stats['tone_rows_cleared'] = crm_conn.execute(
-            "SELECT COUNT(*) FROM tone_analysis_results WHERE person_id = ?",
-            (canonical_secondary_id,)
-        ).fetchone()[0]
+        stats['tone_rows_cleared'] = 0
+        if _tone_analysis_results_table_exists(crm_conn):
+            stats['tone_rows_cleared'] = crm_conn.execute(
+                "SELECT COUNT(*) FROM tone_analysis_results WHERE person_id = ?",
+                (canonical_secondary_id,)
+            ).fetchone()[0]
         logger.info(f"   {stats['tone_rows_cleared']} tone analysis rows to clear")
 
         # 4. Count relationships
@@ -552,16 +568,18 @@ def merge_people(primary_id: str, secondary_id: str, dry_run: bool = True) -> di
         # and simply deleting it lets the primary's next tone-analysis
         # request compute a fresh score from the merged data instead of
         # carrying forward a score computed from only half of it.
-        cursor = crm_conn.execute(
-            "SELECT COUNT(*) FROM tone_analysis_results WHERE person_id = ?",
-            (canonical_secondary_id,)
-        )
-        stats['tone_rows_cleared'] = cursor.fetchone()[0]
-        if stats['tone_rows_cleared'] > 0:
-            crm_conn.execute(
-                "DELETE FROM tone_analysis_results WHERE person_id = ?",
+        stats['tone_rows_cleared'] = 0
+        if _tone_analysis_results_table_exists(crm_conn):
+            cursor = crm_conn.execute(
+                "SELECT COUNT(*) FROM tone_analysis_results WHERE person_id = ?",
                 (canonical_secondary_id,)
             )
+            stats['tone_rows_cleared'] = cursor.fetchone()[0]
+            if stats['tone_rows_cleared'] > 0:
+                crm_conn.execute(
+                    "DELETE FROM tone_analysis_results WHERE person_id = ?",
+                    (canonical_secondary_id,)
+                )
         logger.info(f"   Tone analysis rows cleared: {stats['tone_rows_cleared']}")
 
         # 4c. Merge relationships (raw SQL within same transaction)

--- a/tests/test_cleanup_orphaned_records.py
+++ b/tests/test_cleanup_orphaned_records.py
@@ -1,0 +1,138 @@
+"""
+Tests for scripts/cleanup_orphaned_records.py's tone_analysis_results
+handling (#910).
+
+No test file previously existed for this script at all. `cleanup_orphaned_records`
+reads/writes `data/people_entities.json`, `data/crm.db`, and `data/interactions.db`
+via hardcoded relative paths -- deliberately not something #910 should change
+(the script has always worked this way, for every other table it covers) --
+so these tests `monkeypatch.chdir` into a temp directory shaped like a real
+`data/` tree rather than patching the function's internals.
+"""
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from api.services.link_override import LinkOverrideStore
+from api.services.person_facts import PersonFactStore
+from api.services.relationship import RelationshipStore
+from api.services.source_entity import SourceEntityStore
+from api.services.tone_analysis_store import ToneAnalysisStore
+
+pytestmark = pytest.mark.unit
+
+
+def _sample_result(score: float = 65.0) -> dict:
+    return {
+        "user_score": score, "partner_score": score, "combined_score": score,
+        "user_sample_count": 2, "partner_sample_count": 2,
+    }
+
+
+@pytest.fixture
+def orphan_cleanup_env(tmp_path, monkeypatch):
+    """A temp cwd shaped like a real data/ tree: people_entities.json plus
+    crm.db (real schema, via the real store classes, to avoid hand-authoring
+    one that could drift from production) and an empty interactions.db."""
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    crm_db_path = str(data_dir / "crm.db")
+    interactions_db_path = str(data_dir / "interactions.db")
+
+    # Instantiating these against the temp crm.db creates their tables via
+    # each class's own CREATE TABLE IF NOT EXISTS -- the same schema
+    # cleanup_orphaned_records.py expects to find, without duplicating it
+    # here by hand.
+    RelationshipStore(crm_db_path)
+    PersonFactStore(crm_db_path)
+    LinkOverrideStore(Path(crm_db_path))
+    SourceEntityStore(crm_db_path)
+
+    conn = sqlite3.connect(interactions_db_path)
+    conn.execute("""
+        CREATE TABLE interactions (
+            id TEXT PRIMARY KEY, person_id TEXT, timestamp TEXT,
+            source_type TEXT, title TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+    def _write_valid_ids(ids):
+        (data_dir / "people_entities.json").write_text(
+            json.dumps([{"id": i} for i in ids])
+        )
+
+    return {
+        "crm_db_path": crm_db_path,
+        "interactions_db_path": interactions_db_path,
+        "write_valid_ids": _write_valid_ids,
+    }
+
+
+class TestOrphanedToneRows:
+    def test_reports_and_removes_rows_for_a_person_that_no_longer_exists(
+        self, orphan_cleanup_env,
+    ):
+        from scripts.cleanup_orphaned_records import cleanup_orphaned_records
+
+        tone_store = ToneAnalysisStore(orphan_cleanup_env["crm_db_path"])
+        tone_store.upsert("valid-person", "2026-01", 5, _sample_result(70.0))
+        tone_store.upsert("orphaned-person", "2026-01", 5, _sample_result(60.0))
+        tone_store.upsert("orphaned-person", "2026-02", 3, _sample_result(55.0))
+
+        orphan_cleanup_env["write_valid_ids"](["valid-person"])
+
+        dry_run_stats = cleanup_orphaned_records(dry_run=True)
+        assert dry_run_stats["orphan_tone_rows"] == 2
+        # Dry run must not touch anything.
+        assert len(tone_store.get_for_person("orphaned-person")) == 2
+        assert "deleted_tone_rows" not in dry_run_stats
+
+        execute_stats = cleanup_orphaned_records(dry_run=False)
+        assert execute_stats["orphan_tone_rows"] == 2
+        assert execute_stats["deleted_tone_rows"] == 2
+
+        assert tone_store.get_for_person("orphaned-person") == []
+        # The valid person's own row is untouched.
+        assert len(tone_store.get_for_person("valid-person")) == 1
+        assert tone_store.get_month("valid-person", "2026-01").result["user_score"] == 70.0
+
+    def test_no_orphaned_rows_reports_zero_and_deletes_nothing(self, orphan_cleanup_env):
+        from scripts.cleanup_orphaned_records import cleanup_orphaned_records
+
+        tone_store = ToneAnalysisStore(orphan_cleanup_env["crm_db_path"])
+        tone_store.upsert("valid-person", "2026-01", 5, _sample_result())
+
+        orphan_cleanup_env["write_valid_ids"](["valid-person"])
+
+        stats = cleanup_orphaned_records(dry_run=False)
+        assert stats["orphan_tone_rows"] == 0
+        assert "deleted_tone_rows" not in stats
+        assert len(tone_store.get_for_person("valid-person")) == 1
+
+    def test_missing_tone_analysis_results_table_is_handled_gracefully(
+        self, orphan_cleanup_env,
+    ):
+        """An install where tone analysis has never run has no
+        tone_analysis_results table at all (it's created lazily) -- the
+        cleanup script must not error, and must report zero rather than
+        silently omitting the key."""
+        from scripts.cleanup_orphaned_records import cleanup_orphaned_records
+
+        # Deliberately never instantiate ToneAnalysisStore against this db.
+        orphan_cleanup_env["write_valid_ids"](["valid-person"])
+
+        stats = cleanup_orphaned_records(dry_run=True)
+        assert stats["orphan_tone_rows"] == 0
+
+        stats = cleanup_orphaned_records(dry_run=False)
+        assert stats["orphan_tone_rows"] == 0
+        assert "deleted_tone_rows" not in stats

--- a/tests/test_merge_people.py
+++ b/tests/test_merge_people.py
@@ -350,3 +350,117 @@ class TestMergeOperationDetails:
         assert "gmail" in combined_sources
         assert "calendar" in combined_sources
         assert "slack" in combined_sources
+
+
+class TestMergePeopleToneAnalysisResults:
+    """Real, end-to-end coverage of the #910 addition: merging a person
+    must remove tone_analysis_results rows for the absorbed (secondary)
+    person, and must leave the primary's own rows alone (see the code
+    comment in scripts/merge_people.py for why: unlike person_facts, a
+    stale primary row self-heals via the existing interaction-count
+    freshness check the next time tone analysis runs).
+
+    Unlike TestMergePeople above (which mocks sqlite3.connect entirely),
+    this exercises the real SQL against real temporary SQLite files, using
+    the actual store classes to create schema so it can't drift from
+    production. person_entity, relationship, and post-merge stats/strength
+    refresh dependencies are stubbed since they're unrelated to what #910
+    changed and would otherwise require substantially more fixture work
+    to run for real (e.g. person_entities/person_emails/person_phones
+    lookup-table upkeep, real interaction-derived stats)."""
+
+    @pytest.fixture
+    def merge_env(self, tmp_path, monkeypatch):
+        from api.services.person_entity import PersonEntity, PersonEntityStore
+        from api.services.relationship import RelationshipStore
+        from api.services.source_entity import SourceEntityStore
+        from api.services.person_facts import PersonFactStore, PersonFact
+        from api.services.tone_analysis_store import ToneAnalysisStore
+        from api.services.interaction_store import InteractionStore, Interaction
+        from datetime import datetime, timezone
+
+        crm_db_path = str(tmp_path / "crm.db")
+        interactions_db_path = str(tmp_path / "interactions.db")
+
+        person_store = PersonEntityStore(crm_db_path)
+        RelationshipStore(crm_db_path)  # table only -- no rows needed
+        SourceEntityStore(crm_db_path)  # table only -- no rows needed
+        fact_store = PersonFactStore(crm_db_path)
+        tone_store = ToneAnalysisStore(crm_db_path)
+        interaction_store = InteractionStore(interactions_db_path, strict=False)
+
+        primary = PersonEntity(id="primary-person", canonical_name="Primary Person")
+        secondary = PersonEntity(id="secondary-person", canonical_name="Secondary Person")
+        person_store.add(primary)
+        person_store.add(secondary)
+
+        fact_store.add(PersonFact(person_id="primary-person", category="work", key="k1", value="v1"))
+        fact_store.add(PersonFact(person_id="secondary-person", category="work", key="k2", value="v2"))
+
+        tone_store.upsert("primary-person", "2026-01", 2, {
+            "user_score": 70.0, "partner_score": 70.0, "combined_score": 70.0,
+            "user_sample_count": 1, "partner_sample_count": 1,
+        })
+        tone_store.upsert("secondary-person", "2026-01", 2, {
+            "user_score": 40.0, "partner_score": 40.0, "combined_score": 40.0,
+            "user_sample_count": 1, "partner_sample_count": 1,
+        })
+        tone_store.upsert("secondary-person", "2026-02", 3, {
+            "user_score": 35.0, "partner_score": 35.0, "combined_score": 35.0,
+            "user_sample_count": 1, "partner_sample_count": 1,
+        })
+
+        interaction_store.add(Interaction(
+            id="synthetic-1", person_id="secondary-person",
+            timestamp=datetime.now(timezone.utc), source_type="imessage",
+            title="synthetic message",
+        ))
+
+        monkeypatch.setattr("scripts.merge_people.get_person_entity_store", lambda: person_store)
+        monkeypatch.setattr("scripts.merge_people.get_crm_db_path", lambda: crm_db_path)
+        monkeypatch.setattr("scripts.merge_people.get_interaction_db_path", lambda: interactions_db_path)
+        monkeypatch.setattr("scripts.merge_people.MERGED_IDS_FILE", tmp_path / "merged_ids.json")
+        monkeypatch.setattr("scripts.merge_people.MERGE_LOG_FILE", tmp_path / "merge_log.json")
+        # Unrelated post-merge side effects (#910 doesn't touch either) --
+        # stubbed rather than wired up for real to keep this fixture from
+        # growing into a second copy of person_entity/interaction fixtures.
+        monkeypatch.setattr("api.services.person_stats.refresh_person_stats", lambda *a, **k: {})
+        monkeypatch.setattr("api.services.relationship_metrics.update_strength_for_person", lambda *a, **k: None)
+
+        return {"tone_store": tone_store, "fact_store": fact_store}
+
+    def test_merge_removes_absorbed_persons_tone_rows_but_keeps_primarys(self, merge_env):
+        from scripts.merge_people import merge_people
+
+        stats = merge_people("primary-person", "secondary-person", dry_run=False)
+
+        assert stats["tone_rows_cleared"] == 2
+
+        tone_store = merge_env["tone_store"]
+        assert tone_store.get_for_person("secondary-person") == []
+        primary_rows = tone_store.get_for_person("primary-person")
+        assert len(primary_rows) == 1
+        assert primary_rows[0].result["user_score"] == 70.0  # untouched
+
+    def test_dry_run_reports_the_count_without_deleting_anything(self, merge_env):
+        from scripts.merge_people import merge_people
+
+        stats = merge_people("primary-person", "secondary-person", dry_run=True)
+
+        assert stats["tone_rows_cleared"] == 2
+        tone_store = merge_env["tone_store"]
+        assert len(tone_store.get_for_person("secondary-person")) == 2  # untouched by dry run
+
+    def test_merge_still_clears_facts_for_both_ids(self, merge_env):
+        """Regression guard: the pre-existing facts-cleared-for-both-ids
+        behavior (person_facts, above the new tone_analysis_results step
+        in scripts/merge_people.py) must be unaffected by #910's addition
+        right after it."""
+        from scripts.merge_people import merge_people
+
+        stats = merge_people("primary-person", "secondary-person", dry_run=False)
+
+        assert stats["facts_cleared"] == 2  # one from each id
+        fact_store = merge_env["fact_store"]
+        assert fact_store.get_for_person("primary-person") == []
+        assert fact_store.get_for_person("secondary-person") == []

--- a/tests/test_merge_people.py
+++ b/tests/test_merge_people.py
@@ -464,3 +464,55 @@ class TestMergePeopleToneAnalysisResults:
         fact_store = merge_env["fact_store"]
         assert fact_store.get_for_person("primary-person") == []
         assert fact_store.get_for_person("secondary-person") == []
+
+    @pytest.fixture
+    def merge_env_without_tone_table(self, tmp_path, monkeypatch):
+        """Same as merge_env, but the tone_analysis_results table is never
+        created -- reproducing a crm.db from an install where tone
+        analysis has never run (the table is created lazily). Regression
+        coverage for a real bug this addition introduced and fixed in the
+        same round: tests/test_merge_crash_safety.py's fixture builds its
+        own crm.db without this table, and the first version of this
+        change 500'd on it with `no such table: tone_analysis_results`."""
+        from api.services.person_entity import PersonEntity, PersonEntityStore
+        from api.services.relationship import RelationshipStore
+        from api.services.source_entity import SourceEntityStore
+        from api.services.person_facts import PersonFactStore
+        from api.services.interaction_store import InteractionStore
+
+        crm_db_path = str(tmp_path / "crm.db")
+        interactions_db_path = str(tmp_path / "interactions.db")
+
+        person_store = PersonEntityStore(crm_db_path)
+        RelationshipStore(crm_db_path)
+        SourceEntityStore(crm_db_path)
+        PersonFactStore(crm_db_path)
+        InteractionStore(interactions_db_path, strict=False)
+        # Deliberately no ToneAnalysisStore(crm_db_path) call here.
+
+        person_store.add(PersonEntity(id="primary-person", canonical_name="Primary Person"))
+        person_store.add(PersonEntity(id="secondary-person", canonical_name="Secondary Person"))
+
+        monkeypatch.setattr("scripts.merge_people.get_person_entity_store", lambda: person_store)
+        monkeypatch.setattr("scripts.merge_people.get_crm_db_path", lambda: crm_db_path)
+        monkeypatch.setattr("scripts.merge_people.get_interaction_db_path", lambda: interactions_db_path)
+        monkeypatch.setattr("scripts.merge_people.MERGED_IDS_FILE", tmp_path / "merged_ids.json")
+        monkeypatch.setattr("scripts.merge_people.MERGE_LOG_FILE", tmp_path / "merge_log.json")
+        monkeypatch.setattr("api.services.person_stats.refresh_person_stats", lambda *a, **k: {})
+        monkeypatch.setattr("api.services.relationship_metrics.update_strength_for_person", lambda *a, **k: None)
+
+    def test_merge_execute_succeeds_when_tone_analysis_results_table_does_not_exist_yet(
+        self, merge_env_without_tone_table,
+    ):
+        from scripts.merge_people import merge_people
+
+        stats = merge_people("primary-person", "secondary-person", dry_run=False)
+        assert stats["tone_rows_cleared"] == 0
+
+    def test_merge_dry_run_succeeds_when_tone_analysis_results_table_does_not_exist_yet(
+        self, merge_env_without_tone_table,
+    ):
+        from scripts.merge_people import merge_people
+
+        stats = merge_people("primary-person", "secondary-person", dry_run=True)
+        assert stats["tone_rows_cleared"] == 0


### PR DESCRIPTION
## TL;DR

Tone analysis results are saved per person and month, but nothing removed those rows when a person was merged into another or deleted, so they orphaned indefinitely. Merging a person now clears the absorbed person's tone rows the same way it already clears their facts, and a separate cleanup script now finds and removes any tone rows left behind for a person who no longer exists at all.

Closes #910

## Design

- **On merge**: `scripts/merge_people.py` deletes the absorbed (secondary) person's `tone_analysis_results` rows in the same crm.db transaction that already clears `person_facts`, right after that step. This is delete-only, not re-keyed onto the survivor, and only touches the absorbed person's rows — the survivor's own rows are deliberately left alone.
  - **Why delete, not re-key**: the table's primary key is `(person_id, period_key)`. Re-keying a row from the absorbed id onto the survivor's id could collide with a `period_key` the survivor already has for the same month, which would need an arbitrary tie-break (keep which score?) for no real benefit.
  - **Why the survivor's own rows are untouched, unlike `person_facts`**: `person_facts` has no way to detect it's gone stale after a merge, so the merge script clears it for *both* ids to force full regeneration. `tone_analysis_results` already has exactly that detection built in — each row's freshness is checked against the person's *current* interaction count on every read (`api/routes/crm.py`'s `analyze_relationship_tone_detailed`). Once the merge repoints the absorbed person's interactions onto the survivor, any month whose count that changes will already show up as stale next time tone analysis runs for the survivor and recompute from the complete, merged history — no explicit clearing needed.
- **On cleanup**: `scripts/cleanup_orphaned_records.py` gets a new step matching its existing `person_facts`/`link_overrides`/`source_entities` pattern exactly (count orphans, print, delete if `--execute`), reporting and removing any `tone_analysis_results` row whose `person_id` isn't in `people_entities.json` anymore. Unlike the tables this script already covers, `tone_analysis_results` is created lazily (only once tone analysis has actually run for someone), so this step is guarded to a no-op rather than erroring on an install where the table doesn't exist yet.

## Implementation Notes

- `scripts/merge_people.py`: new `_tone_analysis_results_table_exists(conn)` helper (used by both the dry-run count and the execute-path count/delete, since the table may not exist yet — see below); a `tone_rows_cleared` stat added alongside `facts_cleared` in the stats dict, the dry-run preview, and both summary printouts. No other phase of the script was touched.
- `api/routes/crm.py`: added `'tone_rows_cleared': 0` to the `/people/merge` endpoint's `total_stats` aggregation dict, matching `facts_cleared`'s existing treatment there.
- `scripts/cleanup_orphaned_records.py`: new step between the existing `person_facts` and `link_overrides` steps, gated on a `sqlite_master` check for the table's existence.
- `api/services/tone_analysis_store.py`: updated the module docstring, which had recorded this as a known gap when the unused `delete_for_person()` method was removed in PR #899.

### A real bug caught by testing, fixed in the same PR

The first version of the `merge_people.py` change queried `tone_analysis_results` unconditionally and broke `tests/test_merge_crash_safety.py`, whose fixture builds a crm.db without that table (exactly the "tone analysis has never run yet" case the table's lazy creation allows for in production too). Added the `_tone_analysis_results_table_exists()` guard and two direct regression tests (`test_merge_execute_succeeds_when_tone_analysis_results_table_does_not_exist_yet`, `test_merge_dry_run_succeeds_when_tone_analysis_results_table_does_not_exist_yet`) reproducing that exact case for `merge_people()` itself, confirmed to fail without the guard.

## Test evidence

### Automated tests

```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest \
    tests/test_cleanup_orphaned_records.py tests/test_merge_people.py tests/test_merge_soft_delete.py \
    tests/test_merge_crash_safety.py tests/test_route_handlers_mutation_lock.py \
    tests/test_tone_analysis_store.py tests/test_tone_analysis_handler.py tests/test_mcp_server.py -q
...
146 passed, 1 warning in 77.91s
```

Full unit suite (part of the pre-push gate): 5780 passed, 8 skipped. Server-free browser suite: 375 passed.

New tests, both against real temporary SQLite files (no mocking of `sqlite3.connect` — using the actual store classes to build schema, so it can't drift from production):

- `tests/test_merge_people.py::TestMergePeopleToneAnalysisResults` (5 tests): runs the real `merge_people()` function end-to-end.
  - `test_merge_removes_absorbed_persons_tone_rows_but_keeps_primarys` — merges two people, each with a stored tone row; asserts the secondary's rows are gone and the primary's row (a different month, in this fixture) is untouched.
  - `test_dry_run_reports_the_count_without_deleting_anything` — same setup, `dry_run=True`; asserts the count is reported but nothing is deleted.
  - `test_merge_still_clears_facts_for_both_ids` — regression guard that the pre-existing `person_facts` behavior (cleared for both ids, directly above the new step) is unaffected.
  - `test_merge_execute_succeeds_when_tone_analysis_results_table_does_not_exist_yet` / `..._dry_run_...` — the missing-table case described above.
- `tests/test_cleanup_orphaned_records.py` (new file — no prior test coverage existed for this script at all): report+delete for an orphaned person's rows, zero-orphans reports zero and deletes nothing, and the missing-table case is handled gracefully.

Confirmed each new test fails without its corresponding fix (manual mutation: reverted the relevant code block, re-ran the specific test, saw it fail with the expected error, restored).

### Manual verification

Not applicable beyond the automated tests above — this is a data-hygiene change to two operator-run scripts with no user-facing surface and no staging/browser verification path; the acceptance criteria ("no rows remain for the absorbed id" and "the cleanup script reports and removes orphaned tone rows") are database-state assertions, which the real-SQLite tests check directly.

## Review focus

- The choice to leave the merge survivor's own tone rows untouched (rather than mirroring `person_facts`'s clear-both-ids behavior) rests on the freshness/interaction-count self-healing property described above — worth double-checking that reasoning holds, since it's the one place this PR deliberately does *not* mirror the `person_facts` precedent it was asked to follow.
- `tone_rows_cleared` is a new stat key; it's surfaced through `/people/merge`'s response the same way `facts_cleared` already is, but the product docs' one example response JSON (`docs/specs/product/api-crm.md`) already omits `facts_cleared` too, so it wasn't updated there for consistency with that existing (non-exhaustive) example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqMhBfLUGZ5cKuqyWe5iqD
