### PR TITLE
feat: cache the heaviest CRM aggregate endpoints

### DIFF
--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -748,8 +748,18 @@ def get_all_birthdays():
     }
 
 
+def _people_cache_eligible(kwargs: dict) -> bool:
+    """Only the parameter shape the CRM page's default load actually uses
+    (no search text, a bounded page size) is worth caching -- a per-keystroke
+    search query or a `limit=10000` export is requested once and never
+    again, so caching it only spends memory and a measurable
+    jsonable_encoder()/json.dumps() pass on every miss for no reuse (#917
+    review finding 6)."""
+    return not kwargs.get("q") and kwargs.get("limit", 50) <= 300
+
+
 @router.get("/people", response_model=PersonListResponse)
-@cached_aggregate()
+@cached_aggregate(should_cache=_people_cache_eligible)
 def list_people(
     q: Optional[str] = Query(default=None, description="Search query"),
     category: Optional[str] = Query(default=None, description="Filter by category"),

--- a/api/routes/crm.py
+++ b/api/routes/crm.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 
 from api.services.person_entity import PersonEntity, get_person_entity_store, compute_person_category
 from api.services.interaction_store import get_interaction_store
+from api.services.aggregate_cache import cached_aggregate
 from config.people_config import InteractionConfig
 from config.settings import settings
 from api.services.source_entity import (
@@ -719,6 +720,7 @@ def get_todays_birthdays():
 
 
 @router.get("/birthdays/all")
+@cached_aggregate()
 def get_all_birthdays():
     """Get all people with birthdays, grouped by date."""
     person_store = get_person_entity_store()
@@ -747,6 +749,7 @@ def get_all_birthdays():
 
 
 @router.get("/people", response_model=PersonListResponse)
+@cached_aggregate()
 def list_people(
     q: Optional[str] = Query(default=None, description="Search query"),
     category: Optional[str] = Query(default=None, description="Filter by category"),
@@ -2494,6 +2497,7 @@ def update_relationship_strengths():
 
 
 @router.get("/statistics", response_model=StatisticsResponse)
+@cached_aggregate()
 def get_crm_statistics():
     """
     Get comprehensive CRM statistics.
@@ -3431,6 +3435,7 @@ def get_me_stats():
 
 
 @router.get("/me/timeline", response_model=TimelineResponse)
+@cached_aggregate()
 def get_me_timeline(
     source_type: Optional[str] = Query(
         default=None,
@@ -3514,6 +3519,7 @@ def get_me_timeline(
 
 
 @router.get("/me/interactions", response_model=MeInteractionsResponse)
+@cached_aggregate()
 def get_me_interactions(
     days_back: int = Query(default=365, ge=1, le=3660, description="Days of history (up to 10 years)"),
     trend_period: str = Query(default="quarter", description="Trend comparison period: week, month, quarter, year"),
@@ -4253,6 +4259,7 @@ def get_family_stats(
 
 
 @router.get("/family/timeline", response_model=TimelineResponse)
+@cached_aggregate()
 def get_family_timeline(
     person_ids: str = Query(
         ...,
@@ -4333,6 +4340,7 @@ def get_family_timeline(
 
 
 @router.get("/family/interactions", response_model=FamilyInteractionsResponse)
+@cached_aggregate()
 def get_family_interactions(
     person_ids: str = Query(
         ...,

--- a/api/services/aggregate_cache.py
+++ b/api/services/aggregate_cache.py
@@ -1,0 +1,246 @@
+"""
+Short-lived response cache for the CRM's heaviest read aggregates (#876).
+
+`/me/interactions`, `/me/timeline`, `/family/interactions`, `/family/timeline`,
+`/birthdays/all`, `/statistics`, and the default-parameter `/people` list all
+recompute from scratch on every request even when nothing in crm.db or
+interactions.db has changed since the last call -- #871/#880 made each of
+those individually fast, but a dashboard switch or a page refresh still pays
+the full cost every time. `AggregateCache.cached()` memoizes a route
+handler's return value for a short TTL, keyed on its resolved query
+parameters plus both databases' `PRAGMA data_version` counters -- the same
+invalidation signal `PersonEntityStore`'s own `get_all()` cache uses (see
+api/services/person_entity.py) -- so a write to either database, from this
+process or any other, makes the next request for an affected key recompute
+rather than serve stale data. The TTL is a backstop bound on memory/entry
+lifetime, not the primary invalidation path: a data_version change makes a
+key's next lookup a miss immediately, regardless of TTL.
+
+Structured as a class (rather than bare module globals) so a test can
+construct an isolated `AggregateCache` pointed at temporary databases, the
+same way `tests/test_person_entity.py` builds a `PersonEntityStore(db_path)`
+instead of fighting the process-wide singleton -- see `get_aggregate_cache()`
+below for the singleton `api/routes/crm.py` actually decorates its handlers
+with.
+"""
+import functools
+import json
+import logging
+import sqlite3
+import threading
+import time
+from collections import OrderedDict
+from typing import Callable, Optional
+
+from fastapi.encoders import jsonable_encoder
+
+from api.services.interaction_store import get_interaction_db_path
+from api.services.person_entity import PersonEntityStore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 300
+MAX_ENTRIES = 200
+MAX_TOTAL_BYTES = 20 * 1024 * 1024  # 20 MB
+
+
+class AggregateCache:
+    """A bounded, TTL-backstopped, data_version-keyed cache for read-only
+    route handlers.
+
+    Each instance owns two persistent, pragma-only SQLite connections (one
+    per database) used solely to read `PRAGMA data_version` cheaply -- the
+    same justification as `PersonEntityStore._get_data_version_connection()`.
+    Every call site of those connections is reached only while holding
+    `self._lock`, so cross-thread use is serialized, which is what makes
+    `check_same_thread=False` safe here despite handlers running on the
+    FastAPI worker threadpool.
+    """
+
+    def __init__(
+        self,
+        crm_db_path: Optional[str] = None,
+        interactions_db_path: Optional[str] = None,
+        max_entries: int = MAX_ENTRIES,
+        max_total_bytes: int = MAX_TOTAL_BYTES,
+    ):
+        self.crm_db_path = crm_db_path or str(PersonEntityStore.CRM_DB_PATH)
+        self.interactions_db_path = interactions_db_path or get_interaction_db_path()
+        self.max_entries = max_entries
+        self.max_total_bytes = max_total_bytes
+
+        self._lock = threading.Lock()
+        self._crm_conn: Optional[sqlite3.Connection] = None
+        self._interactions_conn: Optional[sqlite3.Connection] = None
+        # key -> (expires_at monotonic, jsonable value, size in bytes). Dict
+        # order doubles as LRU order (most-recently-used at the end).
+        self._cache: "OrderedDict[tuple, tuple[float, object, int]]" = OrderedDict()
+        self._total_bytes = 0
+
+    def _get_crm_connection(self) -> sqlite3.Connection:
+        if self._crm_conn is None:
+            self._crm_conn = sqlite3.connect(
+                self.crm_db_path,
+                check_same_thread=False,  # threadpool-safe: pragma-only, guarded by lock
+            )
+        return self._crm_conn
+
+    def _get_interactions_connection(self) -> sqlite3.Connection:
+        if self._interactions_conn is None:
+            self._interactions_conn = sqlite3.connect(
+                self.interactions_db_path,
+                check_same_thread=False,  # threadpool-safe: pragma-only, guarded by lock
+            )
+        return self._interactions_conn
+
+    def _data_versions_locked(self) -> tuple:
+        """Read both PRAGMA data_version counters. Caller must hold `_lock`."""
+        crm_version = self._get_crm_connection().execute("PRAGMA data_version").fetchone()[0]
+        interactions_version = self._get_interactions_connection().execute(
+            "PRAGMA data_version").fetchone()[0]
+        return int(crm_version), int(interactions_version)
+
+    def _evict_locked(self) -> None:
+        """Drop the least-recently-used entries while over either bound.
+        Caller must hold `_lock`."""
+        while self._cache and (len(self._cache) > self.max_entries or
+                                self._total_bytes > self.max_total_bytes):
+            _, (_, _, size) = self._cache.popitem(last=False)
+            self._total_bytes -= size
+
+    def stats(self) -> dict:
+        """Entry count and total cached bytes -- for tests and diagnostics."""
+        with self._lock:
+            return {"entries": len(self._cache), "total_bytes": self._total_bytes}
+
+    def clear(self) -> None:
+        """Drop every cached entry. Test-only escape hatch (production
+        invalidation is via data_version, never a manual clear)."""
+        with self._lock:
+            self._cache.clear()
+            self._total_bytes = 0
+
+    def cached(self, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> Callable:
+        """Memoize a function's return value for `ttl_seconds`, keyed on its
+        resolved keyword arguments plus both databases' current
+        data_version.
+
+        Intended for a FastAPI route handler, applied directly under
+        `@router.get(...)` (i.e. as the innermost decorator) so FastAPI still
+        sees the original function's signature: `functools.wraps` sets
+        `__wrapped__`, which Python's `inspect.signature()` follows by
+        default -- that is what lets FastAPI keep resolving `Query()`
+        parameters from the wrapped function normally.
+
+        Only a successful return is ever cached: an exception (including a
+        raised HTTPException for a non-200 response) propagates before this
+        reaches the cache-store step, so an error response is never cached.
+        """
+        def decorator(func: Callable) -> Callable:
+            identity = f"{func.__module__}.{func.__qualname__}"
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                # FastAPI always calls path operation functions with
+                # resolved Query()/Path() values as keyword arguments, so
+                # this alone covers "every query parameter" without
+                # inspecting the request directly.
+                param_key = tuple(sorted(kwargs.items()))
+
+                with self._lock:
+                    crm_version, interactions_version = self._data_versions_locked()
+                    key = (identity, param_key, crm_version, interactions_version)
+                    cached = self._cache.get(key)
+                    if cached is not None:
+                        expires_at, value, size = cached
+                        if expires_at > time.monotonic():
+                            self._cache.move_to_end(key)
+                            return value
+                        # Expired -- drop it now rather than waiting for a
+                        # bounds-triggered eviction that might never come.
+                        del self._cache[key]
+                        self._total_bytes -= size
+
+                # Compute outside the lock: the wrapped handler can take
+                # tens/hundreds of ms, and holding the lock here would
+                # serialize every cached CRM aggregate request behind
+                # whichever one is currently a cache miss.
+                result = func(*args, **kwargs)
+
+                # The cached (and returned) value is `result` itself, not a
+                # jsonable_encoder()'d copy: some existing CRM unit tests
+                # call a decorated handler directly (bypassing FastAPI) and
+                # expect the same Pydantic model FastAPI would otherwise
+                # serialize later, with normal attribute access -- e.g.
+                # `result.people`, not `result["people"]`. jsonable_encoder
+                # is used only to measure the byte size for the cache's
+                # bounds; it never replaces what's actually stored/returned.
+                size = len(json.dumps(jsonable_encoder(result)).encode("utf-8"))
+
+                with self._lock:
+                    # A concurrent miss for the same key may have already
+                    # stored an entry while this call was computing outside
+                    # the lock -- last writer wins, which is fine, since
+                    # both computed from the same data_version pair and
+                    # therefore the same underlying data.
+                    if key in self._cache:
+                        self._total_bytes -= self._cache[key][2]
+                    self._cache[key] = (time.monotonic() + ttl_seconds, result, size)
+                    self._cache.move_to_end(key)
+                    self._total_bytes += size
+                    self._evict_locked()
+
+                return result
+
+            return wrapper
+
+        return decorator
+
+
+_aggregate_cache: Optional[AggregateCache] = None
+
+
+def get_aggregate_cache() -> AggregateCache:
+    """Process-wide singleton, matching the `get_*()` accessor pattern used
+    throughout `api/services/` (e.g. `get_person_entity_store()`)."""
+    global _aggregate_cache
+    if _aggregate_cache is None:
+        _aggregate_cache = AggregateCache()
+    return _aggregate_cache
+
+
+def cached_aggregate(ttl_seconds: float = DEFAULT_TTL_SECONDS) -> Callable:
+    """Decorator applied to CRM route handlers, backed by the process-wide
+    `AggregateCache` singleton. See `AggregateCache.cached()` for the actual
+    caching behavior.
+
+    Called once per decorated function, at import time -- the returned
+    wrapper closes over whichever `AggregateCache` instance
+    `get_aggregate_cache()` returns at that moment, so `reset_aggregate_cache()`
+    below clears that instance's entries in place rather than swapping in a
+    new one (which the already-decorated handlers would never see).
+    """
+    return get_aggregate_cache().cached(ttl_seconds)
+
+
+def reset_aggregate_cache() -> None:
+    """Clear every cached entry on the process-wide singleton.
+
+    For testing only: several existing CRM unit tests call a decorated route
+    handler (e.g. `get_me_interactions`) directly with its store dependency
+    mocked (`patch('api.routes.crm.get_person_entity_store', ...)`) -- the
+    mock never touches the real crm.db/interactions.db files, so this
+    cache's data_version-keyed entries from an earlier test with the same
+    parameters would otherwise still be a "hit" and mask the new mock's
+    return value entirely. Wired into
+    `tests.reset_singletons.reset_lightweight_singletons()`, which the
+    autouse `reset_singletons_after_test` fixture in `tests/conftest.py`
+    already runs after every test.
+
+    Deliberately does not reassign the module-level `_aggregate_cache`
+    singleton to a fresh instance: `cached_aggregate()` binds each decorated
+    route handler to whatever instance existed at import time, so a new
+    instance here would never be seen by those closures -- only clearing
+    the existing one in place reaches them.
+    """
+    get_aggregate_cache().clear()

--- a/api/services/aggregate_cache.py
+++ b/api/services/aggregate_cache.py
@@ -8,13 +8,12 @@ interactions.db has changed since the last call -- #871/#880 made each of
 those individually fast, but a dashboard switch or a page refresh still pays
 the full cost every time. `AggregateCache.cached()` memoizes a route
 handler's return value for a short TTL, keyed on its resolved query
-parameters plus both databases' `PRAGMA data_version` counters -- the same
-invalidation signal `PersonEntityStore`'s own `get_all()` cache uses (see
-api/services/person_entity.py) -- so a write to either database, from this
-process or any other, makes the next request for an affected key recompute
-rather than serve stale data. The TTL is a backstop bound on memory/entry
-lifetime, not the primary invalidation path: a data_version change makes a
-key's next lookup a miss immediately, regardless of TTL.
+parameters, invalidated whenever either database's `PRAGMA data_version`
+counter changes -- the same invalidation signal `PersonEntityStore`'s own
+`get_all()` cache uses (see api/services/person_entity.py) -- so a write to
+either database, from this process or any other, drops every cached entry
+before the next request. The TTL is a backstop bound on entry lifetime, not
+the primary invalidation path.
 
 Structured as a class (rather than bare module globals) so a test can
 construct an isolated `AggregateCache` pointed at temporary databases, the
@@ -22,83 +21,210 @@ same way `tests/test_person_entity.py` builds a `PersonEntityStore(db_path)`
 instead of fighting the process-wide singleton -- see `get_aggregate_cache()`
 below for the singleton `api/routes/crm.py` actually decorates its handlers
 with.
+
+#917 review findings addressed here (see each method's docstring for detail):
+1. A `PRAGMA data_version` read failure never fails the request -- it falls
+   through to computing uncached and the connection is reopened next call.
+2. `crm.db` is resolved through both `PersonEntityStore.CRM_DB_PATH` and
+   `api.utils.db_paths.get_crm_db_path()` (deduped by `os.path.realpath`),
+   since the stores backing `/statistics` and `/people` use the latter and
+   the two can diverge under a non-default `LIFEOS_CHROMA_PATH`. Connections
+   open with a `mode=rw` URI so a missing file is never silently created.
+4. The byte bound tracks serialized JSON size, which understates real
+   retained heap by roughly 7x (measured) -- `MAX_TOTAL_BYTES` is scaled down
+   by that ratio so it targets a real ~50 MB heap ceiling, not a 20 MB one.
+5. A cache hit returns a deep copy, and a miss stores a deep copy of what it
+   returns, so a caller mutating their own result can never poison the entry
+   another caller (or the same one, later) receives.
+8. The data_version pair is a generation stamp, not part of the key: a
+   change clears every entry outright instead of leaving old-generation
+   entries as unreachable dead weight inside the byte/entry bounds. An entry
+   larger than the byte cap is skipped rather than flushing the cache to
+   make room for it.
+9. Concurrent misses for the same key single-flight behind a per-key
+   `threading.Event`: the first caller computes, the rest wait for it and
+   reuse its result (falling back to computing themselves only if the
+   leader's call raised).
 """
+import copy
 import functools
 import json
 import logging
+import os
 import sqlite3
 import threading
 import time
 from collections import OrderedDict
+from pathlib import Path
 from typing import Callable, Optional
 
 from fastapi.encoders import jsonable_encoder
 
 from api.services.interaction_store import get_interaction_db_path
 from api.services.person_entity import PersonEntityStore
+from api.utils.db_paths import get_crm_db_path
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_TTL_SECONDS = 300
 MAX_ENTRIES = 200
-MAX_TOTAL_BYTES = 20 * 1024 * 1024  # 20 MB
+
+# A ~7 MB serialized-JSON entry was measured to retain ~51 MB of actual
+# Python-object heap once decoded/cached -- nested dicts/lists/model
+# instances cost far more per byte than the compact JSON wire format they
+# came from. MAX_TOTAL_BYTES tracks serialized size (cheap to compute, no
+# new dependency for a real heap profiler), scaled down by that measured
+# ratio so the bound it actually enforces is a real heap ceiling, not a
+# serialized-bytes one.
+HEAP_TO_SERIALIZED_RATIO = 7
+HEAP_TARGET_BYTES = 50 * 1024 * 1024  # ~50 MB real heap ceiling
+MAX_TOTAL_BYTES = HEAP_TARGET_BYTES // HEAP_TO_SERIALIZED_RATIO  # ~7.1 MB serialized
+
+
+def _dedupe_paths(paths: list) -> list:
+    """Distinct filesystem targets among `paths`, preserving first-seen
+    order (`os.path.realpath` normalizes symlinks/`..`/relative segments;
+    it does not require the path to exist)."""
+    seen = {}
+    for p in paths:
+        seen.setdefault(os.path.realpath(p), p)
+    return list(seen.values())
+
+
+def _default_crm_db_paths() -> list:
+    """Every path a CRM store actually reads crm.db from.
+
+    `PersonEntityStore` uses the hardcoded `CRM_DB_PATH`; `SourceEntityStore`
+    and `RelationshipStore` (which back `/statistics`'s and `/people`'s
+    category computation) resolve through `get_crm_db_path()`, derived from
+    `settings.chroma_path`. The two are the same file by default but diverge
+    under a non-default `LIFEOS_CHROMA_PATH` -- watching only one left writes
+    through the other invisible to this cache, bounded only by the TTL
+    (#917 review finding 2).
+    """
+    return _dedupe_paths([str(PersonEntityStore.CRM_DB_PATH), get_crm_db_path()])
+
+
+def _open_existing_db(path: str) -> sqlite3.Connection:
+    """Open `path` for read-write without ever creating it.
+
+    Plain `sqlite3.connect(path)` silently creates a 0-byte (and therefore
+    permanently `data_version`-static) file if `path` doesn't exist yet --
+    exactly the wrong failure mode for a path this cache merely *watches*
+    and never writes to (#917 review finding 2). The `mode=rw` URI param
+    makes SQLite raise instead.
+    """
+    uri = Path(path).absolute().as_uri() + "?mode=rw"
+    return sqlite3.connect(
+        uri,
+        uri=True,
+        check_same_thread=False,  # threadpool-safe: pragma-only, guarded by lock
+    )
 
 
 class AggregateCache:
     """A bounded, TTL-backstopped, data_version-keyed cache for read-only
     route handlers.
 
-    Each instance owns two persistent, pragma-only SQLite connections (one
-    per database) used solely to read `PRAGMA data_version` cheaply -- the
-    same justification as `PersonEntityStore._get_data_version_connection()`.
-    Every call site of those connections is reached only while holding
-    `self._lock`, so cross-thread use is serialized, which is what makes
+    Each instance owns one persistent, pragma-only SQLite connection per
+    watched database path, used solely to read `PRAGMA data_version`
+    cheaply -- the same justification as
+    `PersonEntityStore._get_data_version_connection()`. Every call site of
+    those connections is reached only while holding `self._lock`, so
+    cross-thread use is serialized, which is what makes
     `check_same_thread=False` safe here despite handlers running on the
     FastAPI worker threadpool.
     """
 
     def __init__(
         self,
-        crm_db_path: Optional[str] = None,
+        crm_db_paths: Optional[list] = None,
         interactions_db_path: Optional[str] = None,
         max_entries: int = MAX_ENTRIES,
         max_total_bytes: int = MAX_TOTAL_BYTES,
     ):
-        self.crm_db_path = crm_db_path or str(PersonEntityStore.CRM_DB_PATH)
+        self.crm_db_paths = _dedupe_paths(
+            list(crm_db_paths) if crm_db_paths is not None else _default_crm_db_paths()
+        )
         self.interactions_db_path = interactions_db_path or get_interaction_db_path()
         self.max_entries = max_entries
         self.max_total_bytes = max_total_bytes
 
         self._lock = threading.Lock()
-        self._crm_conn: Optional[sqlite3.Connection] = None
+        self._crm_conns: list = [None] * len(self.crm_db_paths)
         self._interactions_conn: Optional[sqlite3.Connection] = None
-        # key -> (expires_at monotonic, jsonable value, size in bytes). Dict
-        # order doubles as LRU order (most-recently-used at the end).
+        self._version_read_failing = False  # for "log once" on the way down
+
+        # key -> (expires_at monotonic, deep-copied value, size in bytes).
+        # Dict order doubles as LRU order (most-recently-used at the end).
+        # The data_version pair is NOT part of the key -- see
+        # _refresh_generation_locked().
         self._cache: "OrderedDict[tuple, tuple[float, object, int]]" = OrderedDict()
         self._total_bytes = 0
+        self._generation: Optional[tuple] = None
 
-    def _get_crm_connection(self) -> sqlite3.Connection:
-        if self._crm_conn is None:
-            self._crm_conn = sqlite3.connect(
-                self.crm_db_path,
-                check_same_thread=False,  # threadpool-safe: pragma-only, guarded by lock
-            )
-        return self._crm_conn
+        # key -> Event, for single-flight de-duplication of concurrent
+        # misses. Guarded by `_lock` like everything else here.
+        self._in_flight: dict = {}
+
+    def _get_crm_connection(self, index: int) -> sqlite3.Connection:
+        if self._crm_conns[index] is None:
+            self._crm_conns[index] = _open_existing_db(self.crm_db_paths[index])
+        return self._crm_conns[index]
 
     def _get_interactions_connection(self) -> sqlite3.Connection:
         if self._interactions_conn is None:
-            self._interactions_conn = sqlite3.connect(
-                self.interactions_db_path,
-                check_same_thread=False,  # threadpool-safe: pragma-only, guarded by lock
-            )
+            self._interactions_conn = _open_existing_db(self.interactions_db_path)
         return self._interactions_conn
 
-    def _data_versions_locked(self) -> tuple:
-        """Read both PRAGMA data_version counters. Caller must hold `_lock`."""
-        crm_version = self._get_crm_connection().execute("PRAGMA data_version").fetchone()[0]
-        interactions_version = self._get_interactions_connection().execute(
-            "PRAGMA data_version").fetchone()[0]
-        return int(crm_version), int(interactions_version)
+    def _try_read_versions_locked(self) -> Optional[tuple]:
+        """Read every watched database's `PRAGMA data_version`, or `None` if
+        any read fails. Caller must hold `_lock`.
+
+        A missing file, a file mid-replacement (e.g. a backup-restore
+        swap), or any other `sqlite3.Error` must never turn a request that
+        would otherwise succeed into a 500 (#917 review finding 1) -- the
+        caller falls through to computing uncached on `None`. Every open
+        connection is dropped on failure so the *next* call opens fresh
+        (the file may appear, or be restored, in the meantime); logs once
+        per outage rather than once per request.
+        """
+        try:
+            crm_versions = tuple(
+                int(self._get_crm_connection(i).execute("PRAGMA data_version").fetchone()[0])
+                for i in range(len(self.crm_db_paths))
+            )
+            interactions_version = int(
+                self._get_interactions_connection().execute("PRAGMA data_version").fetchone()[0]
+            )
+        except sqlite3.Error as exc:
+            if not self._version_read_failing:
+                logger.warning(
+                    "AggregateCache: PRAGMA data_version read failed (%s); "
+                    "serving every decorated endpoint uncached until it recovers", exc,
+                )
+                self._version_read_failing = True
+            self._crm_conns = [None] * len(self.crm_db_paths)
+            self._interactions_conn = None
+            return None
+
+        self._version_read_failing = False
+        return (crm_versions, interactions_version)
+
+    def _refresh_generation_locked(self, versions: tuple) -> None:
+        """Drop every cached entry if `versions` differs from the last-seen
+        generation. Caller must hold `_lock`.
+
+        Keeping the version pair as a generation stamp rather than inside
+        each entry's key means a write drops stale entries outright instead
+        of merely making them unreachable while they still count against
+        the entry/byte bounds until LRU pressure happens to reclaim them
+        (#917 review finding 8).
+        """
+        if self._generation is not None and self._generation != versions:
+            self._cache.clear()
+            self._total_bytes = 0
+        self._generation = versions
 
     def _evict_locked(self) -> None:
         """Drop the least-recently-used entries while over either bound.
@@ -119,11 +245,19 @@ class AggregateCache:
         with self._lock:
             self._cache.clear()
             self._total_bytes = 0
+            self._generation = None
 
-    def cached(self, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> Callable:
+    def cached(self, ttl_seconds: float = DEFAULT_TTL_SECONDS,
+               should_cache: Optional[Callable[[dict], bool]] = None) -> Callable:
         """Memoize a function's return value for `ttl_seconds`, keyed on its
-        resolved keyword arguments plus both databases' current
-        data_version.
+        resolved keyword arguments, invalidated whenever any watched
+        database's data_version changes.
+
+        `should_cache`, if given, is called with the resolved kwargs dict
+        before anything else; a `False` return bypasses the cache entirely
+        for that call (no read, no store) -- used to keep `/people` search
+        text and unbounded-`limit` pages out of a long-lived in-memory key
+        (#917 review finding 6).
 
         Intended for a FastAPI route handler, applied directly under
         `@router.get(...)` (i.e. as the innermost decorator) so FastAPI still
@@ -135,62 +269,120 @@ class AggregateCache:
         Only a successful return is ever cached: an exception (including a
         raised HTTPException for a non-200 response) propagates before this
         reaches the cache-store step, so an error response is never cached.
+
+        The returned value is always a deep copy, on both a hit and a miss:
+        a caller that mutates its own result in place can never poison the
+        cache, and a caller receiving a hit can never be poisoned by a
+        previous caller's mutation (#917 review finding 5).
         """
         def decorator(func: Callable) -> Callable:
             identity = f"{func.__module__}.{func.__qualname__}"
 
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
+                if should_cache is not None and not should_cache(kwargs):
+                    return func(*args, **kwargs)
+
                 # FastAPI always calls path operation functions with
                 # resolved Query()/Path() values as keyword arguments, so
                 # this alone covers "every query parameter" without
                 # inspecting the request directly.
                 param_key = tuple(sorted(kwargs.items()))
+                key = (identity, param_key)
 
+                is_leader = False
+                event = None
                 with self._lock:
-                    crm_version, interactions_version = self._data_versions_locked()
-                    key = (identity, param_key, crm_version, interactions_version)
-                    cached = self._cache.get(key)
-                    if cached is not None:
-                        expires_at, value, size = cached
-                        if expires_at > time.monotonic():
+                    versions = self._try_read_versions_locked()
+                    if versions is not None:
+                        self._refresh_generation_locked(versions)
+                        cached = self._cache.get(key)
+                        if cached is not None:
+                            expires_at, value, size = cached
+                            if expires_at > time.monotonic():
+                                self._cache.move_to_end(key)
+                                return copy.deepcopy(value)
+                            # Expired -- drop it now rather than waiting for
+                            # a bounds-triggered eviction that might never come.
+                            del self._cache[key]
+                            self._total_bytes -= size
+
+                        # Single-flight: only the first miss for this key
+                        # computes; concurrent others wait for it below.
+                        event = self._in_flight.get(key)
+                        if event is None:
+                            event = threading.Event()
+                            self._in_flight[key] = event
+                            is_leader = True
+
+                if versions is None:
+                    # Cache unavailable this call (see
+                    # _try_read_versions_locked) -- compute uncached rather
+                    # than fail the request.
+                    return func(*args, **kwargs)
+
+                if not is_leader:
+                    # A concurrent call is already computing this exact key;
+                    # wait for it and reuse its result instead of also
+                    # computing (#917 review finding 9).
+                    event.wait(timeout=ttl_seconds)
+                    with self._lock:
+                        cached = self._cache.get(key)
+                        if cached is not None:
+                            expires_at, value, _size = cached
+                            if expires_at > time.monotonic():
+                                self._cache.move_to_end(key)
+                                return copy.deepcopy(value)
+                    # The leader's call raised, its entry already expired,
+                    # or we timed out waiting -- fall back to computing
+                    # ourselves rather than waiting forever.
+                    return func(*args, **kwargs)
+
+                # Leader path: compute outside the lock (the wrapped handler
+                # can take tens/hundreds of ms, and holding the lock here
+                # would serialize every cached CRM aggregate request behind
+                # whichever one is currently a cache miss). Followers must
+                # not be woken until the result is actually visible in
+                # `self._cache` -- waking them right after `func()` returns,
+                # before the store below runs, is exactly what a follower's
+                # own fallback ("nothing cached yet -> compute it myself")
+                # is for, silently turning single-flight into "everyone
+                # computes anyway" under real timing (a bug caught only by
+                # measuring over real concurrent HTTP load, not the unit
+                # test's synthetic slow function -- the store there was fast
+                # enough to usually win the race).
+                try:
+                    result = func(*args, **kwargs)
+
+                    # Deep-copy what's stored (and returned): the caller of
+                    # this very call could still mutate `result` in place,
+                    # but that must never reach the cached entry another
+                    # caller receives later (#917 review finding 5).
+                    # jsonable_encoder is used only to measure a byte size
+                    # for the cache's bounds; it never replaces what's
+                    # actually stored/returned.
+                    stored = copy.deepcopy(result)
+                    size = len(json.dumps(jsonable_encoder(stored)).encode("utf-8"))
+
+                    with self._lock:
+                        if size > self.max_total_bytes:
+                            # Too big to ever fit -- skip caching it rather
+                            # than evicting everything else to make room
+                            # (#917 review finding 8).
+                            pass
+                        else:
+                            if key in self._cache:
+                                self._total_bytes -= self._cache[key][2]
+                            self._cache[key] = (time.monotonic() + ttl_seconds, stored, size)
                             self._cache.move_to_end(key)
-                            return value
-                        # Expired -- drop it now rather than waiting for a
-                        # bounds-triggered eviction that might never come.
-                        del self._cache[key]
-                        self._total_bytes -= size
+                            self._total_bytes += size
+                            self._evict_locked()
 
-                # Compute outside the lock: the wrapped handler can take
-                # tens/hundreds of ms, and holding the lock here would
-                # serialize every cached CRM aggregate request behind
-                # whichever one is currently a cache miss.
-                result = func(*args, **kwargs)
-
-                # The cached (and returned) value is `result` itself, not a
-                # jsonable_encoder()'d copy: some existing CRM unit tests
-                # call a decorated handler directly (bypassing FastAPI) and
-                # expect the same Pydantic model FastAPI would otherwise
-                # serialize later, with normal attribute access -- e.g.
-                # `result.people`, not `result["people"]`. jsonable_encoder
-                # is used only to measure the byte size for the cache's
-                # bounds; it never replaces what's actually stored/returned.
-                size = len(json.dumps(jsonable_encoder(result)).encode("utf-8"))
-
-                with self._lock:
-                    # A concurrent miss for the same key may have already
-                    # stored an entry while this call was computing outside
-                    # the lock -- last writer wins, which is fine, since
-                    # both computed from the same data_version pair and
-                    # therefore the same underlying data.
-                    if key in self._cache:
-                        self._total_bytes -= self._cache[key][2]
-                    self._cache[key] = (time.monotonic() + ttl_seconds, result, size)
-                    self._cache.move_to_end(key)
-                    self._total_bytes += size
-                    self._evict_locked()
-
-                return result
+                    return result
+                finally:
+                    with self._lock:
+                        self._in_flight.pop(key, None)
+                    event.set()
 
             return wrapper
 
@@ -209,7 +401,8 @@ def get_aggregate_cache() -> AggregateCache:
     return _aggregate_cache
 
 
-def cached_aggregate(ttl_seconds: float = DEFAULT_TTL_SECONDS) -> Callable:
+def cached_aggregate(ttl_seconds: float = DEFAULT_TTL_SECONDS,
+                      should_cache: Optional[Callable[[dict], bool]] = None) -> Callable:
     """Decorator applied to CRM route handlers, backed by the process-wide
     `AggregateCache` singleton. See `AggregateCache.cached()` for the actual
     caching behavior.
@@ -220,7 +413,7 @@ def cached_aggregate(ttl_seconds: float = DEFAULT_TTL_SECONDS) -> Callable:
     below clears that instance's entries in place rather than swapping in a
     new one (which the already-decorated handlers would never see).
     """
-    return get_aggregate_cache().cached(ttl_seconds)
+    return get_aggregate_cache().cached(ttl_seconds, should_cache=should_cache)
 
 
 def reset_aggregate_cache() -> None:
@@ -230,12 +423,11 @@ def reset_aggregate_cache() -> None:
     handler (e.g. `get_me_interactions`) directly with its store dependency
     mocked (`patch('api.routes.crm.get_person_entity_store', ...)`) -- the
     mock never touches the real crm.db/interactions.db files, so this
-    cache's data_version-keyed entries from an earlier test with the same
-    parameters would otherwise still be a "hit" and mask the new mock's
-    return value entirely. Wired into
-    `tests.reset_singletons.reset_lightweight_singletons()`, which the
-    autouse `reset_singletons_after_test` fixture in `tests/conftest.py`
-    already runs after every test.
+    cache's entries from an earlier test with the same parameters would
+    otherwise still be a "hit" and mask the new mock's return value
+    entirely. Wired into `tests.reset_singletons.reset_lightweight_singletons()`,
+    which the autouse `reset_singletons_after_test` fixture in
+    `tests/conftest.py` already runs after every test.
 
     Deliberately does not reassign the module-level `_aggregate_cache`
     singleton to a fresh instance: `cached_aggregate()` binds each decorated

--- a/api/services/aggregate_cache.py
+++ b/api/services/aggregate_cache.py
@@ -29,7 +29,7 @@ with.
    `api.utils.db_paths.get_crm_db_path()` (deduped by `os.path.realpath`),
    since the stores backing `/statistics` and `/people` use the latter and
    the two can diverge under a non-default `LIFEOS_CHROMA_PATH`. Connections
-   open with a `mode=rw` URI so a missing file is never silently created.
+   open read-only with a `mode=ro` URI so a missing file is never silently created.
 4. The byte bound tracks serialized JSON size, which understates real
    retained heap by roughly 7x (measured) -- `MAX_TOTAL_BYTES` is scaled down
    by that ratio so it targets a real ~50 MB heap ceiling, not a 20 MB one.
@@ -45,6 +45,12 @@ with.
    `threading.Event`: the first caller computes, the rest wait for it and
    reuse its result (falling back to computing themselves only if the
    leader's call raised).
+11. A store re-checks that the generation it read before computing is still
+    current: finding 8's generation-stamp redesign otherwise let a commit
+    that lands while a handler is running get that handler's pre-write
+    result cached under the post-write generation, served stale for the
+    full TTL. A mismatch at store time skips caching -- the next request
+    for that key simply misses and recomputes against the new generation.
 """
 import copy
 import functools
@@ -68,6 +74,15 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TTL_SECONDS = 300
 MAX_ENTRIES = 200
+
+# How long a follower waits for the leader computing its key before giving
+# up and computing itself. Deliberately far shorter than DEFAULT_TTL_SECONDS
+# (which used to also gate this wait): a real handler realistically takes at
+# most a few seconds even on the largest aggregate, so waiting a full 300s
+# would just hold a threadpool worker thread hostage to whatever went wrong
+# with the leader (an unexpected hang, not merely a slow query) far longer
+# than any request should ever legitimately take (#917 review nit).
+FOLLOWER_WAIT_TIMEOUT_SECONDS = 30
 
 # A ~7 MB serialized-JSON entry was measured to retain ~51 MB of actual
 # Python-object heap once decoded/cached -- nested dicts/lists/model
@@ -106,15 +121,19 @@ def _default_crm_db_paths() -> list:
 
 
 def _open_existing_db(path: str) -> sqlite3.Connection:
-    """Open `path` for read-write without ever creating it.
+    """Open `path` read-only, without ever creating it.
 
     Plain `sqlite3.connect(path)` silently creates a 0-byte (and therefore
     permanently `data_version`-static) file if `path` doesn't exist yet --
     exactly the wrong failure mode for a path this cache merely *watches*
-    and never writes to (#917 review finding 2). The `mode=rw` URI param
-    makes SQLite raise instead.
+    and never writes to (#917 review finding 2). The `mode=ro` URI param
+    makes SQLite raise instead of creating it, and -- verified against a
+    WAL-mode database, which every store here uses -- a read-only
+    connection still sees `PRAGMA data_version` change correctly after an
+    external write, so there is no need for `mode=rw` (which would also
+    have worked, but claims write access this connection never uses).
     """
-    uri = Path(path).absolute().as_uri() + "?mode=rw"
+    uri = Path(path).absolute().as_uri() + "?mode=ro"
     return sqlite3.connect(
         uri,
         uri=True,
@@ -325,7 +344,7 @@ class AggregateCache:
                     # A concurrent call is already computing this exact key;
                     # wait for it and reuse its result instead of also
                     # computing (#917 review finding 9).
-                    event.wait(timeout=ttl_seconds)
+                    event.wait(timeout=FOLLOWER_WAIT_TIMEOUT_SECONDS)
                     with self._lock:
                         cached = self._cache.get(key)
                         if cached is not None:
@@ -357,15 +376,36 @@ class AggregateCache:
                     # Deep-copy what's stored (and returned): the caller of
                     # this very call could still mutate `result` in place,
                     # but that must never reach the cached entry another
-                    # caller receives later (#917 review finding 5).
-                    # jsonable_encoder is used only to measure a byte size
-                    # for the cache's bounds; it never replaces what's
-                    # actually stored/returned.
+                    # caller receives later (#917 review finding 5). This
+                    # roughly doubles a warm hit's CPU cost relative to a
+                    # shallow return (measured: a 235 KB /me/timeline page
+                    # went from ~2.5ms to ~4.6ms of *added* work over real
+                    # HTTP -- still far under the 20ms target, but worth
+                    # knowing if a response size this decorates grows a lot
+                    # further). jsonable_encoder is used only to measure a
+                    # byte size for the cache's bounds; it never replaces
+                    # what's actually stored/returned.
                     stored = copy.deepcopy(result)
                     size = len(json.dumps(jsonable_encoder(stored)).encode("utf-8"))
 
                     with self._lock:
-                        if size > self.max_total_bytes:
+                        # Re-check the generation against what THIS call
+                        # read before computing, not whatever it is now: a
+                        # commit that lands while `func()` above is running
+                        # advances `self._generation` (via a later request's
+                        # own version read) before this store runs, so
+                        # storing unconditionally would cache a pre-write
+                        # result under the post-write generation and serve
+                        # it for the full TTL -- exactly the staleness this
+                        # cache exists to prevent (#917 review finding 11,
+                        # introduced by finding 8's generation-stamp
+                        # redesign: the old version-in-key design was
+                        # immune, since a V1-computed entry stored under a
+                        # V1 key was simply never looked up again once the
+                        # generation moved to V2).
+                        if self._generation != versions:
+                            pass
+                        elif size > self.max_total_bytes:
                             # Too big to ever fit -- skip caching it rather
                             # than evicting everything else to make room
                             # (#917 review finding 8).
@@ -380,9 +420,19 @@ class AggregateCache:
 
                     return result
                 finally:
+                    # Wake followers before dropping the in-flight marker:
+                    # a brand-new request arriving in between would
+                    # otherwise see neither a cache entry (if the store
+                    # above was skipped) nor an in-flight event, and start
+                    # a second, fully redundant computation rather than
+                    # falling into the (already-set, so non-blocking)
+                    # follower path and getting the same "compute it
+                    # myself" fallback that path already has (#917 review
+                    # nit: single-flight is best-effort, not exact, but this
+                    # ordering narrows the gap).
+                    event.set()
                     with self._lock:
                         self._in_flight.pop(key, None)
-                    event.set()
 
             return wrapper
 

--- a/docs/specs/product/api-crm.md
+++ b/docs/specs/product/api-crm.md
@@ -6,6 +6,8 @@
 
 Every `/api/crm/*` HTTP endpoint. Split out of the main [api-reference.md](api-reference.md) because the CRM endpoint catalog is large enough to deserve its own file. For the consumer view of the CRM features these endpoints back, see the [CRM specs](crm-ui.md).
 
+`GET /api/crm/people`, `/statistics`, `/me/interactions`, `/me/timeline`, `/family/interactions`, `/family/timeline`, and `/birthdays/all` are backed by a short-lived, data-version-keyed response cache — see [architecture.md](../technical/architecture.md) for how it's keyed and invalidated. This is transparent to callers: response shape, status codes, and freshness (any write anywhere in the CRM data invalidates the relevant cached responses immediately) are unchanged.
+
 ---
 
 ## Table of Contents
@@ -658,3 +660,4 @@ Sync Apple Contacts to the CRM. Creates SourceEntity records for all contacts. O
 - [crm-graph.md](crm-graph.md) — Consumer view of the graph and relationship model
 - [crm-analytics.md](crm-analytics.md) — Consumer view of the family/me/birthday/relationship dashboards
 - [data-model.md](data-model.md) — Two-tier data model semantics behind every endpoint here
+- [architecture.md](../technical/architecture.md) — `AggregateCache`, the response cache behind the endpoints noted above

--- a/docs/specs/product/api-crm.md
+++ b/docs/specs/product/api-crm.md
@@ -6,7 +6,7 @@
 
 Every `/api/crm/*` HTTP endpoint. Split out of the main [api-reference.md](api-reference.md) because the CRM endpoint catalog is large enough to deserve its own file. For the consumer view of the CRM features these endpoints back, see the [CRM specs](crm-ui.md).
 
-`GET /api/crm/people`, `/statistics`, `/me/interactions`, `/me/timeline`, `/family/interactions`, `/family/timeline`, and `/birthdays/all` are backed by a short-lived, data-version-keyed response cache — see [architecture.md](../technical/architecture.md) for how it's keyed and invalidated. This is transparent to callers: response shape, status codes, and freshness (any write anywhere in the CRM data invalidates the relevant cached responses immediately) are unchanged.
+`GET /api/crm/people` (only for the default page shape — no search text, `limit` ≤ 300), `/statistics`, `/me/interactions`, `/me/timeline`, `/family/interactions`, `/family/timeline`, and `/birthdays/all` are backed by a short-lived, data-version-keyed response cache — see [architecture.md](../technical/architecture.md) for how it's keyed and invalidated. Response shape and status codes are unchanged. Freshness is bounded by a five-minute TTL rather than guaranteed immediate: a write to the CRM data invalidates a cached response well within that window, but a response can otherwise be up to five minutes old, and a time-windowed aggregate (computed from the request time) freezes "now" for the life of the cached entry that served it.
 
 ---
 

--- a/docs/specs/product/crm-analytics.md
+++ b/docs/specs/product/crm-analytics.md
@@ -8,7 +8,7 @@ The aggregated views that sit alongside the people list: Family Dashboard (`/fam
 
 See [crm-ui.md](crm-ui.md) for the CRM index and the sibling specs that cover people, interactions, and the graph.
 
-Each dashboard's heaviest endpoint (its interactions/timeline aggregate, plus `/statistics`, `/birthdays/all`, and the default people list) is served from a short-lived server cache: a repeat request with the same parameters, from any client, returns instantly until a change is made anywhere in the CRM data — see [architecture.md](../technical/architecture.md) for how the cache is keyed and invalidated.
+Each dashboard's heaviest endpoint (its interactions/timeline aggregate, plus `/statistics`, `/birthdays/all`, and the default people list) is served from a short-lived server cache, bounded by a five-minute TTL: a repeat request with the same parameters, from any client, returns instantly and a change anywhere in the CRM data invalidates it well within that window — see [architecture.md](../technical/architecture.md) for how the cache is keyed and invalidated.
 
 ---
 

--- a/docs/specs/product/crm-analytics.md
+++ b/docs/specs/product/crm-analytics.md
@@ -8,6 +8,8 @@ The aggregated views that sit alongside the people list: Family Dashboard (`/fam
 
 See [crm-ui.md](crm-ui.md) for the CRM index and the sibling specs that cover people, interactions, and the graph.
 
+Each dashboard's heaviest endpoint (its interactions/timeline aggregate, plus `/statistics`, `/birthdays/all`, and the default people list) is served from a short-lived server cache: a repeat request with the same parameters, from any client, returns instantly until a change is made anywhere in the CRM data — see [architecture.md](../technical/architecture.md) for how the cache is keyed and invalidated.
+
 ---
 
 ## Table of Contents
@@ -264,5 +266,6 @@ Each panel has a refresh button to re-extract insights on demand.
 - [crm-interactions.md](crm-interactions.md) — Interaction source ingestion (the dashboards aggregate over these)
 - [crm-graph.md](crm-graph.md) — Relationship graph (some dashboards link out to the graph view)
 - [api-reference.md](api-reference.md) — Full HTTP endpoint catalog
+- [architecture.md](../technical/architecture.md) — `AggregateCache`, the response cache these dashboards' heaviest endpoints share
 - [journal-analytics.md](journal-analytics.md) — Sibling analytics view (daily-journal emotion wheel) using the same pre-aggregated-response, graceful-window-fallback pattern
 - [configuration.md](../../guides/configuration.md) — `LIFEOS_PARTNER_NAME`, `LIFEOS_THERAPIST_PATTERNS`, `LIFEOS_PERSONAL_RELATIONSHIP_PATTERNS`

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -124,7 +124,7 @@ settings-derived one, deduped by `os.path.realpath` (the two are the same
 file by default, but can diverge under a non-default `LIFEOS_CHROMA_PATH`)
 — plus `interactions.db`, each read from a long-lived, pragma-only
 connection following the same pattern as `PersonEntityStore`'s own
-data_version connection above, opened with a `mode=rw` URI so a missing
+data_version connection above, opened read-only with a `mode=ro` URI so a missing
 file is never silently created. A `PRAGMA data_version` read failure (a
 missing file, a file mid-replacement) never fails the request: it logs
 once and falls through to computing uncached, reopening the connection on

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -109,19 +109,41 @@ before persisting changes.
 `aggregate_cache.py`'s `AggregateCache` memoizes the return value of the
 CRM's heaviest read endpoints — `/me/interactions`, `/me/timeline`,
 `/family/interactions`, `/family/timeline`, `/birthdays/all`, `/statistics`,
-and `/people` — applied via a `@cached_aggregate()` decorator directly under
-each route's `@router.get(...)`. The cache key is the route's resolved
-keyword arguments (every query parameter FastAPI resolved) plus both
-`crm.db` and `interactions.db`'s `PRAGMA data_version`, read from two
-long-lived, pragma-only connections following the same pattern as
-`PersonEntityStore`'s own data_version connection above. A commit to either
-database — from this process or another — makes the next request for an
-affected cache key recompute; a 300-second TTL is a backstop bound on entry
-lifetime, not the primary invalidation path. Entries are bounded by count
-(200) and total serialized bytes (20 MB), evicted least-recently-used; a
-raised exception (including an `HTTPException` for a non-200 response)
-propagates before the cache-store step, so error responses are never
-cached.
+and `/people` (only for its default page shape — no search text, `limit` ≤
+300; a search or a large export is requested once and never reused, so it
+bypasses the cache rather than spending memory and encode time on an entry
+that will never hit) — applied via a `@cached_aggregate()` decorator
+directly under each route's `@router.get(...)`. The cache key is the
+route's resolved keyword arguments (every query parameter FastAPI
+resolved); the data_version pair is a *generation stamp* held outside the
+key, so a commit anywhere drops every existing entry outright rather than
+merely making old-generation keys unreachable inside the bounds below.
+`crm.db` is watched at every path a CRM store actually reads it from —
+`PersonEntityStore`'s hardcoded path and `api.utils.db_paths.get_crm_db_path()`'s
+settings-derived one, deduped by `os.path.realpath` (the two are the same
+file by default, but can diverge under a non-default `LIFEOS_CHROMA_PATH`)
+— plus `interactions.db`, each read from a long-lived, pragma-only
+connection following the same pattern as `PersonEntityStore`'s own
+data_version connection above, opened with a `mode=rw` URI so a missing
+file is never silently created. A `PRAGMA data_version` read failure (a
+missing file, a file mid-replacement) never fails the request: it logs
+once and falls through to computing uncached, reopening the connection on
+the next call. A 300-second TTL is a backstop bound on entry lifetime, not
+the primary invalidation path — a response can be up to five minutes old
+with no intervening writes, and a time-windowed aggregate (computed from
+the request time) freezes "now" for the life of the entry that served it.
+Concurrent misses for the same key single-flight behind a per-key
+`threading.Event`, so only the first caller actually computes. Entries are
+bounded by count (200) and total serialized bytes (~7 MB, deliberately far
+below the 20 MB a naive reading suggests: a serialized-JSON byte undercounts
+the retained Python-object heap by roughly 7x, measured, so the bound
+targets a real ~50 MB heap ceiling rather than a 20 MB serialized one); an
+entry larger than the byte cap is skipped rather than evicting everything
+else to make room for it. The cached (and returned) value is always a deep
+copy, so a caller mutating its own result can never poison another
+caller's hit. A raised exception (including an `HTTPException` for a
+non-200 response) propagates before the cache-store step, so error
+responses are never cached.
 
 **Relationships:**
 - `relationship.py` - Relationship store

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -93,6 +93,7 @@ Per-backend capabilities (personas, handoff, history ownership, usage capture) a
 - `person_facts.py` - Fact extraction and storage
 - `person_indexer.py` - Person search indexing
 - `person_stats.py` - Statistics computation
+- `aggregate_cache.py` - Response cache for the heaviest CRM aggregate endpoints (see below)
 
 `PersonEntityStore.get_all()` keeps a process-local cache of hydrated
 `PersonEntity` objects for the people list and CRM aggregate views. Cache
@@ -104,6 +105,23 @@ invalidates the cached people list on the next read. Callers receive a new
 list object on each call, but entity objects are shared, so write paths that
 mutate a person fetched from the full list must refetch that person by ID
 before persisting changes.
+
+`aggregate_cache.py`'s `AggregateCache` memoizes the return value of the
+CRM's heaviest read endpoints — `/me/interactions`, `/me/timeline`,
+`/family/interactions`, `/family/timeline`, `/birthdays/all`, `/statistics`,
+and `/people` — applied via a `@cached_aggregate()` decorator directly under
+each route's `@router.get(...)`. The cache key is the route's resolved
+keyword arguments (every query parameter FastAPI resolved) plus both
+`crm.db` and `interactions.db`'s `PRAGMA data_version`, read from two
+long-lived, pragma-only connections following the same pattern as
+`PersonEntityStore`'s own data_version connection above. A commit to either
+database — from this process or another — makes the next request for an
+affected cache key recompute; a 300-second TTL is a backstop bound on entry
+lifetime, not the primary invalidation path. Entries are bounded by count
+(200) and total serialized bytes (20 MB), evicted least-recently-used; a
+raised exception (including an `HTTPException` for a non-200 response)
+propagates before the cache-store step, so error responses are never
+cached.
 
 **Relationships:**
 - `relationship.py` - Relationship store
@@ -463,5 +481,7 @@ Tests are in `tests/` with naming convention `test_*.py`.
 - [Client Surfaces](client-surfaces.md) -- HTTP consumers and breaking-change policy
 - [Frontend](frontend.md) -- UI components and patterns
 - [API Reference](../product/api-reference.md) -- API endpoint contracts
+- [CRM Dashboards & Insights](../product/crm-analytics.md) -- The dashboards `AggregateCache` serves
+- [CRM API Reference](../product/api-crm.md) -- The specific endpoints `AggregateCache` covers
 - [ADR-001: Python/FastAPI](../../adr/001-python-fastapi.md) -- Why Python/FastAPI was chosen
 - [Python Conventions](../standards/python-conventions.md) -- Coding style and module patterns

--- a/tests/reset_singletons.py
+++ b/tests/reset_singletons.py
@@ -28,6 +28,7 @@ def reset_lightweight_singletons() -> None:
     - ConversationStore
     - HybridSearch
     - BM25Index
+    - AggregateCache (cache entries only -- see reset_aggregate_cache())
 
     Does NOT reset embedding service (causes slow model reload).
     """
@@ -37,12 +38,14 @@ def reset_lightweight_singletons() -> None:
     from api.services.bm25_index import reset_bm25_index
     from api.services.perf_trace import reset_perf_trace_store
     from api.services.llm_client import reset_local_llm
+    from api.services.aggregate_cache import reset_aggregate_cache
 
     reset_service_health()
     reset_conversation_store()
     reset_hybrid_search()
     reset_bm25_index()
     reset_perf_trace_store()
+    reset_aggregate_cache()
     reset_local_llm()
 
 

--- a/tests/test_aggregate_cache.py
+++ b/tests/test_aggregate_cache.py
@@ -1,0 +1,325 @@
+"""
+Tests for the CRM aggregate response cache (#876).
+
+`AggregateCache` memoizes a route handler's return value, keyed on its
+resolved query parameters plus both databases' `PRAGMA data_version`
+counters, so a second identical request is served instantly until either
+database is written to (from any connection, in this process or another) or
+a short TTL backstop expires. These tests build isolated `AggregateCache`
+instances against temporary SQLite files -- the same pattern
+`tests/test_person_entity.py` uses for `PersonEntityStore(db_path)` -- rather
+than the process-wide `get_aggregate_cache()` singleton, so nothing here
+touches real data or depends on run order relative to other test files.
+"""
+import sqlite3
+import threading
+import time
+
+import pytest
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.testclient import TestClient
+
+from api.services.aggregate_cache import AggregateCache
+
+pytestmark = pytest.mark.unit
+
+
+def _make_db(path) -> str:
+    """A minimal but valid SQLite file at `path` -- AggregateCache only ever
+    reads PRAGMA data_version from it, so the schema doesn't matter."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+    return str(path)
+
+
+@pytest.fixture
+def cache(tmp_path):
+    """A fresh, isolated AggregateCache backed by two temporary databases."""
+    crm_db = _make_db(tmp_path / "crm.db")
+    interactions_db = _make_db(tmp_path / "interactions.db")
+    return AggregateCache(crm_db_path=crm_db, interactions_db_path=interactions_db)
+
+
+def _commit_external_write(db_path: str) -> None:
+    """Write to `db_path` from a brand-new connection -- models a write from
+    another process/request, which is exactly what PRAGMA data_version is
+    meant to detect."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("INSERT INTO marker (value) VALUES ('external-write')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestCacheHit:
+    """A second call with identical parameters is served from cache, fast,
+    with an identical body -- and does not recompute."""
+
+    def test_second_call_is_fast_and_identical_and_does_not_recompute(self, cache):
+        calls = []
+
+        @cache.cached()
+        def endpoint(days_back: int = 30, trend_period: str = "quarter"):
+            calls.append(1)
+            return {"days_back": days_back, "trend_period": trend_period, "call_number": len(calls)}
+
+        first = endpoint(days_back=30, trend_period="quarter")
+
+        start = time.perf_counter()
+        second = endpoint(days_back=30, trend_period="quarter")
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert second == first
+        assert len(calls) == 1, "second call must be served from cache, not recomputed"
+        assert elapsed_ms < 20, f"cache hit took {elapsed_ms:.2f}ms, expected under 20ms"
+
+
+class TestPerParameterKeys:
+    """Different parameters get independent cache entries; revisiting an
+    earlier parameter set still hits its own cached entry."""
+
+    def test_distinct_parameters_are_not_conflated(self, cache):
+        calls = []
+
+        @cache.cached()
+        def endpoint(x: int = 0):
+            calls.append(x)
+            return {"x": x, "call_number": len(calls)}
+
+        result_a = endpoint(x=1)
+        result_b = endpoint(x=2)
+        assert result_a != result_b
+        assert len(calls) == 2
+
+        # Revisiting x=1's parameters hits its own cached entry.
+        result_a_again = endpoint(x=1)
+        assert result_a_again == result_a
+        assert len(calls) == 2
+
+
+class TestDataVersionInvalidation:
+    """A commit from a separate SQLite connection to either database
+    invalidates every cached entry (the next lookup for an affected key
+    misses and recomputes)."""
+
+    def test_external_write_to_crm_db_invalidates(self, cache):
+        calls = []
+
+        @cache.cached()
+        def endpoint():
+            calls.append(1)
+            return {"call_number": len(calls)}
+
+        first = endpoint()
+        assert len(calls) == 1
+
+        # Unchanged databases: still a hit.
+        assert endpoint() == first
+        assert len(calls) == 1
+
+        _commit_external_write(cache.crm_db_path)
+
+        second = endpoint()
+        assert len(calls) == 2, "a crm.db commit from another connection must invalidate the cache"
+        assert second != first
+
+    def test_external_write_to_interactions_db_invalidates(self, cache):
+        calls = []
+
+        @cache.cached()
+        def endpoint():
+            calls.append(1)
+            return {"call_number": len(calls)}
+
+        endpoint()
+        assert len(calls) == 1
+
+        _commit_external_write(cache.interactions_db_path)
+
+        endpoint()
+        assert len(calls) == 2, (
+            "an interactions.db commit from another connection must invalidate the cache"
+        )
+
+    def test_ttl_expiry_forces_recompute_even_with_unchanged_data_version(self, cache):
+        """The TTL is a backstop bound, independent of data_version."""
+        calls = []
+
+        @cache.cached(ttl_seconds=0.01)
+        def endpoint():
+            calls.append(1)
+            return {"call_number": len(calls)}
+
+        endpoint()
+        time.sleep(0.05)
+        endpoint()
+        assert len(calls) == 2
+
+
+class TestErrorsAreNeverCached:
+    """A raised exception (an HTTPException for a non-200 response, or any
+    other) is never cached -- the next identical call re-executes the
+    handler rather than replaying the failure or, worse, a stale success."""
+
+    def test_raised_http_exception_is_not_cached(self, cache):
+        calls = []
+
+        @cache.cached()
+        def endpoint(should_fail: bool = True):
+            calls.append(1)
+            if should_fail:
+                raise HTTPException(status_code=400, detail="bad request")
+            return {"ok": True}
+
+        with pytest.raises(HTTPException):
+            endpoint(should_fail=True)
+        with pytest.raises(HTTPException):
+            endpoint(should_fail=True)
+
+        assert len(calls) == 2, "an error response must never be cached"
+        assert cache.stats()["entries"] == 0
+
+    def test_success_after_a_failed_call_is_cached_normally(self, cache):
+        calls = []
+
+        @cache.cached()
+        def endpoint(should_fail: bool = False):
+            calls.append(1)
+            if should_fail:
+                raise HTTPException(status_code=500, detail="boom")
+            return {"ok": True, "call_number": len(calls)}
+
+        with pytest.raises(HTTPException):
+            endpoint(should_fail=True)
+
+        first = endpoint(should_fail=False)
+        second = endpoint(should_fail=False)
+        assert second == first
+        assert len(calls) == 2  # one failure + one success; the retry hit cache
+
+
+class TestBounds:
+    """The cache never grows past its configured entry-count or byte bound."""
+
+    def test_entry_count_is_bounded(self, tmp_path):
+        crm_db = _make_db(tmp_path / "crm.db")
+        interactions_db = _make_db(tmp_path / "interactions.db")
+        cache = AggregateCache(crm_db_path=crm_db, interactions_db_path=interactions_db,
+                                max_entries=3, max_total_bytes=10 * 1024 * 1024)
+
+        @cache.cached()
+        def endpoint(x: int):
+            return {"x": x, "padding": "a" * 100}
+
+        for i in range(10):
+            endpoint(x=i)
+
+        assert cache.stats()["entries"] <= 3
+
+    def test_total_bytes_is_bounded(self, tmp_path):
+        crm_db = _make_db(tmp_path / "crm.db")
+        interactions_db = _make_db(tmp_path / "interactions.db")
+        # Each entry is roughly 1-2KB; a 5KB cap should hold only a few.
+        cache = AggregateCache(crm_db_path=crm_db, interactions_db_path=interactions_db,
+                                max_entries=1000, max_total_bytes=5 * 1024)
+
+        @cache.cached()
+        def endpoint(x: int):
+            return {"x": x, "padding": "a" * 1000}
+
+        for i in range(50):
+            endpoint(x=i)
+
+        stats = cache.stats()
+        assert stats["total_bytes"] <= 5 * 1024
+        assert stats["entries"] < 50, "the byte bound must have evicted older entries"
+
+    def test_clear_empties_the_cache(self, cache):
+        @cache.cached()
+        def endpoint():
+            return {"ok": True}
+
+        endpoint()
+        assert cache.stats()["entries"] == 1
+
+        cache.clear()
+        assert cache.stats() == {"entries": 0, "total_bytes": 0}
+
+
+class TestThreadSafety:
+    """Concurrent calls (same and different parameters) from many threads
+    never raise or corrupt the cache -- the lock genuinely serializes access
+    to the shared dict and both data_version connections."""
+
+    def test_concurrent_calls_do_not_raise_or_corrupt_state(self, cache):
+        calls = []
+        call_lock = threading.Lock()
+        errors = []
+
+        @cache.cached()
+        def endpoint(x: int):
+            with call_lock:
+                calls.append(1)
+            return {"x": x}
+
+        def worker(thread_id):
+            try:
+                for i in range(30):
+                    endpoint(x=(thread_id + i) % 5)
+            except Exception as exc:  # noqa: BLE001 -- want to see any failure
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(16)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent access raised: {errors}"
+        # At most 5 distinct parameter values were ever requested.
+        assert cache.stats()["entries"] <= 5
+
+
+class TestFastAPIIntegration:
+    """The decorator works through FastAPI's own request handling, not just
+    as a plain Python function call: Query() parameters are still resolved
+    (functools.wraps' __wrapped__ preserves the signature FastAPI inspects),
+    and a real HTTP round trip hits the cache on a repeat request."""
+
+    @pytest.fixture
+    def api_client(self, cache):
+        calls = []
+        app = FastAPI()
+
+        @app.get("/widgets")
+        @cache.cached()
+        def list_widgets(count: int = Query(default=1), label: str = Query(default="a")):
+            calls.append(1)
+            return {"count": count, "label": label, "call_number": len(calls)}
+
+        return TestClient(app), calls
+
+    def test_query_params_still_resolve_and_repeat_request_hits_cache(self, api_client):
+        client, calls = api_client
+
+        first = client.get("/widgets?count=5&label=x")
+        assert first.status_code == 200
+        assert first.json()["count"] == 5
+        assert first.json()["label"] == "x"
+        assert len(calls) == 1
+
+        second = client.get("/widgets?count=5&label=x")
+        assert second.status_code == 200
+        assert second.json() == first.json()
+        assert len(calls) == 1, "identical request must be served from cache"
+
+        # A different query param is an independent entry.
+        third = client.get("/widgets?count=5&label=y")
+        assert third.status_code == 200
+        assert third.json()["label"] == "y"
+        assert len(calls) == 2

--- a/tests/test_aggregate_cache.py
+++ b/tests/test_aggregate_cache.py
@@ -1,16 +1,18 @@
 """
-Tests for the CRM aggregate response cache (#876).
+Tests for the CRM aggregate response cache (#876, #917).
 
 `AggregateCache` memoizes a route handler's return value, keyed on its
-resolved query parameters plus both databases' `PRAGMA data_version`
-counters, so a second identical request is served instantly until either
-database is written to (from any connection, in this process or another) or
-a short TTL backstop expires. These tests build isolated `AggregateCache`
-instances against temporary SQLite files -- the same pattern
-`tests/test_person_entity.py` uses for `PersonEntityStore(db_path)` -- rather
-than the process-wide `get_aggregate_cache()` singleton, so nothing here
-touches real data or depends on run order relative to other test files.
+resolved query parameters, invalidated whenever either watched database's
+`PRAGMA data_version` counter changes, so a second identical request is
+served instantly until either database is written to (from any connection,
+in this process or another) or a short TTL backstop expires. These tests
+build isolated `AggregateCache` instances against temporary SQLite files --
+the same pattern `tests/test_person_entity.py` uses for
+`PersonEntityStore(db_path)` -- rather than the process-wide
+`get_aggregate_cache()` singleton, so nothing here touches real data or
+depends on run order relative to other test files.
 """
+import os
 import sqlite3
 import threading
 import time
@@ -19,7 +21,7 @@ import pytest
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.testclient import TestClient
 
-from api.services.aggregate_cache import AggregateCache
+from api.services.aggregate_cache import AggregateCache, _default_crm_db_paths
 
 pytestmark = pytest.mark.unit
 
@@ -41,7 +43,7 @@ def cache(tmp_path):
     """A fresh, isolated AggregateCache backed by two temporary databases."""
     crm_db = _make_db(tmp_path / "crm.db")
     interactions_db = _make_db(tmp_path / "interactions.db")
-    return AggregateCache(crm_db_path=crm_db, interactions_db_path=interactions_db)
+    return AggregateCache(crm_db_paths=[crm_db], interactions_db_path=interactions_db)
 
 
 def _commit_external_write(db_path: str) -> None:
@@ -54,6 +56,21 @@ def _commit_external_write(db_path: str) -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+def _best_of(fn, n=3):
+    """Fastest of `n` timed calls to `fn()`, in milliseconds -- reduces
+    flakiness from an occasional scheduling hiccup on a loaded box (#917
+    review finding 10) versus asserting on a single sample."""
+    best = None
+    result = None
+    for _ in range(n):
+        start = time.perf_counter()
+        result = fn()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        if best is None or elapsed_ms < best:
+            best = elapsed_ms
+    return best, result
 
 
 class TestCacheHit:
@@ -70,13 +87,11 @@ class TestCacheHit:
 
         first = endpoint(days_back=30, trend_period="quarter")
 
-        start = time.perf_counter()
-        second = endpoint(days_back=30, trend_period="quarter")
-        elapsed_ms = (time.perf_counter() - start) * 1000
+        best_ms, second = _best_of(lambda: endpoint(days_back=30, trend_period="quarter"))
 
         assert second == first
         assert len(calls) == 1, "second call must be served from cache, not recomputed"
-        assert elapsed_ms < 20, f"cache hit took {elapsed_ms:.2f}ms, expected under 20ms"
+        assert best_ms < 20, f"best-of-3 cache hit took {best_ms:.2f}ms, expected under 20ms"
 
 
 class TestPerParameterKeys:
@@ -122,7 +137,7 @@ class TestDataVersionInvalidation:
         assert endpoint() == first
         assert len(calls) == 1
 
-        _commit_external_write(cache.crm_db_path)
+        _commit_external_write(cache.crm_db_paths[0])
 
         second = endpoint()
         assert len(calls) == 2, "a crm.db commit from another connection must invalidate the cache"
@@ -159,6 +174,32 @@ class TestDataVersionInvalidation:
         time.sleep(0.05)
         endpoint()
         assert len(calls) == 2
+
+    def test_version_change_drops_entries_outright_not_just_orphans_them(self, cache):
+        """The data_version pair is a generation stamp, not part of the
+        cache key: a write must clear stale entries immediately rather than
+        leaving them counted against the entry/byte bounds until LRU
+        pressure happens to reclaim them (#917 review finding 8)."""
+        @cache.cached()
+        def endpoint_a(x: int):
+            return {"x": x}
+
+        @cache.cached()
+        def endpoint_b(y: int):
+            return {"y": y}
+
+        endpoint_a(x=1)
+        endpoint_b(y=2)
+        assert cache.stats()["entries"] == 2
+
+        _commit_external_write(cache.crm_db_paths[0])
+
+        # The generation check happens lazily, on the next call that reads
+        # data_version -- but that one call must drop *every* stale entry
+        # outright (not just make its own key's old version unreachable),
+        # so calling endpoint_a again leaves only its fresh entry, not two.
+        endpoint_a(x=1)
+        assert cache.stats()["entries"] == 1
 
 
 class TestErrorsAreNeverCached:
@@ -209,7 +250,7 @@ class TestBounds:
     def test_entry_count_is_bounded(self, tmp_path):
         crm_db = _make_db(tmp_path / "crm.db")
         interactions_db = _make_db(tmp_path / "interactions.db")
-        cache = AggregateCache(crm_db_path=crm_db, interactions_db_path=interactions_db,
+        cache = AggregateCache(crm_db_paths=[crm_db], interactions_db_path=interactions_db,
                                 max_entries=3, max_total_bytes=10 * 1024 * 1024)
 
         @cache.cached()
@@ -225,7 +266,7 @@ class TestBounds:
         crm_db = _make_db(tmp_path / "crm.db")
         interactions_db = _make_db(tmp_path / "interactions.db")
         # Each entry is roughly 1-2KB; a 5KB cap should hold only a few.
-        cache = AggregateCache(crm_db_path=crm_db, interactions_db_path=interactions_db,
+        cache = AggregateCache(crm_db_paths=[crm_db], interactions_db_path=interactions_db,
                                 max_entries=1000, max_total_bytes=5 * 1024)
 
         @cache.cached()
@@ -250,39 +291,228 @@ class TestBounds:
         cache.clear()
         assert cache.stats() == {"entries": 0, "total_bytes": 0}
 
-
-class TestThreadSafety:
-    """Concurrent calls (same and different parameters) from many threads
-    never raise or corrupt the cache -- the lock genuinely serializes access
-    to the shared dict and both data_version connections."""
-
-    def test_concurrent_calls_do_not_raise_or_corrupt_state(self, cache):
-        calls = []
-        call_lock = threading.Lock()
-        errors = []
+    def test_entry_larger_than_cap_is_skipped_not_flushed(self, tmp_path):
+        """An entry that alone exceeds the byte cap must be skipped, not
+        stored at the cost of evicting everything else already cached
+        (#917 review finding 8)."""
+        crm_db = _make_db(tmp_path / "crm.db")
+        interactions_db = _make_db(tmp_path / "interactions.db")
+        cache = AggregateCache(crm_db_paths=[crm_db], interactions_db_path=interactions_db,
+                                max_entries=1000, max_total_bytes=1000)
 
         @cache.cached()
-        def endpoint(x: int):
-            with call_lock:
-                calls.append(1)
+        def small_endpoint(x: int):
             return {"x": x}
 
-        def worker(thread_id):
-            try:
-                for i in range(30):
-                    endpoint(x=(thread_id + i) % 5)
-            except Exception as exc:  # noqa: BLE001 -- want to see any failure
-                errors.append(exc)
+        @cache.cached()
+        def huge_endpoint():
+            return {"padding": "a" * 5000}
 
-        threads = [threading.Thread(target=worker, args=(t,)) for t in range(16)]
+        small_endpoint(x=1)
+        small_endpoint(x=2)
+        small_endpoint(x=3)
+        entries_before = cache.stats()["entries"]
+        assert entries_before == 3
+
+        huge_endpoint()  # far bigger than max_total_bytes
+
+        stats = cache.stats()
+        assert stats["entries"] == entries_before, (
+            "an oversized entry must be skipped, not flush the existing cache"
+        )
+        assert stats["total_bytes"] <= 1000
+
+
+class TestMutationSafety:
+    """A caller mutating its own returned object can never poison the cache
+    for a later caller, and a cache hit can never hand out a reference a
+    concurrent caller could poison either (#917 review finding 5)."""
+
+    def test_mutating_a_returned_dict_does_not_poison_the_cache(self, cache):
+        @cache.cached()
+        def endpoint():
+            return {"items": ["original"]}
+
+        first = endpoint()
+        first["items"].append("MUTATED-BY-CALLER")
+        first["items"][0] = "ALSO-MUTATED"
+
+        second = endpoint()
+        assert second == {"items": ["original"]}, (
+            f"cached entry was poisoned by a caller mutation: {second}"
+        )
+
+    def test_two_hits_return_independent_objects(self, cache):
+        @cache.cached()
+        def endpoint():
+            return {"items": ["original"]}
+
+        endpoint()  # populate the cache
+        a = endpoint()
+        b = endpoint()
+        assert a == b
+        assert a is not b, "each call must return its own independent copy"
+
+
+class TestVersionReadFailure:
+    """A PRAGMA data_version read failure (missing file, mid-replacement
+    file, any other sqlite3.Error) must never turn a request that would
+    otherwise succeed into a failure -- it falls through to computing
+    uncached (#917 review finding 1)."""
+
+    def test_missing_crm_db_directory_falls_through_to_uncached(self, tmp_path):
+        missing_path = str(tmp_path / "does" / "not" / "exist" / "crm.db")
+        interactions_db = _make_db(tmp_path / "interactions.db")
+        cache = AggregateCache(crm_db_paths=[missing_path], interactions_db_path=interactions_db)
+
+        calls = []
+
+        @cache.cached()
+        def endpoint():
+            calls.append(1)
+            return {"ok": True, "call_number": len(calls)}
+
+        # Must not raise -- this is the "endpoint still returns 200" case.
+        result = endpoint()
+        assert result == {"ok": True, "call_number": 1}
+        assert len(calls) == 1
+
+        # Since the version read can't succeed, nothing is ever cached --
+        # a second call recomputes too, rather than the process crashing or
+        # (worse) serving something stale forever.
+        result2 = endpoint()
+        assert result2 == {"ok": True, "call_number": 2}
+        assert len(calls) == 2
+        assert cache.stats()["entries"] == 0
+
+    def test_recovers_once_the_file_appears(self, tmp_path):
+        """The connection is dropped and reopened on the next call after a
+        failure, so a file created after the fact (e.g. by a sync process)
+        is picked up without restarting the server."""
+        crm_db_path = str(tmp_path / "crm.db")  # does not exist yet
+        interactions_db = _make_db(tmp_path / "interactions.db")
+        cache = AggregateCache(crm_db_paths=[crm_db_path], interactions_db_path=interactions_db)
+
+        calls = []
+
+        @cache.cached()
+        def endpoint():
+            calls.append(1)
+            return {"call_number": len(calls)}
+
+        endpoint()
+        assert len(calls) == 1
+        assert cache.stats()["entries"] == 0  # never cached -- crm.db didn't exist
+
+        _make_db(crm_db_path)  # now it exists
+
+        endpoint()  # first successful version read -- establishes a generation, computes once more
+        endpoint()  # now a real hit
+        assert len(calls) == 2
+        assert cache.stats()["entries"] == 1
+
+
+class TestMultipleCrmPaths:
+    """The stores behind `/statistics` and `/people` (SourceEntityStore,
+    RelationshipStore) resolve crm.db through `get_crm_db_path()`, while
+    `PersonEntityStore` uses a hardcoded path -- the two are the same file
+    by default but can diverge under a non-default `LIFEOS_CHROMA_PATH`.
+    When they do, a write through *either* must invalidate (#917 review
+    finding 2)."""
+
+    def test_write_through_either_watched_crm_path_invalidates(self, tmp_path):
+        crm_db_a = _make_db(tmp_path / "crm_a.db")
+        crm_db_b = _make_db(tmp_path / "crm_b.db")
+        interactions_db = _make_db(tmp_path / "interactions.db")
+        cache = AggregateCache(crm_db_paths=[crm_db_a, crm_db_b],
+                                interactions_db_path=interactions_db)
+
+        calls = []
+
+        @cache.cached()
+        def endpoint():
+            calls.append(1)
+            return {"call_number": len(calls)}
+
+        endpoint()
+        assert len(calls) == 1
+        assert endpoint() == {"call_number": 1}  # still a hit
+
+        _commit_external_write(crm_db_b)
+        endpoint()
+        assert len(calls) == 2, "a write through the second watched crm.db path must invalidate"
+
+        _commit_external_write(crm_db_a)
+        endpoint()
+        assert len(calls) == 3, "a write through the first watched crm.db path must invalidate"
+
+    def test_identical_paths_are_deduped_to_one_connection(self, tmp_path):
+        crm_db = _make_db(tmp_path / "crm.db")
+        interactions_db = _make_db(tmp_path / "interactions.db")
+        # The same file, named two different (but equivalent) ways.
+        same_file_again = str(tmp_path) + os.sep + "." + os.sep + "crm.db"
+        cache = AggregateCache(crm_db_paths=[crm_db, same_file_again],
+                                interactions_db_path=interactions_db)
+        assert len(cache.crm_db_paths) == 1
+
+    def test_default_discovery_watches_both_when_settings_diverge(self, tmp_path, monkeypatch):
+        """Simulates a relocated LIFEOS_CHROMA_PATH: PersonEntityStore's
+        hardcoded path and get_crm_db_path()'s settings-derived path point
+        at two different files. AggregateCache's auto-discovery (used by
+        the process-wide singleton, not the `cache` fixture above, which
+        always passes crm_db_paths explicitly) must watch both."""
+        import api.services.aggregate_cache as aggregate_cache_module
+        from api.services.person_entity import PersonEntityStore
+
+        person_entity_path = tmp_path / "person_entity_crm.db"
+        relocated_path = tmp_path / "relocated_crm.db"
+        _make_db(person_entity_path)
+        _make_db(relocated_path)
+
+        monkeypatch.setattr(PersonEntityStore, "CRM_DB_PATH", person_entity_path)
+        monkeypatch.setattr(aggregate_cache_module, "get_crm_db_path", lambda: str(relocated_path))
+
+        paths = _default_crm_db_paths()
+        resolved = {os.path.realpath(p) for p in paths}
+        assert resolved == {os.path.realpath(str(person_entity_path)),
+                             os.path.realpath(str(relocated_path))}
+
+
+class TestSingleFlight:
+    """Concurrent misses for the same key compute once; the rest wait for
+    the first caller and reuse its result (#917 review finding 9)."""
+
+    def test_concurrent_misses_for_the_same_key_compute_once(self, cache):
+        calls = []
+        call_lock = threading.Lock()
+        started = threading.Event()
+
+        @cache.cached()
+        def slow_endpoint():
+            with call_lock:
+                calls.append(1)
+            started.set()
+            time.sleep(0.3)  # long enough that followers arrive while this runs
+            return {"call_number": len(calls)}
+
+        results = []
+        results_lock = threading.Lock()
+
+        def worker():
+            result = slow_endpoint()
+            with results_lock:
+                results.append(result)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
         for t in threads:
             t.start()
+        started.wait(timeout=2)
         for t in threads:
-            t.join()
+            t.join(timeout=5)
 
-        assert not errors, f"concurrent access raised: {errors}"
-        # At most 5 distinct parameter values were ever requested.
-        assert cache.stats()["entries"] <= 5
+        assert len(calls) == 1, f"expected exactly one real computation, got {len(calls)}"
+        assert len(results) == 8
+        assert all(r == {"call_number": 1} for r in results)
 
 
 class TestFastAPIIntegration:

--- a/tests/test_aggregate_cache.py
+++ b/tests/test_aggregate_cache.py
@@ -515,6 +515,89 @@ class TestSingleFlight:
         assert all(r == {"call_number": 1} for r in results)
 
 
+class TestGenerationRaceDuringCompute:
+    """A commit that lands while the leader is still computing must never
+    get that leader's pre-write result cached under the post-write
+    generation (#917 review finding 11, introduced by finding 8's
+    generation-stamp redesign: the old version-in-key design was immune,
+    since a pre-write result stored under the pre-write key was simply
+    never looked up again once the generation moved on).
+
+    Reproduction shape, matching the review: request 1 starts computing
+    (reads the pre-write generation), an external commit lands, request 2
+    arrives (reads the post-write generation, becomes a single-flight
+    follower of request 1 since nothing is cached yet), request 1 finishes
+    and attempts its store. Without the fix, that store succeeds --
+    unconditionally -- so request 2 (waking as a follower) and any later
+    request both get the stale pre-write value from the cache. With the
+    fix, the store is skipped (the generation moved since request 1 read
+    it), so request 2 falls back to computing its own fresh result, and a
+    later request 3 gets a fresh (correct) cache entry from its own
+    computation."""
+
+    def test_write_during_leader_compute_is_not_served_stale(self, cache):
+        state = {"value": "BEFORE"}
+        handler_calls = []
+        leader_started = threading.Event()
+
+        @cache.cached()
+        def endpoint():
+            handler_calls.append(1)
+            # Read first, same as a real aggregate query snapshotting its
+            # data at the start -- then (only the leader, first call) take
+            # a while to actually finish, long enough for the external
+            # write and request 2 below to both land before it returns.
+            value = state["value"]
+            if len(handler_calls) == 1:
+                leader_started.set()
+                time.sleep(0.3)
+            return {"value": value}
+
+        results = {}
+
+        def req1():
+            results["req1"] = endpoint()
+
+        t1 = threading.Thread(target=req1)
+        t1.start()
+        leader_started.wait(timeout=5)
+
+        # External write lands while request 1 (the leader) is still
+        # "computing" (sleeping) -- this is what advances the generation
+        # before request 1's store runs.
+        state["value"] = "AFTER"
+        _commit_external_write(cache.crm_db_paths[0])
+
+        def req2():
+            results["req2"] = endpoint()
+
+        t2 = threading.Thread(target=req2)
+        t2.start()
+        # Give request 2 time to read the (now advanced) generation and
+        # register as a single-flight follower of request 1 before request
+        # 1 finishes and attempts its store.
+        time.sleep(0.1)
+
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        # Request 1 correctly reflects the (pre-write) data it actually read.
+        assert results["req1"] == {"value": "BEFORE"}
+        # Request 2, woken as a follower, must never receive request 1's
+        # stale result -- it must fall back to computing its own, fresh one.
+        assert results["req2"] == {"value": "AFTER"}, (
+            f"follower must not be served the leader's pre-write result: {results['req2']}"
+        )
+
+        # Request 3, well after everything has settled and no more writes
+        # have happened, must also see the post-write value -- proving
+        # nothing stale was left cached under the new generation either.
+        req3 = endpoint()
+        assert req3 == {"value": "AFTER"}, (
+            f"a later request must never see a stale cached entry: {req3}"
+        )
+
+
 class TestFastAPIIntegration:
     """The decorator works through FastAPI's own request handling, not just
     as a plain Python function call: Query() parameters are still resolved

--- a/tests/test_aggregate_cache_routes.py
+++ b/tests/test_aggregate_cache_routes.py
@@ -1,0 +1,154 @@
+"""
+Static + integration guard: the seven endpoints #876/#917 promise to cache
+actually carry the `AggregateCache` wrapper, and at least one of them
+demonstrably invalidates through a real `TestClient` request when an
+external connection commits to a temporary `crm.db` (#917 review finding 3).
+
+`tests/test_aggregate_cache.py` only ever decorates synthetic local
+functions with `AggregateCache.cached()` directly -- deleting
+`@cached_aggregate()` from every handler in `api/routes/crm.py` would leave
+that file's suite fully green, so it alone doesn't lock in that the real
+routes are wired up. This file does.
+"""
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.routes.crm import router as crm_router
+
+pytestmark = pytest.mark.unit
+
+# The seven (method, path) pairs #876/#917 cache. Kept as a literal set
+# (rather than re-deriving it from the router) so a change to what's cached
+# is a deliberate edit here too, not just a silent pass-through.
+CACHED_ROUTES = {
+    ("GET", "/api/crm/birthdays/all"),
+    ("GET", "/api/crm/people"),
+    ("GET", "/api/crm/statistics"),
+    ("GET", "/api/crm/me/timeline"),
+    ("GET", "/api/crm/me/interactions"),
+    ("GET", "/api/crm/family/timeline"),
+    ("GET", "/api/crm/family/interactions"),
+}
+
+
+def _cached_route_pairs():
+    for route in crm_router.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None) or set()
+        if path is None:
+            continue
+        for method in methods:
+            yield method, path, route
+
+
+class TestSevenEndpointsAreWrapped:
+    """Each of the seven cached (method, path) pairs' registered endpoint is
+    specifically the AggregateCache wrapper -- not merely *some* decorator
+    (functools.wraps means __wrapped__ alone doesn't prove that; the
+    wrapper's own code must come from aggregate_cache.py)."""
+
+    def test_every_listed_route_carries_the_cache_wrapper(self):
+        import inspect
+
+        seen = set()
+        for method, path, route in _cached_route_pairs():
+            if (method, path) not in CACHED_ROUTES:
+                continue
+            seen.add((method, path))
+            endpoint = route.endpoint
+            assert getattr(endpoint, "__wrapped__", None) is not None, (
+                f"{method} {path}: endpoint has no __wrapped__ (not decorated at all?)"
+            )
+            source_file = inspect.getsourcefile(endpoint) or ""
+            assert source_file.endswith("aggregate_cache.py"), (
+                f"{method} {path}: endpoint's own code is defined in {source_file}, "
+                "not aggregate_cache.py -- some other decorator, not the cache wrapper"
+            )
+
+        assert seen == CACHED_ROUTES, (
+            f"expected all seven cached routes to be found in the router, "
+            f"missing: {CACHED_ROUTES - seen}"
+        )
+
+    def test_no_other_crm_route_carries_the_cache_wrapper(self):
+        """A route NOT in CACHED_ROUTES should not accidentally be cached
+        either -- catches a decorator applied to the wrong handler."""
+        import inspect
+
+        for method, path, route in _cached_route_pairs():
+            if (method, path) in CACHED_ROUTES:
+                continue
+            endpoint = route.endpoint
+            source_file = inspect.getsourcefile(endpoint) or ""
+            assert not source_file.endswith("aggregate_cache.py"), (
+                f"{method} {path} is cached but not in the expected list"
+            )
+
+
+class TestRealRouteInvalidatesThroughTestClient:
+    """A real HTTP request to a real decorated route hits the cache, and an
+    external commit to a temporary crm.db (substituted for the process-wide
+    singleton's watched path) forces a recompute -- proven through
+    TestClient, not a synthetic function (#917 review finding 3)."""
+
+    def test_birthdays_all_recomputes_after_an_external_crm_db_commit(
+        self, tmp_path, monkeypatch,
+    ):
+        from unittest.mock import patch
+
+        from api.main import app
+        from api.services.aggregate_cache import get_aggregate_cache
+
+        # Substitute the singleton's watched crm.db (and stop watching
+        # interactions.db by pointing it at the same harmless temp file --
+        # get_all_birthdays never touches interactions data) with a fresh,
+        # real, temporary database, and reset its connections so the next
+        # read opens against the substituted path rather than a stale
+        # handle to the real one.
+        temp_crm_db = tmp_path / "crm.db"
+        conn = sqlite3.connect(str(temp_crm_db))
+        conn.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+
+        cache = get_aggregate_cache()
+        monkeypatch.setattr(cache, "crm_db_paths", [str(temp_crm_db)])
+        monkeypatch.setattr(cache, "interactions_db_path", str(temp_crm_db))
+        monkeypatch.setattr(cache, "_crm_conns", [None])
+        monkeypatch.setattr(cache, "_interactions_conn", None)
+        cache.clear()
+
+        calls = []
+
+        class _CountingStore:
+            def get_all(self):
+                calls.append(1)
+                return []
+
+        client = TestClient(app)
+        with patch("api.routes.crm.get_person_entity_store", return_value=_CountingStore()):
+            first = client.get("/api/crm/birthdays/all")
+            assert first.status_code == 200
+            assert len(calls) == 1
+
+            second = client.get("/api/crm/birthdays/all")
+            assert second.status_code == 200
+            assert len(calls) == 1, "identical repeat request must hit the cache"
+
+            # External commit to the substituted crm.db, from a brand-new
+            # connection -- exactly what PRAGMA data_version is meant to
+            # detect, over an actual HTTP round trip this time.
+            write_conn = sqlite3.connect(str(temp_crm_db))
+            write_conn.execute("INSERT INTO marker DEFAULT VALUES")
+            write_conn.commit()
+            write_conn.close()
+
+            third = client.get("/api/crm/birthdays/all")
+            assert third.status_code == 200
+            assert len(calls) == 2, (
+                "an external commit to the watched crm.db must force a recompute"
+            )
+
+        cache.clear()

--- a/tests/test_me_family_aggregates_oracle.py
+++ b/tests/test_me_family_aggregates_oracle.py
@@ -918,6 +918,12 @@ class TestFamilyTimeline:
         monkeypatch.setattr('api.routes.crm.get_person_entity_store', lambda: pstore)
         monkeypatch.setattr('api.routes.crm.MY_PERSON_ID', MY_PERSON_ID)
 
+        # This call and test_excludes_non_selected_people()'s below share the
+        # exact same parameters against the same seeded dataset shape -- they
+        # only get independent results because the CRM aggregate response
+        # cache (#917) is cleared between every test (autouse
+        # reset_aggregate_cache() in tests/reset_singletons.py), not because
+        # anything here makes the calls distinguishable to it.
         result = get_family_timeline(person_ids="p-close", source_type=None, days_back=365, date=None, offset=0, limit=100)
         assert result.count == 5
         assert all("Close Family" in item.title for item in result.items)

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -206,7 +206,14 @@ class TestMeInteractionsEndpoint:
 
     def test_get_all_not_called_more_than_once(self, mock_stores):
         """None of the Me handlers may call the load-all-people store method
-        more than once per request (#871 acceptance criterion)."""
+        more than once per request (#871 acceptance criterion).
+
+        Asserts exactly 1, not <= 1: the CRM aggregate response cache (#917)
+        sits outside these mocked stores and is cleared before every test
+        (see reset_aggregate_cache() in tests/reset_singletons.py), so a hit
+        (0 calls) is not a possibility here -- `== 1` still distinguishes
+        "called once" from "the handler never ran at all," which `<= 1`
+        would silently accept."""
         from api.routes.crm import get_me_interactions
 
         person_store, interaction_store = mock_stores
@@ -215,7 +222,7 @@ class TestMeInteractionsEndpoint:
             with patch('api.routes.crm.get_interaction_store', return_value=interaction_store):
                 get_me_interactions(days_back=365)
 
-        assert person_store.get_all.call_count <= 1
+        assert person_store.get_all.call_count == 1
 
     def test_filters_by_date_range(self):
         """Date filtering is passed through to the SQL aggregate queries."""

--- a/tests/test_route_handlers_no_shared_connections.py
+++ b/tests/test_route_handlers_no_shared_connections.py
@@ -62,6 +62,9 @@ STORE_MODULES = [
     "api/services/relationship_insights.py",
     "api/services/apple_photos.py",
     "api/services/tone_analysis_store.py",
+    # #876: AggregateCache's two data_version connections follow the same
+    # marked exception as PersonEntityStore's.
+    "api/services/aggregate_cache.py",
 ]
 
 


### PR DESCRIPTION
## TL;DR

The CRM's heaviest dashboard endpoints — the Me and Family interaction/timeline aggregates, the birthdays page, the overall statistics, and the default people list — now answer a repeat request almost instantly instead of recomputing every time, as long as nothing in the underlying data has actually changed. A refresh, a second browser tab, or returning to a dashboard after the client-side cache (from the sibling navigation PR) has expired all get served from a short-lived server-side cache, bounded by a five-minute TTL. The moment any change is made anywhere in the CRM data, the next request recomputes.

Closes #876 (part 2 of 2 — the sibling PR is client-side navigation).

**Update:** an adversarial review found ten issues, all fixed (including a real concurrency bug found only while verifying one of the fixes against real HTTP load). A follow-up verification pass then found one more, introduced by one of those fixes — a store-time generation race — also fixed; see the review thread for both rounds' finding-by-finding responses.

## Design

A small, bounded, in-memory cache sits directly in front of each of these endpoints. Its freshness signal is SQLite's own per-database commit counter (the same mechanism the people-list cache already uses), read from every file a CRM store actually reads crm.db from (this can be more than one path under a non-default `LIFEOS_CHROMA_PATH`) plus the interactions database — so a cached response is invalidated automatically the moment any of them is written to, from this server process or any other. That data-version signal is a *generation stamp*: any change drops every cached entry outright, not just the ones whose specific parameters changed. A five-minute TTL also bounds how long an entry can live regardless, as a safety net. The cache never grows unbounded (entries or memory), never serves a caller a reference it could accidentally corrupt for someone else, never caches a response nobody will ask for twice (a search query, a huge export), and never turns a failure to read its own freshness signal into a failure of the request it's trying to help.

## Implementation Notes

- `api/services/aggregate_cache.py` — `AggregateCache` class: one long-lived, pragma-only SQLite connection per watched database path (`check_same_thread=False`, marked `# threadpool-safe: pragma-only, guarded by lock`), opened with a `mode=ro` URI so a missing file is never created (verified read-only still sees `PRAGMA data_version` change on a WAL-mode database after an external write); `PRAGMA data_version` reads are wrapped in `try/except sqlite3.Error`, falling through to an uncached call and reopening the connection next time. `crm.db` is resolved from both `PersonEntityStore.CRM_DB_PATH` and `api.utils.db_paths.get_crm_db_path()`, deduped by `os.path.realpath`. The version pair is a generation stamp outside the cache key (a change clears everything); the leader re-checks its own pre-compute generation against the current one at store time, so a commit that lands mid-computation makes the store a no-op instead of caching a stale result under the new generation. `.cached(ttl_seconds, should_cache=None)` is the decorator factory; `should_cache(kwargs) -> bool`, if given, bypasses the cache entirely (no read, no store) when it returns `False`. Every hit and miss returns/stores `copy.deepcopy(...)`. Concurrent misses for the same key single-flight behind a per-key `threading.Event` (30s follower timeout, not the 300s TTL). `MAX_TOTAL_BYTES` (~7.1 MB serialized) is scaled from a documented, measured ~7x serialized-to-heap ratio to target a real ~50 MB heap ceiling; an entry over the cap is skipped, not stored at the cost of flushing everything else.
- `api/routes/crm.py` — `@cached_aggregate()` on six handlers; `@cached_aggregate(should_cache=_people_cache_eligible)` on `list_people` (`not q and limit <= 300`).
- `tests/test_aggregate_cache.py` — unit tests against isolated `AggregateCache` instances (temporary SQLite files, the `tests/test_person_entity.py` pattern), covering every behavior above.
- `tests/test_aggregate_cache_routes.py` (new) — walks the real `api.routes.crm` router and asserts each of the seven cached paths' endpoint is specifically the cache wrapper (by source file, not just presence of `__wrapped__`); a `TestClient` test proving a real route recomputes after an external commit to a substituted crm.db.
- `tests/reset_singletons.py`, `tests/test_route_handlers_no_shared_connections.py` — unchanged from the original PR (the singleton-reset wiring and the `STORE_MODULES` guard entry).
- `tests/test_me_page.py`, `tests/test_me_family_aggregates_oracle.py` — a weakened assertion restored and two coupling-to-the-autouse-reset sites commented, per review finding 10.
- `docs/specs/technical/architecture.md`, `docs/specs/product/crm-analytics.md`, `docs/specs/product/api-crm.md` — rewritten to match the current design and drop the freshness overclaim the review caught.

## Test evidence

### Automated tests

```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_aggregate_cache.py tests/test_aggregate_cache_routes.py -q
collected 25 items
.........................                                                [100%]
============================== 25 passed in 4.57s ===============================
```

`tests/test_aggregate_cache.py` (22 tests): cache hit under 20ms (best-of-3) with an identical body and no recompute; per-parameter keys; external-commit invalidation to both watched databases, plus that a version change drops entries outright rather than leaving them as dead weight; TTL-independent-of-data_version expiry; errors never cached, success-after-failure cached normally; entry-count and byte bounds respected, an oversized entry skipped rather than flushing the cache, `clear()`; mutation of a returned object never poisons the cache, two hits return independent objects; a version-read failure (missing directory) falls through to uncached rather than raising, and recovers once the file appears; multiple watched crm.db paths — a write through either invalidates, identical paths dedupe, and the auto-discovery constructor watches both under a simulated relocated `LIFEOS_CHROMA_PATH`; concurrent misses for the same key compute exactly once; a commit landing mid-compute is never served stale to a follower or a later request (the generation-race fix, mutation-verified against the unguarded store); the decorator survives real FastAPI `Query()` resolution and a real HTTP round trip.

`tests/test_aggregate_cache_routes.py` (3 tests): all seven listed routes carry the cache wrapper specifically (not just some decorator) and no other CRM route does; an external `sqlite3` commit to a temporary crm.db substituted for the process-wide singleton forces a real `GET /api/crm/birthdays/all` to recompute through `TestClient`.

Full suite (under the shared push lock, rebased onto #909's tip `5b45c8c`): **5835 passed, 8 skipped** (unit, one pre-existing skip is the environment-dependent `test_my_person_id_is_valid_uuid`, confirmed to fail identically on the base branch) and **301 passed** (server-free browser) — no failures.

### Manual verification

Ran a private staging instance (`~/.venvs/lifeos/bin/python`, port 8029, this worktree, staging `.env`) against a read-only copy of the real CRM/interactions databases:

- **Finding 6 (default-shape-only caching):** `/people?sort=strength&limit=300` still caches (0.97s → 0.011s); `/people?q=test` stays ~0.11s on both calls (no cache read/write at all now); `/people?limit=10000` stays ~2.8-3.0s on both calls — no more encode overhead paid for entries that are never reused.
- **Finding 9 (single-flight) — this is where the real bug surfaced:** 8 parallel `curl` requests to a cold `/me/interactions?days_back=999` key, before the fix, completed at 11-13s each (worse than the review's own pre-single-flight baseline, because now up to 8 real concurrent SQL aggregations were contending for the same resources — a genuine regression from a half-correct single-flight implementation). After moving the wake signal to after the cache store completes: all 8 requests complete together in ~1.3s wall clock.
- Re-confirmed invalidation and byte-identical bodies are unaffected by any of the above changes.

## Review focus

- The generation-race fix (the leader re-checking its pre-compute `versions` against `self._generation` at store time): this is the second concurrency bug found in this cache in two review rounds (the first was the single-flight wake-ordering bug), so it's worth a careful independent look rather than trusting the mutation test alone.
- Whether the ~50 MB heap-ceiling target (via the documented 7x ratio), the 5-minute TTL, and the 30s follower timeout are the right numbers — still reasonable defaults, not measurements against sustained production traffic.
- This PR does not touch `web/crm.html`; the client-side navigation PR (#909, now merged) was independent and reviewed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

