### PR TITLE
feat(agents): mirror remote Claude Code and Codex transcripts and add resume-here (#866)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -211,6 +211,16 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to start agent_viz prefetch loop: {e}")
 
+    # Startup: background transcript mirror — pulls each registered
+    # host's Claude Code/Codex transcripts onto this box so remote sessions
+    # reach parity with local ones on /agents. No-op when no hosts are
+    # registered.
+    try:
+        from api.services import agent_transcript_mirror
+        agent_transcript_mirror.start()
+    except Exception as e:
+        logger.error(f"Failed to start agent transcript mirror loop: {e}")
+
     # Hint for new users who haven't set their person ID yet
     if not settings.my_person_id and settings.user_name and settings.user_name != "User":
         logger.info(
@@ -265,6 +275,12 @@ async def lifespan(app: FastAPI):
     try:
         from api.services import agent_viz_summary_prefetch
         agent_viz_summary_prefetch.stop()
+    except Exception:
+        pass
+
+    try:
+        from api.services import agent_transcript_mirror
+        agent_transcript_mirror.stop()
     except Exception:
         pass
 

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -361,6 +361,46 @@ def _cli_session_to_dict(cli: CliSession) -> dict[str, Any]:
     }
 
 
+def _read_cli_transcript_events(session_id: str) -> list[dict[str, Any]]:
+    """Normalized events for a `cc:`/`cx:` session.
+
+    Tries the local transcript root first, then each mirrored remote
+    host's copy in turn — the first non-empty
+    result wins. Used by `/events`, `/stream`, `/summary`, and the viz
+    prefetcher so a mirrored session's transcript reads identically to a
+    local one. Raises `ValueError` (mirrors `read_normalized_events`) for
+    an id that fails validation or carries neither prefix.
+    """
+    from config.settings import settings
+    from api.services import agent_transcript_mirror as mirror
+
+    if session_id.startswith("cc:"):
+        from api.services.claude_code import session_ingest as cc
+
+        events = cc.read_normalized_events(session_id, settings.claude_code_projects_dir)
+        if events:
+            return events
+        for host_dir in mirror.mirrored_transcript_dirs("claude_code"):
+            events = cc.read_normalized_events(session_id, host_dir)
+            if events:
+                return events
+        return []
+
+    if session_id.startswith("cx:"):
+        from api.services.codex import session_ingest as cx
+
+        events = cx.read_normalized_events(session_id, settings.codex_sessions_dir)
+        if events:
+            return events
+        for host_dir in mirror.mirrored_transcript_dirs("codex"):
+            events = cx.read_normalized_events(session_id, host_dir)
+            if events:
+                return events
+        return []
+
+    raise ValueError(f"unsupported session_id prefix: {session_id!r}")
+
+
 def _build_snapshot() -> dict[str, Any]:
     session_store = _get_session_store()
     transcript_store = _get_transcript_store()
@@ -436,6 +476,81 @@ def _build_snapshot() -> dict[str, Any]:
     session_dicts.extend(cx_sessions)
     edges.extend(cx_edges)
 
+    # Mirrored remote transcripts: merge alongside the local cc/cx
+    # rows above. A session already present from a LOCAL transcript wins on
+    # id collision — a mirror lags behind by up to one interval, so if this
+    # host somehow has both, the fresher local copy is preferred. Popping a
+    # match from cli_by_id here (like the cc/cx blocks above) means status
+    # comes from hook events and detail from the mirrored transcript; with
+    # no hook row the mirrored row's own `host` (the remote host name) is
+    # left untouched rather than overwritten with this API host's name.
+    try:
+        from api.services import agent_transcript_mirror
+        mirrored_cc, mirrored_cx, mirrored_edges = agent_transcript_mirror.mirrored_snapshot()
+    except Exception as exc:  # noqa: BLE001 — never break the snapshot on a mirror failure
+        logger.warning("mirrored transcript snapshot failed: %s", exc)
+        mirrored_cc, mirrored_cx, mirrored_edges = [], [], []
+
+    local_ids = {sd.get("session_id") for sd in session_dicts}
+    # Ids the mirrored merge loop below actually APPENDED a row for, mapped
+    # to the SOURCE HOST that row came from. A mirrored edge (below) is kept
+    # only when both its endpoints are ids appended here AND both came from
+    # the same host's batch: a local id collision leaves that id pointing at
+    # the local row, not the mirrored one an edge was derived from, and two
+    # different mirrored hosts can carry the same parent session id — so the
+    # host is recorded per id rather than tracked as flat membership alone.
+    appended_mirrored_host_by_id: dict[str, str] = {}
+    for sd in (*mirrored_cc, *mirrored_cx):
+        sid = sd.get("session_id") or ""
+        if not sid or sid in local_ids:
+            continue
+        sd.setdefault(
+            "short_label",
+            _short_label_for_snapshot(
+                sid,
+                sd.get("last_activity_at") or 0.0,
+                sd.get("status") or "",
+            ),
+        )
+        sd["custom_label"] = agent_viz_label_override.get_override(sid)
+        # Capture the mirror's own source host BEFORE the hook overlay below
+        # can rewrite `sd["host"]` to the hook-reported hostname — a
+        # subagent row has no hook row of its own, so it keeps the mirror
+        # directory's host, and comparing that against a parent's
+        # hook-overlaid host would falsely disagree whenever the registry
+        # key differs from the remote machine's actual hostname.
+        source_host = sd.get("host") or ""
+        cli = cli_by_id.pop(sid, None)
+        if cli is not None:
+            _apply_cli_session_to_dict(sd, cli)
+        session_dicts.append(sd)
+        local_ids.add(sid)
+        appended_mirrored_host_by_id[sid] = source_host
+
+    # Extend edges with the mirrored hosts' own parent-subagent spawn
+    # edges — the local cc/cx blocks above already do this
+    # (`edges.extend(cc_edges)` / `edges.extend(cx_edges)`); this does the
+    # same for the mirrored merge. An edge survives only when both endpoints
+    # were appended by the loop above AND both came from the same host's
+    # batch (`appended_mirrored_host_by_id`): a local id collision leaves
+    # that id pointing at the local row rather than the mirrored one the
+    # edge came from, and a session id can be present on two different
+    # mirrored hosts at once, so matching on id alone is not sufficient.
+    # Also dedupe on `(from, to, type)`: a session mirrored from two hosts,
+    # or an id collision, can otherwise emit the identical spawn edge twice.
+    seen_mirrored_edges: set[tuple[Any, Any, Any]] = set()
+    for e in mirrored_edges:
+        frm, to = e.get("from"), e.get("to")
+        frm_host = appended_mirrored_host_by_id.get(frm)
+        to_host = appended_mirrored_host_by_id.get(to)
+        if frm_host is None or to_host is None or frm_host != to_host:
+            continue
+        key = (frm, to, e.get("type"))
+        if key in seen_mirrored_edges:
+            continue
+        seen_mirrored_edges.add(key)
+        edges.append(e)
+
     # Whatever's left in cli_by_id had no local transcript — a remote host,
     # or (rarely) a local hook post that raced ahead of the transcript
     # scan's cache. Bound to the same recency window the transcript scan
@@ -467,6 +582,11 @@ def _build_snapshot() -> dict[str, Any]:
         "sessions": session_dicts,
         "edges": edges,
         "generated_at": int(time.time()),
+        # So the drawer's "resume here" host picker can offer THIS
+        # machine even when `GET /api/agents/hosts` isn't reachable —
+        # every page already polls /snapshot, so no extra request is
+        # needed for the frontend's fallback list.
+        "api_host": api_host_name(),
     }
 
 
@@ -541,10 +661,7 @@ async def get_session_events(
         if not _claude_code_enabled():
             raise HTTPException(status_code=404, detail="claude_code viz disabled")
         try:
-            from config.settings import settings
-            from api.services.claude_code import session_ingest as cc
-
-            events = cc.read_normalized_events(session_id, settings.claude_code_projects_dir)
+            events = _read_cli_transcript_events(session_id)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         tail = events[-limit:] if len(events) > limit else events
@@ -554,10 +671,7 @@ async def get_session_events(
         if not _codex_enabled():
             raise HTTPException(status_code=404, detail="codex viz disabled")
         try:
-            from config.settings import settings
-            from api.services.codex import session_ingest as cx
-
-            events = cx.read_normalized_events(session_id, settings.codex_sessions_dir)
+            events = _read_cli_transcript_events(session_id)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         tail = events[-limit:] if len(events) > limit else events
@@ -592,16 +706,23 @@ async def get_session_summary(session_id: str) -> dict[str, Any]:
         if not _claude_code_enabled():
             raise HTTPException(status_code=404, detail="claude_code viz disabled")
         try:
-            from config.settings import settings
-            from api.services.claude_code import session_ingest as cc
-
-            events = cc.read_normalized_events(session_id, settings.claude_code_projects_dir)
+            events = _read_cli_transcript_events(session_id)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         # Find this CC session in the cached snapshot to pull label + activity.
         cc_sessions, _ = _claude_code_snapshot()
         match = next((s for s in cc_sessions if s.get("session_id") == session_id), None)
+        if match is None:
+            # Not a local transcript — check every mirrored host too, so a
+            # remote session's summary still gets a real label/status
+            # instead of falling back to the bare session_id below.
+            try:
+                from api.services import agent_transcript_mirror
+                mirrored_cc, _mirrored_cx, _mirrored_edges = agent_transcript_mirror.mirrored_snapshot()
+                match = next((s for s in mirrored_cc if s.get("session_id") == session_id), None)
+            except Exception as exc:  # noqa: BLE001 — summary still works with defaults
+                logger.warning("mirrored snapshot lookup failed for %s: %s", session_id, exc)
         if match:
             label = str(match.get("label") or session_id)
             last_activity = float(match.get("last_activity_at") or 0.0)
@@ -610,15 +731,19 @@ async def get_session_summary(session_id: str) -> dict[str, Any]:
         if not _codex_enabled():
             raise HTTPException(status_code=404, detail="codex viz disabled")
         try:
-            from config.settings import settings
-            from api.services.codex import session_ingest as cx
-
-            events = cx.read_normalized_events(session_id, settings.codex_sessions_dir)
+            events = _read_cli_transcript_events(session_id)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         cx_sessions, _ = _codex_snapshot()
         match = next((s for s in cx_sessions if s.get("session_id") == session_id), None)
+        if match is None:
+            try:
+                from api.services import agent_transcript_mirror
+                _mirrored_cc, mirrored_cx, _mirrored_edges = agent_transcript_mirror.mirrored_snapshot()
+                match = next((s for s in mirrored_cx if s.get("session_id") == session_id), None)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("mirrored snapshot lookup failed for %s: %s", session_id, exc)
         if match:
             label = str(match.get("label") or session_id)
             last_activity = float(match.get("last_activity_at") or 0.0)
@@ -1416,6 +1541,10 @@ class CCResumeRequest(BaseModel):
     """Body for POST /api/agents/sessions/{id}/resume — accepts overrides
     for the spawn env when the systemd-inherited env isn't enough."""
     extra_env: dict[str, str] = {}
+    # "Resume here": an explicit target machine, overriding the
+    # session's recorded host. Blank/unset resumes where the session ran.
+    # See `_resolve_target_host`.
+    target_host: str | None = Field(default=None, max_length=255)
 
 
 class CCPaneBindRequest(BaseModel):
@@ -1903,6 +2032,121 @@ def _check_session_host_or_409(session_id: str) -> str | None:
     return target
 
 
+def _resume_command_text(session_id: str) -> str:
+    """Render the exact resume command for `session_id`, cwd-portable
+    (`cd <cwd> && ...`) so it's paste-able into any terminal.
+
+    Called from THREE sites: `_resolve_target_host`'s 400 `detail.command`
+    field, for a target the operator picked that this API can't launch on
+    itself; and the codex and Claude Code launchers' own 400 branches,
+    when `Popen`'s child `os.chdir` fails because the
+    resolved cwd doesn't exist/isn't a directory/isn't accessible on this
+    host. The launchers still build their own `inner_rendered`
+    independently for their SUCCESS path, and the renderings differ: this
+    function prepends `cd <cwd> && `, theirs doesn't. Do not refactor the
+    launchers' success-path rendering through it without accounting for
+    that difference — only their 400 branches call this function, to
+    render the copyable command text. Resolves cwd via the same
+    local-then-mirrored lookup `/focus` uses, falling back to the
+    `cli_sessions` row's own `cwd` when neither has a transcript for this
+    id — the common case for a remote-hosted session this API has never
+    mirrored. Returns `""` — never raises — when the id can't be
+    resolved at all, or when no cwd resolves for it, so a caller never
+    renders a command missing its `cd`; the drawer suppresses the
+    command box entirely on an empty string.
+    """
+    import shlex
+
+    from config.settings import settings
+
+    if session_id.startswith("cx:"):
+        from api.services.codex import session_ingest as cx
+        try:
+            bare = cx.validate_session_id(session_id)
+        except ValueError:
+            return ""
+        cwd = ""
+        try:
+            cwd = _lookup_cx_session_meta(session_id).decoded_cwd or ""
+        except HTTPException:
+            pass
+        template = (settings.codex_resume_inner_cmd or "").strip()
+    elif session_id.startswith("cc:"):
+        from api.services.claude_code import session_ingest as cc
+        try:
+            bare = cc.validate_session_id(session_id)
+        except ValueError:
+            return ""
+        if ":agent:" in bare:
+            bare = bare.split(":agent:", 1)[0]
+        cwd = ""
+        try:
+            meta, bare = _lookup_cc_session_meta(session_id)
+            cwd = meta.decoded_cwd or ""
+        except HTTPException:
+            pass
+        template = (settings.cc_resume_inner_cmd or "").strip()
+    else:
+        return ""
+
+    if not cwd:
+        try:
+            cli = _get_session_store().get_cli_session(session_id)
+        except Exception:  # noqa: BLE001 — a store error must not break command rendering
+            cli = None
+        if cli is not None and cli.cwd:
+            cwd = cli.cwd
+
+    inner = template.replace("{session_id}", bare).replace("{cwd}", cwd)
+    if not inner:
+        return ""
+    if not cwd:
+        # No cwd resolved at all (local scan missed,
+        # no mirrored transcript, no cli_sessions row) — rendering the
+        # inner command WITHOUT `cd <cwd> &&` would offer a command that
+        # resumes in whatever directory the operator happens to be in,
+        # not the session's actual project. Render nothing rather than a
+        # misleading command; the caller (the drawer) suppresses the
+        # command box entirely when this returns "".
+        return ""
+    return f"cd {shlex.quote(cwd)} && {inner}"
+
+
+def _resolve_target_host(session_id: str, target_host: str | None) -> str | None:
+    """Resolve resume/focus's launch target, honoring an explicit
+    `target_host` override ("resume here").
+
+    - Unset/blank `target_host`: falls through to
+      `_check_session_host_or_409` (including its 409 for an
+      unregistered host).
+    - `target_host` equal to this API host's own name: launch locally
+      (`None`) — OVERRIDES the session's recorded host, which is the
+      whole point of "resume here".
+    - `target_host` a key in `settings.agent_hosts`: launch there over
+      ssh (its target string) — also an override of the recorded host.
+    - Anything else: 400 with a `detail` object carrying `error` and the
+      full resume `command` text, so the caller can offer it for copying
+      rather than trying to launch somewhere this API can't reach.
+    """
+    target_host = (target_host or "").strip()
+    if not target_host:
+        return _check_session_host_or_409(session_id)
+    if target_host == api_host_name():
+        return None
+    from config.settings import settings
+
+    target = settings.agent_hosts.get(target_host)
+    if target:
+        return target
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "error": f"host {target_host!r} is not this API host and not in LIFEOS_AGENT_HOSTS",
+            "command": _resume_command_text(session_id),
+        },
+    )
+
+
 async def _resume_codex_session(
     session_id: str,
     body: "CCResumeRequest | None",
@@ -1943,10 +2187,16 @@ async def _resume_codex_session(
         # a remote session's rollout file isn't under this API's local
         # `codex_sessions_dir`; its cwd comes from the `cli_sessions` row.
         cli = _get_session_store().get_cli_session(session_id)
-        if cli is None or not cli.cwd:
-            raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
-        from types import SimpleNamespace
-        target = SimpleNamespace(decoded_cwd=cli.cwd)
+        if cli is not None and cli.cwd:
+            from types import SimpleNamespace
+            target = SimpleNamespace(decoded_cwd=cli.cwd)
+        else:
+            # No cli_sessions row — e.g. a "resume here" targeted at
+            # a session known only from its mirrored transcript. Fall back
+            # to the transcript's own cwd via the same lookup /focus uses.
+            target = _lookup_cx_session_meta(session_id)
+            if not target.decoded_cwd:
+                raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
     else:
         # Widen lookback for resume so older sessions are still resolvable.
         metas = cx.discover_sessions(
@@ -1954,15 +2204,31 @@ async def _resume_codex_session(
             lookback_days=max(int(settings.codex_lookback_days), 365),
         )
         target = next((m for m in metas if m.raw_session_id == bare), None)
-        if target is None:
-            raise HTTPException(status_code=404, detail=f"session {session_id} not found")
         # Codex stores cwd inside session_meta, populated by parse_session. The
         # snapshot prepopulates it but on a fresh resume call we may need to
         # re-parse to recover it (cheap — one jsonl read).
-        if not target.decoded_cwd:
+        if target is not None and not target.decoded_cwd:
             target, _ = cx.parse_session(target)
-        if not target.decoded_cwd:
-            raise HTTPException(status_code=404, detail=f"session {session_id} has no cwd")
+        if target is None or not target.decoded_cwd:
+            # The local scan missed — e.g. "resume here" targeted at this
+            # API host for a session whose transcript lives on another
+            # (mirrored) machine. Fall through to the same mirror-aware
+            # chain `_resume_command_text` performs: the mirrored-
+            # transcript lookup, then the `cli_sessions` row's own cwd,
+            # before giving up.
+            try:
+                target = _lookup_cx_session_meta(session_id)
+            except HTTPException:
+                target = None
+            if target is None or not target.decoded_cwd:
+                cli = _get_session_store().get_cli_session(session_id)
+                if cli is not None and cli.cwd:
+                    from types import SimpleNamespace
+                    target = SimpleNamespace(decoded_cwd=cli.cwd)
+                else:
+                    target = None
+        if target is None or not target.decoded_cwd:
+            raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
 
     inner_template = (settings.codex_resume_inner_cmd or "").strip()
     inner_rendered = (
@@ -2009,9 +2275,37 @@ async def _resume_codex_session(
             stderr=subprocess.PIPE,
             start_new_session=True,
         )
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=500, detail=f"resume binary not found: {exc}") from exc
     except OSError as exc:
+        # A mirrored session's cwd is the REMOTE
+        # machine's path — on this (local, non-ssh) branch it's used as-is
+        # for `Popen(cwd=...)`, which may not exist, may not be a
+        # directory, or may not be traversable on THIS host when the
+        # session was mirrored from elsewhere (e.g. "resume here" back
+        # onto the API host for a session whose transcript lives only on
+        # a remote box). Depending on which, `Popen`'s child `os.chdir`
+        # raises `FileNotFoundError` (ENOENT), `NotADirectoryError`
+        # (ENOTDIR — the cwd is a regular file), or `PermissionError`
+        # (EACCES) — all `OSError` subclasses. Checking `exc.filename ==
+        # popen_cwd` FIRST, across all three, is what makes the
+        # discrimination exact: only the child's `os.chdir` failure blames
+        # the cwd itself as `exc.filename`; a missing-executable
+        # `FileNotFoundError` blames argv[0] instead, and no other
+        # `Popen` failure carries the cwd as its filename at all. Without
+        # this, the cwd case renders a 500 that (for the ENOENT case)
+        # misleadingly blames "resume binary not found" when the binary is
+        # fine, and — because a 500's `detail` is a bare string — skips
+        # the copyable-command fallback `panel.js` already knows how to
+        # render for a 400.
+        if not remote_ssh_target and popen_cwd and exc.filename == popen_cwd:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"cwd {popen_cwd!r} does not exist on this host",
+                    "command": _resume_command_text(session_id),
+                },
+            ) from exc
+        if isinstance(exc, FileNotFoundError):
+            raise HTTPException(status_code=500, detail=f"resume binary not found: {exc}") from exc
         raise HTTPException(status_code=500, detail=f"resume spawn failed: {exc}") from exc
 
     clipboard_text = ""
@@ -2112,10 +2406,12 @@ async def resume_claude_code_session(
     if not session_id.startswith("cx:") and not session_id.startswith("cc:"):
         raise HTTPException(status_code=400, detail="resume is only available for Claude Code or Codex sessions")
 
-    # (#849/#851) A session registered on a different, but REGISTERED
-    # (settings.agent_hosts), host resumes over ssh; an unregistered host
+    # An explicit `target_host` ("resume here") overrides the session's
+    # recorded host; unset falls through to `_check_session_host_or_409` —
+    # a session registered on a different, but REGISTERED
+    # (settings.agent_hosts), host resumes over ssh, an unregistered host
     # still 409s rather than silently no-op'ing.
-    remote_ssh_target = _check_session_host_or_409(session_id)
+    remote_ssh_target = _resolve_target_host(session_id, body.target_host if body else None)
 
     if session_id.startswith("cx:"):
         return await _resume_codex_session(session_id, body, remote_ssh_target=remote_ssh_target)
@@ -2163,10 +2459,16 @@ async def _resume_claude_code_launcher(
         # from the `cli_sessions` row instead (populated by the remote
         # host's own hook script over HTTP, host-agnostic by design — #849).
         cli = _get_session_store().get_cli_session(session_id)
-        if cli is None or not cli.cwd:
-            raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
-        from types import SimpleNamespace
-        target = SimpleNamespace(decoded_cwd=cli.cwd)
+        if cli is not None and cli.cwd:
+            from types import SimpleNamespace
+            target = SimpleNamespace(decoded_cwd=cli.cwd)
+        else:
+            # No cli_sessions row — e.g. a "resume here" targeted at
+            # a session known only from its mirrored transcript. Fall back
+            # to the transcript's own cwd via the same lookup /focus uses.
+            target, _bare_unused = _lookup_cc_session_meta(session_id)
+            if not target.decoded_cwd:
+                raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
     else:
         # Find the matching jsonl to recover the working directory.
         metas = cc.discover_sessions(
@@ -2174,6 +2476,24 @@ async def _resume_claude_code_launcher(
             lookback_days=max(int(settings.claude_code_lookback_days), 365),  # widen lookback for resume
         )
         target = next((m for m in metas if m.raw_session_id == bare), None)
+        if target is None or not target.decoded_cwd:
+            # The local scan missed — e.g. "resume here" targeted at this
+            # API host for a session whose transcript lives on another
+            # (mirrored) machine. Fall through to the same mirror-aware
+            # chain `_resume_command_text` performs: the mirrored-
+            # transcript lookup, then the `cli_sessions` row's own cwd,
+            # before giving up.
+            try:
+                target, _bare_unused = _lookup_cc_session_meta(session_id)
+            except HTTPException:
+                target = None
+            if target is None or not target.decoded_cwd:
+                cli = _get_session_store().get_cli_session(session_id)
+                if cli is not None and cli.cwd:
+                    from types import SimpleNamespace
+                    target = SimpleNamespace(decoded_cwd=cli.cwd)
+                else:
+                    target = None
         if target is None or not target.decoded_cwd:
             raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
 
@@ -2247,9 +2567,31 @@ async def _resume_claude_code_launcher(
             stderr=subprocess.PIPE,
             start_new_session=True,
         )
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=500, detail=f"resume binary not found: {exc}") from exc
     except OSError as exc:
+        # Same cross-machine cwd mismatch as the codex
+        # launcher above: a mirrored session's cwd is the REMOTE machine's
+        # path, so on this local branch it may not exist, may not be a
+        # directory, or may not be traversable on this host at all. The
+        # child's `os.chdir` raises `FileNotFoundError` (ENOENT),
+        # `NotADirectoryError` (ENOTDIR — the cwd is a regular file), or
+        # `PermissionError` (EACCES) — all `OSError` subclasses — with
+        # `exc.filename` set to the cwd; a missing-executable
+        # `FileNotFoundError` blames argv[0] instead, and no other `Popen`
+        # failure carries the cwd as its filename. Checking `exc.filename
+        # == popen_cwd` across all three fails with a 400 carrying the
+        # copyable command instead of letting the ENOENT case fall through
+        # to a 500 that misleadingly blames the resume binary rather than
+        # the cwd.
+        if not remote_ssh_target and popen_cwd and exc.filename == popen_cwd:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"cwd {popen_cwd!r} does not exist on this host",
+                    "command": _resume_command_text(session_id),
+                },
+            ) from exc
+        if isinstance(exc, FileNotFoundError):
+            raise HTTPException(status_code=500, detail=f"resume binary not found: {exc}") from exc
         raise HTTPException(status_code=500, detail=f"resume spawn failed: {exc}") from exc
 
     # Push a cwd-portable form of the inner command to the system
@@ -2410,6 +2752,33 @@ def _lookup_cc_session_meta(session_id: str):
                 )
                 return meta, bare
 
+    # Not under the local projects dir — check every mirrored
+    # remote host's copy too, so /focus's FD-probe fallback and the
+    # summary path can resolve a mirrored session the same way a local
+    # one resolves above.
+    from api.services import agent_transcript_mirror as mirror
+
+    for host_dir in mirror.mirrored_transcript_dirs("claude_code"):
+        for proj in host_dir.iterdir():
+            if not proj.is_dir():
+                continue
+            candidate = proj / f"{bare}.jsonl"
+            if candidate.exists():
+                try:
+                    mtime = candidate.stat().st_mtime
+                except OSError:
+                    mtime = 0.0
+                project_key = proj.name
+                meta = SessionMeta(
+                    session_id=CC_PREFIX + bare,
+                    raw_session_id=bare,
+                    project_key=project_key,
+                    decoded_cwd=decode_project_key(project_key),
+                    jsonl_path=str(candidate),
+                    mtime=mtime,
+                )
+                return meta, bare
+
     raise HTTPException(status_code=404, detail=f"session {session_id} not found")
 
 
@@ -2433,6 +2802,18 @@ def _lookup_cx_session_meta(session_id: str):
         lookback_days=max(int(settings.codex_lookback_days), 365),
     )
     target = next((m for m in metas if m.raw_session_id == bare), None)
+    if target is None:
+        # Not local — check every mirrored remote host's copy too.
+        from api.services import agent_transcript_mirror as mirror
+
+        for host_dir in mirror.mirrored_transcript_dirs("codex"):
+            metas = cx.discover_sessions(
+                sessions_dir=host_dir,
+                lookback_days=max(int(settings.codex_lookback_days), 365),
+            )
+            target = next((m for m in metas if m.raw_session_id == bare), None)
+            if target is not None:
+                break
     if target is None:
         raise HTTPException(status_code=404, detail=f"session {session_id} not found")
     if not target.decoded_cwd:
@@ -2558,7 +2939,10 @@ async def cc_pane_bind(request: Request, body: CCPaneBindRequest) -> dict[str, A
 
 
 @router.post("/sessions/{session_id}/focus")
-async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
+async def focus_claude_code_session(
+    session_id: str,
+    body: CCResumeRequest | None = None,
+) -> dict[str, Any]:
     """Activate the WezTerm pane running this Claude Code session.
 
     Resolution order:
@@ -2586,9 +2970,10 @@ async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
     if not session_id.startswith("cc:") and not is_cx:
         raise HTTPException(status_code=400, detail="focus is only available for Claude Code or Codex sessions")
 
-    # (#849/#851) A session registered on a different, but REGISTERED host
-    # resumes over ssh; an unregistered host still 409s.
-    remote_ssh_target = _check_session_host_or_409(session_id)
+    # A session registered on a different, but REGISTERED
+    # host resumes over ssh; an unregistered host still 409s. An explicit
+    # `target_host` ("resume here") overrides the session's recorded host.
+    remote_ssh_target = _resolve_target_host(session_id, body.target_host if body else None)
 
     try:
         from config.settings import settings
@@ -2716,12 +3101,9 @@ async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
 
 async def _stream_claude_code_session(session_id: str, backfill: int):
     """Per-session SSE generator for Claude Code (cc:-prefixed) sessions."""
-    from config.settings import settings
-    from api.services.claude_code import session_ingest as cc
-
     yield ": ok\n\n"
     try:
-        events = cc.read_normalized_events(session_id, settings.claude_code_projects_dir)
+        events = _read_cli_transcript_events(session_id)
     except Exception as exc:  # noqa: BLE001
         yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
         return
@@ -2738,7 +3120,7 @@ async def _stream_claude_code_session(session_id: str, backfill: int):
     while True:
         await asyncio.sleep(1.0)
         try:
-            events = cc.read_normalized_events(session_id, settings.claude_code_projects_dir)
+            events = _read_cli_transcript_events(session_id)
         except Exception:
             events = []
         if len(events) > line_count:
@@ -2769,12 +3151,9 @@ async def _stream_codex_session(session_id: str, backfill: int):
     `/sessions/{id}/stream` only dispatched `cc:` here, so opening a Codex
     session's panel fell through to the LifeOS transcript store and 400'd.)
     """
-    from config.settings import settings
-    from api.services.codex import session_ingest as cx
-
     yield ": ok\n\n"
     try:
-        events = cx.read_normalized_events(session_id, settings.codex_sessions_dir)
+        events = _read_cli_transcript_events(session_id)
     except Exception as exc:  # noqa: BLE001
         yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
         return
@@ -2789,7 +3168,7 @@ async def _stream_codex_session(session_id: str, backfill: int):
     while True:
         await asyncio.sleep(1.0)
         try:
-            events = cx.read_normalized_events(session_id, settings.codex_sessions_dir)
+            events = _read_cli_transcript_events(session_id)
         except Exception:
             events = []
         if len(events) > line_count:

--- a/api/services/agent_transcript_mirror.py
+++ b/api/services/agent_transcript_mirror.py
@@ -1,0 +1,494 @@
+"""Mirrors Claude Code / Codex transcripts from registered remote hosts.
+
+Local `cli_sessions` rows (posted by `scripts/lifeos-agent-hook.sh`) give a
+remote session status and a prompt preview, but nothing else — token counts,
+cost, tool calls, and the transcript feed only exist for a transcript this
+API host can read off its own disk. This module closes that gap: a
+background loop periodically rsyncs each registered host's Claude Code and
+Codex transcript directories into a per-host mirror on this box, read-only,
+so `api/routes/agents.py`'s snapshot builder can ingest them exactly like a
+local transcript and merely stamp the result with the remote host's name.
+
+Layout: `<mirror_root>/<host>/claude_code/` and `<mirror_root>/<host>/codex/`,
+one subtree per host in `settings.agent_hosts`, mirroring the source
+directory structure (`~/.claude/projects/<cwd>/*.jsonl` and
+`~/.codex/sessions/<y>/<m>/<d>/rollout-*.jsonl`) so the existing
+`session_ingest.discover_sessions()` scanners work unmodified against a
+mirrored root.
+
+Public surface:
+- `mirror_root()` / `host_dirs(host)` — path helpers.
+- `mirror_host(host, ssh_target, ...)` — one host's incremental pull.
+- `mirror_once(...)` — every registered host, concurrently.
+- `start()` / `stop()` — the background interval loop (wired into
+  `api/main.py`'s lifespan next to `agent_viz_summary_prefetch`).
+- `mirrored_snapshot()` — `(cc_rows, cx_rows, edges)` for every mirrored host.
+- `mirrored_transcript_dirs(engine)` — per-host dirs for the events/stream/
+  focus lookups in `api/routes/agents.py`.
+
+Constraints: ssh + rsync only, no new dependencies; read-only
+on the remote (never `--delete` on the remote side, never push); an
+unreachable host must not delay or break any other host's mirror tick.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# `(host, engine, message)` triples this process has already warned about
+# for an unreadable/missing source directory (rsync exit 23/24 whose
+# stderr names a `change_dir ... failed`). Emitted once per distinct
+# triple for the life of the process rather than never or every tick
+# (which would spam the log every mirror
+# interval for a host that legitimately can't be reached).
+_source_dir_warned: set[tuple[str, str, str]] = set()
+
+# rsync's own I/O timeout (distinct from ssh's ConnectTimeout) — bounds a
+# half-open connection that accepted the TCP handshake but then stalls.
+_RSYNC_IO_TIMEOUT_SECONDS = 30
+# Wall-clock cap on the whole `subprocess.run` call, well above the rsync
+# --timeout above so that timeout (not this one) is what normally fires.
+_RSYNC_SUBPROCESS_TIMEOUT = _RSYNC_IO_TIMEOUT_SECONDS + 30
+
+RsyncRunner = Callable[[list[str]], "subprocess.CompletedProcess"]
+
+
+@dataclass
+class MirrorResult:
+    """Outcome of mirroring one host's transcripts (both engines)."""
+    host: str
+    ok: bool
+    error: str = ""
+
+
+# `api/services/agent_transcript_mirror.py` -> repo root is three
+# `.parent`s up — same pattern as `cc_wezterm_store.DEFAULT_DB_PATH`.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def mirror_root() -> Path:
+    """The transcript mirror's root directory.
+
+    A relative `settings.agent_transcript_mirror_dir` (the default,
+    `"data/agent-transcript-mirror"`) is anchored to the REPO ROOT, not the
+    process's current working directory. An absolute or `~`-prefixed value
+    (already absolute after `os.path.expanduser`) is returned as-is.
+    """
+    from config.settings import settings
+
+    raw = Path(os.path.expanduser(settings.agent_transcript_mirror_dir))
+    if raw.is_absolute():
+        return raw
+    return _REPO_ROOT / raw
+
+
+# Alphanumeric first/last char; `.`, `-`, and `_` allowed in the middle
+# only — real hostnames never start or end with `.`/`-`/`_`. This positive
+# allowlist rejects shapes rsync/ssh could misinterpret as an option or an
+# expansion — a bare `-e`, `--delete`, `~`, `$HOME`, whitespace-only —
+# since nothing starting with `-` or `.` gets through, and no `/`, `\`, or
+# whitespace can appear anywhere.
+# It does NOT reject every embedded `..` — `a..b` matches, since `.` is a
+# permitted middle character and there's no adjacency check. That's
+# harmless in practice: the result is an ordinary single path segment
+# (`host_dirs()` never joins it as `../..`), not a traversal.
+_HOST_NAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$")
+_MAX_HOST_NAME_LEN = 253  # the DNS hostname length limit — a generous, well-known bound
+
+
+def _sanitize_host(host: str) -> str:
+    """Raise `ValueError` if `host` isn't a plausible hostname."""
+    if not host or len(host) > _MAX_HOST_NAME_LEN or not _HOST_NAME_RE.match(host):
+        raise ValueError(f"unsafe host name for transcript mirror: {host!r}")
+    return host
+
+
+def host_dirs(host: str) -> tuple[Path, Path]:
+    """`(<root>/<host>/claude_code, <root>/<host>/codex)`. Raises
+    `ValueError` via `_sanitize_host` for an unsafe host name."""
+    safe = _sanitize_host(host)
+    root = mirror_root() / safe
+    return root / "claude_code", root / "codex"
+
+
+def _rsync_argv(ssh_target: str, remote_dir: str, dst_dir: Path) -> list[str]:
+    """Build one incremental, read-only rsync pull.
+
+    `-rt` (recursive, preserve mtimes) is the minimum needed for rsync's
+    default quick-check (size + mtime) to skip unchanged files on the next
+    tick — without `-t` the destination's mtime would always differ from
+    the source's, forcing a full re-transfer every run. No `--delete`
+    (never remove local mirror files just because the remote host has
+    since deleted them) and no owner/group preservation (`-a`'s `-o`/`-g` need
+    privileges this process doesn't have and aren't meaningful once files
+    cross machines). `remote_dir` is passed through as-is (it may contain
+    `~`, which the remote shell expands) — never touched or expanded here.
+    """
+    from config.settings import settings
+
+    ssh_opts = (
+        f"ssh -o BatchMode=yes -o ConnectTimeout={settings.agent_ssh_connect_timeout}"
+    )
+    remote_spec = f"{ssh_target}:{remote_dir.rstrip('/')}/"
+    return [
+        "rsync", "-rtz",
+        "--timeout", str(_RSYNC_IO_TIMEOUT_SECONDS),
+        "-e", ssh_opts,
+        "--include=*/", "--include=*.jsonl", "--exclude=*",
+        # `--` stops rsync from parsing anything after
+        # it as an option — an `agent_hosts` VALUE beginning with `-`
+        # would otherwise be interpreted as a flag rather than a
+        # positional source/destination.
+        "--",
+        remote_spec,
+        f"{dst_dir}/",
+    ]
+
+
+def _default_runner(argv: list[str]) -> "subprocess.CompletedProcess":
+    return subprocess.run(  # noqa: S603 — fixed argv, no shell=True
+        argv, capture_output=True, timeout=_RSYNC_SUBPROCESS_TIMEOUT, check=False,
+    )
+
+
+def _decode(data: Any) -> str:
+    if isinstance(data, bytes):
+        return data.decode("utf-8", errors="replace")
+    return str(data or "")
+
+
+# rsync's own summary trailer, e.g. "rsync error: unexplained error (code
+# 255) at io.c(232) [Receiver=3.2.7]" — byte-identical whether the
+# underlying cause is a DNS failure, a refused connection, or an
+# unroutable address, so it carries no diagnostic value of its own.
+_RSYNC_TRAILER_RE = re.compile(r"^rsync error: .* \(code \d+\)")
+
+# ssh's own benign first-connect notice, e.g. "Warning: Permanently added
+# '127.0.0.1' (ED25519) to the list of known hosts.": only appears the
+# first tick that learns a host key, and unlike the rejected-key/
+# auth-failure line right after it, carries no diagnostic value — skip it
+# the same way the rsync trailer is skipped.
+_SSH_KNOWN_HOSTS_WARNING_RE = re.compile(r"^Warning: Permanently added ")
+
+
+def _diagnostic_stderr_line(stderr: str) -> str:
+    """The first non-blank stderr line that ISN'T rsync's own trailer or
+    ssh's benign known-hosts warning — typically ssh's own error (`ssh:
+    connect to host X port 22: Connection refused`, `ssh: Could not
+    resolve hostname X: ...`, or an auth failure), which takes priority
+    over the generic rsync trailer. Falls back to `last_nonempty_line`
+    (the trailer itself) when there's nothing else in stderr at all."""
+    from api.services.agent_worker.remote_spawn import last_nonempty_line
+
+    for line in (stderr or "").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _RSYNC_TRAILER_RE.match(stripped) or _SSH_KNOWN_HOSTS_WARNING_RE.match(stripped):
+            continue
+        return stripped
+    return last_nonempty_line(stderr)
+
+
+def mirror_host(
+    host: str,
+    ssh_target: str,
+    *,
+    runner: Optional[RsyncRunner] = None,
+) -> MirrorResult:
+    """Pull both engines' transcripts for one host. Never raises.
+
+    Runs one rsync invocation per engine so a directory that doesn't exist
+    on the remote (e.g. a host that never runs Codex) doesn't block the
+    other engine's pull. Logs exactly one warning line for the host if
+    either engine failed — naming the host and a diagnostic stderr line
+    via `_diagnostic_stderr_line` — and returns a failed `MirrorResult`;
+    it never raises.
+
+    Exit codes 23 ("partial transfer due to error" — some files skipped,
+    typically non-regular files this pull's `--include`/`--exclude`
+    already excludes) and 24 ("partial transfer due to vanished source
+    files") are treated as SUCCESS: both are the
+    expected outcome of pulling a transcript a live CLI is actively
+    writing to on the remote end, not a real failure — the file(s) that
+    mattered still transferred.
+    """
+    from config.settings import settings
+
+    run = runner or _default_runner
+    try:
+        cc_dst, cx_dst = host_dirs(host)
+    except ValueError as exc:
+        logger.warning("transcript mirror: skipping host %r: %s", host, exc)
+        return MirrorResult(host=host, ok=False, error=str(exc))
+
+    errors: list[str] = []
+    for engine, remote_dir, dst_dir in (
+        ("claude_code", settings.claude_code_projects_dir, cc_dst),
+        ("codex", settings.codex_sessions_dir, cx_dst),
+    ):
+        try:
+            dst_dir.mkdir(parents=True, exist_ok=True)
+            argv = _rsync_argv(ssh_target, remote_dir, dst_dir)
+            result = run(argv)
+            rc = getattr(result, "returncode", 0)
+            if rc in (23, 24):
+                # 23/24 count as success (below), but a source directory
+                # that doesn't exist or can't be read on the remote is
+                # worth knowing about. Log the diagnostic line at debug
+                # always, and once per (host, engine, message) at warning
+                # when it specifically names a directory the remote rsync
+                # couldn't enter.
+                stderr = _decode(getattr(result, "stderr", ""))
+                diag = _diagnostic_stderr_line(stderr)
+                if diag:
+                    logger.debug(
+                        "transcript mirror: host %s %s rsync exited %d: %s",
+                        host, engine, rc, diag,
+                    )
+                    if "change_dir" in diag and "failed" in diag:
+                        key = (host, engine, diag)
+                        if key not in _source_dir_warned:
+                            _source_dir_warned.add(key)
+                            logger.warning(
+                                "transcript mirror: host %s %s source directory "
+                                "unreadable, skipping: %s",
+                                host, engine, diag,
+                            )
+            elif rc != 0:
+                stderr = _decode(getattr(result, "stderr", ""))
+                errors.append(_diagnostic_stderr_line(stderr) or f"rsync exited {rc}")
+        except Exception as exc:  # noqa: BLE001 — one host's failure must not break the tick
+            errors.append(str(exc))
+
+    if errors:
+        logger.warning("transcript mirror: host %s failed: %s", host, errors[0])
+        return MirrorResult(host=host, ok=False, error=errors[0])
+    return MirrorResult(host=host, ok=True)
+
+
+def mirror_once(*, runner: Optional[RsyncRunner] = None) -> dict[str, MirrorResult]:
+    """Mirror every registered host concurrently. Returns `{host: MirrorResult}`.
+
+    Skips the API's own host (nothing to mirror from itself) and is a
+    no-op — no logging, no thread pool — when `settings.agent_hosts` is
+    empty. Hosts run in a small thread pool so one slow or unreachable
+    host cannot delay any other.
+    """
+    from config.settings import settings
+    from api.services.agent_worker.remote_spawn import api_host_name
+
+    this_host = api_host_name()
+    hosts = {
+        name: target for name, target in dict(settings.agent_hosts).items()
+        if name != this_host
+    }
+    if not hosts:
+        return {}
+
+    results: dict[str, MirrorResult] = {}
+    with ThreadPoolExecutor(max_workers=min(8, len(hosts))) as pool:
+        future_to_host = {
+            pool.submit(mirror_host, name, target, runner=runner): name
+            for name, target in hosts.items()
+        }
+        for future in as_completed(future_to_host):
+            name = future_to_host[future]
+            try:
+                results[name] = future.result()
+            except Exception as exc:  # noqa: BLE001 — a crashed future must not break the tick
+                logger.warning("transcript mirror: host %s crashed: %s", name, exc)
+                results[name] = MirrorResult(host=name, ok=False, error=str(exc))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Background loop
+# ---------------------------------------------------------------------------
+
+_task: asyncio.Task[None] | None = None
+_task_lock = threading.Lock()
+
+
+async def _mirror_loop() -> None:
+    from config.settings import settings
+
+    while True:
+        try:
+            await asyncio.to_thread(mirror_once)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — never let the loop die quietly
+            logger.exception("transcript mirror loop tick failed")
+        interval = float(getattr(settings, "agent_transcript_mirror_interval_seconds", 120))
+        await asyncio.sleep(max(1.0, interval))
+
+
+def start() -> None:
+    """Launch the background loop. Idempotent, and a no-op when disabled
+    or when no hosts are registered — mirrors
+    `agent_viz_summary_prefetch.start()`'s shape."""
+    global _task
+    with _task_lock:
+        if _task is not None and not _task.done():
+            return
+        try:
+            from config.settings import settings
+            enabled = bool(getattr(settings, "agent_transcript_mirror_enabled", True))
+            hosts = dict(getattr(settings, "agent_hosts", {}) or {})
+        except Exception:  # noqa: BLE001
+            enabled = True
+            hosts = {}
+        if not enabled or not hosts:
+            logger.info("agent transcript mirror disabled or no hosts registered")
+            return
+        loop = asyncio.get_event_loop()
+        _task = loop.create_task(_mirror_loop(), name="agent_transcript_mirror")
+        logger.info("agent transcript mirror loop started (%d host(s))", len(hosts))
+
+
+def stop() -> None:
+    """Cancel the loop on shutdown."""
+    global _task
+    with _task_lock:
+        if _task is None:
+            return
+        _task.cancel()
+        _task = None
+
+
+# ---------------------------------------------------------------------------
+# Snapshot + lookup surface consumed by api/routes/agents.py
+# ---------------------------------------------------------------------------
+
+
+def _mirrored_host_dirs() -> list[Path]:
+    root = mirror_root()
+    if not root.exists() or not root.is_dir():
+        return []
+    try:
+        return sorted((p for p in root.iterdir() if p.is_dir()), key=lambda p: p.name)
+    except OSError:
+        return []
+
+
+def mirrored_transcript_dirs(engine: str) -> list[Path]:
+    """Per-host mirrored transcript dirs for one engine, existing only.
+
+    `engine` is `"claude_code"` or `"codex"`. Used by the events/stream/
+    focus lookups in `api/routes/agents.py` as the fallback search path
+    once the local transcript root misses.
+    """
+    sub = "claude_code" if engine == "claude_code" else "codex"
+    dirs: list[Path] = []
+    for host_dir in _mirrored_host_dirs():
+        candidate = host_dir / sub
+        if candidate.exists() and candidate.is_dir():
+            dirs.append(candidate)
+    return dirs
+
+
+def _demote_inferred_running(row: dict[str, Any]) -> None:
+    """Mutates `row` in place: an INFERRED `running`
+    status on a mirrored row is demoted to `inactive`. A `running` whose
+    `status_inferred` is `False` is left untouched — that would mean an
+    authoritative process-scan signal reached here, which can't happen for
+    a mirrored row (`live_counts={}` in the callers above), but leaving it
+    alone rather than asserting is the more conservative failure mode.
+    """
+    if row.get("status") == "running" and row.get("status_inferred") is True:
+        row["status"] = "inactive"
+
+
+def mirrored_snapshot(
+    cache_ttl: float = 30.0,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """`(cc_rows, cx_rows, edges)` — one snapshot row per mirrored session,
+    across every mirrored host, plus the parent-subagent spawn edges each
+    engine's own `build_snapshot()` derives. Never raises: a bad mirror for
+    one host is logged and skipped, the rest still return.
+
+    Every row gets `host` set to the mirrored host's directory name and
+    `mirrored = True`. `live_counts={}` is passed to each engine's
+    `build_snapshot()` so a mirrored row is never promoted to `running` by
+    a LOCAL process scan — but that only blocks the process-scan branch of
+    `_infer_status`; its mtime-under-10-minutes branch still says
+    `running` for a freshly mirrored transcript regardless of `live_counts`
+    (AC 7 requires a remote session's `running` status to come ONLY from
+    hook events). So an inferred `running` (never one
+    with `status_inferred=False` — that would mean a genuine hook-status
+    merge already happened upstream, which never runs this early) is
+    demoted here to `inactive` — the same "resumable, not actively
+    running" bucket `_infer_status` itself falls into just past the 10
+    minute mark. `_build_snapshot`'s hook-event overlay
+    (`_apply_cli_session_to_dict`) then restores `running` afterwards when
+    a hook row for this session id actually reports it.
+
+    The caller (`_build_snapshot`) is responsible for dropping any edge
+    whose endpoint didn't end up with a row in the final merged snapshot
+    (e.g. an id collision with a local transcript that wins).
+    """
+    from api.services.claude_code import session_ingest as cc
+    from api.services.codex import session_ingest as cx
+
+    cc_rows: list[dict[str, Any]] = []
+    cx_rows: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+    for host_dir in _mirrored_host_dirs():
+        host_name = host_dir.name
+        cc_dir = host_dir / "claude_code"
+        if cc_dir.exists() and cc_dir.is_dir():
+            try:
+                sessions, cc_edges = cc.build_snapshot(
+                    projects_dir=cc_dir, cache_ttl=cache_ttl, live_counts={},
+                )
+                # `build_snapshot()` returns `list(entry.sessions)` — a
+                # shallow copy of the LIST, so these row dicts are the
+                # SAME objects `cc`'s own ingest cache holds. Copying each
+                # row here, before mutating it, keeps that cache's dicts
+                # untouched — otherwise `host`/`mirrored` and (via
+                # `_demote_inferred_running` and the hook overlay
+                # `_build_snapshot` applies afterward) `status`/
+                # `status_inferred` get written straight into the cached
+                # entry, so a rebuild inside `cache_ttl` after the hook row
+                # that produced the overlay has vanished (pruned, or a
+                # failed `list_cli_sessions()` call) would otherwise replay
+                # the stale cached mutation instead of recomputing it, in
+                # violation of AC 7.
+                sessions = [dict(row) for row in sessions]
+                for row in sessions:
+                    row["host"] = host_name
+                    row["mirrored"] = True
+                    _demote_inferred_running(row)
+                cc_rows.extend(sessions)
+                edges.extend(cc_edges)
+            except Exception as exc:  # noqa: BLE001 — one host must not break the snapshot
+                logger.warning("mirrored claude_code snapshot failed for host %s: %s", host_name, exc)
+        cx_dir = host_dir / "codex"
+        if cx_dir.exists() and cx_dir.is_dir():
+            try:
+                sessions, cx_edges = cx.build_snapshot(
+                    sessions_dir=cx_dir, cache_ttl=cache_ttl, live_counts={},
+                )
+                # See the identical comment in the claude_code branch
+                # above — same aliasing against `cx`'s own ingest cache.
+                sessions = [dict(row) for row in sessions]
+                for row in sessions:
+                    row["host"] = host_name
+                    row["mirrored"] = True
+                    _demote_inferred_running(row)
+                cx_rows.extend(sessions)
+                edges.extend(cx_edges)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("mirrored codex snapshot failed for host %s: %s", host_name, exc)
+    return cc_rows, cx_rows, edges

--- a/api/services/agent_viz_summary_prefetch.py
+++ b/api/services/agent_viz_summary_prefetch.py
@@ -123,17 +123,19 @@ async def _summarize_one(session: dict[str, Any]) -> bool:
         if sid.startswith("cc:"):
             from api.routes.agents import _claude_code_enabled
             if _claude_code_enabled():
-                from config.settings import settings
-                from api.services.claude_code import session_ingest as cc
-                events = cc.read_normalized_events(sid, settings.claude_code_projects_dir)
+                # Mirror-aware — a mirrored session's transcript isn't
+                # under the local claude_code_projects_dir; falls back to
+                # each registered host's mirrored copy the same way
+                # /events does.
+                from api.routes.agents import _read_cli_transcript_events
+                events = _read_cli_transcript_events(sid)
             else:
                 events = []
         elif sid.startswith("cx:"):
             from api.routes.agents import _codex_enabled
             if _codex_enabled():
-                from config.settings import settings
-                from api.services.codex import session_ingest as cx
-                events = cx.read_normalized_events(sid, settings.codex_sessions_dir)
+                from api.routes.agents import _read_cli_transcript_events
+                events = _read_cli_transcript_events(sid)
             else:
                 events = []
         else:

--- a/api/services/claude_code/session_ingest.py
+++ b/api/services/claude_code/session_ingest.py
@@ -866,12 +866,21 @@ def build_snapshot(
     limit: int = 200,
     cache_ttl: float = _CACHE_TTL,
     now: float | None = None,
+    live_counts: dict[str, int] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Return `(sessions, edges)` for the /agents snapshot. Cached.
 
     Edges include parent→subagent spawn edges. Subagent nodes are synthetic;
     they don't have their own jsonl. The cache is bypassed entirely when
     `cache_ttl <= 0` (no read, no write) so tests get a fresh snapshot.
+
+    `live_counts`: pass a `{cwd: count}` map to use instead of
+    scanning THIS machine's own processes — `{}` guarantees no row is
+    promoted to `running` by a local process scan, which is what the
+    remote transcript mirror needs (a mirrored session never has a
+    process on this host; its liveness must come only from hook events).
+    `None` (the default) preserves today's behavior exactly: scan local
+    `claude` processes via `live_claude_cwd_counts()`.
     """
     now_t = now if now is not None else time.time()
     key = _cache_key(projects_dir, lookback_days)
@@ -884,7 +893,7 @@ def build_snapshot(
     sessions: list[dict[str, Any]] = []
     edges: list[dict[str, Any]] = []
     # One process-scan per snapshot tick — shared across every session.
-    cwd_counts = live_claude_cwd_counts(now=now_t)
+    cwd_counts = live_counts if live_counts is not None else live_claude_cwd_counts(now=now_t)
     # First pass: parse every discovered session with mtime-only status.
     # Process-detection promotion is layered on per-cwd below so we don't
     # over-attribute `running` to historical sessions sharing a project dir.

--- a/api/services/codex/session_ingest.py
+++ b/api/services/codex/session_ingest.py
@@ -747,8 +747,16 @@ def build_snapshot(
     limit: int = 200,
     cache_ttl: float = _CACHE_TTL,
     now: float | None = None,
+    live_counts: dict[str, int] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Return `(sessions, edges)` for the /agents snapshot. Cached."""
+    """Return `(sessions, edges)` for the /agents snapshot. Cached.
+
+    `live_counts`: see the identical parameter on the Claude Code
+    adapter's `build_snapshot` — pass `{}` to guarantee no row is promoted
+    to `running` by a local process scan (used by the remote transcript
+    mirror). `None` (default) preserves today's behavior: scan local
+    `codex` processes via `live_codex_cwd_counts()`.
+    """
     now_t = now if now is not None else time.time()
     key = _cache_key(sessions_dir, lookback_days)
     if cache_ttl > 0:
@@ -758,7 +766,7 @@ def build_snapshot(
                 return list(entry.sessions), list(entry.edges)
 
     sessions: list[dict[str, Any]] = []
-    cwd_counts = live_codex_cwd_counts(now=now_t)
+    cwd_counts = live_counts if live_counts is not None else live_codex_cwd_counts(now=now_t)
 
     parsed_by_cwd: dict[str, list[SessionMeta]] = {}
     for meta in discover_sessions(sessions_dir, lookback_days=lookback_days, limit=limit, now=now_t):

--- a/config/settings.py
+++ b/config/settings.py
@@ -936,6 +936,34 @@ class Settings(BaseSettings):
                     "ConnectTimeout=<this>`). Applies to remote spawn, remote "
                     "kill, and remote resume/focus alike."
     )
+    # Mirrors each registered host's Claude Code / Codex transcripts onto
+    # this box over ssh+rsync so a remote session shows tokens, cost, and a
+    # transcript feed on /agents exactly like a local one.
+    agent_transcript_mirror_enabled: bool = Field(
+        default=True,
+        alias="LIFEOS_AGENT_TRANSCRIPT_MIRROR_ENABLED",
+        description="When true, a background loop periodically pulls new "
+                    "Claude Code and Codex transcript files from every host "
+                    "in LIFEOS_AGENT_HOSTS. Safe to leave on by default: "
+                    "agent_hosts defaults to {}, so with no hosts registered "
+                    "the mirror never runs anything."
+    )
+    agent_transcript_mirror_dir: str = Field(
+        default="data/agent-transcript-mirror",
+        alias="LIFEOS_AGENT_TRANSCRIPT_MIRROR_DIR",
+        description="Root directory the transcript mirror writes into, one "
+                    "subdirectory per registered host "
+                    "(`<root>/<host>/claude_code/`, `<root>/<host>/codex/`). "
+                    "Read-only mirror of remote data — never written to by "
+                    "anything else."
+    )
+    agent_transcript_mirror_interval_seconds: int = Field(
+        default=120,
+        alias="LIFEOS_AGENT_TRANSCRIPT_MIRROR_INTERVAL_SECONDS",
+        description="How often the transcript mirror loop re-pulls each "
+                    "registered host. Each pull is an incremental rsync, so "
+                    "a short interval costs little when nothing changed."
+    )
     agent_model_catalog_ttl_seconds: int = Field(
         default=86400,
         alias="LIFEOS_AGENT_MODEL_CATALOG_TTL_SECONDS",

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -1,7 +1,7 @@
 # Agent Worker Setup
 
 > **Status:** Complete
-> **Last Updated:** 2026-09-04
+> **Last Updated:** 2026-09-05
 > **Audience:** Operators
 
 One-time setup for the external agent worker that picks up `#agent`-tagged tasks and executes them via Claude (Anthropic Managed Agents) or a local Gemma model.
@@ -554,6 +554,42 @@ The Apple Data Agent's own export/import pipeline
 ([operations.md](operations.md)) is the supported path for cross-machine
 Apple data, not this mechanism.
 
+### Remote session parity: transcript mirror
+
+Once a host is in the registry above, `/agents` can also mirror its
+Claude Code and Codex transcripts onto this box — the difference between a
+remote session showing only status and a prompt preview versus real token
+counts, cost, tool calls, and a live transcript feed. See
+[product/agent-viz.md § Remote session parity](../specs/product/agent-viz.md#remote-session-parity)
+for what the operator sees and
+[technical/agent-viz.md § Remote transcript mirror](../specs/technical/agent-viz.md#remote-transcript-mirror)
+for the mechanism.
+
+**Settings** are all in `.env`, all optional, and safe on a fresh install
+since `LIFEOS_AGENT_HOSTS` defaults to `{}` (the mirror is a no-op with
+nothing registered) — see [configuration.md § Remote Session Parity](configuration.md#remote-session-parity-transcript-mirror)
+for the full variable reference, including that a relative
+`LIFEOS_AGENT_TRANSCRIPT_MIRROR_DIR` resolves against the repo root, not
+the process's working directory.
+
+**What a registered host needs, beyond the ssh prerequisites above:**
+
+- The same key-based, non-interactive ssh auth already required for card
+  assignment — the mirror reuses it, no separate credential.
+- `rsync` installed on both this box and the remote machine (the same
+  pattern `scripts/apple_data_agent.sh` uses for the Apple export
+  pipeline) — the mirror pull runs `rsync` locally, over ssh to the
+  remote side.
+- Nothing else — the mirror never writes to the remote host. It only
+  reads `~/.claude/projects/` and `~/.codex/sessions/` (or whatever
+  `LIFEOS_CLAUDE_CODE_PROJECTS_DIR` / `LIFEOS_CODEX_SESSIONS_DIR` are set
+  to, assumed the same relative-to-home layout on every registered host)
+  and pulls `*.jsonl` files one-way onto this box.
+
+An unreachable host is skipped with one log line and never blocks another
+host's pull or the API's own responsiveness — see the technical doc for
+the concurrency and failure-isolation details.
+
 ## Working directory: run a local or cloud card in an isolated checkout
 
 By default the local (`#local`) and remote (`#cloud`) routes run wherever
@@ -648,5 +684,6 @@ suggestions to keep iteration cheap:
 - [Human Queue](human-queue.md) — `done_when` auto-resolve checks require this worker to be running
 - [Agent Worker — Technical](../specs/technical/agent-worker.md#card-assignment-851) — Host registry and ssh spawn mechanism this guide's setup section covers operationally
 - [Agent Worker — Technical § Working directory](../specs/technical/agent-worker.md#working-directory-925) — Guard implementation this guide's working-directory section covers operationally
+- [Agent Viz — Technical](../specs/technical/agent-viz.md#remote-transcript-mirror) — The transcript mirror mechanism this guide's setup section covers operationally
 - [Operations](operations.md) — Apple Data Agent export/import, the supported path for cross-machine Apple data this guide's remote-host section can't reach
 - Epic [#98](https://github.com/nbramia/LifeOS/issues/98) — full agent-worker design

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,7 +1,7 @@
 # Configuration Guide
 
 **Status:** Complete
-**Last Updated:** 2026-09-04
+**Last Updated:** 2026-09-05
 **Audience:** Operators
 
 **This is the single authoritative reference for every `LIFEOS_*` environment variable and the third-party service variables (`ANTHROPIC_API_KEY`, `OLLAMA_*`, `SLACK_*`, `TELEGRAM_*`, `MONARCH_*`) that LifeOS reads.** Other guides reference this file rather than restating defaults — when documentation conflicts, this file wins (and `config/settings.py` wins over both, since the code is the source of truth).
@@ -259,6 +259,16 @@ See [guides/agent-worker-setup.md § Card assignment](agent-worker-setup.md#card
 | `LIFEOS_AGENT_MODEL_CATALOG_TTL_SECONDS` | int (seconds) | `86400` | How long `GET /api/agents/models` caches each engine's model list before re-querying providers. |
 | `LIFEOS_CODEX_MODELS_CACHE_PATH` | str | `~/.codex/models_cache.json` | Path to the Codex CLI's own model-catalog cache, read by the model catalog endpoint for the codex engine's picker list. |
 | `LIFEOS_OPENAI_API_KEY` | str | *(empty)* | Optional OpenAI API key, used ONLY as the model-catalog fallback when `LIFEOS_CODEX_MODELS_CACHE_PATH` is missing/unreadable. Never used to run turns — Codex sessions are subscription-billed through the CLI itself, never the API. |
+
+## Remote Session Parity (transcript mirror)
+
+Pulls each `LIFEOS_AGENT_HOSTS` entry's Claude Code and Codex transcripts onto this box over ssh+rsync so a remote session shows tokens, cost, and a transcript feed on `/agents` exactly like a local one. See [guides/agent-worker-setup.md § Remote session parity: transcript mirror](agent-worker-setup.md#remote-session-parity-transcript-mirror) for the operator walkthrough and [specs/technical/agent-viz.md § Remote transcript mirror](../specs/technical/agent-viz.md#remote-transcript-mirror) for the mechanism.
+
+| Variable | Type | Default | Sets |
+|---|---|---|---|
+| `LIFEOS_AGENT_TRANSCRIPT_MIRROR_ENABLED` | bool | `true` | Whether the background loop pulls transcripts from every `LIFEOS_AGENT_HOSTS` entry. Safe to leave on: with no hosts registered the mirror has nothing to pull. |
+| `LIFEOS_AGENT_TRANSCRIPT_MIRROR_DIR` | str | `data/agent-transcript-mirror` | Root directory the mirror writes into, one subdirectory per registered host. A relative path resolves against the repo root, not the process's working directory. Read-only mirror of remote data — nothing else writes here. |
+| `LIFEOS_AGENT_TRANSCRIPT_MIRROR_INTERVAL_SECONDS` | int (seconds) | `120` | How often the mirror loop re-pulls each registered host. Each pull is an incremental rsync, so a short interval costs little when nothing changed. |
 
 ## Claude Code Orchestration (`/claude` Telegram command)
 

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -141,6 +141,24 @@ A Claude Code or Codex session doesn't have to run on the machine hosting the AP
 
 This is opt-in: the endpoint is disabled (503) until an operator sets `LIFEOS_AGENT_HOOK_TOKEN`, and each machine needs the installer run once plus a small local env file with the API URL and that same token. See [guides/agents-go-to.md](../../guides/agents-go-to.md) for setup.
 
+### Remote session parity
+
+Registration alone gives a remote session status and a prompt preview, but
+not the rest — token counts, dollar cost, tool-call counts, and the
+transcript feed only exist for a jsonl this API host can read off its own
+disk. For every host in the [operator's host registry](../../guides/agent-worker-setup.md#card-assignment-running-a-card-on-another-machine-851),
+a background loop periodically pulls that host's Claude Code and Codex
+transcript files onto this box over ssh (read-only, incremental — see
+[technical/agent-viz.md](../technical/agent-viz.md#remote-transcript-mirror)
+for the mechanism). The ingest scans those mirrored copies alongside the
+local ones, so a remote session reaches full parity with a local one:
+real tokens, cost, tool calls, and a live transcript feed in the drawer,
+merged with the registration event's status the same way a local
+transcript already merges (event status wins; token/cost detail stays
+transcript-derived). A mirrored session's `running` status can only come
+from a registration event, never from a process scan on this machine — a
+transcript existing here doesn't mean the CLI is actually running here.
+
 ---
 
 ## Graph tab — Status semantics
@@ -254,15 +272,33 @@ Resume + Go To are **off by default** because spawning GUI terminals from a syst
 
 A session registered from another host (see "Cross-machine CLI session registration" above) resumes and focuses over ssh when that host is one of the operator's registered hosts (see [Card assignment](../technical/agent-worker.md#card-assignment-851)) — the same launcher runs remotely, so Resume and Go To work wherever the session actually lives. Only a host the operator hasn't registered still 409s: the error names that host, so the operator knows to go there instead of getting a silent no-op or a misleading 404.
 
+### Resume here
+
+Next to Resume, the drawer offers a small host picker listing this API's
+own machine plus every registered host — "resume here" lets the operator
+choose where the session should actually open, regardless of which
+machine it originally ran on:
+
+- Choosing this API's own machine or a registered host launches there over
+  the same mechanism as above (locally, or over ssh), overriding the
+  session's recorded host.
+- Choosing a machine that isn't this API host and isn't registered can't
+  be launched from here — the drawer instead shows the exact resume
+  command (`cd <cwd> && claude --resume <id>` or the Codex equivalent) as
+  copyable text, so the operator can paste it into a terminal on that
+  machine themselves. The command is omitted when the session's cwd
+  can't be resolved — there's nothing to show.
+
 ---
 
 ## Privacy and exposure
 
-- The transcript scan and Resume/Go To/kill primitives only ever touch **this** machine. Cross-machine visibility is opt-in and one-directional: another machine's hook posts a small lifecycle event (host, cwd, branch, status, a truncated prompt preview) to this API — this API never reaches out to, or reads files from, another machine.
+- The Resume/Go To/kill primitives act only on **this** machine and on a registered host over ssh (see below); the local transcript scan reads only this machine's own transcript directories. Cross-machine visibility is otherwise opt-in and one-directional: another machine's hook posts a small lifecycle event (host, cwd, branch, status, a truncated prompt preview) to this API.
+- The transcript mirror is the one path where this API reads files from another machine: for each host in `LIFEOS_AGENT_HOSTS` (empty by default), unless `LIFEOS_AGENT_TRANSCRIPT_MIRROR_ENABLED` is disabled, it pulls that host's Claude Code and Codex transcripts read-only over ssh onto this box. Nothing is ever written back to a remote host.
 - The registration endpoint (`POST /api/agents/cli-sessions/events`) is bearer-token gated and disabled by default (503 until `LIFEOS_AGENT_HOOK_TOKEN` is set) — unlike the kill/resume endpoints below, it's meant to be reachable over Tailscale, since that's the whole point.
 - Transcript payloads are truncated to 240 chars in the feed previews — click an event to see the full payload only on demand. A registered session's prompt preview is truncated to 200 characters at the source.
 - The kill, resume, and pane-bind (`/cc-pane-bind`, `/cx-pane-bind`) endpoints are **local-network only**. They must not be exposed via Tailscale Funnel or the public MCP HTTP transport (the gates live in [api/routes/agents.py](../../../api/routes/agents.py); see the technical spec for the threat model). Resume and Go To act on sessions recorded as running on this API's own host directly, and on a registered host over ssh; a session on an unregistered host returns an error naming that host instead.
-- Claude Code ingest is strictly read-only — LifeOS opens jsonl files for reading and never writes back.
+- Claude Code ingest is strictly read-only — LifeOS opens jsonl files for reading and never writes back, whether the file lives on this machine or in the transcript mirror.
 
 ---
 
@@ -286,6 +322,9 @@ All in `.env`. None are required — the defaults work for the standard LifeOS i
 | `LIFEOS_CODEX_RESUME_CMD` | Codex launcher template. Same substitution surface as `LIFEOS_CC_RESUME_CMD`. | `wezterm cli spawn --cwd {cwd} -- {inner_command}` |
 | `LIFEOS_CODEX_RESUME_INNER_CMD` | Inner command inside the spawned terminal — the actual `codex resume` invocation. | `codex resume {session_id}` |
 | `LIFEOS_AGENT_HOOK_TOKEN` | Bearer token required from `scripts/lifeos-agent-hook.sh` on `POST /api/agents/cli-sessions/events`. Empty (default) disables the endpoint (503) — a fresh clone accepts no cross-machine session data until this is set. | `` |
+| `LIFEOS_AGENT_TRANSCRIPT_MIRROR_ENABLED` | Enable the remote transcript mirror loop. Safe on by default — with no hosts in `LIFEOS_AGENT_HOSTS` it never runs anything. | `true` |
+| `LIFEOS_AGENT_TRANSCRIPT_MIRROR_DIR` | Local directory the mirror writes into, one subdirectory per registered host. A relative path resolves against the repo root, not the process's working directory. | `data/agent-transcript-mirror` |
+| `LIFEOS_AGENT_TRANSCRIPT_MIRROR_INTERVAL_SECONDS` | How often each registered host's transcripts are re-pulled. Each pull is incremental, so a short interval costs little when nothing changed. | `120` |
 
 ---
 

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete
 **Owner:** API Gateway
-**Last Updated:** 2026-09-04
+**Last Updated:** 2026-09-05
 
 Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Four adjacent catalogs split out for size:
 
@@ -712,6 +712,8 @@ Get usage summary with stats for 24h, 7d, 30d, and all-time. Includes daily cost
 ## Card Assignment Endpoints (#851)
 
 Card kill/resume/focus/registration endpoints are documented in [agent-viz.md § Endpoints](../technical/agent-viz.md#endpoints) alongside the rest of the `/agents` operator-control surface, per item 6 of this file's Table of Contents. These two are new to this issue and don't fit that page's visualization framing, so they're listed here instead — full mechanism in [agent-worker.md § Card assignment](../technical/agent-worker.md#card-assignment-851).
+
+`POST /sessions/{id}/resume` and `/focus` also accept an optional `target_host` in the body — "resume here". Full contract in [agent-viz.md § Resume target host](../technical/agent-viz.md#resume-target-host).
 
 ### GET /api/agents/models
 

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -19,14 +19,15 @@ Engineering view of the `/agents` page — endpoint shapes, ingest paths, status
 7. [Status inference (Claude Code)](#status-inference-claude-code)
 8. [Live process detection](#live-process-detection)
 9. [Cross-machine CLI session registration](#cross-machine-cli-session-registration)
-10. [Snapshot caching](#snapshot-caching)
-11. [D3 force-graph](#d3-force-graph)
-12. [Side-panel SSE](#side-panel-sse)
-13. [Operator kill](#operator-kill)
-14. [Claude Code resume + Go To](#claude-code-resume--go-to)
-15. [Worker resilience](#worker-resilience)
-16. [Security boundaries](#security-boundaries)
-17. [Related Documents](#related-documents)
+10. [Remote transcript mirror](#remote-transcript-mirror)
+11. [Snapshot caching](#snapshot-caching)
+12. [D3 force-graph](#d3-force-graph)
+13. [Side-panel SSE](#side-panel-sse)
+14. [Operator kill](#operator-kill)
+15. [Claude Code resume + Go To](#claude-code-resume--go-to)
+16. [Worker resilience](#worker-resilience)
+17. [Security boundaries](#security-boundaries)
+18. [Related Documents](#related-documents)
 
 ---
 
@@ -78,12 +79,12 @@ All under `/api/agents`. Local-network only, with one deliberate exception: `POS
 |---|---|
 | `GET /snapshot` | One-shot full snapshot. Use for first-paint or when the SSE stream drops. |
 | `GET /stream` | SSE: emits a full snapshot every 2s. Tolerant to per-tick failures (yields an `error` event and continues). |
-| `GET /sessions/{id}/events?limit=N` | Last N transcript events (default 200, max 2000). Dispatches by `cc:` prefix to the Claude Code ingest path. |
-| `GET /sessions/{id}/stream?backfill=N` | Per-session SSE: backfill last N events (default 50, max 500), then live-tail. Closes cleanly when the session reaches terminal status (LifeOS) or after 5 min idle (Claude Code). |
+| `GET /sessions/{id}/events?limit=N` | Last N transcript events (default 200, max 2000). Dispatches by `cc:` prefix to the Claude Code ingest path. Falls back to each mirrored host's copy of the transcript when the local scan finds nothing. |
+| `GET /sessions/{id}/stream?backfill=N` | Per-session SSE: backfill last N events (default 50, max 500), then live-tail. Closes cleanly when the session reaches terminal status (LifeOS) or after 5 min idle (Claude Code). Same local-then-mirrored fallback as `/events`. |
 | `POST /sessions/{id}/kill` | Operator kill — body `{reason: ""}`. LifeOS sessions only. Cascades to descendants in the subtree. |
 | `PUT /sessions/{id}/label` | Set or clear an operator-pinned manual label — body `{label: ""}`. Non-empty pins a custom node name that overrides the auto-derived label and AI summary label everywhere it's shown, except where it is itself the row's raw id (`session_id`, the prefix-stripped id, or `task_id`), which the graph node and search dropdown skip; empty clears it. Durable in `data/agent_viz_label_overrides.db` (in-process cache, lazy-loaded). Works for both LifeOS and `cc:` sessions. |
-| `POST /sessions/{id}/resume` | Resume a Claude Code session — body `{extra_env: {}}`. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Spawns a WezTerm tab via `wezterm cli spawn`, captures the pane id from stdout, and stores `session_id → pane_id` in `data/cc_wezterm.db` so Focus can target it later. 409 if the `cli_sessions` row for this id records a `host` other than this API's own (see [Cross-machine CLI session registration](#cross-machine-cli-session-registration)). |
-| `POST /sessions/{id}/focus` | Activate the WezTerm pane for this session (Go To). `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Resolves the pane id from the cached mapping first, then falls back to an FD probe (lsof + /proc + wezterm cli list) so it works for sessions never opened via Resume. 404 only when both the cache *and* the probe come up empty; 410 when the pane existed but is gone and no replacement is found. Same 409-for-remote-host rule as `/resume`. |
+| `POST /sessions/{id}/resume` | Resume a Claude Code or Codex session — body `{extra_env: {}, target_host: null}`. `cc:`/`cx:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED` / `LIFEOS_CODEX_RESUME_ENABLED`. Spawns a WezTerm tab via `wezterm cli spawn`, captures the pane id from stdout, and stores `session_id → pane_id` in `data/cc_wezterm.db` so Focus can target it later. `target_host` ("resume here") overrides the launch target: unset/blank falls through to `_check_session_host_or_409` — 409 if the `cli_sessions` row for this id records a `host` other than this API's own and that host isn't registered (see [Cross-machine CLI session registration](#cross-machine-cli-session-registration)); set to this API's own host name or a `LIFEOS_AGENT_HOSTS` entry launches there instead, regardless of the session's recorded host; set to anything else 400s with `detail = {error, command}` — `command` is the exact resume command, cwd-prefixed, for the operator to copy and run themselves. |
+| `POST /sessions/{id}/focus` | Activate the WezTerm pane for this session (Go To). `cc:`/`cx:`-prefixed ids. Gated on `LIFEOS_CC_RESUME_ENABLED` for `cc:` ids, `LIFEOS_CODEX_RESUME_ENABLED` for `cx:` ids. Resolves the pane id from the cached mapping first, then falls back to an FD probe (lsof + /proc + wezterm cli list) so it works for sessions never opened via Resume. 404 only when both the cache *and* the probe come up empty; 410 when the pane existed but is gone and no replacement is found. Same `target_host` override and 409/400 rules as `/resume`. |
 | `POST /cc-pane-bind` | Localhost-only endpoint called by the Claude Code SessionStart hook. Body `{session_id, pane_id, cwd}`. Upserts the mapping in `cc_wezterm.db` so Go To can target newly-started `claude` invocations without a probe. 403 from non-loopback callers. |
 | `POST /cx-pane-bind` | Codex sibling of `/cc-pane-bind`. Same body shape and localhost-only gate; keys `cx:`-prefixed rows in the same store. |
 | `POST /cli-sessions/events` | Cross-machine session registration (#849) — see [Cross-machine CLI session registration](#cross-machine-cli-session-registration). Bearer-token gated, reachable from any host. Body `{engine, event, session_id, host, cwd?, transcript_path?, branch?, model?, prompt_preview?, task_id?, pane_id?, wezterm_pid?}`. |
@@ -144,9 +145,12 @@ A successful drop always re-fetches the board (`fetchBoard()`) rather than mutat
 {
   "sessions": [{ /* see below */ }],
   "edges":    [{ "from": "<parent_session_id>", "to": "<child_session_id>", "type": "spawn" }],
-  "generated_at": 1716777600
+  "generated_at": 1716777600,
+  "api_host": "this-api-host"
 }
 ```
+
+`api_host` is `api_host_name()` — the same value every session row's own `host` falls back to. It lets the drawer's "resume here" host picker (`web/agents/panel.js`) offer THIS machine as a launch target from `/snapshot` alone, when `GET /api/agents/hosts` is unreachable or fails — see [Resume target host](#resume-target-host) below.
 
 One session row, unified shape (both sources):
 
@@ -184,6 +188,7 @@ One session row, unified shape (both sources):
 | `host` | str | The machine this session is running on (#849). Always present — LifeOS and locally-scanned CLI rows get the API's own host (`api_host_name()`); a row that also has (or only has) a `cli_sessions` registration gets that row's `host` instead. |
 | `branch` | str \| null | Git branch of the session's cwd, from the most recent registration event. Only present on a session with at least one `cli_sessions` row. |
 | `prompt_preview` | str \| null | Most recent user prompt, truncated to 200 chars, from the most recent `user_prompt_submit` registration event. Only present on a session with at least one `cli_sessions` row. |
+| `mirrored` | bool | Present and `true` only on a row ingested from a mirrored remote host's transcript — see [Remote transcript mirror](#remote-transcript-mirror) below. |
 
 ---
 
@@ -312,6 +317,55 @@ Worker (`lifeos_agent`) rows use `s.host or api_host_name()` directly in `_sessi
 `scripts/lifeos-agent-hook.sh` is a single portable script (bash 3.2-compatible for macOS) that serves every hook event — engine and event name are passed as argv (`lifeos-agent-hook.sh claude_code session_start`). It reads the hook's JSON stdin payload via `jq`, adds the hostname (`hostname` with any domain suffix stripped), the cwd's git branch (`git -C "$cwd" rev-parse --abbrev-ref HEAD`), and `$LIFEOS_TASK_ID`, and POSTs to `/cli-sessions/events` with `curl --max-time 2`. It sources a small env file (`~/.config/lifeos/agent-hook.env`, override via `$LIFEOS_AGENT_HOOK_ENV`) for `LIFEOS_API_URL` / `LIFEOS_AGENT_HOOK_TOKEN` — values already in the environment take precedence over the file. Every non-fatal condition (missing `jq`/`curl`, empty stdin, no token configured, API unreachable) exits 0 silently and writes nothing to stdout, so it can never block or corrupt the CLI's own hook processing. Pane fields are included only when `$WEZTERM_PANE` is set — unlike `claude-session-pane.sh`, running outside WezTerm is a normal case, not a silent no-op, since registration doesn't depend on a pane to exist.
 
 `scripts/install-agent-hooks.sh` appends one entry per event to `~/.claude/settings.json` and `~/.codex/hooks.json` (overridable via `LIFEOS_CLAUDE_SETTINGS` / `LIFEOS_CODEX_HOOKS` for testing), identifying a prior install by the substring `lifeos-agent-hook.sh` in an existing entry's `command` so re-running it is a no-op. Every other tool's entries — Orca, atuin, a legacy `claude-session-pane.sh` / `codex-session-pane.sh` entry — are left untouched. Writes via temp file + `mv`. The installed command wraps the absolute path of the script in *this* checkout so a moved or deleted checkout degrades to a no-op instead of an error: `bash -c 's="<path>"; [ -x "$s" ] && exec "$s" <engine> <event>; exit 0'`. It never writes the token itself — it prints setup instructions for the operator.
+
+---
+
+## Remote transcript mirror
+
+`api/services/agent_transcript_mirror.py` closes the gap registration alone leaves: a `cli_sessions` row gives a remote session status and a prompt preview, but token counts, cost, tool-call counts, and the transcript feed all require an actual jsonl on this host's filesystem. The mirror pulls one, read-only, over ssh+rsync.
+
+### Layout
+
+`mirror_root()` (default `data/agent-transcript-mirror`, `LIFEOS_AGENT_TRANSCRIPT_MIRROR_DIR`) holds one subdirectory per registered host, mirroring each source directory's own internal structure so the existing `discover_sessions()` scanners work against it unmodified:
+
+```
+<mirror_root>/<host>/claude_code/<encoded-cwd>/<session>.jsonl
+<mirror_root>/<host>/codex/<year>/<month>/<day>/rollout-*.jsonl
+```
+
+`host_dirs(host)` sanitizes `host` before deriving these paths via a positive allowlist (alphanumeric first/last character, `.`/`-`/`_` allowed in the middle only, nothing starting with `-` or `.`, no `/`, `\`, or whitespace anywhere) rather than a reject-list — a malformed `LIFEOS_AGENT_HOSTS` key that would otherwise be misread as an rsync/ssh option (`-e`, `--delete`, `~`, `$HOME`) is rejected (`ValueError`) before ever reaching a path join, so it can't write outside the mirror root.
+
+### The pull
+
+`mirror_host(host, ssh_target, *, runner=...)` runs one `rsync` invocation per engine (`-rtz`, `--include=*/ --include=*.jsonl --exclude=*`, a `--` separator before the source/destination positionals so an `agent_hosts` value beginning with `-` can't be misread as a flag, over `ssh -o BatchMode=yes -o ConnectTimeout=<agent_ssh_connect_timeout>`, its own `--timeout` bounding a half-open connection). Read-only pull: no `--delete` on the remote side, never a push. `-t` (preserve mtimes) is what makes rsync's default quick-check (size + mtime) skip an unchanged file on the next tick — the source `remote_dir` string (`claude_code_projects_dir` / `codex_sessions_dir`, which may contain `~`) is passed through verbatim so the REMOTE shell expands it, never this process. `runner` is an injectable `Callable[[list[str]], subprocess.CompletedProcess]` (mirrors `remote_spawn.kill_remote_process_group`'s seam) so tests never shell out.
+
+Both engines are attempted even if one fails (a host that only runs one CLI shouldn't lose the other engine's mirror). Exit codes 23 ("partial transfer due to error") and 24 ("partial transfer due to vanished source files") are treated as SUCCESS — both are the expected outcome of pulling a transcript a live CLI is actively writing to, not a real failure — but are still worth knowing about: the diagnostic stderr line (`_diagnostic_stderr_line`, the first non-blank line that's neither rsync's own generic trailer nor ssh's benign "Permanently added ... to the list of known hosts" first-connect notice) is logged at `debug` every time, and at `warning` once per `(host, engine, message)` for the life of the process when it specifically names a source directory rsync couldn't enter (`change_dir ... failed`) — so a host that legitimately never runs one engine, or has a permissions problem, is surfaced exactly once per `(host, engine, message)` rather than on every tick. Any OTHER exit code produces one `warning` line for the host — `host <name> failed: <diagnostic line>` — and a `MirrorResult(ok=False)`; nothing raises. `mirror_once(*, runner=...)` mirrors every host in `settings.agent_hosts` except the API's own host (`remote_spawn.api_host_name()`) concurrently in a small `ThreadPoolExecutor`, so one slow or unreachable host never delays another. `start()`/`stop()` wrap this in an `asyncio.to_thread`-driven interval loop (`agent_transcript_mirror_interval_seconds`, default 120s), wired into `api/main.py`'s lifespan next to `agent_viz_summary_prefetch`'s identical shape; a no-op — no task scheduled, no per-tick logging — when disabled or when `agent_hosts` is empty.
+
+### Ingest + status merge
+
+`mirrored_snapshot()` walks every host subdirectory that exists and calls the SAME `cc.build_snapshot()` / `cx.build_snapshot()` the local scan uses, pointed at the mirrored directory instead of the local one, then stamps every row `host = <mirrored host name>` and `mirrored = True`.
+
+`_build_snapshot()` merges these rows in one pass, placed after the existing local cc/cx blocks and before the leftover-`cli_sessions` synthetic-row pass: a mirrored row whose `session_id` already appears among the locally-discovered rows is skipped (local transcript wins — it can only be fresher, since the mirror lags by up to one interval); otherwise it's popped against the same `cli_by_id` map the local rows already consume from, so `_apply_cli_session_to_dict` applies identically — **status comes from the hook event, token/cost/tool-call detail from the mirrored transcript**. When there's no matching hook row, the mirrored row's own `host` (the remote host's name) is left as-is rather than overwritten with `api_host_name()` — that overwrite is only correct for a row that genuinely ran on this API host.
+
+`mirrored_snapshot()` also returns each host's own parent-subagent spawn edges, which `_build_snapshot()` extends `edges` with. An edge is kept only when both endpoints are ids the merge loop above actually *appended* a row for, and both endpoints came from the same source host's batch (`appended_mirrored_host_by_id`, a dict mapping each appended id to the host it was appended from) — not the broader `local_ids`, which contains every id whether appended or skipped for a collision. Keying on the source host, not just id membership, is what tells apart two distinct cases: a session id that lost an id collision to a local transcript (its edge must not attach to the unrelated local row that won the collision), and a session id present on *two mirrored hosts* (an edge from one host's batch must not attach to the other host's unrelated parent row, since they merely happen to share an id). Edges are also deduped on `(from, to, type)`: the same session mirrored from two hosts, or an id collision on the child end, can otherwise derive the identical edge twice.
+
+Each mirrored row is copied (`dict(row)`) before `mirrored_snapshot()` stamps `host`/`mirrored`/demotion onto it — `cc.build_snapshot()`/`cx.build_snapshot()` return `list(entry.sessions)`, a shallow copy of the *list* whose row dicts are the same objects the 30s ingest cache (see "Snapshot caching" below) holds, so mutating them in place would corrupt the cache. Without the copy, `_build_snapshot()`'s hook-event overlay (`_apply_cli_session_to_dict`, applied to the SAME dict just above) would write a genuine `status="running", status_inferred=False` into the cached entry; if that hook row then vanished and a rebuild happened inside the cache TTL, `_demote_inferred_running` (guarded on `status_inferred is True`) couldn't correct the now-`False` cached row, replaying `running` with no hook evidence behind it at all.
+
+### Liveness exclusion
+
+Both `cc.build_snapshot()` and `cx.build_snapshot()` take an optional `live_counts: dict[str, int] | None = None`. `None` (every existing caller) scans this machine's own processes via `live_claude_cwd_counts()` / `live_codex_cwd_counts()`. `mirrored_snapshot()` passes `{}`, guaranteeing a mirrored row's cwd can never match a "live" entry — a mirrored transcript existing on this host says nothing about whether the CLI process is actually running here, so the per-cwd process-count promotion to authoritative `running` (see "Live process detection" above) must never fire for one.
+
+`live_counts={}` alone isn't sufficient, though: `_infer_status`'s mtime-under-10-minutes branch returns inferred `running` regardless of `live_counts` — it's a separate rule from the process-scan branch, and rsync preserves the remote mtime, so a freshly-pulled mirrored transcript trips it every time. `mirrored_snapshot()` closes this by demoting an inferred `running` row (`status_inferred is True`) to `inactive` before returning it. `_build_snapshot()`'s existing hook-event overlay (`_apply_cli_session_to_dict`) then restores `running` afterwards for any row that also has a matching `cli_sessions` entry reporting it — so a mirrored session's `running` status can, in the end, only come from that merged event row, via this demote-then-restore step rather than from the mtime-based inference alone.
+
+### Events, stream, and summary
+
+`_read_cli_transcript_events(session_id)` (in `api/routes/agents.py`) tries the local transcript root first, then each mirrored host's copy in turn via `mirrored_transcript_dirs(engine)`, returning the first non-empty result — used by `GET /sessions/{id}/events`, `/stream`, `/summary`, and the viz prefetcher (`agent_viz_summary_prefetch._summarize_one`) so a mirrored session's transcript reads identically to a local one everywhere the API reads events. `_lookup_cc_session_meta` / `_lookup_cx_session_meta` (the `/focus` FD-probe's session-metadata resolver) apply the same local-then-mirrored search, so a mirrored-only session (no live `cli_sessions` row) still resolves for `/focus` and for `_resume_command_text`'s cwd lookup rather than a bare "not found."
+
+### Resume target host
+
+`CCResumeRequest.target_host` (optional, on both `/resume` and `/focus`) lets the operator override the launch target regardless of the session's recorded host — `_resolve_target_host(session_id, target_host)`: blank/unset falls through to `_check_session_host_or_409` (including its 409); a value equal to `api_host_name()` launches locally; a value in `settings.agent_hosts` launches over ssh to that target; anything else 400s with `detail = {"error": ..., "command": <the resume command text>}` so the drawer can render it for copying. `_resume_command_text(session_id)` is called from THREE sites — `_resolve_target_host`'s 400 above, plus both launcher functions' own cwd-failure 400 branches described below — but only for rendering that copyable command text; the launchers still build their own `inner_rendered` independently for their success path, and it isn't a byte-for-byte match: this function prepends `cd <cwd> && `. It resolves cwd local-transcript-first, then mirrored, then the `cli_sessions` row's own `cwd` as a last resort — the common case for a `target_host` override on a session this host has never mirrored. When no cwd resolves at all, it returns `""` rather than a bare inner command missing its `cd`, which would otherwise resume in whatever directory the operator's terminal happens to be in; the drawer suppresses the command box entirely on an empty string.
+
+The two launcher functions (`_resume_claude_code_launcher`, `_resume_codex_session`) have their own local (`target_host` is this API host, or unset) fallback chain, independent of `_resume_command_text`'s cwd resolution: the local `discover_sessions` scan first, then the same mirrored-transcript lookup `/focus` uses, then the `cli_sessions` row's own `cwd` as a last resort — so "resume here" onto this API host also resolves a cwd for a session this host has only ever seen mirrored or via a hook event, not just one with a local transcript. Because a mirrored session's cwd is the REMOTE machine's path, that cwd may not exist, may not be a directory, or may not be accessible on this host at all on the local (non-ssh) branch; the child's failed `os.chdir` then raises `FileNotFoundError` (ENOENT), `NotADirectoryError` (ENOTDIR — the cwd is a regular file), or `PermissionError` (EACCES) — all `OSError` subclasses — and the launcher distinguishes a cwd failure from any other spawn failure via `exc.filename` (set to the cwd by the failed `os.chdir`, never to argv[0] for these three) checked in a single merged `except OSError` handler: a cwd failure 400s with the copyable command (calling `_resume_command_text` above) instead of falling through to a 500 — "resume binary not found" specifically preserved for a genuine missing-executable `FileNotFoundError`, "resume spawn failed" for anything else.
 
 ---
 
@@ -521,3 +575,4 @@ Per-source guarantees:
 - [Observability](observability.md) — Adjacent traces / health surfaces
 - [Task Management — Technical](task-management.md) — `TaskManager`, the store the board's cards are read from
 - [Scheduler — Technical](scheduler.md) — `SchedulerStore`, the store the Scheduled column is read from
+- [Agent Worker Setup — Guide](../../guides/agent-worker-setup.md#remote-session-parity-transcript-mirror) — Operator setup for the host registry and the transcript mirror's settings/prerequisites

--- a/tests/test_agent_resume_remote.py
+++ b/tests/test_agent_resume_remote.py
@@ -205,3 +205,564 @@ def test_remote_focus_falls_back_to_launcher_and_returns_focus_shape(client, rem
 
     argv = popen_mock.call_args.args[0]
     assert argv[0] == "ssh"
+
+
+# ---------------------------------------------------------------------------
+# "Resume here" — explicit target_host override
+# ---------------------------------------------------------------------------
+
+
+def test_target_host_registry_host_overrides_sessions_recorded_host(client, remote_cc_session, monkeypatch):
+    """The session is registered on "laptop"; posting a DIFFERENT registry
+    host as target_host must launch there instead — proving target_host
+    overrides the recorded host rather than merely confirming it."""
+    from config.settings import settings
+    monkeypatch.setattr(
+        settings, "agent_hosts",
+        {"laptop": "user@laptop.example", "studio": "user@studio.example"},
+        raising=False,
+    )
+    proc = MagicMock()
+    proc.communicate.return_value = (b"42\n", b"")
+    proc.returncode = 0
+    proc.pid = 9999
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/sessions/{remote_cc_session}/resume", json={"target_host": "studio"})
+    assert resp.status_code == 200
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] == "ssh"
+    assert "user@studio.example" in argv
+    assert "user@laptop.example" not in argv
+
+
+def test_target_host_api_host_launches_locally(client, tmp_path, monkeypatch):
+    """A session with NO cli_sessions row (purely local transcript) posted
+    with target_host equal to this API's own name behaves exactly like the
+    existing local launch path — proving the "this machine" entry in the
+    resume-host list is a real, working option."""
+    from config.settings import settings
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    # Encoded-cwd dirs replace EVERY "-" with "/" on decode — a hyphenated
+    # segment name would decode wrong ("local-proj" -> "local/proj"), so
+    # this fixture's project segment is deliberately hyphen-free.
+    projects_dir = tmp_path / "claude_code_projects"
+    proj = projects_dir / "-home-user-Code-localproj"
+    proj.mkdir(parents=True)
+    (proj / "local-sess-1.jsonl").write_text('{"type": "user", "message": {"role": "user", "content": "hi"}}\n')
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(projects_dir), raising=False)
+
+    proc = MagicMock()
+    proc.communicate.return_value = (b"5\n", b"")
+    proc.returncode = 0
+    proc.pid = 4242
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:local-sess-1/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cwd"] == "/home/user/Code/localproj"
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] != "ssh"  # launched locally, not wrapped in ssh
+
+
+def test_target_host_unknown_host_400s_with_copyable_command(client, remote_cc_session, monkeypatch):
+    popen_mock = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        f"/api/agents/sessions/{remote_cc_session}/resume",
+        json={"target_host": "nonexistent-host"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict)
+    assert "nonexistent-host" in detail["error"]
+    assert "claude --resume cc-uuid-on-laptop" in detail["command"]
+    assert "/home/user/Code/project" in detail["command"]
+    popen_mock.assert_not_called()  # never launched anywhere
+
+
+def test_target_host_unknown_host_400s_with_empty_command_when_no_cwd_resolves(
+    client, tmp_path, monkeypatch,
+):
+    """A session that resolves to NO cwd anywhere (no
+    local transcript, no mirrored transcript, no `cli_sessions` row) must
+    render an EMPTY `command`, not a bare inner command missing its `cd
+    <cwd> &&` prefix — that would offer a command that resumes wherever
+    the operator's terminal happens to be, not the session's actual
+    project. Contrast with `test_target_host_unknown_host_400s_with_
+    copyable_command` above, whose session DOES have a cwd and keeps its
+    non-empty, `cd`-prefixed command."""
+    from config.settings import settings
+    from api.services import agent_transcript_mirror
+
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --dangerously-skip-permissions --resume {session_id}")
+    monkeypatch.setattr(
+        settings, "claude_code_projects_dir", str(tmp_path / "empty-local-projects"), raising=False,
+    )
+    monkeypatch.setattr(agent_transcript_mirror, "mirror_root", lambda: tmp_path / "empty-mirror-root")
+    popen_mock = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:00000000-0000-0000-0000-000000000000/resume",
+        json={"target_host": "nonexistent-host"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["command"] == ""
+    popen_mock.assert_not_called()
+
+
+def test_absent_target_host_preserves_existing_409(client, remote_cc_session, monkeypatch):
+    """No target_host in the body at all — an unregistered recorded host
+    still 409s."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {}, raising=False)  # "laptop" isn't registered
+    popen_mock = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/sessions/{remote_cc_session}/resume", json={})
+    assert resp.status_code == 409
+    popen_mock.assert_not_called()
+
+
+def test_target_host_resume_falls_back_to_mirrored_transcript_cwd_with_no_cli_row(
+    client, tmp_path, monkeypatch,
+):
+    """A session known ONLY from its mirrored transcript (no cli_sessions
+    row at all — the hook's registration expired or never fired) must still
+    resolve a cwd for a "resume here" targeted at a registered host, via
+    _lookup_cc_session_meta's mirrored-dir fallback rather than the
+    cli_sessions row this scenario doesn't have."""
+    from config.settings import settings
+    from api.services import agent_transcript_mirror
+
+    monkeypatch.setattr(settings, "agent_hosts", {"laptop": "user@laptop.example"}, raising=False)
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    mirror_root = tmp_path / "mirror-root"
+    monkeypatch.setattr(agent_transcript_mirror, "mirror_root", lambda: mirror_root)
+    cc_dir = mirror_root / "laptop" / "claude_code" / "-home-user-mirroredproj"
+    cc_dir.mkdir(parents=True)
+    (cc_dir / "mirror-only-sess.jsonl").write_text(
+        '{"type": "user", "message": {"role": "user", "content": "hi"}}\n'
+    )
+
+    proc = MagicMock()
+    proc.communicate.return_value = (b"9\n", b"")
+    proc.returncode = 0
+    proc.pid = 5151
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:mirror-only-sess/resume",
+        json={"target_host": "laptop"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cwd"] == "/home/user/mirroredproj"
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] == "ssh"
+    assert "user@laptop.example" in argv
+
+
+def test_target_host_api_host_resume_falls_back_to_cli_session_cwd_with_no_transcript_at_all(
+    client, tmp_path, monkeypatch,
+):
+    """A session known ONLY from its `cli_sessions` row —
+    no local transcript AND no mirrored transcript for it at all (e.g. the
+    hook registered it but neither transcript scan has caught up yet) —
+    must still resolve a cwd for "resume here" targeted at THIS API host,
+    via the local branch's FINAL `cli_sessions`-cwd fallback
+    (`api/routes/agents.py`'s `_resume_claude_code_launcher`, the `cli =
+    _get_session_store().get_cli_session(session_id)` sub-branch inside
+    the local `else`). Mutation-proved by deleting the sub-branch (leaving
+    `target = None` unconditionally): every other test in this file stays
+    green, so only this test binds the fallback."""
+    from config.settings import settings
+    from api.services import agent_transcript_mirror
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    # No local transcript for this session id anywhere.
+    monkeypatch.setattr(
+        settings, "claude_code_projects_dir", str(tmp_path / "empty-local-projects"), raising=False,
+    )
+    # No mirrored transcript either — an empty (nonexistent) mirror root.
+    monkeypatch.setattr(agent_transcript_mirror, "mirror_root", lambda: tmp_path / "empty-mirror-root")
+
+    store = agents_route._get_session_store()
+    store.record_cli_session_event(
+        engine="claude_code", event="session_start", session_id="cli-only-sess",
+        host="laptop", cwd="/home/user/cli-only-proj", branch="main",
+    )
+
+    proc = MagicMock()
+    proc.communicate.return_value = (b"9\n", b"")
+    proc.returncode = 0
+    proc.pid = 7171
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:cli-only-sess/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cwd"] == "/home/user/cli-only-proj"
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] != "ssh"  # launched locally, not wrapped in ssh
+
+
+def test_target_host_api_host_codex_resume_falls_back_to_cli_session_cwd_with_no_transcript_at_all(
+    client, tmp_path, monkeypatch,
+):
+    """Codex sibling of the test above — the same unbound
+    `cli_sessions`-cwd fallback sub-branch in `_resume_codex_session`'s
+    local `else`."""
+    from config.settings import settings
+    from api.services import agent_transcript_mirror
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "codex_resume_enabled", True)
+    monkeypatch.setattr(settings, "codex_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "codex_resume_inner_cmd", "codex resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.setattr(
+        settings, "codex_sessions_dir", str(tmp_path / "empty-local-codex-sessions"), raising=False,
+    )
+    monkeypatch.setattr(agent_transcript_mirror, "mirror_root", lambda: tmp_path / "empty-mirror-root")
+
+    store = agents_route._get_session_store()
+    store.record_cli_session_event(
+        engine="codex", event="session_start", session_id="cli-only-cx-sess",
+        host="laptop", cwd="/home/user/cli-only-cxproj", branch="main",
+    )
+
+    proc = MagicMock()
+    proc.communicate.return_value = (b"9\n", b"")
+    proc.returncode = 0
+    proc.pid = 7272
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        "/api/agents/sessions/cx:cli-only-cx-sess/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cwd"] == "/home/user/cli-only-cxproj"
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] != "ssh"  # launched locally, not wrapped in ssh
+
+
+def test_target_host_api_host_resume_falls_back_to_mirrored_cc_transcript_cwd(
+    client, tmp_path, monkeypatch,
+):
+    """"Resume here" targeted at the API HOST ITSELF (not a registered
+    remote) for a Claude Code session known only from its mirrored
+    transcript must still resolve a cwd: the launcher's local `else`
+    branch falls through to `_lookup_cc_session_meta`'s mirror-aware
+    lookup, the same way the `remote_ssh_target` branch above does,
+    rather than relying solely on the local `claude_code_projects_dir`
+    scan."""
+    from config.settings import settings
+    from api.services import agent_transcript_mirror
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    # No session lives under the local projects dir — force the local
+    # discover_sessions scan to miss so the fallback chain is exercised.
+    monkeypatch.setattr(
+        settings, "claude_code_projects_dir", str(tmp_path / "empty-local-projects"), raising=False,
+    )
+
+    mirror_root = tmp_path / "mirror-root"
+    monkeypatch.setattr(agent_transcript_mirror, "mirror_root", lambda: mirror_root)
+    cc_dir = mirror_root / "laptop" / "claude_code" / "-home-user-mirroredproj"
+    cc_dir.mkdir(parents=True)
+    (cc_dir / "mirror-only-sess-api.jsonl").write_text(
+        '{"type": "user", "message": {"role": "user", "content": "hi"}}\n'
+    )
+
+    proc = MagicMock()
+    proc.communicate.return_value = (b"9\n", b"")
+    proc.returncode = 0
+    proc.pid = 6161
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:mirror-only-sess-api/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cwd"] == "/home/user/mirroredproj"
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] != "ssh"  # launched locally, not wrapped in ssh
+
+
+def test_target_host_api_host_resume_falls_back_to_mirrored_codex_transcript_cwd(
+    client, tmp_path, monkeypatch,
+):
+    """Codex sibling of the test above — the same local-branch fallback gap
+    (round-1 finding #1) applied to `_resume_codex_session`'s `else`
+    branch."""
+    from config.settings import settings
+    from api.services import agent_transcript_mirror
+    from api.routes import agents as agents_route
+    from tests.test_codex_ingest import _write_rollout, _session_meta
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "codex_resume_enabled", True)
+    monkeypatch.setattr(settings, "codex_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "codex_resume_inner_cmd", "codex resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    # No local codex sessions dir has this rollout — force the local
+    # discover_sessions scan to miss.
+    monkeypatch.setattr(
+        settings, "codex_sessions_dir", str(tmp_path / "empty-local-codex-sessions"), raising=False,
+    )
+
+    mirror_root = tmp_path / "mirror-root"
+    monkeypatch.setattr(agent_transcript_mirror, "mirror_root", lambda: mirror_root)
+    cx_dir = mirror_root / "laptop" / "codex"
+    _write_rollout(cx_dir, "mirror-only-cx-api", [_session_meta(cwd="/home/user/mirroredcxproj")])
+
+    proc = MagicMock()
+    proc.communicate.return_value = (b"9\n", b"")
+    proc.returncode = 0
+    proc.pid = 6262
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        "/api/agents/sessions/cx:mirror-only-cx-api/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cwd"] == "/home/user/mirroredcxproj"
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] != "ssh"  # launched locally, not wrapped in ssh
+
+
+def test_target_host_api_host_local_launch_with_missing_cwd_400s_with_command(
+    client, tmp_path, monkeypatch,
+):
+    """A mirrored session's cwd is the REMOTE machine's path. "Resume
+    here" targeted at THIS API host (local branch) for such a session,
+    when the cwd doesn't exist, must 400 with `{error, command}` naming
+    the cwd — not a bare-string 500 that blames the resume binary and
+    loses the copyable-command fallback the drawer otherwise renders."""
+    from config.settings import settings
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    projects_dir = tmp_path / "claude_code_projects"
+    proj = projects_dir / "-home-user-Code-probeproj"
+    proj.mkdir(parents=True)
+    (proj / "missing-cwd-sess.jsonl").write_text(
+        '{"type": "user", "message": {"role": "user", "content": "hi"}}\n'
+    )
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(projects_dir), raising=False)
+
+    def _raise(argv, cwd=None, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", cwd)
+    monkeypatch.setattr("subprocess.Popen", _raise)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:missing-cwd-sess/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict)
+    assert "/home/user/Code/probeproj" in detail["error"]
+    assert "resume binary" not in detail["error"]
+    assert "claude --resume missing-cwd-sess" in detail["command"]
+    assert "cd /home/user/Code/probeproj" in detail["command"]
+
+
+def test_target_host_api_host_local_launch_missing_binary_still_500s(
+    client, tmp_path, monkeypatch,
+):
+    """Sibling contrast: when `Popen` raises `FileNotFoundError` for the
+    EXECUTABLE (not the cwd) on the same local-launch path, the existing
+    500 "resume binary not found" behavior must be unchanged — the new
+    cwd-vs-binary distinction must not misfire on a real missing-binary
+    case (mutation-proved: swapping the `exc.filename == popen_cwd` check
+    to always take the 400 branch turns this into a 400)."""
+    from config.settings import settings
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "no-such-binary --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    projects_dir = tmp_path / "claude_code_projects"
+    proj = projects_dir / "-home-user-Code-probeproj2"
+    proj.mkdir(parents=True)
+    (proj / "missing-binary-sess.jsonl").write_text(
+        '{"type": "user", "message": {"role": "user", "content": "hi"}}\n'
+    )
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(projects_dir), raising=False)
+
+    def _raise(argv, cwd=None, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "no-such-binary")
+    monkeypatch.setattr("subprocess.Popen", _raise)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:missing-binary-sess/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 500
+    assert "resume binary not found" in resp.json()["detail"].lower()
+
+
+def test_target_host_api_host_local_launch_with_cwd_that_is_a_file_400s_with_command(
+    client, tmp_path, monkeypatch,
+):
+    """A mirrored cwd that exists on this host but is a regular file, not
+    a directory, raises `NotADirectoryError` (ENOTDIR) — a distinct
+    `OSError` subclass from a missing path. The merged `except OSError`
+    handler must catch this too, not just `FileNotFoundError`, or it
+    500s with a bare-string detail that loses the copyable-command
+    fallback. Mutation-proved: narrowing the merged `except OSError` back
+    to `except FileNotFoundError` makes this 500 instead of 400 (see the
+    mutation-proof note below)."""
+    from config.settings import settings
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    projects_dir = tmp_path / "claude_code_projects"
+    proj = projects_dir / "-home-user-Code-notdirproj"
+    proj.mkdir(parents=True)
+    (proj / "notdir-sess.jsonl").write_text(
+        '{"type": "user", "message": {"role": "user", "content": "hi"}}\n'
+    )
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(projects_dir), raising=False)
+
+    def _raise(argv, cwd=None, **kwargs):
+        raise NotADirectoryError(20, "Not a directory", cwd)
+    monkeypatch.setattr("subprocess.Popen", _raise)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:notdir-sess/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict)
+    assert "/home/user/Code/notdirproj" in detail["error"]
+    assert "resume binary" not in detail["error"]
+    assert "claude --resume notdir-sess" in detail["command"]
+    assert "cd /home/user/Code/notdirproj" in detail["command"]
+
+
+def test_target_host_api_host_local_launch_with_inaccessible_cwd_400s_with_command(
+    client, tmp_path, monkeypatch,
+):
+    """Same as the ENOTDIR case above, for `PermissionError` (EACCES) —
+    genuinely reachable via a
+    Linux-to-Linux mirror pair where the mirrored cwd's parent directory
+    exists on this host but is mode 700, owned by someone else (e.g.
+    `/home/otheruser` when the API host also runs another operator's
+    sessions). Mutation-proved the same way: narrowing the merged `except
+    OSError` back to `except FileNotFoundError` turns this into a 500."""
+    from config.settings import settings
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    projects_dir = tmp_path / "claude_code_projects"
+    proj = projects_dir / "-home-otheruser-Code-eaccesproj"
+    proj.mkdir(parents=True)
+    (proj / "eacces-sess.jsonl").write_text(
+        '{"type": "user", "message": {"role": "user", "content": "hi"}}\n'
+    )
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(projects_dir), raising=False)
+
+    def _raise(argv, cwd=None, **kwargs):
+        raise PermissionError(13, "Permission denied", cwd)
+    monkeypatch.setattr("subprocess.Popen", _raise)
+
+    resp = client.post(
+        "/api/agents/sessions/cc:eacces-sess/resume",
+        json={"target_host": "this-api-host"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict)
+    assert "/home/otheruser/Code/eaccesproj" in detail["error"]
+    assert "resume binary" not in detail["error"]
+    assert "claude --resume eacces-sess" in detail["command"]
+    assert "cd /home/otheruser/Code/eaccesproj" in detail["command"]
+
+
+def test_target_host_unknown_host_400s_on_focus_too(client, remote_cc_session, monkeypatch):
+    popen_mock = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(
+        f"/api/agents/sessions/{remote_cc_session}/focus",
+        json={"target_host": "nonexistent-host"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict)
+    assert "command" in detail

--- a/tests/test_agent_transcript_mirror.py
+++ b/tests/test_agent_transcript_mirror.py
@@ -1,0 +1,741 @@
+"""Tests for `api/services/agent_transcript_mirror.py`: the incremental
+ssh+rsync pull of each registered host's Claude Code/Codex transcripts.
+
+No real ssh/rsync is invoked. `_FakeRsyncRunner` stands in for the injectable
+`runner` — it records every invocation's argv (proving the shape of the real
+command) and performs a minimal, mtime-aware `*.jsonl` copy from a plain
+local "remote" directory into the mirror destination, so the copy/skip
+behavior can be asserted on real files without a network. Fixtures are
+synthetic per repo convention.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from api.services import agent_transcript_mirror as mirror
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeRsyncRunner:
+    """Records argv and performs a rsync-`-rt`-like incremental *.jsonl
+    copy (skip if dest is newer/equal-size). `fail_hosts` names ssh targets
+    (the string before the first `:` in the source spec) that should
+    simulate an unreachable host instead of copying.
+
+    This HONORS the argv: a short-option bundle carrying `t` (e.g. `-rtz`)
+    is what makes the fake preserve mtime on copy (`shutil.copy2`, mirroring
+    real rsync's `-t`) and therefore lets a later tick detect "unchanged" at
+    all; without it (or with `--ignore-times`/`--whole-file`, which force a
+    full re-transfer in real rsync), every file is always re-copied.
+    """
+
+    def __init__(self, fail_hosts: frozenset = frozenset()):
+        self.calls: list[list[str]] = []
+        self.copied_by_call: list[list[str]] = []
+        self.fail_hosts = fail_hosts
+
+    def __call__(self, argv: list[str]) -> "subprocess.CompletedProcess":
+        self.calls.append(argv)
+        remote_spec = argv[-2]
+        dst = Path(argv[-1])
+        target, remote_dir = remote_spec.split(":", 1)
+        remote_dir = remote_dir.rstrip("/")
+
+        if target in self.fail_hosts:
+            self.copied_by_call.append([])
+            return subprocess.CompletedProcess(
+                args=argv, returncode=255, stdout=b"",
+                stderr=b"ssh: connect to host x port 22: Connection refused\n",
+            )
+
+        has_dash_t = any(
+            a.startswith("-") and not a.startswith("--") and "t" in a[1:] for a in argv
+        )
+        preserves_mtime = (
+            has_dash_t and "--ignore-times" not in argv and "--whole-file" not in argv
+        )
+
+        copied: list[str] = []
+        src_root = Path(remote_dir)
+        if src_root.exists():
+            for jsonl in sorted(src_root.rglob("*.jsonl")):
+                rel = jsonl.relative_to(src_root)
+                dest_file = dst / rel
+                if (
+                    preserves_mtime
+                    and dest_file.exists()
+                    and dest_file.stat().st_mtime >= jsonl.stat().st_mtime
+                    and dest_file.stat().st_size == jsonl.stat().st_size
+                ):
+                    continue  # unchanged — rsync's quick check would skip this
+                dest_file.parent.mkdir(parents=True, exist_ok=True)
+                if preserves_mtime:
+                    shutil.copy2(jsonl, dest_file)  # copy2 preserves mtime, like rsync -t
+                else:
+                    shutil.copy(jsonl, dest_file)  # no -t — mtime not preserved, forces re-copy next tick
+                copied.append(str(rel))
+        self.copied_by_call.append(copied)
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=b"", stderr=b"")
+
+
+def _configure(monkeypatch, tmp_path, cc_dir, cx_dir, agent_hosts, this_host="api-host"):
+    from config.settings import settings
+    from api.services.agent_worker import remote_spawn
+
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(cc_dir), raising=False)
+    monkeypatch.setattr(settings, "codex_sessions_dir", str(cx_dir), raising=False)
+    monkeypatch.setattr(settings, "agent_hosts", agent_hosts, raising=False)
+    monkeypatch.setattr(settings, "agent_transcript_mirror_dir", str(tmp_path / "mirror"), raising=False)
+    monkeypatch.setattr(settings, "agent_ssh_connect_timeout", 5, raising=False)
+    monkeypatch.setattr(remote_spawn, "api_host_name", lambda: this_host)
+
+
+# ---------------------------------------------------------------------------
+# argv shape
+# ---------------------------------------------------------------------------
+
+
+def test_rsync_argv_is_readonly_incremental_pull_to_correct_dest(tmp_path, monkeypatch):
+    cc_dir = tmp_path / "remote-claude-projects"
+    cx_dir = tmp_path / "remote-codex-sessions"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+    runner = _FakeRsyncRunner()
+
+    result = mirror.mirror_host("laptop", "user@laptop.example", runner=runner)
+
+    assert result.ok is True
+    assert len(runner.calls) == 2  # one rsync invocation per engine
+
+    cc_dst, cx_dst = mirror.host_dirs("laptop")
+    for argv, remote_dir, dst_dir in zip(runner.calls, (cc_dir, cx_dir), (cc_dst, cx_dst)):
+        assert argv[0] == "rsync"
+        assert "-rtz" in argv
+        joined = " ".join(argv)
+        assert "BatchMode=yes" in joined
+        assert "ConnectTimeout=5" in joined
+        assert "--delete" not in argv  # never delete on the remote side (pull, not sync)
+        # Source is the ssh target + the settings path (passed through
+        # as-is — the remote shell, not this process, expands `~`).
+        assert argv[-2] == f"user@laptop.example:{remote_dir}/"
+        assert argv[-1] == f"{dst_dir}/"
+
+
+def test_rsync_argv_has_separator_before_positional_operands(tmp_path, monkeypatch):
+    """Round-1 finding #15: `--` must precede the source/dest so an
+    `agent_hosts` VALUE beginning with `-` can't be parsed by rsync as an
+    option rather than a positional operand."""
+    cc_dir = tmp_path / "remote-claude-projects"
+    cx_dir = tmp_path / "remote-codex-sessions"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+    runner = _FakeRsyncRunner()
+
+    mirror.mirror_host("laptop", "user@laptop.example", runner=runner)
+
+    for argv in runner.calls:
+        assert argv[-3] == "--"
+
+
+def test_rsync_argv_never_pushes_local_to_remote(tmp_path, monkeypatch):
+    """The destination (last argv element) is always a LOCAL path under the
+    mirror root, never the ssh target — this is a pull, never a push."""
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+    runner = _FakeRsyncRunner()
+
+    mirror.mirror_host("laptop", "user@laptop.example", runner=runner)
+
+    for argv in runner.calls:
+        assert "user@laptop.example" not in argv[-1]
+        assert str(mirror.mirror_root()) in argv[-1]
+
+
+# ---------------------------------------------------------------------------
+# copy
+# ---------------------------------------------------------------------------
+
+
+def test_copy_lands_under_per_host_engine_dirs(tmp_path, monkeypatch):
+    cc_dir = tmp_path / "remote-claude-projects"
+    (cc_dir / "-home-user-proj").mkdir(parents=True)
+    (cc_dir / "-home-user-proj" / "abc.jsonl").write_text('{"type": "user"}\n')
+    cx_dir = tmp_path / "remote-codex-sessions" / "2026" / "08" / "01"
+    cx_dir.mkdir(parents=True)
+    (cx_dir / "rollout-2026-08-01T00-00-00-xyz.jsonl").write_text('{"type": "session_meta"}\n')
+    _configure(monkeypatch, tmp_path, tmp_path / "remote-claude-projects",
+               tmp_path / "remote-codex-sessions", {"laptop": "user@laptop.example"})
+    runner = _FakeRsyncRunner()
+
+    result = mirror.mirror_host("laptop", "user@laptop.example", runner=runner)
+    assert result.ok is True
+
+    cc_dst, cx_dst = mirror.host_dirs("laptop")
+    assert cc_dst == mirror.mirror_root() / "laptop" / "claude_code"
+    assert cx_dst == mirror.mirror_root() / "laptop" / "codex"
+
+    cc_file = cc_dst / "-home-user-proj" / "abc.jsonl"
+    assert cc_file.exists()
+    assert cc_file.read_text() == '{"type": "user"}\n'
+
+    cx_file = cx_dst / "2026" / "08" / "01" / "rollout-2026-08-01T00-00-00-xyz.jsonl"
+    assert cx_file.exists()
+    assert cx_file.read_text() == '{"type": "session_meta"}\n'
+
+
+# ---------------------------------------------------------------------------
+# skip-unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_second_tick_does_not_retransfer_unchanged_file(tmp_path, monkeypatch):
+    cc_dir = tmp_path / "remote-claude-projects"
+    (cc_dir / "proj").mkdir(parents=True)
+    (cc_dir / "proj" / "s1.jsonl").write_text("{}\n")
+    cx_dir = tmp_path / "remote-codex-sessions"
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+    runner = _FakeRsyncRunner()
+
+    mirror.mirror_host("laptop", "user@laptop.example", runner=runner)
+    first_cc_copied = runner.copied_by_call[0]
+    assert first_cc_copied == ["proj/s1.jsonl"]  # positive: copied on tick 1
+
+    mirror.mirror_host("laptop", "user@laptop.example", runner=runner)
+    second_cc_copied = runner.copied_by_call[2]  # [cc1, cx1, cc2, cx2]
+    assert second_cc_copied == []  # positive: nothing copied on tick 2
+
+    # The mirrored file is still byte-identical to the source — proves
+    # tick 2 didn't disturb it (e.g. via a truncate-then-fail).
+    cc_dst, _cx_dst = mirror.host_dirs("laptop")
+    dest = cc_dst / "proj" / "s1.jsonl"
+    src = cc_dir / "proj" / "s1.jsonl"
+    assert dest.read_text() == src.read_text()
+
+    # Both ticks used rsync's ordinary quick-check flags — no
+    # --whole-file/--ignore-times that would force a full retransfer.
+    for argv in runner.calls:
+        assert "--whole-file" not in argv
+        assert "--ignore-times" not in argv
+
+
+def test_changed_file_is_retransferred(tmp_path, monkeypatch):
+    cc_dir = tmp_path / "remote-claude-projects"
+    (cc_dir / "proj").mkdir(parents=True)
+    src = cc_dir / "proj" / "s1.jsonl"
+    src.write_text("{}\n")
+    cx_dir = tmp_path / "remote-codex-sessions"
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+    runner = _FakeRsyncRunner()
+
+    mirror.mirror_host("laptop", "user@laptop.example", runner=runner)
+
+    time.sleep(1.05)  # ensure a distinct mtime second (filesystem mtime resolution)
+    src.write_text('{"type": "user"}\n')
+    mirror.mirror_host("laptop", "user@laptop.example", runner=runner)
+
+    second_cc_copied = runner.copied_by_call[2]
+    assert second_cc_copied == ["proj/s1.jsonl"]  # positive: re-copied because it changed
+
+
+# ---------------------------------------------------------------------------
+# unreachable host
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_host_logs_one_line_others_still_mirror(tmp_path, monkeypatch, caplog):
+    remote_root = tmp_path / "remote"
+    cc_dir = remote_root / "cc"
+    (cc_dir / "proj").mkdir(parents=True)
+    (cc_dir / "proj" / "a.jsonl").write_text("{}\n")
+    cx_dir = remote_root / "cx"
+    cx_dir.mkdir()
+    _configure(
+        monkeypatch, tmp_path, cc_dir, cx_dir,
+        {"deadhost": "user@deadhost.example", "goodhost": "user@goodhost.example"},
+    )
+    runner = _FakeRsyncRunner(fail_hosts=frozenset({"user@deadhost.example"}))
+    caplog.set_level(logging.WARNING, logger="api.services.agent_transcript_mirror")
+
+    results = mirror.mirror_once(runner=runner)
+
+    assert results["deadhost"].ok is False
+    assert results["goodhost"].ok is True
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "deadhost" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "Connection refused" in warnings[0].getMessage()
+
+    # goodhost's own pull actually completed with real files — proves the
+    # dead host didn't break or block it.
+    good_cc_dst, _ = mirror.host_dirs("goodhost")
+    assert (good_cc_dst / "proj" / "a.jsonl").exists()
+
+
+def test_unreachable_host_result_is_failed_and_no_exception_raised(tmp_path, monkeypatch):
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"deadhost": "user@deadhost.example"})
+    runner = _FakeRsyncRunner(fail_hosts=frozenset({"user@deadhost.example"}))
+
+    result = mirror.mirror_host("deadhost", "user@deadhost.example", runner=runner)
+    assert result.ok is False
+    assert result.error  # non-empty, carries the stderr tail
+
+
+# ---------------------------------------------------------------------------
+# rsync exit codes 23/24 — expected during a live write, not real failures
+# ---------------------------------------------------------------------------
+
+
+def test_rsync_exit_23_is_treated_as_success(tmp_path, monkeypatch):
+    """Round-1 finding #6: exit 23 ("partial transfer due to error" —
+    typically a non-regular file this pull's --include/--exclude already
+    filters out) means the transfer that mattered still succeeded."""
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+
+    def _partial_runner(argv):
+        return subprocess.CompletedProcess(args=argv, returncode=23, stdout=b"", stderr=b"")
+
+    result = mirror.mirror_host("laptop", "user@laptop.example", runner=_partial_runner)
+    assert result.ok is True
+
+
+def test_rsync_exit_24_is_treated_as_success(tmp_path, monkeypatch):
+    """Exit 24 ("partial transfer due to vanished source files") is the
+    EXPECTED outcome of pulling a transcript a live CLI is actively
+    writing to on the remote end — not a real failure."""
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+
+    def _vanished_runner(argv):
+        return subprocess.CompletedProcess(args=argv, returncode=24, stdout=b"", stderr=b"")
+
+    result = mirror.mirror_host("laptop", "user@laptop.example", runner=_vanished_runner)
+    assert result.ok is True
+
+
+def test_rsync_exit_other_than_23_24_still_fails(tmp_path, monkeypatch):
+    """Guards against over-correction: only 23 and 24 are treated as
+    success — every other non-zero code is still a real failure."""
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+
+    def _real_failure_runner(argv):
+        return subprocess.CompletedProcess(
+            args=argv, returncode=12, stdout=b"",
+            stderr=b"rsync: error in rsync protocol data stream (code 12)\n",
+        )
+
+    result = mirror.mirror_host("laptop", "user@laptop.example", runner=_real_failure_runner)
+    assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic stderr line — skip rsync's own generic trailer
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostic_stderr_line_prefers_ssh_error_over_rsync_trailer(tmp_path, monkeypatch):
+    """Round-1 finding #7: `last_nonempty_line` alone always picked rsync's
+    own generic trailer, byte-identical across NXDOMAIN, connection-refused,
+    and unroutable-address failures. The first non-trailer stderr line
+    (ssh's own diagnostic) is preferred."""
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+
+    stderr = (
+        b"ssh: connect to host laptop.example port 22: Connection timed out\n"
+        b"rsync: connection unexpectedly closed (0 bytes received so far) [Receiver]\n"
+        b"rsync error: unexplained error (code 255) at io.c(232) [Receiver=3.2.7]\n"
+    )
+
+    def _timeout_runner(argv):
+        return subprocess.CompletedProcess(args=argv, returncode=255, stdout=b"", stderr=stderr)
+
+    result = mirror.mirror_host("laptop", "user@laptop.example", runner=_timeout_runner)
+    assert result.ok is False
+    assert "Connection timed out" in result.error
+    assert "rsync error:" not in result.error
+
+
+def test_diagnostic_stderr_line_falls_back_to_trailer_when_nothing_else(tmp_path, monkeypatch):
+    """When stderr is ONLY the rsync trailer (no preceding ssh line at
+    all), that trailer is still surfaced rather than an empty error."""
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+
+    stderr = b"rsync error: unexplained error (code 255) at io.c(232) [Receiver=3.2.7]\n"
+
+    def _trailer_only_runner(argv):
+        return subprocess.CompletedProcess(args=argv, returncode=255, stdout=b"", stderr=stderr)
+
+    result = mirror.mirror_host("laptop", "user@laptop.example", runner=_trailer_only_runner)
+    assert result.ok is False
+    assert "rsync error:" in result.error
+
+
+def test_diagnostic_stderr_line_skips_ssh_known_hosts_warning():
+    """`_SSH_KNOWN_HOSTS_WARNING_RE` is in `_diagnostic_stderr_line`'s skip
+    condition so ssh's benign first-connect notice ("Warning: Permanently
+    added ... to the list of known hosts.") never gets picked as the
+    'diagnostic' line ahead of the real ssh error right after it, which
+    would otherwise bury the actual failure behind noise on every
+    first-connect tick. Mutation-proved: dropping the
+    `_SSH_KNOWN_HOSTS_WARNING_RE.match(...)` disjunct from the skip
+    condition makes this return the known-hosts line instead."""
+    stderr = (
+        "Warning: Permanently added '127.0.0.1' (ED25519) to the list of known hosts.\n"
+        "ssh: connect to host laptop.example port 22: Connection refused\n"
+        "rsync error: unexplained error (code 255) at io.c(232) [Receiver=3.2.7]\n"
+    )
+
+    diag = mirror._diagnostic_stderr_line(stderr)
+
+    assert diag == "ssh: connect to host laptop.example port 22: Connection refused"
+
+
+@pytest.fixture
+def _reset_source_dir_warned():
+    """`_source_dir_warned` is a never-cleared module
+    global that accumulates (host, engine, message) keys for the life of
+    the process — without resetting it before AND after a test that
+    exercises the once-per-triple WARNING, the assertion becomes
+    order-dependent under `-n auto --dist loadscope` (another test in the
+    same worker could have already warned for the identical triple, or
+    could run afterward and be silently starved of its own first
+    warning)."""
+    mirror._source_dir_warned.clear()
+    yield
+    mirror._source_dir_warned.clear()
+
+
+def test_rsync_exit_23_with_unreadable_source_dir_warns_once_then_stays_quiet(
+    tmp_path, monkeypatch, caplog, _reset_source_dir_warned,
+):
+    """rc-23/24 debug logging plus a once-per-(host, engine, message)
+    WARNING fires when the diagnostic line specifically names an
+    unreadable source directory. Neither of the other rc-23/24 tests
+    catches a regression here: both pass `stderr=b""`, so `diag` is empty
+    and the whole block is skipped. Mutation-proved: replacing the
+    `if rc in (23, 24): ...` body with `pass` leaves this failing (no
+    DEBUG, no WARNING on either call) while the rest of the suite stays
+    green.
+
+    Only the codex engine's pull fails here (the runner keys off the
+    remote source dir in argv) so the assertions can pin an exact WARNING
+    count of one per `mirror_host` call, not two."""
+    cc_dir = tmp_path / "remote-claude-projects"
+    cx_dir = tmp_path / "remote-codex-sessions"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"laptop": "user@laptop.example"})
+
+    stderr = (
+        b'rsync: change_dir "/home/user/.codex/sessions" failed: '
+        b"No such file or directory (2)\n"
+        b"rsync error: unexplained error (code 23) at main.c(123) [Receiver=3.2.7]\n"
+    )
+
+    def _mixed_runner(argv):
+        remote_spec = argv[-2]
+        if "codex" in remote_spec:
+            return subprocess.CompletedProcess(args=argv, returncode=23, stdout=b"", stderr=stderr)
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=b"", stderr=b"")
+
+    caplog.set_level(logging.DEBUG, logger="api.services.agent_transcript_mirror")
+
+    result1 = mirror.mirror_host("laptop", "user@laptop.example", runner=_mixed_runner)
+    assert result1.ok is True
+
+    def _records(level):
+        return [r for r in caplog.records if r.levelno == level and "laptop" in r.getMessage()]
+
+    warnings_after_first = _records(logging.WARNING)
+    debugs_after_first = _records(logging.DEBUG)
+    assert len(warnings_after_first) == 1, [r.getMessage() for r in warnings_after_first]
+    assert "unreadable" in warnings_after_first[0].getMessage()
+    assert len(debugs_after_first) == 1, [r.getMessage() for r in debugs_after_first]
+
+    caplog.clear()
+
+    result2 = mirror.mirror_host("laptop", "user@laptop.example", runner=_mixed_runner)
+    assert result2.ok is True
+
+    warnings_after_second = _records(logging.WARNING)
+    debugs_after_second = _records(logging.DEBUG)
+    assert warnings_after_second == [], "warned twice for the same (host, engine, message) triple"
+    assert len(debugs_after_second) == 1, "debug logging must fire on every call, not just the first"
+
+
+def test_mirror_once_runs_hosts_concurrently_not_serially(tmp_path, monkeypatch):
+    """Asserting on `len(set(idents)) > 1` alone still depends on thread
+    scheduling: `mirror_host` is submitted per HOST into one
+    `ThreadPoolExecutor`, but CPython's own worker-reuse behavior can land
+    two hosts' calls on the SAME worker thread even when `mirror_once`
+    genuinely dispatches concurrently — a scheduling coincidence, not a
+    property, and measured to flake in both directions on an
+    otherwise-idle box.
+
+    Bound here on a `threading.Barrier(len(hosts))`: the fake runner
+    blocks on it every call. A genuinely CONCURRENT dispatch has both
+    hosts' threads alive and calling into the runner around the same
+    time, so the barrier releases quickly on every one of its 2 rounds
+    (2 engines x 2 hosts). A SERIAL implementation runs `mirror_host`
+    for `hostA` to completion — both of its engine calls — before
+    `hostB` ever starts, so `hostA`'s first call waits alone until the
+    barrier's own short timeout trips, breaking the barrier (permanently,
+    for every party) and turning BOTH hosts' results into failures. No
+    timing assertion: the test's outcome (both hosts `ok`, or both
+    hosts failed) is decided by the barrier by construction, not by how
+    fast anything ran."""
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir,
+               {"hostA": "user@hostA.example", "hostB": "user@hostB.example"})
+
+    # Ample margin above any real thread-startup latency, tiny next to a
+    # human-perceptible test run — a serial implementation blocks the sole
+    # caller thread on `barrier.wait()` until this 5s timeout trips (it
+    # resolves AT the bound, not under it — see the docstring above for
+    # why that still turns both hosts' results into failures).
+    barrier = threading.Barrier(2, timeout=5)
+
+    def _recording_runner(argv):
+        barrier.wait()
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=b"", stderr=b"")
+
+    results = mirror.mirror_once(runner=_recording_runner)
+
+    assert results["hostA"].ok is True, results["hostA"].error
+    assert results["hostB"].ok is True, results["hostB"].error
+
+
+# ---------------------------------------------------------------------------
+# mirror_root() path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_mirror_root_relative_default_anchors_to_repo_root_not_cwd(tmp_path, monkeypatch):
+    """Round-1 finding #14: a relative `agent_transcript_mirror_dir` (the
+    default, "data/agent-transcript-mirror") must resolve against the REPO
+    ROOT, not the process's current working directory — same precedent as
+    `cc_wezterm_store.DEFAULT_DB_PATH`."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_transcript_mirror_dir", "data/agent-transcript-mirror", raising=False)
+    # A cwd that is NOT the repo root — if mirror_root() resolved relative
+    # to cwd (the bug), the result would land under tmp_path instead.
+    monkeypatch.chdir(tmp_path)
+
+    root = mirror.mirror_root()
+
+    expected_repo_root = Path(mirror.__file__).resolve().parent.parent.parent
+    assert root == expected_repo_root / "data" / "agent-transcript-mirror"
+    assert not str(root).startswith(str(tmp_path))
+
+
+def test_mirror_root_absolute_value_returned_unchanged(tmp_path, monkeypatch):
+    from config.settings import settings
+    abs_dir = tmp_path / "custom-mirror-root"
+    monkeypatch.setattr(settings, "agent_transcript_mirror_dir", str(abs_dir), raising=False)
+    assert mirror.mirror_root() == abs_dir
+
+
+def test_mirror_root_tilde_prefixed_value_expands_under_home(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_transcript_mirror_dir", "~/synthetic-mirror-root", raising=False)
+    assert mirror.mirror_root() == Path.home() / "synthetic-mirror-root"
+
+
+# ---------------------------------------------------------------------------
+# host-name sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_host_dirs_rejects_traversal_and_hidden_names():
+    for bad in ["../escape", "a/b", "a\\b", ".hidden", ""]:
+        with pytest.raises(ValueError):
+            mirror.host_dirs(bad)
+
+
+def test_host_dirs_rejects_shell_and_flag_like_names():
+    """Round-1 finding #16: the old reject-list (`/`, `\\`, `..`, leading
+    `.`, empty) let through shapes rsync/ssh could misinterpret as an
+    option or an expansion. The new positive allowlist closes them too."""
+    for bad in [
+        "-e", "--delete",       # would be parsed as an rsync/ssh flag
+        "~", "~laptop",         # shell tilde-expansion
+        "$HOME", "${HOME}",     # shell variable expansion
+        " ", "\t", "host name",  # whitespace-only / embedded whitespace
+        "trailing-",            # trailing hyphen — not a plausible hostname
+        "trailing.",            # trailing dot — not a plausible hostname
+        "a" * 300,              # implausibly long
+    ]:
+        with pytest.raises(ValueError):
+            mirror.host_dirs(bad)
+
+
+def test_unsafe_host_name_is_skipped_without_writing_outside_root(tmp_path, monkeypatch, caplog):
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir, {"../escape": "user@evil.example"})
+    runner = _FakeRsyncRunner()
+    caplog.set_level(logging.WARNING, logger="api.services.agent_transcript_mirror")
+
+    result = mirror.mirror_host("../escape", "user@evil.example", runner=runner)
+
+    assert result.ok is False
+    assert runner.calls == []  # rsync never invoked for an unsafe host name
+    root = mirror.mirror_root()
+    assert not (root.parent / "escape").exists()
+
+
+# ---------------------------------------------------------------------------
+# no-op with no hosts / disabled
+# ---------------------------------------------------------------------------
+
+
+def test_mirror_once_is_noop_with_no_hosts_configured(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {}, raising=False)
+    runner = _FakeRsyncRunner()
+
+    results = mirror.mirror_once(runner=runner)
+
+    assert results == {}
+    assert runner.calls == []
+
+
+def test_mirror_once_skips_the_api_host_itself(tmp_path, monkeypatch):
+    cc_dir = tmp_path / "cc"
+    cx_dir = tmp_path / "cx"
+    cc_dir.mkdir()
+    cx_dir.mkdir()
+    _configure(monkeypatch, tmp_path, cc_dir, cx_dir,
+               {"this-box": "user@this-box.example"}, this_host="this-box")
+    runner = _FakeRsyncRunner()
+
+    results = mirror.mirror_once(runner=runner)
+
+    assert results == {}
+    assert runner.calls == []
+
+
+def test_start_is_noop_when_disabled(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_transcript_mirror_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "agent_hosts", {"laptop": "user@laptop.example"}, raising=False)
+
+    mirror.start()
+    assert mirror._task is None
+    mirror.stop()  # no crash on stop with nothing started
+
+
+def test_start_is_noop_with_no_hosts_registered(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_transcript_mirror_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "agent_hosts", {}, raising=False)
+
+    mirror.start()
+    assert mirror._task is None
+
+
+async def test_start_creates_task_that_ticks_and_stop_cancels_it(monkeypatch):
+    """Round-1 finding #12: only the disabled/no-hosts no-op cases were
+    covered — AC 4's "the API stays responsive" half (the loop actually
+    runs a tick, and can be stopped) was unbound. No timing assertions
+    (they flake under xdist) — a bounded poll loop, not a fixed sleep."""
+    from config.settings import settings
+
+    monkeypatch.setattr(settings, "agent_transcript_mirror_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "agent_hosts", {"laptop": "user@laptop.example"}, raising=False)
+    # Long enough that only the FIRST tick fires during this test — a
+    # short interval could let a second tick race the assertions below.
+    monkeypatch.setattr(settings, "agent_transcript_mirror_interval_seconds", 3600, raising=False)
+
+    tick_calls: list[int] = []
+    monkeypatch.setattr(mirror, "mirror_once", lambda **kw: (tick_calls.append(1), {})[1])
+
+    mirror.start()
+    try:
+        assert mirror._task is not None
+        for _ in range(200):
+            if tick_calls:
+                break
+            await asyncio.sleep(0.01)
+        assert tick_calls, "the loop never performed its first tick"
+        assert not mirror._task.done()  # still alive, parked in its (long) interval sleep
+    finally:
+        mirror.stop()
+        assert mirror._task is None
+
+
+async def test_mirror_loop_invokes_mirror_once_through_to_thread(monkeypatch):
+    """The other half of finding #12: the tick must run `mirror_once`
+    through `asyncio.to_thread` (so a slow/hanging rsync can't block the
+    event loop) — patches that seam directly rather than inferring it from
+    timing."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_transcript_mirror_interval_seconds", 3600, raising=False)
+
+    to_thread_calls: list = []
+
+    async def _fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(func)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", _fake_to_thread)
+    monkeypatch.setattr(mirror, "mirror_once", lambda: {})
+
+    task = asyncio.create_task(mirror._mirror_loop())
+    try:
+        for _ in range(200):
+            if to_thread_calls:
+                break
+            await asyncio.sleep(0.01)
+        assert to_thread_calls, "the loop never reached its first tick"
+        assert to_thread_calls[0] is mirror.mirror_once
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/tests/test_agent_transcript_mirror_events.py
+++ b/tests/test_agent_transcript_mirror_events.py
@@ -1,0 +1,231 @@
+"""Tests for mirrored-transcript resolution on the events/stream/summary
+routes: `_read_cli_transcript_events` (the shared local-then-mirrored
+lookup) and its use by `GET /sessions/{id}/events`, `/stream`, and
+`/summary`.
+"""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services import agent_transcript_mirror
+from api.services.agent_worker.session_store import SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+pytestmark = pytest.mark.unit
+
+
+def _iso(offset: float = 0.0) -> str:
+    return datetime.fromtimestamp(time.time() + offset, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _write_cc_transcript(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        {"type": "user", "timestamp": _iso(-10), "message": {"role": "user", "content": "mirrored hello"}},
+        {
+            "type": "assistant", "timestamp": _iso(-5),
+            "message": {
+                "role": "assistant", "model": "claude-sonnet-5",
+                "content": [{"type": "text", "text": "mirrored reply"}],
+                "usage": {"input_tokens": 10, "output_tokens": 20,
+                          "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            },
+        },
+    ]
+    with path.open("w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    agents_route._label_cache.clear()
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", lambda: ([], []))
+    monkeypatch.setattr(agents_route, "_codex_snapshot", lambda: ([], []))
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    yield session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def mirror_root(tmp_path: Path, monkeypatch):
+    root = tmp_path / "mirror-root"
+    monkeypatch.setattr(agent_transcript_mirror, "mirror_root", lambda: root)
+    return root
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+# ---------------------------------------------------------------------------
+# The shared helper directly
+# ---------------------------------------------------------------------------
+
+
+def test_read_cli_transcript_events_falls_back_to_mirrored_dir(mirror_root):
+    _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-e1.jsonl")
+
+    events = agents_route._read_cli_transcript_events("cc:sess-e1")
+
+    assert len(events) == 2
+    assert events[0]["kind"] == "user_message"
+    assert events[0]["payload"]["text"] == "mirrored hello"
+    assert events[1]["kind"] == "assistant_message"
+
+
+def test_read_cli_transcript_events_local_wins_over_mirrored(mirror_root, tmp_path, monkeypatch):
+    """A local transcript exists for the same id — the mirrored copy must
+    never be consulted (local-first)."""
+    from config.settings import settings
+
+    local_dir = tmp_path / "local-claude-projects"
+    _write_cc_transcript(local_dir / "-home-user-proj" / "sess-e2.jsonl")
+    # Overwrite the local copy's user text so it's distinguishable.
+    local_file = local_dir / "-home-user-proj" / "sess-e2.jsonl"
+    lines = local_file.read_text().splitlines()
+    lines[0] = json.dumps({"type": "user", "timestamp": _iso(-10),
+                            "message": {"role": "user", "content": "LOCAL hello"}})
+    local_file.write_text("\n".join(lines) + "\n")
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(local_dir), raising=False)
+
+    # A DIFFERENT mirrored copy for the same id, distinguishable by text.
+    _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-e2.jsonl")
+
+    events = agents_route._read_cli_transcript_events("cc:sess-e2")
+    assert events[0]["payload"]["text"] == "LOCAL hello"
+
+
+def test_read_cli_transcript_events_returns_empty_when_nowhere_found(mirror_root):
+    assert agents_route._read_cli_transcript_events("cc:does-not-exist") == []
+
+
+# ---------------------------------------------------------------------------
+# _lookup_cc_session_meta / _lookup_cx_session_meta mirrored fallback
+# (used by /focus's FD-probe resolution and by _resume_command_text's cwd
+# lookup for a "resume here" target on a session with no local transcript
+# and no cli_sessions row).
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_cc_session_meta_finds_mirrored_session(mirror_root):
+    _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-lookup-1.jsonl")
+
+    meta, bare = agents_route._lookup_cc_session_meta("cc:sess-lookup-1")
+
+    assert bare == "sess-lookup-1"
+    assert meta.decoded_cwd == "/home/user/proj"
+    assert meta.jsonl_path.endswith("sess-lookup-1.jsonl")
+
+
+def test_lookup_cx_session_meta_finds_mirrored_session(mirror_root):
+    cx_dir = mirror_root / "studio" / "codex" / "2026" / "08" / "01"
+    cx_dir.mkdir(parents=True)
+    rollout = cx_dir / "rollout-2026-08-01T00-00-00-cx-lookup-1.jsonl"
+    lines = [{"type": "session_meta", "timestamp": _iso(-10), "payload": {"cwd": "/home/user/proj3"}}]
+    with rollout.open("w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+
+    meta = agents_route._lookup_cx_session_meta("cx:cx-lookup-1")
+
+    assert meta.decoded_cwd == "/home/user/proj3"
+
+
+def test_read_cli_transcript_events_codex_mirrored(mirror_root):
+    cx_dir = mirror_root / "studio" / "codex" / "2026" / "08" / "01"
+    cx_dir.mkdir(parents=True)
+    rollout = cx_dir / "rollout-2026-08-01T00-00-00-cx-e3.jsonl"
+    lines = [
+        {"type": "event_msg", "timestamp": _iso(-5), "payload": {"type": "user_message", "message": "codex hi"}},
+    ]
+    with rollout.open("w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+
+    events = agents_route._read_cli_transcript_events("cx:cx-e3")
+    assert len(events) == 1
+    assert events[0]["payload"]["text"] == "codex hi"
+
+
+# ---------------------------------------------------------------------------
+# GET /sessions/{id}/events
+# ---------------------------------------------------------------------------
+
+
+def test_events_endpoint_returns_mirrored_transcript_for_remote_session(client, stores, mirror_root):
+    _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-e4.jsonl")
+
+    r = client.get("/api/agents/sessions/cc:sess-e4/events")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 2
+    assert body["events"][0]["payload"]["text"] == "mirrored hello"
+
+
+# ---------------------------------------------------------------------------
+# GET /sessions/{id}/stream
+# ---------------------------------------------------------------------------
+
+
+def test_stream_endpoint_returns_mirrored_transcript_for_remote_session(client, stores, mirror_root):
+    _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-e5.jsonl")
+
+    lines: list[str] = []
+    with client.stream("GET", "/api/agents/sessions/cc:sess-e5/stream?backfill=5") as r:
+        assert r.status_code == 200
+        for line in r.iter_lines():
+            lines.append(line)
+            if "mirrored reply" in line:
+                break  # got the assistant backfill event — no need to wait for idle-close
+
+    joined = "\n".join(lines)
+    assert "mirrored hello" in joined
+    assert "mirrored reply" in joined
+
+
+# ---------------------------------------------------------------------------
+# GET /sessions/{id}/summary — produces a real label for a mirrored session
+# ---------------------------------------------------------------------------
+
+
+def test_summary_endpoint_resolves_label_for_mirrored_session(client, stores, mirror_root, monkeypatch):
+    _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-e6.jsonl")
+
+    captured = {}
+
+    async def fake_summarize(session_id, *, label, last_activity_at, events, status):
+        captured["label"] = label
+        captured["last_activity_at"] = last_activity_at
+        captured["status"] = status
+        captured["n_events"] = len(events)
+
+        class _Result:
+            def as_dict(self_inner):
+                return {"short_label": "mirrored summary", "body": "..."}
+        return _Result()
+
+    monkeypatch.setattr(agents_route.agent_viz_summary, "summarize_session", fake_summarize)
+
+    r = client.get("/api/agents/sessions/cc:sess-e6/summary")
+    assert r.status_code == 200
+    assert r.json()["short_label"] == "mirrored summary"
+    # The label passed to summarize_session came from the MIRRORED snapshot
+    # row (not the bare session_id fallback), proving the mirrored-snapshot
+    # lookup fired.
+    assert captured["label"] != "cc:sess-e6"
+    assert captured["n_events"] == 2

--- a/tests/test_agent_transcript_mirror_snapshot.py
+++ b/tests/test_agent_transcript_mirror_snapshot.py
@@ -1,0 +1,690 @@
+"""Snapshot-ingest tests for mirrored remote transcripts.
+
+Covers the acceptance criteria that `GET /api/agents/snapshot` returns one
+row for a mirrored Claude Code/Codex session, host attribution, the
+event-over-transcript status merge (reusing `_apply_cli_session_to_dict`
+against a MIRRORED row instead of a local one), liveness exclusion (a
+mirrored row must never be promoted to `running` by a local process scan),
+and id-collision resolution (local transcript wins).
+
+Builds real synthetic jsonl fixtures under a tmp mirror root and exercises
+the real `agent_transcript_mirror.mirrored_snapshot()` -> `_build_snapshot()`
+path — not a mocked snapshot — so the liveness-exclusion wiring
+(`build_snapshot(..., live_counts={})`) is actually under test.
+"""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services import agent_transcript_mirror
+from api.services.agent_worker.session_store import SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+pytestmark = pytest.mark.unit
+
+# Captured before any test monkeypatches `agents_route._claude_code_snapshot`
+# to a stub — lets the liveness-exclusion contrast test restore the REAL
+# local scan for its second half without depending on monkeypatch's
+# per-test teardown ordering relative to its own re-patch.
+_REAL_CLAUDE_CODE_SNAPSHOT = agents_route._claude_code_snapshot
+
+
+def _iso(offset: float = 0.0) -> str:
+    return datetime.fromtimestamp(time.time() + offset, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _write_cc_transcript(path: Path, session_id: str) -> None:
+    """A minimal-but-real Claude Code transcript: one user turn, one
+    assistant turn with real usage tokens."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        {"type": "user", "timestamp": _iso(-10), "message": {"role": "user", "content": "hello"}},
+        {
+            "type": "assistant",
+            "timestamp": _iso(-5),
+            "message": {
+                "role": "assistant", "model": "claude-sonnet-5",
+                "content": [{"type": "text", "text": "hi there"}],
+                "usage": {
+                    "input_tokens": 321, "output_tokens": 654,
+                    "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+                },
+            },
+        },
+    ]
+    with path.open("w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    agents_route._label_cache.clear()
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", lambda: ([], []))
+    monkeypatch.setattr(agents_route, "_codex_snapshot", lambda: ([], []))
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    yield session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def mirror_root(tmp_path: Path, monkeypatch):
+    root = tmp_path / "mirror-root"
+    monkeypatch.setattr(agent_transcript_mirror, "mirror_root", lambda: root)
+    return root
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+# ---------------------------------------------------------------------------
+# One row, host attribution, real token/dollar fields
+# ---------------------------------------------------------------------------
+
+
+def test_mirrored_cc_session_produces_one_row_with_host_and_real_tokens(client, stores, mirror_root):
+    _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-1.jsonl", "sess-1")
+
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    matches = [s for s in r.json()["sessions"] if s["session_id"] == "cc:sess-1"]
+    assert len(matches) == 1
+    row = matches[0]
+    assert row["host"] == "laptop"
+    assert row["mirrored"] is True
+    assert row["total_input_tokens"] == 321
+    assert row["total_output_tokens"] == 654
+    assert row["source"] == "claude_code"
+
+
+def test_mirrored_subagent_spawn_edge_is_preserved(client, stores, mirror_root):
+    """`_build_snapshot`'s merge block extends `edges` with
+    `build_snapshot`'s edges return value, so a mirrored session's own
+    Task/Agent tool-use spawn produces both the synthetic subagent NODE
+    and the edge connecting it to its parent, rather than rendering the
+    node disconnected in the graph."""
+    from tests.test_claude_code_ingest import _assistant_event
+
+    proj = mirror_root / "laptop" / "claude_code" / "-home-user-proj"
+    proj.mkdir(parents=True)
+    with (proj / "sess-edge.jsonl").open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_assistant_event(tool_uses=[
+            {"id": "tu_mirror_1", "name": "Agent", "input": {"prompt": "child task"}},
+        ])) + "\n")
+
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    body = r.json()
+    ids = [s["session_id"] for s in body["sessions"]]
+    child_id = next((i for i in ids if ":agent:tu_mirror_1" in i), None)
+    assert child_id is not None, f"expected a synthetic subagent row, got {ids}"
+    assert any(
+        e["type"] == "spawn" and e["from"] == "cc:sess-edge" and e["to"] == child_id
+        for e in body["edges"]
+    ), f"expected a spawn edge cc:sess-edge -> {child_id}, got {body['edges']}"
+
+
+def test_mirrored_subagent_spawn_edge_survives_hook_host_relabel(client, stores, mirror_root):
+    """The parent row has a hook (`cli_sessions`) row whose `host` differs
+    from the mirror directory name it was ingested from — e.g. the
+    registry key `mac-mini` used by `LIFEOS_AGENT_HOSTS` versus the
+    machine's own reported hostname `Mac-Mini`. The subagent row has no
+    hook row of its own (its id is synthesized from the tool_use id), so
+    it keeps the mirror directory's host untouched.
+
+    Comparing the two endpoints' hosts must use the SOURCE host each row
+    was mirrored from, not the host left in `sd["host"]` after the hook
+    overlay ran on the parent — otherwise a mismatched registry key vs.
+    hostname makes every mirrored parent+subagent edge look like it
+    crosses hosts and gets dropped.
+    """
+    from tests.test_claude_code_ingest import _assistant_event
+
+    session_store, _ = stores
+    proj = mirror_root / "Mac-Mini" / "claude_code" / "-home-user-proj"
+    proj.mkdir(parents=True)
+    with (proj / "sess-relabel.jsonl").open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_assistant_event(tool_uses=[
+            {"id": "tu_relabel_1", "name": "Agent", "input": {"prompt": "child task"}},
+        ])) + "\n")
+
+    session_store.record_cli_session_event(
+        engine="claude_code", event="user_prompt_submit",
+        session_id="sess-relabel", host="mac-mini", cwd="/home/user/proj",
+    )
+
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    body = r.json()
+    parent = next(s for s in body["sessions"] if s["session_id"] == "cc:sess-relabel")
+    assert parent["host"] == "mac-mini"  # hook-overlaid host wins for the parent row
+    child_id = next(
+        (s["session_id"] for s in body["sessions"] if ":agent:tu_relabel_1" in s["session_id"]),
+        None,
+    )
+    assert child_id is not None, f"expected a synthetic subagent row, got {[s['session_id'] for s in body['sessions']]}"
+    assert any(
+        e["type"] == "spawn" and e["from"] == "cc:sess-relabel" and e["to"] == child_id
+        for e in body["edges"]
+    ), f"expected a spawn edge cc:sess-relabel -> {child_id} despite the host relabel, got {body['edges']}"
+
+
+def test_mirrored_codex_session_produces_one_row_with_host(client, stores, mirror_root):
+    cx_dir = mirror_root / "studio" / "codex" / "2026" / "08" / "01"
+    cx_dir.mkdir(parents=True)
+    rollout = cx_dir / "rollout-2026-08-01T00-00-00-cx-sess-2.jsonl"
+    lines = [
+        {"type": "session_meta", "timestamp": _iso(-10), "payload": {"cwd": "/home/user/proj2"}},
+        {"type": "event_msg", "timestamp": _iso(-5), "payload": {"type": "user_message", "message": "hi"}},
+    ]
+    with rollout.open("w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+
+    r = client.get("/api/agents/snapshot")
+    matches = [s for s in r.json()["sessions"] if s["session_id"] == "cx:cx-sess-2"]
+    assert len(matches) == 1
+    assert matches[0]["host"] == "studio"
+    assert matches[0]["mirrored"] is True
+    assert matches[0]["source"] == "codex"
+
+
+# ---------------------------------------------------------------------------
+# Status merge: hook events win over the transcript's own inferred status;
+# token/cost stay transcript-derived.
+# ---------------------------------------------------------------------------
+
+
+def test_status_merge_prefers_hook_events_over_mirrored_transcript(client, stores, mirror_root):
+    session_store, _ = stores
+    _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-3.jsonl", "sess-3")
+
+    session_store.record_cli_session_event(
+        engine="claude_code", event="user_prompt_submit",
+        session_id="sess-3", host="laptop", cwd="/home/user/proj",
+    )
+
+    r = client.get("/api/agents/snapshot")
+    matches = [s for s in r.json()["sessions"] if s["session_id"] == "cc:sess-3"]
+    assert len(matches) == 1
+    row = matches[0]
+    assert row["status"] == "running"  # from the hook event, not the transcript's mtime guess
+    assert row["status_inferred"] is False
+    # Token/cost detail is still the transcript's, not zeroed by the merge.
+    assert row["total_input_tokens"] == 321
+    assert row["total_output_tokens"] == 654
+
+
+def test_mirrored_row_with_fresh_mtime_and_no_hook_row_is_not_running(client, stores, mirror_root):
+    """Round-1 finding #4 (the negative half — the positive half is
+    `test_status_merge_prefers_hook_events_over_mirrored_transcript`
+    above, which already proves a hook row reporting `running` survives
+    onto a mirrored row untouched, `status_inferred: False`).
+
+    AC 7 is unambiguous: "a remote session's `running` status comes only
+    from hook events." `live_counts={}` only blocks `_infer_status`'s
+    PROCESS-SCAN branch (`has_live_process`) — its separate
+    mtime-under-10-minutes branch still returns `("running", True)`
+    regardless of `live_counts`, since `_write_cc_transcript` writes the
+    file "now". With NO cli_sessions row at all (zero hook events), a
+    freshly-mirrored transcript must not show `running`."""
+    _write_cc_transcript(
+        mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-fresh.jsonl", "sess-fresh",
+    )
+
+    r = client.get("/api/agents/snapshot")
+    matches = [s for s in r.json()["sessions"] if s["session_id"] == "cc:sess-fresh"]
+    assert len(matches) == 1
+    # Pin the exact demotion TARGET, not merely "not
+    # running" — `showResume` (web/agents/panel.js) only renders Resume
+    # for a status in {TERMINAL, "inactive", "yielded"}, so demoting to
+    # any other non-resumable status (e.g. "blocked", "idle") would still
+    # satisfy `!= "running"` while hiding the Resume control on every
+    # freshly-mirrored remote session — the exact defect this guard exists
+    # to prevent.
+    assert matches[0]["status"] == "inactive"
+    assert matches[0]["status_inferred"] is True
+
+
+def test_demoted_status_is_a_showresume_eligible_status():
+    """Ties `_demote_inferred_running`'s hardcoded
+    demotion target to the frontend's `showResumeFor` acceptance set, so a
+    change to either side that breaks the pairing is caught here rather
+    than only by a live drawer. `web/agents/panel.js`'s `showResumeFor`
+    accepts exactly `{"inactive", "yielded"}` plus the TERMINAL statuses
+    (`completed`, `failed`, `budget_exceeded`, `ended` — see `TERMINAL` in
+    `web/agents/panel.js`); demoting to anything outside that set (e.g.
+    "blocked", "idle") would hide Resume on every freshly-mirrored session."""
+    import re
+
+    panel_js = Path(__file__).resolve().parent.parent / "web" / "agents" / "panel.js"
+    source = panel_js.read_text(encoding="utf-8")
+    # `updateMeta` and `_renderHeader` both call a single shared
+    # `showResumeFor(s)` function — anchor on that function body (not
+    # `const showResume = ...`, which isn't the definition site) so this
+    # binds the one copy both call sites share, rather than a copy that
+    # could drift.
+    match = re.search(
+        r"function showResumeFor\(s\) \{[\s\S]*?status === '(\w+)' \|\| s\.status === '(\w+)'\)",
+        source,
+    )
+    assert match, "showResumeFor's status literals moved — update this test's regex"
+    eligible_non_terminal = {match.group(1), match.group(2)}
+
+    row: dict = {"status": "running", "status_inferred": True}
+    agent_transcript_mirror._demote_inferred_running(row)
+    assert row["status"] in eligible_non_terminal, (
+        f"_demote_inferred_running's target {row['status']!r} is not one of "
+        f"showResume's eligible non-terminal statuses {eligible_non_terminal!r} "
+        "— Resume would be hidden on every freshly-mirrored session"
+    )
+
+
+def test_hook_reported_running_survives_even_if_demotion_ran_after_the_merge():
+    """The `test_status_merge_prefers_hook_events_over_mirrored_transcript`
+    test above doesn't bind the demote-before-overlay ordering: it would
+    pass identically even with `_demote_inferred_running` deleted
+    entirely, since `_apply_cli_session_to_dict` always overwrites
+    `status` last in the real pipeline.
+
+    This test proves the actual safety property instead: even if a future
+    refactor called `_demote_inferred_running` a second time AFTER the
+    hook overlay already ran, a hook row genuinely reporting `running`
+    must still survive, because `_demote_inferred_running` only touches a
+    row whose `status_inferred` is `True` — and the overlay always sets
+    it `False`. Mutation-proved: dropping that guard (demoting whenever
+    `status == "running"`, regardless of `status_inferred`) makes this
+    test fail while leaving the pipeline's own call site behavior
+    unchanged."""
+    from api.routes.agents import _apply_cli_session_to_dict
+    from api.services.agent_worker.session_store import CliSession
+
+    row: dict = {"status": "running", "status_inferred": True}
+    cli = CliSession(
+        session_id="cc:sess-order", engine="claude_code", host="laptop",
+        status="running", started_at=0, last_event_at=0,
+        cwd="/home/user/proj", branch="", prompt_preview="",
+    )
+
+    # Overlay first (hook event wins), THEN demotion — a reversed order a
+    # future refactor might introduce.
+    _apply_cli_session_to_dict(row, cli)
+    agent_transcript_mirror._demote_inferred_running(row)
+
+    assert row["status"] == "running"
+    assert row["status_inferred"] is False
+
+
+# ---------------------------------------------------------------------------
+# Cache aliasing: a hook overlay must never leak into the
+# ingest cache that `mirrored_snapshot()` reads from.
+# ---------------------------------------------------------------------------
+
+
+def test_hook_overlay_does_not_leak_into_ingest_cache_within_ttl(
+    client, stores, mirror_root,
+):
+    """`cc.build_snapshot()`/`cx.build_snapshot()` return
+    `list(entry.sessions)` — a shallow copy of the LIST, so the row DICTS
+    inside are the SAME objects held by `cc`'s own ingest cache
+    (`_snapshot_cache`, 30s default TTL — live in production via
+    `mirrored_snapshot()`'s own `cache_ttl=30.0` default). Without
+    `mirrored_snapshot()` copying each row before mutating it (`host`,
+    `mirrored`, the demotion), `_build_snapshot`'s hook overlay
+    (`_apply_cli_session_to_dict`) would mutate them AGAIN with a genuine
+    `status="running", status_inferred=False` — writing that straight into
+    the cached entry. If the hook row then vanishes (pruned, or a failed
+    `list_cli_sessions()` call) and a rebuild happens INSIDE the cache TTL,
+    `_demote_inferred_running` (guarded on `status_inferred is True`) can't
+    fix the now-`False` cached row, so it replays `running` with zero
+    hook evidence — a straight violation of AC 7 ("a remote session's
+    `running` status comes only from hook events").
+
+    Mutation-proved: reverting `mirrored_snapshot()`'s `sessions = [dict(row)
+    for row in sessions]` copy (mutating the cache's own dicts again)
+    makes this fail — the second snapshot stays `running`/`status_inferred:
+    False` instead of demoting back to `inactive`/`True`."""
+    import sqlite3
+
+    session_store, _ = stores
+    _write_cc_transcript(
+        mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-ttl.jsonl", "sess-ttl",
+    )
+
+    # A genuine hook event ("user_prompt_submit" -> CLI_STATUS_RUNNING)
+    # overlays `status="running", status_inferred=False` onto the mirrored
+    # row on this first request.
+    session_store.record_cli_session_event(
+        engine="claude_code", event="user_prompt_submit",
+        session_id="sess-ttl", host="laptop", cwd="/home/user/proj",
+    )
+
+    r1 = client.get("/api/agents/snapshot")
+    matches1 = [s for s in r1.json()["sessions"] if s["session_id"] == "cc:sess-ttl"]
+    assert len(matches1) == 1
+    assert matches1[0]["status"] == "running"
+    assert matches1[0]["status_inferred"] is False
+
+    # Drop the hook row — simulates it being pruned, or a `list_cli_sessions`
+    # read that raced ahead and missed it. Deletes directly against the
+    # store's sqlite file rather than through a public API, since
+    # SessionStore exposes no delete for cli_sessions rows.
+    conn = sqlite3.connect(str(session_store.db_path))
+    try:
+        conn.execute("DELETE FROM cli_sessions WHERE session_id = ?", ("cc:sess-ttl",))
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Rebuild INSIDE the cache TTL (no sleep, no invalidate_cache() call) —
+    # the whole point is that this hits the still-warm 30s cache.
+    r2 = client.get("/api/agents/snapshot")
+    matches2 = [s for s in r2.json()["sessions"] if s["session_id"] == "cc:sess-ttl"]
+    assert len(matches2) == 1
+    assert matches2[0]["status"] == "inactive", (
+        "the hook overlay leaked into the ingest cache — a rebuild inside "
+        "the TTL replayed 'running' with no hook row backing it"
+    )
+    assert matches2[0]["status_inferred"] is True
+
+
+# ---------------------------------------------------------------------------
+# Liveness exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_mirrored_row_not_promoted_to_running_by_local_process_scan(client, stores, mirror_root, monkeypatch):
+    """A mirrored session's cwd matching a LOCAL live `claude` process must
+    NOT promote it to `running` — that would be a false liveness signal for
+    a process that isn't actually on this machine. Contrast with an
+    equivalent LOCAL row, which the live-process-scan liveness check DOES
+    promote."""
+    cc_dir = mirror_root / "laptop" / "claude_code" / "-home-user-proj"
+    _write_cc_transcript(cc_dir / "sess-4.jsonl", "sess-4")
+    # Old mtime so the mtime-only heuristic alone would NOT say "running".
+    import os
+    old = time.time() - 3600
+    os.utime(cc_dir / "sess-4.jsonl", (old, old))
+
+    from api.services.claude_code import session_ingest as cc
+    # Pretend a LOCAL claude process has this cwd live — if liveness
+    # exclusion is broken (live_counts=None instead of {} for mirrored
+    # rows), this would promote the mirrored row to `running`.
+    monkeypatch.setattr(cc, "live_claude_cwd_counts", lambda now=None: {"/home/user/proj": 1})
+    cc.invalidate_cache()
+
+    r = client.get("/api/agents/snapshot")
+    matches = [s for s in r.json()["sessions"] if s["session_id"] == "cc:sess-4"]
+    assert len(matches) == 1
+    assert matches[0]["status"] != "running"
+    assert matches[0]["status_inferred"] is True  # never touched by the (excluded) process scan
+
+    # Contrast: an equivalent LOCAL (non-mirrored) session in the SAME cwd
+    # with the SAME old mtime DOES get promoted — proving the local process
+    # scan itself still works and the mirrored row is being deliberately
+    # excluded, not just failing to match for an unrelated reason.
+    local_projects_dir = mirror_root.parent / "local-claude-projects"
+    local_cc_dir = local_projects_dir / "-home-user-proj"
+    _write_cc_transcript(local_cc_dir / "sess-4-local.jsonl", "sess-4-local")
+    os.utime(local_cc_dir / "sess-4-local.jsonl", (old, old))
+    from config.settings import settings
+    monkeypatch.setattr(settings, "claude_code_projects_dir", str(local_projects_dir), raising=False)
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", _REAL_CLAUDE_CODE_SNAPSHOT)
+    cc.invalidate_cache()
+
+    r2 = client.get("/api/agents/snapshot")
+    local_matches = [s for s in r2.json()["sessions"] if s["session_id"] == "cc:sess-4-local"]
+    assert len(local_matches) == 1
+    assert local_matches[0]["status"] == "running"
+    assert local_matches[0]["status_inferred"] is False
+
+
+def test_mirrored_codex_row_not_promoted_to_running_by_local_process_scan(client, stores, mirror_root, monkeypatch):
+    """Codex sibling of the claude_code liveness-exclusion test above —
+    `cx.build_snapshot`'s own `live_counts` parameter must be honored the
+    same way."""
+    cx_dir = mirror_root / "studio" / "codex" / "2026" / "08" / "01"
+    cx_dir.mkdir(parents=True)
+    rollout = cx_dir / "rollout-2026-08-01T00-00-00-cx-sess-5.jsonl"
+    lines = [
+        {"type": "session_meta", "timestamp": _iso(-3700), "payload": {"cwd": "/home/user/proj5"}},
+        {"type": "event_msg", "timestamp": _iso(-3700), "payload": {"type": "user_message", "message": "hi"}},
+    ]
+    with rollout.open("w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+    import os
+    old = time.time() - 3600
+    os.utime(rollout, (old, old))
+
+    from api.services.codex import session_ingest as cx
+    # Pretend a LOCAL codex process has this cwd live — if liveness
+    # exclusion is broken, this would promote the mirrored row to `running`.
+    monkeypatch.setattr(cx, "live_codex_cwd_counts", lambda now=None: {"/home/user/proj5": 1})
+    cx.invalidate_cache()
+
+    r = client.get("/api/agents/snapshot")
+    matches = [s for s in r.json()["sessions"] if s["session_id"] == "cx:cx-sess-5"]
+    assert len(matches) == 1
+    assert matches[0]["status"] != "running"
+    assert matches[0]["status_inferred"] is True
+
+
+# ---------------------------------------------------------------------------
+# Id collision — local transcript wins
+# ---------------------------------------------------------------------------
+
+
+def test_id_collision_local_transcript_wins_single_row(client, stores, mirror_root, monkeypatch):
+    session_id = "collide-1"
+    _write_cc_transcript(
+        mirror_root / "laptop" / "claude_code" / "-home-user-proj" / f"{session_id}.jsonl", session_id,
+    )
+
+    local_row = {
+        "session_id": f"cc:{session_id}",
+        "task_id": session_id,
+        "status": "inactive",
+        "routing": "claude_code",
+        "parent_session_id": None,
+        "root_session_id": f"cc:{session_id}",
+        "spawn_depth": 0,
+        "yield_waiting_for": [],
+        "managed_agent_session_id": None,
+        "started_at": 1000,
+        "last_activity_at": 2000,
+        "total_input_tokens": 999,  # deliberately different from the mirrored copy
+        "total_output_tokens": 999,
+        "total_cache_creation_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "total_dollars": 0.0,
+        "total_active_seconds": 0.0,
+        "expected_output": None,
+        "label": "local-copy",
+        "model_label": "Sonnet",
+        "last_event_kind": "assistant",
+        "tool_call_count": 0,
+        "error_count": 0,
+        "source": "claude_code",
+        "status_inferred": True,
+        "project_key": "-home-user-proj",
+        "decoded_cwd": "/home/user/proj",
+    }
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", lambda: ([local_row], []))
+
+    r = client.get("/api/agents/snapshot")
+    matches = [s for s in r.json()["sessions"] if s["session_id"] == f"cc:{session_id}"]
+    assert len(matches) == 1  # exactly one row despite existing in both sources
+    assert matches[0]["total_input_tokens"] == 999  # the LOCAL copy's data, not the mirrored one's
+    assert matches[0].get("mirrored") is not True
+
+
+def test_id_collision_does_not_reparent_mirrored_subagent_onto_local_row(
+    client, stores, mirror_root, monkeypatch,
+):
+    """`cc:collide-2` exists LOCALLY (no subagent) and is
+    separately MIRRORED from `studio` WITH a subagent spawn. The id
+    collision means the local row wins (same as the test above) — but the
+    mirrored session's spawn edge must NOT survive by attaching itself to
+    the (unrelated) local row that happens to share the id: that would
+    show the LOCAL session spawning a subagent it never spawned. Mutation-
+    proved: reverting the edge filter to check `from`/`to` against the
+    broader `local_ids` (which already contains every collided id) instead
+    of `appended_mirrored_ids` makes this edge reappear."""
+    from tests.test_claude_code_ingest import _assistant_event
+
+    session_id = "collide-2"
+    proj = mirror_root / "studio" / "claude_code" / "-remote-elsewhere"
+    proj.mkdir(parents=True)
+    with (proj / f"{session_id}.jsonl").open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_assistant_event(tool_uses=[
+            {"id": "tu_collide_2", "name": "Agent", "input": {"prompt": "child task"}},
+        ])) + "\n")
+
+    local_row = {
+        "session_id": f"cc:{session_id}",
+        "task_id": session_id,
+        "status": "inactive",
+        "routing": "claude_code",
+        "parent_session_id": None,
+        "root_session_id": f"cc:{session_id}",
+        "spawn_depth": 0,
+        "yield_waiting_for": [],
+        "managed_agent_session_id": None,
+        "started_at": 1000,
+        "last_activity_at": 2000,
+        "total_input_tokens": 111,
+        "total_output_tokens": 111,
+        "total_cache_creation_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "total_dollars": 0.0,
+        "total_active_seconds": 0.0,
+        "expected_output": None,
+        "label": "local-copy",
+        "model_label": "Sonnet",
+        "last_event_kind": "assistant",
+        "tool_call_count": 0,
+        "error_count": 0,
+        "source": "claude_code",
+        "status_inferred": True,
+        "project_key": "-home-user-localproj",
+        "decoded_cwd": "/home/user/localproj",
+    }
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", lambda: ([local_row], []))
+
+    r = client.get("/api/agents/snapshot")
+    body = r.json()
+    matches = [s for s in body["sessions"] if s["session_id"] == f"cc:{session_id}"]
+    assert len(matches) == 1
+    assert matches[0]["decoded_cwd"] == "/home/user/localproj"  # the local row won, as above
+
+    # The child subagent row itself doesn't collide (its id is derived
+    # from the tool_use id) and still gets mirrored in as its own row —
+    # but no edge should point FROM the collided parent id at all.
+    ids = [s["session_id"] for s in body["sessions"]]
+    child_id = next((i for i in ids if ":agent:tu_collide_2" in i), None)
+    assert child_id is not None, f"expected the mirrored subagent's own row, got {ids}"
+    assert not any(
+        e["type"] == "spawn" and e["from"] == f"cc:{session_id}"
+        for e in body["edges"]
+    ), f"a collided mirrored session's spawn edge leaked onto the local row: {body['edges']}"
+
+
+def test_mirrored_spawn_edge_not_duplicated_when_mirrored_from_two_hosts(
+    client, stores, mirror_root,
+):
+    """The identical session+subagent transcript mirrored
+    from TWO hosts must not emit the same spawn edge twice — each host's
+    own `cc.build_snapshot()` call independently derives the same
+    `(from, to, type)` edge, and only ONE copy should survive the merge."""
+    from tests.test_claude_code_ingest import _assistant_event
+
+    payload = json.dumps(_assistant_event(tool_uses=[
+        {"id": "tu_dup_1", "name": "Agent", "input": {"prompt": "child task"}},
+    ])) + "\n"
+    for host in ("hostA", "hostB"):
+        proj = mirror_root / host / "claude_code" / "-remote-dupproj"
+        proj.mkdir(parents=True)
+        (proj / "dup-sess.jsonl").write_text(payload)
+
+    r = client.get("/api/agents/snapshot")
+    body = r.json()
+    spawn_edges = [
+        e for e in body["edges"]
+        if e["type"] == "spawn" and e["from"] == "cc:dup-sess"
+    ]
+    assert len(spawn_edges) == 1, f"expected exactly one spawn edge, got {spawn_edges}"
+
+
+def test_mirrored_vs_mirrored_id_collision_does_not_reparent_subagent_across_hosts(
+    client, stores, mirror_root,
+):
+    """`test_id_collision_does_not_reparent_mirrored_subagent_onto_local_row`
+    above covers the local-vs-mirrored id-collision edge leak; this covers
+    the MIRRORED-vs-MIRRORED case: the same session id present on TWO
+    mirrored hosts (e.g. two `LIFEOS_AGENT_HOSTS` entries resolving to the
+    same machine) must not re-parent a subagent edge across hosts.
+    `hostA` mirrors `cc:shared-parent` with no subagent;
+    `hostB` mirrors a DIFFERENT session that happens to carry the SAME id
+    `cc:shared-parent`, WITH a subagent spawn. `hostA` sorts first
+    (`_mirrored_host_dirs()` is alphabetical), so `hostA`'s row wins the id
+    collision and is the one actually present in the final snapshot under
+    `cc:shared-parent`. `hostB`'s child subagent row doesn't collide (its id
+    is derived from the tool_use id) and is mirrored in as its own row —
+    but the spawn edge `cc:shared-parent -> child` must NOT survive: the
+    parent id in the snapshot belongs to `hostA`'s unrelated session, not
+    `hostB`'s. Mutation-proved: reverting to a flat appended-ids SET
+    (dropping the per-host mapping) makes this edge reappear, because
+    `cc:shared-parent` and the child id are both "appended" ids even though
+    they came from different hosts' batches."""
+    from tests.test_claude_code_ingest import _assistant_event
+
+    session_id = "shared-parent"
+    proj_a = mirror_root / "hostA" / "claude_code" / "-remote-hosta-proj"
+    proj_a.mkdir(parents=True)
+    (proj_a / f"{session_id}.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": _iso(-10),
+                    "message": {"role": "user", "content": "hello from hostA"}}) + "\n"
+    )
+
+    proj_b = mirror_root / "hostB" / "claude_code" / "-remote-hostb-proj"
+    proj_b.mkdir(parents=True)
+    (proj_b / f"{session_id}.jsonl").write_text(
+        json.dumps(_assistant_event(tool_uses=[
+            {"id": "tu_reparent", "name": "Agent", "input": {"prompt": "child task"}},
+        ])) + "\n"
+    )
+
+    r = client.get("/api/agents/snapshot")
+    body = r.json()
+    matches = [s for s in body["sessions"] if s["session_id"] == f"cc:{session_id}"]
+    assert len(matches) == 1
+    assert matches[0]["host"] == "hostA"  # confirms hostA's row is the one that won
+
+    ids = [s["session_id"] for s in body["sessions"]]
+    child_id = next((i for i in ids if ":agent:tu_reparent" in i), None)
+    assert child_id is not None, f"expected hostB's mirrored subagent row, got {ids}"
+    assert any(s["session_id"] == child_id and s["host"] == "hostB" for s in body["sessions"])
+
+    assert not any(
+        e["type"] == "spawn" and e["from"] == f"cc:{session_id}" and e["to"] == child_id
+        for e in body["edges"]
+    ), (
+        f"hostB's subagent edge re-parented onto hostA's unrelated "
+        f"cc:{session_id} row: {body['edges']}"
+    )

--- a/tests/test_agent_viz_api.py
+++ b/tests/test_agent_viz_api.py
@@ -57,6 +57,17 @@ def test_snapshot_empty(client, stores):
 
 
 @pytest.mark.unit
+def test_snapshot_reports_api_host(client, stores, monkeypatch):
+    """The drawer's "resume here" host picker needs the
+    API host's own name to build its fallback list even when
+    `GET /api/agents/hosts` isn't reachable — /snapshot must carry it."""
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "synthetic-api-host")
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    assert r.json()["api_host"] == "synthetic-api-host"
+
+
+@pytest.mark.unit
 def test_snapshot_sessions_and_edges(client, stores):
     session_store, transcript_store = stores
     parent = session_store.create(task_id="root-task", status=STATUS_RUNNING, routing="claude")

--- a/tests/test_agents_resume_here_ui_browser.py
+++ b/tests/test_agents_resume_here_ui_browser.py
@@ -532,7 +532,7 @@ GRAPH_SNAPSHOT_RUNNING = {
             "total_output_tokens": 20,
             "total_dollars": 0.01,
             "spawn_depth": 0,
-            "label": "graph-resume-target",
+            "label": "Graph resume target session",
             "custom_label": None,
             "short_label": None,
             "is_subagent": False,
@@ -583,8 +583,8 @@ def _open_graph_panel_on_running_session(page: Page, base_url, pending_stream_ro
     # the Graph tab's static markup is unhidden.
     page.wait_for_selector("#search-input")
     page.select_option("#filter-recency", "all")
-    page.locator("#search-input").fill("graph-resume-target")
-    result = page.locator(".search-result", has_text="graph-resume-target")
+    page.locator("#search-input").fill("resume target session")
+    result = page.locator(".search-result", has_text="resume target session")
     expect(result).to_be_visible()
     result.click()
 

--- a/tests/test_agents_resume_here_ui_browser.py
+++ b/tests/test_agents_resume_here_ui_browser.py
@@ -1,0 +1,633 @@
+"""Browser test for the /agents drawer's "resume here" control.
+
+Serves `web/` itself from an ephemeral port (like
+`test_agents_board_ui_browser.py` / `test_voice_mic_block_ui_browser.py`)
+and stubs every `/api/` call the page makes, including `GET
+/api/agents/hosts` — the assertions are about the JS in
+`web/agents/panel.js`, not the live backend. No `requires_server` marker,
+so this runs at pre-push (`browser and not requires_server`).
+
+Covers: the resume-host `<select>` lists the API host plus every registry
+host, choosing a host and clicking Resume sends `target_host` in the POST
+body, and a stubbed 400 whose detail carries a `command` renders it as
+copyable text in the drawer instead of only a toast.
+"""
+import copy
+import http.server
+import json
+import re
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+# Obviously synthetic — same shape GET /api/agents/hosts returns.
+_HOSTS_FIXTURE = {
+    "hosts": [
+        {"name": "studio", "ssh_target": "", "online": True, "is_api_host": True},
+        {"name": "laptop", "ssh_target": "user@laptop.example", "online": True, "is_api_host": False},
+    ],
+    "refreshed_at": "2026-01-01T00:00:00Z",
+}
+
+_MODEL_CATALOG = {
+    "engines": {"claude": [], "codex": [], "local": [], "hermes": []},
+    "refreshed_at": "2026-01-01T00:00:00Z",
+    "stale": False,
+}
+
+_SESSION_CARD = {
+    "kind": "task", "id": "t1", "title": "Fix the flaky test",
+    "notes": "", "status": "in_progress", "tags": ["claude"], "assignee": "claude",
+    "fields": {}, "context": "Work", "updated_at": "2026-01-01T00:00:00+00:00",
+    "pending_question": None,
+    "session": {
+        "session_id": "cc:test-session-1",
+        "source": "claude_code",
+        "routing": "claude_code",
+        "status": "inactive",
+        "status_inferred": True,
+        "host": "laptop",
+        "branch": "",
+        "prompt_preview": "",
+        "decoded_cwd": "/home/user/proj",
+        "total_dollars": 0.01,
+        "total_input_tokens": 10,
+        "total_output_tokens": 20,
+        "spawn_depth": 0,
+        "label": "Test session",
+        "custom_label": None,
+        "short_label": None,
+        "is_subagent": False,
+    },
+}
+
+
+def _board_fixture(card=None):
+    return {
+        "lanes": {
+            "unassigned": [], "assigned": [card or _SESSION_CARD], "in_progress": [],
+            "human_queue": [], "scheduled": [], "review": [], "done": [],
+        },
+        "generated_at": 0,
+    }
+
+
+def _session_card(**session_overrides):
+    """Deep copy of `_SESSION_CARD` with `session` field overrides — lets a
+    test vary the linked session's `host` (or other fields) without
+    mutating the shared module-level fixture."""
+    card = copy.deepcopy(_SESSION_CARD)
+    card["session"].update(session_overrides)
+    return card
+
+
+class _AgentsHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the agents board the way api/main.py does: `/agents` is
+    agents.html and the module tree hangs off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/agents", "/"):
+            return str(WEB_DIR / "agents.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def agents_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _AgentsHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _open_board_with_drawer(
+    page: Page, base_url, *, resume_status=200, resume_detail=None,
+    hosts_status=200, hosts_fixture=None, hang_hosts=False, snapshot_api_host=None,
+    capture_focus=False, focus_status=200, focus_detail=None,
+    card=None, omit_api_host=False, pending_stream_routes=None,
+):
+    """Loads /agents, stubs every API call, opens the one card's drawer
+    (which mounts a SessionPanel for its linked `claude_code` session),
+    and returns the list of parsed JSON bodies posted to .../resume (or,
+    with `capture_focus=True`, a `(resume_calls, focus_calls)` pair).
+
+    `hosts_status`/`hosts_fixture` let a test simulate GET /api/agents/hosts
+    404ing (unavailable) or returning a custom host list; `hang_hosts`
+    simulates it never responding at all (never calls `route.fulfill`, so
+    the request stays pending — Playwright's documented pattern for a
+    loading-state test). `snapshot_api_host` feeds GET /api/agents/snapshot's
+    `api_host` field the resume-host fallback reads when /hosts is
+    unavailable. `pending_stream_routes`, when given a list, appends
+    `GET /api/agents/board/stream`'s (board.js's `EventSource`) Playwright
+    `route` object to it WITHOUT fulfilling — letting a test fulfill it
+    itself, later, once the drawer's PRE-update state has already been
+    asserted. Fulfilling inside this helper's own
+    handler would race the initial render, since `connectStream()` opens
+    this connection at page load, before the test's click ever happens.
+    """
+    resume_calls: list[dict] = []
+    focus_calls: list[dict] = []
+
+    def handler(route):
+        req = route.request
+        url = req.url
+        if url.endswith("/api/agents/board/stream"):
+            if pending_stream_routes is not None:
+                pending_stream_routes.append(route)
+            return  # never fulfilled here — inert unless a test fulfills it later
+        if re.search(r"/api/agents/board(\?|$)", url):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(_board_fixture(card)))
+            return
+        if url.endswith("/api/agents/hosts"):
+            if hang_hosts:
+                return  # never fulfilled — simulates a hanging endpoint
+            body = hosts_fixture if hosts_fixture is not None else _HOSTS_FIXTURE
+            route.fulfill(status=hosts_status, content_type="application/json", body=json.dumps(body))
+            return
+        if re.search(r"/api/agents/snapshot(\?|$)", url):
+            payload = {"sessions": [], "edges": [], "generated_at": 0}
+            # `omit_api_host` simulates a snapshot
+            # response that genuinely carries no `api_host` field (as
+            # opposed to `snapshot_api_host` below, which supplies one) —
+            # `_apiHostName()` treats a missing/non-string field as
+            # "unknown", not as the empty string.
+            if not omit_api_host:
+                payload["api_host"] = snapshot_api_host or "synthetic-api-host"
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(payload))
+            return
+        if url.endswith("/api/agents/models"):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(_MODEL_CATALOG))
+            return
+        if re.search(r"/sessions/[^/]+/summary", url):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps({"short_label": "", "body": ""}))
+            return
+        if re.search(r"/sessions/[^/]+/events", url):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps({"events": [], "total": 0}))
+            return
+        if re.search(r"/sessions/[^/]+/resume", url) and req.method == "POST":
+            try:
+                resume_calls.append(json.loads(req.post_data or "{}"))
+            except json.JSONDecodeError:
+                resume_calls.append({})
+            if resume_status == 200:
+                body = {
+                    "spawned": True, "pid": 4242, "pane_id": None,
+                    "command": [], "cwd": "/home/user/proj",
+                    "inner_command": "", "clipboard_copied": False,
+                }
+            else:
+                body = {"detail": resume_detail}
+            route.fulfill(status=resume_status, content_type="application/json", body=json.dumps(body))
+            return
+        if re.search(r"/sessions/[^/]+/focus", url) and req.method == "POST":
+            try:
+                focus_calls.append(json.loads(req.post_data or "{}"))
+            except json.JSONDecodeError:
+                focus_calls.append({})
+            if focus_status == 200:
+                body = {"focused": True}
+            else:
+                body = {"detail": focus_detail}
+            route.fulfill(status=focus_status, content_type="application/json", body=json.dumps(body))
+            return
+        # Default: stub anything else empty so nothing depends on a live server.
+        route.fulfill(status=200, content_type="application/json", body="{}")
+
+    page.route("**/api/**", handler)
+    page.set_viewport_size({"width": 1280, "height": 800})
+    page.goto(f"{base_url}/agents")
+    page.wait_for_selector('.board-card[data-card-id="t1"]')
+    page.locator('.board-card[data-card-id="t1"]').click()
+    page.wait_for_selector('[data-action="resume"]')
+    if capture_focus:
+        return resume_calls, focus_calls
+    return resume_calls
+
+
+class TestResumeHostSelect:
+    def test_select_lists_api_host_and_registry_hosts(self, page: Page, agents_base_url):
+        _open_board_with_drawer(page, agents_base_url)
+        select = page.locator('[data-action="resume-host"]')
+        expect(select).to_be_visible()
+        options = select.locator("option").all_inner_texts()
+        assert any("studio" in o for o in options), options
+        assert any("this machine" in o for o in options), options
+        assert any(o.strip() == "laptop" for o in options), options
+
+
+class TestResumeSendsTargetHost:
+    def test_choosing_host_and_clicking_resume_sends_target_host(self, page: Page, agents_base_url):
+        resume_calls = _open_board_with_drawer(page, agents_base_url)
+        page.locator('[data-action="resume-host"]').select_option("laptop")
+        with page.expect_response(lambda r: "/resume" in r.url):
+            page.locator('[data-action="resume"]').click()
+        assert resume_calls, "no resume POST was captured"
+        assert resume_calls[-1].get("target_host") == "laptop"
+
+    def test_choosing_a_different_host_sends_that_one(self, page: Page, agents_base_url):
+        resume_calls = _open_board_with_drawer(page, agents_base_url)
+        page.locator('[data-action="resume-host"]').select_option("studio")
+        with page.expect_response(lambda r: "/resume" in r.url):
+            page.locator('[data-action="resume"]').click()
+        assert resume_calls[-1].get("target_host") == "studio"
+
+
+class TestResumeCommandOn400:
+    def test_400_with_command_renders_copyable_command_text(self, page: Page, agents_base_url):
+        expected_command = "cd /home/user/proj && claude --resume test-session-1"
+        _open_board_with_drawer(
+            page, agents_base_url, resume_status=400,
+            resume_detail={
+                "error": "host 'ghost' is not this API host and not in LIFEOS_AGENT_HOSTS",
+                "command": expected_command,
+            },
+        )
+        with page.expect_response(lambda r: "/resume" in r.url):
+            page.locator('[data-action="resume"]').click()
+
+        code = page.locator('[data-field="resume-command-text"]')
+        expect(code).to_be_visible()
+        expect(code).to_have_text(expected_command)
+
+    def test_a_200_response_does_not_show_the_command_box(self, page: Page, agents_base_url):
+        _open_board_with_drawer(page, agents_base_url)
+        box = page.locator('[data-field="resume-command"]')
+        # Present in the DOM (rendered whenever Resume is shown) but hidden
+        # until a 400-with-command response actually populates it.
+        expect(box).to_be_hidden()
+        with page.expect_response(lambda r: "/resume" in r.url):
+            page.locator('[data-action="resume"]').click()
+        expect(box).to_be_hidden()
+
+
+class TestResumeHostSelectFallback:
+    """When GET /api/agents/hosts is unavailable or fails, the select must
+    still offer a real, selectable API host — not just the session's own
+    recorded host."""
+
+    def test_404_hosts_endpoint_falls_back_to_api_host_and_session_host(self, page: Page, agents_base_url):
+        _open_board_with_drawer(page, agents_base_url, hosts_status=404, snapshot_api_host="fallback-api-host")
+        select = page.locator('[data-action="resume-host"]')
+        expect(select.locator("option")).to_have_count(2)
+        options = select.locator("option").all_inner_texts()
+        assert any("fallback-api-host" in o and "this machine" in o for o in options), options
+        assert any(o.strip() == "laptop" for o in options), options
+        # And it must be a real, selectable option — not decorative text.
+        select.select_option("fallback-api-host")
+        assert select.input_value() == "fallback-api-host"
+
+    def test_hanging_hosts_endpoint_falls_back_after_timeout(self, page: Page, agents_base_url):
+        """The fetch carries an AbortSignal.timeout, so
+        a GET /api/agents/hosts that never responds doesn't permanently
+        leave the select with zero options."""
+        _open_board_with_drawer(page, agents_base_url, hang_hosts=True, snapshot_api_host="hang-fallback-host")
+        select = page.locator('[data-action="resume-host"]')
+        expect(select.locator("option")).to_have_count(2, timeout=8000)
+        options = select.locator("option").all_inner_texts()
+        assert any("hang-fallback-host" in o and "this machine" in o for o in options), options
+        assert any(o.strip() == "laptop" for o in options), options
+
+
+class TestResumeHostOptionValue:
+    def test_dotted_host_name_option_value_matches_display_text(self, page: Page, agents_base_url):
+        """`escapeAttr` builds the option's
+        `value=` attribute from a template string, replacing every char
+        outside `[a-zA-Z0-9_-]` with `_` — a dotted host like
+        `mac-mini.local` must display correctly and NOT post the mangled
+        `mac-mini_local`. Options are now built via
+        `document.createElement('option')` with `.value` assigned as a
+        property, so the posted value matches the registry name exactly."""
+        dotted_hosts = {
+            "hosts": [
+                {"name": "studio", "ssh_target": "", "online": True, "is_api_host": True},
+                {"name": "mac-mini.local", "ssh_target": "user@mac-mini.local", "online": True, "is_api_host": False},
+            ],
+            "refreshed_at": "2026-01-01T00:00:00Z",
+        }
+        resume_calls = _open_board_with_drawer(page, agents_base_url, hosts_fixture=dotted_hosts)
+        select = page.locator('[data-action="resume-host"]')
+        select.select_option("mac-mini.local")
+        with page.expect_response(lambda r: "/resume" in r.url):
+            page.locator('[data-action="resume"]').click()
+        assert resume_calls, "no resume POST was captured"
+        assert resume_calls[-1].get("target_host") == "mac-mini.local"
+
+
+class TestResumeHostsValidation:
+    def test_hosts_response_with_invalid_rows_is_filtered(self, page: Page, agents_base_url):
+        """Round-1 finding #17: a row with no non-empty string `name`
+        (missing, or explicitly null) must not render as a bogus
+        'null'/'undefined' option that would post a bogus target_host."""
+        bad_hosts = {
+            "hosts": [
+                {"name": "studio", "is_api_host": True},
+                {"name": None, "is_api_host": True},
+                {"is_api_host": False},
+                {"name": "laptop", "is_api_host": False},
+            ],
+        }
+        _open_board_with_drawer(page, agents_base_url, hosts_fixture=bad_hosts)
+        select = page.locator('[data-action="resume-host"]')
+        options = select.locator("option").all_inner_texts()
+        assert not any(("null" in o or "undefined" in o) for o in options), options
+        assert any(o.strip() == "laptop" for o in options), options
+        expect(select.locator("option")).to_have_count(2)
+
+
+class TestFocusSendsTargetHost:
+    """`_focusSession` must send the selected
+    resume-host as `target_host` — the UI side of the backend's `/focus`
+    `target_host` param."""
+
+    def test_focus_sends_selected_target_host(self, page: Page, agents_base_url):
+        _resume_calls, focus_calls = _open_board_with_drawer(page, agents_base_url, capture_focus=True)
+        page.locator('[data-action="resume-host"]').select_option("studio")
+        with page.expect_response(lambda r: "/focus" in r.url):
+            page.locator('[data-action="focus"]').click()
+        assert focus_calls, "no focus POST was captured"
+        assert focus_calls[-1].get("target_host") == "studio"
+
+    def test_focus_400_with_command_renders_copyable_command_text(self, page: Page, agents_base_url):
+        """The other half of finding #13: a 400 whose detail carries
+        `{error, command}` must render as readable, copyable text — the
+        same handling `_resumeSession` already has — not `[object Object]`."""
+        expected_command = "cd /home/user/proj && claude --resume test-session-1"
+        _resume_calls, _focus_calls = _open_board_with_drawer(
+            page, agents_base_url, capture_focus=True, focus_status=400,
+            focus_detail={
+                "error": "host 'ghost' is not this API host and not in LIFEOS_AGENT_HOSTS",
+                "command": expected_command,
+            },
+        )
+        with page.expect_response(lambda r: "/focus" in r.url):
+            page.locator('[data-action="focus"]').click()
+        code = page.locator('[data-field="resume-command-text"]')
+        expect(code).to_be_visible()
+        expect(code).to_have_text(expected_command)
+
+
+class TestResumeHostSelectIncludesSessionsOwnHost:
+    """The registry list from `GET /api/agents/hosts`
+    alone may not include this session's own recorded host — e.g. it was
+    registered by the hook on a machine not listed in LIFEOS_AGENT_HOSTS.
+    Without adding it, the select defaults to its first option (the API
+    host after the `is_api_host` sort) and "Go To"/"Resume" silently
+    target the wrong machine."""
+
+    def test_session_host_missing_from_registry_is_added_and_selected(self, page: Page, agents_base_url):
+        card = _session_card(host="orchard")  # not in _HOSTS_FIXTURE
+        _open_board_with_drawer(page, agents_base_url, card=card)
+        select = page.locator('[data-action="resume-host"]')
+        options = select.locator("option").all_inner_texts()
+        assert any(o.strip() == "orchard" for o in options), options
+        assert select.input_value() == "orchard"
+
+    def test_resume_still_targets_the_added_session_host_by_default(self, page: Page, agents_base_url):
+        card = _session_card(host="orchard")
+        resume_calls = _open_board_with_drawer(page, agents_base_url, card=card)
+        with page.expect_response(lambda r: "/resume" in r.url):
+            page.locator('[data-action="resume"]').click()
+        assert resume_calls, "no resume POST was captured"
+        assert resume_calls[-1].get("target_host") == "orchard"
+
+
+class TestNoKnowableHostOmitsTargetHost:
+    """When neither `/api/agents/hosts` nor
+    `/api/agents/snapshot`'s `api_host` resolves AND the session itself
+    carries no recorded host, there is nothing real to offer — the select
+    must not fall back to sending the human-readable placeholder "this
+    host" as a machine identifier (a 400 in practice)."""
+
+    def test_placeholder_option_has_empty_value(self, page: Page, agents_base_url):
+        card = _session_card(host="")
+        _open_board_with_drawer(page, agents_base_url, card=card, hosts_status=404, omit_api_host=True)
+        select = page.locator('[data-action="resume-host"]')
+        expect(select.locator("option")).to_have_count(1)
+        assert select.input_value() == ""
+
+    def test_resume_omits_target_host_entirely(self, page: Page, agents_base_url):
+        card = _session_card(host="")
+        resume_calls = _open_board_with_drawer(
+            page, agents_base_url, card=card, hosts_status=404, omit_api_host=True,
+        )
+        with page.expect_response(lambda r: "/resume" in r.url):
+            page.locator('[data-action="resume"]').click()
+        assert resume_calls, "no resume POST was captured"
+        assert "target_host" not in resume_calls[-1]
+
+
+class TestUpdateMetaHidesResumeWhenSessionGoesLive:
+    """`updateMeta` (the in-place refresh a board SSE
+    tick uses) must re-evaluate `showResume` — a mirrored session
+    commonly opens `inactive` (Resume + host select rendered) and later
+    flips to `running` via a hook event with no full re-render in
+    between. The stale controls must be hidden once the session is
+    actually live, not just at the next full drawer open."""
+
+    def test_resume_and_select_hide_when_status_flips_to_running(self, page: Page, agents_base_url):
+        """The drawer must be FOCUSED (e.g. the operator mid-edit in
+        Notes) for this to isolate `updateMeta` specifically:
+        `updateOpenDrawer` (board.js) skips its full drawer rebuild
+        (`renderDrawer`, which would reopen the panel from scratch and
+        incidentally recompute `showResume` correctly on its own) while
+        the drawer has focus — `panel.updateMeta` is the ONLY thing that
+        still runs in that case, which is exactly the reachable scenario
+        finding #8 reported live."""
+        running_card = _session_card(status="running", status_inferred=False)
+        pending_routes = []
+        _open_board_with_drawer(page, agents_base_url, pending_stream_routes=pending_routes)
+        resume_btn = page.locator('[data-action="resume"]')
+        select = page.locator('[data-action="resume-host"]')
+        # Pre-update state, asserted BEFORE any SSE frame is sent — proves
+        # this is a live transition, not the initial render already having
+        # the running status baked in.
+        expect(resume_btn).to_be_visible()
+        expect(select).to_be_visible()
+        page.locator('[data-field="notes"]').click()
+
+        assert pending_routes, "no SSE connection to /api/agents/board/stream was captured"
+        frame = "event: board\ndata: " + json.dumps(_board_fixture(running_card)) + "\n\n"
+        pending_routes[0].fulfill(status=200, content_type="text/event-stream", body=frame)
+
+        expect(resume_btn).to_be_hidden(timeout=8000)
+        expect(select).to_be_hidden(timeout=8000)
+
+    def test_resume_and_select_reappear_if_status_goes_back_inactive(self, page: Page, agents_base_url):
+        """Contrast case: the toggle must work in both directions, not
+        just hide-and-forget — a session that goes live and later becomes
+        resumable again must show Resume/select once more. Kept focused
+        throughout for the same reason as the test above."""
+        running_card = _session_card(status="running", status_inferred=False)
+        inactive_again_card = _session_card(status="inactive", status_inferred=True)
+        pending_routes = []
+        _open_board_with_drawer(page, agents_base_url, pending_stream_routes=pending_routes)
+        resume_btn = page.locator('[data-action="resume"]')
+        select = page.locator('[data-action="resume-host"]')
+        expect(resume_btn).to_be_visible()
+        page.locator('[data-field="notes"]').click()
+
+        assert pending_routes, "no SSE connection to /api/agents/board/stream was captured"
+        # `retry: 50` tells EventSource to reconnect quickly once this
+        # response ends, so the second frame below can ride the natural
+        # reconnect instead of waiting out the ~3s browser default.
+        frame1 = "retry: 50\nevent: board\ndata: " + json.dumps(_board_fixture(running_card)) + "\n\n"
+        pending_routes[0].fulfill(status=200, content_type="text/event-stream", body=frame1)
+        expect(resume_btn).to_be_hidden(timeout=8000)
+        expect(select).to_be_hidden(timeout=8000)
+
+        for _ in range(50):
+            if len(pending_routes) >= 2:
+                break
+            page.wait_for_timeout(100)
+        assert len(pending_routes) >= 2, "SSE did not reconnect after the first frame"
+        frame2 = "event: board\ndata: " + json.dumps(_board_fixture(inactive_again_card)) + "\n\n"
+        pending_routes[1].fulfill(status=200, content_type="text/event-stream", body=frame2)
+
+        expect(resume_btn).to_be_visible(timeout=8000)
+        expect(select).to_be_visible(timeout=8000)
+
+
+# ---------------------------------------------------------------------------
+# The Board-tab tests above all open the drawer on an `inactive` card, so
+# the elements are already rendered before `updateMeta` ever runs. That
+# doesn't exercise a drawer opened on a `running` session: `_renderHeader`
+# always creates the Resume button and host select (hidden when
+# `!showResume`), so `updateMeta`'s `querySelector` lookups find them and
+# the toggle can show them once the session ends — the routine case
+# (every session ends). The Graph tab is the tab where this path is
+# unconditionally reachable — panel.open() only runs on node/search-result
+# click, and the only refresh path once the panel is open is graph.js's
+# applySnapshot -> panel.updateMeta (no full re-render on every tick, unlike
+# the Board tab's unfocused-drawer self-heal).
+# ---------------------------------------------------------------------------
+
+GRAPH_SNAPSHOT_RUNNING = {
+    "sessions": [
+        {
+            "session_id": "cc:graph-resume-target",
+            "status": "running",
+            "status_inferred": False,
+            "routing": "claude_code",
+            "source": "claude_code",
+            "host": "laptop",
+            "branch": "",
+            "prompt_preview": "",
+            "started_at": 1000,
+            "last_activity_at": 2000,
+            "total_input_tokens": 10,
+            "total_output_tokens": 20,
+            "total_dollars": 0.01,
+            "spawn_depth": 0,
+            "label": "graph-resume-target",
+            "custom_label": None,
+            "short_label": None,
+            "is_subagent": False,
+            "decoded_cwd": "/home/synthetic/proj",
+        },
+    ],
+    "edges": [],
+    "generated_at": 1234567890,
+}
+
+
+def _open_graph_panel_on_running_session(page: Page, base_url, pending_stream_routes):
+    """Loads /agents, opens the Graph tab, and opens the side panel for a
+    session whose INITIAL status is `running` — the case the Board-tab
+    helper above never reaches, since its fixture card always starts
+    `inactive`. Captures (without fulfilling) the Graph tab's own
+    `GET /api/agents/stream` EventSource route in `pending_stream_routes`
+    so the test can push a later snapshot frame itself, after the
+    pre-transition state has already been asserted."""
+
+    def handler(route):
+        req = route.request
+        url = req.url
+        if url.endswith("/api/agents/stream"):
+            pending_stream_routes.append(route)
+            return  # never fulfilled here — captured for the test to drive
+        if re.search(r"/api/agents/snapshot(\?|$)", url):
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps(GRAPH_SNAPSHOT_RUNNING))
+            return
+        if url.endswith("/api/agents/hosts"):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(_HOSTS_FIXTURE))
+            return
+        if re.search(r"/api/agents/board(\?|$)", url) or url.endswith("/api/agents/board/stream"):
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps({"lanes": {}, "generated_at": 0}))
+            return
+        # Default: stub anything else empty so nothing depends on a live server.
+        route.fulfill(status=200, content_type="application/json", body="{}")
+
+    page.route("**/api/**", handler)
+    page.goto(f"{base_url}/agents")
+    page.click('[data-tab="graph"]')
+    # Not `#filter-host` — graph.js hides that filter's wrapping `<label>`
+    # entirely when the snapshot has one distinct host or fewer
+    # (`updateHostOptions`), which this single-session fixture always is.
+    # `#search-input` isn't conditionally hidden and is present as soon as
+    # the Graph tab's static markup is unhidden.
+    page.wait_for_selector("#search-input")
+    page.select_option("#filter-recency", "all")
+    page.locator("#search-input").fill("graph-resume-target")
+    result = page.locator(".search-result", has_text="graph-resume-target")
+    expect(result).to_be_visible()
+    result.click()
+
+
+class TestGraphTabRendersResumeControlsOnLiveSessionForLaterReveal:
+    def test_running_session_gets_hidden_but_present_controls_that_become_visible_and_populated_on_terminal(
+        self, page: Page, agents_base_url,
+    ):
+        pending_routes = []
+        _open_graph_panel_on_running_session(page, agents_base_url, pending_routes)
+
+        panel = page.locator("#panel")
+        resume_btn = panel.locator('[data-action="resume"]')
+        select = panel.locator('[data-action="resume-host"]')
+
+        # Pre-transition: the session is `running`, so Resume is not
+        # actionable yet — but (finding #1's fix) the elements must already
+        # be IN THE DOM, just hidden, so a later in-place `updateMeta` can
+        # reveal them. Under the pre-fix (revert-to-conditional-creation)
+        # behaviour these elements never exist at all, and `to_have_count(1)`
+        # below fails.
+        expect(resume_btn).to_have_count(1)
+        expect(select).to_have_count(1)
+        expect(resume_btn).to_be_hidden()
+        expect(select).to_be_hidden()
+
+        assert pending_routes, "no SSE connection to /api/agents/stream was captured"
+        terminal_snapshot = json.loads(json.dumps(GRAPH_SNAPSHOT_RUNNING))
+        terminal_snapshot["sessions"][0]["status"] = "completed"
+        terminal_snapshot["sessions"][0]["status_inferred"] = False
+        frame = "event: snapshot\ndata: " + json.dumps(terminal_snapshot) + "\n\n"
+        pending_routes[0].fulfill(status=200, content_type="text/event-stream", body=frame)
+
+        # Positive direction: once the session reaches a terminal state,
+        # Resume and the host select must end up VISIBLE — the routine case
+        # (every session ends) that finding #1 reported as unreachable via
+        # updateMeta alone on the Graph tab.
+        expect(resume_btn).to_be_visible(timeout=8000)
+        expect(select).to_be_visible(timeout=8000)
+        # And POPULATED, not merely visible with no options — panel.js's
+        # `_populateResumeHosts` is called at initial `_renderHeader` time
+        # (bound to `canResume`, not `showResume`), so the options should
+        # already be there by the time visibility flips.
+        options = select.locator("option").all_inner_texts()
+        assert any("studio" in o for o in options), options
+        assert any(o.strip() == "laptop" for o in options), options

--- a/web/agents.html
+++ b/web/agents.html
@@ -658,6 +658,44 @@
   }
   .panel-resume:hover { background: var(--accent); color: var(--bg-primary); }
   .panel-resume:disabled { opacity: 0.6; cursor: progress; }
+  .panel-resume-host {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    line-height: 1;
+    padding: 0.3rem 0.35rem;
+    border-radius: 4px;
+    float: right;
+    margin-right: 0.5rem;
+    max-width: 9rem;
+  }
+  .resume-command {
+    margin-top: 0.4rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .resume-command[hidden] { display: none; }
+  .resume-command code {
+    flex: 1;
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    background: var(--bg-elev);
+    border-radius: 4px;
+    padding: 0.25rem 0.4rem;
+    word-break: break-all;
+  }
+  .resume-command button {
+    font-size: 0.7rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    border-radius: 4px;
+    padding: 0.2rem 0.45rem;
+    cursor: pointer;
+  }
+  .resume-command button:hover { background: var(--accent); color: var(--bg-primary); }
   .panel-focus {
     background: var(--bg-card);
     border: 1px solid var(--text-dim);

--- a/web/agents/panel.js
+++ b/web/agents/panel.js
@@ -48,6 +48,18 @@ export function sourceLabelFor(d) {
   return 'LifeOS agent';
 }
 
+// Single source of truth for whether a session should
+// offer Resume + the resume-host select. Both `_renderHeader` (decides
+// whether the elements exist at all) and `updateMeta` (decides whether
+// they're currently visible) call this, so an edit to the expression
+// can't desync creation from visibility.
+export function showResumeFor(s) {
+  const isCli = (s.source === 'claude_code' || s.source === 'codex');
+  const isSubagent = !!s.is_subagent;
+  return isCli && !isSubagent
+    && (TERMINAL.has(s.status) || s.status === 'inactive' || s.status === 'yielded');
+}
+
 export function escapeHtml(s) {
   return String(s)
     .replace(/&/g, '&amp;')
@@ -232,6 +244,57 @@ export function prettyPayload(payload) {
 
 const _EVENTS_RETRY_DELAYS = [800, 1600, 3200];  // ms; ~5.6s before giving up
 
+// "Resume here" host list — same across every panel instance, so
+// fetch it once per page load and cache the promise rather than re-fetching
+// on every panel render. If GET /api/agents/hosts is unavailable (404),
+// takes too long, or the request fails,
+// `_resumeHosts()` returns null and `_populateResumeHosts` builds a
+// fallback list itself.
+//
+// A `null`/empty result re-arms the cache so a later
+// interaction — reopening the panel, or the endpoint becoming reachable
+// mid-session — retries instead of being stuck with a permanently empty
+// select for the page's whole life.
+let _resumeHostsPromise = null;
+
+async function _resumeHosts() {
+  if (!_resumeHostsPromise) {
+    _resumeHostsPromise = fetch('/api/agents/hosts', { signal: AbortSignal.timeout(5000) })
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => (data && Array.isArray(data.hosts) ? data.hosts : null))
+      // A row with no non-empty string `name` would
+      // render `undefined`/`null` as its option value and label — drop it.
+      .then(hosts => {
+        const valid = (hosts || []).filter(h => h && typeof h.name === 'string' && h.name);
+        return valid.length ? valid : null;
+      })
+      .catch(() => null);
+    _resumeHostsPromise.then(hosts => {
+      if (!hosts) _resumeHostsPromise = null;
+    });
+  }
+  return _resumeHostsPromise;
+}
+
+// The API host's own name, for the fallback list when
+// `/api/agents/hosts` isn't available — `GET /api/agents/snapshot` (which
+// every page already polls) carries it. Cached the same way, with the
+// same retry-on-failure re-arming as `_resumeHosts()`.
+let _apiHostPromise = null;
+
+async function _apiHostName() {
+  if (!_apiHostPromise) {
+    _apiHostPromise = fetch('/api/agents/snapshot', { signal: AbortSignal.timeout(5000) })
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => (data && typeof data.api_host === 'string' && data.api_host) ? data.api_host : null)
+      .catch(() => null);
+    _apiHostPromise.then(name => {
+      if (!name) _apiHostPromise = null;
+    });
+  }
+  return _apiHostPromise;
+}
+
 /**
  * A self-contained session-detail panel mounted into `container`.
  *
@@ -316,6 +379,23 @@ export class SessionPanel {
 
     const killBtn = root.querySelector('[data-action="kill"]');
     const isCli = (s.source === 'claude_code' || s.source === 'codex');
+
+    // `_renderHeader` always CREATES the Resume
+    // button and resume-host select whenever `isCli && !isSubagent` (see
+    // below), starting them `hidden` per `showResumeFor`. A poll tick only
+    // calls `updateMeta`, which never re-renders — this toggles the
+    // ALREADY-RENDERED elements' visibility, in BOTH directions: hiding
+    // Resume (spawning a redundant second terminal) on a session that's
+    // actually live, and showing it once a live session reaches a
+    // resumable status. Both `updateMeta` and `_renderHeader` call the
+    // same `showResumeFor` predicate so the two can't drift apart.
+    const showResume = showResumeFor(s);
+    const resumeBtn = root.querySelector('[data-action="resume"]');
+    const resumeHostSelect = root.querySelector('[data-action="resume-host"]');
+    if (resumeBtn) resumeBtn.hidden = !showResume;
+    if (resumeHostSelect) resumeHostSelect.hidden = !showResume;
+    if (!showResume) this._hideResumeCommand();
+
     if (live && !isCli && !killBtn) {
       const header = root.querySelector('.panel-header');
       if (header) {
@@ -340,7 +420,14 @@ export class SessionPanel {
     const isCli = (s.source === 'claude_code' || s.source === 'codex');
     const isSubagent = !!s.is_subagent;
     const showKill = live && !isCli;
-    const showResume = isCli && !isSubagent && (TERMINAL.has(s.status) || s.status === 'inactive' || s.status === 'yielded');
+    // `canResume` gates whether the Resume button, the
+    // resume-host select, and the resume-command box are CREATED — a drawer
+    // opened on a `running` session must still get these elements so a
+    // later `updateMeta` (the only refresh path on the Graph tab) can show
+    // them once the session reaches a resumable status. `showResume` only
+    // gates their INITIAL visibility.
+    const canResume = isCli && !isSubagent;
+    const showResume = showResumeFor(s);
     const showGoTo = isCli && !isSubagent;
     const sourceLabel = sourceLabelFor(s);
     const inferredHint = s.status_inferred ? ' (inferred)' : '';
@@ -348,7 +435,8 @@ export class SessionPanel {
       <div class="panel-header">
         <button class="panel-close" aria-label="Close" data-action="close">×</button>
         ${showKill ? '<button class="panel-kill" data-action="kill">Kill</button>' : ''}
-        ${showResume ? '<button class="panel-resume" data-action="resume" title="Open a new wezterm tab and run claude --resume">Resume</button>' : ''}
+        ${canResume ? `<button class="panel-resume" data-action="resume" title="Open a new wezterm tab and run claude --resume"${showResume ? '' : ' hidden'}>Resume</button>` : ''}
+        ${canResume ? `<select class="panel-resume-host" data-action="resume-host" title="Resume on this machine"${showResume ? '' : ' hidden'}></select>` : ''}
         ${showGoTo ? '<button class="panel-focus" data-action="focus" title="Jump to the existing wezterm pane for this session (or run Resume if there isn\'t one).">Go To</button>' : ''}
         <div class="label" data-field="label" title="Click to rename this session">${escapeHtml(s.custom_label || s.label || s.session_id)}</div>
         <div class="cwd-hint" data-field="cwd-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-all">${s.decoded_cwd ? escapeHtml(s.decoded_cwd) : ''}</div>
@@ -364,6 +452,11 @@ export class SessionPanel {
           <span data-field="depth">${s.spawn_depth ? `<span class="badge">depth ${s.spawn_depth}</span>` : ''}</span>
         </div>
         ${s.prompt_preview ? `<div class="prompt-preview-hint" data-field="prompt-preview-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-word">“${escapeHtml(s.prompt_preview)}”</div>` : ''}
+        ${canResume ? `
+        <div class="resume-command" data-field="resume-command" hidden>
+          <code data-field="resume-command-text"></code>
+          <button data-action="copy-resume-command">Copy</button>
+        </div>` : ''}
       </div>
       <div class="session-summary loading" data-field="session-summary">
         <div class="ss-label">Summary</div>
@@ -376,21 +469,124 @@ export class SessionPanel {
     const labelEl = root.querySelector('[data-field="label"]');
     if (labelEl) labelEl.onclick = () => this._startLabelEdit(s);
     if (showKill) root.querySelector('[data-action="kill"]').onclick = () => this.openKillModal(s);
-    if (showResume) root.querySelector('[data-action="resume"]').onclick = () => this._resumeSession(s);
+    if (canResume) {
+      root.querySelector('[data-action="resume"]').onclick = () => this._resumeSession(s);
+      this._populateResumeHosts(s);
+      const copyBtn = root.querySelector('[data-action="copy-resume-command"]');
+      if (copyBtn) copyBtn.onclick = () => this._copyResumeCommand();
+    }
     if (showGoTo) root.querySelector('[data-action="focus"]').onclick = () => this._focusSession(s);
+  }
+
+  // "Resume here": populate the host <select> next to Resume with
+  // the API host plus every registry host from GET /api/agents/hosts. When
+  // that isn't available or fails, build a
+  // real fallback instead of only ever offering the
+  // session's own recorded host: the API host (learned from
+  // `/api/agents/snapshot`'s `api_host` field) plus this session's own
+  // host, deduplicated — so "resume here" onto THIS machine is still an
+  // option even without the registry endpoint. Defaults the selection to
+  // the session's recorded host so a plain click behaves like before.
+  async _populateResumeHosts(s) {
+    const select = this.container.querySelector('[data-action="resume-host"]');
+    if (!select) return;
+    let hosts = await _resumeHosts();
+    if (!hosts || !hosts.length) {
+      const apiHost = await _apiHostName();
+      hosts = [];
+      const seen = new Set();
+      if (apiHost) { hosts.push({ name: apiHost, is_api_host: true }); seen.add(apiHost); }
+      if (s.host && !seen.has(s.host)) hosts.push({ name: s.host, is_api_host: false });
+      // No API host is knowable (no `/api/agents/hosts`
+      // AND no `api_host` from `/api/agents/snapshot`) and this session
+      // carries no recorded host either — there is genuinely nothing to
+      // offer. Use an EMPTY value, not the human-readable placeholder
+      // "this host": that string would get sent verbatim as
+      // `target_host`, a machine identifier the backend 400s on. An empty
+      // value falls through `targetHost ? {...} : {}` in `_resumeSession`/
+      // `_focusSession`, omitting `target_host` from the request body.
+      if (!hosts.length) hosts = [{ name: '', label: 'this host', is_api_host: false }];
+    } else {
+      hosts = hosts.slice().sort((a, b) => (b.is_api_host ? 1 : 0) - (a.is_api_host ? 1 : 0));
+      // The registry list alone may not include this
+      // session's own host — e.g. it was registered by the hook on a
+      // machine not listed in LIFEOS_AGENT_HOSTS. Without it, the select
+      // defaults to its first option (the API host) and "Go To"/"Resume"
+      // silently target the wrong machine. Add it so the session's actual
+      // host is always a real, selectable, default-selected option.
+      if (s.host && !hosts.some(h => h.name === s.host)) {
+        hosts.push({ name: s.host, is_api_host: false });
+      }
+    }
+    // Build options as real elements and assign `.value`
+    // / `.textContent` as PROPERTIES — a template-string `value="${escapeAttr(...)}"`
+    // mangled a dotted/hyphenated host (e.g. "mac-mini.local") into an
+    // underscored value the backend doesn't recognize, while displaying
+    // the correct name, and it left `select.value = s.host` unable to
+    // match any option at all.
+    select.innerHTML = '';
+    for (const h of hosts) {
+      const suffix = h.is_api_host ? ' (this machine)' : '';
+      const opt = document.createElement('option');
+      opt.value = h.name;
+      opt.textContent = h.label || (h.name + suffix);
+      select.appendChild(opt);
+    }
+    if (s.host && hosts.some(h => h.name === s.host)) select.value = s.host;
+  }
+
+  _showResumeCommand(command, note) {
+    const box = this.container.querySelector('[data-field="resume-command"]');
+    const codeEl = this.container.querySelector('[data-field="resume-command-text"]');
+    if (box && codeEl && command) {
+      codeEl.textContent = command;
+      box.hidden = false;
+    }
+    showToast(note || 'Copy the command below to run it on that host.', true);
+  }
+
+  _hideResumeCommand() {
+    const box = this.container.querySelector('[data-field="resume-command"]');
+    if (box) box.hidden = true;
+  }
+
+  async _copyResumeCommand() {
+    const codeEl = this.container.querySelector('[data-field="resume-command-text"]');
+    const text = codeEl ? codeEl.textContent : '';
+    if (!text) return;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try { await navigator.clipboard.writeText(text); showToast('Command copied.', false); return; } catch (_) {}
+    }
+    showToast('Select and copy the command manually.', true);
   }
 
   async _focusSession(s) {
     const btn = this.container.querySelector('[data-action="focus"]');
+    // The resume-host select is created whenever Go
+    // To is (`canResume` and `showGoTo` are both `isCli && !isSubagent`),
+    // but may be `hidden` on a live, non-terminal session — read it
+    // defensively rather than assuming a non-hidden or even present
+    // element.
+    const select = this.container.querySelector('[data-action="resume-host"]');
+    const targetHost = select ? select.value : '';
     if (btn) { btn.disabled = true; btn.textContent = 'Locating…'; }
     try {
       const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/focus`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(targetHost ? { target_host: targetHost } : {}),
       });
       if (!r.ok) {
         const text = await r.text();
-        let msg = text;
-        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+        // Reuse _resumeSession's object-detail handling
+        // so a 400 with `{error, command}` renders the message, not
+        // `[object Object]` from a bare String() coercion.
+        let detail = text;
+        try { const j = JSON.parse(text); detail = (j.detail !== undefined) ? j.detail : text; } catch (_) {}
+        if (r.status === 400 && detail && typeof detail === 'object' && detail.command) {
+          this._showResumeCommand(detail.command, detail.error);
+          return;
+        }
+        const msg = (detail && typeof detail === 'object') ? (detail.error || JSON.stringify(detail)) : detail;
         if (r.status === 404) {
           showToast(`Couldn't locate pane — session not running, wezterm unreachable, or SessionStart hook not installed.`, true);
         } else if (r.status === 410) {
@@ -410,15 +606,27 @@ export class SessionPanel {
 
   async _resumeSession(s) {
     const btn = this.container.querySelector('[data-action="resume"]');
+    const select = this.container.querySelector('[data-action="resume-host"]');
+    const targetHost = select ? select.value : '';
     if (btn) { btn.disabled = true; btn.textContent = 'Resuming…'; }
+    this._hideResumeCommand();
     try {
       const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/resume`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(targetHost ? { target_host: targetHost } : {}),
       });
       if (!r.ok) {
         const text = await r.text();
-        let msg = text;
-        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+        let detail = text;
+        try { const j = JSON.parse(text); detail = (j.detail !== undefined) ? j.detail : text; } catch (_) {}
+        // A 400 whose detail carries a `command` means this API
+        // can't launch on the chosen host itself — offer the command for
+        // copying instead of treating it as a hard failure.
+        if (r.status === 400 && detail && typeof detail === 'object' && detail.command) {
+          this._showResumeCommand(detail.command, detail.error);
+          return;
+        }
+        const msg = (detail && typeof detail === 'object') ? (detail.error || JSON.stringify(detail)) : detail;
         throw new Error(`HTTP ${r.status}: ${msg}`);
       }
       const result = await r.json();


### PR DESCRIPTION
## TL;DR

A remote session on a registered host used to show only its status and a
prompt preview on `/agents` — no token counts, no cost, no transcript feed,
because those require reading the session's actual transcript file, and
that file lives on the remote machine, not on the machine hosting the API.
A background service now pulls each registered host's Claude Code and
Codex transcripts onto the API box over ssh, read-only and incrementally,
so a remote session shows the same detail as a local one. The drawer's
Resume button also gains a "resume here" host picker: choose any
registered machine (or this one) to launch on, regardless of where the
session originally ran, or copy the exact resume command when the chosen
machine isn't one this API can reach directly.

Part of #866

## Design

The mirror is a new background service, not a change to how transcripts
are read: it writes into a `<host>/claude_code/` and `<host>/codex/`
subtree per registered host, mirroring each source's own directory
layout, so the existing per-source scanners work against a mirrored
root exactly as they do against the local one. A mirrored row is
explicitly excluded from local liveness inference — a transcript
existing on this box says nothing about whether the CLI process is
actually running here — so a mirrored session's "running" status can
only come from the existing cross-machine hook-event registration, never
from a process scan. On an id collision, the local transcript wins,
since it can only be fresher than a mirror that lags by up to one pull
interval.

"Resume here" is a thin override on top of the existing resume/focus
host resolution: an explicit target machine short-circuits the session's
recorded host, landing on a local launch, an ssh launch to a registered
host, or (for anywhere else) the resume command rendered as copyable
text instead of a failed launch attempt.

## Implementation Notes

- `api/services/agent_transcript_mirror.py` (new) — the mirror service:
  `mirror_host`/`mirror_once` (incremental rsync per engine per host,
  concurrent across hosts via a small thread pool, one warning line per
  failed host), `start`/`stop` (interval loop, no-op when disabled or no
  hosts registered), `mirrored_snapshot` (per-host `build_snapshot` calls
  with `live_counts={}`), `mirrored_transcript_dirs` (fallback search
  path for events/stream/focus).
- `api/services/claude_code/session_ingest.py` / `codex/session_ingest.py`
  — `build_snapshot` gains an optional `live_counts` parameter; `None`
  (every existing caller) preserves current behavior exactly.
- `api/routes/agents.py` — `_build_snapshot` merges mirrored rows after
  the existing local cc/cx blocks (local wins on id collision, status
  merges from hook events the same way a local row already does); new
  `_read_cli_transcript_events` helper (local-then-mirrored) backs
  `/events`, `/stream`, `/summary`, and the viz prefetcher;
  `_lookup_cc_session_meta`/`_lookup_cx_session_meta` search mirrored
  dirs after the local root misses; `CCResumeRequest.target_host` +
  `_resolve_target_host` + `_resume_command_text` implement "resume
  here" for both `/resume` and `/focus`.
- `api/services/agent_viz_summary_prefetch.py` — the `cc:`/`cx:` branches
  of `_summarize_one` route through `_read_cli_transcript_events` so a
  mirrored session's fallback summary isn't permanently poisoned by an
  empty local read (this cache is shared with the on-demand `/summary`
  route, so a bad prefetched fallback would otherwise leak there too).
- `config/settings.py` — three new settings:
  `LIFEOS_AGENT_TRANSCRIPT_MIRROR_ENABLED` (default `true`, safe since
  `agent_hosts` defaults to `{}`), `_DIR`, `_INTERVAL_SECONDS`.
- `api/main.py` — `agent_transcript_mirror.start()`/`stop()` wired into
  the lifespan next to `agent_viz_summary_prefetch`.
- `web/agents/panel.js` / `web/agents.html` — resume-host `<select>`
  (populated from `GET /api/agents/hosts` when available, falling back
  to the session's own host), a copyable command box for the 400 case,
  `target_host` sent in the resume POST body.

## Test evidence

### Automated tests

```
tests/test_agent_transcript_mirror.py ................        14 passed
tests/test_agent_transcript_mirror_snapshot.py .........        6 passed
tests/test_agent_transcript_mirror_events.py ............       9 passed
tests/test_agent_resume_remote.py .......................      12 passed
tests/test_agents_resume_here_ui_browser.py .................. 5 passed
```

Full server-free browser suite (`browser and not requires_server`): 365
passed. Pre-push hook (the authoritative gate): full unit suite 5780
passed / 8 skipped, full server-free browser suite 292 passed — both
green on the pushed branch.

**Mutation proof** — every new/modified test proved to fail against a
reverted production hunk, then confirmed passing again after restore
(procedure: commit, mutate one hunk, run the targeted test(s), record
failure, `git checkout HEAD -- <file>`, re-run to confirm green):

| Hunk mutated | Test(s) that failed | Failure observed |
|---|---|---|
| `mirror_host`: rsync-failure detection disabled | `test_unreachable_host_logs_one_line_others_still_mirror`, `test_unreachable_host_result_is_failed_and_no_exception_raised` | `MirrorResult(ok=True)` for a failing host |
| `_sanitize_host`: validation removed | `test_host_dirs_rejects_traversal_and_hidden_names`, `test_unsafe_host_name_is_skipped_without_writing_outside_root` | `ValueError` never raised for `../escape` etc. |
| `mirror_once`: API-host skip + no-hosts no-op removed | `test_mirror_once_skips_the_api_host_itself`, `test_mirror_once_is_noop_with_no_hosts_configured` | mirrored the API's own host; `ThreadPoolExecutor(max_workers=0)` crash |
| `start()`: disabled/no-hosts guard removed | `test_start_is_noop_when_disabled`, `test_start_is_noop_with_no_hosts_registered` | task scheduled despite disabled/empty config |
| rsync argv: `-t` (preserve-times) dropped | `test_rsync_argv_is_readonly_incremental_pull_to_correct_dest` | `-rtz` not in argv |
| `mirror_once`: forced serial (`max_workers=1`) | `test_mirror_once_runs_hosts_concurrently_not_serially` | 1.2s elapsed vs. the <0.9s bound |
| rsync argv: source/dest swapped (push not pull) | `test_rsync_argv_never_pushes_local_to_remote`, `test_copy_lands_under_per_host_engine_dirs`, `test_second_tick_does_not_retransfer_unchanged_file`, `test_changed_file_is_retransferred` | argv unparseable / files never copied |
| `cc.build_snapshot`: `live_counts` param removed | `test_mirrored_row_not_promoted_to_running_by_local_process_scan` | mirrored row promoted to `running` |
| `cx.build_snapshot`: `live_counts` param removed | `test_mirrored_codex_row_not_promoted_to_running_by_local_process_scan` | same, Codex side |
| `_build_snapshot`: mirrored-merge loop emptied | `test_mirrored_cc_session_produces_one_row_with_host_and_real_tokens`, `test_mirrored_codex_session_produces_one_row_with_host` | 0 matching rows instead of 1 |
| `_build_snapshot`: id-collision dedup check removed | `test_id_collision_local_transcript_wins_single_row` | 2 rows instead of 1 |
| `_build_snapshot`: `_apply_cli_session_to_dict` call removed from merge | `test_status_merge_prefers_hook_events_over_mirrored_transcript` | duplicate row (never popped from `cli_by_id`) |
| `_read_cli_transcript_events`: mirrored fallback removed | `test_read_cli_transcript_events_falls_back_to_mirrored_dir`, `test_read_cli_transcript_events_codex_mirrored`, `test_events_endpoint_returns_mirrored_transcript_for_remote_session` (+ `test_stream_endpoint_returns_mirrored_transcript_for_remote_session`, same code path, not re-run live to avoid an SSE idle-wait) | `[]` instead of the mirrored events |
| `get_session_summary`: mirrored-snapshot fallback removed | `test_summary_endpoint_resolves_label_for_mirrored_session` | label fell back to the bare session id |
| `_lookup_cc_session_meta` / `_lookup_cx_session_meta`: mirrored fallback removed | `test_lookup_cc_session_meta_finds_mirrored_session`, `test_lookup_cx_session_meta_finds_mirrored_session` | 404 instead of resolving |
| `_resolve_target_host`: override short-circuited | `test_target_host_registry_host_overrides_sessions_recorded_host`, `test_target_host_unknown_host_400s_with_copyable_command`, `test_target_host_unknown_host_400s_on_focus_too` | wrong ssh target / no 400 |
| `_resume_command_text`: cwd-prefix rendering removed | `test_target_host_unknown_host_400s_with_copyable_command` | cwd missing from the command text |
| resume launchers: mirrored/cli_sessions cwd fallback removed | `test_target_host_resume_falls_back_to_mirrored_transcript_cwd_with_no_cli_row` | 404 instead of resolving cwd from the mirrored transcript |
| `panel.js` `_resumeSession`: `target_host` dropped from POST body | `test_choosing_host_and_clicking_resume_sends_target_host`, `test_choosing_a_different_host_sends_that_one` | `target_host` missing from the captured request body |
| `panel.js` `_showResumeCommand`: DOM update removed | `test_400_with_command_renders_copyable_command_text` | command box stayed hidden |
| `panel.js` `_populateResumeHosts`: select left empty | `test_select_lists_api_host_and_registry_hosts` | no options rendered |
| `agents.html` CSS: `.resume-command[hidden]` override removed | `test_a_200_response_does_not_show_the_command_box` | command box visible when it shouldn't be (a real bug this fix catches — an author `display:flex` rule silently overrides the browser's default `[hidden]` styling regardless of specificity, since author styles win over user-agent styles) |

### Manual verification

N/A — no live remote host available in this environment to mirror from.
All behavior is covered by the automated tests above, which exercise the
real production code paths (`mirror_host`/`mirror_once`/`mirrored_snapshot`)
against a fake rsync runner and real synthetic transcript fixtures rather
than mocking the ingest layer.

## Review focus

- `api/services/agent_transcript_mirror.py` — the rsync flag choices
  (`-rtz`, no `-a`/no ownership preservation, no `--delete`) and the
  per-host failure isolation in `mirror_host`.
- `api/routes/agents.py`'s `_build_snapshot` mirrored-merge block — id
  collision resolution and the point where `host` is deliberately left
  as the mirrored row's own rather than overwritten.
- `_resolve_target_host` / `_resume_command_text` — the three-way branch
  (local / registered / everything-else-gets-a-copyable-command) and the
  cwd resolution fallback chain (local transcript → mirrored transcript
  → `cli_sessions` row).
- `web/agents/panel.js` — the host-select population and its graceful
  fallback when `GET /api/agents/hosts` (#901) isn't available yet.

## Deferred / out of scope

- Running the worker itself on a remote machine — unchanged, per the
  issue's stated scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
